### PR TITLE
feat(agents): add Angular support to frontend delegation rules

### DIFF
--- a/src/agents/frontend-ui-ux-engineer.ts
+++ b/src/agents/frontend-ui-ux-engineer.ts
@@ -66,7 +66,7 @@ Before coding, understand the context and commit to a BOLD aesthetic direction:
 
 **CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
 
-Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+Then implement working code (HTML/CSS/JS, React, Vue, Angular, etc.) that is:
 - Production-grade and functional
 - Visually striking and memorable
 - Cohesive with a clear aesthetic point-of-view

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -189,10 +189,11 @@ STOP searching when:
 
 ### GATE: Frontend Files (HARD BLOCK - zero tolerance)
 
-| Extension | Action | No Exceptions |
-|-----------|--------|---------------|
+| Extension / Pattern | Action | No Exceptions |
+|---------------------|--------|---------------|
 | \`.tsx\`, \`.jsx\` | DELEGATE | Even "just add className" |
 | \`.vue\`, \`.svelte\` | DELEGATE | Even single prop change |
+| \`.component.ts\`, \`.component.html\` | DELEGATE | Angular components |
 | \`.css\`, \`.scss\`, \`.sass\`, \`.less\` | DELEGATE | Even color/margin tweak |
 
 **Detection triggers**: File extension OR keywords (UI, UX, component, button, modal, animation, styling, responsive, layout)
@@ -425,7 +426,7 @@ If the user's approach seems problematic:
 
 | Constraint | No Exceptions |
 |------------|---------------|
-| Frontend files (.tsx/.jsx/.vue/.svelte/.css) | Always delegate |
+| Frontend files (.tsx/.jsx/.vue/.svelte/.css/.component.ts/.component.html) | Always delegate |
 | Type error suppression (\`as any\`, \`@ts-ignore\`) | Never |
 | Commit without explicit request | Never |
 | Speculate about unread code | Never |


### PR DESCRIPTION
## Summary
- Add Angular to frontend-ui-ux-engineer's framework list
- Add Angular file patterns (`.component.ts`, `.component.html`) to Sisyphus delegation gate

## Changes
- `frontend-ui-ux-engineer.ts`: Include Angular in supported frameworks
- `sisyphus.ts`: Add Angular component patterns to frontend file detection table and hard blocks constraint

## Why
The frontend agent previously only mentioned React and Vue explicitly. Angular projects use naming conventions (`.component.ts`, `.component.html`) rather than unique extensions, so pattern-based detection was added to ensure Angular components are properly delegated to the frontend specialist agent.