### PR TITLE
feat(hooks): add transcript caching to reduce PostToolUse latency

### DIFF
--- a/src/hooks/claude-code-hooks/index.ts
+++ b/src/hooks/claude-code-hooks/index.ts
@@ -24,7 +24,7 @@ import {
   type PreCompactContext,
 } from "./pre-compact"
 import { cacheToolInput, getToolInput } from "./tool-input-cache"
-import { recordToolUse, recordToolResult, getTranscriptPath, recordUserMessage } from "./transcript"
+import { recordToolUse, recordToolResult, getTranscriptPath, recordUserMessage, clearCachedClaudeTranscript } from "./transcript"
 import type { PluginConfig } from "./types"
 import { log, isHookDisabled } from "../../shared"
 import type { ContextCollector } from "../../features/context-injector"
@@ -347,6 +347,7 @@ export function createClaudeCodeHooksHook(
           sessionErrorState.delete(sessionInfo.id)
           sessionInterruptState.delete(sessionInfo.id)
           sessionFirstMessageProcessed.delete(sessionInfo.id)
+          clearCachedClaudeTranscript(sessionInfo.id)
         }
         return
       }

--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -5,7 +5,7 @@ import type {
 } from "./types"
 import { findMatchingHooks, executeHookCommand, objectToSnakeCase, transformToolName, log } from "../../shared"
 import { DEFAULT_CONFIG } from "./plugin-config"
-import { buildTranscriptFromSession, deleteTempTranscript } from "./transcript"
+import { getPostToolUseTranscriptPath } from "./transcript"
 import { isHookCommandDisabled, type PluginExtendedConfig } from "./config-loader"
 
 export interface PostToolUseClient {
@@ -56,144 +56,137 @@ export async function executePostToolUseHooks(
     return { block: false }
   }
 
-  // PORT FROM DISABLED: Build Claude Code compatible transcript (temp file)
-  let tempTranscriptPath: string | null = null
+  let transcriptPath = ctx.transcriptPath
 
-  try {
-    // Try to build full transcript from API if client available
-    if (ctx.client) {
-      tempTranscriptPath = await buildTranscriptFromSession(
-        ctx.client,
-        ctx.sessionId,
+  // Try to build full transcript from API if client available
+  if (ctx.client) {
+    transcriptPath = await getPostToolUseTranscriptPath({
+      client: ctx.client,
+      sessionId: ctx.sessionId,
+      directory: ctx.cwd,
+      toolName: ctx.toolName,
+      toolInput: ctx.toolInput,
+    }) ?? transcriptPath
+  }
+
+  const stdinData: PostToolUseInput = {
+    session_id: ctx.sessionId,
+    transcript_path: transcriptPath,
+    cwd: ctx.cwd,
+    permission_mode: ctx.permissionMode ?? "bypassPermissions",
+    hook_event_name: "PostToolUse",
+    tool_name: transformedToolName,
+    tool_input: objectToSnakeCase(ctx.toolInput),
+    tool_response: objectToSnakeCase(ctx.toolOutput),
+    tool_use_id: ctx.toolUseId,
+    hook_source: "opencode-plugin",
+  }
+
+  const messages: string[] = []
+  const warnings: string[] = []
+  let firstHookName: string | undefined
+
+  const startTime = Date.now()
+
+  for (const matcher of matchers) {
+    for (const hook of matcher.hooks) {
+      if (hook.type !== "command") continue
+
+      if (isHookCommandDisabled("PostToolUse", hook.command, extendedConfig ?? null)) {
+        log("PostToolUse hook command skipped (disabled by config)", { command: hook.command, toolName: ctx.toolName })
+        continue
+      }
+
+      const hookName = hook.command.split("/").pop() || hook.command
+      if (!firstHookName) firstHookName = hookName
+
+      const result = await executeHookCommand(
+        hook.command,
+        JSON.stringify(stdinData),
         ctx.cwd,
-        ctx.toolName,
-        ctx.toolInput
+        { forceZsh: DEFAULT_CONFIG.forceZsh, zshPath: DEFAULT_CONFIG.zshPath }
       )
-    }
 
-    const stdinData: PostToolUseInput = {
-      session_id: ctx.sessionId,
-      // Use temp transcript if available, otherwise fallback to append-based
-      transcript_path: tempTranscriptPath ?? ctx.transcriptPath,
-      cwd: ctx.cwd,
-      permission_mode: ctx.permissionMode ?? "bypassPermissions",
-      hook_event_name: "PostToolUse",
-      tool_name: transformedToolName,
-      tool_input: objectToSnakeCase(ctx.toolInput),
-      tool_response: objectToSnakeCase(ctx.toolOutput),
-      tool_use_id: ctx.toolUseId,
-      hook_source: "opencode-plugin",
-    }
+      if (result.stdout) {
+        messages.push(result.stdout)
+      }
 
-    const messages: string[] = []
-    const warnings: string[] = []
-    let firstHookName: string | undefined
-
-    const startTime = Date.now()
-
-    for (const matcher of matchers) {
-      for (const hook of matcher.hooks) {
-        if (hook.type !== "command") continue
-
-        if (isHookCommandDisabled("PostToolUse", hook.command, extendedConfig ?? null)) {
-          log("PostToolUse hook command skipped (disabled by config)", { command: hook.command, toolName: ctx.toolName })
-          continue
+      if (result.exitCode === 2) {
+        if (result.stderr) {
+          warnings.push(`[${hookName}]\n${result.stderr.trim()}`)
         }
+        continue
+      }
 
-        const hookName = hook.command.split("/").pop() || hook.command
-        if (!firstHookName) firstHookName = hookName
-
-        const result = await executeHookCommand(
-          hook.command,
-          JSON.stringify(stdinData),
-          ctx.cwd,
-          { forceZsh: DEFAULT_CONFIG.forceZsh, zshPath: DEFAULT_CONFIG.zshPath }
-        )
-
-        if (result.stdout) {
-          messages.push(result.stdout)
+      if (result.exitCode === 0 && result.stdout) {
+        try {
+          const output = JSON.parse(result.stdout) as PostToolUseOutput
+          if (output.decision === "block") {
+            return {
+              block: true,
+              reason: output.reason || result.stderr,
+              message: messages.join("\n"),
+              warnings: warnings.length > 0 ? warnings : undefined,
+              elapsedMs: Date.now() - startTime,
+              hookName: firstHookName,
+              toolName: transformedToolName,
+              additionalContext: output.hookSpecificOutput?.additionalContext,
+              continue: output.continue,
+              stopReason: output.stopReason,
+              suppressOutput: output.suppressOutput,
+              systemMessage: output.systemMessage,
+            }
+          }
+          if (output.hookSpecificOutput?.additionalContext || output.continue !== undefined || output.systemMessage || output.suppressOutput === true || output.stopReason !== undefined) {
+            return {
+              block: false,
+              message: messages.join("\n"),
+              warnings: warnings.length > 0 ? warnings : undefined,
+              elapsedMs: Date.now() - startTime,
+              hookName: firstHookName,
+              toolName: transformedToolName,
+              additionalContext: output.hookSpecificOutput?.additionalContext,
+              continue: output.continue,
+              stopReason: output.stopReason,
+              suppressOutput: output.suppressOutput,
+              systemMessage: output.systemMessage,
+            }
+          }
+        } catch {
         }
-
-        if (result.exitCode === 2) {
-          if (result.stderr) {
-            warnings.push(`[${hookName}]\n${result.stderr.trim()}`)
-          }
-          continue
-        }
-
-        if (result.exitCode === 0 && result.stdout) {
-          try {
-            const output = JSON.parse(result.stdout) as PostToolUseOutput
-            if (output.decision === "block") {
-              return {
-                block: true,
-                reason: output.reason || result.stderr,
-                message: messages.join("\n"),
-                warnings: warnings.length > 0 ? warnings : undefined,
-                elapsedMs: Date.now() - startTime,
-                hookName: firstHookName,
-                toolName: transformedToolName,
-                additionalContext: output.hookSpecificOutput?.additionalContext,
-                continue: output.continue,
-                stopReason: output.stopReason,
-                suppressOutput: output.suppressOutput,
-                systemMessage: output.systemMessage,
-              }
+      } else if (result.exitCode !== 0 && result.exitCode !== 2) {
+        try {
+          const output = JSON.parse(result.stdout || "{}") as PostToolUseOutput
+          if (output.decision === "block") {
+            return {
+              block: true,
+              reason: output.reason || result.stderr,
+              message: messages.join("\n"),
+              warnings: warnings.length > 0 ? warnings : undefined,
+              elapsedMs: Date.now() - startTime,
+              hookName: firstHookName,
+              toolName: transformedToolName,
+              additionalContext: output.hookSpecificOutput?.additionalContext,
+              continue: output.continue,
+              stopReason: output.stopReason,
+              suppressOutput: output.suppressOutput,
+              systemMessage: output.systemMessage,
             }
-            if (output.hookSpecificOutput?.additionalContext || output.continue !== undefined || output.systemMessage || output.suppressOutput === true || output.stopReason !== undefined) {
-              return {
-                block: false,
-                message: messages.join("\n"),
-                warnings: warnings.length > 0 ? warnings : undefined,
-                elapsedMs: Date.now() - startTime,
-                hookName: firstHookName,
-                toolName: transformedToolName,
-                additionalContext: output.hookSpecificOutput?.additionalContext,
-                continue: output.continue,
-                stopReason: output.stopReason,
-                suppressOutput: output.suppressOutput,
-                systemMessage: output.systemMessage,
-              }
-            }
-          } catch {
           }
-        } else if (result.exitCode !== 0 && result.exitCode !== 2) {
-          try {
-            const output = JSON.parse(result.stdout || "{}") as PostToolUseOutput
-            if (output.decision === "block") {
-              return {
-                block: true,
-                reason: output.reason || result.stderr,
-                message: messages.join("\n"),
-                warnings: warnings.length > 0 ? warnings : undefined,
-                elapsedMs: Date.now() - startTime,
-                hookName: firstHookName,
-                toolName: transformedToolName,
-                additionalContext: output.hookSpecificOutput?.additionalContext,
-                continue: output.continue,
-                stopReason: output.stopReason,
-                suppressOutput: output.suppressOutput,
-                systemMessage: output.systemMessage,
-              }
-            }
-          } catch {
-          }
+        } catch {
         }
       }
     }
+  }
 
-    const elapsedMs = Date.now() - startTime
+  const elapsedMs = Date.now() - startTime
 
-    return {
-      block: false,
-      message: messages.length > 0 ? messages.join("\n") : undefined,
-      warnings: warnings.length > 0 ? warnings : undefined,
-      elapsedMs,
-      hookName: firstHookName,
-      toolName: transformedToolName,
-    }
-  } finally {
-    // PORT FROM DISABLED: Cleanup temp file to avoid disk accumulation
-    deleteTempTranscript(tempTranscriptPath)
+  return {
+    block: false,
+    message: messages.length > 0 ? messages.join("\n") : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+    elapsedMs,
+    hookName: firstHookName,
+    toolName: transformedToolName,
   }
 }

--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -60,13 +60,17 @@ export async function executePostToolUseHooks(
 
   // Try to build full transcript from API if client available
   if (ctx.client) {
-    transcriptPath = await getPostToolUseTranscriptPath({
-      client: ctx.client,
-      sessionId: ctx.sessionId,
-      directory: ctx.cwd,
-      toolName: ctx.toolName,
-      toolInput: ctx.toolInput,
-    }) ?? transcriptPath
+    try {
+      transcriptPath = await getPostToolUseTranscriptPath({
+        client: ctx.client,
+        sessionId: ctx.sessionId,
+        directory: ctx.cwd,
+        toolName: ctx.toolName,
+        toolInput: ctx.toolInput,
+      }) ?? transcriptPath
+    } catch (error) {
+      log(`Failed to get transcript path, using fallback: ${error}`)
+    }
   }
 
   const stdinData: PostToolUseInput = {

--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -152,7 +152,8 @@ export async function executePostToolUseHooks(
               systemMessage: output.systemMessage,
             }
           }
-        } catch {
+        } catch (e) {
+          log("warn", "Failed to parse hook output JSON", e)
         }
       } else if (result.exitCode !== 0 && result.exitCode !== 2) {
         try {

--- a/src/hooks/claude-code-hooks/transcript.test.ts
+++ b/src/hooks/claude-code-hooks/transcript.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  clearCachedClaudeTranscript,
+  getPostToolUseTranscriptPath,
+} from "./transcript"
+
+describe("claude-code-hooks transcript caching", () => {
+  const TEST_DIR = join(tmpdir(), `claude-transcript-test-${Date.now()}`)
+
+  const createClient = () => {
+    let messagesCalls = 0
+    const client = {
+      session: {
+        messages: async () => {
+          messagesCalls++
+          return {
+            data: [
+              {
+                info: { role: "assistant" },
+                parts: [
+                  {
+                    type: "tool",
+                    tool: "read",
+                    state: { status: "completed", input: { path: "README.md" } },
+                  },
+                ],
+              },
+            ],
+          }
+        },
+      },
+    }
+
+    return { client, getCalls: () => messagesCalls }
+  }
+
+  afterEach(() => {
+    clearCachedClaudeTranscript("session-1")
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  describe("#given a session with cached transcript", () => {
+    describe("#when called multiple times", () => {
+      it("#then should reuse cached transcript and append entries", async () => {
+        const { client, getCalls } = createClient()
+
+        const first = await getPostToolUseTranscriptPath({
+          client,
+          sessionId: "session-1",
+          directory: TEST_DIR,
+          toolName: "Read",
+          toolInput: { path: "README.md" },
+        })
+
+        expect(first).not.toBeNull()
+        expect(getCalls()).toBe(1)
+        expect(existsSync(first as string)).toBe(true)
+
+        const firstLines = readFileSync(first as string, "utf-8")
+          .trim()
+          .split("\n")
+        expect(firstLines.length).toBe(2)
+
+        const second = await getPostToolUseTranscriptPath({
+          client,
+          sessionId: "session-1",
+          directory: TEST_DIR,
+          toolName: "Edit",
+          toolInput: { oldString: "a", newString: "b" },
+        })
+
+        expect(second).toBe(first)
+        expect(getCalls()).toBe(1)
+
+        const secondLines = readFileSync(second as string, "utf-8")
+          .trim()
+          .split("\n")
+        expect(secondLines.length).toBe(3)
+      })
+    })
+  })
+})

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -180,6 +180,7 @@ export async function getPostToolUseTranscriptPath(params: {
       cachedClaudeTranscripts.set(params.sessionId, { path: cached.path, lastUsed: Date.now() })
       return cached.path
     } catch {
+      deleteTempTranscript(cached.path)
       cachedClaudeTranscripts.delete(params.sessionId)
     }
   }

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -8,6 +8,13 @@ import { getClaudeConfigDir } from "../../shared"
 
 const TRANSCRIPT_DIR = join(getClaudeConfigDir(), "transcripts")
 
+interface CachedClaudeTranscript {
+  path: string
+  lastUsed: number
+}
+
+const cachedClaudeTranscripts = new Map<string, CachedClaudeTranscript>()
+
 export function getTranscriptPath(sessionId: string): string {
   return join(TRANSCRIPT_DIR, `${sessionId}.jsonl`)
 }
@@ -116,6 +123,65 @@ interface DisabledTranscriptEntry {
   }
 }
 
+function formatClaudeToolUseEntry(toolName: string, toolInput: Record<string, unknown>): string {
+  const entry: DisabledTranscriptEntry = {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: transformToolName(toolName),
+          input: toolInput,
+        },
+      ],
+    },
+  }
+  return JSON.stringify(entry)
+}
+
+export function clearCachedClaudeTranscript(sessionId: string): void {
+  const cached = cachedClaudeTranscripts.get(sessionId)
+  if (cached) {
+    deleteTempTranscript(cached.path)
+    cachedClaudeTranscripts.delete(sessionId)
+  }
+}
+
+export async function getPostToolUseTranscriptPath(params: {
+  client: {
+    session: {
+      messages: (opts: { path: { id: string }; query?: { directory: string } }) => Promise<unknown>
+    }
+  }
+  sessionId: string
+  directory: string
+  toolName: string
+  toolInput: Record<string, unknown>
+}): Promise<string | null> {
+  const cached = cachedClaudeTranscripts.get(params.sessionId)
+  if (cached && existsSync(cached.path)) {
+    appendFileSync(cached.path, formatClaudeToolUseEntry(params.toolName, params.toolInput) + "\n")
+    cachedClaudeTranscripts.set(params.sessionId, { path: cached.path, lastUsed: Date.now() })
+    return cached.path
+  }
+
+  const path = await buildTranscriptFromSession(
+    params.client,
+    params.sessionId,
+    params.directory,
+    params.toolName,
+    params.toolInput
+  )
+
+  if (!path) {
+    return null
+  }
+
+  cachedClaudeTranscripts.set(params.sessionId, { path, lastUsed: Date.now() })
+  return path
+}
+
 /**
  * Build Claude Code compatible transcript from session messages
  * 
@@ -163,41 +229,13 @@ export async function buildTranscriptFromSession(
           if (!part.state?.input) continue
 
           const rawToolName = part.tool as string
-          const toolName = transformToolName(rawToolName)
-
-          const entry: DisabledTranscriptEntry = {
-            type: "assistant",
-            message: {
-              role: "assistant",
-              content: [
-                {
-                  type: "tool_use",
-                  name: toolName,
-                  input: part.state.input,
-                },
-              ],
-            },
-          }
-          entries.push(JSON.stringify(entry))
+          entries.push(formatClaudeToolUseEntry(rawToolName, part.state.input))
         }
       }
     }
 
     // Always add current tool call as the last entry
-    const currentEntry: DisabledTranscriptEntry = {
-      type: "assistant",
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            name: transformToolName(currentToolName),
-            input: currentToolInput,
-          },
-        ],
-      },
-    }
-    entries.push(JSON.stringify(currentEntry))
+    entries.push(formatClaudeToolUseEntry(currentToolName, currentToolInput))
 
     // Write to temp file
     const tempPath = join(

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -15,6 +15,18 @@ interface CachedClaudeTranscript {
 
 const cachedClaudeTranscripts = new Map<string, CachedClaudeTranscript>()
 
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+function evictStaleCacheEntries(): void {
+  const now = Date.now()
+  for (const [sessionId, cached] of cachedClaudeTranscripts) {
+    if (now - cached.lastUsed > CACHE_TTL_MS) {
+      deleteTempTranscript(cached.path)
+      cachedClaudeTranscripts.delete(sessionId)
+    }
+  }
+}
+
 export function getTranscriptPath(sessionId: string): string {
   return join(TRANSCRIPT_DIR, `${sessionId}.jsonl`)
 }
@@ -159,11 +171,17 @@ export async function getPostToolUseTranscriptPath(params: {
   toolName: string
   toolInput: Record<string, unknown>
 }): Promise<string | null> {
+  evictStaleCacheEntries()
+
   const cached = cachedClaudeTranscripts.get(params.sessionId)
-  if (cached && existsSync(cached.path)) {
-    appendFileSync(cached.path, formatClaudeToolUseEntry(params.toolName, params.toolInput) + "\n")
-    cachedClaudeTranscripts.set(params.sessionId, { path: cached.path, lastUsed: Date.now() })
-    return cached.path
+  if (cached) {
+    try {
+      appendFileSync(cached.path, formatClaudeToolUseEntry(params.toolName, params.toolInput) + "\n")
+      cachedClaudeTranscripts.set(params.sessionId, { path: cached.path, lastUsed: Date.now() })
+      return cached.path
+    } catch {
+      cachedClaudeTranscripts.delete(params.sessionId)
+    }
   }
 
   const path = await buildTranscriptFromSession(


### PR DESCRIPTION
# feat(hooks): add transcript caching to reduce PostToolUse latency

- Add session-scoped transcript cache to avoid full rebuild per tool call
- Cache keyed by sessionId with TTL-based cleanup
- Add getPostToolUseTranscriptPath() that returns cached path when valid
- Add clearCachedClaudeTranscript() for explicit invalidation
- Export new functions for adapter extensibility (Codex compatibility prep)

## Summary

- Add session-scoped transcript caching to eliminate redundant full-session rebuilds on every tool call
- Reduce PostToolUse hook latency from O(n) to O(1) for repeated tool calls within same session

## Changes

- `src/hooks/claude-code-hooks/transcript.ts`: Added `cachedClaudeTranscripts` Map with sessionId key, `getPostToolUseTranscriptPath()` for cache-first retrieval, `clearCachedClaudeTranscript()` for explicit invalidation
- `src/hooks/claude-code-hooks/post-tool-use.ts`: Updated to use cached transcript path instead of rebuilding each time
- `src/hooks/claude-code-hooks/transcript.test.ts`: Added unit tests for caching behavior

## Testing

```bash
bun run typecheck
bun test src/hooks/claude-code-hooks/transcript.test.ts
```

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add session-scoped transcript caching to cut PostToolUse latency for repeated tool calls. We now reuse a per-session transcript file and append new tool_use entries instead of rebuilding from the session each time.

- **New Features**
  - Added getPostToolUseTranscriptPath to return a cached transcript path when available, building once on first use and appending subsequent tool_use entries.
  - Added cache eviction: 5-minute TTL and clearCachedClaudeTranscript, wired to session.deleted.
  - Updated PostToolUse to use the cached transcript path with a safe fallback on errors; added tests to verify cache reuse and append behavior, plus logging for hook JSON parse failures.

<sup>Written for commit b0457779935e0adedc69e826c724c4c8c67c2111. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

