### PR TITLE
fix(git-master): inject watermark only when enabled instead of overriding defaults

### DIFF
--- a/src/features/builtin-skills/git-master/SKILL.md
+++ b/src/features/builtin-skills/git-master/SKILL.md
@@ -529,33 +529,6 @@ IF style == SHORT:
 3. Is it similar to examples from git log?
 
 If ANY check fails -> REWRITE message.
-
-### 5.5 Commit Footer & Co-Author (Configurable)
-
-**Check oh-my-opencode.json for these flags:**
-- `git_master.commit_footer` (default: true) - adds footer message
-- `git_master.include_co_authored_by` (default: true) - adds co-author trailer
-
-If enabled, add Sisyphus attribution to EVERY commit:
-
-1. **Footer in commit body (if `commit_footer: true`):**
-```
-Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
-```
-
-2. **Co-authored-by trailer (if `include_co_authored_by: true`):**
-```
-Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
-```
-
-**Example (both enabled):**
-```bash
-git commit -m "{Commit Message}" -m "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)" -m "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>"
-```
-
-**To disable:** Set in oh-my-opencode.json:
-```json
-{ "git_master": { "commit_footer": false, "include_co_authored_by": false } }
 ```
 </execution>
 

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -622,35 +622,8 @@ IF style == SHORT:
 3. Is it similar to examples from git log?
 
 If ANY check fails -> REWRITE message.
-
-### 5.5 Commit Footer & Co-Author (Configurable)
-
-**Check oh-my-opencode.json for these flags:**
-- \`git_master.commit_footer\` (default: true) - adds footer message
-- \`git_master.include_co_authored_by\` (default: true) - adds co-author trailer
-
-If enabled, add Sisyphus attribution to EVERY commit:
-
-1. **Footer in commit body (if \`commit_footer: true\`):**
 \`\`\`
-Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
-\`\`\`
-
-2. **Co-authored-by trailer (if \`include_co_authored_by: true\`):**
-\`\`\`
-Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
-\`\`\`
-
-**Example (both enabled):**
-\`\`\`bash
-git commit -m "{Commit Message}" -m "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)" -m "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>"
-\`\`\`
-
-**To disable:** Set in oh-my-opencode.json:
-\`\`\`json
-{ "git_master": { "commit_footer": false, "include_co_authored_by": false } }
-\`\`\`
-</execution>
+\</execution>
 
 ---
 

--- a/src/features/opencode-skill-loader/skill-content.ts
+++ b/src/features/opencode-skill-loader/skill-content.ts
@@ -59,22 +59,62 @@ async function extractSkillTemplate(skill: LoadedSkill): Promise<string> {
 
 export { clearSkillCache, getAllSkills, extractSkillTemplate }
 
-function injectGitMasterConfig(template: string, config?: GitMasterConfig): string {
-	if (!config) return template
+export function injectGitMasterConfig(template: string, config?: GitMasterConfig): string {
+	const commitFooter = config?.commit_footer ?? true
+	const includeCoAuthoredBy = config?.include_co_authored_by ?? true
 
-	const commitFooter = config.commit_footer ?? true
-	const includeCoAuthoredBy = config.include_co_authored_by ?? true
+	if (!commitFooter && !includeCoAuthoredBy) {
+		return template
+	}
 
-	const configHeader = `## Git Master Configuration (from oh-my-opencode.json)
+	const sections: string[] = []
 
-**IMPORTANT: These values override the defaults in section 5.5:**
-- \`commit_footer\`: ${commitFooter} ${!commitFooter ? "(DISABLED - do NOT add footer)" : ""}
-- \`include_co_authored_by\`: ${includeCoAuthoredBy} ${!includeCoAuthoredBy ? "(DISABLED - do NOT add Co-authored-by)" : ""}
+	sections.push(`### 5.5 Commit Footer & Co-Author`)
+	sections.push(``)
+	sections.push(`Add Sisyphus attribution to EVERY commit:`)
+	sections.push(``)
 
----
+	if (commitFooter) {
+		sections.push(`1. **Footer in commit body:**`)
+		sections.push("```")
+		sections.push(`Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)`)
+		sections.push("```")
+		sections.push(``)
+	}
 
-`
-	return configHeader + template
+	if (includeCoAuthoredBy) {
+		sections.push(`${commitFooter ? "2" : "1"}. **Co-authored-by trailer:**`)
+		sections.push("```")
+		sections.push(`Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>`)
+		sections.push("```")
+		sections.push(``)
+	}
+
+	if (commitFooter && includeCoAuthoredBy) {
+		sections.push(`**Example (both enabled):**`)
+		sections.push("```bash")
+		sections.push(`git commit -m "{Commit Message}" -m "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)" -m "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>"`)
+		sections.push("```")
+	} else if (commitFooter) {
+		sections.push(`**Example:**`)
+		sections.push("```bash")
+		sections.push(`git commit -m "{Commit Message}" -m "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)"`)
+		sections.push("```")
+	} else if (includeCoAuthoredBy) {
+		sections.push(`**Example:**`)
+		sections.push("```bash")
+		sections.push(`git commit -m "{Commit Message}" -m "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>"`)
+		sections.push("```")
+	}
+
+	const injection = sections.join("\n")
+
+	const insertionPoint = template.indexOf("```\n</execution>")
+	if (insertionPoint !== -1) {
+		return template.slice(0, insertionPoint) + "```\n\n" + injection + "\n</execution>" + template.slice(insertionPoint + "```\n</execution>".length)
+	}
+
+	return template + "\n\n" + injection
 }
 
 export function resolveSkillContent(skillName: string, options?: SkillResolutionOptions): string | null {
@@ -82,8 +122,8 @@ export function resolveSkillContent(skillName: string, options?: SkillResolution
 	const skill = skills.find((s) => s.name === skillName)
 	if (!skill) return null
 
-	if (skillName === "git-master" && options?.gitMasterConfig) {
-		return injectGitMasterConfig(skill.template, options.gitMasterConfig)
+	if (skillName === "git-master") {
+		return injectGitMasterConfig(skill.template, options?.gitMasterConfig)
 	}
 
 	return skill.template
@@ -102,8 +142,8 @@ export function resolveMultipleSkills(skillNames: string[], options?: SkillResol
 	for (const name of skillNames) {
 		const template = skillMap.get(name)
 		if (template) {
-			if (name === "git-master" && options?.gitMasterConfig) {
-				resolved.set(name, injectGitMasterConfig(template, options.gitMasterConfig))
+			if (name === "git-master") {
+				resolved.set(name, injectGitMasterConfig(template, options?.gitMasterConfig))
 			} else {
 				resolved.set(name, template)
 			}
@@ -125,8 +165,8 @@ export async function resolveSkillContentAsync(
 
 	const template = await extractSkillTemplate(skill)
 
-	if (skillName === "git-master" && options?.gitMasterConfig) {
-		return injectGitMasterConfig(template, options.gitMasterConfig)
+	if (skillName === "git-master") {
+		return injectGitMasterConfig(template, options?.gitMasterConfig)
 	}
 
 	return template
@@ -152,8 +192,8 @@ export async function resolveMultipleSkillsAsync(
 		const skill = skillMap.get(name)
 		if (skill) {
 			const template = await extractSkillTemplate(skill)
-			if (name === "git-master" && options?.gitMasterConfig) {
-				resolved.set(name, injectGitMasterConfig(template, options.gitMasterConfig))
+			if (name === "git-master") {
+				resolved.set(name, injectGitMasterConfig(template, options?.gitMasterConfig))
 			} else {
 				resolved.set(name, template)
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     skills: mergedSkills,
     mcpManager: skillMcpManager,
     getSessionID: getSessionIDForMcp,
+    gitMasterConfig: pluginConfig.git_master,
   });
   const skillMcpTool = createSkillMcpTool({
     manager: skillMcpManager,

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -104,7 +104,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       pluginConfig.agents,
       ctx.directory,
       config.model as string | undefined,
-      pluginConfig.categories
+      pluginConfig.categories,
+      pluginConfig.git_master
     );
 
     // Claude Code agents: Do NOT apply permission migration

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -4,6 +4,7 @@ import { TOOL_DESCRIPTION_NO_SKILLS, TOOL_DESCRIPTION_PREFIX } from "./constants
 import type { SkillArgs, SkillInfo, SkillLoadOptions } from "./types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 import { getAllSkills, extractSkillTemplate } from "../../features/opencode-skill-loader/skill-content"
+import { injectGitMasterConfig } from "../../features/opencode-skill-loader/skill-content"
 import type { SkillMcpManager, SkillMcpClientInfo, SkillMcpServerContext } from "../../features/skill-mcp-manager"
 import type { Tool, Resource, Prompt } from "@modelcontextprotocol/sdk/types.js"
 
@@ -164,7 +165,12 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
         throw new Error(`Skill "${args.name}" not found. Available skills: ${available || "none"}`)
       }
 
-      const body = await extractSkillBody(skill)
+      let body = await extractSkillBody(skill)
+
+      if (args.name === "git-master") {
+        body = injectGitMasterConfig(body, options.gitMasterConfig)
+      }
+
       const dir = skill.path ? dirname(skill.path) : skill.resolvedPath || process.cwd()
 
       const output = [

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -1,5 +1,6 @@
 import type { SkillScope, LoadedSkill } from "../../features/opencode-skill-loader/types"
 import type { SkillMcpManager } from "../../features/skill-mcp-manager"
+import type { GitMasterConfig } from "../../config/schema"
 
 export interface SkillArgs {
   name: string
@@ -25,4 +26,6 @@ export interface SkillLoadOptions {
   mcpManager?: SkillMcpManager
   /** Session ID getter for MCP client identification */
   getSessionID?: () => string
+  /** Git master configuration for watermark/co-author settings */
+  gitMasterConfig?: GitMasterConfig
 }


### PR DESCRIPTION
## Summary

Fixes inconsistent git-master watermark behavior where the watermark (commit footer and co-author) was sometimes added even when disabled in `oh-my-opencode.json`.

## Root Cause

1. **Missing config propagation**: The `skill` tool (used via `/git-master` or direct skill loading) did not receive `gitMasterConfig` - only `sisyphus_task` passed it correctly
2. **Unreliable approach**: The previous approach was "default ON in template, inject DISABLED override" - LLMs sometimes ignored the negative override instruction

## Solution

Refactored to "inject only when enabled" approach:

- **Remove** hardcoded watermark section (5.5) from base templates (`skills.ts` and `SKILL.md`)
- **Dynamically inject** section 5.5 based on config values:
  - Both enabled → full section with footer + co-author
  - Only footer → just footer instructions
  - Only co-author → just co-author instructions
  - Both disabled → no injection (clean prompt)
- **Default is still ON** (both default to `true` when no config)
- **Fix config propagation** to `skill` tool via `SkillLoadOptions`

## Behavior Matrix

| Scenario | Before | After |
|----------|--------|-------|
| No config | ✅ Watermark ON | ✅ Watermark ON |
| Both `true` | ✅ Watermark ON | ✅ Watermark ON |
| Both `false` | ❌ Sometimes added anyway | ✅ No watermark |
| Footer only | ❌ Inconsistent | ✅ Only footer |
| Co-author only | ❌ Inconsistent | ✅ Only co-author |

## Files Changed

- `src/features/builtin-skills/skills.ts` - Remove hardcoded section 5.5
- `src/features/builtin-skills/git-master/SKILL.md` - Remove hardcoded section 5.5
- `src/features/opencode-skill-loader/skill-content.ts` - Refactor `injectGitMasterConfig` for positive injection
- `src/features/opencode-skill-loader/skill-content.test.ts` - Add comprehensive tests
- `src/tools/skill/types.ts` - Add `gitMasterConfig` to `SkillLoadOptions`
- `src/tools/skill/tools.ts` - Use config for git-master skill
- `src/index.ts` - Pass `gitMasterConfig` to `createSkillTool`

## Testing

- ✅ TypeScript: No errors
- ✅ Tests: 1119 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent git-master watermarking by injecting the footer/co-author only when enabled, instead of overriding defaults. Ensures gitMasterConfig is passed to the skill tool so disabled settings are respected.

- **Bug Fixes**
  - Remove hardcoded watermark section from base templates; inject section 5.5 only when enabled (footer, co-author, or both).
  - Propagate gitMasterConfig via SkillLoadOptions and apply injection in skill loader/tool paths.
  - Keep default behavior ON when no config is provided.
  - Add tests covering disabled, default, and partial combinations.

<sup>Written for commit e36385e671511b5dfb5ff99e75ed582d78b2a8de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

