### PR TITLE
fix(background-agent): prevent false failure notifications on network errors

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -187,32 +187,61 @@ export class BackgroundManager {
       },
     }).catch((error) => {
       const errorMessage = error instanceof Error ? error.message : String(error)
+      const errorName = error?.name ?? ""
       log("[background-agent] prompt error:", { 
         sessionID, 
         agent: input.agent,
-        errorName: error?.name,
+        errorName,
         errorMessage,
       })
       
-      // Only treat as fatal if it's clearly an agent/session creation issue.
-      // Network timeouts, connection drops, and SDK issues should NOT mark task as failed
-      // since the session may still be running successfully (common during high API load).
-      const isFatalError = 
-        errorMessage.includes("agent.name") || 
-        errorMessage.includes("undefined") ||
-        errorMessage.includes("not found") ||
-        errorMessage.includes("not registered") ||
-        errorMessage.includes("does not exist")
+      // INVERTED LOGIC: Treat errors as fatal by default.
+      // Only skip notification for known TRANSIENT network errors where
+      // the session may still be running successfully (common during high API load).
+      // 
+      // Transient errors: network timeouts, connection drops, empty SDK errors
+      // These indicate the request failed to send, but the session may have started.
+      const isTransientNetworkError = 
+        errorName === "TimeoutError" ||
+        errorName === "AbortError" ||
+        errorName === "FetchError" ||
+        errorMessage.includes("ETIMEDOUT") ||
+        errorMessage.includes("ECONNRESET") ||
+        errorMessage.includes("ECONNREFUSED") ||
+        errorMessage.includes("ENOTFOUND") ||
+        errorMessage.includes("EAI_AGAIN") ||
+        errorMessage.includes("EPIPE") ||
+        errorMessage.includes("ENETUNREACH") ||
+        errorMessage.includes("EHOSTUNREACH") ||
+        errorMessage.includes("socket hang up") ||
+        errorMessage.includes("network request failed") ||
+        errorMessage.includes("connection timed out") ||
+        errorMessage.includes("request timed out") ||
+        // Empty error object {} from SDK issues - session likely still running
+        (errorMessage === "{}" || errorMessage === "")
       
-      if (!isFatalError) {
-        log("[background-agent] Non-fatal prompt error, letting polling detect actual status:", sessionID)
+      if (isTransientNetworkError) {
+        log("[background-agent] Transient network error, letting polling detect actual status:", sessionID)
         return
       }
       
+      // All other errors are fatal: auth, permission, invalid payload, agent not found, etc.
+      // Mark task as failed immediately to release concurrency and notify parent.
       const existingTask = this.findBySession(sessionID)
       if (existingTask) {
         existingTask.status = "error"
-        existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
+        // Provide specific error message for agent-related issues (stricter matching)
+        const isAgentNotFoundError = 
+          errorMessage.includes("agent") && (
+            errorMessage.includes("not found") || 
+            errorMessage.includes("not registered") || 
+            errorMessage.includes("does not exist")
+          )
+        if (isAgentNotFoundError) {
+          existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
+        } else {
+          existingTask.error = `Background task failed: ${errorMessage}`
+        }
         existingTask.completedAt = new Date()
         if (existingTask.concurrencyKey) {
           this.concurrencyManager.release(existingTask.concurrencyKey)
@@ -432,10 +461,41 @@ export class BackgroundManager {
         parts: [{ type: "text", text: input.prompt }],
       },
     }).catch((error) => {
-      log("[background-agent] resume prompt error:", error)
-      existingTask.status = "error"
       const errorMessage = error instanceof Error ? error.message : String(error)
-      existingTask.error = errorMessage
+      const errorName = error?.name ?? ""
+      log("[background-agent] resume prompt error:", { 
+        sessionID: existingTask.sessionID, 
+        agent: existingTask.agent,
+        errorName,
+        errorMessage,
+      })
+      
+      // Same transient network error handling as launch()
+      const isTransientNetworkError = 
+        errorName === "TimeoutError" ||
+        errorName === "AbortError" ||
+        errorName === "FetchError" ||
+        errorMessage.includes("ETIMEDOUT") ||
+        errorMessage.includes("ECONNRESET") ||
+        errorMessage.includes("ECONNREFUSED") ||
+        errorMessage.includes("ENOTFOUND") ||
+        errorMessage.includes("EAI_AGAIN") ||
+        errorMessage.includes("EPIPE") ||
+        errorMessage.includes("ENETUNREACH") ||
+        errorMessage.includes("EHOSTUNREACH") ||
+        errorMessage.includes("socket hang up") ||
+        errorMessage.includes("network request failed") ||
+        errorMessage.includes("connection timed out") ||
+        errorMessage.includes("request timed out") ||
+        (errorMessage === "{}" || errorMessage === "")
+      
+      if (isTransientNetworkError) {
+        log("[background-agent] Transient network error on resume, letting polling detect actual status:", existingTask.sessionID)
+        return
+      }
+      
+      existingTask.status = "error"
+      existingTask.error = `Resume failed: ${errorMessage}`
       existingTask.completedAt = new Date()
 
       // Release concurrency on error to prevent slot leaks

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -186,16 +186,33 @@ export class BackgroundManager {
         parts: [{ type: "text", text: input.prompt }],
       },
     }).catch((error) => {
-      log("[background-agent] promptAsync error:", error)
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      log("[background-agent] prompt error:", { 
+        sessionID, 
+        agent: input.agent,
+        errorName: error?.name,
+        errorMessage,
+      })
+      
+      // Only treat as fatal if it's clearly an agent/session creation issue.
+      // Network timeouts, connection drops, and SDK issues should NOT mark task as failed
+      // since the session may still be running successfully (common during high API load).
+      const isFatalError = 
+        errorMessage.includes("agent.name") || 
+        errorMessage.includes("undefined") ||
+        errorMessage.includes("not found") ||
+        errorMessage.includes("not registered") ||
+        errorMessage.includes("does not exist")
+      
+      if (!isFatalError) {
+        log("[background-agent] Non-fatal prompt error, letting polling detect actual status:", sessionID)
+        return
+      }
+      
       const existingTask = this.findBySession(sessionID)
       if (existingTask) {
         existingTask.status = "error"
-        const errorMessage = error instanceof Error ? error.message : String(error)
-        if (errorMessage.includes("agent.name") || errorMessage.includes("undefined")) {
-          existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
-        } else {
-          existingTask.error = errorMessage
-        }
+        existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
         existingTask.completedAt = new Date()
         if (existingTask.concurrencyKey) {
           this.concurrencyManager.release(existingTask.concurrencyKey)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -218,7 +218,7 @@ export class BackgroundManager {
         errorMessage.includes("connection timed out") ||
         errorMessage.includes("request timed out") ||
         // Empty error object {} from SDK issues - session likely still running
-        (errorMessage === "{}" || errorMessage === "")
+        errorMessage === "{}" || errorMessage === "" || errorMessage === "[object Object]"
       
       if (isTransientNetworkError) {
         log("[background-agent] Transient network error, letting polling detect actual status:", sessionID)
@@ -487,7 +487,7 @@ export class BackgroundManager {
         errorMessage.includes("network request failed") ||
         errorMessage.includes("connection timed out") ||
         errorMessage.includes("request timed out") ||
-        (errorMessage === "{}" || errorMessage === "")
+        errorMessage === "{}" || errorMessage === "" || errorMessage === "[object Object]"
       
       if (isTransientNetworkError) {
         log("[background-agent] Transient network error on resume, letting polling detect actual status:", existingTask.sessionID)


### PR DESCRIPTION
## Summary

Fixes false-positive background task failure notifications during high API load (e.g., Antigravity during Anthropic OAuth migration).

## Problem

When API providers are under heavy load, `session.prompt()` throws network errors (timeouts, connection drops) even when the background session is still running successfully.

**Before**: ALL errors immediately marked task as 'error' and notified parent agent → Agent sees "Background agents failed" → Pivots to fallback strategies unnecessarily

**After**: Only fatal errors (agent not found, not registered) mark task as failed. Network errors are logged and polling detects actual completion/failure.

## Root Cause Analysis

From logs during high Antigravity load:
```
[background-agent] promptAsync error: {}
[background-agent] notifyParentSession called for task: "bg_09c21064"  ← Error notification sent
...
[background-agent] Sent notification: {"taskId":"bg_09c21064","allComplete":true}  ← Task actually completed!
```

The empty error `{}` indicates a network/SDK issue, not an agent failure. The task continued running and completed successfully, but the agent had already received the failure notification.

## Changes

- Only treat errors as fatal if they clearly indicate agent/session creation issues
- Non-fatal errors (network, timeout, SDK) are logged but don't mark task as failed
- Polling mechanism detects actual completion/failure status

## Testing

- [x] All 46 background-agent tests pass
- [x] Type check passes
- [x] Build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false background task failure notifications when session.prompt() hits transient network/SDK errors. Errors are fatal by default; only known network timeouts/drops are skipped, and polling confirms real completion.

- **Bug Fixes**
  - Narrow transient handling: only skip for specific network/SDK errors; added codes/signatures (“network request failed”, “connection/request timed out”, “[object Object]”). Removed broad matches that misclassified errors.
  - Stricter agent-not-found detection: requires “agent” plus “not found”/“not registered”/“does not exist”; removed broad “undefined” matches.
  - Add structured logging (sessionID, agent, error name/message) for easier debugging.
  - Release concurrency on resume fatal errors; standardized messages (“Background task failed…”, “Resume failed…”).

<sup>Written for commit 86c1366ffd9438d2c6c93e71f44aa36285a959e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

