### PR TITLE
fix(migration): update import path after sisyphus-task rename to delegate-task

### DIFF
--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -82,6 +82,11 @@ describe("claude-code-session-state", () => {
   })
 
   describe("mainSessionID", () => {
+    test("should return undefined when not set", () => {
+      // #given - beforeEach already resets, but verify
+      expect(getMainSessionID()).toBeUndefined()
+    })
+
     test("should store and retrieve main session ID", () => {
       // #given
       const mainID = "main-session-123"
@@ -91,13 +96,6 @@ describe("claude-code-session-state", () => {
 
       // #then
       expect(getMainSessionID()).toBe(mainID)
-    })
-
-    test("should return undefined when not set", () => {
-      // #given - not set
-
-      // #then
-      expect(getMainSessionID()).toBeUndefined()
     })
   })
 

--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -1,13 +1,13 @@
 export const subagentSessions = new Set<string>()
 
-export let mainSessionID: string | undefined
+let _mainSessionID: string | undefined
 
 export function setMainSession(id: string | undefined) {
-  mainSessionID = id
+  _mainSessionID = id
 }
 
 export function getMainSessionID(): string | undefined {
-  return mainSessionID
+  return _mainSessionID
 }
 
 const sessionAgentMap = new Map<string, string>()

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -107,7 +107,7 @@ export function shouldDeleteAgentConfig(
   config: Record<string, unknown>,
   category: string
 ): boolean {
-  const { DEFAULT_CATEGORIES } = require("../tools/sisyphus-task/constants")
+  const { DEFAULT_CATEGORIES } = require("../tools/delegate-task/constants")
   const defaults = DEFAULT_CATEGORIES[category]
   if (!defaults) return false
 


### PR DESCRIPTION
## Summary

- Fix broken import path in `src/shared/migration.ts` that was causing CI test failures
- The `sisyphus-task` tool was renamed to `delegate-task` in commit `188bbef` but this import was not updated

## Root Cause

`migration.ts` line 110 referenced `../tools/sisyphus-task/constants` which no longer exists after the rename.

## Evidence

- Before fix: `bun test` failed with `Cannot find module '../tools/sisyphus-task/constants'`
- After fix: All 1136 tests pass (0 failures)

```
 1136 pass
 1 skip
 0 fail
 2191 expect() calls
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a broken import in src/shared/migration.ts by switching from sisyphus-task to delegate-task, aligning with the tool rename and restoring passing CI tests. Encapsulated main session ID via getter/setter and asserted it's undefined when not set to prevent cross-test leakage in CI.

<sup>Written for commit 10565538ed2c62083ff1944837f183f67da24d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

