### PR TITLE
refactor: remove hardcoded fallback models from agents and categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,18 +103,22 @@ oh-my-opencode/
 
 ## AGENT MODELS
 
-| Agent | Default Model | Purpose |
-|-------|---------------|---------|
-| Sisyphus | anthropic/claude-opus-4-5 | Primary orchestrator with extended thinking |
-| oracle | openai/gpt-5.2 | Read-only consultation, high-IQ debugging |
-| librarian | opencode/glm-4.7-free | Multi-repo analysis, docs, GitHub search |
-| explore | opencode/grok-code | Fast codebase exploration (contextual grep) |
-| frontend-ui-ux-engineer | google/gemini-3-pro-preview | UI generation, visual design |
-| document-writer | google/gemini-3-flash | Technical documentation |
-| multimodal-looker | google/gemini-3-flash | PDF/image analysis |
-| Prometheus (Planner) | anthropic/claude-opus-4-5 | Strategic planning, interview mode |
-| Metis (Plan Consultant) | anthropic/claude-sonnet-4-5 | Pre-planning analysis |
-| Momus (Plan Reviewer) | anthropic/claude-sonnet-4-5 | Plan validation |
+Models are inherited from system default (OpenCode config) unless overridden via user config.
+
+| Agent | Model | Purpose |
+|-------|-------|---------|
+| Sisyphus | *(inherited)* | Primary orchestrator with extended thinking |
+| oracle | *(inherited)* | Read-only consultation, high-IQ debugging |
+| librarian | *(inherited)* | Multi-repo analysis, docs, GitHub search |
+| explore | *(inherited)* | Fast codebase exploration (contextual grep) |
+| frontend-ui-ux-engineer | *(inherited)* | UI generation, visual design |
+| document-writer | *(inherited)* | Technical documentation |
+| multimodal-looker | *(inherited)* | PDF/image analysis |
+| Prometheus (Planner) | *(inherited)* | Strategic planning, interview mode |
+| Metis (Plan Consultant) | *(inherited)* | Pre-planning analysis |
+| Momus (Plan Reviewer) | *(inherited)* | Plan validation |
+
+**Resolution chain**: User config → Parent model → System default
 
 ## COMMANDS
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -2060,10 +2060,7 @@
           "prompt_append": {
             "type": "string"
           }
-        },
-        "required": [
-          "model"
-        ]
+        }
       }
     },
     "claude_code": {

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -12,12 +12,12 @@ agents/
 ├── sisyphus.ts                 # Main prompt (640 lines)
 ├── sisyphus-junior.ts          # Delegated task executor
 ├── sisyphus-prompt-builder.ts  # Dynamic prompt generation
-├── oracle.ts                   # Strategic advisor (GPT-5.2)
-├── librarian.ts                # Multi-repo research (GLM-4.7-free)
-├── explore.ts                  # Fast grep (Grok Code)
-├── frontend-ui-ux-engineer.ts  # UI specialist (Gemini 3 Pro)
-├── document-writer.ts          # Technical writer (Gemini 3 Flash)
-├── multimodal-looker.ts        # Media analyzer (Gemini 3 Flash)
+├── oracle.ts                   # Strategic advisor
+├── librarian.ts                # Multi-repo research
+├── explore.ts                  # Fast contextual grep
+├── frontend-ui-ux-engineer.ts  # UI specialist
+├── document-writer.ts          # Technical writer
+├── multimodal-looker.ts        # Media analyzer
 ├── prometheus-prompt.ts        # Planning (1196 lines) - interview mode
 ├── metis.ts                    # Plan consultant - pre-planning analysis
 ├── momus.ts                    # Plan reviewer - validation
@@ -28,18 +28,22 @@ agents/
 
 ## AGENT MODELS
 
+Models are inherited from system default (OpenCode config) unless overridden via user config.
+
 | Agent | Model | Temperature | Purpose |
 |-------|-------|-------------|---------|
-| Sisyphus | anthropic/claude-opus-4-5 | 0.1 | Primary orchestrator, todo-driven |
-| oracle | openai/gpt-5.2 | 0.1 | Read-only consultation, debugging |
-| librarian | opencode/glm-4.7-free | 0.1 | Docs, GitHub search, OSS examples |
-| explore | opencode/grok-code | 0.1 | Fast contextual grep |
-| frontend-ui-ux-engineer | google/gemini-3-pro-preview | 0.7 | UI generation, visual design |
-| document-writer | google/gemini-3-flash | 0.3 | Technical documentation |
-| multimodal-looker | google/gemini-3-flash | 0.1 | PDF/image analysis |
-| Prometheus | anthropic/claude-opus-4-5 | 0.1 | Strategic planning, interview mode |
-| Metis | anthropic/claude-sonnet-4-5 | 0.1 | Pre-planning gap analysis |
-| Momus | anthropic/claude-sonnet-4-5 | 0.1 | Plan validation |
+| Sisyphus | *(inherited)* | 0.1 | Primary orchestrator, todo-driven |
+| oracle | *(inherited)* | 0.1 | Read-only consultation, debugging |
+| librarian | *(inherited)* | 0.1 | Docs, GitHub search, OSS examples |
+| explore | *(inherited)* | 0.1 | Fast contextual grep |
+| frontend-ui-ux-engineer | *(inherited)* | 0.7 | UI generation, visual design |
+| document-writer | *(inherited)* | 0.3 | Technical documentation |
+| multimodal-looker | *(inherited)* | 0.1 | PDF/image analysis |
+| Prometheus | *(inherited)* | 0.1 | Strategic planning, interview mode |
+| Metis | *(inherited)* | 0.1 | Pre-planning gap analysis |
+| Momus | *(inherited)* | 0.1 | Plan validation |
+
+**Model Resolution**: User config (`agents.{name}.model`) → Parent model → System default model
 
 ## HOW TO ADD
 

--- a/src/agents/document-writer.ts
+++ b/src/agents/document-writer.ts
@@ -11,9 +11,7 @@ export const DOCUMENT_WRITER_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createDocumentWriterAgent(
-  model: string | undefined
-): AgentConfig {
+export function createDocumentWriterAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([])
 
   return {

--- a/src/agents/document-writer.ts
+++ b/src/agents/document-writer.ts
@@ -2,8 +2,6 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "google/gemini-3-flash-preview"
-
 export const DOCUMENT_WRITER_PROMPT_METADATA: AgentPromptMetadata = {
   category: "specialist",
   cost: "CHEAP",
@@ -14,7 +12,7 @@ export const DOCUMENT_WRITER_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createDocumentWriterAgent(
-  model: string = DEFAULT_MODEL
+  model: string | undefined
 ): AgentConfig {
   const restrictions = createAgentToolRestrictions([])
 
@@ -220,5 +218,3 @@ You are a technical writer who creates documentation that developers actually wa
 </guide>`,
   }
 }
-
-export const documentWriterAgent = createDocumentWriterAgent()

--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -2,8 +2,6 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "opencode/grok-code"
-
 export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
   category: "exploration",
   cost: "FREE",
@@ -24,7 +22,7 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createExploreAgent(model: string = DEFAULT_MODEL): AgentConfig {
+export function createExploreAgent(model: string | undefined): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",
@@ -121,5 +119,3 @@ Use the right tool for the job:
 Flood with parallel calls. Cross-validate findings across multiple tools.`,
   }
 }
-
-export const exploreAgent = createExploreAgent()

--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -22,7 +22,7 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createExploreAgent(model: string | undefined): AgentConfig {
+export function createExploreAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",

--- a/src/agents/frontend-ui-ux-engineer.ts
+++ b/src/agents/frontend-ui-ux-engineer.ts
@@ -17,9 +17,7 @@ export const FRONTEND_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createFrontendUiUxEngineerAgent(
-  model: string | undefined
-): AgentConfig {
+export function createFrontendUiUxEngineerAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([])
 
   return {

--- a/src/agents/frontend-ui-ux-engineer.ts
+++ b/src/agents/frontend-ui-ux-engineer.ts
@@ -2,8 +2,6 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "google/gemini-3-pro-preview"
-
 export const FRONTEND_PROMPT_METADATA: AgentPromptMetadata = {
   category: "specialist",
   cost: "CHEAP",
@@ -20,7 +18,7 @@ export const FRONTEND_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createFrontendUiUxEngineerAgent(
-  model: string = DEFAULT_MODEL
+  model: string | undefined
 ): AgentConfig {
   const restrictions = createAgentToolRestrictions([])
 
@@ -105,5 +103,3 @@ Match implementation complexity to aesthetic vision:
 Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. You are capable of extraordinary creative work—don't hold back.`,
   }
 }
-
-export const frontendUiUxEngineerAgent = createFrontendUiUxEngineerAgent()

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,27 +1,14 @@
-import type { AgentConfig } from "@opencode-ai/sdk"
-import { sisyphusAgent } from "./sisyphus"
-import { oracleAgent } from "./oracle"
-import { librarianAgent } from "./librarian"
-import { exploreAgent } from "./explore"
-import { frontendUiUxEngineerAgent } from "./frontend-ui-ux-engineer"
-import { documentWriterAgent } from "./document-writer"
-import { multimodalLookerAgent } from "./multimodal-looker"
-import { metisAgent } from "./metis"
-import { orchestratorSisyphusAgent } from "./orchestrator-sisyphus"
-import { momusAgent } from "./momus"
-
-export const builtinAgents: Record<string, AgentConfig> = {
-  Sisyphus: sisyphusAgent,
-  oracle: oracleAgent,
-  librarian: librarianAgent,
-  explore: exploreAgent,
-  "frontend-ui-ux-engineer": frontendUiUxEngineerAgent,
-  "document-writer": documentWriterAgent,
-  "multimodal-looker": multimodalLookerAgent,
-  "Metis (Plan Consultant)": metisAgent,
-  "Momus (Plan Reviewer)": momusAgent,
-  "orchestrator-sisyphus": orchestratorSisyphusAgent,
-}
+export { createSisyphusAgent } from "./sisyphus"
+export { createOracleAgent, ORACLE_PROMPT_METADATA } from "./oracle"
+export { createLibrarianAgent, LIBRARIAN_PROMPT_METADATA } from "./librarian"
+export { createExploreAgent, EXPLORE_PROMPT_METADATA } from "./explore"
+export { createFrontendUiUxEngineerAgent, FRONTEND_PROMPT_METADATA } from "./frontend-ui-ux-engineer"
+export { createDocumentWriterAgent, DOCUMENT_WRITER_PROMPT_METADATA } from "./document-writer"
+export { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "./multimodal-looker"
+export { createMetisAgent, metisPromptMetadata } from "./metis"
+export { createOrchestratorSisyphusAgent, orchestratorSisyphusPromptMetadata } from "./orchestrator-sisyphus"
+export { createMomusAgent, momusPromptMetadata } from "./momus"
+export { createSisyphusJuniorAgentWithOverrides, createSisyphusJuniorAgent, SISYPHUS_JUNIOR_DEFAULTS } from "./sisyphus-junior"
 
 export * from "./types"
 export { createBuiltinAgents } from "./utils"

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -19,7 +19,7 @@ export const LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createLibrarianAgent(model: string | undefined): AgentConfig {
+export function createLibrarianAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -2,8 +2,6 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "opencode/glm-4.7-free"
-
 export const LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
   category: "exploration",
   cost: "CHEAP",
@@ -21,7 +19,7 @@ export const LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
   ],
 }
 
-export function createLibrarianAgent(model: string = DEFAULT_MODEL): AgentConfig {
+export function createLibrarianAgent(model: string | undefined): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",
@@ -325,5 +323,3 @@ grep_app_searchGitHub(query: "useQuery")
 `,
   }
 }
-
-export const librarianAgent = createLibrarianAgent()

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -278,9 +278,7 @@ const metisRestrictions = createAgentToolRestrictions([
   "delegate_task",
 ])
 
-const DEFAULT_MODEL = "anthropic/claude-opus-4-5"
-
-export function createMetisAgent(model: string = DEFAULT_MODEL): AgentConfig {
+export function createMetisAgent(model: string | undefined): AgentConfig {
   return {
     description:
       "Pre-planning consultant that analyzes requests to identify hidden intentions, ambiguities, and AI failure points.",
@@ -292,8 +290,6 @@ export function createMetisAgent(model: string = DEFAULT_MODEL): AgentConfig {
     thinking: { type: "enabled", budgetTokens: 32000 },
   } as AgentConfig
 }
-
-export const metisAgent: AgentConfig = createMetisAgent()
 
 export const metisPromptMetadata: AgentPromptMetadata = {
   category: "advisor",

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -278,7 +278,7 @@ const metisRestrictions = createAgentToolRestrictions([
   "delegate_task",
 ])
 
-export function createMetisAgent(model: string | undefined): AgentConfig {
+export function createMetisAgent(model?: string): AgentConfig {
   return {
     description:
       "Pre-planning consultant that analyzes requests to identify hidden intentions, ambiguities, and AI failure points.",

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -389,7 +389,7 @@ Use structured format, **in the same language as the work plan**.
 **FINAL REMINDER**: You are a DOCUMENTATION reviewer, not a DESIGN consultant. The author's implementation direction is SACRED. Your job ends at "Is this well-documented enough to execute?" - NOT "Is this the right approach?"
 `
 
-export function createMomusAgent(model: string | undefined): AgentConfig {
+export function createMomusAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -17,8 +17,6 @@ import { createAgentToolRestrictions } from "../shared/permission-compat"
  * implementation.
  */
 
-const DEFAULT_MODEL = "openai/gpt-5.2"
-
 export const MOMUS_SYSTEM_PROMPT = `You are a work plan review expert. You review the provided work plan (.sisyphus/plans/{name}.md in the current working project directory) according to **unified, consistent criteria** that ensure clarity, verifiability, and completeness.
 
 **CRITICAL FIRST RULE**:
@@ -391,7 +389,7 @@ Use structured format, **in the same language as the work plan**.
 **FINAL REMINDER**: You are a DOCUMENTATION reviewer, not a DESIGN consultant. The author's implementation direction is SACRED. Your job ends at "Is this well-documented enough to execute?" - NOT "Is this the right approach?"
 `
 
-export function createMomusAgent(model: string = DEFAULT_MODEL): AgentConfig {
+export function createMomusAgent(model: string | undefined): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",
@@ -409,14 +407,12 @@ export function createMomusAgent(model: string = DEFAULT_MODEL): AgentConfig {
     prompt: MOMUS_SYSTEM_PROMPT,
   } as AgentConfig
 
-  if (isGptModel(model)) {
+  if (model && isGptModel(model)) {
     return { ...base, reasoningEffort: "medium", textVerbosity: "high" } as AgentConfig
   }
 
   return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } } as AgentConfig
 }
-
-export const momusAgent = createMomusAgent()
 
 export const momusPromptMetadata: AgentPromptMetadata = {
   category: "advisor",

--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -9,9 +9,7 @@ export const MULTIMODAL_LOOKER_PROMPT_METADATA: AgentPromptMetadata = {
   triggers: [],
 }
 
-export function createMultimodalLookerAgent(
-  model: string | undefined
-): AgentConfig {
+export function createMultimodalLookerAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolAllowlist(["read"])
 
   return {

--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -2,8 +2,6 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { createAgentToolAllowlist } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "google/gemini-3-flash"
-
 export const MULTIMODAL_LOOKER_PROMPT_METADATA: AgentPromptMetadata = {
   category: "utility",
   cost: "CHEAP",
@@ -12,7 +10,7 @@ export const MULTIMODAL_LOOKER_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createMultimodalLookerAgent(
-  model: string = DEFAULT_MODEL
+  model: string | undefined
 ): AgentConfig {
   const restrictions = createAgentToolAllowlist(["read"])
 
@@ -57,5 +55,3 @@ Response rules:
 Your output goes straight to the main agent for continued work.`,
   }
 }
-
-export const multimodalLookerAgent = createMultimodalLookerAgent()

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -95,7 +95,7 @@ Organize your final answer in three tiers:
 
 Your response goes directly to the user with no intermediate processing. Make your final message self-contained: a clear recommendation they can act on immediately, covering both what to do and why.`
 
-export function createOracleAgent(model: string | undefined): AgentConfig {
+export function createOracleAgent(model?: string): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -3,8 +3,6 @@ import type { AgentPromptMetadata } from "./types"
 import { isGptModel } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
-const DEFAULT_MODEL = "openai/gpt-5.2"
-
 export const ORACLE_PROMPT_METADATA: AgentPromptMetadata = {
   category: "advisor",
   cost: "EXPENSIVE",
@@ -97,7 +95,7 @@ Organize your final answer in three tiers:
 
 Your response goes directly to the user with no intermediate processing. Make your final message self-contained: a clear recommendation they can act on immediately, covering both what to do and why.`
 
-export function createOracleAgent(model: string = DEFAULT_MODEL): AgentConfig {
+export function createOracleAgent(model: string | undefined): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "write",
     "edit",
@@ -115,11 +113,9 @@ export function createOracleAgent(model: string = DEFAULT_MODEL): AgentConfig {
     prompt: ORACLE_SYSTEM_PROMPT,
   } as AgentConfig
 
-  if (isGptModel(model)) {
+  if (model && isGptModel(model)) {
     return { ...base, reasoningEffort: "medium", textVerbosity: "high" } as AgentConfig
   }
 
   return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } } as AgentConfig
 }
-
-export const oracleAgent = createOracleAgent()

--- a/src/agents/orchestrator-sisyphus.ts
+++ b/src/agents/orchestrator-sisyphus.ts
@@ -1458,8 +1458,6 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
     .replace("{SKILLS_SECTION}", skillsSection)
 }
 
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
-
 export function createOrchestratorSisyphusAgent(ctx?: OrchestratorContext): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "task",
@@ -1469,7 +1467,7 @@ export function createOrchestratorSisyphusAgent(ctx?: OrchestratorContext): Agen
     description:
       "Orchestrates work via delegate_task() to complete ALL tasks in a todo list until fully done",
     mode: "primary" as const,
-    model: ctx?.model ?? DEFAULT_MODEL,
+    model: ctx?.model,
     temperature: 0.1,
     prompt: buildDynamicOrchestratorPrompt(ctx),
     thinking: { type: "enabled", budgetTokens: 32000 },
@@ -1477,8 +1475,6 @@ export function createOrchestratorSisyphusAgent(ctx?: OrchestratorContext): Agen
     ...restrictions,
   } as AgentConfig
 }
-
-export const orchestratorSisyphusAgent: AgentConfig = createOrchestratorSisyphusAgent()
 
 export const orchestratorSisyphusPromptMetadata: AgentPromptMetadata = {
   category: "advisor",

--- a/src/agents/sisyphus-junior.test.ts
+++ b/src/agents/sisyphus-junior.test.ts
@@ -72,7 +72,19 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
   })
 
   describe("defaults", () => {
-    test("uses default model when no override", () => {
+    test("uses systemDefaultModel when no override", () => {
+      // #given
+      const override = {}
+      const systemDefaultModel = "anthropic/claude-sonnet-4-5"
+
+      // #when
+      const result = createSisyphusJuniorAgentWithOverrides(override, systemDefaultModel)
+
+      // #then
+      expect(result.model).toBe(systemDefaultModel)
+    })
+
+    test("uses undefined model when no override and no systemDefaultModel", () => {
       // #given
       const override = {}
 
@@ -80,7 +92,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       const result = createSisyphusJuniorAgentWithOverrides(override)
 
       // #then
-      expect(result.model).toBe(SISYPHUS_JUNIOR_DEFAULTS.model)
+      expect(result.model).toBeUndefined()
     })
 
     test("uses default temperature when no override", () => {
@@ -96,19 +108,20 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
   })
 
   describe("disable semantics", () => {
-    test("disable: true causes override block to be ignored", () => {
+    test("disable: true causes override block to be ignored, uses systemDefaultModel", () => {
       // #given
       const override = {
         disable: true,
         model: "openai/gpt-5.2",
         temperature: 0.9,
       }
+      const systemDefaultModel = "anthropic/claude-sonnet-4-5"
 
       // #when
-      const result = createSisyphusJuniorAgentWithOverrides(override)
+      const result = createSisyphusJuniorAgentWithOverrides(override, systemDefaultModel)
 
-      // #then - defaults should be used, not the overrides
-      expect(result.model).toBe(SISYPHUS_JUNIOR_DEFAULTS.model)
+      // #then - systemDefaultModel should be used, not the overrides
+      expect(result.model).toBe(systemDefaultModel)
       expect(result.temperature).toBe(SISYPHUS_JUNIOR_DEFAULTS.temperature)
     })
   })

--- a/src/agents/sisyphus-junior.ts
+++ b/src/agents/sisyphus-junior.ts
@@ -78,7 +78,6 @@ function buildSisyphusJuniorPrompt(promptAppend?: string): string {
 const BLOCKED_TOOLS = ["task", "delegate_task"]
 
 export const SISYPHUS_JUNIOR_DEFAULTS = {
-  model: "anthropic/claude-sonnet-4-5",
   temperature: 0.1,
 } as const
 
@@ -90,7 +89,7 @@ export function createSisyphusJuniorAgentWithOverrides(
     override = undefined
   }
 
-  const model = override?.model ?? systemDefaultModel ?? SISYPHUS_JUNIOR_DEFAULTS.model
+  const model = override?.model ?? systemDefaultModel
   const temperature = override?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
 
   const promptAppend = override?.prompt_append
@@ -123,7 +122,7 @@ export function createSisyphusJuniorAgentWithOverrides(
     base.top_p = override.top_p
   }
 
-  if (isGptModel(model)) {
+  if (model && isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" } as AgentConfig
   }
 
@@ -184,7 +183,7 @@ export function createSisyphusJuniorAgent(
     } as AgentConfig
   }
 
-  if (isGptModel(model)) {
+  if (model && isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" } as AgentConfig
   }
 

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -14,8 +14,6 @@ import {
   categorizeTools,
 } from "./sisyphus-prompt-builder"
 
-const DEFAULT_MODEL = "anthropic/claude-opus-4-5"
-
 const SISYPHUS_ROLE_SECTION = `<Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
 
@@ -607,7 +605,7 @@ function buildDynamicSisyphusPrompt(
 }
 
 export function createSisyphusAgent(
-  model: string = DEFAULT_MODEL,
+  model: string | undefined,
   availableAgents?: AvailableAgent[],
   availableToolNames?: string[],
   availableSkills?: AvailableSkill[]
@@ -630,11 +628,9 @@ export function createSisyphusAgent(
     permission,
   }
 
-  if (isGptModel(model)) {
+  if (model && isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" }
   }
 
   return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } }
 }
-
-export const sisyphusAgent = createSisyphusAgent()

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -605,7 +605,7 @@ function buildDynamicSisyphusPrompt(
 }
 
 export function createSisyphusAgent(
-  model: string | undefined,
+  model?: string,
   availableAgents?: AvailableAgent[],
   availableToolNames?: string[],
   availableSkills?: AvailableSkill[]

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -3,16 +3,28 @@ import { createBuiltinAgents } from "./utils"
 import type { AgentConfig } from "@opencode-ai/sdk"
 
 describe("createBuiltinAgents with model overrides", () => {
-  test("Sisyphus with default model has thinking config", () => {
-    // #given - no overrides
+  test("Sisyphus with systemDefaultModel has thinking config", () => {
+    // #given
+    const systemDefaultModel = "anthropic/claude-opus-4-5"
 
     // #when
-    const agents = createBuiltinAgents()
+    const agents = createBuiltinAgents([], {}, undefined, systemDefaultModel)
 
     // #then
     expect(agents.Sisyphus.model).toBe("anthropic/claude-opus-4-5")
     expect(agents.Sisyphus.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
     expect(agents.Sisyphus.reasoningEffort).toBeUndefined()
+  })
+
+  test("Sisyphus with no systemDefaultModel has undefined model", () => {
+    // #given - no overrides, no systemDefaultModel
+
+    // #when
+    const agents = createBuiltinAgents()
+
+    // #then
+    expect(agents.Sisyphus.model).toBeUndefined()
+    expect(agents.Sisyphus.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
   })
 
   test("Sisyphus with GPT model override has reasoningEffort, no thinking", () => {
@@ -43,17 +55,16 @@ describe("createBuiltinAgents with model overrides", () => {
     expect(agents.Sisyphus.thinking).toBeUndefined()
   })
 
-  test("Oracle with default model has reasoningEffort", () => {
-    // #given - no overrides
+  test("Oracle with no systemDefaultModel has undefined model and thinking config", () => {
+    // #given - no overrides, no systemDefaultModel
 
     // #when
     const agents = createBuiltinAgents()
 
     // #then
-    expect(agents.oracle.model).toBe("openai/gpt-5.2")
-    expect(agents.oracle.reasoningEffort).toBe("medium")
-    expect(agents.oracle.textVerbosity).toBe("high")
-    expect(agents.oracle.thinking).toBeUndefined()
+    expect(agents.oracle.model).toBeUndefined()
+    expect(agents.oracle.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+    expect(agents.oracle.reasoningEffort).toBeUndefined()
   })
 
   test("Oracle with Claude model override has thinking, no reasoningEffort", () => {
@@ -104,7 +115,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"])
 
     // #then
-    expect(agent.model).toBe("google/gemini-3-pro-preview")
+    expect(agent.model).toBeUndefined()
     expect(agent.temperature).toBe(0.7)
   })
 
@@ -228,7 +239,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"])
 
     // #then
-    expect(agent.model).toBe("openai/gpt-5.2")
+    expect(agent.model).toBeUndefined()
     expect(agent.temperature).toBe(0.1)
     expect(agent.prompt).toContain("Role: Designer-Turned-Developer")
     expect(agent.prompt).toContain("Task description")

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -9,7 +9,7 @@ import { createFrontendUiUxEngineerAgent, FRONTEND_PROMPT_METADATA } from "./fro
 import { createDocumentWriterAgent, DOCUMENT_WRITER_PROMPT_METADATA } from "./document-writer"
 import { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "./multimodal-looker"
 import { createMetisAgent } from "./metis"
-import { createOrchestratorSisyphusAgent, orchestratorSisyphusAgent } from "./orchestrator-sisyphus"
+import { createOrchestratorSisyphusAgent } from "./orchestrator-sisyphus"
 import { createMomusAgent } from "./momus"
 import type { AvailableAgent } from "./sisyphus-prompt-builder"
 import { deepMerge } from "../shared"
@@ -28,8 +28,7 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   "multimodal-looker": createMultimodalLookerAgent,
   "Metis (Plan Consultant)": createMetisAgent,
   "Momus (Plan Reviewer)": createMomusAgent,
-  "orchestrator-sisyphus": orchestratorSisyphusAgent,
-}
+} as Record<BuiltinAgentName, AgentSource>
 
 /**
  * Metadata for each agent, used to build Sisyphus's dynamic prompt sections

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -151,7 +151,7 @@ export function createBuiltinAgents(
     if (disabledAgents.includes(agentName)) continue
 
     const override = agentOverrides[agentName]
-    const model = override?.model
+    const model = override?.model ?? systemDefaultModel
 
     let config = buildAgent(source, model, mergedCategories, gitMasterConfig)
 

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -18,7 +18,11 @@ import { resolveMultipleSkills } from "../features/opencode-skill-loader/skill-c
 
 type AgentSource = AgentFactory | AgentConfig
 
-const agentSources: Record<BuiltinAgentName, AgentSource> = {
+// orchestrator-sisyphus is excluded because it requires special parameters (not just model)
+// and is handled separately in createBuiltinAgents()
+type StandardAgentName = Exclude<BuiltinAgentName, "orchestrator-sisyphus">
+
+const agentSources: Record<StandardAgentName, AgentSource> = {
   Sisyphus: createSisyphusAgent,
   oracle: createOracleAgent,
   librarian: createLibrarianAgent,
@@ -28,7 +32,7 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   "multimodal-looker": createMultimodalLookerAgent,
   "Metis (Plan Consultant)": createMetisAgent,
   "Momus (Plan Reviewer)": createMomusAgent,
-} as Record<BuiltinAgentName, AgentSource>
+}
 
 /**
  * Metadata for each agent, used to build Sisyphus's dynamic prompt sections
@@ -141,10 +145,9 @@ export function createBuiltinAgents(
     : DEFAULT_CATEGORIES
 
   for (const [name, source] of Object.entries(agentSources)) {
-    const agentName = name as BuiltinAgentName
+    const agentName = name as StandardAgentName
 
     if (agentName === "Sisyphus") continue
-    if (agentName === "orchestrator-sisyphus") continue
     if (disabledAgents.includes(agentName)) continue
 
     const override = agentOverrides[agentName]

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -154,7 +154,7 @@ export const SisyphusAgentConfigSchema = z.object({
 })
 
 export const CategoryConfigSchema = z.object({
-  model: z.string(),
+  model: z.string().optional(),
   variant: z.string().optional(),
   temperature: z.number().min(0).max(2).optional(),
   top_p: z.number().min(0).max(1).optional(),

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -12,7 +12,7 @@ describe("Prometheus category config resolution", () => {
 
     // #then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.2")
+    expect(config?.model).toBeUndefined() // Models are no longer hardcoded in categories
     expect(config?.temperature).toBe(0.1)
   })
 
@@ -25,7 +25,7 @@ describe("Prometheus category config resolution", () => {
 
     // #then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("google/gemini-3-pro-preview")
+    expect(config?.model).toBeUndefined() // Models are no longer hardcoded in categories
     expect(config?.temperature).toBe(0.7)
   })
 
@@ -73,7 +73,7 @@ describe("Prometheus category config resolution", () => {
 
     // #then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.2")
+    expect(config?.model).toBeUndefined() // Models are no longer hardcoded in categories
     expect(config?.temperature).toBe(0.1)
   })
 

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -204,8 +204,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
           model:
             prometheusOverride?.model ??
             categoryConfig?.model ??
-            defaultModel ??
-            "anthropic/claude-opus-4-5",
+            defaultModel,
           mode: "primary" as const,
           prompt: PROMETHEUS_SYSTEM_PROMPT,
           permission: PROMETHEUS_PERMISSION,

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -369,10 +369,9 @@ describe("shouldDeleteAgentConfig", () => {
   })
 
   test("returns true when all fields match category defaults", () => {
-    // #given: Config with fields matching category defaults
+    // #given: Config with fields matching category defaults (model is not in defaults anymore)
     const config = {
       category: "visual-engineering",
-      model: "google/gemini-3-pro-preview",
       temperature: 0.7,
     }
 

--- a/src/tools/delegate-task/constants.ts
+++ b/src/tools/delegate-task/constants.ts
@@ -185,31 +185,24 @@ The more explicit your prompt, the better the results.
 
 export const DEFAULT_CATEGORIES: Record<string, CategoryConfig> = {
   "visual-engineering": {
-    model: "google/gemini-3-pro-preview",
     temperature: 0.7,
   },
   ultrabrain: {
-    model: "openai/gpt-5.2",
     temperature: 0.1,
   },
   artistry: {
-    model: "google/gemini-3-pro-preview",
     temperature: 0.9,
   },
   quick: {
-    model: "anthropic/claude-haiku-4-5",
     temperature: 0.3,
   },
   "most-capable": {
-    model: "anthropic/claude-opus-4-5",
     temperature: 0.1,
   },
   writing: {
-    model: "google/gemini-3-flash-preview",
     temperature: 0.5,
   },
   general: {
-    model: "anthropic/claude-sonnet-4-5",
     temperature: 0.3,
   },
 }

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -38,23 +38,23 @@ function resolveCategoryConfig(
 
 describe("sisyphus-task", () => {
   describe("DEFAULT_CATEGORIES", () => {
-    test("visual-engineering category has gemini model", () => {
+    test("visual-engineering category has no hardcoded model (inherits from system)", () => {
       // #given
       const category = DEFAULT_CATEGORIES["visual-engineering"]
 
       // #when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("google/gemini-3-pro-preview")
+      expect(category.model).toBeUndefined()
       expect(category.temperature).toBe(0.7)
     })
 
-    test("ultrabrain category has gpt model", () => {
+    test("ultrabrain category has no hardcoded model (inherits from system)", () => {
       // #given
       const category = DEFAULT_CATEGORIES["ultrabrain"]
 
       // #when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("openai/gpt-5.2")
+      expect(category.model).toBeUndefined()
       expect(category.temperature).toBe(0.1)
     })
   })
@@ -126,7 +126,7 @@ describe("sisyphus-task", () => {
       expect(result).toBeNull()
     })
 
-    test("returns default config for builtin category", () => {
+    test("returns default config for builtin category with no model (inherits from parent/system)", () => {
       // #given
       const categoryName = "visual-engineering"
 
@@ -135,7 +135,7 @@ describe("sisyphus-task", () => {
 
       // #then
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.config.model).toBeUndefined()
       expect(result!.promptAppend).toContain("VISUAL/UI")
     })
 
@@ -212,17 +212,17 @@ describe("sisyphus-task", () => {
       expect(result!.config.temperature).toBe(0.3)
     })
 
-    test("category default model takes precedence over parentModelString", () => {
-      // #given - builtin category has default model, parent model should NOT override it
+    test("parentModelString is used when category has no model (builtin categories no longer have hardcoded models)", () => {
+      // #given - builtin category has no hardcoded model, parent model provides fallback
       const categoryName = "visual-engineering"
       const parentModelString = "cliproxy/claude-opus-4-5"
 
       // #when
       const result = resolveCategoryConfig(categoryName, { parentModelString })
 
-      // #then - category default model wins, parent model is ignored for builtin categories
+      // #then - parent model is used since categories no longer have hardcoded models
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.config.model).toBe("cliproxy/claude-opus-4-5")
     })
 
     test("parentModelString is used as fallback when category has no default model", () => {
@@ -255,7 +255,7 @@ describe("sisyphus-task", () => {
       expect(result!.config.model).toBe("my-provider/my-model")
     })
 
-    test("default model is used when no user model and no parentModelString", () => {
+    test("model is undefined when no user model, no parentModelString, and no systemDefaultModel", () => {
       // #given
       const categoryName = "visual-engineering"
 
@@ -264,7 +264,7 @@ describe("sisyphus-task", () => {
 
       // #then
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.config.model).toBeUndefined()
     })
   })
 
@@ -438,7 +438,7 @@ describe("sisyphus-task", () => {
       const mockManager = { launch: async () => ({}) }
       const mockClient = {
         app: { agents: async () => ({ data: [] }) },
-        config: { get: async () => ({}) },
+        config: { get: async () => ({ model: "anthropic/claude-sonnet-4-5" }) },
         session: {
           get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "test-session" } }),
@@ -615,15 +615,15 @@ describe("sisyphus-task", () => {
       
       const mockClient = {
         session: {
+          create: async () => ({ data: { id: "ses_sync_error" } }),
           get: async () => ({ data: { directory: "/project" } }),
-          create: async () => ({ data: { id: "ses_sync_error_test" } }),
           prompt: async () => {
             throw new Error("JSON Parse error: Unexpected EOF")
           },
           messages: async () => ({ data: [] }),
           status: async () => ({ data: {} }),
         },
-        config: { get: async () => ({}) },
+        config: { get: async () => ({ model: "anthropic/claude-sonnet-4-5" }) },
         app: {
           agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
         },
@@ -683,7 +683,7 @@ describe("sisyphus-task", () => {
           }),
           status: async () => ({ data: { "ses_sync_success": { type: "idle" } } }),
         },
-        config: { get: async () => ({}) },
+        config: { get: async () => ({ model: "anthropic/claude-sonnet-4-5" }) },
         app: {
           agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
         },
@@ -736,7 +736,7 @@ describe("sisyphus-task", () => {
           messages: async () => ({ data: [] }),
           status: async () => ({ data: {} }),
         },
-        config: { get: async () => ({}) },
+        config: { get: async () => ({ model: "anthropic/claude-sonnet-4-5" }) },
         app: {
           agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
         },
@@ -879,37 +879,32 @@ describe("sisyphus-task", () => {
   })
 
   describe("modelInfo detection via resolveCategoryConfig", () => {
-    test("when parentModelString exists but default model wins - modelInfo should report category-default", () => {
-      // #given - Bug scenario: parentModelString is passed but userModel is undefined,
-      // and the resolution order is: userModel ?? parentModelString ?? defaultModel
-      // If parentModelString matches the resolved model, it's "inherited"
-      // If defaultModel matches, it's "category-default"
+    test("when no model sources exist - resolved model should be undefined", () => {
+      // #given - Categories no longer have hardcoded default models
       const categoryName = "ultrabrain"
       const parentModelString = undefined
       
       // #when
       const resolved = resolveCategoryConfig(categoryName, { parentModelString })
       
-      // #then - actualModel should be defaultModel, type should be "category-default"
+      // #then - model is undefined when no sources provide a model
       expect(resolved).not.toBeNull()
       const actualModel = resolved!.config.model
-      const defaultModel = DEFAULT_CATEGORIES[categoryName]?.model
-      expect(actualModel).toBe(defaultModel)
-      expect(actualModel).toBe("openai/gpt-5.2")
+      expect(actualModel).toBeUndefined()
     })
 
-    test("category default model takes precedence over parentModelString for builtin category", () => {
-      // #given - builtin ultrabrain category has default model gpt-5.2
+    test("parentModelString is used as fallback when category has no default model", () => {
+      // #given - builtin ultrabrain category no longer has a default model
       const categoryName = "ultrabrain"
       const parentModelString = "cliproxy/claude-opus-4-5"
       
       // #when
       const resolved = resolveCategoryConfig(categoryName, { parentModelString })
       
-      // #then - category default model wins, not the parent model
+      // #then - parentModelString is used as fallback
       expect(resolved).not.toBeNull()
       const actualModel = resolved!.config.model
-      expect(actualModel).toBe("openai/gpt-5.2")
+      expect(actualModel).toBe("cliproxy/claude-opus-4-5")
     })
 
     test("when user defines model - modelInfo should report user-defined regardless of parentModelString", () => {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -443,7 +443,7 @@ ${textContent || "(No text output)"}`
         const categoryDefaultModel = DEFAULT_CATEGORIES[args.category]?.model
 
         if (!actualModel) {
-          return `No model configured. Set a model in your OpenCode config, plugin config, or use a category with a default model.`
+          return `No model configured. Set a model in your OpenCode config, plugin config, or category config.`
         }
 
         if (!parseModelString(actualModel)) {


### PR DESCRIPTION
## Summary

- Remove hardcoded default models from agent factory functions and category configurations
- Models are now inherited from system default (OpenCode config) unless overridden via user config
- Cleaner configuration model where users control model selection at the system level

## Changes

### Agent Factory Functions
Changed signatures from `model: string = DEFAULT_MODEL` to `model: string | undefined`:
- `src/agents/sisyphus.ts`
- `src/agents/sisyphus-junior.ts`
- `src/agents/orchestrator-sisyphus.ts`
- `src/agents/oracle.ts`
- `src/agents/librarian.ts`
- `src/agents/explore.ts`
- `src/agents/frontend-ui-ux-engineer.ts`
- `src/agents/document-writer.ts`
- `src/agents/multimodal-looker.ts`
- `src/agents/metis.ts`
- `src/agents/momus.ts`

### Category Defaults
- `src/tools/delegate-task/constants.ts` - `DEFAULT_CATEGORIES` no longer include `model` field

### Schema
- `src/config/schema.ts` - `CategoryConfigSchema.model` is now optional

### Config Handler
- `src/plugin-handlers/config-handler.ts` - Removed hardcoded fallback from Prometheus config

### Tests
- Updated 4 test files to expect new behavior (model = undefined when not configured)

### Documentation
- Updated `AGENTS.md` and `src/agents/AGENTS.md` to reflect that models are inherited from system config

## Model Resolution Chain

```
userConfig?.model → parentModelString → systemDefaultModel
```

## Breaking Changes

None - existing user configs with explicit model overrides continue to work. Users without explicit overrides will now use their system default model instead of the previously hardcoded defaults.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed hardcoded fallback models from agents and task categories. Models now inherit from the system default (OpenCode config) unless users override them.

- **Refactors**
  - Agent factory functions use model?: string (no built-in defaults).
  - DEFAULT_CATEGORIES no longer set a model; CategoryConfigSchema.model is optional.
  - Index exports create* functions and prompt metadata; removed pre-instantiated agents.
  - Prometheus config no longer hardcodes a fallback; resolves from user/category/system defaults.
  - Updated tests, docs, and delegate_task error message; model resolution: user config → parent model → system default.

<sup>Written for commit c92131c3086115e739a614cd3d69a5d43a6ece9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

