### PR TITLE
fix: store UI-selected model for first message model inheritance

### DIFF
--- a/src/features/builtin-skills/skills.test.ts
+++ b/src/features/builtin-skills/skills.test.ts
@@ -61,7 +61,7 @@ describe("createBuiltinSkills", () => {
 		expect(agentBrowserSkill!.template).toContain("agent-browser snapshot")
 	})
 
-	test("always includes frontend-ui-ux and git-master skills", () => {
+	test("always includes frontend-ui-ux, git-master, and dev-browser skills", () => {
 		// #given - both provider options
 
 		// #when
@@ -72,18 +72,19 @@ describe("createBuiltinSkills", () => {
 		for (const skills of [defaultSkills, agentBrowserSkills]) {
 			expect(skills.find((s) => s.name === "frontend-ui-ux")).toBeDefined()
 			expect(skills.find((s) => s.name === "git-master")).toBeDefined()
+			expect(skills.find((s) => s.name === "dev-browser")).toBeDefined()
 		}
 	})
 
-	test("returns exactly 3 skills regardless of provider", () => {
+	test("returns exactly 4 skills regardless of provider", () => {
 		// #given
 
 		// #when
 		const defaultSkills = createBuiltinSkills()
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
 
-		// #then
-		expect(defaultSkills).toHaveLength(3)
-		expect(agentBrowserSkills).toHaveLength(3)
+		// #then - browserSkill + frontend-ui-ux + git-master + dev-browser = 4
+		expect(defaultSkills).toHaveLength(4)
+		expect(agentBrowserSkills).toHaveLength(4)
 	})
 })

--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -7,6 +7,10 @@ import {
   setMainSession,
   getMainSessionID,
   _resetForTesting,
+  setSessionModel,
+  getSessionModel,
+  clearSessionModel,
+  updateSessionModel,
 } from "./state"
 
 describe("claude-code-session-state", () => {
@@ -16,6 +20,9 @@ describe("claude-code-session-state", () => {
     clearSessionAgent("test-session-1")
     clearSessionAgent("test-session-2")
     clearSessionAgent("test-prometheus-session")
+    clearSessionModel("test-session-1")
+    clearSessionModel("test-session-2")
+    clearSessionModel("test-model-session")
   })
 
   describe("setSessionAgent", () => {
@@ -157,6 +164,104 @@ describe("claude-code-session-state", () => {
 
       // #then - should be updated
       expect(getSessionAgent(sessionID)).toBe(newAgent)
+    })
+  })
+
+  describe("setSessionModel", () => {
+    test("should store model for session", () => {
+      // #given
+      const sessionID = "test-model-session"
+      const model = { providerID: "grok", modelID: "grok-2" }
+
+      // #when
+      setSessionModel(sessionID, model)
+
+      // #then
+      expect(getSessionModel(sessionID)).toEqual(model)
+    })
+
+    test("should NOT overwrite existing model (first-write wins)", () => {
+      // #given
+      const sessionID = "test-model-session"
+      const firstModel = { providerID: "grok", modelID: "grok-2" }
+      const secondModel = { providerID: "anthropic", modelID: "claude-sonnet-4-5" }
+      setSessionModel(sessionID, firstModel)
+
+      // #when - try to overwrite
+      setSessionModel(sessionID, secondModel)
+
+      // #then - first model preserved
+      expect(getSessionModel(sessionID)).toEqual(firstModel)
+    })
+
+    test("should return undefined for unknown session", () => {
+      // #given - no session set
+
+      // #when / #then
+      expect(getSessionModel("unknown-session")).toBeUndefined()
+    })
+  })
+
+  describe("updateSessionModel", () => {
+    test("should overwrite existing model", () => {
+      // #given
+      const sessionID = "test-model-session"
+      const firstModel = { providerID: "grok", modelID: "grok-2" }
+      const secondModel = { providerID: "anthropic", modelID: "claude-sonnet-4-5" }
+      setSessionModel(sessionID, firstModel)
+
+      // #when - force update
+      updateSessionModel(sessionID, secondModel)
+
+      // #then
+      expect(getSessionModel(sessionID)).toEqual(secondModel)
+    })
+  })
+
+  describe("clearSessionModel", () => {
+    test("should remove model from session", () => {
+      // #given
+      const sessionID = "test-model-session"
+      const model = { providerID: "grok", modelID: "grok-2" }
+      setSessionModel(sessionID, model)
+      expect(getSessionModel(sessionID)).toEqual(model)
+
+      // #when
+      clearSessionModel(sessionID)
+
+      // #then
+      expect(getSessionModel(sessionID)).toBeUndefined()
+    })
+  })
+
+  describe("issue #1024 integration scenario", () => {
+    test("should store UI-selected model on first message for delegate_task fallback", () => {
+      // #given - User selects grok model via UI before first message
+      const sessionID = "test-first-message-session"
+      const uiSelectedModel = { providerID: "grok", modelID: "grok-2" }
+
+      // #when - chat.message hook fires with input.model (simulating UI selection)
+      setSessionModel(sessionID, uiSelectedModel)
+
+      // #then - delegate_task can retrieve the model as fallback
+      const sessionModel = getSessionModel(sessionID)
+      expect(sessionModel).toEqual(uiSelectedModel)
+      expect(sessionModel?.providerID).toBe("grok")
+      expect(sessionModel?.modelID).toBe("grok-2")
+    })
+
+    test("should preserve first model selection (no overwrite on subsequent messages)", () => {
+      // #given - First message with grok model
+      const sessionID = "test-first-message-session"
+      const firstModel = { providerID: "grok", modelID: "grok-2" }
+      setSessionModel(sessionID, firstModel)
+
+      // #when - Second message with different model (shouldn't happen normally, but test the safety)
+      const secondModel = { providerID: "anthropic", modelID: "claude-opus-4" }
+      setSessionModel(sessionID, secondModel)
+
+      // #then - First model preserved
+      expect(getSessionModel(sessionID)).toEqual(firstModel)
     })
   })
 })

--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -14,6 +14,8 @@ export function getMainSessionID(): string | undefined {
 export function _resetForTesting(): void {
   _mainSessionID = undefined
   subagentSessions.clear()
+  sessionAgentMap.clear()
+  sessionModelMap.clear()
 }
 
 const sessionAgentMap = new Map<string, string>()
@@ -34,4 +36,29 @@ export function getSessionAgent(sessionID: string): string | undefined {
 
 export function clearSessionAgent(sessionID: string): void {
   sessionAgentMap.delete(sessionID)
+}
+
+export interface SessionModel {
+  providerID: string
+  modelID: string
+}
+
+const sessionModelMap = new Map<string, SessionModel>()
+
+export function setSessionModel(sessionID: string, model: SessionModel): void {
+  if (!sessionModelMap.has(sessionID)) {
+    sessionModelMap.set(sessionID, model)
+  }
+}
+
+export function updateSessionModel(sessionID: string, model: SessionModel): void {
+  sessionModelMap.set(sessionID, model)
+}
+
+export function getSessionModel(sessionID: string): SessionModel | undefined {
+  return sessionModelMap.get(sessionID)
+}
+
+export function clearSessionModel(sessionID: string): void {
+  sessionModelMap.delete(sessionID)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ import {
   setSessionAgent,
   updateSessionAgent,
   clearSessionAgent,
+  setSessionModel,
+  clearSessionModel,
 } from "./features/claude-code-session-state";
 import {
   builtinTools,
@@ -336,6 +338,14 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         setSessionAgent(input.sessionID, input.agent);
       }
 
+      // Store UI-selected model for first message (before prevMessage exists)
+      if (input.model?.providerID && input.model?.modelID) {
+        setSessionModel(input.sessionID, {
+          providerID: input.model.providerID,
+          modelID: input.model.modelID,
+        });
+      }
+
       const message = (output as { message: { variant?: string } }).message
       if (firstMessageVariantGate.shouldOverride(input.sessionID)) {
         const variant = resolveAgentVariant(pluginConfig, input.agent)
@@ -465,6 +475,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
          }
          if (sessionInfo?.id) {
            clearSessionAgent(sessionInfo.id);
+           clearSessionModel(sessionInfo.id);
            resetMessageCursor(sessionInfo.id);
            firstMessageVariantGate.clear(sessionInfo.id);
            await skillMcpManager.disconnectSession(sessionInfo.id);

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -10,7 +10,7 @@ import { resolveMultipleSkillsAsync } from "../../features/opencode-skill-loader
 import { discoverSkills } from "../../features/opencode-skill-loader"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
-import { subagentSessions, getSessionAgent } from "../../features/claude-code-session-state"
+import { subagentSessions, getSessionAgent, getSessionModel } from "../../features/claude-code-session-state"
 import { log, getAgentToolRestrictions, resolveModel, getOpenCodeConfigPaths, findByNameCaseInsensitive, equalsIgnoreCase } from "../../shared"
 import { fetchAvailableModels } from "../../shared/model-availability"
 import { resolveModelWithFallback } from "../../shared/model-resolver"
@@ -264,9 +264,11 @@ Prompts MUST be in English.`
         prevMessageAgent: prevMessage?.agent,
         resolvedParentAgent: parentAgent,
       })
+      // Get stored session model as fallback (for first message before prevMessage exists)
+      const sessionModel = getSessionModel(ctx.sessionID)
       const parentModel = prevMessage?.model?.providerID && prevMessage?.model?.modelID
         ? { providerID: prevMessage.model.providerID, modelID: prevMessage.model.modelID }
-        : undefined
+        : sessionModel
 
       if (args.session_id) {
         if (runInBackground) {


### PR DESCRIPTION
## Summary
- Fix Sisyphus to use the model selected via UI before the first message is sent
- Add session model storage to capture model info in `chat.message` hook
- Use stored session model as fallback in `delegate_task` when `prevMessage` is unavailable

## Changes
- `state.ts`: Add `SessionModel` interface and storage functions (`setSessionModel`, `getSessionModel`, `clearSessionModel`, `updateSessionModel`)
- `index.ts`: Store UI-selected model in `chat.message` hook, cleanup in `session.deleted` event
- `tools.ts`: Use stored session model as fallback for first message scenario

## Test plan
- Added 7 unit tests (67 pass, 1 skip, 0 fail)
- Manual test: Select model in new session, trigger Sisyphus on first message, verify selected model is used

Fixes #1024

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model inheritance at session start so the UI-selected model is used on the first message, preventing Sisyphus from defaulting to the wrong model.

- **Bug Fixes**
  - Persist the session’s selected model (first-write wins) with set/get/update/clear helpers.
  - Save the UI-selected model in the chat.message hook and clear it on session.deleted.
  - Use the stored session model as fallback in delegate_task when prevMessage is not available.
  - Added unit tests covering model storage and the first-message fallback scenario.

<sup>Written for commit 4f8400742d5fec1b87713d39a32a79bedbb26a12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

