### PR TITLE
fix(ci): add post-publish verification for platform binaries

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -111,3 +111,27 @@ jobs:
           npm publish --access public $TAG_ARG
         env:
           NPM_CONFIG_PROVENANCE: false
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify publish
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          PKG_NAME="oh-my-opencode-${{ matrix.platform }}"
+          VERSION="${{ inputs.version }}"
+
+          echo "Verifying ${PKG_NAME}@${VERSION} is available on npm..."
+
+          # Wait for npm registry to propagate (up to 60 seconds)
+          for i in {1..12}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/${PKG_NAME}/${VERSION}")
+            if [ "$STATUS" = "200" ]; then
+              echo "✓ ${PKG_NAME}@${VERSION} successfully published and verified"
+              exit 0
+            fi
+            echo "  Attempt $i/12: waiting for npm registry propagation..."
+            sleep 5
+          done
+
+          echo "✗ ERROR: ${PKG_NAME}@${VERSION} not found on npm after publishing"
+          echo "  This may indicate a publish failure. Please check npm logs."
+          exit 1


### PR DESCRIPTION
## Summary

Add post-publish verification step and fix missing `NODE_AUTH_TOKEN` in the platform publish workflow to prevent silent publish failures.

## Problem

The v3.1.2 Windows binary was not published to npm while the main package was published successfully (#1171). This caused users to receive a version mismatch:
- `oh-my-opencode@3.1.2` (main package) - published
- `oh-my-opencode-windows-x64@3.1.2` - **NOT** published (latest was still 3.1.1)

Users still experienced the cross-compilation segfault bug (oven-sh/bun#18416) because they got the old v3.1.1 binary.

## Solution

1. **Add post-publish verification step**: After `npm publish`, verify the package is actually available on npm registry
   - Polls npm registry for up to 60 seconds to account for propagation delay
   - Fails explicitly if package is not found, making the issue visible in CI

2. **Add `NODE_AUTH_TOKEN` env var**: Ensure npm authentication is properly configured for the publish step

## Changes

- `.github/workflows/publish-platform.yml`:
  - Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to publish step
  - Add new "Verify publish" step with retry logic

## Testing

This is a CI workflow change. To test:
1. Trigger `publish-platform.yml` manually with a test version
2. Verify the new verification step runs and confirms package availability

## Related Issues

- Fixes #1171
- Related to #873, #844, #1019

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-publish verification step for platform binaries and sets NODE_AUTH_TOKEN in the publish workflow. This prevents silent npm publish failures like the missing Windows v3.1.2 binary; fixes #1171.

- **Bug Fixes**
  - Add NODE_AUTH_TOKEN to npm publish step for proper authentication.
  - Add a verification step that polls the npm registry for up to 60s and fails if the package isn’t found.

<sup>Written for commit 5f34fbac3001320fd7a07c813a70419f368ceba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

