### PR TITLE
fix: skip notification when background tasks are still running

### DIFF
--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -29,6 +29,8 @@ interface SessionNotificationConfig {
   skipIfIncompleteTodos?: boolean
   /** Maximum number of sessions to track before cleanup (default: 100) */
   maxTrackedSessions?: number
+  /** Callback to check if there are pending background tasks (default: undefined - no check) */
+  hasPendingBackgroundTasks?: () => boolean
 }
 
 type Platform = "darwin" | "linux" | "win32" | "unsupported"
@@ -156,6 +158,7 @@ export function createSessionNotification(
     idleConfirmationDelay: 1500,
     skipIfIncompleteTodos: true,
     maxTrackedSessions: 100,
+    hasPendingBackgroundTasks: undefined as (() => boolean) | undefined,
     ...config,
   }
 
@@ -227,6 +230,10 @@ export function createSessionNotification(
 
     executingNotifications.add(sessionID)
     try {
+      if (mergedConfig.hasPendingBackgroundTasks?.()) {
+        return
+      }
+
       if (mergedConfig.skipIfIncompleteTodos) {
         const hasPendingWork = await hasIncompleteTodos(ctx, sessionID)
         if (notificationVersions.get(sessionID) !== version) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     : null;
   
   // Check for conflicting notification plugins before creating session-notification
+  // backgroundManagerRef is set later after BackgroundManager is created
+  let backgroundManagerRef: BackgroundManager | null = null;
   let sessionNotification = null;
   if (isHookEnabled("session-notification")) {
     const forceEnable = pluginConfig.notification?.force_enable ?? false;
@@ -124,7 +126,12 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         allPlugins: externalNotifier.allPlugins,
       });
     } else {
-      sessionNotification = createSessionNotification(ctx);
+      sessionNotification = createSessionNotification(ctx, {
+        hasPendingBackgroundTasks: () => {
+          if (!backgroundManagerRef) return false;
+          return backgroundManagerRef.getRunningTasks().length > 0;
+        },
+      });
     }
   }
 
@@ -270,6 +277,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       })
     },
   });
+
+  backgroundManagerRef = backgroundManager;
 
   const atlasHook = isHookEnabled("atlas")
     ? createAtlasHook(ctx, { directory: ctx.directory, backgroundManager })


### PR DESCRIPTION
## Summary
- Add `hasPendingBackgroundTasks` callback to `SessionNotificationConfig` interface
- Check for running background tasks before sending notification
- Wire up the callback in `index.ts` to use `backgroundManager.getRunningTasks()`

## Problem
Notifications fire when a background agent completes, even if other background agents are still running. This happens because:

1. When a background agent completes, it calls `notifyParentSession()` which prompts the parent session
2. After the prompt is processed, the parent session becomes idle
3. The `session.idle` event fires for the parent (main) session
4. Since the parent is the main session, the existing notification filters don't skip it
5. Desktop notification is sent even though other background tasks may still be running

## Solution
Add a new optional callback `hasPendingBackgroundTasks` to the `SessionNotificationConfig` that is checked before sending a notification. When `backgroundManager.getRunningTasks().length > 0`, the notification is skipped.

This ensures notifications only fire when the session is truly idle (no background tasks running and waiting for user input).

## Testing
Built and tested locally. The fix correctly skips notifications when background tasks are still running.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented session notifications from firing while any background tasks are still running. Notifications now trigger only when the session is truly idle.

- **Bug Fixes**
  - Added hasPendingBackgroundTasks to SessionNotificationConfig and checked it before sending notifications.
  - Wired the callback to BackgroundManager.getRunningTasks() in index.ts to skip notifications when tasks remain.

<sup>Written for commit 7b3b9ab9d34a206da77ea89ee44bb1d7b04a5716. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

