### PR TITLE
feat(session-manager): add session_rename tool

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,6 +24,7 @@ import {
   session_read,
   session_search,
   session_info,
+  session_rename,
 } from "./session-manager"
 
 export { sessionExists } from "./session-manager/storage"
@@ -68,4 +69,5 @@ export const builtinTools: Record<string, ToolDefinition> = {
   session_read,
   session_search,
   session_info,
+  session_rename,
 }

--- a/src/tools/session-manager/constants.ts
+++ b/src/tools/session-manager/constants.ts
@@ -94,4 +94,16 @@ Example:
 session_delete(session_id="ses_abc123", confirm=true)
 Successfully deleted session ses_abc123`
 
+export const SESSION_RENAME_DESCRIPTION = `Rename/retitle an OpenCode session.
+
+Updates the title field in session metadata. The title is displayed in session_list and session_info outputs.
+
+Arguments:
+- session_id (required): Session ID to rename (e.g., "ses_abc123")
+- new_title (required): New title for the session (can be empty to clear)
+
+Example:
+session_rename(session_id="ses_abc123", new_title="Implement auth feature")
+Successfully renamed session ses_abc123 to "Implement auth feature"`
+
 export const TOOL_NAME_PREFIX = "session_"

--- a/src/tools/session-manager/constants.ts
+++ b/src/tools/session-manager/constants.ts
@@ -99,11 +99,18 @@ export const SESSION_RENAME_DESCRIPTION = `Rename/retitle an OpenCode session.
 Updates the title field in session metadata. The title is displayed in session_list and session_info outputs.
 
 Arguments:
-- session_id (required): Session ID to rename (e.g., "ses_abc123")
+- session_id (optional): Session ID to rename. Defaults to current session if not provided.
 - new_title (required): New title for the session (can be empty to clear)
 
-Example:
-session_rename(session_id="ses_abc123", new_title="Implement auth feature")
-Successfully renamed session ses_abc123 to "Implement auth feature"`
+IMPORTANT: If the user asks to rename a session without specifying a title (e.g., "rename this session" or "give this session a descriptive name"), YOU must generate an appropriate title based on the conversation context before calling this tool. Analyze the key topics, tasks, or themes discussed and create a concise, descriptive title (max 80 chars).
+
+Example - user provides title:
+User: "rename this session to Auth Implementation"
+session_rename(new_title="Auth Implementation")
+
+Example - user doesn't provide title (YOU generate it):
+User: "rename this session"
+[You analyze the conversation: discussed React hooks, state management, useEffect patterns]
+session_rename(new_title="React Hooks & State Management Deep Dive")`
 
 export const TOOL_NAME_PREFIX = "session_"

--- a/src/tools/session-manager/constants.ts
+++ b/src/tools/session-manager/constants.ts
@@ -100,7 +100,7 @@ Updates the title field in session metadata. The title is displayed in session_l
 
 Arguments:
 - session_id (optional): Session ID to rename. Defaults to current session if not provided.
-- new_title (required): New title for the session (can be empty to clear)
+- new_title (required): New title for the session (cannot be empty)
 
 IMPORTANT: If the user asks to rename a session without specifying a title (e.g., "rename this session" or "give this session a descriptive name"), YOU must generate an appropriate title based on the conversation context before calling this tool. Analyze the key topics, tasks, or themes discussed and create a concise, descriptive title (max 80 chars).
 

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -22,6 +22,7 @@ mock.module("./constants", () => ({
   SESSION_SEARCH_DESCRIPTION: "test",
   SESSION_INFO_DESCRIPTION: "test",
   SESSION_DELETE_DESCRIPTION: "test",
+  SESSION_RENAME_DESCRIPTION: "test",
   TOOL_NAME_PREFIX: "session_",
 }))
 

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -496,22 +496,23 @@ describe("session-manager storage - renameSession", () => {
     expect(afterMetadata.time.updated).toBeGreaterThan(originalUpdated)
   })
 
-  test("handles empty string title by clearing title field", async () => {
+  test("handles empty string title by keeping existing title", async () => {
     // #given existing session with title
     const projectID = "test-project-123"
     const sessionID = "ses_test_456"
-    createSessionMetadata(projectID, sessionID, "Some Title")
+    const originalTitle = "Some Title"
+    createSessionMetadata(projectID, sessionID, originalTitle)
 
     // #when renaming with empty string
     const result = await storage.renameSession(sessionID, "")
 
-    // #then title is cleared (undefined or empty)
+    // #then title is preserved (empty strings are ignored to prevent TUI crashes)
     expect(result).toBe(true)
 
     const sessionPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
     const content = await Bun.file(sessionPath).text()
     const metadata = JSON.parse(content)
-    expect(metadata.title === undefined || metadata.title === "").toBe(true)
+    expect(metadata.title).toBe(originalTitle)
   })
 
   test("preserves other metadata fields when renaming", async () => {

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -313,3 +313,255 @@ describe("session-manager storage - getMainSessions", () => {
     expect(sessions.length).toBe(2)
   })
 })
+
+describe("session-manager storage - findSessionMetadataPath", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+    mkdirSync(TEST_DIR, { recursive: true })
+    mkdirSync(TEST_MESSAGE_STORAGE, { recursive: true })
+    mkdirSync(TEST_PART_STORAGE, { recursive: true })
+    mkdirSync(TEST_SESSION_STORAGE, { recursive: true })
+    mkdirSync(TEST_TODO_DIR, { recursive: true })
+    mkdirSync(TEST_TRANSCRIPT_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  function createSessionMetadata(projectID: string, sessionID: string, title?: string) {
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    mkdirSync(projectDir, { recursive: true })
+    const metadata = {
+      id: sessionID,
+      directory: `/test/path/${projectID}`,
+      time: {
+        created: Date.now(),
+        updated: Date.now(),
+      },
+      title: title || undefined,
+    }
+    writeFileSync(join(projectDir, `${sessionID}.json`), JSON.stringify(metadata, null, 2))
+  }
+
+  test("returns empty string for non-existent session", () => {
+    // #given non-existent session ID
+    const sessionID = "ses_doesnotexist_12345"
+
+    // #when searching for metadata path
+    const path = storage.findSessionMetadataPath(sessionID)
+
+    // #then returns empty string
+    expect(path).toBe("")
+  })
+
+  test("returns correct path when session exists in nested directory", () => {
+    // #given existing session in nested directory structure
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    createSessionMetadata(projectID, sessionID)
+
+    // #when searching for metadata path
+    const path = storage.findSessionMetadataPath(sessionID)
+
+    // #then returns full path to session JSON file
+    const expectedPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
+    expect(path).toBe(expectedPath)
+    expect(existsSync(path)).toBe(true)
+  })
+
+  test("handles multiple projects and finds correct session", () => {
+    // #given sessions in multiple project directories
+    const projectA = "project-a"
+    const projectB = "project-b"
+    const sessionA = "ses_a_123"
+    const sessionB = "ses_b_456"
+
+    createSessionMetadata(projectA, sessionA)
+    createSessionMetadata(projectB, sessionB)
+
+    // #when searching for specific session
+    const pathA = storage.findSessionMetadataPath(sessionA)
+    const pathB = storage.findSessionMetadataPath(sessionB)
+
+    // #then returns correct paths for each session
+    expect(pathA).toBe(join(TEST_SESSION_STORAGE, projectA, `${sessionA}.json`))
+    expect(pathB).toBe(join(TEST_SESSION_STORAGE, projectB, `${sessionB}.json`))
+  })
+
+  test("returns empty string when SESSION_STORAGE does not exist", () => {
+    // #given SESSION_STORAGE directory removed
+    rmSync(TEST_SESSION_STORAGE, { recursive: true, force: true })
+    const nonExistentSession = "ses_any_789"
+
+    // #when searching in non-existent storage
+    const path = storage.findSessionMetadataPath(nonExistentSession)
+
+    // #then returns empty string gracefully
+    expect(path).toBe("")
+  })
+})
+
+describe("session-manager storage - renameSession", () => {
+  beforeEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+    mkdirSync(TEST_DIR, { recursive: true })
+    mkdirSync(TEST_MESSAGE_STORAGE, { recursive: true })
+    mkdirSync(TEST_PART_STORAGE, { recursive: true })
+    mkdirSync(TEST_SESSION_STORAGE, { recursive: true })
+    mkdirSync(TEST_TODO_DIR, { recursive: true })
+    mkdirSync(TEST_TRANSCRIPT_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  function createSessionMetadata(projectID: string, sessionID: string, title?: string) {
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    mkdirSync(projectDir, { recursive: true })
+    const metadata = {
+      id: sessionID,
+      directory: `/test/path/${projectID}`,
+      time: {
+        created: Date.now(),
+        updated: Date.now(),
+      },
+      title: title || undefined,
+    }
+    writeFileSync(join(projectDir, `${sessionID}.json`), JSON.stringify(metadata, null, 2))
+  }
+
+  test("returns false for non-existent session", async () => {
+    // #given non-existent session ID
+    const sessionID = "ses_doesnotexist_12345"
+
+    // #when attempting to rename
+    const result = await storage.renameSession(sessionID, "New Title")
+
+    // #then returns false
+    expect(result).toBe(false)
+  })
+
+  test("successfully renames existing session and updates title", async () => {
+    // #given existing session with initial title
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    const initialTitle = "Initial Title"
+    createSessionMetadata(projectID, sessionID, initialTitle)
+
+    // #when renaming session
+    const newTitle = "Updated Title"
+    const result = await storage.renameSession(sessionID, newTitle)
+
+    // #then returns true and updates title in metadata
+    expect(result).toBe(true)
+
+    const sessionPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
+    const content = await Bun.file(sessionPath).text()
+    const metadata = JSON.parse(content)
+    expect(metadata.title).toBe(newTitle)
+  })
+
+  test("updates time.updated timestamp when renaming", async () => {
+    // #given existing session
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    createSessionMetadata(projectID, sessionID, "Original Title")
+
+    const sessionPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
+    const beforeContent = await Bun.file(sessionPath).text()
+    const beforeMetadata = JSON.parse(beforeContent)
+    const originalUpdated = beforeMetadata.time.updated
+
+    // Wait to ensure timestamp difference
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // #when renaming session
+    const result = await storage.renameSession(sessionID, "New Title")
+
+    // #then time.updated is greater than original
+    expect(result).toBe(true)
+
+    const afterContent = await Bun.file(sessionPath).text()
+    const afterMetadata = JSON.parse(afterContent)
+    expect(afterMetadata.time.updated).toBeGreaterThan(originalUpdated)
+  })
+
+  test("handles empty string title by clearing title field", async () => {
+    // #given existing session with title
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    createSessionMetadata(projectID, sessionID, "Some Title")
+
+    // #when renaming with empty string
+    const result = await storage.renameSession(sessionID, "")
+
+    // #then title is cleared (undefined or empty)
+    expect(result).toBe(true)
+
+    const sessionPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
+    const content = await Bun.file(sessionPath).text()
+    const metadata = JSON.parse(content)
+    expect(metadata.title === undefined || metadata.title === "").toBe(true)
+  })
+
+  test("preserves other metadata fields when renaming", async () => {
+    // #given existing session with metadata
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    createSessionMetadata(projectID, sessionID, "Original")
+
+    const sessionPath = join(TEST_SESSION_STORAGE, projectID, `${sessionID}.json`)
+    const beforeContent = await Bun.file(sessionPath).text()
+    const beforeMetadata = JSON.parse(beforeContent)
+
+    // #when renaming session
+    await storage.renameSession(sessionID, "New Title")
+
+    // #then other fields remain unchanged
+    const afterContent = await Bun.file(sessionPath).text()
+    const afterMetadata = JSON.parse(afterContent)
+
+    expect(afterMetadata.id).toBe(beforeMetadata.id)
+    expect(afterMetadata.directory).toBe(beforeMetadata.directory)
+    expect(afterMetadata.time.created).toBe(beforeMetadata.time.created)
+  })
+
+  test("handles invalid JSON gracefully", async () => {
+    // #given session file with invalid JSON
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    mkdirSync(projectDir, { recursive: true })
+    const sessionPath = join(projectDir, `${sessionID}.json`)
+    writeFileSync(sessionPath, "{ invalid json }")
+
+    // #when attempting to rename
+    const result = await storage.renameSession(sessionID, "New Title")
+
+    // #then returns false due to parse error
+    expect(result).toBe(false)
+  })
+
+  test("handles file system errors gracefully", async () => {
+    // #given existing session
+    const projectID = "test-project-123"
+    const sessionID = "ses_test_456"
+    createSessionMetadata(projectID, sessionID, "Title")
+
+    // #when attempting to rename (should handle any errors gracefully)
+    const result = await storage.renameSession(sessionID, "New Title")
+
+    // #then should return boolean (either true or false, not throw)
+    expect(typeof result).toBe("boolean")
+  })
+})

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -482,7 +482,7 @@ describe("session-manager storage - renameSession", () => {
     const beforeMetadata = JSON.parse(beforeContent)
     const originalUpdated = beforeMetadata.time.updated
 
-    // Wait to ensure timestamp difference
+    // #given time has passed to ensure timestamp difference
     await new Promise((resolve) => setTimeout(resolve, 10))
 
     // #when renaming session

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from "node:fs"
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { MESSAGE_STORAGE, PART_STORAGE, SESSION_STORAGE, TODO_DIR, TRANSCRIPT_DIR } from "./constants"
 import type { SessionMessage, SessionInfo, TodoItem, SessionMetadata } from "./types"
@@ -224,6 +224,40 @@ export async function getSessionInfo(sessionID: string): Promise<SessionInfo | n
   const todos = await readSessionTodos(sessionID)
   const transcriptEntries = await readSessionTranscript(sessionID)
 
+  let title: string | undefined
+
+  if (existsSync(SESSION_STORAGE)) {
+    try {
+      const projectDirs = await readdir(SESSION_STORAGE, { withFileTypes: true })
+      for (const projectDir of projectDirs) {
+        if (!projectDir.isDirectory()) continue
+
+        const projectPath = join(SESSION_STORAGE, projectDir.name)
+        const sessionFiles = await readdir(projectPath)
+
+        for (const file of sessionFiles) {
+          if (!file.endsWith(".json")) continue
+
+          try {
+            const content = await readFile(join(projectPath, file), "utf-8")
+            const meta = JSON.parse(content) as SessionMetadata
+
+            if (meta.id === sessionID) {
+              title = meta.title
+              break
+            }
+          } catch {
+            continue
+          }
+        }
+
+        if (title !== undefined) break
+      }
+    } catch {
+      // Ignore errors
+    }
+  }
+
   return {
     id: sessionID,
     message_count: messages.length,
@@ -232,7 +266,55 @@ export async function getSessionInfo(sessionID: string): Promise<SessionInfo | n
     agents_used: Array.from(agentsUsed),
     has_todos: todos.length > 0,
     has_transcript: transcriptEntries > 0,
+    title,
     todos,
     transcript_entries: transcriptEntries,
+  }
+}
+
+export function findSessionMetadataPath(sessionID: string): string {
+  if (!existsSync(SESSION_STORAGE)) return ""
+
+  try {
+    const projectDirs = readdirSync(SESSION_STORAGE)
+    for (const projectDir of projectDirs) {
+      const projectPath = join(SESSION_STORAGE, projectDir)
+      
+      try {
+        const stat = Bun.file(projectPath)
+        if (!stat) continue
+      } catch {
+        continue
+      }
+
+      const sessionFile = `${sessionID}.json`
+      const sessionPath = join(projectPath, sessionFile)
+      
+      if (existsSync(sessionPath)) {
+        return sessionPath
+      }
+    }
+  } catch {
+    return ""
+  }
+
+  return ""
+}
+
+export async function renameSession(sessionID: string, newTitle: string): Promise<boolean> {
+  const sessionPath = findSessionMetadataPath(sessionID)
+  if (!sessionPath) return false
+
+  try {
+    const content = await readFile(sessionPath, "utf-8")
+    const metadata = JSON.parse(content) as SessionMetadata
+
+    metadata.title = newTitle || undefined
+    metadata.time.updated = Date.now()
+
+    await writeFile(sessionPath, JSON.stringify(metadata, null, 2), "utf-8")
+    return true
+  } catch {
+    return false
   }
 }

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -309,7 +309,7 @@ export async function renameSession(sessionID: string, newTitle: string): Promis
     const content = await readFile(sessionPath, "utf-8")
     const metadata = JSON.parse(content) as SessionMetadata
 
-    metadata.title = newTitle || undefined
+    metadata.title = newTitle && newTitle.trim() ? newTitle.trim() : metadata.title
     metadata.time.updated = Date.now()
 
     await writeFile(sessionPath, JSON.stringify(metadata, null, 2), "utf-8")

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -257,20 +257,14 @@ export function findSessionMetadataPath(sessionID: string): string {
   if (!existsSync(SESSION_STORAGE)) return ""
 
   try {
-    const projectDirs = readdirSync(SESSION_STORAGE)
+    const projectDirs = readdirSync(SESSION_STORAGE, { withFileTypes: true })
     for (const projectDir of projectDirs) {
-      const projectPath = join(SESSION_STORAGE, projectDir)
-      
-      try {
-        const stat = Bun.file(projectPath)
-        if (!stat) continue
-      } catch {
-        continue
-      }
+      if (!projectDir.isDirectory()) continue
 
+      const projectPath = join(SESSION_STORAGE, projectDir.name)
       const sessionFile = `${sessionID}.json`
       const sessionPath = join(projectPath, sessionFile)
-      
+
       if (existsSync(sessionPath)) {
         return sessionPath
       }

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -204,6 +204,19 @@ export async function readSessionTranscript(sessionID: string): Promise<number> 
   }
 }
 
+async function getSessionTitle(sessionID: string): Promise<string | undefined> {
+  const metadataPath = findSessionMetadataPath(sessionID)
+  if (!metadataPath) return undefined
+
+  try {
+    const content = await readFile(metadataPath, "utf-8")
+    const meta = JSON.parse(content) as SessionMetadata
+    return meta.title
+  } catch {
+    return undefined
+  }
+}
+
 export async function getSessionInfo(sessionID: string): Promise<SessionInfo | null> {
   const messages = await readSessionMessages(sessionID)
   if (messages.length === 0) return null
@@ -224,39 +237,7 @@ export async function getSessionInfo(sessionID: string): Promise<SessionInfo | n
   const todos = await readSessionTodos(sessionID)
   const transcriptEntries = await readSessionTranscript(sessionID)
 
-  let title: string | undefined
-
-  if (existsSync(SESSION_STORAGE)) {
-    try {
-      const projectDirs = await readdir(SESSION_STORAGE, { withFileTypes: true })
-      for (const projectDir of projectDirs) {
-        if (!projectDir.isDirectory()) continue
-
-        const projectPath = join(SESSION_STORAGE, projectDir.name)
-        const sessionFiles = await readdir(projectPath)
-
-        for (const file of sessionFiles) {
-          if (!file.endsWith(".json")) continue
-
-          try {
-            const content = await readFile(join(projectPath, file), "utf-8")
-            const meta = JSON.parse(content) as SessionMetadata
-
-            if (meta.id === sessionID) {
-              title = meta.title
-              break
-            }
-          } catch {
-            continue
-          }
-        }
-
-        if (title !== undefined) break
-      }
-    } catch {
-      // Ignore errors
-    }
-  }
+  const title = await getSessionTitle(sessionID)
 
   return {
     id: sessionID,

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -154,4 +154,30 @@ describe("session-manager tools", () => {
     //#then should handle gracefully (schema validation or error message)
     expect(typeof result).toBe("string")
   })
+
+  test("session_rename uses current session when session_id not provided", async () => {
+    //#given only new_title provided, no session_id
+    const args = { new_title: "Default Session Title" }
+    
+    //#when executing rename
+    const result = await session_rename.execute(args, mockContext)
+    
+    //#then should attempt to rename using context.sessionID ("test-session")
+    expect(typeof result).toBe("string")
+    // Will return "not found" since test-session doesn't exist, but proves it used the context
+    expect(result).toContain("test-session")
+  })
+
+  test("session_rename prefers explicit session_id over context", async () => {
+    //#given both session_id and new_title provided
+    const args = { session_id: "ses_explicit", new_title: "Explicit Title" }
+    
+    //#when executing rename
+    const result = await session_rename.execute(args, mockContext)
+    
+    //#then should use the explicit session_id, not context.sessionID
+    expect(typeof result).toBe("string")
+    expect(result).toContain("ses_explicit")
+    expect(result).not.toContain("test-session")
+  })
 })

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -162,9 +162,8 @@ describe("session-manager tools", () => {
     //#when executing rename
     const result = await session_rename.execute(args, mockContext)
     
-    //#then should attempt to rename using context.sessionID ("test-session")
+    //#then result references context.sessionID ("test-session"), proving fallback worked
     expect(typeof result).toBe("string")
-    // Will return "not found" since test-session doesn't exist, but proves it used the context
     expect(result).toContain("test-session")
   })
 

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -144,15 +144,15 @@ describe("session-manager tools", () => {
     expect(typeof result).toBe("string")
   })
 
-  test("session_rename validates required parameters", async () => {
-    //#given missing new_title parameter
-    const args = { session_id: "ses_test123" } as any
+  test("session_rename rejects empty title", async () => {
+    //#given empty new_title parameter
+    const args = { session_id: "ses_test123", new_title: "" }
     
     //#when attempting to execute
     const result = await session_rename.execute(args, mockContext)
     
-    //#then should handle gracefully (schema validation or error message)
-    expect(typeof result).toBe("string")
+    //#then should return error about empty title
+    expect(result).toContain("cannot be empty")
   })
 
   test("session_rename uses current session when session_id not provided", async () => {

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { session_list, session_read, session_search, session_info } from "./tools"
+import { session_list, session_read, session_search, session_info, session_rename } from "./tools"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 
 const mockContext: ToolContext = {
@@ -119,6 +119,39 @@ describe("session-manager tools", () => {
   test("session_info executes with valid session", async () => {
     const result = await session_info.execute({ session_id: "ses_test123" }, mockContext)
     
+    expect(typeof result).toBe("string")
+  })
+
+  test("session_rename handles non-existent session", async () => {
+    //#given non-existent session ID
+    const args = { session_id: "ses_nonexistent", new_title: "New Title" }
+    
+    //#when executing rename
+    const result = await session_rename.execute(args, mockContext)
+    
+    //#then returns error message
+    expect(result).toContain("not found")
+  })
+
+  test("session_rename successfully renames session", async () => {
+    //#given valid session ID and new title
+    const args = { session_id: "ses_test123", new_title: "Updated Title" }
+    
+    //#when executing rename
+    const result = await session_rename.execute(args, mockContext)
+    
+    //#then returns a string result (success or failure)
+    expect(typeof result).toBe("string")
+  })
+
+  test("session_rename validates required parameters", async () => {
+    //#given missing new_title parameter
+    const args = { session_id: "ses_test123" } as any
+    
+    //#when attempting to execute
+    const result = await session_rename.execute(args, mockContext)
+    
+    //#then should handle gracefully (schema validation or error message)
     expect(typeof result).toBe("string")
   })
 })

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -4,8 +4,9 @@ import {
   SESSION_READ_DESCRIPTION,
   SESSION_SEARCH_DESCRIPTION,
   SESSION_INFO_DESCRIPTION,
+  SESSION_RENAME_DESCRIPTION,
 } from "./constants"
-import { getAllSessions, getMainSessions, getSessionInfo, readSessionMessages, readSessionTodos, sessionExists } from "./storage"
+import { getAllSessions, getMainSessions, getSessionInfo, readSessionMessages, readSessionTodos, renameSession, sessionExists } from "./storage"
 import {
   filterSessionsByDate,
   formatSessionInfo,
@@ -14,7 +15,7 @@ import {
   formatSearchResults,
   searchInSession,
 } from "./utils"
-import type { SessionListArgs, SessionReadArgs, SessionSearchArgs, SessionInfoArgs, SearchResult } from "./types"
+import type { SessionListArgs, SessionReadArgs, SessionSearchArgs, SessionInfoArgs, SessionRenameArgs, SearchResult } from "./types"
 
 const SEARCH_TIMEOUT_MS = 60_000
 const MAX_SESSIONS_TO_SCAN = 50
@@ -139,6 +140,32 @@ export const session_info: ToolDefinition = tool({
       }
 
       return formatSessionInfo(info)
+    } catch (e) {
+      return `Error: ${e instanceof Error ? e.message : String(e)}`
+    }
+  },
+})
+
+export const session_rename: ToolDefinition = tool({
+  description: SESSION_RENAME_DESCRIPTION,
+  args: {
+    session_id: tool.schema.string().describe("Session ID to rename"),
+    new_title: tool.schema.string().describe("New title for the session"),
+  },
+  execute: async (args: SessionRenameArgs, _context) => {
+    try {
+      if (!sessionExists(args.session_id)) {
+        return `Session not found: ${args.session_id}`
+      }
+
+      const success = await renameSession(args.session_id, args.new_title)
+
+      if (success) {
+        const titleDisplay = args.new_title ? `"${args.new_title}"` : "(cleared)"
+        return `Successfully renamed session ${args.session_id} to ${titleDisplay}`
+      }
+
+      return `Failed to rename session ${args.session_id}`
     } catch (e) {
       return `Error: ${e instanceof Error ? e.message : String(e)}`
     }

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -149,23 +149,34 @@ export const session_info: ToolDefinition = tool({
 export const session_rename: ToolDefinition = tool({
   description: SESSION_RENAME_DESCRIPTION,
   args: {
-    session_id: tool.schema.string().describe("Session ID to rename"),
+    session_id: tool.schema.string().optional().describe("Session ID to rename (default: current session)"),
     new_title: tool.schema.string().describe("New title for the session"),
   },
-  execute: async (args: SessionRenameArgs, _context) => {
+  execute: async (args: SessionRenameArgs, context) => {
     try {
-      if (!sessionExists(args.session_id)) {
-        return `Session not found: ${args.session_id}`
+      const toolCtx = context as { sessionID: string }
+      const sessionId = args.session_id || toolCtx.sessionID
+
+      if (!sessionId) {
+        return "Error: No session ID provided and could not determine current session"
       }
 
-      const success = await renameSession(args.session_id, args.new_title)
+      if (!args.new_title || args.new_title.trim() === "") {
+        return "Error: Title cannot be empty. Please provide a descriptive title for the session."
+      }
+
+      if (!sessionExists(sessionId)) {
+        return `Session not found: ${sessionId}`
+      }
+
+      const success = await renameSession(sessionId, args.new_title.trim())
 
       if (success) {
         const titleDisplay = args.new_title ? `"${args.new_title}"` : "(cleared)"
-        return `Successfully renamed session ${args.session_id} to ${titleDisplay}`
+        return `Successfully renamed session ${sessionId} to ${titleDisplay}`
       }
 
-      return `Failed to rename session ${args.session_id}`
+      return `Failed to rename session ${sessionId}`
     } catch (e) {
       return `Error: ${e instanceof Error ? e.message : String(e)}`
     }

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -29,6 +29,7 @@ export interface SessionInfo {
   agents_used: string[]
   has_todos: boolean
   has_transcript: boolean
+  title?: string
   todos?: TodoItem[]
   transcript_entries?: number
 }
@@ -96,4 +97,9 @@ export interface SessionInfoArgs {
 export interface SessionDeleteArgs {
   session_id: string
   confirm: boolean
+}
+
+export interface SessionRenameArgs {
+  session_id: string
+  new_title: string
 }

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -100,6 +100,6 @@ export interface SessionDeleteArgs {
 }
 
 export interface SessionRenameArgs {
-  session_id: string
+  session_id?: string
   new_title: string
 }

--- a/src/tools/session-manager/utils.ts
+++ b/src/tools/session-manager/utils.ts
@@ -14,9 +14,10 @@ export async function formatSessionList(sessionIDs: string[]): Promise<string> {
     return "No valid sessions found."
   }
 
-  const headers = ["Session ID", "Messages", "First", "Last", "Agents"]
+  const headers = ["Session ID", "Title", "Messages", "First", "Last", "Agents"]
   const rows = infos.map((info) => [
     info.id,
+    info.title || "(no title)",
     info.message_count.toString(),
     info.first_message?.toISOString().split("T")[0] ?? "N/A",
     info.last_message?.toISOString().split("T")[0] ?? "N/A",
@@ -86,6 +87,7 @@ export function formatSessionMessages(
 export function formatSessionInfo(info: SessionInfo): string {
   const lines = [
     `Session ID: ${info.id}`,
+    `Title: ${info.title || "(no title)"}`,
     `Messages: ${info.message_count}`,
     `Date Range: ${info.first_message?.toISOString() ?? "N/A"} to ${info.last_message?.toISOString() ?? "N/A"}`,
     `Agents Used: ${info.agents_used.join(", ") || "none"}`,


### PR DESCRIPTION
## Summary

Add `session_rename` tool to the session-manager.

The session-manager already provides `session_list`, `session_read`, `session_search`, and `session_info` tools for reading session data. However, renaming a session currently requires manual intervention through the TUI (`Ctrl+R` in session list). This adds `session_rename` to complete the toolset, allowing the LLM to rename sessions programmatically without user interaction.

## What This Does

- Adds `session_rename` tool that updates the `title` field in session metadata JSON files
- Defaults to current session when `session_id` is not provided
- Instructs the LLM to auto-generate descriptive titles from conversation context when user doesn't specify one
- Displays session titles in `session_list` and `session_info` outputs

## Files Changed

| File | Change |
|------|--------|
| `types.ts` | Add `SessionRenameArgs` interface |
| `constants.ts` | Add `SESSION_RENAME_DESCRIPTION` with LLM instructions |
| `storage.ts` | Add `findSessionMetadataPath`, `renameSession`, `getSessionTitle` |
| `tools.ts` | Implement `session_rename` tool |
| `utils.ts` | Display title in `formatSessionList` and `formatSessionInfo` |
| `index.ts` | Export `session_rename` in `builtinTools` |

## Testing

Full TDD approach with BDD comments.

```bash
bun run typecheck  # passes
bun run build      # succeeds
bun test           # 92 tests pass
```

## Usage

```typescript
// With explicit title
session_rename(new_title="Auth Implementation")

// With explicit session
session_rename(session_id="ses_abc123", new_title="New Title")

// User says "rename this session" without title
// LLM analyzes conversation context and generates appropriate title
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session_rename tool to rename sessions programmatically and surface titles in session_list and session_info. It defaults to the current session, validates titles to prevent TUI crashes, and guides the model to auto-generate a descriptive title when the user doesn’t provide one.

- **New Features**
  - Added session_rename with new_title and optional session_id (falls back to current session).
  - Titles now shown in session_list and session_info.
  - Storage helpers: findSessionMetadataPath and renameSession; internal getSessionTitle for info display.
  - Tests cover rename tool and storage behavior.

- **Bug Fixes**
  - Prevent TUI crash by rejecting empty titles at the tool layer.
  - Storage preserves the existing title if an empty string slips through.
  - Graceful handling for missing sessions, invalid JSON, and FS errors.

<sup>Written for commit a326de8e052c58e1deba8fa866ef0f86fcc7c701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

