### PR TITLE
fix: respect TUI variant (ctrl+t) and inherit it for auto prompts

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "bun:test"
+import { describe, test, expect, beforeEach, mock } from "bun:test"
 import { afterEach } from "bun:test"
 import { tmpdir } from "node:os"
 import type { PluginInput } from "@opencode-ai/plugin"
@@ -175,6 +175,53 @@ function createBackgroundManager(): BackgroundManager {
   }
   return new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
 }
+
+describe("BackgroundManager.notifyParentSession", () => {
+  test("should inherit variant from parent session last message when notifying", async () => {
+    // #given
+    const promptMock = mock(async () => ({}))
+    const messagesMock = mock(async () => ({
+      data: [
+        {
+          info: {
+            agent: "sisyphus",
+            model: { providerID: "openai", modelID: "gpt-5.2", variant: "xhigh" },
+          },
+        },
+      ],
+    }))
+    const client = {
+      session: {
+        prompt: promptMock,
+        messages: messagesMock,
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    const task = createMockTask({
+      id: "task-variant-test",
+      sessionID: "child-session-1",
+      parentSessionID: "parent-session-1",
+      parentAgent: "sisyphus",
+      status: "completed",
+      startedAt: new Date(Date.now() - 1000),
+      completedAt: new Date(),
+    })
+
+    // #when
+    await (manager as unknown as { notifyParentSession: (t: BackgroundTask) => Promise<void> }).notifyParentSession(task)
+
+    // Clean up process listeners started by BackgroundManager
+    manager.shutdown()
+
+    // #then
+    expect(promptMock).toHaveBeenCalled()
+    const callArgs = (promptMock as unknown as { mock: { calls: Array<[any]> } }).mock.calls[0]?.[0]
+    expect(callArgs).toBeDefined()
+    expect(callArgs.path.id).toBe("parent-session-1")
+    expect(callArgs.body.variant).toBe("xhigh")
+  })
+})
 
 function getConcurrencyManager(manager: BackgroundManager): ConcurrencyManager {
   return (manager as unknown as { concurrencyManager: ConcurrencyManager }).concurrencyManager
@@ -2086,4 +2133,3 @@ describe("BackgroundManager.shutdown session abort", () => {
     expect(() => manager.shutdown()).not.toThrow()
   })
 })
-

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1024,17 +1024,27 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
 
     let agent: string | undefined = task.parentAgent
     let model: { providerID: string; modelID: string } | undefined
+    let variant: string | undefined
 
     try {
       const messagesResp = await this.client.session.messages({ path: { id: task.parentSessionID } })
       const messages = (messagesResp.data ?? []) as Array<{
-        info?: { agent?: string; model?: { providerID: string; modelID: string }; modelID?: string; providerID?: string }
+        info?: {
+          agent?: string
+          model?: { providerID: string; modelID: string; variant?: string }
+          modelID?: string
+          providerID?: string
+          variant?: string
+        }
       }>
       for (let i = messages.length - 1; i >= 0; i--) {
         const info = messages[i].info
         if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
           agent = info.agent ?? task.parentAgent
-          model = info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+          model = info.model
+            ? { providerID: info.model.providerID, modelID: info.model.modelID }
+            : (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+          variant = info.variant ?? info.model?.variant
           break
         }
       }
@@ -1045,12 +1055,14 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
       model = currentMessage?.model?.providerID && currentMessage?.model?.modelID
         ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
         : undefined
+      variant = currentMessage?.model?.variant
     }
 
     log("[background-agent] notifyParentSession context:", {
       taskId: task.id,
       resolvedAgent: agent,
       resolvedModel: model,
+      resolvedVariant: variant,
     })
 
     try {
@@ -1060,6 +1072,7 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
           noReply: !allComplete,
           ...(agent !== undefined ? { agent } : {}),
           ...(model !== undefined ? { model } : {}),
+          ...(variant !== undefined ? { variant } : {}),
           parts: [{ type: "text", text: notification }],
         },
       })

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -29,14 +29,14 @@ describe("atlas hook", () => {
     } as unknown as Parameters<typeof createAtlasHook>[0] & { _promptMock: ReturnType<typeof mock> }
   }
 
-  function setupMessageStorage(sessionID: string, agent: string): void {
+  function setupMessageStorage(sessionID: string, agent: string, model?: { providerID: string; modelID: string; variant?: string }): void {
     const messageDir = join(MESSAGE_STORAGE, sessionID)
     if (!existsSync(messageDir)) {
       mkdirSync(messageDir, { recursive: true })
     }
     const messageData = {
       agent,
-      model: { providerID: "anthropic", modelID: "claude-opus-4-5" },
+      model: model ?? { providerID: "anthropic", modelID: "claude-opus-4-5" },
     }
     writeFileSync(join(messageDir, "msg_test001.json"), JSON.stringify(messageData))
   }
@@ -652,6 +652,43 @@ describe("atlas hook", () => {
       expect(callArgs.path.id).toBe(MAIN_SESSION_ID)
       expect(callArgs.body.parts[0].text).toContain("incomplete tasks")
       expect(callArgs.body.parts[0].text).toContain("2 remaining")
+    })
+
+    test("should preserve parent session variant when injecting continuation", async () => {
+      // #given - boulder state with incomplete plan and parent message has a variant
+      const planPath = join(TEST_DIR, "test-plan-variant.md")
+      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+
+      const state: BoulderState = {
+        active_plan: planPath,
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: [MAIN_SESSION_ID],
+        plan_name: "test-plan-variant",
+      }
+      writeBoulderState(TEST_DIR, state)
+
+      // Force atlas hook to fall back to message storage (no session.messages mock)
+      setupMessageStorage(MAIN_SESSION_ID, "atlas", {
+        providerID: "openai",
+        modelID: "gpt-5.2",
+        variant: "xhigh",
+      })
+
+      const mockInput = createMockPluginInput()
+      const hook = createAtlasHook(mockInput)
+
+      // #when
+      await hook.handler({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: MAIN_SESSION_ID },
+        },
+      })
+
+      // #then
+      expect(mockInput._promptMock).toHaveBeenCalled()
+      const callArgs = mockInput._promptMock.mock.calls[0][0]
+      expect(callArgs.body.variant).toBe("xhigh")
     })
 
     test("should not inject when no boulder state exists", async () => {

--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -449,20 +449,28 @@ export function createAtlasHook(
       log(`[${HOOK_NAME}] Injecting boulder continuation`, { sessionID, planName, remaining })
 
       let model: { providerID: string; modelID: string } | undefined
+      let variant: string | undefined
       try {
         const messagesResp = await ctx.client.session.messages({ path: { id: sessionID } })
         const messages = (messagesResp.data ?? []) as Array<{
-          info?: { model?: { providerID: string; modelID: string }; modelID?: string; providerID?: string }
+          info?: {
+            model?: { providerID: string; modelID: string; variant?: string }
+            modelID?: string
+            providerID?: string
+            variant?: string
+          }
         }>
         for (let i = messages.length - 1; i >= 0; i--) {
           const info = messages[i].info
           const msgModel = info?.model
           if (msgModel?.providerID && msgModel?.modelID) {
             model = { providerID: msgModel.providerID, modelID: msgModel.modelID }
+            variant = info?.variant ?? msgModel.variant
             break
           }
           if (info?.providerID && info?.modelID) {
             model = { providerID: info.providerID, modelID: info.modelID }
+            variant = info.variant
             break
           }
         }
@@ -472,6 +480,7 @@ export function createAtlasHook(
         model = currentMessage?.model?.providerID && currentMessage?.model?.modelID
           ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
           : undefined
+        variant = currentMessage?.model?.variant
       }
 
        await ctx.client.session.prompt({
@@ -479,6 +488,7 @@ export function createAtlasHook(
          body: {
             agent: "atlas",
            ...(model !== undefined ? { model } : {}),
+           ...(variant !== undefined ? { variant } : {}),
            parts: [{ type: "text", text: prompt }],
          },
          query: { directory: ctx.directory },

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -5,6 +5,14 @@ import { ContextCollector } from "../../features/context-injector"
 import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
 
+function openaiModel() {
+  return { providerID: "openai", modelID: "gpt-5.2" }
+}
+
+function anthropicModel() {
+  return { providerID: "anthropic", modelID: "claude-opus-4-5" }
+}
+
 describe("keyword-detector message transform", () => {
   let logCalls: Array<{ msg: string; data?: unknown }>
   let logSpy: ReturnType<typeof spyOn>
@@ -164,7 +172,7 @@ describe("keyword-detector session filtering", () => {
 
     // #when - non-main session triggers ultrawork keyword
     await hook["chat.message"](
-      { sessionID: subagentSessionID },
+      { sessionID: subagentSessionID, model: anthropicModel() },
       output
     )
 
@@ -209,7 +217,7 @@ describe("keyword-detector session filtering", () => {
 
     // #when - any session triggers keyword detection
     await hook["chat.message"](
-      { sessionID: "any-session" },
+      { sessionID: "any-session", model: anthropicModel() },
       output
     )
 
@@ -237,6 +245,28 @@ describe("keyword-detector session filtering", () => {
 
     // #then - existing variant should remain
     expect(output.message.variant).toBe("low")
+    expect(toastCalls).toContain("Ultrawork Mode Activated")
+  })
+
+  test("should respect input.variant from OpenCode (ctrl+t) even in ultrawork", async () => {
+    // #given - user already selected a variant via OpenCode (variant_cycle)
+    setMainSession(undefined)
+
+    const toastCalls: string[] = []
+    const hook = createKeywordDetectorHook(createMockPluginInput({ toastCalls }))
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw do this task" }],
+    }
+
+    // #when
+    await hook["chat.message"](
+      { sessionID: "any-session", model: openaiModel(), variant: "high" },
+      output
+    )
+
+    // #then - plugin should preserve the user-selected variant
+    expect(output.message.variant).toBe("high")
     expect(toastCalls).toContain("Ultrawork Mode Activated")
   })
 })
@@ -306,12 +336,56 @@ describe("keyword-detector word boundary", () => {
 
     // #when - message with standalone 'ulw' is processed
     await hook["chat.message"](
-      { sessionID: "any-session" },
+      { sessionID: "any-session", model: openaiModel() },
       output
     )
 
     // #then - ultrawork should be triggered
+    expect(output.message.variant).toBe("xhigh")
+    expect(toastCalls).toContain("Ultrawork Mode Activated")
+  })
+
+  test("should prefer model keywords over provider (google provider running claude)", async () => {
+    // #given
+    setMainSession(undefined)
+
+    const toastCalls: string[] = []
+    const hook = createKeywordDetectorHook(createMockPluginInput({ toastCalls }))
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw do this task" }],
+    }
+
+    // #when
+    await hook["chat.message"](
+      { sessionID: "any-session", model: { providerID: "google", modelID: "claude-opus-4.5" } },
+      output
+    )
+
+    // #then
     expect(output.message.variant).toBe("max")
+    expect(toastCalls).toContain("Ultrawork Mode Activated")
+  })
+
+  test("should infer xhigh for github-copilot running gpt", async () => {
+    // #given
+    setMainSession(undefined)
+
+    const toastCalls: string[] = []
+    const hook = createKeywordDetectorHook(createMockPluginInput({ toastCalls }))
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ultrawork please" }],
+    }
+
+    // #when
+    await hook["chat.message"](
+      { sessionID: "any-session", model: { providerID: "github-copilot", modelID: "gpt-5.2" } },
+      output
+    )
+
+    // #then
+    expect(output.message.variant).toBe("xhigh")
     expect(toastCalls).toContain("Ultrawork Mode Activated")
   })
 

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -10,6 +10,32 @@ export * from "./detector"
 export * from "./constants"
 export * from "./types"
 
+type ModelInfo = { providerID: string; modelID: string }
+
+function inferUltraworkVariant(model?: ModelInfo): string | undefined {
+  // Best-effort: in practice, providers can be proxies (e.g., github-copilot)
+  // and some custom providers can route "claude" via a non-anthropic providerID.
+  // Model keywords are therefore the highest signal.
+  if (!model) {
+    // Backwards-compatible default when OpenCode doesn't provide model info.
+    return "max"
+  }
+
+  const modelID = model.modelID.toLowerCase()
+  const providerID = model.providerID.toLowerCase()
+
+  if (modelID.includes("claude")) return "max"
+  if (modelID.includes("gpt") || modelID.includes("o1") || modelID.includes("o3")) return "xhigh"
+  if (modelID.includes("gemini")) return "high"
+
+  if (providerID === "anthropic" || providerID === "amazon-bedrock") return "max"
+  if (providerID === "openai") return "xhigh"
+  if (providerID === "google" || providerID === "google-vertex") return "high"
+
+  // Unknown provider/model: do not guess a variant name.
+  return undefined
+}
+
 export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextCollector) {
   return {
     "chat.message": async (
@@ -17,6 +43,7 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
         sessionID: string
         agent?: string
         model?: { providerID: string; modelID: string }
+        variant?: string
         messageID?: string
       },
       output: {
@@ -25,6 +52,12 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
       }
     ): Promise<void> => {
       const promptText = extractPromptText(output.parts)
+
+      // Respect the user's selected variant (e.g. ctrl+t / variant_cycle) if OpenCode
+      // already decided on one for this message.
+      if (input.variant !== undefined && output.message.variant === undefined) {
+        output.message.variant = input.variant
+      }
 
       if (isSystemDirective(promptText)) {
         log(`[keyword-detector] Skipping system directive message`, { sessionID: input.sessionID })
@@ -71,7 +104,10 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
         log(`[keyword-detector] Ultrawork mode activated`, { sessionID: input.sessionID })
 
         if (output.message.variant === undefined) {
-          output.message.variant = "max"
+          const inferred = inferUltraworkVariant(input.model)
+          if (inferred !== undefined) {
+            output.message.variant = inferred
+          }
         }
 
         ctx.client.tui

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from "./features/context-injector";
 import { applyAgentVariant, resolveAgentVariant, resolveVariantForModel } from "./shared/agent-variant";
 import { createFirstMessageVariantGate } from "./shared/first-message-variant";
+import { applyChatMessageVariant } from "./shared/chat-message-variant";
 import {
   discoverUserClaudeSkills,
   discoverProjectClaudeSkills,
@@ -401,24 +402,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       }
 
       const message = (output as { message: { variant?: string } }).message
-      if (firstMessageVariantGate.shouldOverride(input.sessionID)) {
-        const variant = input.model && input.agent
-          ? resolveVariantForModel(pluginConfig, input.agent, input.model)
-          : resolveAgentVariant(pluginConfig, input.agent)
-        if (variant !== undefined) {
-          message.variant = variant
-        }
-        firstMessageVariantGate.markApplied(input.sessionID)
-      } else {
-        if (input.model && input.agent && message.variant === undefined) {
-          const variant = resolveVariantForModel(pluginConfig, input.agent, input.model)
-          if (variant !== undefined) {
-            message.variant = variant
-          }
-        } else {
-          applyAgentVariant(pluginConfig, input.agent, message)
-        }
-      }
+      applyChatMessageVariant(pluginConfig, firstMessageVariantGate, input, message)
 
       await keywordDetector?.["chat.message"]?.(input, output);
       await claudeCodeHooks["chat.message"]?.(input, output);

--- a/src/shared/chat-message-variant.test.ts
+++ b/src/shared/chat-message-variant.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { createFirstMessageVariantGate } from "./first-message-variant"
+import { applyChatMessageVariant } from "./chat-message-variant"
+
+describe("applyChatMessageVariant", () => {
+  test("respects input.variant even on the first message", () => {
+    // #given
+    const gate = createFirstMessageVariantGate()
+    gate.markSessionCreated({ id: "session-1" })
+
+    const message: { variant?: string } = {}
+
+    // #when
+    applyChatMessageVariant(
+      {},
+      gate,
+      {
+        sessionID: "session-1",
+        agent: "sisyphus",
+        model: { providerID: "openai", modelID: "gpt-5.2" },
+        variant: "xhigh",
+      },
+      message
+    )
+
+    // #then
+    expect(message.variant).toBe("xhigh")
+    expect(gate.shouldOverride("session-1")).toBe(false)
+  })
+
+  test("applies agent/provider fallback on first message when no input.variant", () => {
+    // #given
+    const gate = createFirstMessageVariantGate()
+    gate.markSessionCreated({ id: "session-1" })
+
+    const message: { variant?: string } = {}
+
+    // #when
+    applyChatMessageVariant(
+      {},
+      gate,
+      {
+        sessionID: "session-1",
+        agent: "sisyphus",
+        model: { providerID: "openai", modelID: "gpt-5.2" },
+      },
+      message
+    )
+
+    // #then
+    expect(message.variant).toBe("medium")
+  })
+
+  test("does not override an already-set message.variant on first message", () => {
+    // #given
+    const gate = createFirstMessageVariantGate()
+    gate.markSessionCreated({ id: "session-1" })
+    const message: { variant?: string } = { variant: "xhigh" }
+
+    // #when
+    applyChatMessageVariant(
+      {},
+      gate,
+      {
+        sessionID: "session-1",
+        agent: "sisyphus",
+        model: { providerID: "openai", modelID: "gpt-5.2" },
+      },
+      message
+    )
+
+    // #then
+    expect(message.variant).toBe("xhigh")
+  })
+})

--- a/src/shared/chat-message-variant.ts
+++ b/src/shared/chat-message-variant.ts
@@ -1,0 +1,51 @@
+import type { OhMyOpenCodeConfig } from "../config"
+import { applyAgentVariant, resolveAgentVariant, resolveVariantForModel } from "./agent-variant"
+
+export type FirstMessageVariantGate = {
+  shouldOverride(sessionID?: string): boolean
+  markApplied(sessionID?: string): void
+}
+
+export type ChatMessageInput = {
+  sessionID?: string
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+}
+
+export type ChatMessage = { variant?: string }
+
+export function applyChatMessageVariant(
+  config: OhMyOpenCodeConfig,
+  gate: FirstMessageVariantGate,
+  input: ChatMessageInput,
+  message: ChatMessage
+): void {
+  // Respect user-selected variant (e.g. ctrl+t / variant_cycle) before any plugin defaults.
+  if (input.variant !== undefined && message.variant === undefined) {
+    message.variant = input.variant
+  }
+
+  // The first message in a newly created root session historically didn't pick up
+  // agent/category defaults, so we apply them once. Never override an existing variant.
+  if (gate.shouldOverride(input.sessionID)) {
+    const resolved = input.model && input.agent
+      ? resolveVariantForModel(config, input.agent, input.model)
+      : resolveAgentVariant(config, input.agent)
+
+    if (resolved !== undefined && message.variant === undefined) {
+      message.variant = resolved
+    }
+    gate.markApplied(input.sessionID)
+    return
+  }
+
+  if (input.model && input.agent && message.variant === undefined) {
+    const resolved = resolveVariantForModel(config, input.agent, input.model)
+    if (resolved !== undefined) {
+      message.variant = resolved
+    }
+  } else {
+    applyAgentVariant(config, input.agent, message)
+  }
+}


### PR DESCRIPTION
## Summary

- Ensures user-selected `variant` (ctrl+t / variant_cycle) is never overridden by plugin defaults, including on the first message of a new session
- Makes auto-generated prompts (background task completion + atlas continuation) inherit the parent session’s `variant` for consistent reasoning level

## Changes

- keyword-detector: respect `input.variant` and use provider/model-aware ultrawork variant inference only as fallback
- background-agent: include parent `variant` when sending completion notifications to the parent session
- atlas: include parent `variant` when injecting boulder continuation prompts
- index: centralize chat.message variant precedence logic to prevent first-message gate from overriding ctrl+t selection
- tests: add coverage for variant precedence and inheritance scenarios


## Testing

```bash
bun run typecheck
bun test
```

## Related Issues

 Closes #521

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the user-selected reasoning variant (Ctrl+T) across all messages and make auto-generated prompts inherit the parent session’s variant. Centralizes variant precedence to prevent defaults from overriding user choice and improves ultrawork variant inference.

- **Bug Fixes**
  - Preserve input.variant on all chat messages, including the first in a new session.
  - Auto prompts (background task completion, atlas continuation) inherit the parent session’s variant.
  - Keyword detector respects input.variant and infers ultrawork variant by model/provider when unset.

- **Refactors**
  - Centralized variant precedence in shared/chat-message-variant and applied it in index.
  - Added tests for variant precedence and inheritance across keyword-detector, atlas, and background-agent.

<sup>Written for commit e93525c2db3481948874cc8915b385360268660d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

