### PR TITLE
fix: prevent zombie processes with proper process lifecycle management

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1396,7 +1396,8 @@ function registerProcessSignal(
   const listener = () => {
     handler()
     if (exitAfter) {
-      process.exit(0)
+      // Delay exit to next tick so other signal handlers can complete their cleanup
+      setImmediate(() => process.exit(0))
     }
   }
   process.on(signal, listener)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1396,8 +1396,9 @@ function registerProcessSignal(
   const listener = () => {
     handler()
     if (exitAfter) {
-      // Delay exit to allow other signal handlers time to complete async cleanup
-      setTimeout(() => process.exit(0), 100)
+      // Set exitCode and schedule exit after delay to allow other handlers to complete async cleanup
+      process.exitCode = 0
+      setTimeout(() => process.exit(), 100)
     }
   }
   process.on(signal, listener)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1396,8 +1396,8 @@ function registerProcessSignal(
   const listener = () => {
     handler()
     if (exitAfter) {
-      // Delay exit to next tick so other signal handlers can complete their cleanup
-      setImmediate(() => process.exit(0))
+      // Delay exit to allow other signal handlers time to complete async cleanup
+      setTimeout(() => process.exit(0), 100)
     }
   }
   process.on(signal, listener)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1397,8 +1397,9 @@ function registerProcessSignal(
     handler()
     if (exitAfter) {
       // Set exitCode and schedule exit after delay to allow other handlers to complete async cleanup
+      // Use 6s delay to accommodate LSP cleanup (5s timeout + 1s SIGKILL wait)
       process.exitCode = 0
-      setTimeout(() => process.exit(), 100)
+      setTimeout(() => process.exit(), 6000)
     }
   }
   process.on(signal, listener)

--- a/src/features/skill-mcp-manager/manager.ts
+++ b/src/features/skill-mcp-manager/manager.ts
@@ -117,19 +117,17 @@ export class SkillMcpManager {
     // Note: 'exit' event is synchronous-only in Node.js, so we use 'beforeExit' for async cleanup
     // However, 'beforeExit' is not emitted on explicit process.exit() calls
     // Signal handlers are made async to properly await cleanup
+    // Don't call process.exit() - let background-agent manager handle the final exit
 
     process.on("SIGINT", async () => {
       await cleanup()
-      process.exit(0)
     })
     process.on("SIGTERM", async () => {
       await cleanup()
-      process.exit(0)
     })
     if (process.platform === "win32") {
       process.on("SIGBREAK", async () => {
         await cleanup()
-        process.exit(0)
       })
     }
   }

--- a/src/features/skill-mcp-manager/manager.ts
+++ b/src/features/skill-mcp-manager/manager.ts
@@ -114,11 +114,10 @@ export class SkillMcpManager {
       this.pendingConnections.clear()
     }
 
-    // Note: 'exit' event is synchronous-only in Node.js, so we use 'beforeExit' for async cleanup
-    // However, 'beforeExit' is not emitted on explicit process.exit() calls
-    // Signal handlers are made async to properly await cleanup
-    // Don't call process.exit() - let background-agent manager handle the final exit
-    // Use void + catch to handle async cleanup without blocking or throwing
+    // Note: Node's 'exit' event is synchronous-only, so we rely on signal handlers for async cleanup.
+    // Signal handlers invoke the async cleanup function and ignore errors so they don't block or throw.
+    // Don't call process.exit() here - let the background-agent manager handle the final process exit.
+    // Use void + catch to trigger async cleanup without awaiting it in the signal handler.
 
     process.on("SIGINT", () => void cleanup().catch(() => {}))
     process.on("SIGTERM", () => void cleanup().catch(() => {}))

--- a/src/features/skill-mcp-manager/manager.ts
+++ b/src/features/skill-mcp-manager/manager.ts
@@ -118,17 +118,12 @@ export class SkillMcpManager {
     // However, 'beforeExit' is not emitted on explicit process.exit() calls
     // Signal handlers are made async to properly await cleanup
     // Don't call process.exit() - let background-agent manager handle the final exit
+    // Use void + catch to handle async cleanup without blocking or throwing
 
-    process.on("SIGINT", async () => {
-      await cleanup()
-    })
-    process.on("SIGTERM", async () => {
-      await cleanup()
-    })
+    process.on("SIGINT", () => void cleanup().catch(() => {}))
+    process.on("SIGTERM", () => void cleanup().catch(() => {}))
     if (process.platform === "win32") {
-      process.on("SIGBREAK", async () => {
-        await cleanup()
-      })
+      process.on("SIGBREAK", () => void cleanup().catch(() => {}))
     }
   }
 

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -141,10 +141,19 @@ export async function spawnTmuxPane(
   const title = `omo-subagent-${description.slice(0, 20)}`
   const titleProc = spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
     stdout: "ignore",
-    stderr: "ignore",
+    stderr: "pipe",
   })
-  // Await process exit to prevent zombie processes
-  await titleProc.exited
+  const titleExitCode = await titleProc.exited
+  if (titleExitCode !== 0) {
+    const { log } = await import("../logger")
+    const titleStderr = await new Response(titleProc.stderr).text()
+    log("[spawnTmuxPane] WARNING: failed to set pane title", {
+      paneId,
+      title,
+      exitCode: titleExitCode,
+      stderr: titleStderr.trim(),
+    })
+  }
 
   return { success: true, paneId }
 }
@@ -221,10 +230,20 @@ export async function replaceTmuxPane(
   const title = `omo-subagent-${description.slice(0, 20)}`
   const titleProc = spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
     stdout: "ignore",
-    stderr: "ignore",
+    stderr: "pipe",
   })
-  // Await process exit to prevent zombie processes
-  await titleProc.exited
+  const titleExitCode = await titleProc.exited
+  if (titleExitCode !== 0) {
+    let titleStderr = ""
+    try {
+      titleStderr = await new Response(titleProc.stderr).text()
+    } catch {}
+    log("[replaceTmuxPane] WARNING: failed to set pane title", {
+      paneId,
+      exitCode: titleExitCode,
+      stderr: titleStderr.trim(),
+    })
+  }
 
   log("[replaceTmuxPane] SUCCESS", { paneId, sessionId })
   return { success: true, paneId }

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -143,12 +143,11 @@ export async function spawnTmuxPane(
     stdout: "ignore",
     stderr: "pipe",
   })
+  // Drain stderr immediately to avoid backpressure
+  const stderrPromise = new Response(titleProc.stderr).text().catch(() => "")
   const titleExitCode = await titleProc.exited
   if (titleExitCode !== 0) {
-    let titleStderr = ""
-    try {
-      titleStderr = await new Response(titleProc.stderr).text()
-    } catch {}
+    const titleStderr = await stderrPromise
     log("[spawnTmuxPane] WARNING: failed to set pane title", {
       paneId,
       title,
@@ -234,12 +233,11 @@ export async function replaceTmuxPane(
     stdout: "ignore",
     stderr: "pipe",
   })
+  // Drain stderr immediately to avoid backpressure
+  const stderrPromise = new Response(titleProc.stderr).text().catch(() => "")
   const titleExitCode = await titleProc.exited
   if (titleExitCode !== 0) {
-    let titleStderr = ""
-    try {
-      titleStderr = await new Response(titleProc.stderr).text()
-    } catch {}
+    const titleStderr = await stderrPromise
     log("[replaceTmuxPane] WARNING: failed to set pane title", {
       paneId,
       exitCode: titleExitCode,

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -146,7 +146,10 @@ export async function spawnTmuxPane(
   const titleExitCode = await titleProc.exited
   if (titleExitCode !== 0) {
     const { log } = await import("../logger")
-    const titleStderr = await new Response(titleProc.stderr).text()
+    let titleStderr = ""
+    try {
+      titleStderr = await new Response(titleProc.stderr).text()
+    } catch {}
     log("[spawnTmuxPane] WARNING: failed to set pane title", {
       paneId,
       title,

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -145,7 +145,6 @@ export async function spawnTmuxPane(
   })
   const titleExitCode = await titleProc.exited
   if (titleExitCode !== 0) {
-    const { log } = await import("../logger")
     let titleStderr = ""
     try {
       titleStderr = await new Response(titleProc.stderr).text()

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -139,10 +139,12 @@ export async function spawnTmuxPane(
   }
 
   const title = `omo-subagent-${description.slice(0, 20)}`
-  spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
+  const titleProc = spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
     stdout: "ignore",
     stderr: "ignore",
   })
+  // Await process exit to prevent zombie processes
+  await titleProc.exited
 
   return { success: true, paneId }
 }
@@ -217,10 +219,12 @@ export async function replaceTmuxPane(
   }
 
   const title = `omo-subagent-${description.slice(0, 20)}`
-  spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
+  const titleProc = spawn([tmux, "select-pane", "-t", paneId, "-T", title], {
     stdout: "ignore",
     stderr: "ignore",
   })
+  // Await process exit to prevent zombie processes
+  await titleProc.exited
 
   log("[replaceTmuxPane] SUCCESS", { paneId, sessionId })
   return { success: true, paneId }

--- a/src/tools/interactive-bash/tools.ts
+++ b/src/tools/interactive-bash/tools.ts
@@ -96,20 +96,19 @@ The Bash tool can execute these commands directly. Do NOT retry with interactive
 
       const timeoutPromise = new Promise<never>((_, reject) => {
         const id = setTimeout(() => {
+          const timeoutError = new Error(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`)
           try {
             proc.kill()
-            proc.exited
-              .then(() => {
-                reject(new Error(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`))
-              })
-              .catch((err) => {
-                reject(err instanceof Error ? err : new Error(String(err)))
-              })
-          } catch (err) {
-            reject(err instanceof Error ? err : new Error(String(err)))
+            // Fire-and-forget: wait for process exit in background to avoid zombies
+            void proc.exited.catch(() => {})
+          } catch {
+            // Ignore kill errors; we'll still reject with timeoutError below
           }
+          reject(timeoutError)
         }, DEFAULT_TIMEOUT_MS)
-        proc.exited.then(() => clearTimeout(id))
+        proc.exited
+          .then(() => clearTimeout(id))
+          .catch(() => clearTimeout(id))
       })
 
       // Read stdout and stderr in parallel to avoid race conditions

--- a/src/tools/interactive-bash/tools.ts
+++ b/src/tools/interactive-bash/tools.ts
@@ -95,10 +95,19 @@ The Bash tool can execute these commands directly. Do NOT retry with interactive
       })
 
       const timeoutPromise = new Promise<never>((_, reject) => {
-        const id = setTimeout(async () => {
-          proc.kill()
-          await proc.exited
-          reject(new Error(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`))
+        const id = setTimeout(() => {
+          try {
+            proc.kill()
+            proc.exited
+              .then(() => {
+                reject(new Error(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`))
+              })
+              .catch((err) => {
+                reject(err instanceof Error ? err : new Error(String(err)))
+              })
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error(String(err)))
+          }
         }, DEFAULT_TIMEOUT_MS)
         proc.exited.then(() => clearTimeout(id))
       })

--- a/src/tools/interactive-bash/tools.ts
+++ b/src/tools/interactive-bash/tools.ts
@@ -95,8 +95,9 @@ The Bash tool can execute these commands directly. Do NOT retry with interactive
       })
 
       const timeoutPromise = new Promise<never>((_, reject) => {
-        const id = setTimeout(() => {
+        const id = setTimeout(async () => {
           proc.kill()
+          await proc.exited
           reject(new Error(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`))
         }, DEFAULT_TIMEOUT_MS)
         proc.exited.then(() => clearTimeout(id))

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -48,21 +48,13 @@ class LSPServerManager {
 
     process.on("exit", cleanup)
 
-    process.on("SIGINT", () => {
-      cleanup()
-      process.exit(0)
-    })
-
-    process.on("SIGTERM", () => {
-      cleanup()
-      process.exit(0)
-    })
+    // Don't call process.exit() here - let other handlers complete their cleanup first
+    // The background-agent manager handles the final exit call
+    process.on("SIGINT", cleanup)
+    process.on("SIGTERM", cleanup)
 
     if (process.platform === "win32") {
-      process.on("SIGBREAK", () => {
-        cleanup()
-        process.exit(0)
-      })
+      process.on("SIGBREAK", cleanup)
     }
   }
 
@@ -532,8 +524,11 @@ export class LSPClient {
       this.connection.dispose()
       this.connection = null
     }
-    this.proc?.kill()
-    this.proc = null
+    if (this.proc) {
+      this.proc.kill()
+      await this.proc.exited
+      this.proc = null
+    }
     this.processExited = true
     this.diagnosticsStore.clear()
   }

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -71,7 +71,7 @@ class LSPServerManager {
     process.on("SIGTERM", () => void asyncCleanup())
 
     if (process.platform === "win32") {
-      process.on("SIGBREAK", syncCleanup)
+      process.on("SIGBREAK", () => void asyncCleanup())
     }
   }
 

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -547,11 +547,14 @@ export class LSPClient {
       try {
         proc.kill()
         // Wait for exit with timeout to prevent indefinite hang
-        const exitWithTimeout = Promise.race([
-          proc.exited,
-          new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        const timeoutPromise = new Promise<void>((resolve) => {
+          timeoutId = setTimeout(resolve, 5000)
+        })
+        await Promise.race([
+          proc.exited.finally(() => timeoutId && clearTimeout(timeoutId)),
+          timeoutPromise,
         ])
-        await exitWithTimeout
       } catch {}
     }
     this.processExited = true

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -544,6 +544,7 @@ export class LSPClient {
     const proc = this.proc
     if (proc) {
       this.proc = null
+      let exitedBeforeTimeout = false
       try {
         proc.kill()
         // Wait for exit with timeout to prevent indefinite hang
@@ -552,9 +553,15 @@ export class LSPClient {
           timeoutId = setTimeout(resolve, 5000)
         })
         await Promise.race([
-          proc.exited.finally(() => timeoutId && clearTimeout(timeoutId)),
+          proc.exited.then(() => { exitedBeforeTimeout = true }).finally(() => timeoutId && clearTimeout(timeoutId)),
           timeoutPromise,
         ])
+        if (!exitedBeforeTimeout) {
+          log("[LSPClient] Process did not exit within timeout, escalating to SIGKILL")
+          try {
+            proc.kill("SIGKILL")
+          } catch {}
+        }
       } catch {}
     }
     this.processExited = true

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -546,7 +546,12 @@ export class LSPClient {
       this.proc = null
       try {
         proc.kill()
-        await proc.exited
+        // Wait for exit with timeout to prevent indefinite hang
+        const exitWithTimeout = Promise.race([
+          proc.exited,
+          new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+        ])
+        await exitWithTimeout
       } catch {}
     }
     this.processExited = true

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -67,11 +67,11 @@ class LSPServerManager {
     // Don't call process.exit() here - let other handlers complete their cleanup first
     // The background-agent manager handles the final exit call
     // Use async handlers to properly await LSP subprocess cleanup
-    process.on("SIGINT", () => void asyncCleanup())
-    process.on("SIGTERM", () => void asyncCleanup())
+    process.on("SIGINT", () => void asyncCleanup().catch(() => {}))
+    process.on("SIGTERM", () => void asyncCleanup().catch(() => {}))
 
     if (process.platform === "win32") {
-      process.on("SIGBREAK", () => void asyncCleanup())
+      process.on("SIGBREAK", () => void asyncCleanup().catch(() => {}))
     }
   }
 
@@ -560,6 +560,11 @@ export class LSPClient {
           log("[LSPClient] Process did not exit within timeout, escalating to SIGKILL")
           try {
             proc.kill("SIGKILL")
+            // Wait briefly for SIGKILL to take effect
+            await Promise.race([
+              proc.exited,
+              new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+            ])
           } catch {}
         }
       } catch {}

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -33,10 +33,12 @@ class LSPServerManager {
   }
 
   private registerProcessCleanup(): void {
-    const cleanup = () => {
+    // Synchronous cleanup for 'exit' event (cannot await)
+    const syncCleanup = () => {
       for (const [, managed] of this.clients) {
         try {
-          managed.client.stop()
+          // Fire-and-forget during sync exit - process is terminating
+          void managed.client.stop().catch(() => {})
         } catch {}
       }
       this.clients.clear()
@@ -46,15 +48,30 @@ class LSPServerManager {
       }
     }
 
-    process.on("exit", cleanup)
+    // Async cleanup for signal handlers - properly await all stops
+    const asyncCleanup = async () => {
+      const stopPromises: Promise<void>[] = []
+      for (const [, managed] of this.clients) {
+        stopPromises.push(managed.client.stop().catch(() => {}))
+      }
+      await Promise.allSettled(stopPromises)
+      this.clients.clear()
+      if (this.cleanupInterval) {
+        clearInterval(this.cleanupInterval)
+        this.cleanupInterval = null
+      }
+    }
+
+    process.on("exit", syncCleanup)
 
     // Don't call process.exit() here - let other handlers complete their cleanup first
     // The background-agent manager handles the final exit call
-    process.on("SIGINT", cleanup)
-    process.on("SIGTERM", cleanup)
+    // Use async handlers to properly await LSP subprocess cleanup
+    process.on("SIGINT", () => void asyncCleanup())
+    process.on("SIGTERM", () => void asyncCleanup())
 
     if (process.platform === "win32") {
-      process.on("SIGBREAK", cleanup)
+      process.on("SIGBREAK", syncCleanup)
     }
   }
 
@@ -524,10 +541,13 @@ export class LSPClient {
       this.connection.dispose()
       this.connection = null
     }
-    if (this.proc) {
-      this.proc.kill()
-      await this.proc.exited
+    const proc = this.proc
+    if (proc) {
       this.proc = null
+      try {
+        proc.kill()
+        await proc.exited
+      } catch {}
     }
     this.processExited = true
     this.diagnosticsStore.clear()


### PR DESCRIPTION
## Summary

This PR addresses zombie/orphan process issues when running oh-my-opencode with tmux integration by fixing improper process lifecycle management.

## Root Cause Analysis

Investigation revealed multiple causes of zombie processes:

1. **Fire-and-forget spawns** - `spawn()` calls in tmux-utils.ts that never awaited `proc.exited`
2. **Competing signal handlers** - LSP client, skill-mcp-manager, and background-agent all registered SIGINT/SIGTERM handlers that called `process.exit(0)` independently, causing race conditions where the first to exit would terminate before others completed cleanup
3. **Non-awaited kill() calls** - Timeout handlers and stop() methods called `proc.kill()` without waiting for the process to actually exit

## Changes

### 1. Fix fire-and-forget spawns in tmux-utils.ts
- `spawnTmuxPane()`: Now awaits `proc.exited` for the pane title setting command
- `replaceTmuxPane()`: Same fix applied

### 2. Coordinate signal handlers
- **LSP client**: Removed `process.exit(0)` from signal handlers - now just performs cleanup
- **skill-mcp-manager**: Same fix - removes competing exit calls
- **background-agent manager**: Remains the single coordinator for process exit

### 3. Await process exit after kill()
- **interactive-bash tools.ts**: Timeout handler now awaits `proc.exited` after `proc.kill()`
- **LSP client stop()**: Now awaits `proc.exited` after killing the LSP server process

## Investigation Notes

- **setRawMode is NOT the cause** - This codebase doesn't use `setRawMode`; it's managed by OpenCode core
- OpenCode core uses `setRawMode` for terminal color detection, which can conflict with child process spawning
- The practical fixes focus on proper process lifecycle management

## Testing

- [x] TypeScript type check passes
- [x] All 51 relevant tests pass
- [x] LSP diagnostics clean on all changed files

## Related

- Builds on existing zombie prevention work from #1240

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zombie/orphan processes by fixing process lifecycle and coordinating shutdown when running with tmux. Processes now exit cleanly and are properly reaped.

- **Bug Fixes**
  - tmux-utils: await pane title command proc.exited, drain stderr, and log warnings on failure.
  - Shutdown: remove process.exit() from LSP client and skill-mcp-manager; LSP signal handlers perform async cleanup; background-agent sets process.exitCode and delays final exit by 6s to allow cleanup.
  - Kills: interactive-bash timeout kills and waits in background on proc.exited; LSP client stop() waits 5s and escalates to SIGKILL if needed.

<sup>Written for commit 15205c4b38a20b1ea253daeccf8d94f9bbe4d1b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

