### PR TITLE
fix: use fallback chain when connected-providers cache missing

### DIFF
--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -489,7 +489,7 @@ describe("resolveModelWithFallback", () => {
       expect(logSpy).toHaveBeenCalledWith("No available model found in fallback chain, falling through to system default")
     })
 
-    test("returns undefined when availableModels empty and no connected providers cache exists", () => {
+    test("uses first fallback entry when availableModels empty and no connected providers cache exists", () => {
       // #given - both model cache and connected-providers cache are missing (first run)
       const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
       const input: ExtendedModelResolutionInput = {
@@ -497,14 +497,15 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-opus-4-5" },
         ],
         availableModels: new Set(),
-        systemDefaultModel: undefined, // no system default configured
+        systemDefaultModel: undefined,
       }
 
       // #when
       const result = resolveModelWithFallback(input)
 
-      // #then - should return undefined to let OpenCode use Provider.defaultModel()
-      expect(result).toBeUndefined()
+      // #then - should use first fallback entry (fixes category model ignored bug)
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
       cacheSpy.mockRestore()
     })
 
@@ -568,25 +569,26 @@ describe("resolveModelWithFallback", () => {
       cacheSpy.mockRestore()
     })
 
-    test("falls through to system default when no cache and systemDefaultModel is provided", () => {
-      // #given - no cache but system default is configured
-      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
-      const input: ExtendedModelResolutionInput = {
-        fallbackChain: [
-          { providers: ["anthropic"], model: "claude-opus-4-5" },
-        ],
-        availableModels: new Set(),
-        systemDefaultModel: "google/gemini-3-pro",
-      }
+	test("uses first fallback entry when no cache exists (fixes category model ignored bug)", () => {
+		// #given - no cache but fallback chain is configured
+		const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+		const input: ExtendedModelResolutionInput = {
+			fallbackChain: [
+				{ providers: ["anthropic"], model: "claude-opus-4-5", variant: "max" },
+			],
+			availableModels: new Set(),
+			systemDefaultModel: "google/gemini-3-pro",
+		}
 
-      // #when
-      const result = resolveModelWithFallback(input)
+		// #when
+		const result = resolveModelWithFallback(input)
 
-      // #then - should fall through to system default
-      expect(result!.model).toBe("google/gemini-3-pro")
-      expect(result!.source).toBe("system-default")
-      cacheSpy.mockRestore()
-    })
+		// #then - should use first fallback entry, NOT system default
+		expect(result!.model).toBe("anthropic/claude-opus-4-5")
+		expect(result!.source).toBe("provider-fallback")
+		expect(result!.variant).toBe("max")
+		cacheSpy.mockRestore()
+	})
 
     test("returns system default when fallbackChain is not provided", () => {
       // #given

--- a/src/shared/model-resolver.ts
+++ b/src/shared/model-resolver.ts
@@ -98,7 +98,18 @@ export function resolveModelWithFallback(
 			const connectedSet = connectedProviders ? new Set(connectedProviders) : null
 
 			if (connectedSet === null) {
-				log("Model fallback chain skipped (no connected providers cache) - falling through to system default")
+				// FIX: Use fallback chain first entry instead of skipping to systemDefault
+				const firstEntry = fallbackChain[0]
+				if (firstEntry && firstEntry.providers.length > 0) {
+					const model = `${firstEntry.providers[0]}/${firstEntry.model}`
+					log("Model resolved via fallback chain (no cache, using first entry)", {
+						provider: firstEntry.providers[0],
+						model: firstEntry.model,
+						variant: firstEntry.variant,
+					})
+					return { model, source: "provider-fallback", variant: firstEntry.variant }
+				}
+				log("Model fallback chain empty - falling through to system default")
 			} else {
 				for (const entry of fallbackChain) {
 					for (const provider of entry.providers) {


### PR DESCRIPTION
## Summary

- Fix category model configurations being ignored when `connected-providers.json` cache doesn't exist
- Use first fallback chain entry instead of skipping to systemDefaultModel

## Problem

When `connected-providers.json` cache is missing (first run or cache cleared), `resolveModelWithFallback()` was skipping the entire fallback chain and falling through to `systemDefaultModel`. This caused all category-specific model configurations (quick, visual-engineering, ultrabrain, etc.) to be ignored.

**Related Issues**: #1264, #1295

## Solution

When cache is `null`, use the first entry in the fallback chain instead of skipping:

```typescript
if (connectedSet === null) {
  const firstEntry = fallbackChain[0]
  if (firstEntry && firstEntry.providers.length > 0) {
    const model = `${firstEntry.providers[0]}/${firstEntry.model}`
    return { model, source: "provider-fallback", variant: firstEntry.variant }
  }
}
```

## Testing

- Updated 2 existing tests to reflect new behavior
- All 46 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes category-specific model selection when connected-providers.json is missing by using the first fallback chain entry instead of the system default. Ensures categories like quick, visual-engineering, and ultrabrain use their intended models on first run or after cache clear.

- **Bug Fixes**
  - When no connected-providers cache exists, resolveModelWithFallback now picks the first fallback entry (preserving variant) and marks source as provider-fallback.
  - Updated tests to reflect the new behavior.

<sup>Written for commit 7ef706fa9d047fedddfc1709ac6d85d84f86ba0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

