### PR TITLE
fix(model-requirements): use provider-specific variants for github-copilot

### DIFF
--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -211,4 +211,40 @@ describe("resolveVariantForModel", () => {
     // then
     expect(variant).toBe("max")
   })
+
+  test("returns thinking variant for github-copilot provider with claude-opus-4-5", () => {
+    // #given - github-copilot doesn't support "max" variant, only "standard" and "thinking"
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "github-copilot", modelID: "claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then - should return "thinking" instead of "max"
+    expect(variant).toBe("thinking")
+  })
+
+  test("returns thinking variant for github-copilot claude in oracle agent", () => {
+    // #given - oracle agent with github-copilot provider
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "github-copilot", modelID: "claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "oracle", model)
+
+    // #then - copilot claude gets "thinking" variant
+    expect(variant).toBe("thinking")
+  })
+
+  test("returns high variant for github-copilot gemini-3-pro in oracle agent", () => {
+    // #given - oracle agent with github-copilot provider and gemini model
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "github-copilot", modelID: "gemini-3-pro" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "oracle", model)
+
+    // #then - copilot gemini gets "high" variant (not "max")
+    expect(variant).toBe("high")
+  })
 })

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -28,18 +28,25 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const sisyphus = AGENT_MODEL_REQUIREMENTS["sisyphus"]
 
     // #when - accessing Sisyphus requirement
-    // #then - fallbackChain exists with claude-opus-4-5 as first entry, glm-4.7-free as last
+    // #then - fallbackChain exists with claude-opus-4-5 (anthropic) as first entry, glm-4.7-free as last
     expect(sisyphus).toBeDefined()
     expect(sisyphus.fallbackChain).toBeArray()
-    expect(sisyphus.fallbackChain).toHaveLength(5)
+    expect(sisyphus.fallbackChain).toHaveLength(6)
     expect(sisyphus.requiresAnyModel).toBe(true)
 
+    // First entry: anthropic/opencode gets "max" variant
     const primary = sisyphus.fallbackChain[0]
     expect(primary.providers[0]).toBe("anthropic")
     expect(primary.model).toBe("claude-opus-4-5")
     expect(primary.variant).toBe("max")
 
-    const last = sisyphus.fallbackChain[4]
+    // Second entry: github-copilot gets "thinking" variant (copilot doesn't support "max")
+    const copilotEntry = sisyphus.fallbackChain[1]
+    expect(copilotEntry.providers[0]).toBe("github-copilot")
+    expect(copilotEntry.model).toBe("claude-opus-4-5")
+    expect(copilotEntry.variant).toBe("thinking")
+
+    const last = sisyphus.fallbackChain[5]
     expect(last.providers[0]).toBe("opencode")
     expect(last.model).toBe("glm-4.7-free")
   })

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -14,7 +14,8 @@ export type ModelRequirement = {
 export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["zai-coding-plan"], model: "glm-4.7" },
@@ -31,8 +32,10 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   oracle: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
     ],
   },
    librarian: {
@@ -62,7 +65,8 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   prometheus: {
     fallbackChain: [
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
@@ -71,18 +75,22 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   metis: {
     fallbackChain: [
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   momus: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "medium" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
+      { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   atlas: {
@@ -100,29 +108,36 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "visual-engineering": {
     fallbackChain: [
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
       { providers: ["zai-coding-plan"], model: "glm-4.7" },
     ],
   },
   ultrabrain: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "xhigh" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
     ],
   },
    deep: {
      fallbackChain: [
        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
-       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+       { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+       { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
+       { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+       { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
      ],
      requiresModel: "gpt-5.2-codex",
    },
    artistry: {
      fallbackChain: [
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
-       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+       { providers: ["google", "opencode"], model: "gemini-3-pro", variant: "max" },
+       { providers: ["github-copilot"], model: "gemini-3-pro", variant: "high" },
+       { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+       { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
      ],
      requiresModel: "gemini-3-pro",
@@ -143,7 +158,8 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-high": {
     fallbackChain: [
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["anthropic", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["github-copilot"], model: "claude-opus-4-5", variant: "thinking" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
     ],


### PR DESCRIPTION
## Summary

GitHub Copilot's Claude models only support `standard` and `thinking` variants (fixed 4K thinking budget), not `max` which is supported by the direct Anthropic API. Similarly, Copilot's Gemini models support `high` but not `max`.

This PR splits fallback chain entries in `model-requirements.ts` so that provider-specific variants are used:

| Provider | Claude Variant | Gemini Variant |
|----------|---------------|----------------|
| anthropic | max | - |
| opencode | max | max |
| github-copilot | thinking | high |
| google | - | max |

## Changes

- Split combined `["anthropic", "github-copilot", "opencode"]` entries into separate provider-specific entries
- Updated affected agents: sisyphus, oracle, prometheus, metis, momus
- Updated affected categories: visual-engineering, ultrabrain, deep, artistry, unspecified-high
- Added tests for github-copilot variant resolution

## Testing

- `bun test src/shared/` passes (435 tests)
- Verified variant resolution returns `thinking` for github-copilot Claude models
- Verified variant resolution returns `high` for github-copilot Gemini models

## Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] Tests updated and passing
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use provider-specific model variants so GitHub Copilot gets supported options for Claude and Gemini, preventing unsupported-variant errors. Improves reliability of model selection across agents and categories.

- **Bug Fixes**
  - Split fallback chain entries by provider in model-requirements.ts.
  - Copilot: Claude uses thinking; Gemini uses high. Anthropic/Google/Opencode keep max where supported.
  - Updated agents and categories: sisyphus, oracle, prometheus, metis, momus; visual-engineering, ultrabrain, deep, artistry, unspecified-high.
  - Added tests for Copilot variant resolution; shared tests pass.

<sup>Written for commit 3f1808fd487f33d4ae04d86559df61d7f7699a8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

