### PR TITLE
feat: add customizable fallback chains and improved model matching (Fixes #1307)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.2.1",
-        "oh-my-opencode-darwin-x64": "3.2.1",
-        "oh-my-opencode-linux-arm64": "3.2.1",
-        "oh-my-opencode-linux-arm64-musl": "3.2.1",
-        "oh-my-opencode-linux-x64": "3.2.1",
-        "oh-my-opencode-linux-x64-musl": "3.2.1",
-        "oh-my-opencode-windows-x64": "3.2.1",
+        "oh-my-opencode-darwin-arm64": "3.2.2",
+        "oh-my-opencode-darwin-x64": "3.2.2",
+        "oh-my-opencode-linux-arm64": "3.2.2",
+        "oh-my-opencode-linux-arm64-musl": "3.2.2",
+        "oh-my-opencode-linux-x64": "3.2.2",
+        "oh-my-opencode-linux-x64-musl": "3.2.2",
+        "oh-my-opencode-windows-x64": "3.2.2",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IvhHRUXTr/g/hJlkKTU2oCdgRl2BDl/Qre31Rukhs4NumlvME6iDmdnm8mM7bTxugfCBkfUUr7QJLxxLhzjdLA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-KyfoWcANfcvpfanrrX+Wc8vH8vr9mvr7dJMHBe2bkvuhdtHnLHOG18hQwLg6jk4HhdoZAeBEmkolOsK2k4XajA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-V2JbAdThAVfhBOcb+wBPZrAI0vBxPPRBdvmAixAxBOFC49CIJUrEFIRBUYFKhSQGHYWrNy8z0zJYoNQm4oQPog=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ajZ1E36Ixwdz6rvSUKUI08M2xOaNIl1ZsdVjknZTrPRtct9xgS+BEFCoSCov9bnV/9DrZD3mlZtO/+FFDbseUg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-SeT8P7Icq5YH/AIaEF28J4q+ifUnOqO2UgMFtdFusr8JLadYFy+6dTdeAuD2uGGToDQ3ZNKuaG+lo84KzEhA5w=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ItJsYfigXcOa8/ejTjopC4qk5BCeYioMQ693kPTpeYHK3ByugTjJk8aamE7bHlVnmrdgWldz91QFzaP82yOAdg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wJUEVVUn1gyVIFNV4mxWg9cYo1rQdTKUXdGLfiqPiyQhWhZLRfPJ+9qpghvIVv7Dne6rzkbhYWdwdk/tew5RtQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/TvjYe/Kb//ZSHnJzgRj0QPKpS5Y2nermVTSaMTGS2btObXQyQWzuphDhsVRu60SVrNLbflHzfuTdqb3avDjyA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-p/XValXi1RRTZV8mEsdStXwZBkyQpgZjB41HLf0VfizPMAKRr6/bhuFZ9BDZFIhcDnLYcGV54MAVEsWms5yC2A=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ka5j+tjuQkNnpESVzcTzW5tZMlBhOfP9F12+UaR72cIcwFpSoLMBp84rV6R0vXM0zUcrrN7mPeW66DvQ6A0XQQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-G7aNMqAMO2P+wUUaaAV8sXymm59cX4G9aVNXKAd/PM6RgFWh2F4HkXkOhOdHKYZzCl1QRhjh672mNillYsvebg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ISl0sTNShKCgPFO+rsDqEDsvVHQAMfOSAxO0KuWbHFKaH+KaRV4d3N/ihgxZ2M94CZjJLzZEuln+6kLZ93cvzQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-pyqTGlNxirKxQgXx9YJBq2y8KN/1oIygVupClmws7dDPj9etI1l8fs/SBEnMsYzMqTlGbLVeJ5+kj9p+yg7YDA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-KeiJLQvJuZ+UYf/+eMsQXvCiHDRPk6tD15lL+qruLvU19va62JqMNvTuOv97732uF19iG0ZMiiVhqIMbSyVPqQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -135,6 +135,12 @@ export const AgentOverrideConfigSchema = z.object({
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   /** Provider-specific options. Passed directly to OpenCode SDK. */
   providerOptions: z.record(z.string(), z.unknown()).optional(),
+  /** Custom fallback chain for model resolution. Overrides built-in agent fallback chains. */
+  fallback_chain: z.array(z.object({
+    providers: z.array(z.string()),
+    model: z.string(),
+    variant: z.string().optional(),
+  })).optional(),
 })
 
 export const AgentOverridesSchema = z.object({
@@ -189,6 +195,12 @@ export const CategoryConfigSchema = z.object({
   prompt_append: z.string().optional(),
   /** Mark agent as unstable - forces background mode for monitoring. Auto-enabled for gemini/minimax models. */
   is_unstable_agent: z.boolean().optional(),
+  /** Custom fallback chain for model resolution. Each entry specifies providers, model, and optional variant. */
+  fallback_chain: z.array(z.object({
+    providers: z.array(z.string()),
+    model: z.string(),
+    variant: z.string().optional(),
+  })).optional(),
 })
 
 export const BuiltinCategoryNameSchema = z.enum([

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -101,6 +101,13 @@ export const BuiltinCommandNameSchema = z.enum([
   "start-work",
 ])
 
+export const FallbackChainEntrySchema = z.object({
+  providers: z.array(z.string()),
+  model: z.string(),
+  variant: z.string().optional(),
+})
+export const FallbackChainSchema = z.array(FallbackChainEntrySchema)
+
 export const AgentOverrideConfigSchema = z.object({
   /** @deprecated Use `category` instead. Model is inherited from category defaults. */
   model: z.string().optional(),
@@ -136,11 +143,7 @@ export const AgentOverrideConfigSchema = z.object({
   /** Provider-specific options. Passed directly to OpenCode SDK. */
   providerOptions: z.record(z.string(), z.unknown()).optional(),
   /** Custom fallback chain for model resolution. Overrides built-in agent fallback chains. */
-  fallback_chain: z.array(z.object({
-    providers: z.array(z.string()),
-    model: z.string(),
-    variant: z.string().optional(),
-  })).optional(),
+  fallback_chain: FallbackChainSchema.optional(),
 })
 
 export const AgentOverridesSchema = z.object({
@@ -196,11 +199,7 @@ export const CategoryConfigSchema = z.object({
   /** Mark agent as unstable - forces background mode for monitoring. Auto-enabled for gemini/minimax models. */
   is_unstable_agent: z.boolean().optional(),
   /** Custom fallback chain for model resolution. Each entry specifies providers, model, and optional variant. */
-  fallback_chain: z.array(z.object({
-    providers: z.array(z.string()),
-    model: z.string(),
-    variant: z.string().optional(),
-  })).optional(),
+  fallback_chain: FallbackChainSchema.optional(),
 })
 
 export const BuiltinCategoryNameSchema = z.enum([

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -305,4 +305,107 @@ describe("resolveVariantForModel", () => {
     // #then
     expect(variant).toBe("category-fallback-variant")
   })
+
+  // Edge case tests for PR #1307 fix
+  test("does not select variant when provider matches but model does not", () => {
+    // given
+    const config = {
+      agents: {
+        testAgent: {
+          fallback_chain: [
+            { providers: ["anthropic"], model: "claude-opus-4", variant: "max" }
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "claude-sonnet-4" } // Different model
+
+    // when
+    const variant = resolveVariantForModel(config, "testAgent", model)
+
+    // then
+    expect(variant).toBeUndefined()
+  })
+
+  test("selects variant when provider matches and entry has no model", () => {
+    // given
+    const config = {
+      agents: {
+        testAgent: {
+          fallback_chain: [
+            { providers: ["anthropic"], variant: "high" } // No model specified
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "any-model" }
+
+    // when
+    const variant = resolveVariantForModel(config, "testAgent", model)
+
+    // then
+    expect(variant).toBe("high")
+  })
+
+  test("does not match when modelID is undefined but entry requires model", () => {
+    // given
+    const config = {
+      agents: {
+        testAgent: {
+          fallback_chain: [
+            { providers: ["anthropic"], model: "claude-opus-4", variant: "max" }
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: undefined } as any // Forced undefined
+
+    // when
+    const variant = resolveVariantForModel(config, "testAgent", model)
+
+    // then
+    expect(variant).toBeUndefined()
+  })
+
+  test("skips mismatched entries and finds later matching entry", () => {
+    // given
+    const config = {
+      agents: {
+        testAgent: {
+          fallback_chain: [
+            { providers: ["anthropic"], model: "claude-opus-4", variant: "max" }, // Wrong model
+            { providers: ["anthropic"], model: "claude-sonnet-4", variant: "high" } // Correct
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "claude-sonnet-4" }
+
+    // when
+    const variant = resolveVariantForModel(config, "testAgent", model)
+
+    // then
+    expect(variant).toBe("high")
+  })
+
+  test("respects model matching for entries with multiple providers", () => {
+    // given
+    const config = {
+      agents: {
+        testAgent: {
+          fallback_chain: [
+            { providers: ["anthropic", "openai"], model: "gpt-4", variant: "high" }
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    // Provider matches (anthropic) but model (claude-opus-4) doesn't match gpt-4
+    const model = { providerID: "anthropic", modelID: "claude-opus-4" }
+
+    // when
+    const variant = resolveVariantForModel(config, "testAgent", model)
+
+    // then
+    expect(variant).toBeUndefined()
+  })
 })

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -211,4 +211,98 @@ describe("resolveVariantForModel", () => {
     // then
     expect(variant).toBe("max")
   })
+
+  test("matches model with antigravity- prefix to base model", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "antigravity-claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBe("max")
+  })
+
+  test("uses user-defined fallback_chain when provided for agent", () => {
+    // #given
+    const config = {
+      agents: {
+        sisyphus: {
+          fallback_chain: [
+            { providers: ["custom-provider"], model: "custom-model", variant: "custom-variant" }
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "custom-provider", modelID: "custom-model" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBe("custom-variant")
+  })
+
+  test("uses user-defined fallback_chain when provided for category", () => {
+    // #given
+    const config = {
+      agents: {
+        "custom-agent": { category: "my-category" }
+      },
+      categories: {
+        "my-category": {
+          model: "some/model",
+          fallback_chain: [
+            { providers: ["google"], model: "gemini-3-pro", variant: "high" }
+          ]
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "google", modelID: "antigravity-gemini-3-pro" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "custom-agent", model)
+
+    // #then
+    expect(variant).toBe("high")
+  })
+
+  test("falls back to agent variant when no fallback chain matches", () => {
+    // #given
+    const config = {
+      agents: {
+        "custom-agent": { variant: "fallback-variant" }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "unknown-provider", modelID: "unknown-model" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "custom-agent", model)
+
+    // #then
+    expect(variant).toBe("fallback-variant")
+  })
+
+  test("falls back to category variant when no fallback chain matches", () => {
+    // #given
+    const config = {
+      agents: {
+        "custom-agent": { category: "my-category" }
+      },
+      categories: {
+        "my-category": {
+          model: "some/model",
+          variant: "category-fallback-variant"
+        }
+      }
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "unknown-provider", modelID: "unknown-model" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "custom-agent", model)
+
+    // #then
+    expect(variant).toBe("category-fallback-variant")
+  })
 })

--- a/src/shared/agent-variant.ts
+++ b/src/shared/agent-variant.ts
@@ -1,10 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config"
-import { findCaseInsensitive } from "./case-insensitive"
 import { 
   AGENT_MODEL_REQUIREMENTS, 
   CATEGORY_MODEL_REQUIREMENTS, 
-  getEffectiveFallbackChain,
-  getEffectiveCategoryFallbackChain,
   type FallbackEntry 
 } from "./model-requirements"
 
@@ -79,38 +76,65 @@ export function resolveVariantForModel(
   const agentOverrides = config.agents as
     | Record<string, AgentOverrideWithFallback>
     | undefined
-  const agentOverride = agentOverrides ? findCaseInsensitive(agentOverrides, agentName) : undefined
+  const agentOverride = agentOverrides
+    ? agentOverrides[agentName]
+      ?? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentName.toLowerCase())?.[1]
+    : undefined
 
-  const userAgentFallback = agentOverride?.fallback_chain
-  const effectiveAgentChain = getEffectiveFallbackChain(agentName, userAgentFallback)
-  
-  if (effectiveAgentChain.length > 0) {
+  // 1. User-provided agent fallback chain takes absolute priority
+  if (agentOverride?.fallback_chain && agentOverride.fallback_chain.length > 0) {
     const chainVariant = findVariantInChain(
-      effectiveAgentChain,
+      agentOverride.fallback_chain,
       currentModel.providerID,
       currentModel.modelID
     )
     if (chainVariant) return chainVariant
   }
 
+  // 2. User-provided agent variant override
+  if (agentOverride?.variant) return agentOverride.variant
+
   const categoryName = agentOverride?.category
   if (categoryName) {
     const categoryConfig = config.categories?.[categoryName] as CategoryConfigWithFallback | undefined
-    const userCategoryFallback = categoryConfig?.fallback_chain
-    const effectiveCategoryChain = getEffectiveCategoryFallbackChain(categoryName, userCategoryFallback)
     
-    if (effectiveCategoryChain.length > 0) {
+    // 3. User-provided category fallback chain
+    if (categoryConfig?.fallback_chain && categoryConfig.fallback_chain.length > 0) {
       const chainVariant = findVariantInChain(
-        effectiveCategoryChain,
+        categoryConfig.fallback_chain,
         currentModel.providerID,
         currentModel.modelID
       )
       if (chainVariant) return chainVariant
     }
+
+    // 4. Category variant override
     if (categoryConfig?.variant) return categoryConfig.variant
   }
 
-  if (agentOverride?.variant) return agentOverride.variant
+  // 5. Default agent fallback chain
+  const defaultAgentChain = AGENT_MODEL_REQUIREMENTS[agentName]?.fallbackChain
+  if (defaultAgentChain) {
+    const chainVariant = findVariantInChain(
+      defaultAgentChain,
+      currentModel.providerID,
+      currentModel.modelID
+    )
+    if (chainVariant) return chainVariant
+  }
+
+  // 6. Default category fallback chain
+  if (categoryName) {
+    const defaultCategoryChain = CATEGORY_MODEL_REQUIREMENTS[categoryName]?.fallbackChain
+    if (defaultCategoryChain) {
+      const chainVariant = findVariantInChain(
+        defaultCategoryChain,
+        currentModel.providerID,
+        currentModel.modelID
+      )
+      if (chainVariant) return chainVariant
+    }
+  }
 
   return undefined
 }

--- a/src/shared/agent-variant.ts
+++ b/src/shared/agent-variant.ts
@@ -1,5 +1,44 @@
 import type { OhMyOpenCodeConfig } from "../config"
-import { AGENT_MODEL_REQUIREMENTS, CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
+import { findCaseInsensitive } from "./case-insensitive"
+import { 
+  AGENT_MODEL_REQUIREMENTS, 
+  CATEGORY_MODEL_REQUIREMENTS, 
+  getEffectiveFallbackChain,
+  getEffectiveCategoryFallbackChain,
+  type FallbackEntry 
+} from "./model-requirements"
+
+const MODEL_PREFIXES_TO_STRIP = ["antigravity-", "proxy-", "custom-"]
+
+function normalizeModelId(modelId: string): string {
+  let normalized = modelId
+  for (const prefix of MODEL_PREFIXES_TO_STRIP) {
+    if (normalized.startsWith(prefix)) {
+      normalized = normalized.slice(prefix.length)
+      break
+    }
+  }
+  return normalized
+}
+
+function modelMatches(modelId: string, pattern: string): boolean {
+  if (modelId === pattern) return true
+  if (normalizeModelId(modelId) === pattern) return true
+  if (modelId === normalizeModelId(pattern)) return true
+  if (normalizeModelId(modelId) === normalizeModelId(pattern)) return true
+  return false
+}
+
+type AgentOverrideWithFallback = { 
+  variant?: string
+  category?: string
+  fallback_chain?: FallbackEntry[]
+}
+
+type CategoryConfigWithFallback = {
+  variant?: string
+  fallback_chain?: FallbackEntry[]
+}
 
 export function resolveAgentVariant(
   config: OhMyOpenCodeConfig,
@@ -38,40 +77,62 @@ export function resolveVariantForModel(
   currentModel: { providerID: string; modelID: string },
 ): string | undefined {
   const agentOverrides = config.agents as
-    | Record<string, { variant?: string; category?: string }>
+    | Record<string, AgentOverrideWithFallback>
     | undefined
-  const agentOverride = agentOverrides
-    ? agentOverrides[agentName]
-      ?? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentName.toLowerCase())?.[1]
-    : undefined
-  if (agentOverride?.variant) {
-    return agentOverride.variant
+  const agentOverride = agentOverrides ? findCaseInsensitive(agentOverrides, agentName) : undefined
+
+  const userAgentFallback = agentOverride?.fallback_chain
+  const effectiveAgentChain = getEffectiveFallbackChain(agentName, userAgentFallback)
+  
+  if (effectiveAgentChain.length > 0) {
+    const chainVariant = findVariantInChain(
+      effectiveAgentChain,
+      currentModel.providerID,
+      currentModel.modelID
+    )
+    if (chainVariant) return chainVariant
   }
 
-  const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentName]
-  if (agentRequirement) {
-    return findVariantInChain(agentRequirement.fallbackChain, currentModel)
-  }
   const categoryName = agentOverride?.category
   if (categoryName) {
-    const categoryRequirement = CATEGORY_MODEL_REQUIREMENTS[categoryName]
-    if (categoryRequirement) {
-      return findVariantInChain(categoryRequirement.fallbackChain, currentModel)
+    const categoryConfig = config.categories?.[categoryName] as CategoryConfigWithFallback | undefined
+    const userCategoryFallback = categoryConfig?.fallback_chain
+    const effectiveCategoryChain = getEffectiveCategoryFallbackChain(categoryName, userCategoryFallback)
+    
+    if (effectiveCategoryChain.length > 0) {
+      const chainVariant = findVariantInChain(
+        effectiveCategoryChain,
+        currentModel.providerID,
+        currentModel.modelID
+      )
+      if (chainVariant) return chainVariant
     }
+    if (categoryConfig?.variant) return categoryConfig.variant
   }
+
+  if (agentOverride?.variant) return agentOverride.variant
 
   return undefined
 }
 
 function findVariantInChain(
-  fallbackChain: { providers: string[]; model: string; variant?: string }[],
-  currentModel: { providerID: string; modelID: string },
+  fallbackChain: FallbackEntry[],
+  providerID: string,
+  modelID?: string,
 ): string | undefined {
   for (const entry of fallbackChain) {
-    if (
-      entry.providers.includes(currentModel.providerID)
-      && entry.model === currentModel.modelID
-    ) {
+    if (entry.providers.includes(providerID)) {
+      if (modelID && entry.model) {
+        if (modelMatches(modelID, entry.model)) {
+          return entry.variant
+        }
+      } else {
+        return entry.variant
+      }
+    }
+  }
+  for (const entry of fallbackChain) {
+    if (entry.providers.includes(providerID)) {
       return entry.variant
     }
   }

--- a/src/shared/agent-variant.ts
+++ b/src/shared/agent-variant.ts
@@ -146,18 +146,13 @@ function findVariantInChain(
 ): string | undefined {
   for (const entry of fallbackChain) {
     if (entry.providers.includes(providerID)) {
-      if (modelID && entry.model) {
-        if (modelMatches(modelID, entry.model)) {
+      if (entry.model) {
+        if (modelID && modelMatches(modelID, entry.model)) {
           return entry.variant
         }
       } else {
         return entry.variant
       }
-    }
-  }
-  for (const entry of fallbackChain) {
-    if (entry.providers.includes(providerID)) {
-      return entry.variant
     }
   }
   return undefined

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -1,7 +1,7 @@
 export type FallbackEntry = {
   providers: string[]
   model: string
-  variant?: string // Entry-specific variant (e.g., GPT→high, Opus→max)
+  variant?: string
 }
 
 export type ModelRequirement = {
@@ -9,6 +9,32 @@ export type ModelRequirement = {
   variant?: string // Default variant (used when entry doesn't specify one)
   requiresModel?: string // If set, only activates when this model is available (fuzzy match)
   requiresAnyModel?: boolean // If true, requires at least ONE model in fallbackChain to be available (or empty availability treated as unavailable)
+}
+
+export type FallbackChainConfig = {
+  providers: string[]
+  model: string
+  variant?: string
+}
+
+export function getEffectiveFallbackChain(
+  agentName: string,
+  userFallbackChain?: FallbackChainConfig[],
+): FallbackEntry[] {
+  if (userFallbackChain && userFallbackChain.length > 0) {
+    return userFallbackChain
+  }
+  return AGENT_MODEL_REQUIREMENTS[agentName]?.fallbackChain ?? []
+}
+
+export function getEffectiveCategoryFallbackChain(
+  categoryName: string,
+  userFallbackChain?: FallbackChainConfig[],
+): FallbackEntry[] {
+  if (userFallbackChain && userFallbackChain.length > 0) {
+    return userFallbackChain
+  }
+  return CATEGORY_MODEL_REQUIREMENTS[categoryName]?.fallbackChain ?? []
 }
 
 export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {


### PR DESCRIPTION
Replaces #1307.

## Summary

This PR adds support for customizable fallback chains and improves model ID matching to handle prefixed models (like `antigravity-*`).

### Changes in this PR (Fixes for #1307)
1. **Resolved merge conflicts** with `dev` branch.
2. **CLA Signed**.
3. **Refactored Schema**: Extracted shared `FallbackChainSchema` in `src/config/schema.ts` to deduplicate definitions.
4. **Fixed Logic Bug**: `findVariantInChain` now strictly requires model match when `entry.model` is defined (prevents incorrect provider-only fallback).
5. **Added Tests**: Comprehensive edge case tests in `src/shared/agent-variant.test.ts` covering model mismatches, chain ordering, and multi-provider entries.

### Original Description
- Fallback chains are hardcoded in `model-requirements.ts`
- Variant resolution only works with exact provider/model matches
- No support for custom model names like `antigravity-gemini-3-pro`

### Solution
1. **Customizable fallback chains** - Users can now define their own fallback chains in `oh-my-opencode.json`.
2. **Model ID normalization** - Strips common routing prefixes when matching models.
3. **Improved variant fallback** - Falls back to category/agent variant when model-based resolution fails.

### Testing
All tests pass, including new edge case tests for the logic fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds customizable fallback chains for agents and categories and improves model matching (handles prefixed IDs like antigravity-*). Fixes #1307 by allowing user-defined chains to override built-ins and ensuring precise variant selection.

- **New Features**
  - Add fallback_chain config to agents and categories for custom model/provider fallbacks.
  - Normalize model IDs by stripping common prefixes for matching.
  - Clear priority: agent fallback_chain → agent variant → category fallback_chain → category variant → built-in chains.

- **Bug Fixes**
  - Require a model match when entry.model is set.
  - Correct handling of multi-provider entries with strict model checks.
  - Add tests for prefixed models, chain ordering, and mismatch edge cases.

<sup>Written for commit c1125a322bd0ac8b832615ba6f35e010c2e7decc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

