### PR TITLE
feat: update unspecified-high default model to claude-opus-4-6

### DIFF
--- a/src/tools/delegate-task/constants.ts
+++ b/src/tools/delegate-task/constants.ts
@@ -199,7 +199,7 @@ export const DEFAULT_CATEGORIES: Record<string, CategoryConfig> = {
   artistry: { model: "google/gemini-3-pro", variant: "high" },
   quick: { model: "anthropic/claude-haiku-4-5" },
   "unspecified-low": { model: "anthropic/claude-sonnet-4-5" },
-  "unspecified-high": { model: "anthropic/claude-opus-4-5", variant: "max" },
+  "unspecified-high": { model: "anthropic/claude-opus-4-6", variant: "max" },
   writing: { model: "google/gemini-3-flash" },
 }
 
@@ -347,7 +347,7 @@ FOR EVERY TASK, YOU MUST RECOMMEND:
 | \`artistry\` | Highly creative/artistic tasks, novel ideas | google/gemini-3-pro |
 | \`quick\` | Trivial tasks - single file, typo fixes | anthropic/claude-haiku-4-5 |
 | \`unspecified-low\` | Moderate effort, doesn't fit other categories | anthropic/claude-sonnet-4-5 |
-| \`unspecified-high\` | High effort, doesn't fit other categories | anthropic/claude-opus-4-5 |
+| \`unspecified-high\` | High effort, doesn't fit other categories | anthropic/claude-opus-4-6 |
 | \`writing\` | Documentation, prose, technical writing | google/gemini-3-flash |
 
 ### AVAILABLE SKILLS (ALWAYS EVALUATE ALL)


### PR DESCRIPTION
Claude Opus 4.6 was released on Feb 5, 2026.
Update DEFAULT_CATEGORIES and documentation to use opus-4-6 instead of opus-4-5 for consistency with model-requirements.ts which already has opus-4-6 in fallback chains.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Update `DEFAULT_CATEGORIES["unspecified-high"]` from `claude-opus-4-5` to `claude-opus-4-6`
- Update documentation table to reflect the new model

## Context

Claude Opus 4.6 was released on February 5, 2026. The `model-requirements.ts` already has `claude-opus-4-6` as the first fallback in the chain, but `constants.ts` still referenced the older version.
This PR ensures consistency between:
- `DEFAULT_CATEGORIES` (was 4-5, now 4-6)
- `PLAN_AGENT_SYSTEM_PREPEND` documentation table (was 4-5, now 4-6)
- `model-requirements.ts` fallback chains (already 4-6)

## Changes

<!-- What was changed and how. List specific modifications. -->

- `src/tools/delegate-task/constants.ts` line 202: model update
- `src/tools/delegate-task/constants.ts` line 350: documentation update

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the unspecified-high default model from anthropic/claude-opus-4-5 to anthropic/claude-opus-4-6 and update the embedded docs table to match. This keeps DEFAULT_CATEGORIES consistent with model-requirements fallbacks and routes high-effort tasks to the latest Opus model.

<sup>Written for commit 4391a918f0340913adfc8308da3a05c258c2d7da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

