### PR TITLE
fix(hooks): use path.isAbsolute() for cross-platform path detection on Windows

### DIFF
--- a/src/hooks/directory-agents-injector/finder.ts
+++ b/src/hooks/directory-agents-injector/finder.ts
@@ -1,11 +1,11 @@
 import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import { AGENTS_FILENAME } from "./constants";
 
 export function resolveFilePath(rootDirectory: string, path: string): string | null {
   if (!path) return null;
-  if (path.startsWith("/")) return path;
+  if (isAbsolute(path)) return path;
   return resolve(rootDirectory, path);
 }
 

--- a/src/hooks/directory-readme-injector/finder.ts
+++ b/src/hooks/directory-readme-injector/finder.ts
@@ -1,11 +1,11 @@
 import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import { README_FILENAME } from "./constants";
 
 export function resolveFilePath(rootDirectory: string, path: string): string | null {
   if (!path) return null;
-  if (path.startsWith("/")) return path;
+  if (isAbsolute(path)) return path;
   return resolve(rootDirectory, path);
 }
 


### PR DESCRIPTION
## Summary

- Replace `path.startsWith('/')` with `path.isAbsolute()` in directory injector hooks for proper Windows path support

## Problem

`resolveFilePath()` in both `directory-agents-injector` and `directory-readme-injector` uses `path.startsWith('/')` to detect absolute paths. This only works on Unix-like systems where absolute paths begin with `/`.

On Windows, absolute paths start with drive letters (e.g., `C:\Users\...`), so the check fails and the function incorrectly treats them as relative paths, prepending `ctx.directory`.

## Fix

Use Node.js built-in `path.isAbsolute()` which correctly handles both Unix (`/path`) and Windows (`C:\path`, `\server\share`) absolute path formats.

This follows the same pattern already used in `src/features/claude-tasks/storage.ts` (commit 8e349aa).

## Changes (2 files)

| File | Change |
|------|--------|
| `src/hooks/directory-agents-injector/index.ts` | `path.startsWith('/') → isAbsolute(path)` |
| `src/hooks/directory-readme-injector/index.ts` | `path.startsWith('/') → isAbsolute(path)` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Node’s path.isAbsolute() in the directory-agents-injector and directory-readme-injector finders to correctly detect absolute paths on all platforms, fixing Windows path resolution for AGENTS.md and README.md injection.

- **Bug Fixes**
  - Windows absolute paths (e.g., C:\..., \\server\share) are no longer treated as relative or prefixed with the project directory.

<sup>Written for commit c298351d88de9eca0f727798e26a039f009b6c9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

