### PR TITLE
feat: add native agent teams toolset

### DIFF
--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -15,6 +15,8 @@ export const ExperimentalConfigSchema = z.object({
   plugin_load_timeout_ms: z.number().min(1000).optional(),
   /** Wrap hook creation in try/catch to prevent one failing hook from crashing the plugin (default: true at call site) */
   safe_hook_creation: z.boolean().optional(),
+  /** Enable experimental agent teams toolset (default: false) */
+  agent_teams: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -19,6 +19,7 @@ import {
   createAstGrepTools,
   createSessionManagerTools,
   createDelegateTask,
+  createAgentTeamsTools,
   discoverCommandsSync,
   interactive_bash,
   createTaskCreateTool,
@@ -117,6 +118,15 @@ export function createToolRegistry(args: {
       }
     : {}
 
+  const agentTeamsEnabled = pluginConfig.experimental?.agent_teams ?? false
+  const agentTeamsRecord: Record<string, ToolDefinition> = agentTeamsEnabled
+    ? createAgentTeamsTools(managers.backgroundManager, {
+        client: ctx.client,
+        userCategories: pluginConfig.categories,
+        sisyphusJuniorModel: pluginConfig.agents?.["sisyphus-junior"]?.model,
+      })
+    : {}
+
   const allTools: Record<string, ToolDefinition> = {
     ...builtinTools,
     ...createGrepTools(ctx),
@@ -132,6 +142,7 @@ export function createToolRegistry(args: {
     slashcommand: slashcommandTool,
     interactive_bash,
     ...taskToolsRecord,
+    ...agentTeamsRecord,
   }
 
   const filteredTools = filterDisabledTools(allTools, pluginConfig.disabled_tools)

--- a/src/tools/agent-teams/delegation-consistency.test.ts
+++ b/src/tools/agent-teams/delegation-consistency.test.ts
@@ -1,0 +1,189 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundManager } from "../../features/background-agent"
+import { createAgentTeamsTools } from "./tools"
+
+interface LaunchCall {
+  description: string
+  prompt: string
+  agent: string
+  parentSessionID: string
+  parentMessageID: string
+  parentAgent?: string
+  parentModel?: {
+    providerID: string
+    modelID: string
+    variant?: string
+  }
+}
+
+interface ResumeCall {
+  sessionId: string
+  prompt: string
+  parentSessionID: string
+  parentMessageID: string
+  parentAgent?: string
+  parentModel?: {
+    providerID: string
+    modelID: string
+    variant?: string
+  }
+}
+
+interface ToolContextLike {
+  sessionID: string
+  messageID: string
+  abort: AbortSignal
+  agent?: string
+}
+
+function createMockManager(): {
+  manager: BackgroundManager
+  launchCalls: LaunchCall[]
+  resumeCalls: ResumeCall[]
+} {
+  const launchCalls: LaunchCall[] = []
+  const resumeCalls: ResumeCall[] = []
+  const launchedTasks = new Map<string, { id: string; sessionID: string }>()
+  let launchCount = 0
+
+  const manager = {
+    launch: async (args: LaunchCall) => {
+      launchCount += 1
+      launchCalls.push(args)
+      const task = { id: `bg-${launchCount}`, sessionID: `ses-worker-${launchCount}` }
+      launchedTasks.set(task.id, task)
+      return task
+    },
+    getTask: (taskId: string) => launchedTasks.get(taskId),
+    resume: async (args: ResumeCall) => {
+      resumeCalls.push(args)
+      return { id: `resume-${resumeCalls.length}` }
+    },
+  } as unknown as BackgroundManager
+
+  return { manager, launchCalls, resumeCalls }
+}
+
+async function executeJsonTool(
+  tools: ReturnType<typeof createAgentTeamsTools>,
+  toolName: keyof ReturnType<typeof createAgentTeamsTools>,
+  args: Record<string, unknown>,
+  context: ToolContextLike,
+): Promise<unknown> {
+  const output = await tools[toolName].execute(args, context as any)
+  return JSON.parse(output)
+}
+
+describe("agent-teams delegation consistency", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-consistency-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("team delegation forwards parent context like normal delegate-task", async () => {
+    //#given
+    const { manager, launchCalls, resumeCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext: ToolContextLike = {
+      sessionID: "ses-main",
+      messageID: "msg-main",
+      abort: new AbortController().signal,
+    }
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    //#when
+    const spawnResult = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    ) as { error?: string }
+
+    //#then
+    expect(spawnResult.error).toBeUndefined()
+    expect(launchCalls).toHaveLength(1)
+    expect(launchCalls[0].parentAgent).toBe("sisyphus")
+    expect("parentModel" in launchCalls[0]).toBe(true)
+
+    //#when
+    const messageResult = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      leadContext,
+    ) as { error?: string }
+
+    //#then
+    expect(messageResult.error).toBeUndefined()
+    expect(resumeCalls).toHaveLength(1)
+    expect(resumeCalls[0].parentAgent).toBe("sisyphus")
+    expect("parentModel" in resumeCalls[0]).toBe(true)
+  })
+
+  test("send_message accepts teammate agent_id as recipient", async () => {
+    //#given
+    const { manager, resumeCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext: ToolContextLike = {
+      sessionID: "ses-main",
+      messageID: "msg-main",
+      abort: new AbortController().signal,
+    }
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    )
+
+    //#when
+    const messageResult = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1@core",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      leadContext,
+    ) as { error?: string }
+
+    //#then
+    expect(messageResult.error).toBeUndefined()
+    expect(resumeCalls).toHaveLength(1)
+  })
+})

--- a/src/tools/agent-teams/delegation-consistency.test.ts
+++ b/src/tools/agent-teams/delegation-consistency.test.ts
@@ -101,6 +101,7 @@ describe("agent-teams delegation consistency", () => {
       sessionID: "ses-main",
       messageID: "msg-main",
       abort: new AbortController().signal,
+      agent: "sisyphus",
     }
 
     await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)

--- a/src/tools/agent-teams/inbox-store.test.ts
+++ b/src/tools/agent-teams/inbox-store.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { appendInboxMessage, ensureInbox, readInbox } from "./inbox-store"
+import { getTeamInboxPath } from "./paths"
+
+describe("agent-teams inbox store", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-inbox-store-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("readInbox fails on malformed inbox JSON without overwriting file", () => {
+    //#given
+    ensureInbox("core", "team-lead")
+    const inboxPath = getTeamInboxPath("core", "team-lead")
+    writeFileSync(inboxPath, "{", "utf-8")
+
+    //#when
+    const readMalformedInbox = () => readInbox("core", "team-lead", false, false)
+
+    //#then
+    expect(readMalformedInbox).toThrow("team_inbox_parse_failed")
+    expect(readFileSync(inboxPath, "utf-8")).toBe("{")
+  })
+
+  test("appendInboxMessage fails on schema-invalid inbox JSON without overwriting file", () => {
+    //#given
+    ensureInbox("core", "team-lead")
+    const inboxPath = getTeamInboxPath("core", "team-lead")
+    writeFileSync(inboxPath, JSON.stringify({ invalid: true }), "utf-8")
+
+    //#when
+    const appendIntoInvalidInbox = () => {
+      appendInboxMessage("core", "team-lead", {
+        from: "team-lead",
+        text: "hello",
+        timestamp: new Date().toISOString(),
+        read: false,
+        summary: "note",
+      })
+    }
+
+    //#then
+    expect(appendIntoInvalidInbox).toThrow("team_inbox_schema_invalid")
+    expect(readFileSync(inboxPath, "utf-8")).toBe(JSON.stringify({ invalid: true }))
+  })
+})

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { z } from "zod"
+import { acquireLock, ensureDir } from "../../features/claude-tasks/storage"
+import { getTeamInboxDir, getTeamInboxPath } from "./paths"
+import { TeamInboxMessage, TeamInboxMessageSchema } from "./types"
+
+const TeamInboxListSchema = z.array(TeamInboxMessageSchema)
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function withInboxLock<T>(teamName: string, operation: () => T): T {
+  const inboxDir = getTeamInboxDir(teamName)
+  ensureDir(inboxDir)
+  const lock = acquireLock(inboxDir)
+  if (!lock.acquired) {
+    throw new Error("inbox_lock_unavailable")
+  }
+
+  try {
+    return operation()
+  } finally {
+    lock.release()
+  }
+}
+
+function parseInboxFile(content: string): TeamInboxMessage[] {
+  try {
+    const parsed = JSON.parse(content)
+    const result = TeamInboxListSchema.safeParse(parsed)
+    return result.success ? result.data : []
+  } catch {
+    return []
+  }
+}
+
+function readInboxMessages(teamName: string, agentName: string): TeamInboxMessage[] {
+  const path = getTeamInboxPath(teamName, agentName)
+  if (!existsSync(path)) {
+    return []
+  }
+  return parseInboxFile(readFileSync(path, "utf-8"))
+}
+
+function writeInboxMessages(teamName: string, agentName: string, messages: TeamInboxMessage[]): void {
+  const path = getTeamInboxPath(teamName, agentName)
+  writeFileSync(path, JSON.stringify(messages), "utf-8")
+}
+
+export function ensureInbox(teamName: string, agentName: string): void {
+  withInboxLock(teamName, () => {
+    const path = getTeamInboxPath(teamName, agentName)
+    if (!existsSync(path)) {
+      writeFileSync(path, "[]", "utf-8")
+    }
+  })
+}
+
+export function appendInboxMessage(teamName: string, agentName: string, message: TeamInboxMessage): void {
+  withInboxLock(teamName, () => {
+    const path = getTeamInboxPath(teamName, agentName)
+    if (!existsSync(path)) {
+      writeFileSync(path, "[]", "utf-8")
+    }
+    const messages = readInboxMessages(teamName, agentName)
+    messages.push(TeamInboxMessageSchema.parse(message))
+    writeInboxMessages(teamName, agentName, messages)
+  })
+}
+
+export function sendPlainInboxMessage(
+  teamName: string,
+  from: string,
+  to: string,
+  text: string,
+  summary: string,
+  color?: string,
+): void {
+  appendInboxMessage(teamName, to, {
+    from,
+    text,
+    timestamp: nowIso(),
+    read: false,
+    summary,
+    ...(color ? { color } : {}),
+  })
+}
+
+export function sendStructuredInboxMessage(
+  teamName: string,
+  from: string,
+  to: string,
+  payload: Record<string, unknown>,
+  summary?: string,
+): void {
+  appendInboxMessage(teamName, to, {
+    from,
+    text: JSON.stringify(payload),
+    timestamp: nowIso(),
+    read: false,
+    ...(summary ? { summary } : {}),
+  })
+}
+
+export function readInbox(
+  teamName: string,
+  agentName: string,
+  unreadOnly = false,
+  markAsRead = true,
+): TeamInboxMessage[] {
+  return withInboxLock(teamName, () => {
+    const messages = readInboxMessages(teamName, agentName)
+
+    const selected = unreadOnly ? messages.filter((message) => !message.read) : [...messages]
+
+    if (!markAsRead || selected.length === 0) {
+      return selected
+    }
+
+    const updated = messages.map((message) => {
+      if (!unreadOnly) {
+        return { ...message, read: true }
+      }
+
+      if (selected.some((selectedMessage) => selectedMessage.timestamp === message.timestamp && selectedMessage.from === message.from && selectedMessage.text === message.text)) {
+        return { ...message, read: true }
+      }
+      return message
+    })
+
+    writeInboxMessages(teamName, agentName, updated)
+    return selected
+  })
+}
+
+export function buildShutdownRequestId(recipient: string): string {
+  return `shutdown-${Date.now()}@${recipient}`
+}

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -42,13 +42,20 @@ function withInboxLock<T>(teamName: string, operation: () => T): T {
 }
 
 function parseInboxFile(content: string): TeamInboxMessage[] {
+  let parsed: unknown
+
   try {
-    const parsed = JSON.parse(content)
-    const result = TeamInboxListSchema.safeParse(parsed)
-    return result.success ? result.data : []
+    parsed = JSON.parse(content)
   } catch {
-    return []
+    throw new Error("team_inbox_parse_failed")
   }
+
+  const result = TeamInboxListSchema.safeParse(parsed)
+  if (!result.success) {
+    throw new Error("team_inbox_schema_invalid")
+  }
+
+  return result.data
 }
 
 function readInboxMessages(teamName: string, agentName: string): TeamInboxMessage[] {

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -84,10 +84,7 @@ export function appendInboxMessage(teamName: string, agentName: string, message:
   assertValidInboxAgentName(agentName)
   withInboxLock(teamName, () => {
     const path = getTeamInboxPath(teamName, agentName)
-    if (!existsSync(path)) {
-      writeJsonAtomic(path, [])
-    }
-    const messages = readInboxMessages(teamName, agentName)
+    const messages = existsSync(path) ? parseInboxFile(readFileSync(path, "utf-8")) : []
     messages.push(TeamInboxMessageSchema.parse(message))
     writeInboxMessages(teamName, agentName, messages)
   })
@@ -153,18 +150,27 @@ export function readInbox(
       return selected
     }
 
+    const selectedSet = unreadOnly ? new Set(selected) : null
+    let changed = false
+
     const updated = messages.map((message) => {
       if (!unreadOnly) {
+        if (!message.read) {
+          changed = true
+        }
         return { ...message, read: true }
       }
 
-      if (selected.some((selectedMessage) => selectedMessage.timestamp === message.timestamp && selectedMessage.from === message.from && selectedMessage.text === message.text)) {
+      if (selectedSet?.has(message)) {
+        changed = true
         return { ...message, read: true }
       }
       return message
     })
 
-    writeInboxMessages(teamName, agentName, updated)
+    if (changed) {
+      writeInboxMessages(teamName, agentName, updated)
+    }
     return selected
   })
 }

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { z } from "zod"
 import { acquireLock, ensureDir, writeJsonAtomic } from "../../features/claude-tasks/storage"
 import { getTeamInboxDir, getTeamInboxPath } from "./paths"

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -144,24 +144,28 @@ export function readInbox(
   return withInboxLock(teamName, () => {
     const messages = readInboxMessages(teamName, agentName)
 
-    const selected = unreadOnly ? messages.filter((message) => !message.read) : [...messages]
+    const selectedIndexes = new Set<number>()
+    const selected = unreadOnly
+      ? messages.filter((message, index) => {
+          if (!message.read) {
+            selectedIndexes.add(index)
+            return true
+          }
+          return false
+        })
+      : messages.map((message, index) => {
+          selectedIndexes.add(index)
+          return message
+        })
 
     if (!markAsRead || selected.length === 0) {
       return selected
     }
 
-    const selectedSet = unreadOnly ? new Set(selected) : null
     let changed = false
 
-    const updated = messages.map((message) => {
-      if (!unreadOnly) {
-        if (!message.read) {
-          changed = true
-        }
-        return { ...message, read: true }
-      }
-
-      if (selectedSet?.has(message)) {
+    const updated = messages.map((message, index) => {
+      if (selectedIndexes.has(index) && !message.read) {
         changed = true
         return { ...message, read: true }
       }
@@ -171,7 +175,7 @@ export function readInbox(
     if (changed) {
       writeInboxMessages(teamName, agentName, updated)
     }
-    return selected
+    return updated.filter((_, index) => selectedIndexes.has(index))
   })
 }
 

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { z } from "zod"
-import { acquireLock, ensureDir } from "../../features/claude-tasks/storage"
+import { acquireLock, ensureDir, writeJsonAtomic } from "../../features/claude-tasks/storage"
 import { getTeamInboxDir, getTeamInboxPath } from "./paths"
+import { validateAgentNameOrLead, validateTeamName } from "./name-validation"
 import { TeamInboxMessage, TeamInboxMessageSchema } from "./types"
 
 const TeamInboxListSchema = z.array(TeamInboxMessageSchema)
@@ -10,7 +11,22 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+function assertValidTeamName(teamName: string): void {
+  const validationError = validateTeamName(teamName)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
+function assertValidInboxAgentName(agentName: string): void {
+  const validationError = validateAgentNameOrLead(agentName)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
 function withInboxLock<T>(teamName: string, operation: () => T): T {
+  assertValidTeamName(teamName)
   const inboxDir = getTeamInboxDir(teamName)
   ensureDir(inboxDir)
   const lock = acquireLock(inboxDir)
@@ -36,6 +52,8 @@ function parseInboxFile(content: string): TeamInboxMessage[] {
 }
 
 function readInboxMessages(teamName: string, agentName: string): TeamInboxMessage[] {
+  assertValidTeamName(teamName)
+  assertValidInboxAgentName(agentName)
   const path = getTeamInboxPath(teamName, agentName)
   if (!existsSync(path)) {
     return []
@@ -44,24 +62,30 @@ function readInboxMessages(teamName: string, agentName: string): TeamInboxMessag
 }
 
 function writeInboxMessages(teamName: string, agentName: string, messages: TeamInboxMessage[]): void {
+  assertValidTeamName(teamName)
+  assertValidInboxAgentName(agentName)
   const path = getTeamInboxPath(teamName, agentName)
-  writeFileSync(path, JSON.stringify(messages), "utf-8")
+  writeJsonAtomic(path, messages)
 }
 
 export function ensureInbox(teamName: string, agentName: string): void {
+  assertValidTeamName(teamName)
+  assertValidInboxAgentName(agentName)
   withInboxLock(teamName, () => {
     const path = getTeamInboxPath(teamName, agentName)
     if (!existsSync(path)) {
-      writeFileSync(path, "[]", "utf-8")
+      writeJsonAtomic(path, [])
     }
   })
 }
 
 export function appendInboxMessage(teamName: string, agentName: string, message: TeamInboxMessage): void {
+  assertValidTeamName(teamName)
+  assertValidInboxAgentName(agentName)
   withInboxLock(teamName, () => {
     const path = getTeamInboxPath(teamName, agentName)
     if (!existsSync(path)) {
-      writeFileSync(path, "[]", "utf-8")
+      writeJsonAtomic(path, [])
     }
     const messages = readInboxMessages(teamName, agentName)
     messages.push(TeamInboxMessageSchema.parse(message))

--- a/src/tools/agent-teams/inbox-store.ts
+++ b/src/tools/agent-teams/inbox-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, unlinkSync } from "node:fs"
 import { z } from "zod"
 import { acquireLock, ensureDir, writeJsonAtomic } from "../../features/claude-tasks/storage"
 import { getTeamInboxDir, getTeamInboxPath } from "./paths"
@@ -90,6 +90,17 @@ export function appendInboxMessage(teamName: string, agentName: string, message:
     const messages = readInboxMessages(teamName, agentName)
     messages.push(TeamInboxMessageSchema.parse(message))
     writeInboxMessages(teamName, agentName, messages)
+  })
+}
+
+export function clearInbox(teamName: string, agentName: string): void {
+  assertValidTeamName(teamName)
+  assertValidInboxAgentName(agentName)
+  withInboxLock(teamName, () => {
+    const path = getTeamInboxPath(teamName, agentName)
+    if (existsSync(path)) {
+      unlinkSync(path)
+    }
   })
 }
 

--- a/src/tools/agent-teams/index.ts
+++ b/src/tools/agent-teams/index.ts
@@ -1,0 +1,1 @@
+export { createAgentTeamsTools } from "./tools"

--- a/src/tools/agent-teams/messaging-tools.test.ts
+++ b/src/tools/agent-teams/messaging-tools.test.ts
@@ -138,6 +138,38 @@ describe("agent-teams messaging tools", () => {
     expect(resumeCalls).toHaveLength(0)
   })
 
+  test("send_message rejects recipient with empty team suffix", async () => {
+    //#given
+    const { manager, resumeCalls } = createManagerWithImmediateResume()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      { team_name: "core", name: "worker_1", prompt: "Handle release prep", category: "quick" },
+      leadContext,
+    )
+
+    //#when
+    const invalidRecipient = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1@",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      leadContext,
+    ) as { error?: string }
+
+    //#then
+    expect(invalidRecipient.error).toBe("recipient_team_invalid")
+    expect(resumeCalls).toHaveLength(0)
+  })
+
   test("broadcast schedules teammate resumes without serial await", async () => {
     //#given
     const { manager, resumeCalls, resolveAllResumes } = createManagerWithDeferredResume()

--- a/src/tools/agent-teams/messaging-tools.test.ts
+++ b/src/tools/agent-teams/messaging-tools.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundManager } from "../../features/background-agent"
+import { createAgentTeamsTools } from "./tools"
+
+interface TestToolContext {
+  sessionID: string
+  messageID: string
+  agent: string
+  abort: AbortSignal
+}
+
+interface ResumeCall {
+  sessionId: string
+  prompt: string
+}
+
+function createContext(sessionID = "ses-main"): TestToolContext {
+  return {
+    sessionID,
+    messageID: "msg-main",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+  }
+}
+
+async function executeJsonTool(
+  tools: ReturnType<typeof createAgentTeamsTools>,
+  toolName: keyof ReturnType<typeof createAgentTeamsTools>,
+  args: Record<string, unknown>,
+  context: TestToolContext,
+): Promise<unknown> {
+  const output = await tools[toolName].execute(args, context)
+  return JSON.parse(output)
+}
+
+function createManagerWithImmediateResume(): { manager: BackgroundManager; resumeCalls: ResumeCall[] } {
+  const resumeCalls: ResumeCall[] = []
+  let launchCount = 0
+
+  const manager = {
+    launch: async () => {
+      launchCount += 1
+      return { id: `bg-${launchCount}`, sessionID: `ses-worker-${launchCount}` }
+    },
+    getTask: () => undefined,
+    resume: async (args: ResumeCall) => {
+      resumeCalls.push(args)
+      return { id: `resume-${resumeCalls.length}` }
+    },
+  } as unknown as BackgroundManager
+
+  return { manager, resumeCalls }
+}
+
+function createManagerWithDeferredResume(): {
+  manager: BackgroundManager
+  resumeCalls: ResumeCall[]
+  resolveAllResumes: () => void
+} {
+  const resumeCalls: ResumeCall[] = []
+  const pendingResolves: Array<() => void> = []
+  let launchCount = 0
+
+  const manager = {
+    launch: async () => {
+      launchCount += 1
+      return { id: `bg-${launchCount}`, sessionID: `ses-worker-${launchCount}` }
+    },
+    getTask: () => undefined,
+    resume: (args: ResumeCall) => {
+      resumeCalls.push(args)
+      return new Promise<{ id: string }>((resolve) => {
+        pendingResolves.push(() => resolve({ id: `resume-${resumeCalls.length}` }))
+      })
+    },
+  } as unknown as BackgroundManager
+
+  return {
+    manager,
+    resumeCalls,
+    resolveAllResumes: () => {
+      while (pendingResolves.length > 0) {
+        const next = pendingResolves.shift()
+        next?.()
+      }
+    },
+  }
+}
+
+describe("agent-teams messaging tools", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-messaging-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("send_message rejects recipient team suffix mismatch", async () => {
+    //#given
+    const { manager, resumeCalls } = createManagerWithImmediateResume()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      { team_name: "core", name: "worker_1", prompt: "Handle release prep", category: "quick" },
+      leadContext,
+    )
+
+    //#when
+    const mismatchedRecipient = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1@other-team",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      leadContext,
+    ) as { error?: string }
+
+    //#then
+    expect(mismatchedRecipient.error).toBe("recipient_team_mismatch")
+    expect(resumeCalls).toHaveLength(0)
+  })
+
+  test("broadcast schedules teammate resumes without serial await", async () => {
+    //#given
+    const { manager, resumeCalls, resolveAllResumes } = createManagerWithDeferredResume()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    for (const name of ["worker_1", "worker_2", "worker_3"]) {
+      await executeJsonTool(
+        tools,
+        "spawn_teammate",
+        { team_name: "core", name, prompt: "Handle release prep", category: "quick" },
+        leadContext,
+      )
+    }
+
+    //#when
+    const broadcastPromise = executeJsonTool(
+      tools,
+      "send_message",
+      { team_name: "core", type: "broadcast", summary: "sync", content: "Please update status." },
+      leadContext,
+    ) as Promise<{ success?: boolean; message?: string }>
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    //#then
+    expect(resumeCalls).toHaveLength(3)
+
+    //#when
+    resolveAllResumes()
+    const broadcastResult = await broadcastPromise
+
+    //#then
+    expect(broadcastResult.success).toBe(true)
+    expect(broadcastResult.message).toBe("broadcast_sent:3")
+  })
+})

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -1,7 +1,7 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import type { BackgroundManager } from "../../features/background-agent"
 import { buildShutdownRequestId, readInbox, sendPlainInboxMessage, sendStructuredInboxMessage } from "./inbox-store"
-import { getTeamMember, listTeammates, readTeamConfigOrThrow } from "./team-config-store"
+import { getTeamMember, listTeammates, readTeamConfigOrThrow, updateTeamConfig } from "./team-config-store"
 import { validateAgentNameOrLead, validateTeamName } from "./name-validation"
 import { resumeTeammateWithMessage } from "./teammate-runtime"
 import {
@@ -23,6 +23,13 @@ function resolveSenderFromContext(config: TeamConfig, context: TeamToolContext):
 
   const matchedMember = config.members.find((member) => isTeammateMember(member) && member.sessionID === context.sessionID)
   return matchedMember?.name ?? null
+}
+
+function claimLeadSession(teamName: string, nextLeadSessionId: string): TeamConfig {
+  return updateTeamConfig(teamName, (current) => ({
+    ...current,
+    leadSessionId: nextLeadSessionId,
+  }))
 }
 
 export function createSendMessageTool(manager: BackgroundManager): ToolDefinition {
@@ -50,8 +57,12 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
         if (senderError) {
           return JSON.stringify({ error: senderError })
         }
-        const config = readTeamConfigOrThrow(input.team_name)
-        const actor = resolveSenderFromContext(config, context)
+        let config = readTeamConfigOrThrow(input.team_name)
+        let actor = resolveSenderFromContext(config, context)
+        if (!actor && requestedSender === "team-lead") {
+          config = claimLeadSession(input.team_name, context.sessionID)
+          actor = "team-lead"
+        }
         if (!actor) {
           return JSON.stringify({ error: "unauthorized_sender_session" })
         }
@@ -223,8 +234,12 @@ export function createReadInboxTool(): ToolDefinition {
         if (agentError) {
           return JSON.stringify({ error: agentError })
         }
-        const config = readTeamConfigOrThrow(input.team_name)
-        const actor = resolveSenderFromContext(config, context)
+        let config = readTeamConfigOrThrow(input.team_name)
+        let actor = resolveSenderFromContext(config, context)
+        if (!actor && input.agent_name === "team-lead") {
+          config = claimLeadSession(input.team_name, context.sessionID)
+          actor = "team-lead"
+        }
         if (!actor) {
           return JSON.stringify({ error: "unauthorized_reader_session" })
         }

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -212,7 +212,7 @@ export function createReadInboxTool(): ToolDefinition {
       unread_only: tool.schema.boolean().optional().describe("Return only unread messages"),
       mark_as_read: tool.schema.boolean().optional().describe("Mark returned messages as read"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamReadInboxInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
@@ -223,7 +223,15 @@ export function createReadInboxTool(): ToolDefinition {
         if (agentError) {
           return JSON.stringify({ error: agentError })
         }
-        readTeamConfigOrThrow(input.team_name)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveSenderFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_reader_session" })
+        }
+
+        if (actor !== "team-lead" && actor !== input.agent_name) {
+          return JSON.stringify({ error: "unauthorized_reader_session" })
+        }
 
         const messages = readInbox(
           input.team_name,

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -16,6 +16,25 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+function validateRecipientTeam(recipient: unknown, teamName: string): string | null {
+  if (typeof recipient !== "string") {
+    return null
+  }
+
+  const trimmed = recipient.trim()
+  const atIndex = trimmed.indexOf("@")
+  if (atIndex <= 0) {
+    return null
+  }
+
+  const specifiedTeam = trimmed.slice(atIndex + 1).trim()
+  if (!specifiedTeam || specifiedTeam === teamName) {
+    return null
+  }
+
+  return "recipient_team_mismatch"
+}
+
 function resolveSenderFromContext(config: TeamConfig, context: TeamToolContext): string | null {
   if (context.sessionID === config.leadSessionId) {
     return "team-lead"
@@ -44,6 +63,10 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
         const teamError = validateTeamName(input.team_name)
         if (teamError) {
           return JSON.stringify({ error: teamError })
+        }
+        const recipientTeamError = validateRecipientTeam(args.recipient, input.team_name)
+        if (recipientTeamError) {
+          return JSON.stringify({ error: recipientTeamError })
         }
         const requestedSender = input.sender
         const senderError = requestedSender ? validateAgentNameOrLead(requestedSender) : null
@@ -88,11 +111,16 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
           if (!input.summary) {
             return JSON.stringify({ error: "broadcast_requires_summary" })
           }
+          const broadcastSummary = input.summary
           const teammates = listTeammates(config)
           for (const teammate of teammates) {
-            sendPlainInboxMessage(input.team_name, sender, teammate.name, input.content ?? "", input.summary)
-            await resumeTeammateWithMessage(manager, context, input.team_name, teammate, input.summary, input.content ?? "")
+            sendPlainInboxMessage(input.team_name, sender, teammate.name, input.content ?? "", broadcastSummary)
           }
+          await Promise.allSettled(
+            teammates.map((teammate) =>
+              resumeTeammateWithMessage(manager, context, input.team_name, teammate, broadcastSummary, input.content ?? ""),
+            ),
+          )
           return JSON.stringify({ success: true, message: `broadcast_sent:${teammates.length}` })
         }
 

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -28,7 +28,10 @@ function validateRecipientTeam(recipient: unknown, teamName: string): string | n
   }
 
   const specifiedTeam = trimmed.slice(atIndex + 1).trim()
-  if (!specifiedTeam || specifiedTeam === teamName) {
+  if (!specifiedTeam) {
+    return "recipient_team_invalid"
+  }
+  if (specifiedTeam === teamName) {
     return null
   }
 
@@ -55,7 +58,10 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
       summary: tool.schema.string().optional().describe("Short summary"),
       request_id: tool.schema.string().optional().describe("Protocol request id"),
       approve: tool.schema.boolean().optional().describe("Approval flag"),
-      sender: tool.schema.string().optional().describe("Sender name (default: team-lead)"),
+      sender: tool.schema
+        .string()
+        .optional()
+        .describe("Sender name inferred from calling session; explicit value must match resolved sender."),
     },
     execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -1,0 +1,199 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import type { BackgroundManager } from "../../features/background-agent"
+import { buildShutdownRequestId, readInbox, sendPlainInboxMessage, sendStructuredInboxMessage } from "./inbox-store"
+import { getTeamMember, listTeammates, readTeamConfigOrThrow } from "./team-config-store"
+import { resumeTeammateWithMessage } from "./teammate-runtime"
+import {
+  TeamReadInboxInputSchema,
+  TeamSendMessageInputSchema,
+  TeamToolContext,
+  isTeammateMember,
+} from "./types"
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export function createSendMessageTool(manager: BackgroundManager): ToolDefinition {
+  return tool({
+    description: "Send direct or broadcast team messages and protocol responses.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      type: tool.schema.enum(["message", "broadcast", "shutdown_request", "shutdown_response", "plan_approval_response"]),
+      recipient: tool.schema.string().optional().describe("Message recipient"),
+      content: tool.schema.string().optional().describe("Message body"),
+      summary: tool.schema.string().optional().describe("Short summary"),
+      request_id: tool.schema.string().optional().describe("Protocol request id"),
+      approve: tool.schema.boolean().optional().describe("Approval flag"),
+      sender: tool.schema.string().optional().describe("Sender name (default: team-lead)"),
+    },
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
+      try {
+        const input = TeamSendMessageInputSchema.parse(args)
+        const sender = input.sender ?? "team-lead"
+        const config = readTeamConfigOrThrow(input.team_name)
+        const memberNames = new Set(config.members.map((member) => member.name))
+
+        if (input.type === "message") {
+          if (!input.recipient || !input.summary || !input.content) {
+            return JSON.stringify({ error: "message_requires_recipient_summary_content" })
+          }
+          if (!memberNames.has(input.recipient)) {
+            return JSON.stringify({ error: "message_recipient_not_found" })
+          }
+
+          const targetMember = getTeamMember(config, input.recipient)
+          const color = targetMember && isTeammateMember(targetMember) ? targetMember.color : undefined
+          sendPlainInboxMessage(input.team_name, sender, input.recipient, input.content, input.summary, color)
+
+          if (targetMember && isTeammateMember(targetMember)) {
+            await resumeTeammateWithMessage(manager, context, input.team_name, targetMember, input.summary, input.content)
+          }
+
+          return JSON.stringify({ success: true, message: `message_sent:${input.recipient}` })
+        }
+
+        if (input.type === "broadcast") {
+          if (!input.summary) {
+            return JSON.stringify({ error: "broadcast_requires_summary" })
+          }
+          const teammates = listTeammates(config)
+          for (const teammate of teammates) {
+            sendPlainInboxMessage(input.team_name, sender, teammate.name, input.content ?? "", input.summary)
+            await resumeTeammateWithMessage(manager, context, input.team_name, teammate, input.summary, input.content ?? "")
+          }
+          return JSON.stringify({ success: true, message: `broadcast_sent:${teammates.length}` })
+        }
+
+        if (input.type === "shutdown_request") {
+          if (!input.recipient) {
+            return JSON.stringify({ error: "shutdown_request_requires_recipient" })
+          }
+          if (input.recipient === "team-lead") {
+            return JSON.stringify({ error: "cannot_shutdown_team_lead" })
+          }
+          const targetMember = getTeamMember(config, input.recipient)
+          if (!targetMember || !isTeammateMember(targetMember)) {
+            return JSON.stringify({ error: "shutdown_recipient_not_found" })
+          }
+
+          const requestId = buildShutdownRequestId(input.recipient)
+          sendStructuredInboxMessage(
+            input.team_name,
+            "team-lead",
+            input.recipient,
+            {
+              type: "shutdown_request",
+              requestId,
+              from: "team-lead",
+              reason: input.content ?? "",
+              timestamp: nowIso(),
+            },
+            "shutdown_request",
+          )
+
+          await resumeTeammateWithMessage(
+            manager,
+            context,
+            input.team_name,
+            targetMember,
+            "shutdown_request",
+            input.content ?? "Shutdown requested",
+          )
+
+          return JSON.stringify({ success: true, request_id: requestId, target: input.recipient })
+        }
+
+        if (input.type === "shutdown_response") {
+          if (!input.request_id) {
+            return JSON.stringify({ error: "shutdown_response_requires_request_id" })
+          }
+          if (input.approve) {
+            sendStructuredInboxMessage(
+              input.team_name,
+              sender,
+              "team-lead",
+              {
+                type: "shutdown_approved",
+                requestId: input.request_id,
+                from: sender,
+                timestamp: nowIso(),
+                backendType: "native",
+              },
+              "shutdown_approved",
+            )
+            return JSON.stringify({ success: true, message: `shutdown_approved:${input.request_id}` })
+          }
+
+          sendPlainInboxMessage(
+            input.team_name,
+            sender,
+            "team-lead",
+            input.content ?? "Shutdown rejected",
+            "shutdown_rejected",
+          )
+          return JSON.stringify({ success: true, message: `shutdown_rejected:${input.request_id}` })
+        }
+
+        if (!input.recipient) {
+          return JSON.stringify({ error: "plan_response_requires_recipient" })
+        }
+        if (!memberNames.has(input.recipient)) {
+          return JSON.stringify({ error: "plan_response_recipient_not_found" })
+        }
+
+        if (input.approve) {
+          sendStructuredInboxMessage(
+            input.team_name,
+            sender,
+            input.recipient,
+            {
+              type: "plan_approval",
+              approved: true,
+              requestId: input.request_id,
+            },
+            "plan_approved",
+          )
+          return JSON.stringify({ success: true, message: `plan_approved:${input.recipient}` })
+        }
+
+        sendPlainInboxMessage(
+          input.team_name,
+          sender,
+          input.recipient,
+          input.content ?? "Plan rejected",
+          "plan_rejected",
+        )
+        return JSON.stringify({ success: true, message: `plan_rejected:${input.recipient}` })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "send_message_failed" })
+      }
+    },
+  })
+}
+
+export function createReadInboxTool(): ToolDefinition {
+  return tool({
+    description: "Read inbox messages for a team member.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      agent_name: tool.schema.string().describe("Member name"),
+      unread_only: tool.schema.boolean().optional().describe("Return only unread messages"),
+      mark_as_read: tool.schema.boolean().optional().describe("Mark returned messages as read"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamReadInboxInputSchema.parse(args)
+        const messages = readInbox(
+          input.team_name,
+          input.agent_name,
+          input.unread_only ?? false,
+          input.mark_as_read ?? true,
+        )
+        return JSON.stringify(messages)
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "read_inbox_failed" })
+      }
+    },
+  })
+}

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -2,6 +2,7 @@ import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import type { BackgroundManager } from "../../features/background-agent"
 import { buildShutdownRequestId, readInbox, sendPlainInboxMessage, sendStructuredInboxMessage } from "./inbox-store"
 import { getTeamMember, listTeammates, readTeamConfigOrThrow } from "./team-config-store"
+import { validateAgentNameOrLead, validateTeamName } from "./name-validation"
 import { resumeTeammateWithMessage } from "./teammate-runtime"
 import {
   TeamReadInboxInputSchema,
@@ -30,9 +31,20 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
     execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamSendMessageInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
         const sender = input.sender ?? "team-lead"
+        const senderError = validateAgentNameOrLead(sender)
+        if (senderError) {
+          return JSON.stringify({ error: senderError })
+        }
         const config = readTeamConfigOrThrow(input.team_name)
         const memberNames = new Set(config.members.map((member) => member.name))
+        if (sender !== "team-lead" && !memberNames.has(sender)) {
+          return JSON.stringify({ error: "invalid_sender" })
+        }
 
         if (input.type === "message") {
           if (!input.recipient || !input.summary || !input.content) {
@@ -184,6 +196,16 @@ export function createReadInboxTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamReadInboxInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
+        const agentError = validateAgentNameOrLead(input.agent_name)
+        if (agentError) {
+          return JSON.stringify({ error: agentError })
+        }
+        readTeamConfigOrThrow(input.team_name)
+
         const messages = readInbox(
           input.team_name,
           input.agent_name,

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -5,6 +5,7 @@ import { getTeamMember, listTeammates, readTeamConfigOrThrow } from "./team-conf
 import { validateAgentNameOrLead, validateTeamName } from "./name-validation"
 import { resumeTeammateWithMessage } from "./teammate-runtime"
 import {
+  TeamConfig,
   TeamReadInboxInputSchema,
   TeamSendMessageInputSchema,
   TeamToolContext,
@@ -13,6 +14,15 @@ import {
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+function resolveSenderFromContext(config: TeamConfig, context: TeamToolContext): string | null {
+  if (context.sessionID === config.leadSessionId) {
+    return "team-lead"
+  }
+
+  const matchedMember = config.members.find((member) => isTeammateMember(member) && member.sessionID === context.sessionID)
+  return matchedMember?.name ?? null
 }
 
 export function createSendMessageTool(manager: BackgroundManager): ToolDefinition {
@@ -35,12 +45,21 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
         if (teamError) {
           return JSON.stringify({ error: teamError })
         }
-        const sender = input.sender ?? "team-lead"
-        const senderError = validateAgentNameOrLead(sender)
+        const requestedSender = input.sender
+        const senderError = requestedSender ? validateAgentNameOrLead(requestedSender) : null
         if (senderError) {
           return JSON.stringify({ error: senderError })
         }
         const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveSenderFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_sender_session" })
+        }
+        if (requestedSender && requestedSender !== actor) {
+          return JSON.stringify({ error: "sender_context_mismatch" })
+        }
+        const sender = requestedSender ?? actor
+
         const memberNames = new Set(config.members.map((member) => member.name))
         if (sender !== "team-lead" && !memberNames.has(sender)) {
           return JSON.stringify({ error: "invalid_sender" })
@@ -92,12 +111,12 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
           const requestId = buildShutdownRequestId(input.recipient)
           sendStructuredInboxMessage(
             input.team_name,
-            "team-lead",
+            sender,
             input.recipient,
             {
               type: "shutdown_request",
               requestId,
-              from: "team-lead",
+              from: sender,
               reason: input.content ?? "",
               timestamp: nowIso(),
             },

--- a/src/tools/agent-teams/messaging-tools.ts
+++ b/src/tools/agent-teams/messaging-tools.ts
@@ -1,7 +1,7 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import type { BackgroundManager } from "../../features/background-agent"
 import { buildShutdownRequestId, readInbox, sendPlainInboxMessage, sendStructuredInboxMessage } from "./inbox-store"
-import { getTeamMember, listTeammates, readTeamConfigOrThrow, updateTeamConfig } from "./team-config-store"
+import { getTeamMember, listTeammates, readTeamConfigOrThrow } from "./team-config-store"
 import { validateAgentNameOrLead, validateTeamName } from "./name-validation"
 import { resumeTeammateWithMessage } from "./teammate-runtime"
 import {
@@ -23,13 +23,6 @@ function resolveSenderFromContext(config: TeamConfig, context: TeamToolContext):
 
   const matchedMember = config.members.find((member) => isTeammateMember(member) && member.sessionID === context.sessionID)
   return matchedMember?.name ?? null
-}
-
-function claimLeadSession(teamName: string, nextLeadSessionId: string): TeamConfig {
-  return updateTeamConfig(teamName, (current) => ({
-    ...current,
-    leadSessionId: nextLeadSessionId,
-  }))
 }
 
 export function createSendMessageTool(manager: BackgroundManager): ToolDefinition {
@@ -57,12 +50,8 @@ export function createSendMessageTool(manager: BackgroundManager): ToolDefinitio
         if (senderError) {
           return JSON.stringify({ error: senderError })
         }
-        let config = readTeamConfigOrThrow(input.team_name)
-        let actor = resolveSenderFromContext(config, context)
-        if (!actor && requestedSender === "team-lead") {
-          config = claimLeadSession(input.team_name, context.sessionID)
-          actor = "team-lead"
-        }
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveSenderFromContext(config, context)
         if (!actor) {
           return JSON.stringify({ error: "unauthorized_sender_session" })
         }
@@ -234,12 +223,8 @@ export function createReadInboxTool(): ToolDefinition {
         if (agentError) {
           return JSON.stringify({ error: agentError })
         }
-        let config = readTeamConfigOrThrow(input.team_name)
-        let actor = resolveSenderFromContext(config, context)
-        if (!actor && input.agent_name === "team-lead") {
-          config = claimLeadSession(input.team_name, context.sessionID)
-          actor = "team-lead"
-        }
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveSenderFromContext(config, context)
         if (!actor) {
           return JSON.stringify({ error: "unauthorized_reader_session" })
         }

--- a/src/tools/agent-teams/name-validation.test.ts
+++ b/src/tools/agent-teams/name-validation.test.ts
@@ -1,6 +1,11 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
-import { validateAgentName, validateTeamName } from "./name-validation"
+import {
+  validateAgentName,
+  validateAgentNameOrLead,
+  validateTaskId,
+  validateTeamName,
+} from "./name-validation"
 
 describe("agent-teams name validation", () => {
   test("accepts valid team names", () => {
@@ -54,5 +59,20 @@ describe("agent-teams name validation", () => {
     //#then
     expect(validResult).toBeNull()
     expect(invalidResult).toBe("agent_name_invalid")
+  })
+
+  test("allows team-lead for inbox-compatible validation", () => {
+    //#then
+    expect(validateAgentNameOrLead("team-lead")).toBeNull()
+    expect(validateAgentNameOrLead("worker_1")).toBeNull()
+    expect(validateAgentNameOrLead("worker one")).toBe("agent_name_invalid")
+  })
+
+  test("validates task ids", () => {
+    //#then
+    expect(validateTaskId("T-123")).toBeNull()
+    expect(validateTaskId("")).toBe("task_id_required")
+    expect(validateTaskId("../../etc/passwd")).toBe("task_id_invalid")
+    expect(validateTaskId("a".repeat(129))).toBe("task_id_too_long")
   })
 })

--- a/src/tools/agent-teams/name-validation.test.ts
+++ b/src/tools/agent-teams/name-validation.test.ts
@@ -71,8 +71,9 @@ describe("agent-teams name validation", () => {
   test("validates task ids", () => {
     //#then
     expect(validateTaskId("T-123")).toBeNull()
+    expect(validateTaskId("123")).toBe("task_id_invalid")
     expect(validateTaskId("")).toBe("task_id_required")
     expect(validateTaskId("../../etc/passwd")).toBe("task_id_invalid")
-    expect(validateTaskId("a".repeat(129))).toBe("task_id_too_long")
+    expect(validateTaskId(`T-${"a".repeat(127)}`)).toBe("task_id_too_long")
   })
 })

--- a/src/tools/agent-teams/name-validation.test.ts
+++ b/src/tools/agent-teams/name-validation.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
+import { validateAgentName, validateTeamName } from "./name-validation"
+
+describe("agent-teams name validation", () => {
+  test("accepts valid team names", () => {
+    //#given
+    const validNames = ["team_1", "alpha-team", "A1"]
+
+    //#when
+    const result = validNames.map(validateTeamName)
+
+    //#then
+    expect(result).toEqual([null, null, null])
+  })
+
+  test("rejects invalid and empty team names", () => {
+    //#given
+    const blank = ""
+    const invalid = "team space"
+    const tooLong = "a".repeat(65)
+
+    //#when
+    const blankResult = validateTeamName(blank)
+    const invalidResult = validateTeamName(invalid)
+    const tooLongResult = validateTeamName(tooLong)
+
+    //#then
+    expect(blankResult).toBe("team_name_required")
+    expect(invalidResult).toBe("team_name_invalid")
+    expect(tooLongResult).toBe("team_name_too_long")
+  })
+
+  test("rejects reserved teammate name", () => {
+    //#given
+    const reservedName = "team-lead"
+
+    //#when
+    const result = validateAgentName(reservedName)
+
+    //#then
+    expect(result).toBe("agent_name_reserved")
+  })
+
+  test("validates regular agent names", () => {
+    //#given
+    const valid = "worker_1"
+    const invalid = "worker one"
+
+    //#when
+    const validResult = validateAgentName(valid)
+    const invalidResult = validateAgentName(invalid)
+
+    //#then
+    expect(validResult).toBeNull()
+    expect(invalidResult).toBe("agent_name_invalid")
+  })
+})

--- a/src/tools/agent-teams/name-validation.ts
+++ b/src/tools/agent-teams/name-validation.ts
@@ -1,5 +1,7 @@
 const VALID_NAME_RE = /^[A-Za-z0-9_-]+$/
 const MAX_NAME_LENGTH = 64
+const VALID_TASK_ID_RE = /^[A-Za-z0-9_-]+$/
+const MAX_TASK_ID_LENGTH = 128
 
 function validateName(value: string, label: "team" | "agent"): string | null {
   if (!value || !value.trim()) {
@@ -26,4 +28,27 @@ export function validateAgentName(agentName: string): string | null {
     return "agent_name_reserved"
   }
   return validateName(agentName, "agent")
+}
+
+export function validateAgentNameOrLead(agentName: string): string | null {
+  if (agentName === "team-lead") {
+    return null
+  }
+  return validateName(agentName, "agent")
+}
+
+export function validateTaskId(taskId: string): string | null {
+  if (!taskId || !taskId.trim()) {
+    return "task_id_required"
+  }
+
+  if (!VALID_TASK_ID_RE.test(taskId)) {
+    return "task_id_invalid"
+  }
+
+  if (taskId.length > MAX_TASK_ID_LENGTH) {
+    return "task_id_too_long"
+  }
+
+  return null
 }

--- a/src/tools/agent-teams/name-validation.ts
+++ b/src/tools/agent-teams/name-validation.ts
@@ -1,6 +1,6 @@
 const VALID_NAME_RE = /^[A-Za-z0-9_-]+$/
 const MAX_NAME_LENGTH = 64
-const VALID_TASK_ID_RE = /^[A-Za-z0-9_-]+$/
+const VALID_TASK_ID_RE = /^T-[A-Za-z0-9_-]+$/
 const MAX_TASK_ID_LENGTH = 128
 
 function validateName(value: string, label: "team" | "agent"): string | null {

--- a/src/tools/agent-teams/name-validation.ts
+++ b/src/tools/agent-teams/name-validation.ts
@@ -1,0 +1,29 @@
+const VALID_NAME_RE = /^[A-Za-z0-9_-]+$/
+const MAX_NAME_LENGTH = 64
+
+function validateName(value: string, label: "team" | "agent"): string | null {
+  if (!value || !value.trim()) {
+    return `${label}_name_required`
+  }
+
+  if (!VALID_NAME_RE.test(value)) {
+    return `${label}_name_invalid`
+  }
+
+  if (value.length > MAX_NAME_LENGTH) {
+    return `${label}_name_too_long`
+  }
+
+  return null
+}
+
+export function validateTeamName(teamName: string): string | null {
+  return validateName(teamName, "team")
+}
+
+export function validateAgentName(agentName: string): string | null {
+  if (agentName === "team-lead") {
+    return "agent_name_reserved"
+  }
+  return validateName(agentName, "agent")
+}

--- a/src/tools/agent-teams/paths.test.ts
+++ b/src/tools/agent-teams/paths.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  getAgentTeamsRootDir,
+  getTeamConfigPath,
+  getTeamDir,
+  getTeamInboxDir,
+  getTeamInboxPath,
+  getTeamTaskDir,
+  getTeamTaskPath,
+  getTeamsRootDir,
+  getTeamTasksRootDir,
+} from "./paths"
+
+describe("agent-teams paths", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-paths-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("uses project-local .sisyphus directory as storage root", () => {
+    //#given
+    const expectedRoot = join(tempProjectDir, ".sisyphus", "agent-teams")
+
+    //#when
+    const root = getAgentTeamsRootDir()
+
+    //#then
+    expect(root).toBe(expectedRoot)
+  })
+
+  test("builds expected teams and tasks root directories", () => {
+    //#given
+    const expectedRoot = join(tempProjectDir, ".sisyphus", "agent-teams")
+
+    //#when
+    const teamsRoot = getTeamsRootDir()
+    const tasksRoot = getTeamTasksRootDir()
+
+    //#then
+    expect(teamsRoot).toBe(join(expectedRoot, "teams"))
+    expect(tasksRoot).toBe(join(expectedRoot, "tasks"))
+  })
+
+  test("builds team-scoped config, inbox, and task file paths", () => {
+    //#given
+    const teamName = "alpha_team"
+    const agentName = "worker_1"
+    const taskId = "T-123"
+    const expectedTeamDir = join(getTeamsRootDir(), teamName)
+
+    //#when
+    const teamDir = getTeamDir(teamName)
+    const configPath = getTeamConfigPath(teamName)
+    const inboxDir = getTeamInboxDir(teamName)
+    const inboxPath = getTeamInboxPath(teamName, agentName)
+    const taskDir = getTeamTaskDir(teamName)
+    const taskPath = getTeamTaskPath(teamName, taskId)
+
+    //#then
+    expect(teamDir).toBe(expectedTeamDir)
+    expect(configPath).toBe(join(expectedTeamDir, "config.json"))
+    expect(inboxDir).toBe(join(expectedTeamDir, "inboxes"))
+    expect(inboxPath).toBe(join(expectedTeamDir, "inboxes", `${agentName}.json`))
+    expect(taskDir).toBe(join(getTeamTasksRootDir(), teamName))
+    expect(taskPath).toBe(join(getTeamTasksRootDir(), teamName, `${taskId}.json`))
+  })
+})

--- a/src/tools/agent-teams/paths.ts
+++ b/src/tools/agent-teams/paths.ts
@@ -1,10 +1,10 @@
 import { join } from "node:path"
-import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 
+const SISYPHUS_DIR = ".sisyphus"
 const AGENT_TEAMS_DIR = "agent-teams"
 
 export function getAgentTeamsRootDir(): string {
-  return join(getOpenCodeConfigDir({ binary: "opencode" }), AGENT_TEAMS_DIR)
+  return join(process.cwd(), SISYPHUS_DIR, AGENT_TEAMS_DIR)
 }
 
 export function getTeamsRootDir(): string {

--- a/src/tools/agent-teams/paths.ts
+++ b/src/tools/agent-teams/paths.ts
@@ -1,0 +1,40 @@
+import { join } from "node:path"
+import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
+
+const AGENT_TEAMS_DIR = "agent-teams"
+
+export function getAgentTeamsRootDir(): string {
+  return join(getOpenCodeConfigDir({ binary: "opencode" }), AGENT_TEAMS_DIR)
+}
+
+export function getTeamsRootDir(): string {
+  return join(getAgentTeamsRootDir(), "teams")
+}
+
+export function getTeamTasksRootDir(): string {
+  return join(getAgentTeamsRootDir(), "tasks")
+}
+
+export function getTeamDir(teamName: string): string {
+  return join(getTeamsRootDir(), teamName)
+}
+
+export function getTeamConfigPath(teamName: string): string {
+  return join(getTeamDir(teamName), "config.json")
+}
+
+export function getTeamInboxDir(teamName: string): string {
+  return join(getTeamDir(teamName), "inboxes")
+}
+
+export function getTeamInboxPath(teamName: string, agentName: string): string {
+  return join(getTeamInboxDir(teamName), `${agentName}.json`)
+}
+
+export function getTeamTaskDir(teamName: string): string {
+  return join(getTeamTasksRootDir(), teamName)
+}
+
+export function getTeamTaskPath(teamName: string, taskId: string): string {
+  return join(getTeamTaskDir(teamName), `${taskId}.json`)
+}

--- a/src/tools/agent-teams/team-config-store.test.ts
+++ b/src/tools/agent-teams/team-config-store.test.ts
@@ -5,7 +5,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { acquireLock } from "../../features/claude-tasks/storage"
 import { getTeamDir, getTeamTaskDir, getTeamsRootDir } from "./paths"
-import { createTeamConfig, deleteTeamData, teamExists } from "./team-config-store"
+import {
+  createTeamConfig,
+  deleteTeamData,
+  readTeamConfigOrThrow,
+  teamExists,
+  upsertTeammate,
+  writeTeamConfig,
+} from "./team-config-store"
 
 describe("agent-teams team config store", () => {
   let originalCwd: string
@@ -31,15 +38,18 @@ describe("agent-teams team config store", () => {
     const lock = acquireLock(getTeamDir("core"))
     expect(lock.acquired).toBe(true)
 
-    //#when
-    const deleteWhileLocked = () => deleteTeamData("core")
+    try {
+      //#when
+      const deleteWhileLocked = () => deleteTeamData("core")
 
-    //#then
-    expect(deleteWhileLocked).toThrow("team_lock_unavailable")
-    expect(teamExists("core")).toBe(true)
+      //#then
+      expect(deleteWhileLocked).toThrow("team_lock_unavailable")
+      expect(teamExists("core")).toBe(true)
+    } finally {
+      //#when
+      lock.release()
+    }
 
-    //#when
-    lock.release()
     deleteTeamData("core")
 
     //#then
@@ -89,6 +99,43 @@ describe("agent-teams team config store", () => {
     //#then
     expect(existsSync(taskDir)).toBe(false)
     expect(existsSync(teamDir)).toBe(true)
+  })
+
+  test("deleteTeamData fails if team has active teammates", () => {
+    //#given
+    const config = readTeamConfigOrThrow("core")
+    const updated = upsertTeammate(config, {
+      agentId: "teammate@core",
+      name: "teammate",
+      agentType: "sisyphus",
+      category: "test",
+      model: "sisyphus",
+      prompt: "test prompt",
+      color: "#000000",
+      planModeRequired: false,
+      joinedAt: Date.now(),
+      cwd: process.cwd(),
+      subscriptions: [],
+      backendType: "native",
+      isActive: true,
+      sessionID: "ses-sub",
+    })
+    writeTeamConfig("core", updated)
+
+    //#when
+    const deleteWithTeammates = () => deleteTeamData("core")
+
+    //#then
+    expect(deleteWithTeammates).toThrow("team_has_active_members")
+    expect(teamExists("core")).toBe(true)
+
+    //#when - cleanup teammate to allow afterEach to succeed
+    const cleared = { ...updated, members: updated.members.filter(m => m.name === "team-lead") }
+    writeTeamConfig("core", cleared)
+    deleteTeamData("core")
+
+    //#then
+    expect(teamExists("core")).toBe(false)
   })
 
 })

--- a/src/tools/agent-teams/team-config-store.test.ts
+++ b/src/tools/agent-teams/team-config-store.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { acquireLock } from "../../features/claude-tasks/storage"
+import { getTeamDir } from "./paths"
+import { createTeamConfig, deleteTeamData, teamExists } from "./team-config-store"
+
+describe("agent-teams team config store", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-config-store-"))
+    process.chdir(tempProjectDir)
+    createTeamConfig("core", "Core team", "ses-main", tempProjectDir, "sisyphus")
+  })
+
+  afterEach(() => {
+    if (teamExists("core")) {
+      deleteTeamData("core")
+    }
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("deleteTeamData waits for team lock before removing team files", () => {
+    //#given
+    const lock = acquireLock(getTeamDir("core"))
+    expect(lock.acquired).toBe(true)
+
+    //#when
+    const deleteWhileLocked = () => deleteTeamData("core")
+
+    //#then
+    expect(deleteWhileLocked).toThrow("team_lock_unavailable")
+    expect(teamExists("core")).toBe(true)
+
+    //#when
+    lock.release()
+    deleteTeamData("core")
+
+    //#then
+    expect(teamExists("core")).toBe(false)
+  })
+})

--- a/src/tools/agent-teams/team-config-store.test.ts
+++ b/src/tools/agent-teams/team-config-store.test.ts
@@ -1,10 +1,10 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { acquireLock } from "../../features/claude-tasks/storage"
-import { getTeamDir, getTeamTaskDir } from "./paths"
+import { getTeamDir, getTeamTaskDir, getTeamsRootDir } from "./paths"
 import { createTeamConfig, deleteTeamData, teamExists } from "./team-config-store"
 
 describe("agent-teams team config store", () => {
@@ -69,21 +69,26 @@ describe("agent-teams team config store", () => {
     expect(teamExists("core")).toBe(false)
   })
 
-  test("deleteTeamData removes task files before team files", () => {
+  test("deleteTeamData removes task files before deleting team directory", () => {
     //#given
-    const sourceUrl = new URL("./team-config-store.ts", import.meta.url)
-    const source = readFileSync(sourceUrl, "utf-8")
-    const deleteFnStart = source.indexOf("export function deleteTeamData")
-    const deleteFnSlice = deleteFnStart >= 0 ? source.slice(deleteFnStart, deleteFnStart + 700) : ""
+    const taskDir = getTeamTaskDir("core")
+    const teamDir = getTeamDir("core")
+    const teamsRootDir = getTeamsRootDir()
+    expect(existsSync(taskDir)).toBe(true)
+    expect(existsSync(teamDir)).toBe(true)
 
     //#when
-    const taskDeleteIndex = deleteFnSlice.indexOf("rmSync(taskDir")
-    const teamDeleteIndex = deleteFnSlice.indexOf("rmSync(teamDir")
+    chmodSync(teamsRootDir, 0o555)
+    try {
+      const deleteWithBlockedTeamParent = () => deleteTeamData("core")
+      expect(deleteWithBlockedTeamParent).toThrow()
+    } finally {
+      chmodSync(teamsRootDir, 0o755)
+    }
 
     //#then
-    expect(deleteFnStart).toBeGreaterThanOrEqual(0)
-    expect(taskDeleteIndex).toBeGreaterThanOrEqual(0)
-    expect(teamDeleteIndex).toBeGreaterThanOrEqual(0)
-    expect(taskDeleteIndex).toBeLessThan(teamDeleteIndex)
+    expect(existsSync(taskDir)).toBe(false)
+    expect(existsSync(teamDir)).toBe(true)
   })
+
 })

--- a/src/tools/agent-teams/team-config-store.test.ts
+++ b/src/tools/agent-teams/team-config-store.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { acquireLock } from "../../features/claude-tasks/storage"
-import { getTeamDir } from "./paths"
+import { getTeamDir, getTeamTaskDir } from "./paths"
 import { createTeamConfig, deleteTeamData, teamExists } from "./team-config-store"
 
 describe("agent-teams team config store", () => {
@@ -40,6 +40,29 @@ describe("agent-teams team config store", () => {
 
     //#when
     lock.release()
+    deleteTeamData("core")
+
+    //#then
+    expect(teamExists("core")).toBe(false)
+  })
+
+  test("deleteTeamData waits for task lock before removing task files", () => {
+    //#given
+    const lock = acquireLock(getTeamTaskDir("core"))
+    expect(lock.acquired).toBe(true)
+
+    try {
+      //#when
+      const deleteWhileLocked = () => deleteTeamData("core")
+
+      //#then
+      expect(deleteWhileLocked).toThrow("team_task_lock_unavailable")
+      expect(teamExists("core")).toBe(true)
+    } finally {
+      lock.release()
+    }
+
+    //#when
     deleteTeamData("core")
 
     //#then

--- a/src/tools/agent-teams/team-config-store.test.ts
+++ b/src/tools/agent-teams/team-config-store.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { acquireLock } from "../../features/claude-tasks/storage"
@@ -67,5 +67,23 @@ describe("agent-teams team config store", () => {
 
     //#then
     expect(teamExists("core")).toBe(false)
+  })
+
+  test("deleteTeamData removes task files before team files", () => {
+    //#given
+    const sourceUrl = new URL("./team-config-store.ts", import.meta.url)
+    const source = readFileSync(sourceUrl, "utf-8")
+    const deleteFnStart = source.indexOf("export function deleteTeamData")
+    const deleteFnSlice = deleteFnStart >= 0 ? source.slice(deleteFnStart, deleteFnStart + 700) : ""
+
+    //#when
+    const taskDeleteIndex = deleteFnSlice.indexOf("rmSync(taskDir")
+    const teamDeleteIndex = deleteFnSlice.indexOf("rmSync(teamDir")
+
+    //#then
+    expect(deleteFnStart).toBeGreaterThanOrEqual(0)
+    expect(taskDeleteIndex).toBeGreaterThanOrEqual(0)
+    expect(teamDeleteIndex).toBeGreaterThanOrEqual(0)
+    expect(taskDeleteIndex).toBeLessThan(teamDeleteIndex)
   })
 })

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -173,14 +173,16 @@ export function assignNextColor(config: TeamConfig): string {
 
 export function deleteTeamData(teamName: string): void {
   assertValidTeamName(teamName)
-  const teamDir = getTeamDir(teamName)
-  const taskDir = getTeamTaskDir(teamName)
+  withTeamLock(teamName, () => {
+    const teamDir = getTeamDir(teamName)
+    const taskDir = getTeamTaskDir(teamName)
 
-  if (existsSync(teamDir)) {
-    rmSync(teamDir, { recursive: true, force: true })
-  }
+    if (existsSync(teamDir)) {
+      rmSync(teamDir, { recursive: true, force: true })
+    }
 
-  if (existsSync(taskDir)) {
-    rmSync(taskDir, { recursive: true, force: true })
-  }
+    if (existsSync(taskDir)) {
+      rmSync(taskDir, { recursive: true, force: true })
+    }
+  })
 }

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -22,12 +22,21 @@ import {
   TeamTeammateMember,
   isTeammateMember,
 } from "./types"
+import { validateTeamName } from "./name-validation"
 
 function nowMs(): number {
   return Date.now()
 }
 
+function assertValidTeamName(teamName: string): void {
+  const validationError = validateTeamName(teamName)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
 function withTeamLock<T>(teamName: string, operation: () => T): T {
+  assertValidTeamName(teamName)
   const teamDir = getTeamDir(teamName)
   ensureDir(teamDir)
   const lock = acquireLock(teamDir)
@@ -55,6 +64,7 @@ function createLeadMember(teamName: string, leadSessionId: string, cwd: string, 
 }
 
 export function ensureTeamStorageDirs(teamName: string): void {
+  assertValidTeamName(teamName)
   ensureDir(getTeamsRootDir())
   ensureDir(getTeamTasksRootDir())
   ensureDir(getTeamDir(teamName))
@@ -63,6 +73,7 @@ export function ensureTeamStorageDirs(teamName: string): void {
 }
 
 export function teamExists(teamName: string): boolean {
+  assertValidTeamName(teamName)
   return existsSync(getTeamConfigPath(teamName))
 }
 
@@ -75,10 +86,6 @@ export function createTeamConfig(
 ): TeamConfig {
   ensureTeamStorageDirs(teamName)
 
-  if (teamExists(teamName)) {
-    throw new Error("team_already_exists")
-  }
-
   const leadAgentId = `team-lead@${teamName}`
   const config: TeamConfig = {
     name: teamName,
@@ -90,12 +97,16 @@ export function createTeamConfig(
   }
 
   return withTeamLock(teamName, () => {
+    if (teamExists(teamName)) {
+      throw new Error("team_already_exists")
+    }
     writeJsonAtomic(getTeamConfigPath(teamName), TeamConfigSchema.parse(config))
     return config
   })
 }
 
 export function readTeamConfig(teamName: string): TeamConfig | null {
+  assertValidTeamName(teamName)
   return readJsonSafe(getTeamConfigPath(teamName), TeamConfigSchema)
 }
 
@@ -108,6 +119,7 @@ export function readTeamConfigOrThrow(teamName: string): TeamConfig {
 }
 
 export function writeTeamConfig(teamName: string, config: TeamConfig): TeamConfig {
+  assertValidTeamName(teamName)
   return withTeamLock(teamName, () => {
     const validated = TeamConfigSchema.parse(config)
     writeJsonAtomic(getTeamConfigPath(teamName), validated)
@@ -146,6 +158,7 @@ export function assignNextColor(config: TeamConfig): string {
 }
 
 export function deleteTeamData(teamName: string): void {
+  assertValidTeamName(teamName)
   const teamDir = getTeamDir(teamName)
   const taskDir = getTeamTaskDir(teamName)
 

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -1,10 +1,5 @@
 import { existsSync, rmSync } from "node:fs"
-import {
-  acquireLock,
-  ensureDir,
-  readJsonSafe,
-  writeJsonAtomic,
-} from "../../features/claude-tasks/storage"
+import { acquireLock, ensureDir, readJsonSafe, writeJsonAtomic } from "../../features/claude-tasks/storage"
 import {
   getTeamConfigPath,
   getTeamDir,
@@ -175,6 +170,15 @@ export function assignNextColor(config: TeamConfig): string {
 export function deleteTeamData(teamName: string): void {
   assertValidTeamName(teamName)
   withTeamLock(teamName, () => {
+    const config = readJsonSafe(getTeamConfigPath(teamName), TeamConfigSchema)
+    if (!config) {
+      throw new Error("team_not_found")
+    }
+
+    if (listTeammates(config).length > 0) {
+      throw new Error("team_has_active_members")
+    }
+
     withTeamTaskLock(teamName, () => {
       const teamDir = getTeamDir(teamName)
       const taskDir = getTeamTaskDir(teamName)

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -1,0 +1,159 @@
+import { existsSync, rmSync } from "node:fs"
+import {
+  acquireLock,
+  ensureDir,
+  readJsonSafe,
+  writeJsonAtomic,
+} from "../../features/claude-tasks/storage"
+import {
+  getTeamConfigPath,
+  getTeamDir,
+  getTeamInboxDir,
+  getTeamTaskDir,
+  getTeamTasksRootDir,
+  getTeamsRootDir,
+} from "./paths"
+import {
+  TEAM_COLOR_PALETTE,
+  TeamConfig,
+  TeamConfigSchema,
+  TeamLeadMember,
+  TeamMember,
+  TeamTeammateMember,
+  isTeammateMember,
+} from "./types"
+
+function nowMs(): number {
+  return Date.now()
+}
+
+function withTeamLock<T>(teamName: string, operation: () => T): T {
+  const teamDir = getTeamDir(teamName)
+  ensureDir(teamDir)
+  const lock = acquireLock(teamDir)
+  if (!lock.acquired) {
+    throw new Error("team_lock_unavailable")
+  }
+
+  try {
+    return operation()
+  } finally {
+    lock.release()
+  }
+}
+
+function createLeadMember(teamName: string, leadSessionId: string, cwd: string, model: string): TeamLeadMember {
+  return {
+    agentId: `team-lead@${teamName}`,
+    name: "team-lead",
+    agentType: "team-lead",
+    model,
+    joinedAt: nowMs(),
+    cwd,
+    subscriptions: [],
+  }
+}
+
+export function ensureTeamStorageDirs(teamName: string): void {
+  ensureDir(getTeamsRootDir())
+  ensureDir(getTeamTasksRootDir())
+  ensureDir(getTeamDir(teamName))
+  ensureDir(getTeamInboxDir(teamName))
+  ensureDir(getTeamTaskDir(teamName))
+}
+
+export function teamExists(teamName: string): boolean {
+  return existsSync(getTeamConfigPath(teamName))
+}
+
+export function createTeamConfig(
+  teamName: string,
+  description: string,
+  leadSessionId: string,
+  cwd: string,
+  model: string,
+): TeamConfig {
+  ensureTeamStorageDirs(teamName)
+
+  if (teamExists(teamName)) {
+    throw new Error("team_already_exists")
+  }
+
+  const leadAgentId = `team-lead@${teamName}`
+  const config: TeamConfig = {
+    name: teamName,
+    description,
+    createdAt: nowMs(),
+    leadAgentId,
+    leadSessionId,
+    members: [createLeadMember(teamName, leadSessionId, cwd, model)],
+  }
+
+  return withTeamLock(teamName, () => {
+    writeJsonAtomic(getTeamConfigPath(teamName), TeamConfigSchema.parse(config))
+    return config
+  })
+}
+
+export function readTeamConfig(teamName: string): TeamConfig | null {
+  return readJsonSafe(getTeamConfigPath(teamName), TeamConfigSchema)
+}
+
+export function readTeamConfigOrThrow(teamName: string): TeamConfig {
+  const config = readTeamConfig(teamName)
+  if (!config) {
+    throw new Error("team_not_found")
+  }
+  return config
+}
+
+export function writeTeamConfig(teamName: string, config: TeamConfig): TeamConfig {
+  return withTeamLock(teamName, () => {
+    const validated = TeamConfigSchema.parse(config)
+    writeJsonAtomic(getTeamConfigPath(teamName), validated)
+    return validated
+  })
+}
+
+export function listTeammates(config: TeamConfig): TeamTeammateMember[] {
+  return config.members.filter(isTeammateMember)
+}
+
+export function getTeamMember(config: TeamConfig, name: string): TeamMember | undefined {
+  return config.members.find((member) => member.name === name)
+}
+
+export function upsertTeammate(config: TeamConfig, teammate: TeamTeammateMember): TeamConfig {
+  const members = config.members.filter((member) => member.name !== teammate.name)
+  members.push(teammate)
+  return { ...config, members }
+}
+
+export function removeTeammate(config: TeamConfig, agentName: string): TeamConfig {
+  if (agentName === "team-lead") {
+    throw new Error("cannot_remove_team_lead")
+  }
+
+  return {
+    ...config,
+    members: config.members.filter((member) => member.name !== agentName),
+  }
+}
+
+export function assignNextColor(config: TeamConfig): string {
+  const teammateCount = listTeammates(config).length
+  return TEAM_COLOR_PALETTE[teammateCount % TEAM_COLOR_PALETTE.length]
+}
+
+export function deleteTeamData(teamName: string): void {
+  const teamDir = getTeamDir(teamName)
+  const taskDir = getTeamTaskDir(teamName)
+
+  if (existsSync(teamDir)) {
+    rmSync(teamDir, { recursive: true, force: true })
+  }
+
+  if (existsSync(taskDir)) {
+    rmSync(taskDir, { recursive: true, force: true })
+  }
+}

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -23,6 +23,7 @@ import {
   isTeammateMember,
 } from "./types"
 import { validateTeamName } from "./name-validation"
+import { withTeamTaskLock } from "./team-task-store"
 
 function nowMs(): number {
   return Date.now()
@@ -174,15 +175,17 @@ export function assignNextColor(config: TeamConfig): string {
 export function deleteTeamData(teamName: string): void {
   assertValidTeamName(teamName)
   withTeamLock(teamName, () => {
-    const teamDir = getTeamDir(teamName)
-    const taskDir = getTeamTaskDir(teamName)
+    withTeamTaskLock(teamName, () => {
+      const teamDir = getTeamDir(teamName)
+      const taskDir = getTeamTaskDir(teamName)
 
-    if (existsSync(teamDir)) {
-      rmSync(teamDir, { recursive: true, force: true })
-    }
+      if (existsSync(teamDir)) {
+        rmSync(teamDir, { recursive: true, force: true })
+      }
 
-    if (existsSync(taskDir)) {
-      rmSync(taskDir, { recursive: true, force: true })
-    }
+      if (existsSync(taskDir)) {
+        rmSync(taskDir, { recursive: true, force: true })
+      }
+    })
   })
 }

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -179,12 +179,12 @@ export function deleteTeamData(teamName: string): void {
       const teamDir = getTeamDir(teamName)
       const taskDir = getTeamTaskDir(teamName)
 
-      if (existsSync(teamDir)) {
-        rmSync(teamDir, { recursive: true, force: true })
-      }
-
       if (existsSync(taskDir)) {
         rmSync(taskDir, { recursive: true, force: true })
+      }
+
+      if (existsSync(teamDir)) {
+        rmSync(teamDir, { recursive: true, force: true })
       }
     })
   })

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -127,6 +127,20 @@ export function writeTeamConfig(teamName: string, config: TeamConfig): TeamConfi
   })
 }
 
+export function updateTeamConfig(teamName: string, updater: (config: TeamConfig) => TeamConfig): TeamConfig {
+  assertValidTeamName(teamName)
+  return withTeamLock(teamName, () => {
+    const current = readJsonSafe(getTeamConfigPath(teamName), TeamConfigSchema)
+    if (!current) {
+      throw new Error("team_not_found")
+    }
+
+    const next = TeamConfigSchema.parse(updater(current))
+    writeJsonAtomic(getTeamConfigPath(teamName), next)
+    return next
+  })
+}
+
 export function listTeammates(config: TeamConfig): TeamTeammateMember[] {
   return config.members.filter(isTeammateMember)
 }

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -51,7 +51,7 @@ function withTeamLock<T>(teamName: string, operation: () => T): T {
   }
 }
 
-function createLeadMember(teamName: string, leadSessionId: string, cwd: string, model: string): TeamLeadMember {
+function createLeadMember(teamName: string, cwd: string, model: string): TeamLeadMember {
   return {
     agentId: `team-lead@${teamName}`,
     name: "team-lead",
@@ -93,7 +93,7 @@ export function createTeamConfig(
     createdAt: nowMs(),
     leadAgentId,
     leadSessionId,
-    members: [createLeadMember(teamName, leadSessionId, cwd, model)],
+    members: [createLeadMember(teamName, cwd, model)],
   }
 
   return withTeamLock(teamName, () => {

--- a/src/tools/agent-teams/team-config-store.ts
+++ b/src/tools/agent-teams/team-config-store.ts
@@ -51,12 +51,12 @@ function withTeamLock<T>(teamName: string, operation: () => T): T {
   }
 }
 
-function createLeadMember(teamName: string, cwd: string, model: string): TeamLeadMember {
+function createLeadMember(teamName: string, cwd: string, leadModel: string): TeamLeadMember {
   return {
     agentId: `team-lead@${teamName}`,
     name: "team-lead",
     agentType: "team-lead",
-    model,
+    model: leadModel,
     joinedAt: nowMs(),
     cwd,
     subscriptions: [],
@@ -82,7 +82,7 @@ export function createTeamConfig(
   description: string,
   leadSessionId: string,
   cwd: string,
-  model: string,
+  leadModel: string,
 ): TeamConfig {
   ensureTeamStorageDirs(teamName)
 
@@ -93,7 +93,7 @@ export function createTeamConfig(
     createdAt: nowMs(),
     leadAgentId,
     leadSessionId,
-    members: [createLeadMember(teamName, cwd, model)],
+    members: [createLeadMember(teamName, cwd, leadModel)],
   }
 
   return withTeamLock(teamName, () => {

--- a/src/tools/agent-teams/team-lifecycle-tools.test.ts
+++ b/src/tools/agent-teams/team-lifecycle-tools.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundManager } from "../../features/background-agent"
+import { getTeamDir } from "./paths"
+import { createAgentTeamsTools } from "./tools"
+
+interface TestToolContext {
+  sessionID: string
+  messageID: string
+  agent: string
+  abort: AbortSignal
+}
+
+function createContext(sessionID = "ses-main"): TestToolContext {
+  return {
+    sessionID,
+    messageID: "msg-main",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+  }
+}
+
+async function executeJsonTool(
+  tools: ReturnType<typeof createAgentTeamsTools>,
+  toolName: keyof ReturnType<typeof createAgentTeamsTools>,
+  args: Record<string, unknown>,
+  context: TestToolContext,
+): Promise<unknown> {
+  const output = await tools[toolName].execute(args, context)
+  return JSON.parse(output)
+}
+
+describe("agent-teams team lifecycle tools", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-lifecycle-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("team_delete requires lead session authorization", async () => {
+    //#given
+    const tools = createAgentTeamsTools({} as BackgroundManager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    //#when
+    const unauthorized = await executeJsonTool(
+      tools,
+      "team_delete",
+      { team_name: "core" },
+      createContext("ses-intruder"),
+    ) as { error?: string }
+
+    //#then
+    expect(unauthorized.error).toBe("unauthorized_lead_session")
+    expect(existsSync(getTeamDir("core"))).toBe(true)
+  })
+})

--- a/src/tools/agent-teams/team-lifecycle-tools.ts
+++ b/src/tools/agent-teams/team-lifecycle-tools.ts
@@ -1,0 +1,95 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { getTeamConfigPath } from "./paths"
+import { validateTeamName } from "./name-validation"
+import { ensureInbox } from "./inbox-store"
+import {
+  TeamCreateInputSchema,
+  TeamDeleteInputSchema,
+  TeamReadConfigInputSchema,
+  TeamToolContext,
+} from "./types"
+import { createTeamConfig, deleteTeamData, listTeammates, readTeamConfig, readTeamConfigOrThrow } from "./team-config-store"
+
+export function createTeamCreateTool(): ToolDefinition {
+  return tool({
+    description: "Create a team workspace with config, inboxes, and task storage.",
+    args: {
+      team_name: tool.schema.string().describe("Team name (letters, numbers, hyphens, underscores)"),
+      description: tool.schema.string().optional().describe("Team description"),
+    },
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
+      try {
+        const input = TeamCreateInputSchema.parse(args)
+        const nameError = validateTeamName(input.team_name)
+        if (nameError) {
+          return JSON.stringify({ error: nameError })
+        }
+
+        const config = createTeamConfig(
+          input.team_name,
+          input.description ?? "",
+          context.sessionID,
+          process.cwd(),
+          context.agent ?? "native",
+        )
+        ensureInbox(config.name, "team-lead")
+
+        return JSON.stringify({
+          team_name: config.name,
+          team_file_path: getTeamConfigPath(config.name),
+          lead_agent_id: config.leadAgentId,
+        })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_create_failed" })
+      }
+    },
+  })
+}
+
+export function createTeamDeleteTool(): ToolDefinition {
+  return tool({
+    description: "Delete a team and its stored data. Fails if teammates still exist.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamDeleteInputSchema.parse(args)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const teammates = listTeammates(config)
+        if (teammates.length > 0) {
+          return JSON.stringify({
+            error: "team_has_active_members",
+            members: teammates.map((member) => member.name),
+          })
+        }
+
+        deleteTeamData(input.team_name)
+        return JSON.stringify({ success: true, team_name: input.team_name })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_delete_failed" })
+      }
+    },
+  })
+}
+
+export function createTeamReadConfigTool(): ToolDefinition {
+  return tool({
+    description: "Read team configuration and member list.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamReadConfigInputSchema.parse(args)
+        const config = readTeamConfig(input.team_name)
+        if (!config) {
+          return JSON.stringify({ error: "team_not_found" })
+        }
+        return JSON.stringify(config)
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_read_config_failed" })
+      }
+    },
+  })
+}

--- a/src/tools/agent-teams/team-lifecycle-tools.ts
+++ b/src/tools/agent-teams/team-lifecycle-tools.ts
@@ -52,10 +52,13 @@ export function createTeamDeleteTool(): ToolDefinition {
     args: {
       team_name: tool.schema.string().describe("Team name"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamDeleteInputSchema.parse(args)
         const config = readTeamConfigOrThrow(input.team_name)
+        if (context.sessionID !== config.leadSessionId) {
+          return JSON.stringify({ error: "unauthorized_lead_session" })
+        }
         const teammates = listTeammates(config)
         if (teammates.length > 0) {
           return JSON.stringify({

--- a/src/tools/agent-teams/team-lifecycle-tools.ts
+++ b/src/tools/agent-teams/team-lifecycle-tools.ts
@@ -3,12 +3,37 @@ import { getTeamConfigPath } from "./paths"
 import { validateTeamName } from "./name-validation"
 import { ensureInbox } from "./inbox-store"
 import {
+  TeamConfig,
   TeamCreateInputSchema,
   TeamDeleteInputSchema,
   TeamReadConfigInputSchema,
   TeamToolContext,
+  isTeammateMember,
 } from "./types"
 import { createTeamConfig, deleteTeamData, listTeammates, readTeamConfig, readTeamConfigOrThrow } from "./team-config-store"
+
+function resolveReaderFromContext(config: TeamConfig, context: TeamToolContext): "team-lead" | string | null {
+  if (context.sessionID === config.leadSessionId) {
+    return "team-lead"
+  }
+
+  const matchedMember = config.members.find((member) => isTeammateMember(member) && member.sessionID === context.sessionID)
+  return matchedMember?.name ?? null
+}
+
+function toPublicTeamConfig(config: TeamConfig): {
+  team_name: string
+  description: string
+  lead_agent_id: string
+  teammates: Array<{ name: string }>
+} {
+  return {
+    team_name: config.name,
+    description: config.description,
+    lead_agent_id: config.leadAgentId,
+    teammates: listTeammates(config).map((member) => ({ name: member.name })),
+  }
+}
 
 export function createTeamCreateTool(): ToolDefinition {
   return tool({
@@ -82,13 +107,23 @@ export function createTeamReadConfigTool(): ToolDefinition {
     args: {
       team_name: tool.schema.string().describe("Team name"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamReadConfigInputSchema.parse(args)
         const config = readTeamConfig(input.team_name)
         if (!config) {
           return JSON.stringify({ error: "team_not_found" })
         }
+
+        const actor = resolveReaderFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_reader_session" })
+        }
+
+        if (actor !== "team-lead") {
+          return JSON.stringify(toPublicTeamConfig(config))
+        }
+
         return JSON.stringify(config)
       } catch (error) {
         return JSON.stringify({ error: error instanceof Error ? error.message : "team_read_config_failed" })

--- a/src/tools/agent-teams/team-lifecycle-tools.ts
+++ b/src/tools/agent-teams/team-lifecycle-tools.ts
@@ -30,7 +30,7 @@ export function createTeamCreateTool(): ToolDefinition {
           input.description ?? "",
           context.sessionID,
           process.cwd(),
-          context.agent ?? "native",
+          "native/team-lead",
         )
         ensureInbox(config.name, "team-lead")
 

--- a/src/tools/agent-teams/team-task-dependency.test.ts
+++ b/src/tools/agent-teams/team-task-dependency.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
+import {
+  addPendingEdge,
+  createPendingEdgeMap,
+  ensureDependenciesCompleted,
+  ensureForwardStatusTransition,
+  wouldCreateCycle,
+} from "./team-task-dependency"
+import type { TeamTask, TeamTaskStatus } from "./types"
+
+function createTask(id: string, status: TeamTaskStatus, blockedBy: string[] = []): TeamTask {
+  return {
+    id,
+    subject: `Task ${id}`,
+    description: `Description ${id}`,
+    status,
+    blocks: [],
+    blockedBy,
+  }
+}
+
+describe("agent-teams task dependency utilities", () => {
+  test("detects cycle from existing blockedBy chain", () => {
+    //#given
+    const tasks = new Map<string, TeamTask>([
+      ["A", createTask("A", "pending", ["B"])],
+      ["B", createTask("B", "pending")],
+    ])
+    const pending = createPendingEdgeMap()
+    const readTask = (id: string) => tasks.get(id) ?? null
+
+    //#when
+    const hasCycle = wouldCreateCycle("B", "A", pending, readTask)
+
+    //#then
+    expect(hasCycle).toBe(true)
+  })
+
+  test("detects cycle from pending edge map", () => {
+    //#given
+    const tasks = new Map<string, TeamTask>([["A", createTask("A", "pending")]])
+    const pending = createPendingEdgeMap()
+    addPendingEdge(pending, "A", "B")
+    const readTask = (id: string) => tasks.get(id) ?? null
+
+    //#when
+    const hasCycle = wouldCreateCycle("B", "A", pending, readTask)
+
+    //#then
+    expect(hasCycle).toBe(true)
+  })
+
+  test("returns false when dependency graph has no cycle", () => {
+    //#given
+    const tasks = new Map<string, TeamTask>([
+      ["A", createTask("A", "pending")],
+      ["B", createTask("B", "pending", ["A"])],
+    ])
+    const pending = createPendingEdgeMap()
+    const readTask = (id: string) => tasks.get(id) ?? null
+
+    //#when
+    const hasCycle = wouldCreateCycle("C", "B", pending, readTask)
+
+    //#then
+    expect(hasCycle).toBe(false)
+  })
+
+  test("allows forward status transitions and blocks backward transitions", () => {
+    //#then
+    expect(() => ensureForwardStatusTransition("pending", "in_progress")).not.toThrow()
+    expect(() => ensureForwardStatusTransition("in_progress", "completed")).not.toThrow()
+    expect(() => ensureForwardStatusTransition("in_progress", "pending")).toThrow(
+      "invalid_status_transition:in_progress->pending",
+    )
+  })
+
+  test("requires blockers to be completed for in_progress/completed", () => {
+    //#given
+    const tasks = new Map<string, TeamTask>([
+      ["done", createTask("done", "completed")],
+      ["wait", createTask("wait", "pending")],
+    ])
+    const readTask = (id: string) => tasks.get(id) ?? null
+
+    //#then
+    expect(() => ensureDependenciesCompleted("pending", ["wait"], readTask)).not.toThrow()
+    expect(() => ensureDependenciesCompleted("in_progress", ["done"], readTask)).not.toThrow()
+    expect(() => ensureDependenciesCompleted("completed", ["wait"], readTask)).toThrow(
+      "blocked_by_incomplete:wait:pending",
+    )
+  })
+})

--- a/src/tools/agent-teams/team-task-dependency.ts
+++ b/src/tools/agent-teams/team-task-dependency.ts
@@ -1,0 +1,93 @@
+import type { TeamTask, TeamTaskStatus } from "./types"
+
+type PendingEdges = Record<string, Set<string>>
+
+export const TEAM_TASK_STATUS_ORDER: Record<TeamTaskStatus, number> = {
+  pending: 0,
+  in_progress: 1,
+  completed: 2,
+  deleted: 3,
+}
+
+export type TaskReader = (taskId: string) => TeamTask | null
+
+export function wouldCreateCycle(
+  fromTaskId: string,
+  toTaskId: string,
+  pendingEdges: PendingEdges,
+  readTask: TaskReader,
+): boolean {
+  const visited = new Set<string>()
+  const queue: string[] = [toTaskId]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current) {
+      continue
+    }
+
+    if (current === fromTaskId) {
+      return true
+    }
+
+    if (visited.has(current)) {
+      continue
+    }
+    visited.add(current)
+
+    const task = readTask(current)
+    if (task) {
+      for (const dep of task.blockedBy) {
+        if (!visited.has(dep)) {
+          queue.push(dep)
+        }
+      }
+    }
+
+    const pending = pendingEdges[current]
+    if (pending) {
+      for (const dep of pending) {
+        if (!visited.has(dep)) {
+          queue.push(dep)
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+export function ensureForwardStatusTransition(current: TeamTaskStatus, next: TeamTaskStatus): void {
+  const currentOrder = TEAM_TASK_STATUS_ORDER[current]
+  const nextOrder = TEAM_TASK_STATUS_ORDER[next]
+  if (nextOrder < currentOrder) {
+    throw new Error(`invalid_status_transition:${current}->${next}`)
+  }
+}
+
+export function ensureDependenciesCompleted(
+  status: TeamTaskStatus,
+  blockedBy: string[],
+  readTask: TaskReader,
+): void {
+  if (status !== "in_progress" && status !== "completed") {
+    return
+  }
+
+  for (const blockerId of blockedBy) {
+    const blocker = readTask(blockerId)
+    if (blocker && blocker.status !== "completed") {
+      throw new Error(`blocked_by_incomplete:${blockerId}:${blocker.status}`)
+    }
+  }
+}
+
+export function createPendingEdgeMap(): PendingEdges {
+  return {}
+}
+
+export function addPendingEdge(pendingEdges: PendingEdges, from: string, to: string): void {
+  const existing = pendingEdges[from] ?? new Set<string>()
+  existing.add(to)
+  pendingEdges[from] = existing
+}

--- a/src/tools/agent-teams/team-task-store.test.ts
+++ b/src/tools/agent-teams/team-task-store.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createTeamConfig, deleteTeamData } from "./team-config-store"
+import { createTeamTask, deleteTeamTaskFile, readTeamTask } from "./team-task-store"
+
+describe("agent-teams task store", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-task-store-"))
+    process.chdir(tempProjectDir)
+    createTeamConfig("core", "Core team", "ses-main", tempProjectDir, "sisyphus")
+  })
+
+  afterEach(() => {
+    deleteTeamData("core")
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("creates and reads a task", () => {
+    //#given
+    const created = createTeamTask("core", "Subject", "Description")
+
+    //#when
+    const loaded = readTeamTask("core", created.id)
+
+    //#then
+    expect(loaded?.id).toBe(created.id)
+    expect(loaded?.subject).toBe("Subject")
+  })
+
+  test("rejects invalid team name and task id", () => {
+    //#then
+    expect(() => readTeamTask("../../etc", "T-1")).toThrow("team_name_invalid")
+    expect(() => readTeamTask("core", "../../passwd")).toThrow("task_id_invalid")
+    expect(() => deleteTeamTaskFile("core", "../../passwd")).toThrow("task_id_invalid")
+  })
+})

--- a/src/tools/agent-teams/team-task-store.ts
+++ b/src/tools/agent-teams/team-task-store.ts
@@ -9,8 +9,24 @@ import {
 } from "../../features/claude-tasks/storage"
 import { getTeamTaskDir, getTeamTaskPath } from "./paths"
 import { TeamTask, TeamTaskSchema } from "./types"
+import { validateTaskId, validateTeamName } from "./name-validation"
+
+function assertValidTeamName(teamName: string): void {
+  const validationError = validateTeamName(teamName)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
+function assertValidTaskId(taskId: string): void {
+  const validationError = validateTaskId(taskId)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
 
 function withTaskLock<T>(teamName: string, operation: () => T): T {
+  assertValidTeamName(teamName)
   const taskDir = getTeamTaskDir(teamName)
   ensureDir(taskDir)
   const lock = acquireLock(taskDir)
@@ -26,6 +42,8 @@ function withTaskLock<T>(teamName: string, operation: () => T): T {
 }
 
 export function readTeamTask(teamName: string, taskId: string): TeamTask | null {
+  assertValidTeamName(teamName)
+  assertValidTaskId(taskId)
   return readJsonSafe(getTeamTaskPath(teamName, taskId), TeamTaskSchema)
 }
 
@@ -38,6 +56,7 @@ export function readTeamTaskOrThrow(teamName: string, taskId: string): TeamTask 
 }
 
 export function listTeamTasks(teamName: string): TeamTask[] {
+  assertValidTeamName(teamName)
   const taskDir = getTeamTaskDir(teamName)
   if (!existsSync(taskDir)) {
     return []
@@ -50,6 +69,9 @@ export function listTeamTasks(teamName: string): TeamTask[] {
   const tasks: TeamTask[] = []
   for (const file of files) {
     const taskId = file.replace(/\.json$/, "")
+    if (validateTaskId(taskId)) {
+      continue
+    }
     const task = readTeamTask(teamName, taskId)
     if (task) {
       tasks.push(task)
@@ -66,6 +88,7 @@ export function createTeamTask(
   activeForm?: string,
   metadata?: Record<string, unknown>,
 ): TeamTask {
+  assertValidTeamName(teamName)
   if (!subject.trim()) {
     throw new Error("team_task_subject_required")
   }
@@ -89,12 +112,16 @@ export function createTeamTask(
 }
 
 export function writeTeamTask(teamName: string, task: TeamTask): TeamTask {
+  assertValidTeamName(teamName)
+  assertValidTaskId(task.id)
   const validated = TeamTaskSchema.parse(task)
   writeJsonAtomic(getTeamTaskPath(teamName, validated.id), validated)
   return validated
 }
 
 export function deleteTeamTaskFile(teamName: string, taskId: string): void {
+  assertValidTeamName(teamName)
+  assertValidTaskId(taskId)
   const taskPath = getTeamTaskPath(teamName, taskId)
   if (existsSync(taskPath)) {
     unlinkSync(taskPath)
@@ -102,10 +129,12 @@ export function deleteTeamTaskFile(teamName: string, taskId: string): void {
 }
 
 export function readTaskFromDirectory(taskDir: string, taskId: string): TeamTask | null {
+  assertValidTaskId(taskId)
   return readJsonSafe(join(taskDir, `${taskId}.json`), TeamTaskSchema)
 }
 
 export function resetOwnerTasks(teamName: string, ownerName: string): void {
+  assertValidTeamName(teamName)
   withTaskLock(teamName, () => {
     const tasks = listTeamTasks(teamName)
     for (const task of tasks) {
@@ -123,5 +152,6 @@ export function resetOwnerTasks(teamName: string, ownerName: string): void {
 }
 
 export function withTeamTaskLock<T>(teamName: string, operation: () => T): T {
+  assertValidTeamName(teamName)
   return withTaskLock(teamName, operation)
 }

--- a/src/tools/agent-teams/team-task-store.ts
+++ b/src/tools/agent-teams/team-task-store.ts
@@ -1,0 +1,127 @@
+import { existsSync, readdirSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import {
+  acquireLock,
+  ensureDir,
+  generateTaskId,
+  readJsonSafe,
+  writeJsonAtomic,
+} from "../../features/claude-tasks/storage"
+import { getTeamTaskDir, getTeamTaskPath } from "./paths"
+import { TeamTask, TeamTaskSchema } from "./types"
+
+function withTaskLock<T>(teamName: string, operation: () => T): T {
+  const taskDir = getTeamTaskDir(teamName)
+  ensureDir(taskDir)
+  const lock = acquireLock(taskDir)
+  if (!lock.acquired) {
+    throw new Error("team_task_lock_unavailable")
+  }
+
+  try {
+    return operation()
+  } finally {
+    lock.release()
+  }
+}
+
+export function readTeamTask(teamName: string, taskId: string): TeamTask | null {
+  return readJsonSafe(getTeamTaskPath(teamName, taskId), TeamTaskSchema)
+}
+
+export function readTeamTaskOrThrow(teamName: string, taskId: string): TeamTask {
+  const task = readTeamTask(teamName, taskId)
+  if (!task) {
+    throw new Error("team_task_not_found")
+  }
+  return task
+}
+
+export function listTeamTasks(teamName: string): TeamTask[] {
+  const taskDir = getTeamTaskDir(teamName)
+  if (!existsSync(taskDir)) {
+    return []
+  }
+
+  const files = readdirSync(taskDir)
+    .filter((file) => file.endsWith(".json") && file.startsWith("T-"))
+    .sort((a, b) => a.localeCompare(b))
+
+  const tasks: TeamTask[] = []
+  for (const file of files) {
+    const taskId = file.replace(/\.json$/, "")
+    const task = readTeamTask(teamName, taskId)
+    if (task) {
+      tasks.push(task)
+    }
+  }
+
+  return tasks
+}
+
+export function createTeamTask(
+  teamName: string,
+  subject: string,
+  description: string,
+  activeForm?: string,
+  metadata?: Record<string, unknown>,
+): TeamTask {
+  if (!subject.trim()) {
+    throw new Error("team_task_subject_required")
+  }
+
+  return withTaskLock(teamName, () => {
+    const task: TeamTask = {
+      id: generateTaskId(),
+      subject,
+      description,
+      activeForm,
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      ...(metadata ? { metadata } : {}),
+    }
+
+    const validated = TeamTaskSchema.parse(task)
+    writeJsonAtomic(getTeamTaskPath(teamName, validated.id), validated)
+    return validated
+  })
+}
+
+export function writeTeamTask(teamName: string, task: TeamTask): TeamTask {
+  const validated = TeamTaskSchema.parse(task)
+  writeJsonAtomic(getTeamTaskPath(teamName, validated.id), validated)
+  return validated
+}
+
+export function deleteTeamTaskFile(teamName: string, taskId: string): void {
+  const taskPath = getTeamTaskPath(teamName, taskId)
+  if (existsSync(taskPath)) {
+    unlinkSync(taskPath)
+  }
+}
+
+export function readTaskFromDirectory(taskDir: string, taskId: string): TeamTask | null {
+  return readJsonSafe(join(taskDir, `${taskId}.json`), TeamTaskSchema)
+}
+
+export function resetOwnerTasks(teamName: string, ownerName: string): void {
+  withTaskLock(teamName, () => {
+    const tasks = listTeamTasks(teamName)
+    for (const task of tasks) {
+      if (task.owner !== ownerName) {
+        continue
+      }
+      const next: TeamTask = {
+        ...task,
+        owner: undefined,
+        status: task.status === "completed" ? "completed" : "pending",
+      }
+      writeTeamTask(teamName, next)
+    }
+  })
+}
+
+export function withTeamTaskLock<T>(teamName: string, operation: () => T): T {
+  return withTaskLock(teamName, operation)
+}

--- a/src/tools/agent-teams/team-task-tools.ts
+++ b/src/tools/agent-teams/team-task-tools.ts
@@ -1,6 +1,7 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { sendStructuredInboxMessage } from "./inbox-store"
 import { readTeamConfigOrThrow } from "./team-config-store"
+import { validateAgentName, validateTaskId, validateTeamName } from "./name-validation"
 import {
   TeamTaskCreateInputSchema,
   TeamTaskGetInputSchema,
@@ -32,6 +33,10 @@ export function createTeamTaskCreateTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamTaskCreateInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
         readTeamConfigOrThrow(input.team_name)
 
         const task = createTeamTask(
@@ -59,6 +64,10 @@ export function createTeamTaskListTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamTaskListInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
         readTeamConfigOrThrow(input.team_name)
         return JSON.stringify(listTeamTasks(input.team_name))
       } catch (error) {
@@ -78,6 +87,14 @@ export function createTeamTaskGetTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamTaskGetInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
+        const taskIdError = validateTaskId(input.task_id)
+        if (taskIdError) {
+          return JSON.stringify({ error: taskIdError })
+        }
         readTeamConfigOrThrow(input.team_name)
         const task = readTeamTask(input.team_name, input.task_id)
         if (!task) {
@@ -93,6 +110,14 @@ export function createTeamTaskGetTool(): ToolDefinition {
 
 export function notifyOwnerAssignment(teamName: string, task: TeamTask): void {
   if (!task.owner || task.status === "deleted") {
+    return
+  }
+
+  if (validateTeamName(teamName)) {
+    return
+  }
+
+  if (validateAgentName(task.owner)) {
     return
   }
 

--- a/src/tools/agent-teams/team-task-tools.ts
+++ b/src/tools/agent-teams/team-task-tools.ts
@@ -3,21 +3,34 @@ import { sendStructuredInboxMessage } from "./inbox-store"
 import { readTeamConfigOrThrow } from "./team-config-store"
 import { validateAgentNameOrLead, validateTaskId, validateTeamName } from "./name-validation"
 import {
+  TeamConfig,
   TeamTaskCreateInputSchema,
   TeamTaskGetInputSchema,
   TeamTaskListInputSchema,
   TeamTask,
+  TeamToolContext,
+  isTeammateMember,
 } from "./types"
 import { createTeamTask, listTeamTasks, readTeamTask } from "./team-task-store"
 
-function buildTaskAssignmentPayload(task: TeamTask): Record<string, unknown> {
+function buildTaskAssignmentPayload(task: TeamTask, assignedBy: string): Record<string, unknown> {
   return {
     type: "task_assignment",
     taskId: task.id,
     subject: task.subject,
     description: task.description,
+    assignedBy,
     timestamp: new Date().toISOString(),
   }
+}
+
+export function resolveTaskActorFromContext(config: TeamConfig, context: TeamToolContext): "team-lead" | string | null {
+  if (context.sessionID === config.leadSessionId) {
+    return "team-lead"
+  }
+
+  const matchedMember = config.members.find((member) => isTeammateMember(member) && member.sessionID === context.sessionID)
+  return matchedMember?.name ?? null
 }
 
 export function createTeamTaskCreateTool(): ToolDefinition {
@@ -30,14 +43,18 @@ export function createTeamTaskCreateTool(): ToolDefinition {
       active_form: tool.schema.string().optional().describe("Present-continuous form"),
       metadata: tool.schema.record(tool.schema.string(), tool.schema.unknown()).optional().describe("Task metadata"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamTaskCreateInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
         if (teamError) {
           return JSON.stringify({ error: teamError })
         }
-        readTeamConfigOrThrow(input.team_name)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveTaskActorFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_task_session" })
+        }
 
         const task = createTeamTask(
           input.team_name,
@@ -61,14 +78,18 @@ export function createTeamTaskListTool(): ToolDefinition {
     args: {
       team_name: tool.schema.string().describe("Team name"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamTaskListInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
         if (teamError) {
           return JSON.stringify({ error: teamError })
         }
-        readTeamConfigOrThrow(input.team_name)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveTaskActorFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_task_session" })
+        }
         return JSON.stringify(listTeamTasks(input.team_name))
       } catch (error) {
         return JSON.stringify({ error: error instanceof Error ? error.message : "team_task_list_failed" })
@@ -84,7 +105,7 @@ export function createTeamTaskGetTool(): ToolDefinition {
       team_name: tool.schema.string().describe("Team name"),
       task_id: tool.schema.string().describe("Task id"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamTaskGetInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
@@ -95,7 +116,11 @@ export function createTeamTaskGetTool(): ToolDefinition {
         if (taskIdError) {
           return JSON.stringify({ error: taskIdError })
         }
-        readTeamConfigOrThrow(input.team_name)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveTaskActorFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_task_session" })
+        }
         const task = readTeamTask(input.team_name, input.task_id)
         if (!task) {
           return JSON.stringify({ error: "team_task_not_found" })
@@ -108,7 +133,7 @@ export function createTeamTaskGetTool(): ToolDefinition {
   })
 }
 
-export function notifyOwnerAssignment(teamName: string, task: TeamTask): void {
+export function notifyOwnerAssignment(teamName: string, task: TeamTask, assignedBy: string): void {
   if (!task.owner || task.status === "deleted") {
     return
   }
@@ -121,11 +146,15 @@ export function notifyOwnerAssignment(teamName: string, task: TeamTask): void {
     return
   }
 
+  if (validateAgentNameOrLead(assignedBy)) {
+    return
+  }
+
   sendStructuredInboxMessage(
     teamName,
-    "team-lead",
+    assignedBy,
     task.owner,
-    buildTaskAssignmentPayload(task),
+    buildTaskAssignmentPayload(task, assignedBy),
     "task_assignment",
   )
 }

--- a/src/tools/agent-teams/team-task-tools.ts
+++ b/src/tools/agent-teams/team-task-tools.ts
@@ -1,0 +1,106 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { sendStructuredInboxMessage } from "./inbox-store"
+import { readTeamConfigOrThrow } from "./team-config-store"
+import {
+  TeamTaskCreateInputSchema,
+  TeamTaskGetInputSchema,
+  TeamTaskListInputSchema,
+  TeamTask,
+} from "./types"
+import { createTeamTask, listTeamTasks, readTeamTask } from "./team-task-store"
+
+function buildTaskAssignmentPayload(task: TeamTask): Record<string, unknown> {
+  return {
+    type: "task_assignment",
+    taskId: task.id,
+    subject: task.subject,
+    description: task.description,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+export function createTeamTaskCreateTool(): ToolDefinition {
+  return tool({
+    description: "Create a task in team-scoped storage.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      subject: tool.schema.string().describe("Task subject"),
+      description: tool.schema.string().describe("Task description"),
+      active_form: tool.schema.string().optional().describe("Present-continuous form"),
+      metadata: tool.schema.record(tool.schema.string(), tool.schema.unknown()).optional().describe("Task metadata"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamTaskCreateInputSchema.parse(args)
+        readTeamConfigOrThrow(input.team_name)
+
+        const task = createTeamTask(
+          input.team_name,
+          input.subject,
+          input.description,
+          input.active_form,
+          input.metadata,
+        )
+
+        return JSON.stringify(task)
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_task_create_failed" })
+      }
+    },
+  })
+}
+
+export function createTeamTaskListTool(): ToolDefinition {
+  return tool({
+    description: "List tasks for one team.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamTaskListInputSchema.parse(args)
+        readTeamConfigOrThrow(input.team_name)
+        return JSON.stringify(listTeamTasks(input.team_name))
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_task_list_failed" })
+      }
+    },
+  })
+}
+
+export function createTeamTaskGetTool(): ToolDefinition {
+  return tool({
+    description: "Get one task from team-scoped storage.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      task_id: tool.schema.string().describe("Task id"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamTaskGetInputSchema.parse(args)
+        readTeamConfigOrThrow(input.team_name)
+        const task = readTeamTask(input.team_name, input.task_id)
+        if (!task) {
+          return JSON.stringify({ error: "team_task_not_found" })
+        }
+        return JSON.stringify(task)
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_task_get_failed" })
+      }
+    },
+  })
+}
+
+export function notifyOwnerAssignment(teamName: string, task: TeamTask): void {
+  if (!task.owner || task.status === "deleted") {
+    return
+  }
+
+  sendStructuredInboxMessage(
+    teamName,
+    "team-lead",
+    task.owner,
+    buildTaskAssignmentPayload(task),
+    "task_assignment",
+  )
+}

--- a/src/tools/agent-teams/team-task-tools.ts
+++ b/src/tools/agent-teams/team-task-tools.ts
@@ -1,7 +1,7 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { sendStructuredInboxMessage } from "./inbox-store"
 import { readTeamConfigOrThrow } from "./team-config-store"
-import { validateAgentName, validateTaskId, validateTeamName } from "./name-validation"
+import { validateAgentNameOrLead, validateTaskId, validateTeamName } from "./name-validation"
 import {
   TeamTaskCreateInputSchema,
   TeamTaskGetInputSchema,
@@ -117,7 +117,7 @@ export function notifyOwnerAssignment(teamName: string, task: TeamTask): void {
     return
   }
 
-  if (validateAgentName(task.owner)) {
+  if (validateAgentNameOrLead(task.owner)) {
     return
   }
 

--- a/src/tools/agent-teams/team-task-update-tool.ts
+++ b/src/tools/agent-teams/team-task-update-tool.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { readTeamConfigOrThrow } from "./team-config-store"
+import { validateAgentName, validateTaskId, validateTeamName } from "./name-validation"
 import { TeamTaskUpdateInputSchema } from "./types"
 import { updateTeamTask } from "./team-task-update"
 import { notifyOwnerAssignment } from "./team-task-tools"
@@ -22,6 +23,36 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamTaskUpdateInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
+        const taskIdError = validateTaskId(input.task_id)
+        if (taskIdError) {
+          return JSON.stringify({ error: taskIdError })
+        }
+        if (input.owner !== undefined) {
+          const ownerError = validateAgentName(input.owner)
+          if (ownerError) {
+            return JSON.stringify({ error: ownerError })
+          }
+        }
+        if (input.add_blocks) {
+          for (const blockerId of input.add_blocks) {
+            const blockerError = validateTaskId(blockerId)
+            if (blockerError) {
+              return JSON.stringify({ error: blockerError })
+            }
+          }
+        }
+        if (input.add_blocked_by) {
+          for (const dependencyId of input.add_blocked_by) {
+            const dependencyError = validateTaskId(dependencyId)
+            if (dependencyError) {
+              return JSON.stringify({ error: dependencyError })
+            }
+          }
+        }
         readTeamConfigOrThrow(input.team_name)
 
         const task = updateTeamTask(input.team_name, input.task_id, {

--- a/src/tools/agent-teams/team-task-update-tool.ts
+++ b/src/tools/agent-teams/team-task-update-tool.ts
@@ -1,0 +1,48 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { readTeamConfigOrThrow } from "./team-config-store"
+import { TeamTaskUpdateInputSchema } from "./types"
+import { updateTeamTask } from "./team-task-update"
+import { notifyOwnerAssignment } from "./team-task-tools"
+
+export function createTeamTaskUpdateTool(): ToolDefinition {
+  return tool({
+    description: "Update task status, owner, dependencies, and metadata in a team task list.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      task_id: tool.schema.string().describe("Task id"),
+      status: tool.schema.enum(["pending", "in_progress", "completed", "deleted"]).optional().describe("Task status"),
+      owner: tool.schema.string().optional().describe("Task owner"),
+      subject: tool.schema.string().optional().describe("Task subject"),
+      description: tool.schema.string().optional().describe("Task description"),
+      active_form: tool.schema.string().optional().describe("Present-continuous form"),
+      add_blocks: tool.schema.array(tool.schema.string()).optional().describe("Add task ids this task blocks"),
+      add_blocked_by: tool.schema.array(tool.schema.string()).optional().describe("Add blocker task ids"),
+      metadata: tool.schema.record(tool.schema.string(), tool.schema.unknown()).optional().describe("Metadata patch (null removes key)"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamTaskUpdateInputSchema.parse(args)
+        readTeamConfigOrThrow(input.team_name)
+
+        const task = updateTeamTask(input.team_name, input.task_id, {
+          status: input.status,
+          owner: input.owner,
+          subject: input.subject,
+          description: input.description,
+          activeForm: input.active_form,
+          addBlocks: input.add_blocks,
+          addBlockedBy: input.add_blocked_by,
+          metadata: input.metadata,
+        })
+
+        if (input.owner !== undefined) {
+          notifyOwnerAssignment(input.team_name, task)
+        }
+
+        return JSON.stringify(task)
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "team_task_update_failed" })
+      }
+    },
+  })
+}

--- a/src/tools/agent-teams/team-task-update-tool.ts
+++ b/src/tools/agent-teams/team-task-update-tool.ts
@@ -1,9 +1,9 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { readTeamConfigOrThrow } from "./team-config-store"
 import { validateAgentNameOrLead, validateTaskId, validateTeamName } from "./name-validation"
-import { TeamTaskUpdateInputSchema } from "./types"
+import { TeamTaskUpdateInputSchema, TeamToolContext } from "./types"
 import { updateTeamTask } from "./team-task-update"
-import { notifyOwnerAssignment } from "./team-task-tools"
+import { notifyOwnerAssignment, resolveTaskActorFromContext } from "./team-task-tools"
 
 export function createTeamTaskUpdateTool(): ToolDefinition {
   return tool({
@@ -20,7 +20,7 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
       add_blocked_by: tool.schema.array(tool.schema.string()).optional().describe("Add blocker task ids"),
       metadata: tool.schema.record(tool.schema.string(), tool.schema.unknown()).optional().describe("Metadata patch (null removes key)"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamTaskUpdateInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
@@ -33,6 +33,11 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
         }
 
         const config = readTeamConfigOrThrow(input.team_name)
+        const actor = resolveTaskActorFromContext(config, context)
+        if (!actor) {
+          return JSON.stringify({ error: "unauthorized_task_session" })
+        }
+
         const memberNames = new Set(config.members.map((member) => member.name))
         if (input.owner !== undefined) {
           if (input.owner !== "") {
@@ -74,7 +79,7 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
         })
 
         if (input.owner !== undefined) {
-          notifyOwnerAssignment(input.team_name, task)
+          notifyOwnerAssignment(input.team_name, task, actor)
         }
 
         return JSON.stringify(task)

--- a/src/tools/agent-teams/team-task-update-tool.ts
+++ b/src/tools/agent-teams/team-task-update-tool.ts
@@ -1,6 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { readTeamConfigOrThrow } from "./team-config-store"
-import { validateAgentName, validateTaskId, validateTeamName } from "./name-validation"
+import { validateAgentNameOrLead, validateTaskId, validateTeamName } from "./name-validation"
 import { TeamTaskUpdateInputSchema } from "./types"
 import { updateTeamTask } from "./team-task-update"
 import { notifyOwnerAssignment } from "./team-task-tools"
@@ -31,10 +31,19 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
         if (taskIdError) {
           return JSON.stringify({ error: taskIdError })
         }
+
+        const config = readTeamConfigOrThrow(input.team_name)
+        const memberNames = new Set(config.members.map((member) => member.name))
         if (input.owner !== undefined) {
-          const ownerError = validateAgentName(input.owner)
-          if (ownerError) {
-            return JSON.stringify({ error: ownerError })
+          if (input.owner !== "") {
+            const ownerError = validateAgentNameOrLead(input.owner)
+            if (ownerError) {
+              return JSON.stringify({ error: ownerError })
+            }
+
+            if (!memberNames.has(input.owner)) {
+              return JSON.stringify({ error: "owner_not_in_team" })
+            }
           }
         }
         if (input.add_blocks) {
@@ -53,8 +62,6 @@ export function createTeamTaskUpdateTool(): ToolDefinition {
             }
           }
         }
-        readTeamConfigOrThrow(input.team_name)
-
         const task = updateTeamTask(input.team_name, input.task_id, {
           status: input.status,
           owner: input.owner,

--- a/src/tools/agent-teams/team-task-update.ts
+++ b/src/tools/agent-teams/team-task-update.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, unlinkSync } from "node:fs"
 import { join } from "node:path"
 import { readJsonSafe, writeJsonAtomic } from "../../features/claude-tasks/storage"
+import { validateTaskId, validateTeamName } from "./name-validation"
 import { getTeamTaskDir, getTeamTaskPath } from "./paths"
 import {
   addPendingEdge,
@@ -23,11 +24,40 @@ export interface TeamTaskUpdatePatch {
   metadata?: Record<string, unknown>
 }
 
+function assertValidTeamName(teamName: string): void {
+  const validationError = validateTeamName(teamName)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
+function assertValidTaskId(taskId: string): void {
+  const validationError = validateTaskId(taskId)
+  if (validationError) {
+    throw new Error(validationError)
+  }
+}
+
 function writeTaskToPath(path: string, task: TeamTask): void {
   writeJsonAtomic(path, TeamTaskSchema.parse(task))
 }
 
 export function updateTeamTask(teamName: string, taskId: string, patch: TeamTaskUpdatePatch): TeamTask {
+  assertValidTeamName(teamName)
+  assertValidTaskId(taskId)
+
+  if (patch.addBlocks) {
+    for (const blockedTaskId of patch.addBlocks) {
+      assertValidTaskId(blockedTaskId)
+    }
+  }
+
+  if (patch.addBlockedBy) {
+    for (const blockerId of patch.addBlockedBy) {
+      assertValidTaskId(blockerId)
+    }
+  }
+
   return withTeamTaskLock(teamName, () => {
     const taskDir = getTeamTaskDir(teamName)
     const taskPath = getTeamTaskPath(teamName, taskId)

--- a/src/tools/agent-teams/team-task-update.ts
+++ b/src/tools/agent-teams/team-task-update.ts
@@ -118,8 +118,15 @@ export function updateTeamTask(teamName: string, taskId: string, patch: TeamTask
 
     if (patch.status && patch.status !== "deleted") {
       ensureForwardStatusTransition(currentTask.status, patch.status)
-      const effectiveBlockedBy = Array.from(new Set([...(currentTask.blockedBy ?? []), ...(patch.addBlockedBy ?? [])]))
-      ensureDependenciesCompleted(patch.status, effectiveBlockedBy, readTask)
+    }
+
+    const effectiveStatus = patch.status ?? currentTask.status
+    const effectiveBlockedBy = Array.from(new Set([...(currentTask.blockedBy ?? []), ...(patch.addBlockedBy ?? [])]))
+    const shouldValidateDependencies =
+      (patch.status !== undefined || (patch.addBlockedBy?.length ?? 0) > 0) && effectiveStatus !== "deleted"
+
+    if (shouldValidateDependencies) {
+      ensureDependenciesCompleted(effectiveStatus, effectiveBlockedBy, readTask)
     }
 
     let nextTask: TeamTask = { ...currentTask }

--- a/src/tools/agent-teams/team-task-update.ts
+++ b/src/tools/agent-teams/team-task-update.ts
@@ -1,0 +1,210 @@
+import { existsSync, readdirSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import { readJsonSafe, writeJsonAtomic } from "../../features/claude-tasks/storage"
+import { getTeamTaskDir, getTeamTaskPath } from "./paths"
+import {
+  addPendingEdge,
+  createPendingEdgeMap,
+  ensureDependenciesCompleted,
+  ensureForwardStatusTransition,
+  wouldCreateCycle,
+} from "./team-task-dependency"
+import { TeamTask, TeamTaskSchema, TeamTaskStatus } from "./types"
+import { withTeamTaskLock } from "./team-task-store"
+
+export interface TeamTaskUpdatePatch {
+  status?: TeamTaskStatus
+  owner?: string
+  subject?: string
+  description?: string
+  activeForm?: string
+  addBlocks?: string[]
+  addBlockedBy?: string[]
+  metadata?: Record<string, unknown>
+}
+
+function writeTaskToPath(path: string, task: TeamTask): void {
+  writeJsonAtomic(path, TeamTaskSchema.parse(task))
+}
+
+export function updateTeamTask(teamName: string, taskId: string, patch: TeamTaskUpdatePatch): TeamTask {
+  return withTeamTaskLock(teamName, () => {
+    const taskDir = getTeamTaskDir(teamName)
+    const taskPath = getTeamTaskPath(teamName, taskId)
+    const currentTask = readJsonSafe(taskPath, TeamTaskSchema)
+    if (!currentTask) {
+      throw new Error("team_task_not_found")
+    }
+
+    const cache = new Map<string, TeamTask | null>()
+    cache.set(taskId, currentTask)
+
+    const readTask = (id: string): TeamTask | null => {
+      if (cache.has(id)) {
+        return cache.get(id) ?? null
+      }
+      const loaded = readJsonSafe(join(taskDir, `${id}.json`), TeamTaskSchema)
+      cache.set(id, loaded)
+      return loaded
+    }
+
+    const pendingEdges = createPendingEdgeMap()
+
+    if (patch.addBlocks) {
+      for (const blockedTaskId of patch.addBlocks) {
+        if (blockedTaskId === taskId) {
+          throw new Error("team_task_self_block")
+        }
+        if (!readTask(blockedTaskId)) {
+          throw new Error(`team_task_reference_not_found:${blockedTaskId}`)
+        }
+        addPendingEdge(pendingEdges, blockedTaskId, taskId)
+      }
+
+      for (const blockedTaskId of patch.addBlocks) {
+        if (wouldCreateCycle(blockedTaskId, taskId, pendingEdges, readTask)) {
+          throw new Error(`team_task_cycle_detected:${taskId}->${blockedTaskId}`)
+        }
+      }
+    }
+
+    if (patch.addBlockedBy) {
+      for (const blockerId of patch.addBlockedBy) {
+        if (blockerId === taskId) {
+          throw new Error("team_task_self_dependency")
+        }
+        if (!readTask(blockerId)) {
+          throw new Error(`team_task_reference_not_found:${blockerId}`)
+        }
+        addPendingEdge(pendingEdges, taskId, blockerId)
+      }
+
+      for (const blockerId of patch.addBlockedBy) {
+        if (wouldCreateCycle(taskId, blockerId, pendingEdges, readTask)) {
+          throw new Error(`team_task_cycle_detected:${taskId}<-${blockerId}`)
+        }
+      }
+    }
+
+    if (patch.status && patch.status !== "deleted") {
+      ensureForwardStatusTransition(currentTask.status, patch.status)
+      const effectiveBlockedBy = Array.from(new Set([...(currentTask.blockedBy ?? []), ...(patch.addBlockedBy ?? [])]))
+      ensureDependenciesCompleted(patch.status, effectiveBlockedBy, readTask)
+    }
+
+    let nextTask: TeamTask = { ...currentTask }
+
+    if (patch.subject !== undefined) {
+      nextTask.subject = patch.subject
+    }
+    if (patch.description !== undefined) {
+      nextTask.description = patch.description
+    }
+    if (patch.activeForm !== undefined) {
+      nextTask.activeForm = patch.activeForm
+    }
+    if (patch.owner !== undefined) {
+      nextTask.owner = patch.owner
+    }
+
+    const pendingWrites = new Map<string, TeamTask>()
+
+    if (patch.addBlocks) {
+      const existingBlocks = new Set(nextTask.blocks)
+      for (const blockedTaskId of patch.addBlocks) {
+        if (!existingBlocks.has(blockedTaskId)) {
+          nextTask.blocks.push(blockedTaskId)
+          existingBlocks.add(blockedTaskId)
+        }
+
+        const otherPath = getTeamTaskPath(teamName, blockedTaskId)
+        const other = pendingWrites.get(otherPath) ?? readTask(blockedTaskId)
+        if (other && !other.blockedBy.includes(taskId)) {
+          pendingWrites.set(otherPath, { ...other, blockedBy: [...other.blockedBy, taskId] })
+        }
+      }
+    }
+
+    if (patch.addBlockedBy) {
+      const existingBlockedBy = new Set(nextTask.blockedBy)
+      for (const blockerId of patch.addBlockedBy) {
+        if (!existingBlockedBy.has(blockerId)) {
+          nextTask.blockedBy.push(blockerId)
+          existingBlockedBy.add(blockerId)
+        }
+
+        const otherPath = getTeamTaskPath(teamName, blockerId)
+        const other = pendingWrites.get(otherPath) ?? readTask(blockerId)
+        if (other && !other.blocks.includes(taskId)) {
+          pendingWrites.set(otherPath, { ...other, blocks: [...other.blocks, taskId] })
+        }
+      }
+    }
+
+    if (patch.metadata !== undefined) {
+      const merged: Record<string, unknown> = { ...(nextTask.metadata ?? {}) }
+      for (const [key, value] of Object.entries(patch.metadata)) {
+        if (value === null) {
+          delete merged[key]
+        } else {
+          merged[key] = value
+        }
+      }
+      nextTask.metadata = Object.keys(merged).length > 0 ? merged : undefined
+    }
+
+    if (patch.status !== undefined) {
+      nextTask.status = patch.status
+    }
+
+    const allTaskFiles = readdirSync(taskDir).filter((file) => file.endsWith(".json") && file.startsWith("T-"))
+
+    if (nextTask.status === "completed") {
+      for (const file of allTaskFiles) {
+        const otherId = file.replace(/\.json$/, "")
+        if (otherId === taskId) continue
+
+        const otherPath = getTeamTaskPath(teamName, otherId)
+        const other = pendingWrites.get(otherPath) ?? readTask(otherId)
+        if (other?.blockedBy.includes(taskId)) {
+          pendingWrites.set(otherPath, {
+            ...other,
+            blockedBy: other.blockedBy.filter((id) => id !== taskId),
+          })
+        }
+      }
+    }
+
+    if (patch.status === "deleted") {
+      for (const file of allTaskFiles) {
+        const otherId = file.replace(/\.json$/, "")
+        if (otherId === taskId) continue
+
+        const otherPath = getTeamTaskPath(teamName, otherId)
+        const other = pendingWrites.get(otherPath) ?? readTask(otherId)
+        if (!other) continue
+
+        const nextOther = {
+          ...other,
+          blockedBy: other.blockedBy.filter((id) => id !== taskId),
+          blocks: other.blocks.filter((id) => id !== taskId),
+        }
+        pendingWrites.set(otherPath, nextOther)
+      }
+    }
+
+    for (const [path, task] of pendingWrites.entries()) {
+      writeTaskToPath(path, task)
+    }
+
+    if (patch.status === "deleted") {
+      if (existsSync(taskPath)) {
+        unlinkSync(taskPath)
+      }
+      return TeamTaskSchema.parse({ ...nextTask, status: "deleted" })
+    }
+
+    writeTaskToPath(taskPath, nextTask)
+    return TeamTaskSchema.parse(nextTask)
+  })
+}

--- a/src/tools/agent-teams/team-task-update.ts
+++ b/src/tools/agent-teams/team-task-update.ts
@@ -134,7 +134,7 @@ export function updateTeamTask(teamName: string, taskId: string, patch: TeamTask
       nextTask.activeForm = patch.activeForm
     }
     if (patch.owner !== undefined) {
-      nextTask.owner = patch.owner
+      nextTask.owner = patch.owner === "" ? undefined : patch.owner
     }
 
     const pendingWrites = new Map<string, TeamTask>()

--- a/src/tools/agent-teams/teammate-parent-context.test.ts
+++ b/src/tools/agent-teams/teammate-parent-context.test.ts
@@ -21,4 +21,16 @@ describe("agent-teams teammate parent context", () => {
     expect(parentToolContext.messageID).toBe("msg-main")
     expect(parentToolContext.agent).toBe("sisyphus")
   })
+
+  test("leaves agent undefined if missing in tool context", () => {
+    //#when
+    const parentToolContext = buildTeamParentToolContext({
+      sessionID: "ses-main",
+      messageID: "msg-main",
+      abort: new AbortController().signal,
+    })
+
+    //#then
+    expect(parentToolContext.agent).toBeUndefined()
+  })
 })

--- a/src/tools/agent-teams/teammate-parent-context.test.ts
+++ b/src/tools/agent-teams/teammate-parent-context.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+describe("agent-teams teammate parent context", () => {
+  test("forwards incoming abort signal to parent context resolver", () => {
+    //#given
+    const sourceUrl = new URL("./teammate-parent-context.ts", import.meta.url)
+    const source = readFileSync(sourceUrl, "utf-8")
+
+    //#then
+    expect(source.includes("abort: context.abort ?? new AbortController().signal")).toBe(true)
+  })
+})

--- a/src/tools/agent-teams/teammate-parent-context.test.ts
+++ b/src/tools/agent-teams/teammate-parent-context.test.ts
@@ -1,14 +1,24 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
-import { readFileSync } from "node:fs"
+import { buildTeamParentToolContext } from "./teammate-parent-context"
 
 describe("agent-teams teammate parent context", () => {
   test("forwards incoming abort signal to parent context resolver", () => {
     //#given
-    const sourceUrl = new URL("./teammate-parent-context.ts", import.meta.url)
-    const source = readFileSync(sourceUrl, "utf-8")
+    const abortSignal = new AbortController().signal
+
+    //#when
+    const parentToolContext = buildTeamParentToolContext({
+      sessionID: "ses-main",
+      messageID: "msg-main",
+      agent: "sisyphus",
+      abort: abortSignal,
+    })
 
     //#then
-    expect(source.includes("abort: context.abort ?? new AbortController().signal")).toBe(true)
+    expect(parentToolContext.abort).toBe(abortSignal)
+    expect(parentToolContext.sessionID).toBe("ses-main")
+    expect(parentToolContext.messageID).toBe("msg-main")
+    expect(parentToolContext.agent).toBe("sisyphus")
   })
 })

--- a/src/tools/agent-teams/teammate-parent-context.ts
+++ b/src/tools/agent-teams/teammate-parent-context.ts
@@ -1,0 +1,13 @@
+import type { ParentContext } from "../delegate-task/executor"
+import { resolveParentContext } from "../delegate-task/executor"
+import type { ToolContextWithMetadata } from "../delegate-task/types"
+import type { TeamToolContext } from "./types"
+
+export function resolveTeamParentContext(context: TeamToolContext): ParentContext {
+  return resolveParentContext({
+    sessionID: context.sessionID,
+    messageID: context.messageID,
+    agent: context.agent ?? "sisyphus",
+    abort: new AbortController().signal,
+  } as ToolContextWithMetadata)
+}

--- a/src/tools/agent-teams/teammate-parent-context.ts
+++ b/src/tools/agent-teams/teammate-parent-context.ts
@@ -7,7 +7,7 @@ export function buildTeamParentToolContext(context: TeamToolContext): ToolContex
   return {
     sessionID: context.sessionID,
     messageID: context.messageID,
-    agent: context.agent ?? "sisyphus",
+    agent: context.agent,
     abort: context.abort ?? new AbortController().signal,
   }
 }

--- a/src/tools/agent-teams/teammate-parent-context.ts
+++ b/src/tools/agent-teams/teammate-parent-context.ts
@@ -3,11 +3,15 @@ import { resolveParentContext } from "../delegate-task/executor"
 import type { ToolContextWithMetadata } from "../delegate-task/types"
 import type { TeamToolContext } from "./types"
 
-export function resolveTeamParentContext(context: TeamToolContext): ParentContext {
-  return resolveParentContext({
+export function buildTeamParentToolContext(context: TeamToolContext): ToolContextWithMetadata {
+  return {
     sessionID: context.sessionID,
     messageID: context.messageID,
     agent: context.agent ?? "sisyphus",
     abort: context.abort ?? new AbortController().signal,
-  } as ToolContextWithMetadata)
+  }
+}
+
+export function resolveTeamParentContext(context: TeamToolContext): ParentContext {
+  return resolveParentContext(buildTeamParentToolContext(context))
 }

--- a/src/tools/agent-teams/teammate-parent-context.ts
+++ b/src/tools/agent-teams/teammate-parent-context.ts
@@ -8,6 +8,6 @@ export function resolveTeamParentContext(context: TeamToolContext): ParentContex
     sessionID: context.sessionID,
     messageID: context.messageID,
     agent: context.agent ?? "sisyphus",
-    abort: new AbortController().signal,
+    abort: context.abort ?? new AbortController().signal,
   } as ToolContextWithMetadata)
 }

--- a/src/tools/agent-teams/teammate-prompts.ts
+++ b/src/tools/agent-teams/teammate-prompts.ts
@@ -1,0 +1,28 @@
+export function buildLaunchPrompt(
+  teamName: string,
+  teammateName: string,
+  userPrompt: string,
+  categoryPromptAppend?: string,
+): string {
+  const sections = [
+    `You are teammate "${teammateName}" in team "${teamName}".`,
+    `When you need updates, call read_inbox with team_name="${teamName}" and agent_name="${teammateName}".`,
+    "Initial assignment:",
+    userPrompt,
+  ]
+
+  if (categoryPromptAppend) {
+    sections.push("Category guidance:", categoryPromptAppend)
+  }
+
+  return sections.join("\n\n")
+}
+
+export function buildDeliveryPrompt(teamName: string, teammateName: string, summary: string, content: string): string {
+  return [
+    `New team message for "${teammateName}" in team "${teamName}".`,
+    `Summary: ${summary}`,
+    "Content:",
+    content,
+  ].join("\n\n")
+}

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -1,25 +1,10 @@
-import type { PluginInput } from "@opencode-ai/plugin"
-import type { CategoriesConfig } from "../../config/schema"
 import type { BackgroundManager } from "../../features/background-agent"
-import { resolveCategoryExecution, resolveParentContext } from "../delegate-task/executor"
-import type { DelegateTaskArgs, ToolContextWithMetadata } from "../delegate-task/types"
 import { clearInbox, ensureInbox, sendPlainInboxMessage } from "./inbox-store"
 import { assignNextColor, getTeamMember, removeTeammate, updateTeamConfig, upsertTeammate } from "./team-config-store"
 import type { TeamTeammateMember, TeamToolContext } from "./types"
-
-function parseModel(model: string | undefined): { providerID: string; modelID: string } | undefined {
-  if (!model) {
-    return undefined
-  }
-  const separatorIndex = model.indexOf("/")
-  if (separatorIndex <= 0 || separatorIndex >= model.length - 1) {
-    throw new Error("invalid_model_override_format")
-  }
-
-  const providerID = model.slice(0, separatorIndex)
-  const modelID = model.slice(separatorIndex + 1)
-  return { providerID, modelID }
-}
+import { resolveTeamParentContext } from "./teammate-parent-context"
+import { buildDeliveryPrompt, buildLaunchPrompt } from "./teammate-prompts"
+import { resolveSpawnExecution, type TeamCategoryContext } from "./teammate-spawn-execution"
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -37,35 +22,6 @@ function resolveLaunchFailureMessage(status: string | undefined, error: string |
   return "teammate_launch_timeout"
 }
 
-function buildLaunchPrompt(
-  teamName: string,
-  teammateName: string,
-  userPrompt: string,
-  categoryPromptAppend?: string,
-): string {
-  const sections = [
-    `You are teammate "${teammateName}" in team "${teamName}".`,
-    `When you need updates, call read_inbox with team_name="${teamName}" and agent_name="${teammateName}".`,
-    "Initial assignment:",
-    userPrompt,
-  ]
-
-  if (categoryPromptAppend) {
-    sections.push("Category guidance:", categoryPromptAppend)
-  }
-
-  return sections.join("\n\n")
-}
-
-function buildDeliveryPrompt(teamName: string, teammateName: string, summary: string, content: string): string {
-  return [
-    `New team message for "${teammateName}" in team "${teamName}".`,
-    `Summary: ${summary}`,
-    "Content:",
-    content,
-  ].join("\n\n")
-}
-
 export interface SpawnTeammateParams {
   teamName: string
   name: string
@@ -76,99 +32,24 @@ export interface SpawnTeammateParams {
   planModeRequired: boolean
   context: TeamToolContext
   manager: BackgroundManager
-  categoryContext?: {
-    client: PluginInput["client"]
-    userCategories?: CategoriesConfig
-    sisyphusJuniorModel?: string
-  }
-}
-
-interface SpawnExecution {
-  agentType: string
-  teammateModel: string
-  launchModel?: { providerID: string; modelID: string; variant?: string }
-  categoryPromptAppend?: string
-}
-
-async function getSystemDefaultModel(client: PluginInput["client"]): Promise<string | undefined> {
-  try {
-    const openCodeConfig = await client.config.get()
-    return (openCodeConfig as { data?: { model?: string } })?.data?.model
-  } catch {
-    return undefined
-  }
-}
-
-async function resolveSpawnExecution(params: SpawnTeammateParams): Promise<SpawnExecution> {
-  if (params.model) {
-    const launchModel = parseModel(params.model)
-    return {
-      agentType: params.subagentType,
-      teammateModel: params.model,
-      ...(launchModel ? { launchModel } : {}),
-    }
-  }
-
-  if (!params.categoryContext?.client) {
-    return {
-      agentType: params.subagentType,
-      teammateModel: "native",
-    }
-  }
-
-  const parentContext = resolveParentContext({
-    sessionID: params.context.sessionID,
-    messageID: params.context.messageID,
-    agent: params.context.agent ?? "sisyphus",
-    abort: new AbortController().signal,
-  } as ToolContextWithMetadata)
-
-  const inheritedModel = parentContext.model
-    ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
-    : undefined
-
-  const systemDefaultModel = await getSystemDefaultModel(params.categoryContext.client)
-
-  const delegateArgs: DelegateTaskArgs = {
-    description: `[team:${params.teamName}] ${params.name}`,
-    prompt: params.prompt,
-    category: params.category,
-    subagent_type: "sisyphus-junior",
-    run_in_background: true,
-    load_skills: [],
-  }
-
-  const resolution = await resolveCategoryExecution(
-    delegateArgs,
-    {
-      manager: params.manager,
-      client: params.categoryContext.client,
-      directory: process.cwd(),
-      userCategories: params.categoryContext.userCategories,
-      sisyphusJuniorModel: params.categoryContext.sisyphusJuniorModel,
-    },
-    inheritedModel,
-    systemDefaultModel,
-  )
-
-  if (resolution.error) {
-    throw new Error(resolution.error)
-  }
-
-  if (!resolution.categoryModel) {
-    throw new Error("category_model_not_resolved")
-  }
-
-  return {
-    agentType: resolution.agentToUse,
-    teammateModel: `${resolution.categoryModel.providerID}/${resolution.categoryModel.modelID}`,
-    launchModel: resolution.categoryModel,
-    categoryPromptAppend: resolution.categoryPromptAppend,
-  }
+  categoryContext?: TeamCategoryContext
 }
 
 export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTeammateMember> {
-  const execution = await resolveSpawnExecution(params)
+  const parentContext = resolveTeamParentContext(params.context)
+  const execution = await resolveSpawnExecution(
+    {
+      teamName: params.teamName,
+      name: params.name,
+      prompt: params.prompt,
+      category: params.category,
+      subagentType: params.subagentType,
+      model: params.model,
+      manager: params.manager,
+      categoryContext: params.categoryContext,
+    },
+    parentContext,
+  )
 
   let teammate: TeamTeammateMember | undefined
   let launchedTaskID: string | undefined
@@ -209,11 +90,12 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
       description: `[team:${params.teamName}] ${params.name}`,
       prompt: buildLaunchPrompt(params.teamName, params.name, params.prompt, execution.categoryPromptAppend),
       agent: execution.agentType,
-      parentSessionID: params.context.sessionID,
-      parentMessageID: params.context.messageID,
+      parentSessionID: parentContext.sessionID,
+      parentMessageID: parentContext.messageID,
+      parentModel: parentContext.model,
       ...(execution.launchModel ? { model: execution.launchModel } : {}),
       ...(params.category ? { category: params.category } : {}),
-      parentAgent: params.context.agent,
+      parentAgent: parentContext.agent,
     })
     launchedTaskID = launched.id
 
@@ -286,13 +168,16 @@ export async function resumeTeammateWithMessage(
     return
   }
 
+  const parentContext = resolveTeamParentContext(context)
+
   try {
     await manager.resume({
       sessionId: teammate.sessionID,
       prompt: buildDeliveryPrompt(teamName, teammate.name, summary, content),
-      parentSessionID: context.sessionID,
-      parentMessageID: context.messageID,
-      parentAgent: context.agent,
+      parentSessionID: parentContext.sessionID,
+      parentMessageID: parentContext.messageID,
+      parentModel: parentContext.model,
+      parentAgent: parentContext.agent,
     })
   } catch {
     return

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -7,10 +7,13 @@ function parseModel(model: string | undefined): { providerID: string; modelID: s
   if (!model) {
     return undefined
   }
-  const [providerID, modelID] = model.split("/", 2)
-  if (!providerID || !modelID) {
+  const separatorIndex = model.indexOf("/")
+  if (separatorIndex <= 0 || separatorIndex >= model.length - 1) {
     throw new Error("invalid_model_override_format")
   }
+
+  const providerID = model.slice(0, separatorIndex)
+  const modelID = model.slice(separatorIndex + 1)
   return { providerID, modelID }
 }
 

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -1,4 +1,8 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { CategoriesConfig } from "../../config/schema"
 import type { BackgroundManager } from "../../features/background-agent"
+import { resolveCategoryExecution, resolveParentContext } from "../delegate-task/executor"
+import type { DelegateTaskArgs, ToolContextWithMetadata } from "../delegate-task/types"
 import { clearInbox, ensureInbox, sendPlainInboxMessage } from "./inbox-store"
 import { assignNextColor, getTeamMember, removeTeammate, updateTeamConfig, upsertTeammate } from "./team-config-store"
 import type { TeamTeammateMember, TeamToolContext } from "./types"
@@ -33,13 +37,24 @@ function resolveLaunchFailureMessage(status: string | undefined, error: string |
   return "teammate_launch_timeout"
 }
 
-function buildLaunchPrompt(teamName: string, teammateName: string, userPrompt: string): string {
-  return [
+function buildLaunchPrompt(
+  teamName: string,
+  teammateName: string,
+  userPrompt: string,
+  categoryPromptAppend?: string,
+): string {
+  const sections = [
     `You are teammate "${teammateName}" in team "${teamName}".`,
     `When you need updates, call read_inbox with team_name="${teamName}" and agent_name="${teammateName}".`,
     "Initial assignment:",
     userPrompt,
-  ].join("\n\n")
+  ]
+
+  if (categoryPromptAppend) {
+    sections.push("Category guidance:", categoryPromptAppend)
+  }
+
+  return sections.join("\n\n")
 }
 
 function buildDeliveryPrompt(teamName: string, teammateName: string, summary: string, content: string): string {
@@ -55,14 +70,103 @@ export interface SpawnTeammateParams {
   teamName: string
   name: string
   prompt: string
+  category?: string
   subagentType: string
   model?: string
   planModeRequired: boolean
   context: TeamToolContext
   manager: BackgroundManager
+  categoryContext?: {
+    client: PluginInput["client"]
+    userCategories?: CategoriesConfig
+    sisyphusJuniorModel?: string
+  }
+}
+
+interface SpawnExecution {
+  agentType: string
+  teammateModel: string
+  launchModel?: { providerID: string; modelID: string; variant?: string }
+  categoryPromptAppend?: string
+}
+
+async function getSystemDefaultModel(client: PluginInput["client"]): Promise<string | undefined> {
+  try {
+    const openCodeConfig = await client.config.get()
+    return (openCodeConfig as { data?: { model?: string } })?.data?.model
+  } catch {
+    return undefined
+  }
+}
+
+async function resolveSpawnExecution(params: SpawnTeammateParams): Promise<SpawnExecution> {
+  if (!params.category) {
+    const launchModel = parseModel(params.model)
+    return {
+      agentType: params.subagentType,
+      teammateModel: params.model ?? "native",
+      ...(launchModel ? { launchModel } : {}),
+    }
+  }
+
+  if (!params.categoryContext?.client) {
+    throw new Error("category_requires_client_context")
+  }
+
+  const parentContext = resolveParentContext({
+    sessionID: params.context.sessionID,
+    messageID: params.context.messageID,
+    agent: params.context.agent ?? "sisyphus",
+    abort: new AbortController().signal,
+  } as ToolContextWithMetadata)
+
+  const inheritedModel = parentContext.model
+    ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
+    : undefined
+
+  const systemDefaultModel = await getSystemDefaultModel(params.categoryContext.client)
+
+  const delegateArgs: DelegateTaskArgs = {
+    description: `[team:${params.teamName}] ${params.name}`,
+    prompt: params.prompt,
+    category: params.category,
+    subagent_type: "sisyphus-junior",
+    run_in_background: true,
+    load_skills: [],
+  }
+
+  const resolution = await resolveCategoryExecution(
+    delegateArgs,
+    {
+      manager: params.manager,
+      client: params.categoryContext.client,
+      directory: process.cwd(),
+      userCategories: params.categoryContext.userCategories,
+      sisyphusJuniorModel: params.categoryContext.sisyphusJuniorModel,
+    },
+    inheritedModel,
+    systemDefaultModel,
+  )
+
+  if (resolution.error) {
+    throw new Error(resolution.error)
+  }
+
+  if (!resolution.categoryModel) {
+    throw new Error("category_model_not_resolved")
+  }
+
+  return {
+    agentType: resolution.agentToUse,
+    teammateModel: `${resolution.categoryModel.providerID}/${resolution.categoryModel.modelID}`,
+    launchModel: resolution.categoryModel,
+    categoryPromptAppend: resolution.categoryPromptAppend,
+  }
 }
 
 export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTeammateMember> {
+  const execution = await resolveSpawnExecution(params)
+
   let teammate: TeamTeammateMember | undefined
   let launchedTaskID: string | undefined
 
@@ -74,8 +178,9 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
     teammate = {
       agentId: `${params.name}@${params.teamName}`,
       name: params.name,
-      agentType: params.subagentType,
-      model: params.model ?? "native",
+      agentType: execution.agentType,
+      ...(params.category ? { category: params.category } : {}),
+      model: execution.teammateModel,
       prompt: params.prompt,
       color: assignNextColor(current),
       planModeRequired: params.planModeRequired,
@@ -97,14 +202,14 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
     ensureInbox(params.teamName, params.name)
     sendPlainInboxMessage(params.teamName, "team-lead", params.name, params.prompt, "initial_prompt", teammate.color)
 
-    const resolvedModel = parseModel(params.model)
     const launched = await params.manager.launch({
       description: `[team:${params.teamName}] ${params.name}`,
-      prompt: buildLaunchPrompt(params.teamName, params.name, params.prompt),
-      agent: params.subagentType,
+      prompt: buildLaunchPrompt(params.teamName, params.name, params.prompt, execution.categoryPromptAppend),
+      agent: execution.agentType,
       parentSessionID: params.context.sessionID,
       parentMessageID: params.context.messageID,
-      ...(resolvedModel ? { model: resolvedModel } : {}),
+      ...(execution.launchModel ? { model: execution.launchModel } : {}),
+      ...(params.category ? { category: params.category } : {}),
       parentAgent: params.context.agent,
     })
     launchedTaskID = launched.id

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -1,0 +1,148 @@
+import type { BackgroundManager } from "../../features/background-agent"
+import { ensureInbox, sendPlainInboxMessage } from "./inbox-store"
+import { assignNextColor, getTeamMember, readTeamConfigOrThrow, removeTeammate, upsertTeammate, writeTeamConfig } from "./team-config-store"
+import type { TeamTeammateMember, TeamToolContext } from "./types"
+
+function parseModel(model: string | undefined): { providerID: string; modelID: string } | undefined {
+  if (!model) {
+    return undefined
+  }
+  const [providerID, modelID] = model.split("/", 2)
+  if (!providerID || !modelID) {
+    return undefined
+  }
+  return { providerID, modelID }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function buildLaunchPrompt(teamName: string, teammateName: string, userPrompt: string): string {
+  return [
+    `You are teammate "${teammateName}" in team "${teamName}".`,
+    `When you need updates, call read_inbox with team_name="${teamName}" and agent_name="${teammateName}".`,
+    "Initial assignment:",
+    userPrompt,
+  ].join("\n\n")
+}
+
+function buildDeliveryPrompt(teamName: string, teammateName: string, summary: string, content: string): string {
+  return [
+    `New team message for "${teammateName}" in team "${teamName}".`,
+    `Summary: ${summary}`,
+    "Content:",
+    content,
+  ].join("\n\n")
+}
+
+export interface SpawnTeammateParams {
+  teamName: string
+  name: string
+  prompt: string
+  subagentType: string
+  model?: string
+  planModeRequired: boolean
+  context: TeamToolContext
+  manager: BackgroundManager
+}
+
+export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTeammateMember> {
+  const config = readTeamConfigOrThrow(params.teamName)
+
+  if (getTeamMember(config, params.name)) {
+    throw new Error("teammate_already_exists")
+  }
+
+  const teammate: TeamTeammateMember = {
+    agentId: `${params.name}@${params.teamName}`,
+    name: params.name,
+    agentType: params.subagentType,
+    model: params.model ?? "native",
+    prompt: params.prompt,
+    color: assignNextColor(config),
+    planModeRequired: params.planModeRequired,
+    joinedAt: Date.now(),
+    cwd: process.cwd(),
+    subscriptions: [],
+    backendType: "native",
+    isActive: false,
+  }
+
+  writeTeamConfig(params.teamName, upsertTeammate(config, teammate))
+  ensureInbox(params.teamName, params.name)
+  sendPlainInboxMessage(params.teamName, "team-lead", params.name, params.prompt, "initial_prompt", teammate.color)
+
+  try {
+    const resolvedModel = parseModel(params.model)
+    const launched = await params.manager.launch({
+      description: `[team:${params.teamName}] ${params.name}`,
+      prompt: buildLaunchPrompt(params.teamName, params.name, params.prompt),
+      agent: params.subagentType,
+      parentSessionID: params.context.sessionID,
+      parentMessageID: params.context.messageID,
+      ...(resolvedModel ? { model: resolvedModel } : {}),
+      parentAgent: params.context.agent,
+    })
+
+    const start = Date.now()
+    let sessionID = launched.sessionID
+    while (!sessionID && Date.now() - start < 30_000) {
+      await delay(50)
+      const task = params.manager.getTask(launched.id)
+      sessionID = task?.sessionID
+    }
+
+    const nextMember: TeamTeammateMember = {
+      ...teammate,
+      isActive: true,
+      backgroundTaskID: launched.id,
+      ...(sessionID ? { sessionID } : {}),
+    }
+
+    const current = readTeamConfigOrThrow(params.teamName)
+    writeTeamConfig(params.teamName, upsertTeammate(current, nextMember))
+    return nextMember
+  } catch (error) {
+    const rollback = readTeamConfigOrThrow(params.teamName)
+    writeTeamConfig(params.teamName, removeTeammate(rollback, params.name))
+    throw error
+  }
+}
+
+export async function resumeTeammateWithMessage(
+  manager: BackgroundManager,
+  context: TeamToolContext,
+  teamName: string,
+  teammate: TeamTeammateMember,
+  summary: string,
+  content: string,
+): Promise<void> {
+  if (!teammate.sessionID) {
+    return
+  }
+
+  try {
+    await manager.resume({
+      sessionId: teammate.sessionID,
+      prompt: buildDeliveryPrompt(teamName, teammate.name, summary, content),
+      parentSessionID: context.sessionID,
+      parentMessageID: context.messageID,
+      parentAgent: context.agent,
+    })
+  } catch {
+    return
+  }
+}
+
+export async function cancelTeammateRun(manager: BackgroundManager, teammate: TeamTeammateMember): Promise<void> {
+  if (!teammate.backgroundTaskID) {
+    return
+  }
+
+  await manager.cancelTask(teammate.backgroundTaskID, {
+    source: "team_force_kill",
+    abortSession: true,
+    skipNotification: true,
+  })
+}

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -90,10 +90,10 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
     throw new Error("teammate_create_failed")
   }
 
-  ensureInbox(params.teamName, params.name)
-  sendPlainInboxMessage(params.teamName, "team-lead", params.name, params.prompt, "initial_prompt", teammate.color)
-
   try {
+    ensureInbox(params.teamName, params.name)
+    sendPlainInboxMessage(params.teamName, "team-lead", params.name, params.prompt, "initial_prompt", teammate.color)
+
     const resolvedModel = parseModel(params.model)
     const launched = await params.manager.launch({
       description: `[team:${params.teamName}] ${params.name}`,

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -18,6 +18,18 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function resolveLaunchFailureMessage(status: string | undefined, error: string | undefined): string {
+  if (status === "error") {
+    return error ? `teammate_launch_failed:${error}` : "teammate_launch_failed"
+  }
+
+  if (status === "cancelled") {
+    return "teammate_launch_cancelled"
+  }
+
+  return "teammate_launch_timeout"
+}
+
 function buildLaunchPrompt(teamName: string, teammateName: string, userPrompt: string): string {
   return [
     `You are teammate "${teammateName}" in team "${teamName}".`,
@@ -87,17 +99,28 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
 
     const start = Date.now()
     let sessionID = launched.sessionID
+    let latestStatus: string | undefined
+    let latestError: string | undefined
     while (!sessionID && Date.now() - start < 30_000) {
       await delay(50)
       const task = params.manager.getTask(launched.id)
+      latestStatus = task?.status
+      latestError = task?.error
+      if (task?.status === "error" || task?.status === "cancelled") {
+        throw new Error(resolveLaunchFailureMessage(task.status, task.error))
+      }
       sessionID = task?.sessionID
+    }
+
+    if (!sessionID) {
+      throw new Error(resolveLaunchFailureMessage(latestStatus, latestError))
     }
 
     const nextMember: TeamTeammateMember = {
       ...teammate,
       isActive: true,
       backgroundTaskID: launched.id,
-      ...(sessionID ? { sessionID } : {}),
+      sessionID,
     }
 
     const current = readTeamConfigOrThrow(params.teamName)

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -246,6 +246,8 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
     updateTeamConfig(params.teamName, (current) => upsertTeammate(current, nextMember))
     return nextMember
   } catch (error) {
+    const originalError = error
+
     if (launchedTaskID) {
       await params.manager
         .cancelTask(launchedTaskID, {
@@ -255,9 +257,20 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
         })
         .catch(() => undefined)
     }
-    updateTeamConfig(params.teamName, (current) => removeTeammate(current, params.name))
-    clearInbox(params.teamName, params.name)
-    throw error
+
+    try {
+      updateTeamConfig(params.teamName, (current) => removeTeammate(current, params.name))
+    } catch (cleanupError) {
+      void cleanupError
+    }
+
+    try {
+      clearInbox(params.teamName, params.name)
+    } catch (cleanupError) {
+      void cleanupError
+    }
+
+    throw originalError
   }
 }
 

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -9,7 +9,7 @@ function parseModel(model: string | undefined): { providerID: string; modelID: s
   }
   const [providerID, modelID] = model.split("/", 2)
   if (!providerID || !modelID) {
-    return undefined
+    throw new Error("invalid_model_override_format")
   }
   return { providerID, modelID }
 }
@@ -61,6 +61,7 @@ export interface SpawnTeammateParams {
 
 export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTeammateMember> {
   const config = readTeamConfigOrThrow(params.teamName)
+  let launchedTaskID: string | undefined
 
   if (getTeamMember(config, params.name)) {
     throw new Error("teammate_already_exists")
@@ -96,6 +97,7 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
       ...(resolvedModel ? { model: resolvedModel } : {}),
       parentAgent: params.context.agent,
     })
+    launchedTaskID = launched.id
 
     const start = Date.now()
     let sessionID = launched.sessionID
@@ -127,6 +129,16 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
     writeTeamConfig(params.teamName, upsertTeammate(current, nextMember))
     return nextMember
   } catch (error) {
+    if (launchedTaskID) {
+      await params.manager
+        .cancelTask(launchedTaskID, {
+          source: "team_launch_failed",
+          abortSession: true,
+          skipNotification: true,
+        })
+        .catch(() => undefined)
+    }
+
     const rollback = readTeamConfigOrThrow(params.teamName)
     writeTeamConfig(params.teamName, removeTeammate(rollback, params.name))
     throw error

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -70,7 +70,7 @@ export interface SpawnTeammateParams {
   teamName: string
   name: string
   prompt: string
-  category?: string
+  category: string
   subagentType: string
   model?: string
   planModeRequired: boolean
@@ -100,17 +100,20 @@ async function getSystemDefaultModel(client: PluginInput["client"]): Promise<str
 }
 
 async function resolveSpawnExecution(params: SpawnTeammateParams): Promise<SpawnExecution> {
-  if (!params.category) {
+  if (params.model) {
     const launchModel = parseModel(params.model)
     return {
       agentType: params.subagentType,
-      teammateModel: params.model ?? "native",
+      teammateModel: params.model,
       ...(launchModel ? { launchModel } : {}),
     }
   }
 
   if (!params.categoryContext?.client) {
-    throw new Error("category_requires_client_context")
+    return {
+      agentType: params.subagentType,
+      teammateModel: "native",
+    }
   }
 
   const parentContext = resolveParentContext({
@@ -179,7 +182,7 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
       agentId: `${params.name}@${params.teamName}`,
       name: params.name,
       agentType: execution.agentType,
-      ...(params.category ? { category: params.category } : {}),
+      category: params.category,
       model: execution.teammateModel,
       prompt: params.prompt,
       color: assignNextColor(current),

--- a/src/tools/agent-teams/teammate-runtime.ts
+++ b/src/tools/agent-teams/teammate-runtime.ts
@@ -1,6 +1,6 @@
 import type { BackgroundManager } from "../../features/background-agent"
-import { ensureInbox, sendPlainInboxMessage } from "./inbox-store"
-import { assignNextColor, getTeamMember, readTeamConfigOrThrow, removeTeammate, upsertTeammate, writeTeamConfig } from "./team-config-store"
+import { clearInbox, ensureInbox, sendPlainInboxMessage } from "./inbox-store"
+import { assignNextColor, getTeamMember, removeTeammate, updateTeamConfig, upsertTeammate } from "./team-config-store"
 import type { TeamTeammateMember, TeamToolContext } from "./types"
 
 function parseModel(model: string | undefined): { providerID: string; modelID: string } | undefined {
@@ -60,29 +60,36 @@ export interface SpawnTeammateParams {
 }
 
 export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTeammateMember> {
-  const config = readTeamConfigOrThrow(params.teamName)
+  let teammate: TeamTeammateMember | undefined
   let launchedTaskID: string | undefined
 
-  if (getTeamMember(config, params.name)) {
-    throw new Error("teammate_already_exists")
+  updateTeamConfig(params.teamName, (current) => {
+    if (getTeamMember(current, params.name)) {
+      throw new Error("teammate_already_exists")
+    }
+
+    teammate = {
+      agentId: `${params.name}@${params.teamName}`,
+      name: params.name,
+      agentType: params.subagentType,
+      model: params.model ?? "native",
+      prompt: params.prompt,
+      color: assignNextColor(current),
+      planModeRequired: params.planModeRequired,
+      joinedAt: Date.now(),
+      cwd: process.cwd(),
+      subscriptions: [],
+      backendType: "native",
+      isActive: false,
+    }
+
+    return upsertTeammate(current, teammate)
+  })
+
+  if (!teammate) {
+    throw new Error("teammate_create_failed")
   }
 
-  const teammate: TeamTeammateMember = {
-    agentId: `${params.name}@${params.teamName}`,
-    name: params.name,
-    agentType: params.subagentType,
-    model: params.model ?? "native",
-    prompt: params.prompt,
-    color: assignNextColor(config),
-    planModeRequired: params.planModeRequired,
-    joinedAt: Date.now(),
-    cwd: process.cwd(),
-    subscriptions: [],
-    backendType: "native",
-    isActive: false,
-  }
-
-  writeTeamConfig(params.teamName, upsertTeammate(config, teammate))
   ensureInbox(params.teamName, params.name)
   sendPlainInboxMessage(params.teamName, "team-lead", params.name, params.prompt, "initial_prompt", teammate.color)
 
@@ -125,8 +132,7 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
       sessionID,
     }
 
-    const current = readTeamConfigOrThrow(params.teamName)
-    writeTeamConfig(params.teamName, upsertTeammate(current, nextMember))
+    updateTeamConfig(params.teamName, (current) => upsertTeammate(current, nextMember))
     return nextMember
   } catch (error) {
     if (launchedTaskID) {
@@ -138,9 +144,8 @@ export async function spawnTeammate(params: SpawnTeammateParams): Promise<TeamTe
         })
         .catch(() => undefined)
     }
-
-    const rollback = readTeamConfigOrThrow(params.teamName)
-    writeTeamConfig(params.teamName, removeTeammate(rollback, params.name))
+    updateTeamConfig(params.teamName, (current) => removeTeammate(current, params.name))
+    clearInbox(params.teamName, params.name)
     throw error
   }
 }

--- a/src/tools/agent-teams/teammate-spawn-execution.ts
+++ b/src/tools/agent-teams/teammate-spawn-execution.ts
@@ -1,0 +1,119 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { CategoriesConfig } from "../../config/schema"
+import type { BackgroundManager } from "../../features/background-agent"
+import type { ParentContext } from "../delegate-task/executor"
+import { resolveCategoryExecution } from "../delegate-task/executor"
+import type { DelegateTaskArgs } from "../delegate-task/types"
+
+function parseModel(model: string | undefined): { providerID: string; modelID: string } | undefined {
+  if (!model) {
+    return undefined
+  }
+
+  const separatorIndex = model.indexOf("/")
+  if (separatorIndex <= 0 || separatorIndex >= model.length - 1) {
+    throw new Error("invalid_model_override_format")
+  }
+
+  return {
+    providerID: model.slice(0, separatorIndex),
+    modelID: model.slice(separatorIndex + 1),
+  }
+}
+
+async function getSystemDefaultModel(client: PluginInput["client"]): Promise<string | undefined> {
+  try {
+    const openCodeConfig = await client.config.get()
+    return (openCodeConfig as { data?: { model?: string } })?.data?.model
+  } catch {
+    return undefined
+  }
+}
+
+export interface TeamCategoryContext {
+  client: PluginInput["client"]
+  userCategories?: CategoriesConfig
+  sisyphusJuniorModel?: string
+}
+
+export interface SpawnExecutionRequest {
+  teamName: string
+  name: string
+  prompt: string
+  category: string
+  subagentType: string
+  model?: string
+  manager: BackgroundManager
+  categoryContext?: TeamCategoryContext
+}
+
+export interface SpawnExecutionResult {
+  agentType: string
+  teammateModel: string
+  launchModel?: { providerID: string; modelID: string; variant?: string }
+  categoryPromptAppend?: string
+}
+
+export async function resolveSpawnExecution(
+  request: SpawnExecutionRequest,
+  parentContext: ParentContext,
+): Promise<SpawnExecutionResult> {
+  if (request.model) {
+    const launchModel = parseModel(request.model)
+    return {
+      agentType: request.subagentType,
+      teammateModel: request.model,
+      ...(launchModel ? { launchModel } : {}),
+    }
+  }
+
+  if (!request.categoryContext?.client) {
+    return {
+      agentType: request.subagentType,
+      teammateModel: "native",
+    }
+  }
+
+  const inheritedModel = parentContext.model
+    ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
+    : undefined
+
+  const systemDefaultModel = await getSystemDefaultModel(request.categoryContext.client)
+
+  const delegateArgs: DelegateTaskArgs = {
+    description: `[team:${request.teamName}] ${request.name}`,
+    prompt: request.prompt,
+    category: request.category,
+    subagent_type: "sisyphus-junior",
+    run_in_background: true,
+    load_skills: [],
+  }
+
+  const resolution = await resolveCategoryExecution(
+    delegateArgs,
+    {
+      manager: request.manager,
+      client: request.categoryContext.client,
+      directory: process.cwd(),
+      userCategories: request.categoryContext.userCategories,
+      sisyphusJuniorModel: request.categoryContext.sisyphusJuniorModel,
+    },
+    inheritedModel,
+    systemDefaultModel,
+  )
+
+  if (resolution.error) {
+    throw new Error(resolution.error)
+  }
+
+  if (!resolution.categoryModel) {
+    throw new Error("category_model_not_resolved")
+  }
+
+  return {
+    agentType: resolution.agentToUse,
+    teammateModel: `${resolution.categoryModel.providerID}/${resolution.categoryModel.modelID}`,
+    launchModel: resolution.categoryModel,
+    categoryPromptAppend: resolution.categoryPromptAppend,
+  }
+}

--- a/src/tools/agent-teams/teammate-tools.test.ts
+++ b/src/tools/agent-teams/teammate-tools.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundManager } from "../../features/background-agent"
+import { createAgentTeamsTools } from "./tools"
+
+interface TestToolContext {
+  sessionID: string
+  messageID: string
+  agent: string
+  abort: AbortSignal
+}
+
+interface MockManagerHandles {
+  manager: BackgroundManager
+  launchCalls: Array<Record<string, unknown>>
+}
+
+function createMockManager(): MockManagerHandles {
+  const launchCalls: Array<Record<string, unknown>> = []
+
+  const manager = {
+    launch: async (args: Record<string, unknown>) => {
+      launchCalls.push(args)
+      return { id: `bg-${launchCalls.length}`, sessionID: `ses-worker-${launchCalls.length}` }
+    },
+    getTask: () => undefined,
+    resume: async () => ({ id: "resume-1" }),
+    cancelTask: async () => true,
+  } as unknown as BackgroundManager
+
+  return { manager, launchCalls }
+}
+
+function createContext(sessionID = "ses-main"): TestToolContext {
+  return {
+    sessionID,
+    messageID: "msg-main",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+  }
+}
+
+async function executeJsonTool(
+  tools: ReturnType<typeof createAgentTeamsTools>,
+  toolName: keyof ReturnType<typeof createAgentTeamsTools>,
+  args: Record<string, unknown>,
+  context: TestToolContext,
+): Promise<unknown> {
+  const output = await tools[toolName].execute(args, context)
+  return JSON.parse(output)
+}
+
+describe("agent-teams teammate tools", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-teammate-tools-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("spawn_teammate requires lead session authorization", async () => {
+    //#given
+    const { manager, launchCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-lead")
+    const teammateContext = createContext("ses-worker")
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    //#when
+    const unauthorized = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      teammateContext,
+    ) as { error?: string }
+
+    //#then
+    expect(unauthorized.error).toBe("unauthorized_lead_session")
+    expect(launchCalls).toHaveLength(0)
+  })
+})

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import type { BackgroundManager } from "../../features/background-agent"
+import { clearInbox } from "./inbox-store"
 import { validateAgentName, validateTeamName } from "./name-validation"
 import {
   TeamForceKillInputSchema,
@@ -8,7 +9,7 @@ import {
   TeamToolContext,
   isTeammateMember,
 } from "./types"
-import { getTeamMember, readTeamConfigOrThrow, removeTeammate, updateTeamConfig, writeTeamConfig } from "./team-config-store"
+import { getTeamMember, readTeamConfigOrThrow, removeTeammate, updateTeamConfig } from "./team-config-store"
 import { cancelTeammateRun, spawnTeammate } from "./teammate-runtime"
 import { resetOwnerTasks } from "./team-task-store"
 
@@ -86,11 +87,20 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
         }
 
         await cancelTeammateRun(manager, member)
-        const refreshedConfig = readTeamConfigOrThrow(input.team_name)
-        const refreshedMember = getTeamMember(refreshedConfig, input.agent_name)
-        if (refreshedMember && isTeammateMember(refreshedMember)) {
-          writeTeamConfig(input.team_name, removeTeammate(refreshedConfig, input.agent_name))
+        let removed = false
+        updateTeamConfig(input.team_name, (current) => {
+          const refreshedMember = getTeamMember(current, input.agent_name)
+          if (!refreshedMember || !isTeammateMember(refreshedMember)) {
+            return current
+          }
+          removed = true
+          return removeTeammate(current, input.agent_name)
+        })
+
+        if (removed) {
+          clearInbox(input.team_name, input.agent_name)
         }
+
         resetOwnerTasks(input.team_name, input.agent_name)
 
         return JSON.stringify({ success: true, message: `${input.agent_name} stopped` })
@@ -130,15 +140,20 @@ export function createProcessShutdownTool(manager: BackgroundManager): ToolDefin
         }
 
         await cancelTeammateRun(manager, member)
+        let removed = false
 
         updateTeamConfig(input.team_name, (current) => {
           const refreshedMember = getTeamMember(current, input.agent_name)
           if (!refreshedMember || !isTeammateMember(refreshedMember)) {
             return current
           }
-
+          removed = true
           return removeTeammate(current, input.agent_name)
         })
+
+        if (removed) {
+          clearInbox(input.team_name, input.agent_name)
+        }
 
         resetOwnerTasks(input.team_name, input.agent_name)
 

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -21,6 +21,42 @@ export interface AgentTeamsSpawnOptions {
   sisyphusJuniorModel?: string
 }
 
+async function shutdownTeammateWithCleanup(
+  manager: BackgroundManager,
+  context: TeamToolContext,
+  teamName: string,
+  agentName: string,
+): Promise<string | null> {
+  const config = readTeamConfigOrThrow(teamName)
+  if (context.sessionID !== config.leadSessionId) {
+    return "unauthorized_lead_session"
+  }
+
+  const member = getTeamMember(config, agentName)
+  if (!member || !isTeammateMember(member)) {
+    return "teammate_not_found"
+  }
+
+  await cancelTeammateRun(manager, member)
+  let removed = false
+
+  updateTeamConfig(teamName, (current) => {
+    const refreshedMember = getTeamMember(current, agentName)
+    if (!refreshedMember || !isTeammateMember(refreshedMember)) {
+      return current
+    }
+    removed = true
+    return removeTeammate(current, agentName)
+  })
+
+  if (removed) {
+    clearInbox(teamName, agentName)
+  }
+
+  resetOwnerTasks(teamName, agentName)
+  return null
+}
+
 export function createSpawnTeammateTool(manager: BackgroundManager, options?: AgentTeamsSpawnOptions): ToolDefinition {
   return tool({
     description: "Spawn a teammate using native internal agent execution.",
@@ -52,6 +88,11 @@ export function createSpawnTeammateTool(manager: BackgroundManager, options?: Ag
 
         if (input.subagent_type && input.subagent_type !== "sisyphus-junior") {
           return JSON.stringify({ error: "category_conflicts_with_subagent_type" })
+        }
+
+        const config = readTeamConfigOrThrow(input.team_name)
+        if (context.sessionID !== config.leadSessionId) {
+          return JSON.stringify({ error: "unauthorized_lead_session" })
         }
 
         const resolvedSubagentType = input.subagent_type ?? "sisyphus-junior"
@@ -107,31 +148,11 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
         if (agentError) {
           return JSON.stringify({ error: agentError })
         }
-        const config = readTeamConfigOrThrow(input.team_name)
-        if (context.sessionID !== config.leadSessionId) {
-          return JSON.stringify({ error: "unauthorized_lead_session" })
-        }
-        const member = getTeamMember(config, input.agent_name)
-        if (!member || !isTeammateMember(member)) {
-          return JSON.stringify({ error: "teammate_not_found" })
-        }
 
-        await cancelTeammateRun(manager, member)
-        let removed = false
-        updateTeamConfig(input.team_name, (current) => {
-          const refreshedMember = getTeamMember(current, input.agent_name)
-          if (!refreshedMember || !isTeammateMember(refreshedMember)) {
-            return current
-          }
-          removed = true
-          return removeTeammate(current, input.agent_name)
-        })
-
-        if (removed) {
-          clearInbox(input.team_name, input.agent_name)
+        const shutdownError = await shutdownTeammateWithCleanup(manager, context, input.team_name, input.agent_name)
+        if (shutdownError) {
+          return JSON.stringify({ error: shutdownError })
         }
-
-        resetOwnerTasks(input.team_name, input.agent_name)
 
         return JSON.stringify({ success: true, message: `${input.agent_name} stopped` })
       } catch (error) {
@@ -163,32 +184,10 @@ export function createProcessShutdownTool(manager: BackgroundManager): ToolDefin
           return JSON.stringify({ error: agentError })
         }
 
-        const config = readTeamConfigOrThrow(input.team_name)
-        if (context.sessionID !== config.leadSessionId) {
-          return JSON.stringify({ error: "unauthorized_lead_session" })
+        const shutdownError = await shutdownTeammateWithCleanup(manager, context, input.team_name, input.agent_name)
+        if (shutdownError) {
+          return JSON.stringify({ error: shutdownError })
         }
-        const member = getTeamMember(config, input.agent_name)
-        if (!member || !isTeammateMember(member)) {
-          return JSON.stringify({ error: "teammate_not_found" })
-        }
-
-        await cancelTeammateRun(manager, member)
-        let removed = false
-
-        updateTeamConfig(input.team_name, (current) => {
-          const refreshedMember = getTeamMember(current, input.agent_name)
-          if (!refreshedMember || !isTeammateMember(refreshedMember)) {
-            return current
-          }
-          removed = true
-          return removeTeammate(current, input.agent_name)
-        })
-
-        if (removed) {
-          clearInbox(input.team_name, input.agent_name)
-        }
-
-        resetOwnerTasks(input.team_name, input.agent_name)
 
         return JSON.stringify({ success: true, message: `${input.agent_name} removed` })
       } catch (error) {

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -1,4 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { CategoriesConfig } from "../../config/schema"
 import type { BackgroundManager } from "../../features/background-agent"
 import { clearInbox } from "./inbox-store"
 import { validateAgentName, validateTeamName } from "./name-validation"
@@ -13,13 +15,20 @@ import { getTeamMember, readTeamConfigOrThrow, removeTeammate, updateTeamConfig 
 import { cancelTeammateRun, spawnTeammate } from "./teammate-runtime"
 import { resetOwnerTasks } from "./team-task-store"
 
-export function createSpawnTeammateTool(manager: BackgroundManager): ToolDefinition {
+export interface AgentTeamsSpawnOptions {
+  client?: PluginInput["client"]
+  userCategories?: CategoriesConfig
+  sisyphusJuniorModel?: string
+}
+
+export function createSpawnTeammateTool(manager: BackgroundManager, options?: AgentTeamsSpawnOptions): ToolDefinition {
   return tool({
     description: "Spawn a teammate using native internal agent execution.",
     args: {
       team_name: tool.schema.string().describe("Team name"),
       name: tool.schema.string().describe("Teammate name"),
       prompt: tool.schema.string().describe("Initial teammate prompt"),
+      category: tool.schema.string().optional().describe("Optional category (spawns sisyphus-junior with category model/prompt)") ,
       subagent_type: tool.schema.string().optional().describe("Agent name to run (default: sisyphus-junior)"),
       model: tool.schema.string().optional().describe("Optional model override in provider/model format"),
       plan_mode_required: tool.schema.boolean().optional().describe("Enable plan mode flag in teammate metadata"),
@@ -37,15 +46,37 @@ export function createSpawnTeammateTool(manager: BackgroundManager): ToolDefinit
           return JSON.stringify({ error: agentError })
         }
 
+        if (input.category && input.subagent_type && input.subagent_type !== "sisyphus-junior") {
+          return JSON.stringify({ error: "category_conflicts_with_subagent_type" })
+        }
+
+        if (input.category && input.model) {
+          return JSON.stringify({ error: "category_conflicts_with_model_override" })
+        }
+
+        if (input.category && !options?.client) {
+          return JSON.stringify({ error: "category_requires_client_context" })
+        }
+
+        const resolvedSubagentType = input.category ? "sisyphus-junior" : input.subagent_type ?? "sisyphus-junior"
+
         const teammate = await spawnTeammate({
           teamName: input.team_name,
           name: input.name,
           prompt: input.prompt,
-          subagentType: input.subagent_type ?? "sisyphus-junior",
+          category: input.category,
+          subagentType: resolvedSubagentType,
           model: input.model,
           planModeRequired: input.plan_mode_required ?? false,
           context,
           manager,
+          categoryContext: options?.client
+            ? {
+                client: options.client,
+                userCategories: options.userCategories,
+                sisyphusJuniorModel: options.sisyphusJuniorModel,
+              }
+            : undefined,
         })
 
         return JSON.stringify({

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -8,7 +8,7 @@ import {
   TeamToolContext,
   isTeammateMember,
 } from "./types"
-import { getTeamMember, readTeamConfigOrThrow, removeTeammate, writeTeamConfig } from "./team-config-store"
+import { getTeamMember, readTeamConfigOrThrow, removeTeammate, updateTeamConfig, writeTeamConfig } from "./team-config-store"
 import { cancelTeammateRun, spawnTeammate } from "./teammate-runtime"
 import { resetOwnerTasks } from "./team-task-store"
 
@@ -130,7 +130,16 @@ export function createProcessShutdownTool(manager: BackgroundManager): ToolDefin
         }
 
         await cancelTeammateRun(manager, member)
-        writeTeamConfig(input.team_name, removeTeammate(config, input.agent_name))
+
+        updateTeamConfig(input.team_name, (current) => {
+          const refreshedMember = getTeamMember(current, input.agent_name)
+          if (!refreshedMember || !isTeammateMember(refreshedMember)) {
+            return current
+          }
+
+          return removeTeammate(current, input.agent_name)
+        })
+
         resetOwnerTasks(input.team_name, input.agent_name)
 
         return JSON.stringify({ success: true, message: `${input.agent_name} removed` })

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -1,0 +1,121 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import type { BackgroundManager } from "../../features/background-agent"
+import { validateAgentName, validateTeamName } from "./name-validation"
+import {
+  TeamForceKillInputSchema,
+  TeamProcessShutdownInputSchema,
+  TeamSpawnInputSchema,
+  TeamToolContext,
+  isTeammateMember,
+} from "./types"
+import { getTeamMember, readTeamConfigOrThrow, removeTeammate, writeTeamConfig } from "./team-config-store"
+import { cancelTeammateRun, spawnTeammate } from "./teammate-runtime"
+import { resetOwnerTasks } from "./team-task-store"
+
+export function createSpawnTeammateTool(manager: BackgroundManager): ToolDefinition {
+  return tool({
+    description: "Spawn a teammate using native internal agent execution.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      name: tool.schema.string().describe("Teammate name"),
+      prompt: tool.schema.string().describe("Initial teammate prompt"),
+      subagent_type: tool.schema.string().optional().describe("Agent name to run (default: sisyphus-junior)"),
+      model: tool.schema.string().optional().describe("Optional model override in provider/model format"),
+      plan_mode_required: tool.schema.boolean().optional().describe("Enable plan mode flag in teammate metadata"),
+    },
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
+      try {
+        const input = TeamSpawnInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
+
+        const agentError = validateAgentName(input.name)
+        if (agentError) {
+          return JSON.stringify({ error: agentError })
+        }
+
+        const teammate = await spawnTeammate({
+          teamName: input.team_name,
+          name: input.name,
+          prompt: input.prompt,
+          subagentType: input.subagent_type ?? "sisyphus-junior",
+          model: input.model,
+          planModeRequired: input.plan_mode_required ?? false,
+          context,
+          manager,
+        })
+
+        return JSON.stringify({
+          agent_id: teammate.agentId,
+          name: teammate.name,
+          team_name: input.team_name,
+          session_id: teammate.sessionID,
+          task_id: teammate.backgroundTaskID,
+        })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "spawn_teammate_failed" })
+      }
+    },
+  })
+}
+
+export function createForceKillTeammateTool(manager: BackgroundManager): ToolDefinition {
+  return tool({
+    description: "Force stop a teammate and clean up ownership state.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      agent_name: tool.schema.string().describe("Teammate name"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamForceKillInputSchema.parse(args)
+        const config = readTeamConfigOrThrow(input.team_name)
+        const member = getTeamMember(config, input.agent_name)
+        if (!member || !isTeammateMember(member)) {
+          return JSON.stringify({ error: "teammate_not_found" })
+        }
+
+        await cancelTeammateRun(manager, member)
+        writeTeamConfig(input.team_name, removeTeammate(config, input.agent_name))
+        resetOwnerTasks(input.team_name, input.agent_name)
+
+        return JSON.stringify({ success: true, message: `${input.agent_name} stopped` })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "force_kill_teammate_failed" })
+      }
+    },
+  })
+}
+
+export function createProcessShutdownTool(): ToolDefinition {
+  return tool({
+    description: "Finalize an approved shutdown by removing teammate and resetting owned tasks.",
+    args: {
+      team_name: tool.schema.string().describe("Team name"),
+      agent_name: tool.schema.string().describe("Teammate name"),
+    },
+    execute: async (args: Record<string, unknown>): Promise<string> => {
+      try {
+        const input = TeamProcessShutdownInputSchema.parse(args)
+        if (input.agent_name === "team-lead") {
+          return JSON.stringify({ error: "cannot_shutdown_team_lead" })
+        }
+
+        const config = readTeamConfigOrThrow(input.team_name)
+        const member = getTeamMember(config, input.agent_name)
+        if (!member || !isTeammateMember(member)) {
+          return JSON.stringify({ error: "teammate_not_found" })
+        }
+
+        writeTeamConfig(input.team_name, removeTeammate(config, input.agent_name))
+        resetOwnerTasks(input.team_name, input.agent_name)
+
+        return JSON.stringify({ success: true, message: `${input.agent_name} removed` })
+      } catch (error) {
+        return JSON.stringify({ error: error instanceof Error ? error.message : "process_shutdown_failed" })
+      }
+    },
+  })
+}

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -28,7 +28,7 @@ export function createSpawnTeammateTool(manager: BackgroundManager, options?: Ag
       team_name: tool.schema.string().describe("Team name"),
       name: tool.schema.string().describe("Teammate name"),
       prompt: tool.schema.string().describe("Initial teammate prompt"),
-      category: tool.schema.string().optional().describe("Optional category (spawns sisyphus-junior with category model/prompt)") ,
+      category: tool.schema.string().optional().describe("Required category for teammate metadata and routing"),
       subagent_type: tool.schema.string().optional().describe("Agent name to run (default: sisyphus-junior)"),
       model: tool.schema.string().optional().describe("Optional model override in provider/model format"),
       plan_mode_required: tool.schema.boolean().optional().describe("Enable plan mode flag in teammate metadata"),
@@ -46,19 +46,15 @@ export function createSpawnTeammateTool(manager: BackgroundManager, options?: Ag
           return JSON.stringify({ error: agentError })
         }
 
+        if (!input.category || !input.category.trim()) {
+          return JSON.stringify({ error: "category_required" })
+        }
+
         if (input.category && input.subagent_type && input.subagent_type !== "sisyphus-junior") {
           return JSON.stringify({ error: "category_conflicts_with_subagent_type" })
         }
 
-        if (input.category && input.model) {
-          return JSON.stringify({ error: "category_conflicts_with_model_override" })
-        }
-
-        if (input.category && !options?.client) {
-          return JSON.stringify({ error: "category_requires_client_context" })
-        }
-
-        const resolvedSubagentType = input.category ? "sisyphus-junior" : input.subagent_type ?? "sisyphus-junior"
+        const resolvedSubagentType = input.subagent_type ?? "sisyphus-junior"
 
         const teammate = await spawnTeammate({
           teamName: input.team_name,
@@ -100,7 +96,7 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
       team_name: tool.schema.string().describe("Team name"),
       agent_name: tool.schema.string().describe("Teammate name"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamForceKillInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
@@ -112,6 +108,9 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
           return JSON.stringify({ error: agentError })
         }
         const config = readTeamConfigOrThrow(input.team_name)
+        if (context.sessionID !== config.leadSessionId) {
+          return JSON.stringify({ error: "unauthorized_lead_session" })
+        }
         const member = getTeamMember(config, input.agent_name)
         if (!member || !isTeammateMember(member)) {
           return JSON.stringify({ error: "teammate_not_found" })
@@ -149,7 +148,7 @@ export function createProcessShutdownTool(manager: BackgroundManager): ToolDefin
       team_name: tool.schema.string().describe("Team name"),
       agent_name: tool.schema.string().describe("Teammate name"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (args: Record<string, unknown>, context: TeamToolContext): Promise<string> => {
       try {
         const input = TeamProcessShutdownInputSchema.parse(args)
         const teamError = validateTeamName(input.team_name)
@@ -165,6 +164,9 @@ export function createProcessShutdownTool(manager: BackgroundManager): ToolDefin
         }
 
         const config = readTeamConfigOrThrow(input.team_name)
+        if (context.sessionID !== config.leadSessionId) {
+          return JSON.stringify({ error: "unauthorized_lead_session" })
+        }
         const member = getTeamMember(config, input.agent_name)
         if (!member || !isTeammateMember(member)) {
           return JSON.stringify({ error: "teammate_not_found" })

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -101,7 +101,7 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
   })
 }
 
-export function createProcessShutdownTool(): ToolDefinition {
+export function createProcessShutdownTool(manager: BackgroundManager): ToolDefinition {
   return tool({
     description: "Finalize an approved shutdown by removing teammate and resetting owned tasks.",
     args: {
@@ -129,6 +129,7 @@ export function createProcessShutdownTool(): ToolDefinition {
           return JSON.stringify({ error: "teammate_not_found" })
         }
 
+        await cancelTeammateRun(manager, member)
         writeTeamConfig(input.team_name, removeTeammate(config, input.agent_name))
         resetOwnerTasks(input.team_name, input.agent_name)
 

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -28,7 +28,7 @@ export function createSpawnTeammateTool(manager: BackgroundManager, options?: Ag
       team_name: tool.schema.string().describe("Team name"),
       name: tool.schema.string().describe("Teammate name"),
       prompt: tool.schema.string().describe("Initial teammate prompt"),
-      category: tool.schema.string().optional().describe("Required category for teammate metadata and routing"),
+      category: tool.schema.string().describe("Required category for teammate metadata and routing"),
       subagent_type: tool.schema.string().optional().describe("Agent name to run (default: sisyphus-junior)"),
       model: tool.schema.string().optional().describe("Optional model override in provider/model format"),
       plan_mode_required: tool.schema.boolean().optional().describe("Enable plan mode flag in teammate metadata"),
@@ -46,11 +46,11 @@ export function createSpawnTeammateTool(manager: BackgroundManager, options?: Ag
           return JSON.stringify({ error: agentError })
         }
 
-        if (!input.category || !input.category.trim()) {
+        if (!input.category.trim()) {
           return JSON.stringify({ error: "category_required" })
         }
 
-        if (input.category && input.subagent_type && input.subagent_type !== "sisyphus-junior") {
+        if (input.subagent_type && input.subagent_type !== "sisyphus-junior") {
           return JSON.stringify({ error: "category_conflicts_with_subagent_type" })
         }
 

--- a/src/tools/agent-teams/teammate-tools.ts
+++ b/src/tools/agent-teams/teammate-tools.ts
@@ -71,6 +71,14 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamForceKillInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
+        const agentError = validateAgentName(input.agent_name)
+        if (agentError) {
+          return JSON.stringify({ error: agentError })
+        }
         const config = readTeamConfigOrThrow(input.team_name)
         const member = getTeamMember(config, input.agent_name)
         if (!member || !isTeammateMember(member)) {
@@ -78,7 +86,11 @@ export function createForceKillTeammateTool(manager: BackgroundManager): ToolDef
         }
 
         await cancelTeammateRun(manager, member)
-        writeTeamConfig(input.team_name, removeTeammate(config, input.agent_name))
+        const refreshedConfig = readTeamConfigOrThrow(input.team_name)
+        const refreshedMember = getTeamMember(refreshedConfig, input.agent_name)
+        if (refreshedMember && isTeammateMember(refreshedMember)) {
+          writeTeamConfig(input.team_name, removeTeammate(refreshedConfig, input.agent_name))
+        }
         resetOwnerTasks(input.team_name, input.agent_name)
 
         return JSON.stringify({ success: true, message: `${input.agent_name} stopped` })
@@ -99,8 +111,16 @@ export function createProcessShutdownTool(): ToolDefinition {
     execute: async (args: Record<string, unknown>): Promise<string> => {
       try {
         const input = TeamProcessShutdownInputSchema.parse(args)
+        const teamError = validateTeamName(input.team_name)
+        if (teamError) {
+          return JSON.stringify({ error: teamError })
+        }
         if (input.agent_name === "team-lead") {
           return JSON.stringify({ error: "cannot_shutdown_team_lead" })
+        }
+        const agentError = validateAgentName(input.agent_name)
+        if (agentError) {
+          return JSON.stringify({ error: agentError })
         }
 
         const config = readTeamConfigOrThrow(input.team_name)

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -636,6 +636,36 @@ describe("agent-teams tools functional", () => {
     expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
   })
 
+  test("keeps full model id suffix when override contains extra slashes", async () => {
+    //#given
+    const { manager, launchCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const spawnResult = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        model: "openai/gpt-5.3-codex/reasoning",
+      },
+      context,
+    ) as { name?: string; error?: string }
+
+    //#then
+    expect(spawnResult.error).toBeUndefined()
+    expect(spawnResult.name).toBe("worker_1")
+    expect(launchCalls).toHaveLength(1)
+    expect(launchCalls[0].model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.3-codex/reasoning",
+    })
+  })
+
   test("read_inbox returns team_not_found for unknown team", async () => {
     //#given
     const { manager } = createMockManager()
@@ -704,6 +734,113 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(Array.isArray(ownInbox)).toBe(true)
+  })
+
+  test("allows lead session to rotate after restart using team-lead identity", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const originalLead = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, originalLead)
+
+    const restartedLead = createContext("ses-restarted")
+
+    //#when
+    const sendResult = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        sender: "team-lead",
+        recipient: "team-lead",
+        summary: "restart",
+        content: "Lead session migrated",
+      },
+      restartedLead,
+    ) as { success?: boolean; error?: string }
+
+    //#then
+    expect(sendResult.error).toBeUndefined()
+    expect(sendResult.success).toBe(true)
+
+    //#when
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, restartedLead) as {
+      leadSessionId: string
+    }
+
+    //#then
+    expect(config.leadSessionId).toBe("ses-restarted")
+  })
+
+  test("clears old inbox when teammate is removed then re-spawned", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "First run",
+      },
+      context,
+    )
+
+    await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1",
+        summary: "legacy",
+        content: "legacy payload",
+      },
+      context,
+    )
+
+    await executeJsonTool(
+      tools,
+      "force_kill_teammate",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      context,
+    )
+
+    //#when
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Second run",
+      },
+      context,
+    )
+
+    const inbox = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      context,
+    ) as Array<{ text: string; summary?: string }>
+
+    //#then
+    expect(inbox.some((message) => message.text.includes("legacy payload"))).toBe(false)
+    expect(inbox.some((message) => message.summary === "initial_prompt" && message.text.includes("Second run"))).toBe(true)
   })
 
   test("cannot add pending blockers to already in-progress task without status change", async () => {

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { existsSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import { createAgentTeamsTools } from "./tools"
 import { getTeamDir, getTeamInboxPath, getTeamTaskDir } from "./paths"
@@ -11,12 +12,14 @@ interface LaunchCall {
   description: string
   prompt: string
   agent: string
+  category?: string
   parentSessionID: string
   parentMessageID: string
   parentAgent?: string
   model?: {
     providerID: string
     modelID: string
+    variant?: string
   }
 }
 
@@ -99,6 +102,25 @@ function createFailingLaunchManager(): { manager: BackgroundManager; cancelCalls
   } as unknown as BackgroundManager
 
   return { manager, cancelCalls }
+}
+
+function createCategoryClientMock(): PluginInput["client"] {
+  return {
+    config: {
+      get: async () => ({ data: { model: "openai/gpt-5.3-codex" } }),
+    },
+    provider: {
+      list: async () => ({ data: { connected: ["openai", "anthropic"] } }),
+    },
+    model: {
+      list: async () => ({
+        data: [
+          { provider: "openai", id: "gpt-5.3-codex" },
+          { provider: "anthropic", id: "claude-haiku-4-5" },
+        ],
+      }),
+    },
+  } as unknown as PluginInput["client"]
 }
 
 function createContext(sessionID = "ses-main"): TestToolContext {
@@ -273,6 +295,75 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(clearedOwnerTask.owner).toBeUndefined()
+  })
+
+  test("spawns teammate using category resolution like delegate-task", async () => {
+    //#given
+    const { manager, launchCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager, { client: createCategoryClientMock() })
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const spawned = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      context,
+    ) as { name?: string; error?: string }
+
+    //#then
+    expect(spawned.error).toBeUndefined()
+    expect(spawned.name).toBe("worker_1")
+    expect(launchCalls).toHaveLength(1)
+    expect(launchCalls[0].agent).toBe("sisyphus-junior")
+    expect(launchCalls[0].category).toBe("quick")
+    expect(launchCalls[0].model).toBeDefined()
+    const resolvedModel = launchCalls[0].model!
+    expect(launchCalls[0].prompt).toContain("Category guidance:")
+
+    //#when
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
+      members: Array<{ name: string; category?: string; model?: string }>
+    }
+
+    //#then
+    const teammate = config.members.find((member) => member.name === "worker_1")
+    expect(teammate).toBeDefined()
+    expect(teammate?.category).toBe("quick")
+    expect(teammate?.model).toBe(`${resolvedModel.providerID}/${resolvedModel.modelID}`)
+  })
+
+  test("rejects category with incompatible subagent_type", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager, { client: createCategoryClientMock() })
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+        subagent_type: "oracle",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("category_conflicts_with_subagent_type")
   })
 
   test("rejects invalid task id input for task_get", async () => {

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -657,6 +657,112 @@ describe("agent-teams tools functional", () => {
     expect(result.error).toBe("team_not_found")
   })
 
+  test("read_inbox denies cross-member access for non-lead sessions", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      leadContext,
+    )
+
+    const teammateContext = createContext("ses-worker-1")
+
+    //#when
+    const unauthorized = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "team-lead",
+      },
+      teammateContext,
+    ) as { error?: string }
+
+    //#then
+    expect(unauthorized.error).toBe("unauthorized_reader_session")
+
+    //#when
+    const ownInbox = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      teammateContext,
+    ) as unknown[]
+
+    //#then
+    expect(Array.isArray(ownInbox)).toBe(true)
+  })
+
+  test("cannot add pending blockers to already in-progress task without status change", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    const blocker = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Blocker",
+        description: "Unfinished blocker",
+      },
+      context,
+    ) as { id: string }
+
+    const mainTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Main",
+        description: "Main task",
+      },
+      context,
+    ) as { id: string }
+
+    await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: mainTask.id,
+        status: "in_progress",
+      },
+      context,
+    )
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: mainTask.id,
+        add_blocked_by: [blocker.id],
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe(`blocked_by_incomplete:${blocker.id}:pending`)
+  })
+
   test("binds sender to calling context and rejects sender spoofing", async () => {
     //#given
     const { manager } = createMockManager()

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -1032,6 +1032,67 @@ describe("agent-teams tools functional", () => {
     expect(config.leadSessionId).toBe("ses-main")
   })
 
+  test("read_config rejects sessions outside the team", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "read_config",
+      { team_name: "core" },
+      createContext("ses-unknown"),
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("unauthorized_reader_session")
+  })
+
+  test("read_config returns sanitized config for teammate sessions", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    )
+
+    //#when
+    const teammateView = await executeJsonTool(
+      tools,
+      "read_config",
+      { team_name: "core" },
+      createContext("ses-worker-1"),
+    ) as {
+      team_name?: string
+      description?: string
+      lead_agent_id?: string
+      teammates?: Array<{ name: string }>
+      leadSessionId?: string
+      members?: unknown
+    }
+
+    //#then
+    expect(teammateView.team_name).toBe("core")
+    expect(teammateView.description).toBe("")
+    expect(teammateView.lead_agent_id).toBe("team-lead@core")
+    expect(teammateView.teammates).toEqual(expect.arrayContaining([expect.objectContaining({ name: "worker_1" })]))
+    expect("leadSessionId" in teammateView).toBe(false)
+    expect("members" in teammateView).toBe(false)
+  })
+
   test("rejects unknown session claiming team-lead inbox", async () => {
     //#given
     const { manager } = createMockManager()

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -299,6 +299,133 @@ describe("agent-teams tools functional", () => {
     expect(clearedOwnerTask.owner).toBeUndefined()
   })
 
+  test("task tools reject sessions outside the team", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+
+    const createdTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Draft release notes",
+        description: "Prepare release notes for next publish.",
+      },
+      leadContext,
+    ) as { id: string }
+
+    const unknownContext = createContext("ses-unknown")
+
+    //#when
+    const createUnauthorized = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Unauthorized create",
+        description: "Should fail",
+      },
+      unknownContext,
+    ) as { error?: string }
+
+    const listUnauthorized = await executeJsonTool(
+      tools,
+      "team_task_list",
+      { team_name: "core" },
+      unknownContext,
+    ) as { error?: string }
+
+    const getUnauthorized = await executeJsonTool(
+      tools,
+      "team_task_get",
+      { team_name: "core", task_id: createdTask.id },
+      unknownContext,
+    ) as { error?: string }
+
+    const updateUnauthorized = await executeJsonTool(
+      tools,
+      "team_task_update",
+      { team_name: "core", task_id: createdTask.id, status: "in_progress" },
+      unknownContext,
+    ) as { error?: string }
+
+    //#then
+    expect(createUnauthorized.error).toBe("unauthorized_task_session")
+    expect(listUnauthorized.error).toBe("unauthorized_task_session")
+    expect(getUnauthorized.error).toBe("unauthorized_task_session")
+    expect(updateUnauthorized.error).toBe("unauthorized_task_session")
+  })
+
+  test("team_task_update assignment notification sender follows actor session", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    )
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_2",
+        prompt: "Handle QA",
+        category: "quick",
+      },
+      leadContext,
+    )
+
+    const task = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Validate rollout",
+        description: "Run preflight checks",
+      },
+      leadContext,
+    ) as { id: string }
+
+    //#when
+    const updated = await executeJsonTool(
+      tools,
+      "team_task_update",
+      { team_name: "core", task_id: task.id, owner: "worker_2" },
+      createContext("ses-worker-1"),
+    ) as { owner?: string }
+
+    const workerInbox = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_2",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      leadContext,
+    ) as Array<{ summary?: string; from: string; text: string }>
+
+    //#then
+    expect(updated.owner).toBe("worker_2")
+    const assignment = workerInbox.find((message) => message.summary === "task_assignment")
+    expect(assignment).toBeDefined()
+    expect(assignment?.from).toBe("worker_1")
+  })
+
   test("spawns teammate using category resolution like delegate-task", async () => {
     //#given
     const { manager, launchCalls } = createMockManager()

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -1,0 +1,345 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundManager } from "../../features/background-agent"
+import { createAgentTeamsTools } from "./tools"
+import { getTeamDir, getTeamInboxPath, getTeamTaskDir } from "./paths"
+
+interface LaunchCall {
+  description: string
+  prompt: string
+  agent: string
+  parentSessionID: string
+  parentMessageID: string
+  parentAgent?: string
+  model?: {
+    providerID: string
+    modelID: string
+  }
+}
+
+interface ResumeCall {
+  sessionId: string
+  prompt: string
+  parentSessionID: string
+  parentMessageID: string
+  parentAgent?: string
+}
+
+interface CancelCall {
+  taskId: string
+  options?: unknown
+}
+
+interface MockManagerHandles {
+  manager: BackgroundManager
+  launchCalls: LaunchCall[]
+  resumeCalls: ResumeCall[]
+  cancelCalls: CancelCall[]
+}
+
+interface TestToolContext {
+  sessionID: string
+  messageID: string
+  agent: string
+  abort: AbortSignal
+}
+
+function createMockManager(): MockManagerHandles {
+  const launchCalls: LaunchCall[] = []
+  const resumeCalls: ResumeCall[] = []
+  const cancelCalls: CancelCall[] = []
+  const launchedTasks = new Map<string, { id: string; sessionID: string }>()
+  let launchCount = 0
+
+  const manager = {
+    launch: async (args: LaunchCall) => {
+      launchCount += 1
+      launchCalls.push(args)
+      const task = { id: `bg-${launchCount}`, sessionID: `ses-worker-${launchCount}` }
+      launchedTasks.set(task.id, task)
+      return task
+    },
+    getTask: (taskId: string) => launchedTasks.get(taskId),
+    resume: async (args: ResumeCall) => {
+      resumeCalls.push(args)
+      return { id: `resume-${resumeCalls.length}` }
+    },
+    cancelTask: async (taskId: string, options?: unknown) => {
+      cancelCalls.push({ taskId, options })
+      return true
+    },
+  } as unknown as BackgroundManager
+
+  return { manager, launchCalls, resumeCalls, cancelCalls }
+}
+
+function createContext(): TestToolContext {
+  return {
+    sessionID: "ses-main",
+    messageID: "msg-main",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+  }
+}
+
+async function executeJsonTool(
+  tools: ReturnType<typeof createAgentTeamsTools>,
+  toolName: keyof ReturnType<typeof createAgentTeamsTools>,
+  args: Record<string, unknown>,
+  context: TestToolContext,
+): Promise<unknown> {
+  const output = await tools[toolName].execute(args, context)
+  return JSON.parse(output)
+}
+
+describe("agent-teams tools functional", () => {
+  let originalCwd: string
+  let tempProjectDir: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    tempProjectDir = mkdtempSync(join(tmpdir(), "agent-teams-tools-"))
+    process.chdir(tempProjectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(tempProjectDir, { recursive: true, force: true })
+  })
+
+  test("team_create/read_config/delete work with project-local storage", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    //#when
+    const created = await executeJsonTool(
+      tools,
+      "team_create",
+      { team_name: "core", description: "Core team" },
+      context,
+    ) as { team_name: string; team_file_path: string; lead_agent_id: string }
+
+    //#then
+    expect(created.team_name).toBe("core")
+    expect(created.lead_agent_id).toBe("team-lead@core")
+    expect(created.team_file_path).toBe(join(tempProjectDir, ".sisyphus", "agent-teams", "teams", "core", "config.json"))
+    expect(existsSync(created.team_file_path)).toBe(true)
+    expect(existsSync(getTeamInboxPath("core", "team-lead"))).toBe(true)
+
+    //#when
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
+      name: string
+      members: Array<{ name: string }>
+    }
+
+    //#then
+    expect(config.name).toBe("core")
+    expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
+
+    //#when
+    const deleted = await executeJsonTool(tools, "team_delete", { team_name: "core" }, context) as {
+      success: boolean
+    }
+
+    //#then
+    expect(deleted.success).toBe(true)
+    expect(existsSync(getTeamDir("core"))).toBe(false)
+    expect(existsSync(getTeamTaskDir("core"))).toBe(false)
+  })
+
+  test("task tools create/update/get/list and emit assignment inbox message", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const createdTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Draft release notes",
+        description: "Prepare release notes for next publish.",
+      },
+      context,
+    ) as { id: string; status: string }
+
+    //#then
+    expect(createdTask.id).toMatch(/^T-[a-f0-9-]+$/)
+    expect(createdTask.status).toBe("pending")
+
+    //#when
+    const updatedTask = await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+        owner: "worker_1",
+        status: "in_progress",
+      },
+      context,
+    ) as { owner?: string; status: string }
+
+    //#then
+    expect(updatedTask.owner).toBe("worker_1")
+    expect(updatedTask.status).toBe("in_progress")
+
+    //#when
+    const fetchedTask = await executeJsonTool(
+      tools,
+      "team_task_get",
+      { team_name: "core", task_id: createdTask.id },
+      context,
+    ) as { id: string; owner?: string }
+    const listedTasks = await executeJsonTool(tools, "team_task_list", { team_name: "core" }, context) as Array<{ id: string }>
+    const inbox = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      context,
+    ) as Array<{ summary?: string; text: string }>
+
+    //#then
+    expect(fetchedTask.id).toBe(createdTask.id)
+    expect(fetchedTask.owner).toBe("worker_1")
+    expect(listedTasks.some((task) => task.id === createdTask.id)).toBe(true)
+    expect(inbox.some((message) => message.summary === "task_assignment")).toBe(true)
+    const assignment = inbox.find((message) => message.summary === "task_assignment")
+    expect(assignment).toBeDefined()
+    const payload = JSON.parse(assignment!.text) as { type: string; taskId: string }
+    expect(payload.type).toBe("task_assignment")
+    expect(payload.taskId).toBe(createdTask.id)
+  })
+
+  test("spawn_teammate + send_message + force_kill_teammate execute end-to-end", async () => {
+    //#given
+    const { manager, launchCalls, resumeCalls, cancelCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const spawned = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      context,
+    ) as { name: string; session_id: string; task_id: string }
+
+    //#then
+    expect(spawned.name).toBe("worker_1")
+    expect(spawned.session_id).toBe("ses-worker-1")
+    expect(spawned.task_id).toBe("bg-1")
+    expect(launchCalls).toHaveLength(1)
+    expect(launchCalls[0]).toMatchObject({
+      description: "[team:core] worker_1",
+      agent: "sisyphus-junior",
+      parentSessionID: "ses-main",
+      parentMessageID: "msg-main",
+      parentAgent: "sisyphus",
+    })
+
+    //#when
+    const sent = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "worker_1",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      context,
+    ) as { success: boolean }
+
+    //#then
+    expect(sent.success).toBe(true)
+    expect(resumeCalls).toHaveLength(1)
+    expect(resumeCalls[0].sessionId).toBe("ses-worker-1")
+
+    //#given
+    const createdTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Follow-up",
+        description: "Collect teammate update",
+      },
+      context,
+    ) as { id: string }
+    await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+        owner: "worker_1",
+        status: "in_progress",
+      },
+      context,
+    )
+
+    //#when
+    const killed = await executeJsonTool(
+      tools,
+      "force_kill_teammate",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      context,
+    ) as { success: boolean }
+
+    //#then
+    expect(killed.success).toBe(true)
+    expect(cancelCalls).toHaveLength(1)
+    expect(cancelCalls[0].taskId).toBe("bg-1")
+    expect(cancelCalls[0].options).toEqual(
+      expect.objectContaining({
+        source: "team_force_kill",
+        abortSession: true,
+        skipNotification: true,
+      }),
+    )
+
+    //#when
+    const configAfterKill = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
+      members: Array<{ name: string }>
+    }
+    const taskAfterKill = await executeJsonTool(
+      tools,
+      "team_task_get",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+      },
+      context,
+    ) as { owner?: string; status: string }
+
+    //#then
+    expect(configAfterKill.members.some((member) => member.name === "worker_1")).toBe(false)
+    expect(taskAfterKill.owner).toBeUndefined()
+    expect(taskAfterKill.status).toBe("pending")
+  })
+})

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -363,7 +363,8 @@ describe("agent-teams tools functional", () => {
     ) as { error?: string }
 
     //#then
-    expect(result.error).toBe("category_required")
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain("category")
   })
 
   test("rejects category with incompatible subagent_type", async () => {
@@ -929,6 +930,70 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(Array.isArray(ownInbox)).toBe(true)
+  })
+
+  test("read_inbox returns messages with read=true when mark_as_read is enabled", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      context,
+    )
+
+    //#when
+    const unreadBefore = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      context,
+    ) as Array<{ read: boolean }>
+
+    const markedRead = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+        unread_only: true,
+        mark_as_read: true,
+      },
+      context,
+    ) as Array<{ read: boolean }>
+
+    const unreadAfter = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      context,
+    ) as Array<{ read: boolean }>
+
+    //#then
+    expect(unreadBefore.length).toBeGreaterThan(0)
+    expect(unreadBefore.every((message) => message.read === false)).toBe(true)
+    expect(markedRead.length).toBeGreaterThan(0)
+    expect(markedRead.every((message) => message.read === true)).toBe(true)
+    expect(unreadAfter).toHaveLength(0)
   })
 
   test("rejects unknown session claiming team-lead identity", async () => {

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -76,6 +76,24 @@ function createMockManager(): MockManagerHandles {
   return { manager, launchCalls, resumeCalls, cancelCalls }
 }
 
+function createFailingLaunchManager(): BackgroundManager {
+  return {
+    launch: async () => ({ id: "bg-fail" }),
+    getTask: () => ({
+      id: "bg-fail",
+      parentSessionID: "ses-main",
+      parentMessageID: "msg-main",
+      description: "failed launch",
+      prompt: "prompt",
+      agent: "sisyphus-junior",
+      status: "error",
+      error: "launch failed",
+    }),
+    resume: async () => ({ id: "resume-unused" }),
+    cancelTask: async () => true,
+  } as unknown as BackgroundManager
+}
+
 function createContext(): TestToolContext {
   return {
     sessionID: "ses-main",
@@ -225,6 +243,26 @@ describe("agent-teams tools functional", () => {
     expect(payload.taskId).toBe(createdTask.id)
   })
 
+  test("rejects invalid task id input for task_get", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "team_task_get",
+      { team_name: "core", task_id: "../../etc/passwd" },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("task_id_invalid")
+  })
+
   test("spawn_teammate + send_message + force_kill_teammate execute end-to-end", async () => {
     //#given
     const { manager, launchCalls, resumeCalls, cancelCalls } = createMockManager()
@@ -341,5 +379,36 @@ describe("agent-teams tools functional", () => {
     expect(configAfterKill.members.some((member) => member.name === "worker_1")).toBe(false)
     expect(taskAfterKill.owner).toBeUndefined()
     expect(taskAfterKill.status).toBe("pending")
+  })
+
+  test("rolls back teammate when launch fails", async () => {
+    //#given
+    const manager = createFailingLaunchManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const spawnResult = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(spawnResult.error).toBe("teammate_launch_failed:launch failed")
+
+    //#when
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
+      members: Array<{ name: string }>
+    }
+
+    //#then
+    expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
   })
 })

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -76,8 +76,10 @@ function createMockManager(): MockManagerHandles {
   return { manager, launchCalls, resumeCalls, cancelCalls }
 }
 
-function createFailingLaunchManager(): BackgroundManager {
-  return {
+function createFailingLaunchManager(): { manager: BackgroundManager; cancelCalls: CancelCall[] } {
+  const cancelCalls: CancelCall[] = []
+
+  const manager = {
     launch: async () => ({ id: "bg-fail" }),
     getTask: () => ({
       id: "bg-fail",
@@ -90,8 +92,13 @@ function createFailingLaunchManager(): BackgroundManager {
       error: "launch failed",
     }),
     resume: async () => ({ id: "resume-unused" }),
-    cancelTask: async () => true,
+    cancelTask: async (taskId: string, options?: unknown) => {
+      cancelCalls.push({ taskId, options })
+      return true
+    },
   } as unknown as BackgroundManager
+
+  return { manager, cancelCalls }
 }
 
 function createContext(): TestToolContext {
@@ -177,6 +184,16 @@ describe("agent-teams tools functional", () => {
     const context = createContext()
 
     await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      context,
+    )
 
     //#when
     const createdTask = await executeJsonTool(
@@ -241,6 +258,21 @@ describe("agent-teams tools functional", () => {
     const payload = JSON.parse(assignment!.text) as { type: string; taskId: string }
     expect(payload.type).toBe("task_assignment")
     expect(payload.taskId).toBe(createdTask.id)
+
+    //#when
+    const clearedOwnerTask = await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+        owner: "",
+      },
+      context,
+    ) as { owner?: string }
+
+    //#then
+    expect(clearedOwnerTask.owner).toBeUndefined()
   })
 
   test("rejects invalid task id input for task_get", async () => {
@@ -261,6 +293,74 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(result.error).toBe("task_id_invalid")
+  })
+
+  test("requires owner to be a team member when setting task owner", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+    const createdTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Investigate bug",
+        description: "Investigate and report root cause",
+      },
+      context,
+    ) as { id: string }
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+        owner: "ghost_user",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("owner_not_in_team")
+  })
+
+  test("allows assigning team-lead as task owner", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+    const createdTask = await executeJsonTool(
+      tools,
+      "team_task_create",
+      {
+        team_name: "core",
+        subject: "Prepare checklist",
+        description: "Prepare release checklist",
+      },
+      context,
+    ) as { id: string }
+
+    //#when
+    const updated = await executeJsonTool(
+      tools,
+      "team_task_update",
+      {
+        team_name: "core",
+        task_id: createdTask.id,
+        owner: "team-lead",
+      },
+      context,
+    ) as { owner?: string }
+
+    //#then
+    expect(updated.owner).toBe("team-lead")
   })
 
   test("spawn_teammate + send_message + force_kill_teammate execute end-to-end", async () => {
@@ -314,6 +414,24 @@ describe("agent-teams tools functional", () => {
     expect(sent.success).toBe(true)
     expect(resumeCalls).toHaveLength(1)
     expect(resumeCalls[0].sessionId).toBe("ses-worker-1")
+
+    //#when
+    const invalidSender = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        sender: "ghost_user",
+        recipient: "worker_1",
+        summary: "sync",
+        content: "Please update status.",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(invalidSender.error).toBe("invalid_sender")
 
     //#given
     const createdTask = await executeJsonTool(
@@ -381,9 +499,9 @@ describe("agent-teams tools functional", () => {
     expect(taskAfterKill.status).toBe("pending")
   })
 
-  test("rolls back teammate when launch fails", async () => {
+  test("rolls back teammate and cancels background task when launch fails", async () => {
     //#given
-    const manager = createFailingLaunchManager()
+    const { manager, cancelCalls } = createFailingLaunchManager()
     const tools = createAgentTeamsTools(manager)
     const context = createContext()
     await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
@@ -410,5 +528,68 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
+    expect(cancelCalls).toHaveLength(1)
+    expect(cancelCalls[0].taskId).toBe("bg-fail")
+    expect(cancelCalls[0].options).toEqual(
+      expect.objectContaining({
+        source: "team_launch_failed",
+        abortSession: true,
+        skipNotification: true,
+      }),
+    )
+  })
+
+  test("returns explicit error on invalid model override format", async () => {
+    //#given
+    const { manager, launchCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const spawnResult = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        model: "invalid-format",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(spawnResult.error).toBe("invalid_model_override_format")
+    expect(launchCalls).toHaveLength(0)
+
+    //#when
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
+      members: Array<{ name: string }>
+    }
+
+    //#then
+    expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
+  })
+
+  test("read_inbox returns team_not_found for unknown team", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "missing_team",
+        agent_name: "team-lead",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("team_not_found")
   })
 })

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -181,12 +181,13 @@ describe("agent-teams tools functional", () => {
     //#when
     const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, context) as {
       name: string
-      members: Array<{ name: string }>
+      members: Array<{ name: string; model?: string }>
     }
 
     //#then
     expect(config.name).toBe("core")
     expect(config.members.map((member) => member.name)).toEqual(["team-lead"])
+    expect(config.members[0]?.model).toBe("native/team-lead")
 
     //#when
     const deleted = await executeJsonTool(tools, "team_delete", { team_name: "core" }, context) as {
@@ -213,6 +214,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       context,
     )
@@ -338,6 +340,30 @@ describe("agent-teams tools functional", () => {
     expect(teammate).toBeDefined()
     expect(teammate?.category).toBe("quick")
     expect(teammate?.model).toBe(`${resolvedModel.providerID}/${resolvedModel.modelID}`)
+  })
+
+  test("spawn_teammate requires a category", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const context = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, context)
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      context,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("category_required")
   })
 
   test("rejects category with incompatible subagent_type", async () => {
@@ -483,6 +509,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       context,
     ) as { name: string; session_id: string; task_id: string }
@@ -617,6 +644,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       leadContext,
     )
@@ -653,6 +681,78 @@ describe("agent-teams tools functional", () => {
     expect(configAfterShutdown.members.some((member) => member.name === "worker_1")).toBe(false)
   })
 
+  test("force_kill_teammate requires lead session authorization", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    )
+
+    const teammateContext = createContext("ses-worker-1")
+
+    //#when
+    const unauthorized = await executeJsonTool(
+      tools,
+      "force_kill_teammate",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      teammateContext,
+    ) as { error?: string }
+
+    //#then
+    expect(unauthorized.error).toBe("unauthorized_lead_session")
+  })
+
+  test("process_shutdown_approved requires lead session authorization", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+        category: "quick",
+      },
+      leadContext,
+    )
+
+    const teammateContext = createContext("ses-worker-1")
+
+    //#when
+    const unauthorized = await executeJsonTool(
+      tools,
+      "process_shutdown_approved",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      teammateContext,
+    ) as { error?: string }
+
+    //#then
+    expect(unauthorized.error).toBe("unauthorized_lead_session")
+  })
+
   test("rolls back teammate and cancels background task when launch fails", async () => {
     //#given
     const { manager, cancelCalls } = createFailingLaunchManager()
@@ -668,6 +768,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       context,
     ) as { error?: string }
@@ -709,6 +810,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
         model: "invalid-format",
       },
       context,
@@ -742,6 +844,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
         model: "openai/gpt-5.3-codex/reasoning",
       },
       context,
@@ -792,6 +895,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       leadContext,
     )
@@ -827,14 +931,13 @@ describe("agent-teams tools functional", () => {
     expect(Array.isArray(ownInbox)).toBe(true)
   })
 
-  test("allows lead session to rotate after restart using team-lead identity", async () => {
+  test("rejects unknown session claiming team-lead identity", async () => {
     //#given
     const { manager } = createMockManager()
     const tools = createAgentTeamsTools(manager)
-    const originalLead = createContext("ses-main")
-    await executeJsonTool(tools, "team_create", { team_name: "core" }, originalLead)
-
-    const restartedLead = createContext("ses-restarted")
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    const unknownContext = createContext("ses-unknown")
 
     //#when
     const sendResult = await executeJsonTool(
@@ -848,20 +951,43 @@ describe("agent-teams tools functional", () => {
         summary: "restart",
         content: "Lead session migrated",
       },
-      restartedLead,
+      unknownContext,
     ) as { success?: boolean; error?: string }
 
     //#then
-    expect(sendResult.error).toBeUndefined()
-    expect(sendResult.success).toBe(true)
+    expect(sendResult.success).toBeUndefined()
+    expect(sendResult.error).toBe("unauthorized_sender_session")
 
     //#when
-    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, restartedLead) as {
+    const config = await executeJsonTool(tools, "read_config", { team_name: "core" }, leadContext) as {
       leadSessionId: string
     }
 
     //#then
-    expect(config.leadSessionId).toBe("ses-restarted")
+    expect(config.leadSessionId).toBe("ses-main")
+  })
+
+  test("rejects unknown session claiming team-lead inbox", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext("ses-main")
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    const unknownContext = createContext("ses-unknown")
+
+    //#when
+    const result = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "team-lead",
+      },
+      unknownContext,
+    ) as { error?: string }
+
+    //#then
+    expect(result.error).toBe("unauthorized_reader_session")
   })
 
   test("clears old inbox when teammate is removed then re-spawned", async () => {
@@ -878,6 +1004,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "First run",
+        category: "quick",
       },
       context,
     )
@@ -913,6 +1040,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Second run",
+        category: "quick",
       },
       context,
     )
@@ -1004,6 +1132,7 @@ describe("agent-teams tools functional", () => {
         team_name: "core",
         name: "worker_1",
         prompt: "Handle release prep",
+        category: "quick",
       },
       leadContext,
     )

--- a/src/tools/agent-teams/tools.functional.test.ts
+++ b/src/tools/agent-teams/tools.functional.test.ts
@@ -101,9 +101,9 @@ function createFailingLaunchManager(): { manager: BackgroundManager; cancelCalls
   return { manager, cancelCalls }
 }
 
-function createContext(): TestToolContext {
+function createContext(sessionID = "ses-main"): TestToolContext {
   return {
-    sessionID: "ses-main",
+    sessionID,
     messageID: "msg-main",
     agent: "sisyphus",
     abort: new AbortController().signal,
@@ -359,8 +359,21 @@ describe("agent-teams tools functional", () => {
       context,
     ) as { owner?: string }
 
+    const leadInbox = await executeJsonTool(
+      tools,
+      "read_inbox",
+      {
+        team_name: "core",
+        agent_name: "team-lead",
+        unread_only: true,
+        mark_as_read: false,
+      },
+      context,
+    ) as Array<{ summary?: string; text: string }>
+
     //#then
     expect(updated.owner).toBe("team-lead")
+    expect(leadInbox.some((message) => message.summary === "task_assignment")).toBe(true)
   })
 
   test("spawn_teammate + send_message + force_kill_teammate execute end-to-end", async () => {
@@ -431,7 +444,7 @@ describe("agent-teams tools functional", () => {
     ) as { error?: string }
 
     //#then
-    expect(invalidSender.error).toBe("invalid_sender")
+    expect(invalidSender.error).toBe("sender_context_mismatch")
 
     //#given
     const createdTask = await executeJsonTool(
@@ -499,6 +512,56 @@ describe("agent-teams tools functional", () => {
     expect(taskAfterKill.status).toBe("pending")
   })
 
+  test("process_shutdown_approved cancels and removes teammate", async () => {
+    //#given
+    const { manager, cancelCalls } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      leadContext,
+    )
+
+    //#when
+    const shutdownResult = await executeJsonTool(
+      tools,
+      "process_shutdown_approved",
+      {
+        team_name: "core",
+        agent_name: "worker_1",
+      },
+      leadContext,
+    ) as { success: boolean }
+
+    //#then
+    expect(shutdownResult.success).toBe(true)
+    expect(cancelCalls).toHaveLength(1)
+    expect(cancelCalls[0].taskId).toBe("bg-1")
+    expect(cancelCalls[0].options).toEqual(
+      expect.objectContaining({
+        source: "team_force_kill",
+        abortSession: true,
+        skipNotification: true,
+      }),
+    )
+
+    //#when
+    const configAfterShutdown = await executeJsonTool(tools, "read_config", { team_name: "core" }, leadContext) as {
+      members: Array<{ name: string }>
+    }
+
+    //#then
+    expect(configAfterShutdown.members.some((member) => member.name === "worker_1")).toBe(false)
+  })
+
   test("rolls back teammate and cancels background task when launch fails", async () => {
     //#given
     const { manager, cancelCalls } = createFailingLaunchManager()
@@ -537,6 +600,7 @@ describe("agent-teams tools functional", () => {
         skipNotification: true,
       }),
     )
+    expect(existsSync(getTeamInboxPath("core", "worker_1"))).toBe(false)
   })
 
   test("returns explicit error on invalid model override format", async () => {
@@ -591,5 +655,60 @@ describe("agent-teams tools functional", () => {
 
     //#then
     expect(result.error).toBe("team_not_found")
+  })
+
+  test("binds sender to calling context and rejects sender spoofing", async () => {
+    //#given
+    const { manager } = createMockManager()
+    const tools = createAgentTeamsTools(manager)
+    const leadContext = createContext()
+    await executeJsonTool(tools, "team_create", { team_name: "core" }, leadContext)
+    await executeJsonTool(
+      tools,
+      "spawn_teammate",
+      {
+        team_name: "core",
+        name: "worker_1",
+        prompt: "Handle release prep",
+      },
+      leadContext,
+    )
+
+    const teammateContext = createContext("ses-worker-1")
+
+    //#when
+    const spoofed = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        sender: "team-lead",
+        recipient: "worker_1",
+        summary: "spoof",
+        content: "I am lead",
+      },
+      teammateContext,
+    ) as { error?: string }
+
+    //#then
+    expect(spoofed.error).toBe("sender_context_mismatch")
+
+    //#when
+    const validFromContext = await executeJsonTool(
+      tools,
+      "send_message",
+      {
+        team_name: "core",
+        type: "message",
+        recipient: "team-lead",
+        summary: "update",
+        content: "status from worker",
+      },
+      teammateContext,
+    ) as { success?: boolean }
+
+    //#then
+    expect(validFromContext.success).toBe(true)
   })
 })

--- a/src/tools/agent-teams/tools.ts
+++ b/src/tools/agent-teams/tools.ts
@@ -1,16 +1,31 @@
 import type { ToolDefinition } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { CategoriesConfig } from "../../config/schema"
 import { createReadInboxTool, createSendMessageTool } from "./messaging-tools"
 import { createTeamCreateTool, createTeamDeleteTool, createTeamReadConfigTool } from "./team-lifecycle-tools"
 import { createTeamTaskCreateTool, createTeamTaskGetTool, createTeamTaskListTool } from "./team-task-tools"
 import { createTeamTaskUpdateTool } from "./team-task-update-tool"
 import { createForceKillTeammateTool, createProcessShutdownTool, createSpawnTeammateTool } from "./teammate-tools"
 
-export function createAgentTeamsTools(manager: BackgroundManager): Record<string, ToolDefinition> {
+export interface AgentTeamsToolOptions {
+  client?: PluginInput["client"]
+  userCategories?: CategoriesConfig
+  sisyphusJuniorModel?: string
+}
+
+export function createAgentTeamsTools(
+  manager: BackgroundManager,
+  options?: AgentTeamsToolOptions,
+): Record<string, ToolDefinition> {
   return {
     team_create: createTeamCreateTool(),
     team_delete: createTeamDeleteTool(),
-    spawn_teammate: createSpawnTeammateTool(manager),
+    spawn_teammate: createSpawnTeammateTool(manager, {
+      client: options?.client,
+      userCategories: options?.userCategories,
+      sisyphusJuniorModel: options?.sisyphusJuniorModel,
+    }),
     send_message: createSendMessageTool(manager),
     read_inbox: createReadInboxTool(),
     read_config: createTeamReadConfigTool(),

--- a/src/tools/agent-teams/tools.ts
+++ b/src/tools/agent-teams/tools.ts
@@ -1,0 +1,24 @@
+import type { ToolDefinition } from "@opencode-ai/plugin"
+import type { BackgroundManager } from "../../features/background-agent"
+import { createReadInboxTool, createSendMessageTool } from "./messaging-tools"
+import { createTeamCreateTool, createTeamDeleteTool, createTeamReadConfigTool } from "./team-lifecycle-tools"
+import { createTeamTaskCreateTool, createTeamTaskGetTool, createTeamTaskListTool } from "./team-task-tools"
+import { createTeamTaskUpdateTool } from "./team-task-update-tool"
+import { createForceKillTeammateTool, createProcessShutdownTool, createSpawnTeammateTool } from "./teammate-tools"
+
+export function createAgentTeamsTools(manager: BackgroundManager): Record<string, ToolDefinition> {
+  return {
+    team_create: createTeamCreateTool(),
+    team_delete: createTeamDeleteTool(),
+    spawn_teammate: createSpawnTeammateTool(manager),
+    send_message: createSendMessageTool(manager),
+    read_inbox: createReadInboxTool(),
+    read_config: createTeamReadConfigTool(),
+    team_task_create: createTeamTaskCreateTool(),
+    team_task_update: createTeamTaskUpdateTool(),
+    team_task_list: createTeamTaskListTool(),
+    team_task_get: createTeamTaskGetTool(),
+    force_kill_teammate: createForceKillTeammateTool(manager),
+    process_shutdown_approved: createProcessShutdownTool(),
+  }
+}

--- a/src/tools/agent-teams/tools.ts
+++ b/src/tools/agent-teams/tools.ts
@@ -19,6 +19,6 @@ export function createAgentTeamsTools(manager: BackgroundManager): Record<string
     team_task_list: createTeamTaskListTool(),
     team_task_get: createTeamTaskGetTool(),
     force_kill_teammate: createForceKillTeammateTool(manager),
-    process_shutdown_approved: createProcessShutdownTool(),
+    process_shutdown_approved: createProcessShutdownTool(manager),
   }
 }

--- a/src/tools/agent-teams/types.test.ts
+++ b/src/tools/agent-teams/types.test.ts
@@ -1,0 +1,29 @@
+/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
+import { TeamTeammateMemberSchema } from "./types"
+
+describe("agent-teams types", () => {
+  test("rejects reserved agentType for teammate schema", () => {
+    //#given
+    const invalidTeammate = {
+      agentId: "worker@team",
+      name: "worker",
+      agentType: "team-lead",
+      model: "native",
+      prompt: "do work",
+      color: "blue",
+      planModeRequired: false,
+      joinedAt: Date.now(),
+      cwd: "/tmp",
+      subscriptions: [],
+      backendType: "native",
+      isActive: false,
+    }
+
+    //#when
+    const result = TeamTeammateMemberSchema.safeParse(invalidTeammate)
+
+    //#then
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/tools/agent-teams/types.test.ts
+++ b/src/tools/agent-teams/types.test.ts
@@ -9,6 +9,7 @@ describe("agent-teams types", () => {
       agentId: "worker@team",
       name: "worker",
       agentType: "team-lead",
+      category: "quick",
       model: "native",
       prompt: "do work",
       color: "blue",

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -115,10 +115,26 @@ export const TeamSpawnInputSchema = z.object({
   plan_mode_required: z.boolean().optional(),
 })
 
+function normalizeTeamRecipient(recipient: string): string {
+  const trimmed = recipient.trim()
+  const atIndex = trimmed.indexOf("@")
+  if (atIndex <= 0) {
+    return trimmed
+  }
+
+  return trimmed.slice(0, atIndex)
+}
+
 export const TeamSendMessageInputSchema = z.object({
   team_name: z.string(),
   type: TeamSendMessageTypeSchema,
-  recipient: z.string().optional(),
+  recipient: z.string().optional().transform((value) => {
+    if (value === undefined) {
+      return undefined
+    }
+
+    return normalizeTeamRecipient(value)
+  }),
   content: z.string().optional(),
   summary: z.string().optional(),
   request_id: z.string().optional(),

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -30,6 +30,7 @@ export const TeamTeammateMemberSchema = z.object({
   agentType: z.string().refine((value) => value !== "team-lead", {
     message: "agent_type_reserved",
   }),
+  category: z.string().optional(),
   model: z.string(),
   prompt: z.string(),
   color: z.string(),
@@ -108,6 +109,7 @@ export const TeamSpawnInputSchema = z.object({
   team_name: z.string(),
   name: z.string(),
   prompt: z.string(),
+  category: z.string().optional(),
   subagent_type: z.string().optional(),
   model: z.string().optional(),
   plan_mode_required: z.boolean().optional(),

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -27,7 +27,9 @@ export const TeamLeadMemberSchema = z.object({
 export const TeamTeammateMemberSchema = z.object({
   agentId: z.string(),
   name: z.string(),
-  agentType: z.string(),
+  agentType: z.string().refine((value) => value !== "team-lead", {
+    message: "agent_type_reserved",
+  }),
   model: z.string(),
   prompt: z.string(),
   color: z.string(),

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -1,0 +1,180 @@
+import { z } from "zod"
+
+export const TEAM_COLOR_PALETTE = [
+  "blue",
+  "green",
+  "yellow",
+  "purple",
+  "orange",
+  "pink",
+  "cyan",
+  "red",
+] as const
+
+export const TeamTaskStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted"])
+export type TeamTaskStatus = z.infer<typeof TeamTaskStatusSchema>
+
+export const TeamLeadMemberSchema = z.object({
+  agentId: z.string(),
+  name: z.literal("team-lead"),
+  agentType: z.literal("team-lead"),
+  model: z.string(),
+  joinedAt: z.number(),
+  cwd: z.string(),
+  subscriptions: z.array(z.unknown()).default([]),
+}).strict()
+
+export const TeamTeammateMemberSchema = z.object({
+  agentId: z.string(),
+  name: z.string(),
+  agentType: z.string(),
+  model: z.string(),
+  prompt: z.string(),
+  color: z.string(),
+  planModeRequired: z.boolean().default(false),
+  joinedAt: z.number(),
+  cwd: z.string(),
+  subscriptions: z.array(z.unknown()).default([]),
+  backendType: z.literal("native").default("native"),
+  isActive: z.boolean().default(false),
+  sessionID: z.string().optional(),
+  backgroundTaskID: z.string().optional(),
+}).strict()
+
+export const TeamMemberSchema = z.union([TeamLeadMemberSchema, TeamTeammateMemberSchema])
+
+export const TeamConfigSchema = z.object({
+  name: z.string(),
+  description: z.string().default(""),
+  createdAt: z.number(),
+  leadAgentId: z.string(),
+  leadSessionId: z.string(),
+  members: z.array(TeamMemberSchema),
+}).strict()
+
+export const TeamInboxMessageSchema = z.object({
+  from: z.string(),
+  text: z.string(),
+  timestamp: z.string(),
+  read: z.boolean().default(false),
+  summary: z.string().optional(),
+  color: z.string().optional(),
+}).strict()
+
+export const TeamTaskSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  description: z.string(),
+  activeForm: z.string().optional(),
+  status: TeamTaskStatusSchema,
+  blocks: z.array(z.string()).default([]),
+  blockedBy: z.array(z.string()).default([]),
+  owner: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).strict()
+
+export const TeamSendMessageTypeSchema = z.enum([
+  "message",
+  "broadcast",
+  "shutdown_request",
+  "shutdown_response",
+  "plan_approval_response",
+])
+
+export type TeamLeadMember = z.infer<typeof TeamLeadMemberSchema>
+export type TeamTeammateMember = z.infer<typeof TeamTeammateMemberSchema>
+export type TeamMember = z.infer<typeof TeamMemberSchema>
+export type TeamConfig = z.infer<typeof TeamConfigSchema>
+export type TeamInboxMessage = z.infer<typeof TeamInboxMessageSchema>
+export type TeamTask = z.infer<typeof TeamTaskSchema>
+export type TeamSendMessageType = z.infer<typeof TeamSendMessageTypeSchema>
+
+export const TeamCreateInputSchema = z.object({
+  team_name: z.string(),
+  description: z.string().optional(),
+})
+
+export const TeamDeleteInputSchema = z.object({
+  team_name: z.string(),
+})
+
+export const TeamReadConfigInputSchema = z.object({
+  team_name: z.string(),
+})
+
+export const TeamSpawnInputSchema = z.object({
+  team_name: z.string(),
+  name: z.string(),
+  prompt: z.string(),
+  subagent_type: z.string().optional(),
+  model: z.string().optional(),
+  plan_mode_required: z.boolean().optional(),
+})
+
+export const TeamSendMessageInputSchema = z.object({
+  team_name: z.string(),
+  type: TeamSendMessageTypeSchema,
+  recipient: z.string().optional(),
+  content: z.string().optional(),
+  summary: z.string().optional(),
+  request_id: z.string().optional(),
+  approve: z.boolean().optional(),
+  sender: z.string().optional(),
+})
+
+export const TeamReadInboxInputSchema = z.object({
+  team_name: z.string(),
+  agent_name: z.string(),
+  unread_only: z.boolean().optional(),
+  mark_as_read: z.boolean().optional(),
+})
+
+export const TeamTaskCreateInputSchema = z.object({
+  team_name: z.string(),
+  subject: z.string(),
+  description: z.string(),
+  active_form: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const TeamTaskUpdateInputSchema = z.object({
+  team_name: z.string(),
+  task_id: z.string(),
+  status: TeamTaskStatusSchema.optional(),
+  owner: z.string().optional(),
+  subject: z.string().optional(),
+  description: z.string().optional(),
+  active_form: z.string().optional(),
+  add_blocks: z.array(z.string()).optional(),
+  add_blocked_by: z.array(z.string()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const TeamTaskListInputSchema = z.object({
+  team_name: z.string(),
+})
+
+export const TeamTaskGetInputSchema = z.object({
+  team_name: z.string(),
+  task_id: z.string(),
+})
+
+export const TeamForceKillInputSchema = z.object({
+  team_name: z.string(),
+  agent_name: z.string(),
+})
+
+export const TeamProcessShutdownInputSchema = z.object({
+  team_name: z.string(),
+  agent_name: z.string(),
+})
+
+export interface TeamToolContext {
+  sessionID: string
+  messageID: string
+  agent?: string
+}
+
+export function isTeammateMember(member: TeamMember): member is TeamTeammateMember {
+  return member.agentType !== "team-lead"
+}

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -192,6 +192,7 @@ export const TeamProcessShutdownInputSchema = z.object({
 export interface TeamToolContext {
   sessionID: string
   messageID: string
+  abort: AbortSignal
   agent?: string
 }
 

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -30,7 +30,7 @@ export const TeamTeammateMemberSchema = z.object({
   agentType: z.string().refine((value) => value !== "team-lead", {
     message: "agent_type_reserved",
   }),
-  category: z.string().optional(),
+  category: z.string(),
   model: z.string(),
   prompt: z.string(),
   color: z.string(),

--- a/src/tools/agent-teams/types.ts
+++ b/src/tools/agent-teams/types.ts
@@ -109,7 +109,7 @@ export const TeamSpawnInputSchema = z.object({
   team_name: z.string(),
   name: z.string(),
   prompt: z.string(),
-  category: z.string().optional(),
+  category: z.string(),
   subagent_type: z.string().optional(),
   model: z.string().optional(),
   plan_mode_required: z.boolean().optional(),

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -26,7 +26,7 @@ export interface DelegateTaskArgs {
 export interface ToolContextWithMetadata {
   sessionID: string
   messageID: string
-  agent: string
+  agent?: string
   abort: AbortSignal
   metadata?: (input: { title?: string; metadata?: Record<string, unknown> }) => void | Promise<void>
   /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,6 +37,7 @@ type OpencodeClient = PluginInput["client"]
 export { createCallOmoAgent } from "./call-omo-agent"
 export { createLookAt } from "./look-at"
 export { createDelegateTask } from "./delegate-task"
+export { createAgentTeamsTools } from "./agent-teams"
 export {
   createTaskCreateTool,
   createTaskGetTool,


### PR DESCRIPTION
## Summary
- Add a native `agent-teams` tool module with team lifecycle, teammate runtime, inbox messaging, and team-scoped task management tools.
- Wire the new tools into the shared tool registry and plugin entrypoint so they are available without external services.
- Implement teammate execution through internal background agent orchestration, including delivery/resume handling and force-stop/shutdown cleanup flows.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test` *(contains pre-existing unrelated failures in `mcp-oauth`, `unstable-agent-babysitter`, and `prometheus-md-only` test suites)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native agent teams toolset for team lifecycle, local messaging, teammate orchestration, and team-scoped tasks, now gated behind experimental.agent_teams and wired into the tool registry. Data lives under .sisyphus/agent-teams; messaging accepts name@team; auth/ID checks are stricter; parent context propagation allows missing agent; and runtime, deletion, and inbox handling are hardened.

- **New Features**
  - Tools exported via createAgentTeamsTools and enabled when experimental.agent_teams=true.
  - Local storage under .sisyphus/agent-teams for teams, inboxes, and tasks.
  - Messaging: direct/broadcast and protocol (shutdown/plan) with read_inbox; recipient normalization for name@team; auto-resume on delivery.
  - Teammates: category-based spawn, force-kill, and shutdown cleanup via native background orchestration; parent context resolved with abort forwarding and agent optional.
  - Tasks: create/update/list/get with cycle checks and owner notifications.

- **Bug Fixes**
  - Inbox safety: atomic writes, rollback on parse errors, and locked operations.
  - Auth/IDs: T-prefixed task IDs, reserved-name guards, cross-team/session-bound checks, and lead-only spawn authorization.
  - Runtime/messaging: fail fast on invalid model overrides and launch errors; cancel failed launches; dedupe shutdown; clear stale teammate inboxes; rotate lead session.
  - Deletion/task safety: lock team deletion behind config mutex, close race conditions, add traversal guards, and move team existence checks under lock.
  - Delegate-task context: agent field made optional to preserve parent-agent fallback.

<sup>Written for commit bc0a4938980d133ef72e5dfae0c97351c69da3a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

