### PR TITLE
fix(edit): coerce replaceAll string to boolean before execution

### DIFF
--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -39,6 +39,13 @@ export function createToolExecuteBeforeHandler(args: {
       }
     }
 
+    // Coerce string booleans for edit tool (LLMs sometimes output "false"/"true" instead of false/true)
+    if (input.tool === "edit") {
+      if (typeof output.args.replaceAll === "string") {
+        output.args.replaceAll = output.args.replaceAll === "true"
+      }
+    }
+
     if (hooks.ralphLoop && input.tool === "slashcommand") {
       const rawCommand = typeof output.args.command === "string" ? output.args.command : undefined
       const command = rawCommand?.replace(/^\//, "").toLowerCase()


### PR DESCRIPTION
## Summary

- LLMs sometimes output `replaceAll` as a string (`"false"`/`"true"`) instead of a boolean, causing opencode's Go binary to reject it with `expected boolean, received string`
- Adds pre-execution coercion in `tool-execute-before.ts`, following the existing pattern used for the `task` tool's `subagent_type` coercion

## Error being fixed

```
← Edit lib/ui.py [replaceAll=false]
Error: The edit tool was called with invalid arguments: [
  {
    "expected": "boolean",
    "code": "invalid_type",
    "path": ["replaceAll"],
    "message": "Invalid input: expected boolean, received string"
  }
]
```

## Change

```typescript
if (input.tool === "edit") {
  if (typeof output.args.replaceAll === "string") {
    output.args.replaceAll = output.args.replaceAll === "true"
  }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerce the edit tool’s replaceAll argument from "true"/"false" strings to a boolean before execution. Prevents the Go binary’s schema error: “expected boolean, received string.”

<sup>Written for commit f1be1fcb74d58fc59d42d678cec27e0e51e4e014. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

