### PR TITLE
fix(prometheus): normalize paths with realpathSync to support macOS symlinks

### DIFF
--- a/src/hooks/prometheus-md-only/__tests__/path-policy.repro.test.ts
+++ b/src/hooks/prometheus-md-only/__tests__/path-policy.repro.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+const realpathSyncMock = mock((p: string) => p)
+
+mock.module("node:fs", () => ({
+  realpathSync: realpathSyncMock,
+}))
+
+const { isAllowedFile } = await import("../path-policy")
+
+describe("path-policy symlink resolution (repro)", () => {
+  beforeEach(() => {
+    realpathSyncMock.mockClear()
+    realpathSyncMock.mockImplementation((p: string) => p)
+  })
+
+  describe("macOS /Volumes vs /Users mismatch", () => {
+    it("should allow file when workspace uses /Volumes but realpath resolves to /Users", () => {
+      const workspaceRoot = "/Volumes/nsk_intel_mac/project"
+      const filePath = "/Volumes/nsk_intel_mac/project/.sisyphus/plans/my-plan.md"
+
+      realpathSyncMock.mockImplementation((p: string) =>
+        p.replace("/Volumes/nsk_intel_mac", "/Users/nsk_intel_mac"),
+      )
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(true)
+    })
+
+    it("should allow relative file path with symlink resolution", () => {
+      const workspaceRoot = "/Volumes/nsk_intel_mac/project"
+      const filePath = ".sisyphus/plans/my-plan.md"
+
+      realpathSyncMock.mockImplementation((p: string) =>
+        p.replace("/Volumes/nsk_intel_mac", "/Users/nsk_intel_mac"),
+      )
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(true)
+    })
+
+    it("should reject file outside workspace even after realpath resolution", () => {
+      const workspaceRoot = "/Volumes/nsk_intel_mac/project"
+      const filePath = "/Volumes/nsk_intel_mac/other-project/.sisyphus/plans/evil.md"
+
+      realpathSyncMock.mockImplementation((p: string) =>
+        p.replace("/Volumes/nsk_intel_mac", "/Users/nsk_intel_mac"),
+      )
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(false)
+    })
+  })
+
+  describe("resolveCanonical ancestor walk-up for new files", () => {
+    it("should handle non-existent file by walking up to existing parent", () => {
+      const workspaceRoot = "/Volumes/nsk_intel_mac/project"
+      const filePath = "/Volumes/nsk_intel_mac/project/.sisyphus/plans/new-plan.md"
+
+      realpathSyncMock.mockImplementation((p: string) => {
+        if (p.includes("new-plan.md") || p.endsWith("/plans")) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+        }
+        return p.replace("/Volumes/nsk_intel_mac", "/Users/nsk_intel_mac")
+      })
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(true)
+    })
+
+    it("should handle fully non-existent path gracefully", () => {
+      const workspaceRoot = "/project"
+      const filePath = "/project/.sisyphus/plans/test.md"
+
+      realpathSyncMock.mockImplementation(() => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+      })
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(true)
+    })
+  })
+
+  describe("existing security checks preserved", () => {
+    it("should still reject traversal attacks", () => {
+      const workspaceRoot = "/Users/nsk_intel_mac/project"
+      const filePath = "/Users/nsk_intel_mac/project/../../etc/passwd"
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(false)
+    })
+
+    it("should still reject non-.md extensions", () => {
+      const workspaceRoot = "/Users/nsk_intel_mac/project"
+      const filePath = "/Users/nsk_intel_mac/project/.sisyphus/plans/evil.sh"
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(false)
+    })
+
+    it("should still reject files outside .sisyphus", () => {
+      const workspaceRoot = "/Users/nsk_intel_mac/project"
+      const filePath = "/Users/nsk_intel_mac/project/src/index.md"
+
+      expect(isAllowedFile(filePath, workspaceRoot)).toBe(false)
+    })
+  })
+})

--- a/src/hooks/prometheus-md-only/path-policy.ts
+++ b/src/hooks/prometheus-md-only/path-policy.ts
@@ -1,35 +1,46 @@
-import { relative, resolve, isAbsolute } from "node:path"
+import { realpathSync } from "node:fs"
+import path, { relative, resolve, isAbsolute } from "node:path"
 
 import { ALLOWED_EXTENSIONS } from "./constants"
 
-/**
- * Cross-platform path validator for Prometheus file writes.
- * Uses path.resolve/relative instead of string matching to handle:
- * - Windows backslashes (e.g., .sisyphus\\plans\\x.md)
- * - Mixed separators (e.g., .sisyphus\\plans/x.md)
- * - Case-insensitive directory/extension matching
- * - Workspace confinement (blocks paths outside root or via traversal)
- * - Nested project paths (e.g., parent/.sisyphus/... when ctx.directory is parent)
- */
+export function resolveCanonical(targetPath: string): string {
+  try {
+    return realpathSync(targetPath)
+  } catch {
+    /* file doesn't exist — walk up to find an existing ancestor */
+  }
+
+  const parsed = path.parse(targetPath)
+  let dir = parsed.dir
+  let remainder = parsed.base
+
+  while (dir !== path.parse(dir).root) {
+    try {
+      return path.join(realpathSync(dir), remainder)
+    } catch {
+      remainder = path.join(path.basename(dir), remainder)
+      dir = path.dirname(dir)
+    }
+  }
+  return targetPath
+}
+
 export function isAllowedFile(filePath: string, workspaceRoot: string): boolean {
-  // 1. Resolve to absolute path
   const resolved = resolve(workspaceRoot, filePath)
 
-  // 2. Get relative path from workspace root
-  const rel = relative(workspaceRoot, resolved)
+  const canonicalRoot = resolveCanonical(workspaceRoot)
+  const canonicalFile = resolveCanonical(resolved)
 
-  // 3. Reject if escapes root (starts with ".." or is absolute)
+  const rel = relative(canonicalRoot, canonicalFile)
+
   if (rel.startsWith("..") || isAbsolute(rel)) {
     return false
   }
 
-  // 4. Check if .sisyphus/ or .sisyphus\ exists anywhere in the path (case-insensitive)
-  // This handles both direct paths (.sisyphus/x.md) and nested paths (project/.sisyphus/x.md)
   if (!/\.sisyphus[/\\]/i.test(rel)) {
     return false
   }
 
-  // 5. Check extension matches one of ALLOWED_EXTENSIONS (case-insensitive)
   const hasAllowedExtension = ALLOWED_EXTENSIONS.some(
     ext => resolved.toLowerCase().endsWith(ext.toLowerCase())
   )


### PR DESCRIPTION
## Summary

Fixes issue where valid `.sisyphus` file writes are blocked on macOS due to `/Users` vs `/Volumes` path mismatch.

## Problem

On macOS, the system uses **firmlinks** (a type of symlink) so that `/Volumes/Macintosh HD/Users/...` and `/Users/...` resolve to the same physical directory. When the prometheus-md-only hook compares paths using string-based `path.relative()`, it incorrectly determines that a file is outside the workspace root if the two paths use different prefixes.

**Example:**
- `workspaceRoot` = `/Users/nsk_intel_mac/project`
- `filePath` resolves to `/Volumes/Macintosh HD - Data/Users/nsk_intel_mac/project/.sisyphus/plans/plan.md`
- `path.relative()` returns `../../Volumes/...` → **falsely rejected**

## Solution

- Added `resolveCanonical()` function that uses `fs.realpathSync()` to resolve symlinks/firmlinks to their true filesystem path before comparison.
- For non-existent files (new file writes), walks up the directory tree to find an existing ancestor and resolves from there.
- Both `workspaceRoot` and target file path are canonicalized before `path.relative()` comparison.

## Changes

- `src/hooks/prometheus-md-only/path-policy.ts` — Added `resolveCanonical()`, updated `isAllowedFile()` to use canonical paths
- `src/hooks/prometheus-md-only/__tests__/path-policy.repro.test.ts` — Reproduction test covering the `/Volumes` vs `/Users` mismatch scenario

## Testing

Reproduction test included that mocks `realpathSync` to simulate macOS firmlink behavior and verifies the fix resolves the path mismatch correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false rejections of valid .sisyphus markdown writes on macOS by canonicalizing paths before validation. The Prometheus md-only hook now handles /Volumes vs /Users aliases correctly.

- **Bug Fixes**
  - Added resolveCanonical using fs.realpathSync; walks up to an existing parent for new files.
  - Compares canonical workspace and target paths to keep writes within the project root.
  - Added repro tests for /Volumes vs /Users and kept traversal, extension, and folder checks intact.

<sup>Written for commit 242883e74b8b2672c71d9343f80377e3e87abbb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

