### PR TITLE
feat(prometheus): integrate hierarchical plan generation

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -288,9 +288,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -339,9 +336,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -432,9 +426,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -644,9 +635,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -695,9 +683,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -788,9 +773,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1000,9 +982,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1051,9 +1030,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1144,9 +1120,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1356,9 +1329,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1407,9 +1377,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1500,9 +1467,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1715,9 +1679,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1766,9 +1727,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1859,9 +1817,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2071,9 +2026,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2122,9 +2074,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2215,9 +2164,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2427,9 +2373,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2478,9 +2421,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2571,9 +2511,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2783,9 +2720,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2834,9 +2768,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2927,9 +2858,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3139,9 +3067,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3190,9 +3115,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3283,9 +3205,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3495,9 +3414,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3546,9 +3462,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3639,9 +3552,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3851,9 +3761,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3902,9 +3809,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3995,9 +3899,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -4207,9 +4108,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -4258,9 +4156,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -4351,9 +4246,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -4563,9 +4455,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -4614,9 +4503,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -4707,9 +4593,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -4919,9 +4802,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -4970,9 +4850,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -5063,9 +4940,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -5096,6 +4970,13 @@
           "additionalProperties": false
         }
       },
+<<<<<<< HEAD
+=======
+      "additionalProperties": false
+    },
+    "categories": {
+      "type": "object",
+>>>>>>> daef4eb4 (fix(prometheus): (MR CR opinion) resolve tool API mismatches and tree numbering bugs)
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -5668,9 +5549,6 @@
           },
           "tools": {
             "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
             "additionalProperties": {
               "type": "boolean"
             }
@@ -5716,9 +5594,6 @@
         },
         "plugins_override": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "boolean"
           }
@@ -6007,9 +5882,6 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
                     "additionalProperties": {}
                   },
                   "allowed-tools": {
@@ -6108,9 +5980,6 @@
         },
         "providerConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0
@@ -6118,9 +5987,6 @@
         },
         "modelConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -187,9 +187,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -235,9 +232,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -327,9 +321,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -470,9 +461,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -518,9 +506,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -610,9 +595,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -753,9 +735,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -801,9 +780,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -893,9 +869,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1036,9 +1009,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1084,9 +1054,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1176,9 +1143,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1322,9 +1286,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1370,9 +1331,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1462,9 +1420,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1605,9 +1560,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1653,9 +1605,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1745,9 +1694,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -1888,9 +1834,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1936,9 +1879,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2028,9 +1968,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2171,9 +2108,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2219,9 +2153,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2311,9 +2242,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2454,9 +2382,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2502,9 +2427,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2594,9 +2516,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -2737,9 +2656,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2785,9 +2701,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2877,9 +2790,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3020,9 +2930,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3068,9 +2975,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3160,9 +3064,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3303,9 +3204,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3351,9 +3249,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3443,9 +3338,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3586,9 +3478,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3634,9 +3523,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -3726,9 +3612,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -3869,9 +3752,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -3917,9 +3797,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -4009,9 +3886,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             },
             "ultrawork": {
@@ -4046,9 +3920,6 @@
     },
     "categories": {
       "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -4189,9 +4060,6 @@
           },
           "tools": {
             "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
             "additionalProperties": {
               "type": "boolean"
             }
@@ -4237,9 +4105,6 @@
         },
         "plugins_override": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "boolean"
           }
@@ -4528,9 +4393,6 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
                     "additionalProperties": {}
                   },
                   "allowed-tools": {
@@ -4629,9 +4491,6 @@
         },
         "providerConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0
@@ -4639,9 +4498,6 @@
         },
         "modelConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0

--- a/src/agents/prometheus/markdown-renderer-v2.test.ts
+++ b/src/agents/prometheus/markdown-renderer-v2.test.ts
@@ -10,6 +10,7 @@ import {
   renderNode,
   generateNumbering,
 } from "./markdown-renderer-v2"
+import { buildTaskTree } from "../../features/claude-tasks/tree-utils"
 import type { Task } from "../../tools/task/types"
 
 describe("generateNumbering", () => {
@@ -61,8 +62,9 @@ describe("renderNode", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     expect(result).toContain("- [ ] 1. Write unit tests")
     expect(result).toContain("**What to do:**")
@@ -104,8 +106,9 @@ describe("renderNode", () => {
       threadID: "thread-1",
     }
     const allTasks = [parent, child1, child2]
+    const tree = buildTaskTree(allTasks)
 
-    const result = renderNode(parent, 0, [child1, child2], allTasks)
+    const result = renderNode(parent, 0, [child1, child2], tree, allTasks)
 
     expect(result).toContain("- [ ] 1. Implement feature X")
     expect(result).toContain("[1/2]")
@@ -127,8 +130,9 @@ describe("renderNode", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     expect(result).toContain("- [x] 1. Setup database")
   })
@@ -147,8 +151,9 @@ describe("renderNode", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
-    const result = renderNode(task, 2, [], allTasks)
+    const result = renderNode(task, 2, [], tree, allTasks)
 
     expect(result).toStartWith("    - [ ]") // 4 spaces for depth 2
   })
@@ -168,8 +173,9 @@ describe("renderNode", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     expect(result).toContain("**Acceptance Criteria:**")
     expect(result).toContain("Deploying to production")
@@ -668,9 +674,10 @@ describe("renderNode edge cases", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
     //#when
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     //#then - in_progress shows unchecked checkbox
     expect(result).toContain("- [ ]")
@@ -689,9 +696,10 @@ describe("renderNode edge cases", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
     //#when
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     //#then
     expect(result).toContain("- [ ]")
@@ -720,9 +728,10 @@ describe("renderNode edge cases", () => {
       threadID: "thread-1",
     }
     const allTasks = [parent, child]
+    const tree = buildTaskTree(allTasks)
 
     //#when
-    const result = renderNode(parent, 0, [child], allTasks)
+    const result = renderNode(parent, 0, [child], tree, allTasks)
 
     //#then - parent node is single line, no activeForm
     expect(result).not.toContain("Should not appear")
@@ -741,9 +750,10 @@ describe("renderNode edge cases", () => {
       threadID: "thread-1",
     }
     const allTasks = [task]
+    const tree = buildTaskTree(allTasks)
 
     //#when
-    const result = renderNode(task, 0, [], allTasks)
+    const result = renderNode(task, 0, [], tree, allTasks)
 
     //#then
     expect(result).toContain("**What to do:**")

--- a/src/agents/prometheus/markdown-renderer-v2.test.ts
+++ b/src/agents/prometheus/markdown-renderer-v2.test.ts
@@ -1,0 +1,752 @@
+/**
+ * Tests for hierarchical task tree markdown renderer (v2)
+ *
+ * BDD: //#given //#when //#then pattern
+ */
+
+import { describe, expect, it } from "bun:test"
+import {
+  renderTaskTree,
+  renderNode,
+  generateNumbering,
+} from "./markdown-renderer-v2"
+import type { Task } from "../../tools/task/types"
+
+describe("generateNumbering", () => {
+  //#given empty path array
+  //#when generateNumbering is called
+  //#then it returns empty string
+  it("returns empty string for empty path", () => {
+    const result = generateNumbering([])
+    expect(result).toBe("")
+  })
+
+  //#given single-level path [1]
+  //#when generateNumbering is called
+  //#then it returns "1"
+  it("generates single-level numbering", () => {
+    const result = generateNumbering([1])
+    expect(result).toBe("1")
+  })
+
+  //#given two-level path [1, 2]
+  //#when generateNumbering is called
+  //#then it returns "1.2"
+  it("generates two-level numbering", () => {
+    const result = generateNumbering([1, 2])
+    expect(result).toBe("1.2")
+  })
+
+  //#given deep path [1, 2, 3, 4]
+  //#when generateNumbering is called
+  //#then it returns "1.2.3.4"
+  it("generates deep hierarchical numbering", () => {
+    const result = generateNumbering([1, 2, 3, 4])
+    expect(result).toBe("1.2.3.4")
+  })
+})
+
+describe("renderNode", () => {
+  //#given a leaf task with no children
+  //#when renderNode is called
+  //#then it renders with full details and no progress indicator
+  it("renders leaf node with full details", () => {
+    const task: Task = {
+      id: "T-leaf-1",
+      subject: "Write unit tests",
+      description: "Write comprehensive unit tests for the new feature",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    const result = renderNode(task, 0, [], allTasks)
+
+    expect(result).toContain("- [ ] 1. Write unit tests")
+    expect(result).toContain("**What to do:**")
+    expect(result).toContain("Write comprehensive unit tests")
+    expect(result).not.toContain("[0/1]")
+  })
+
+  //#given a parent task with children
+  //#when renderNode is called
+  //#then it renders single line with progress indicator
+  it("renders parent node as single line with progress", () => {
+    const parent: Task = {
+      id: "T-parent-1",
+      subject: "Implement feature X",
+      description: "Complete implementation of feature X",
+      status: "in_progress",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const child1: Task = {
+      id: "T-child-1",
+      subject: "Design API",
+      description: "Design the API",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const child2: Task = {
+      id: "T-child-2",
+      subject: "Write tests",
+      description: "Write tests",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const allTasks = [parent, child1, child2]
+
+    const result = renderNode(parent, 0, [child1, child2], allTasks)
+
+    expect(result).toContain("- [ ] 1. Implement feature X")
+    expect(result).toContain("[1/2]")
+    expect(result).not.toContain("**What to do:**")
+    expect(result).not.toContain("**Acceptance Criteria:**")
+  })
+
+  //#given a completed task
+  //#when renderNode is called
+  //#then checkbox is marked as checked
+  it("renders completed task with checked checkbox", () => {
+    const task: Task = {
+      id: "T-done-1",
+      subject: "Setup database",
+      description: "Setup database",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    const result = renderNode(task, 0, [], allTasks)
+
+    expect(result).toContain("- [x] 1. Setup database")
+  })
+
+  //#given task at depth 2
+  //#when renderNode is called
+  //#then it has 4-space indentation (2 * depth)
+  it("renders with correct indentation for depth", () => {
+    const task: Task = {
+      id: "T-deep-1",
+      subject: "Subtask",
+      description: "A subtask",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    const result = renderNode(task, 2, [], allTasks)
+
+    expect(result).toStartWith("    - [ ]") // 4 spaces for depth 2
+  })
+
+  //#given task with activeForm field
+  //#when renderNode is called on leaf node
+  //#then activeForm is rendered in acceptance criteria section
+  it("includes activeForm in acceptance criteria for leaf", () => {
+    const task: Task = {
+      id: "T-active-1",
+      subject: "Deploy to production",
+      description: "Deploy the application",
+      status: "in_progress",
+      activeForm: "Deploying to production",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    const result = renderNode(task, 0, [], allTasks)
+
+    expect(result).toContain("**Acceptance Criteria:**")
+    expect(result).toContain("Deploying to production")
+  })
+})
+
+describe("renderTaskTree", () => {
+  //#given empty task array
+  //#when renderTaskTree is called
+  //#then it returns empty string
+  it("returns empty string for empty tree", () => {
+    const result = renderTaskTree([])
+    expect(result).toBe("")
+  })
+
+  //#given single root task with no children
+  //#when renderTaskTree is called
+  //#then it renders the single task
+  it("renders single root task", () => {
+    const task: Task = {
+      id: "T-root-1",
+      subject: "Root task",
+      description: "Root description",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+
+    const result = renderTaskTree([task])
+
+    expect(result).toContain("- [ ] 1. Root task")
+    expect(result).toContain("**What to do:**")
+    expect(result).toContain("Root description")
+  })
+
+  //#given two-level tree (parent with one child)
+  //#when renderTaskTree is called
+  //#then it renders parent with progress and child with details
+  it("renders simple two-level hierarchy", () => {
+    const parent: Task = {
+      id: "T-parent-1",
+      subject: "Build feature",
+      description: "Build the feature",
+      status: "in_progress",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const child: Task = {
+      id: "T-child-1",
+      subject: "Write code",
+      description: "Write the code",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const tasks = [parent, child]
+
+    const result = renderTaskTree(tasks)
+
+    expect(result).toContain("- [ ] 1. Build feature [1/1]")
+    expect(result).toContain("  - [x] 1.1. Write code")
+    expect(result).toContain("**What to do:**")
+    expect(result).toContain("Write the code")
+  })
+
+  //#given three-level deep tree
+  //#when renderTaskTree is called
+  //#then it renders all levels with correct numbering
+  it("renders three-level hierarchy with correct numbering", () => {
+    const root: Task = {
+      id: "T-root-1",
+      subject: "Project",
+      description: "Project desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const l1: Task = {
+      id: "T-l1-1",
+      subject: "Phase 1",
+      description: "Phase 1 desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-root-1",
+      threadID: "thread-1",
+    }
+    const l2: Task = {
+      id: "T-l2-1",
+      subject: "Task 1",
+      description: "Task 1 desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-l1-1",
+      threadID: "thread-1",
+    }
+    const tasks = [root, l1, l2]
+
+    const result = renderTaskTree(tasks)
+
+    expect(result).toContain("- [ ] 1. Project [0/1]")
+    expect(result).toContain("  - [ ] 1.1. Phase 1 [0/1]")
+    expect(result).toContain("    - [ ] 1.1.1. Task 1")
+    expect(result).toContain("**What to do:**")
+    expect(result).toContain("Task 1 desc")
+  })
+
+  //#given tree with multiple root tasks
+  //#when renderTaskTree is called
+  //#then it renders all roots with sequential numbering
+  it("renders multiple root tasks", () => {
+    const root1: Task = {
+      id: "T-root-1",
+      subject: "Task A",
+      description: "Task A desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const root2: Task = {
+      id: "T-root-2",
+      subject: "Task B",
+      description: "Task B desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const tasks = [root1, root2]
+
+    const result = renderTaskTree(tasks)
+
+    expect(result).toContain("- [ ] 1. Task A")
+    expect(result).toContain("- [ ] 2. Task B")
+  })
+
+  //#given tree with deleted tasks
+  //#when renderTaskTree is called
+  //#then deleted tasks are filtered out
+  it("filters out deleted tasks", () => {
+    const active: Task = {
+      id: "T-active-1",
+      subject: "Active task",
+      description: "Active",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const deleted: Task = {
+      id: "T-deleted-1",
+      subject: "Deleted task",
+      description: "Deleted",
+      status: "deleted",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const tasks = [active, deleted]
+
+    const result = renderTaskTree(tasks)
+
+    expect(result).toContain("Active task")
+    expect(result).not.toContain("Deleted task")
+  })
+
+  //#given tree exceeding 6 levels deep
+  //#when renderTaskTree is called
+  //#then it renders up to 6 levels and shows warning for deeper nodes
+  it("collapses nodes beyond 6 levels with warning", () => {
+    // Build a 7-level tree
+    const tasks: Task[] = []
+    let parentID: string | undefined = undefined
+
+    for (let i = 0; i < 7; i++) {
+      const task: Task = {
+        id: `T-level-${i}`,
+        subject: `Level ${i} task`,
+        description: `Level ${i} description`,
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        parentID,
+        threadID: "thread-1",
+      }
+      tasks.push(task)
+      parentID = task.id
+    }
+
+    const result = renderTaskTree(tasks)
+
+    // Should have 6 levels rendered
+    expect(result).toContain("- [ ] 1. Level 0 task")
+    expect(result).toContain("  - [ ] 1.1. Level 1 task")
+
+    // Level 6 (7th level, depth index 6) should show warning
+    expect(result).toContain("⚠️ Subtasks collapsed")
+  })
+
+  //#given complex tree with mixed completion states
+  //#when renderTaskTree is called
+  //#then progress indicators reflect actual completion
+  it("calculates progress correctly across tree", () => {
+    const root: Task = {
+      id: "T-root-1",
+      subject: "Root",
+      description: "Root",
+      status: "in_progress",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const child1: Task = {
+      id: "T-child-1",
+      subject: "Child 1",
+      description: "Child 1",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-root-1",
+      threadID: "thread-1",
+    }
+    const child2: Task = {
+      id: "T-child-2",
+      subject: "Child 2",
+      description: "Child 2",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-root-1",
+      threadID: "thread-1",
+    }
+    const tasks = [root, child1, child2]
+
+    const result = renderTaskTree(tasks)
+
+    // Root should show [1/2] (1 completed out of 2 total)
+    expect(result).toContain("[1/2]")
+  })
+})
+
+describe("renderTaskTree edge cases", () => {
+  it("renders multiple siblings at same level with sequential numbering", () => {
+    //#given
+    const parent: Task = {
+      id: "T-parent-1",
+      subject: "Parent",
+      description: "Parent",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const child1: Task = {
+      id: "T-child-1",
+      subject: "First child",
+      description: "First",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const child2: Task = {
+      id: "T-child-2",
+      subject: "Second child",
+      description: "Second",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const child3: Task = {
+      id: "T-child-3",
+      subject: "Third child",
+      description: "Third",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const tasks = [parent, child1, child2, child3]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then
+    expect(result).toContain("1.1. First child")
+    expect(result).toContain("1.2. Second child")
+    expect(result).toContain("1.3. Third child")
+  })
+
+  it("handles orphan tasks as separate roots", () => {
+    //#given - task with parentID pointing to non-existent parent
+    const validRoot: Task = {
+      id: "T-root-1",
+      subject: "Valid root",
+      description: "Valid",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const orphan: Task = {
+      id: "T-orphan-1",
+      subject: "Orphan task",
+      description: "Orphan",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-nonexistent",
+      threadID: "thread-1",
+    }
+    const tasks = [validRoot, orphan]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then - orphan treated as root
+    expect(result).toContain("1. Valid root")
+    expect(result).toContain("2. Orphan task")
+  })
+
+  it("filters deleted children from parent progress", () => {
+    //#given
+    const parent: Task = {
+      id: "T-parent-1",
+      subject: "Parent",
+      description: "Parent",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const activeChild: Task = {
+      id: "T-child-1",
+      subject: "Active child",
+      description: "Active",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const deletedChild: Task = {
+      id: "T-child-2",
+      subject: "Deleted child",
+      description: "Deleted",
+      status: "deleted",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const tasks = [parent, activeChild, deletedChild]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then - only active child counted
+    expect(result).toContain("[1/1]")
+    expect(result).not.toContain("Deleted child")
+  })
+
+  it("aggregates progress across multiple levels", () => {
+    //#given - root with child that has grandchildren
+    const root: Task = {
+      id: "T-root-1",
+      subject: "Project",
+      description: "Project",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const phase1: Task = {
+      id: "T-phase-1",
+      subject: "Phase 1",
+      description: "Phase 1",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-root-1",
+      threadID: "thread-1",
+    }
+    const task1: Task = {
+      id: "T-task-1",
+      subject: "Task 1",
+      description: "Task 1",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-phase-1",
+      threadID: "thread-1",
+    }
+    const task2: Task = {
+      id: "T-task-2",
+      subject: "Task 2",
+      description: "Task 2",
+      status: "completed",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-phase-1",
+      threadID: "thread-1",
+    }
+    const task3: Task = {
+      id: "T-task-3",
+      subject: "Task 3",
+      description: "Task 3",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-phase-1",
+      threadID: "thread-1",
+    }
+    const tasks = [root, phase1, task1, task2, task3]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then
+    expect(result).toContain("1. Project [2/3]")
+    expect(result).toContain("1.1. Phase 1 [2/3]")
+  })
+
+  it("renders only deleted tasks as empty string", () => {
+    //#given
+    const deleted1: Task = {
+      id: "T-deleted-1",
+      subject: "Deleted 1",
+      description: "Deleted",
+      status: "deleted",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const deleted2: Task = {
+      id: "T-deleted-2",
+      subject: "Deleted 2",
+      description: "Deleted",
+      status: "deleted",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const tasks = [deleted1, deleted2]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then
+    expect(result).toBe("")
+  })
+
+  it("handles task with no description gracefully", () => {
+    //#given
+    const task: Task = {
+      id: "T-task-1",
+      subject: "Task without description",
+      description: "",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const tasks = [task]
+
+    //#when
+    const result = renderTaskTree(tasks)
+
+    //#then
+    expect(result).toContain("Task without description")
+    expect(result).toContain("**What to do:**")
+  })
+})
+
+describe("renderNode edge cases", () => {
+  it("renders in_progress task with unchecked checkbox", () => {
+    //#given
+    const task: Task = {
+      id: "T-task-1",
+      subject: "In progress task",
+      description: "Working on it",
+      status: "in_progress",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    //#when
+    const result = renderNode(task, 0, [], allTasks)
+
+    //#then - in_progress shows unchecked checkbox
+    expect(result).toContain("- [ ]")
+    expect(result).not.toContain("- [x]")
+  })
+
+  it("renders pending task with unchecked checkbox", () => {
+    //#given
+    const task: Task = {
+      id: "T-task-1",
+      subject: "Pending task",
+      description: "Not started",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    //#when
+    const result = renderNode(task, 0, [], allTasks)
+
+    //#then
+    expect(result).toContain("- [ ]")
+  })
+
+  it("does not include activeForm for parent nodes", () => {
+    //#given
+    const parent: Task = {
+      id: "T-parent-1",
+      subject: "Parent task",
+      description: "Parent desc",
+      status: "in_progress",
+      activeForm: "Should not appear",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const child: Task = {
+      id: "T-child-1",
+      subject: "Child task",
+      description: "Child desc",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      parentID: "T-parent-1",
+      threadID: "thread-1",
+    }
+    const allTasks = [parent, child]
+
+    //#when
+    const result = renderNode(parent, 0, [child], allTasks)
+
+    //#then - parent node is single line, no activeForm
+    expect(result).not.toContain("Should not appear")
+    expect(result).not.toContain("**Acceptance Criteria:**")
+  })
+
+  it("renders leaf without activeForm omitting acceptance criteria section", () => {
+    //#given
+    const task: Task = {
+      id: "T-task-1",
+      subject: "Simple task",
+      description: "Do something",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: "thread-1",
+    }
+    const allTasks = [task]
+
+    //#when
+    const result = renderNode(task, 0, [], allTasks)
+
+    //#then
+    expect(result).toContain("**What to do:**")
+    expect(result).not.toContain("**Acceptance Criteria:**")
+  })
+})

--- a/src/agents/prometheus/markdown-renderer-v2.ts
+++ b/src/agents/prometheus/markdown-renderer-v2.ts
@@ -1,0 +1,105 @@
+import { buildTaskTree, calculateProgress } from "../../features/claude-tasks/tree-utils"
+import { TASK_MAX_DEPTH } from "../../features/claude-tasks/storage"
+import type { Task } from "../../tools/task/types"
+
+const INDENT = "  "
+
+export function generateNumbering(path: number[]): string {
+  return path.join(".")
+}
+
+export function renderNode(
+  task: Task,
+  depth: number,
+  children: Task[],
+  allTasks: Task[]
+): string {
+  const indent = INDENT.repeat(depth)
+  const checkbox = task.status === "completed" ? "[x]" : "[ ]"
+  
+  const pathArray = getNumberingPath(task, allTasks)
+  const numbering = generateNumbering(pathArray)
+  
+  const isLeaf = children.length === 0
+  
+  if (depth >= TASK_MAX_DEPTH) {
+    return `${indent}- ${checkbox} ${numbering}. ${task.subject} ⚠️ Subtasks collapsed (max depth exceeded)\n`
+  }
+  
+  if (isLeaf) {
+    let output = `${indent}- ${checkbox} ${numbering}. ${task.subject}\n`
+    output += `${indent}  **What to do:**\n`
+    output += `${indent}  ${task.description}\n`
+    
+    if (task.activeForm) {
+      output += `${indent}  **Acceptance Criteria:**\n`
+      output += `${indent}  ${task.activeForm}\n`
+    }
+    
+    return output
+  }
+  
+  const progress = calculateProgress(task.id, allTasks)
+  const progressIndicator = `[${progress.completed}/${progress.total}]`
+  
+  return `${indent}- ${checkbox} ${numbering}. ${task.subject} ${progressIndicator}\n`
+}
+
+function getNumberingPath(task: Task, allTasks: Task[]): number[] {
+  const { byId, childrenByParent, roots } = buildTaskTree(allTasks)
+  const path: number[] = []
+  
+  const ancestors: Task[] = []
+  let current: Task | undefined = task
+  
+  while (current) {
+    ancestors.unshift(current)
+    current = current.parentID ? byId.get(current.parentID) : undefined
+  }
+  
+  for (let i = 0; i < ancestors.length; i++) {
+    const node = ancestors[i]
+    const parent = i > 0 ? ancestors[i - 1] : undefined
+    
+    if (!parent) {
+      const index = roots.findIndex((r) => r.id === node.id)
+      path.push(index + 1)
+    } else {
+      const siblings = childrenByParent.get(parent.id) ?? []
+      const index = siblings.findIndex((s) => s.id === node.id)
+      path.push(index + 1)
+    }
+  }
+  
+  return path
+}
+
+export function renderTaskTree(tasks: Task[]): string {
+  const activeTasks = tasks.filter((t) => t.status !== "deleted")
+  
+  if (activeTasks.length === 0) {
+    return ""
+  }
+  
+  const { roots, childrenByParent } = buildTaskTree(activeTasks)
+  let output = ""
+  
+  function renderRecursive(task: Task, depth: number): void {
+    const children = childrenByParent.get(task.id) ?? []
+    const activeChildren = children.filter((c) => c.status !== "deleted")
+    
+    output += renderNode(task, depth, activeChildren, activeTasks)
+    
+    if (depth < TASK_MAX_DEPTH) {
+      for (const child of activeChildren) {
+        renderRecursive(child, depth + 1)
+      }
+    }
+  }
+  
+  for (const root of roots) {
+    renderRecursive(root, 0)
+  }
+  
+  return output
+}

--- a/src/agents/prometheus/markdown-renderer-v2.ts
+++ b/src/agents/prometheus/markdown-renderer-v2.ts
@@ -1,4 +1,5 @@
 import { buildTaskTree, calculateProgress } from "../../features/claude-tasks/tree-utils"
+import type { TaskTree } from "../../features/claude-tasks/tree-utils"
 import { TASK_MAX_DEPTH } from "../../features/claude-tasks/storage"
 import type { Task } from "../../tools/task/types"
 
@@ -12,12 +13,13 @@ export function renderNode(
   task: Task,
   depth: number,
   children: Task[],
-  allTasks: Task[]
+  tree: TaskTree,
+  activeTasks: Task[]
 ): string {
   const indent = INDENT.repeat(depth)
   const checkbox = task.status === "completed" ? "[x]" : "[ ]"
   
-  const pathArray = getNumberingPath(task, allTasks)
+  const pathArray = getNumberingPath(task, tree)
   const numbering = generateNumbering(pathArray)
   
   const isLeaf = children.length === 0
@@ -39,14 +41,14 @@ export function renderNode(
     return output
   }
   
-  const progress = calculateProgress(task.id, allTasks)
+  const progress = calculateProgress(task.id, activeTasks)
   const progressIndicator = `[${progress.completed}/${progress.total}]`
   
   return `${indent}- ${checkbox} ${numbering}. ${task.subject} ${progressIndicator}\n`
 }
 
-function getNumberingPath(task: Task, allTasks: Task[]): number[] {
-  const { byId, childrenByParent, roots } = buildTaskTree(allTasks)
+function getNumberingPath(task: Task, tree: TaskTree): number[] {
+  const { byId, childrenByParent, roots } = tree
   const path: number[] = []
   
   const ancestors: Task[] = []
@@ -81,14 +83,15 @@ export function renderTaskTree(tasks: Task[]): string {
     return ""
   }
   
-  const { roots, childrenByParent } = buildTaskTree(activeTasks)
+  const tree = buildTaskTree(activeTasks)
+  const { roots, childrenByParent } = tree
   let output = ""
   
   function renderRecursive(task: Task, depth: number): void {
     const children = childrenByParent.get(task.id) ?? []
     const activeChildren = children.filter((c) => c.status !== "deleted")
     
-    output += renderNode(task, depth, activeChildren, activeTasks)
+    output += renderNode(task, depth, activeChildren, tree, activeTasks)
     
     if (depth < TASK_MAX_DEPTH) {
       for (const child of activeChildren) {

--- a/src/agents/prometheus/plan-format-detector.test.ts
+++ b/src/agents/prometheus/plan-format-detector.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for plan format detection (v1 flat vs v2 hierarchical)
+ *
+ * BDD: //#given //#when //#then pattern
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  detectPlanFormat,
+  addFormatMetadata,
+  FORMAT_METADATA_HEADER,
+} from "./plan-format-detector";
+
+describe("detectPlanFormat", () => {
+  //#given a v1 plan with no metadata header
+  //#when detectPlanFormat is called
+  //#then it returns 'v1'
+  it("detects v1 plan (no metadata header)", () => {
+    const v1Plan = `# My Plan
+
+## TL;DR
+
+Quick summary here.
+
+## Context
+
+Some context.`;
+
+    const result = detectPlanFormat(v1Plan);
+    expect(result).toBe("v1");
+  });
+
+  //#given a v2 plan with Plan-Format: 2 metadata
+  //#when detectPlanFormat is called
+  //#then it returns 'v2'
+  it("detects v2 plan (with Plan-Format: 2 metadata)", () => {
+    const v2Plan = `<!-- Plan-Format: 2 -->
+
+# My Plan
+
+## TL;DR
+
+Quick summary here.`;
+
+    const result = detectPlanFormat(v2Plan);
+    expect(result).toBe("v2");
+  });
+
+  //#given empty markdown content
+  //#when detectPlanFormat is called
+  //#then it defaults to 'v1'
+  it("returns v1 for empty content (graceful default)", () => {
+    const result = detectPlanFormat("");
+    expect(result).toBe("v1");
+  });
+
+  //#given only whitespace
+  //#when detectPlanFormat is called
+  //#then it returns 'v1'
+  it("returns v1 for whitespace-only content", () => {
+    const result = detectPlanFormat("   \n\n  \t\n");
+    expect(result).toBe("v1");
+  });
+
+  //#given malformed markdown without metadata
+  //#when detectPlanFormat is called
+  //#then it gracefully returns 'v1'
+  it("returns v1 for malformed content without metadata", () => {
+    const malformed = `
+    \`\`\`
+    random content
+    no headers
+    %%%
+    \`\`\`
+    `;
+
+    const result = detectPlanFormat(malformed);
+    expect(result).toBe("v1");
+  });
+
+  //#given v2 plan with metadata in the first line
+  //#when detectPlanFormat is called
+  //#then it detects the format correctly
+  it("detects v2 format even if metadata is only content on first line", () => {
+    const plan = `<!-- Plan-Format: 2 -->`;
+    const result = detectPlanFormat(plan);
+    expect(result).toBe("v2");
+  });
+
+  //#given v2 plan with metadata before other HTML comments
+  //#when detectPlanFormat is called
+  //#then it finds the Plan-Format metadata
+  it("finds Plan-Format metadata among other HTML comments", () => {
+    const plan = `<!-- Author: Prometheus -->
+<!-- Plan-Format: 2 -->
+<!-- Version: 1.0 -->
+
+# Plan Title`;
+
+    const result = detectPlanFormat(plan);
+    expect(result).toBe("v2");
+  });
+
+  //#given content with Plan-Format: 1 (explicit v1)
+  //#when detectPlanFormat is called
+  //#then it returns 'v1'
+  it("returns v1 when Plan-Format: 1 is explicitly specified", () => {
+    const plan = `<!-- Plan-Format: 1 -->
+
+# Plan Title`;
+
+    const result = detectPlanFormat(plan);
+    expect(result).toBe("v1");
+  });
+
+  //#given content with Plan-Format in lowercase
+  //#when detectPlanFormat is called
+  //#then it case-insensitively matches the metadata
+  it("case-insensitively detects Plan-Format metadata", () => {
+    const plan = `<!-- plan-format: 2 -->
+
+# Plan`;
+
+    const result = detectPlanFormat(plan);
+    expect(result).toBe("v2");
+  });
+
+  //#given content with spaces around colon in metadata
+  //#when detectPlanFormat is called
+  //#then it handles whitespace variations
+  it("handles whitespace variations around metadata colon", () => {
+    const plan1 = `<!-- Plan-Format : 2 -->`;
+    const plan2 = `<!-- Plan-Format:2 -->`;
+    const plan3 = `<!-- Plan-Format  :  2  -->`;
+
+    expect(detectPlanFormat(plan1)).toBe("v2");
+    expect(detectPlanFormat(plan2)).toBe("v2");
+    expect(detectPlanFormat(plan3)).toBe("v2");
+  });
+});
+
+describe("addFormatMetadata", () => {
+  //#given v1 plan content
+  //#when addFormatMetadata is called with version 'v1'
+  //#then it prepends v1 metadata header
+  it("adds v1 format metadata header to content", () => {
+    const content = `# Plan Title
+
+## Section`;
+
+    const result = addFormatMetadata(content, "v1");
+
+    expect(result).toContain(`<!-- Plan-Format: 1 -->`);
+    expect(result).toStartWith(`<!-- Plan-Format: 1 -->`);
+    expect(result).toContain("# Plan Title");
+    expect(result).toContain("## Section");
+  });
+
+  //#given v2 plan content
+  //#when addFormatMetadata is called with version 'v2'
+  //#then it prepends v2 metadata header
+  it("adds v2 format metadata header to content", () => {
+    const content = `# Plan Title
+
+## Section`;
+
+    const result = addFormatMetadata(content, "v2");
+
+    expect(result).toContain(`<!-- Plan-Format: 2 -->`);
+    expect(result).toStartWith(`<!-- Plan-Format: 2 -->`);
+    expect(result).toContain("# Plan Title");
+    expect(result).toContain("## Section");
+  });
+
+  //#given empty content
+  //#when addFormatMetadata is called
+  //#then it returns only the metadata header with newline
+  it("handles empty content gracefully", () => {
+    const result = addFormatMetadata("", "v2");
+
+    expect(result).toStartWith(`<!-- Plan-Format: 2 -->`);
+    expect(result.trim()).toBe(`<!-- Plan-Format: 2 -->`);
+  });
+
+  //#given content that already has metadata
+  //#when addFormatMetadata is called
+  //#then it adds new metadata (doesn't deduplicate)
+  it("adds metadata even if content already has it", () => {
+    const content = `<!-- Plan-Format: 1 -->
+
+# Plan`;
+
+    const result = addFormatMetadata(content, "v2");
+
+    // Should have both the new v2 and the old v1
+    const lines = result.split("\n");
+    const formatLines = lines.filter((line) =>
+      line.includes("Plan-Format:")
+    );
+    expect(formatLines.length).toBeGreaterThan(0);
+    // First line should be v2
+    expect(result.startsWith(`<!-- Plan-Format: 2 -->`)).toBe(true);
+  });
+
+  //#given multiline content
+  //#when addFormatMetadata is called
+  //#then original content is preserved exactly
+  it("preserves original content structure exactly", () => {
+    const content = `# Plan Title
+
+## TL;DR
+
+> Summary line 1
+> Summary line 2
+
+## Context
+
+Details here.
+
+\`\`\`typescript
+const x = 1;
+\`\`\``;
+
+    const result = addFormatMetadata(content, "v2");
+    const contentPart = result.substring(
+      result.indexOf("\n") + 1
+    );
+
+    expect(contentPart.trim()).toBe(content.trim());
+  });
+
+  //#given newlines in content
+  //#when addFormatMetadata is called
+  //#then the separator between metadata and content is correct
+  it("has proper newline separation between metadata and content", () => {
+    const content = `# Plan`;
+    const result = addFormatMetadata(content, "v1");
+
+    const [header, ...rest] = result.split("\n");
+    expect(header).toBe(`<!-- Plan-Format: 1 -->`);
+    expect(rest[0]).toBe(""); // blank line
+    expect(rest[1]).toBe("# Plan");
+  });
+});
+
+describe("FORMAT_METADATA_HEADER constant", () => {
+  //#given the FORMAT_METADATA_HEADER constant
+  //#when exported
+  //#then it follows the correct comment format
+  it("exports correctly formatted metadata header template", () => {
+    expect(typeof FORMAT_METADATA_HEADER).toBe("string");
+    expect(FORMAT_METADATA_HEADER).toContain("<!-- Plan-Format:");
+    expect(FORMAT_METADATA_HEADER).toMatch(/Plan-Format:\s*\{version\}/);
+  });
+});
+
+describe("detectPlanFormat edge cases", () => {
+  it("returns v1 for unknown version numbers (e.g., Plan-Format: 3)", () => {
+    //#given
+    const plan = `<!-- Plan-Format: 3 -->
+
+# Plan`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v1");
+  });
+
+  it("returns v1 for version 0", () => {
+    //#given
+    const plan = `<!-- Plan-Format: 0 -->
+
+# Plan`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v1");
+  });
+
+  it("finds metadata anywhere in document, not just first line", () => {
+    //#given
+    const plan = `# My Plan
+
+Some intro text.
+
+<!-- Plan-Format: 2 -->
+
+## Tasks`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v2");
+  });
+
+  it("handles UPPERCASE Plan-Format", () => {
+    //#given
+    const plan = `<!-- PLAN-FORMAT: 2 -->`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v2");
+  });
+
+  it("handles MixedCase Plan-Format", () => {
+    //#given
+    const plan = `<!-- Plan-FORMAT: 2 -->`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v2");
+  });
+
+  it("ignores Plan-Format in code blocks", () => {
+    //#given - metadata in code block should not be detected
+    const plan = `# Plan
+
+\`\`\`html
+<!-- Plan-Format: 2 -->
+\`\`\`
+
+Regular content here.`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then - regex still matches inside code block (known limitation)
+    expect(result).toBe("v2");
+  });
+
+  it("handles multiple Plan-Format comments (uses first match)", () => {
+    //#given
+    const plan = `<!-- Plan-Format: 2 -->
+<!-- Plan-Format: 1 -->
+
+# Plan`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then
+    expect(result).toBe("v2");
+  });
+
+  it("matches Plan-Format even inside multiline comment", () => {
+    //#given
+    const plan = `<!--
+Plan-Format: 2
+-->
+
+# Plan`;
+
+    //#when
+    const result = detectPlanFormat(plan);
+
+    //#then - regex matches Plan-Format anywhere in string
+    expect(result).toBe("v2");
+  });
+});
+
+describe("addFormatMetadata edge cases", () => {
+  it("handles content with leading whitespace", () => {
+    //#given
+    const content = `   # Plan Title`;
+
+    //#when
+    const result = addFormatMetadata(content, "v2");
+
+    //#then
+    expect(result).toStartWith("<!-- Plan-Format: 2 -->");
+    expect(result).toContain("   # Plan Title");
+  });
+
+  it("handles content with only newlines", () => {
+    //#given
+    const content = `\n\n\n`;
+
+    //#when
+    const result = addFormatMetadata(content, "v1");
+
+    //#then - newlines only is not empty after trim, so adds header
+    expect(result).toStartWith("<!-- Plan-Format: 1 -->");
+  });
+
+  it("handles whitespace-only content as empty", () => {
+    //#given
+    const content = `   \t  `;
+
+    //#when
+    const result = addFormatMetadata(content, "v2");
+
+    //#then
+    expect(result).toBe("<!-- Plan-Format: 2 -->");
+  });
+});

--- a/src/agents/prometheus/plan-format-detector.ts
+++ b/src/agents/prometheus/plan-format-detector.ts
@@ -1,0 +1,57 @@
+/**
+ * Plan format detection for v1 (flat) vs v2 (hierarchical) plan structures
+ *
+ * v1: No format metadata header → defaults to flat structure
+ * v2: Has `Plan-Format: 2` metadata → hierarchical structure
+ *
+ * Backward compatible: Missing metadata → v1
+ */
+
+export const FORMAT_METADATA_HEADER = "<!-- Plan-Format: {version} -->";
+
+/**
+ * Detects plan format version from markdown content
+ *
+ * Looks for HTML comment with `Plan-Format: N` metadata header.
+ * Case-insensitive, whitespace-tolerant. Defaults to v1 if missing.
+ */
+export function detectPlanFormat(
+  markdownContent: string
+): "v1" | "v2" {
+  if (!markdownContent || markdownContent.trim().length === 0) {
+    return "v1";
+  }
+
+  // Look for Plan-Format metadata in HTML comments
+  // Pattern: <!-- Plan-Format: 2 --> (case-insensitive, whitespace-tolerant)
+  const metadataPattern = /<!--\s*plan-format\s*:\s*(\d)\s*-->/i;
+  const match = markdownContent.match(metadataPattern);
+
+  if (match) {
+    const version = match[1];
+    return version === "2" ? "v2" : "v1";
+  }
+
+  // No metadata found → default to v1 (backward compatible)
+  return "v1";
+}
+
+/**
+ * Adds format metadata header to plan content
+ *
+ * Prepends HTML comment with format version at the top of the content.
+ * Preserves original content exactly, adds blank line separator.
+ */
+export function addFormatMetadata(
+  content: string,
+  version: "v1" | "v2"
+): string {
+  const versionNumber = version === "v2" ? "2" : "1";
+  const header = `<!-- Plan-Format: ${versionNumber} -->`;
+
+  if (!content || content.trim().length === 0) {
+    return header;
+  }
+
+  return `${header}\n\n${content}`;
+}

--- a/src/agents/prometheus/plan-generation.ts
+++ b/src/agents/prometheus/plan-generation.ts
@@ -19,12 +19,42 @@ export const PROMETHEUS_PLAN_GENERATION = `# PHASE 2: PLAN GENERATION (Auto-Tran
 
 ## MANDATORY: Register Todo List IMMEDIATELY (NON-NEGOTIABLE)
 
-**The INSTANT you detect a plan generation trigger, you MUST register the following steps as todos using TodoWrite.**
+**The INSTANT you detect a plan generation trigger, you MUST register the following steps using task tools (preferred) or TodoWrite (fallback).**
 
 **This is not optional. This is your first action upon trigger detection.**
 
+### Step 1: Determine which tool to use
+
+**IF task_system is enabled** (you have access to \`task_create\`, \`task_update\`, \`task_list\`, \`task_get\` tools):
+- Use \`task_create\` to register each step with auto-generated IDs
+- Use \`task_update\` to mark progress
+- See example below under "Using Task Tools"
+
+**IF task_system is disabled** (only TodoWrite available):
+- Use TodoWrite as shown in the "Using TodoWrite" example
+- TodoWrite will be available even when tasks are disabled
+
+### Using Task Tools (Preferred when available)
+
 \`\`\`typescript
-// IMMEDIATELY upon trigger detection - NO EXCEPTIONS
+// IMMEDIATELY upon trigger detection - use task_create for each step
+task_create({ subject: "Consult Metis for gap analysis (auto-proceed)", priority: "high" })
+task_create({ subject: "Generate work plan to .sisyphus/plans/{name}.md", priority: "high" })
+task_create({ subject: "Self-review: classify gaps (critical/minor/ambiguous)", priority: "high" })
+task_create({ subject: "Present summary with auto-resolved items and decisions needed", priority: "high" })
+task_create({ subject: "If decisions needed: wait for user, update plan", priority: "high" })
+task_create({ subject: "Ask user about high accuracy mode (Momus review)", priority: "high" })
+task_create({ subject: "If high accuracy: Submit to Momus and iterate until OKAY", priority: "medium" })
+task_create({ subject: "Delete draft file and guide user to /start-work", priority: "medium" })
+
+// Then mark the first task as in_progress
+task_update({ id: "T-xxx", status: "in_progress" })
+\`\`\`
+
+### Using TodoWrite (Fallback when task_system disabled)
+
+\`\`\`typescript
+// IMMEDIATELY upon trigger detection - use TodoWrite as fallback
 todoWrite([
   { id: "plan-1", content: "Consult Metis for gap analysis (auto-proceed)", status: "pending", priority: "high" },
   { id: "plan-2", content: "Generate work plan to .sisyphus/plans/{name}.md", status: "pending", priority: "high" },
@@ -43,7 +73,18 @@ todoWrite([
 - Creates accountability for each phase
 - Enables recovery if session is interrupted
 
-**WORKFLOW:**
+**WORKFLOW (with task tools):**
+1. Trigger detected → **IMMEDIATELY** fire task_create for all 8 steps
+2. Mark first task as \`in_progress\` via task_update → Consult Metis (auto-proceed, no questions)
+3. Mark task-2 as \`in_progress\` → Generate plan immediately
+4. Mark task-3 as \`in_progress\` → Self-review and classify gaps
+5. Mark task-4 as \`in_progress\` → Present summary (with auto-resolved/defaults/decisions)
+6. Mark task-5 as \`in_progress\` → If decisions needed, wait for user and update plan
+7. Mark task-6 as \`in_progress\` → Ask high accuracy question
+8. Continue marking tasks as you progress
+9. NEVER skip a task. NEVER proceed without updating status.
+
+**WORKFLOW (with TodoWrite fallback):**
 1. Trigger detected → **IMMEDIATELY** TodoWrite (plan-1 through plan-8)
 2. Mark plan-1 as \`in_progress\` → Consult Metis (auto-proceed, no questions)
 3. Mark plan-2 as \`in_progress\` → Generate plan immediately
@@ -210,4 +251,84 @@ Question({
   }]
 })
 \`\`\`
+
+
+**Based on user choice:**
+- **Start Work** → Delete draft, guide to `/start-work`
+- **High Accuracy Review** → Enter Momus loop (PHASE 3)
+
+---
+
+## Hierarchical Plan Structure (V2 Format)
+
+When generating plans for complex projects, use hierarchical task structure to better organize work.
+
+### When to Use Hierarchical Structure
+
+Use V2 hierarchical format when:
+- Feature has 3+ logical sub-components
+- Tasks can be parallelized at different levels
+- Work benefits from progress aggregation (parent shows child completion)
+- Deep nesting naturally represents the problem structure
+
+Use V1 flat format when:
+- Simple linear workflow (A → B → C)
+- Few tasks (< 5)
+- No natural grouping exists
+
+### V2 Format Metadata
+
+Add this comment at the top of hierarchical plans:
+\`\`\`markdown
+<!-- Plan-Format: 2 -->
+\`\`\`
+
+### Task Hierarchy Format
+
+\`\`\`markdown
+## TODOs
+
+- [ ] 1. Parent Task [0/2]
+
+  - [ ] 1.1. Child Task A
+
+    **What to do**:
+    - Step 1
+    - Step 2
+
+    **Acceptance Criteria**:
+    - [ ] Criterion 1
+    - [ ] Criterion 2
+
+  - [ ] 1.2. Child Task B
+
+    **What to do**:
+    - Step 1
+
+    **Acceptance Criteria**:
+    - [ ] Criterion 1
+\`\`\`
+
+### Hierarchy Rules
+
+| Rule | Description |
+|------|-------------|
+| **Progress Aggregation** | Parent shows \`[completed/total]\` from children |
+| **Leaf Details** | Only leaf tasks have "What to do" and "Acceptance Criteria" |
+| **Parent Summary** | Parent tasks are single-line with progress only |
+| **Max Depth** | Maximum 6 nesting levels |
+| **Numbering** | Use hierarchical numbering: 1, 1.1, 1.1.1, etc. |
+
+### Execution Order
+
+Tasks are executed in **DFS order** (depth-first):
+1. Start with first root task
+2. Descend to deepest leaf
+3. Complete leaf, move to sibling
+4. When all children complete, parent is implicitly done
+5. Move to next root
+
+This enables natural parallelization: independent subtrees can run simultaneously.
+
+---
 `

--- a/src/agents/prometheus/plan-generation.ts
+++ b/src/agents/prometheus/plan-generation.ts
@@ -36,34 +36,78 @@ export const PROMETHEUS_PLAN_GENERATION = `# PHASE 2: PLAN GENERATION (Auto-Tran
 
 ### Using Task Tools (Preferred when available)
 
+**For flat linear workflows** (simple sequential steps):
 \`\`\`typescript
-// IMMEDIATELY upon trigger detection - use task_create for each step
-task_create({ subject: "Consult Metis for gap analysis (auto-proceed)", priority: "high" })
-task_create({ subject: "Generate work plan to .sisyphus/plans/{name}.md", priority: "high" })
-task_create({ subject: "Self-review: classify gaps (critical/minor/ambiguous)", priority: "high" })
-task_create({ subject: "Present summary with auto-resolved items and decisions needed", priority: "high" })
-task_create({ subject: "If decisions needed: wait for user, update plan", priority: "high" })
-task_create({ subject: "Ask user about high accuracy mode (Momus review)", priority: "high" })
-task_create({ subject: "If high accuracy: Submit to Momus and iterate until OKAY", priority: "medium" })
-task_create({ subject: "Delete draft file and guide user to /start-work", priority: "medium" })
+// Flat workflow - use sequential numbering: 1., 2., 3.
+task_create({ subject: "1. Consult Metis for gap analysis (auto-proceed)", metadata: { priority: "high" } })
+task_create({ subject: "2. Generate work plan to .sisyphus/plans/{name}.md", metadata: { priority: "high" } })
+task_create({ subject: "3. Self-review: classify gaps (critical/minor/ambiguous)", metadata: { priority: "high" } })
+task_create({ subject: "4. Present summary with auto-resolved items and decisions needed", metadata: { priority: "high" } })
+task_create({ subject: "5. If decisions needed: wait for user, update plan", metadata: { priority: "high" } })
+task_create({ subject: "6. Ask user about high accuracy mode (Momus review)", metadata: { priority: "high" } })
+task_create({ subject: "7. If high accuracy: Submit to Momus and iterate until OKAY", metadata: { priority: "medium" } })
+task_create({ subject: "8. Delete draft file and guide user to /start-work", metadata: { priority: "medium" } })
+\`\`\`
 
-// Then mark the first task as in_progress
-task_update({ id: "T-xxx", status: "in_progress" })
+**For hierarchical workflows** (parent-child task structure):
+\`\`\`typescript
+// Hierarchical workflow - use nested numbering: 1., 1.1., 1.1.1.
+// Parent task (root level)
+const parent1 = task_create({ subject: "1. Setup authentication system", metadata: { priority: "high" } })
+// Child tasks (use parentID to establish hierarchy)
+task_create({ subject: "1.1. Implement JWT token generation", parentID: parent1.task.id, metadata: { priority: "high" } })
+task_create({ subject: "1.2. Create login endpoint", parentID: parent1.task.id, metadata: { priority: "high" } })
+task_create({ subject: "1.3. Add password hashing", parentID: parent1.task.id, metadata: { priority: "high" } })
+
+// Another parent task
+const parent2 = task_create({ subject: "2. Build user management", metadata: { priority: "high" } })
+task_create({ subject: "2.1. User CRUD operations", parentID: parent2.task.id, metadata: { priority: "high" } })
+task_create({ subject: "2.2. Role-based permissions", parentID: parent2.task.id, metadata: { priority: "medium" } })
+
+// Deep nesting example (grandchild)
+const child = task_create({ subject: "2.1. User CRUD operations", parentID: parent2.task.id, metadata: { priority: "high" } })
+task_create({ subject: "2.1.1. Create user endpoint", parentID: child.task.id, metadata: { priority: "high" } })
+task_create({ subject: "2.1.2. Update user endpoint", parentID: child.task.id, metadata: { priority: "high" } })
+
+// Capture the auto-generated ID from task_create response, then update
+const response1 = task_create({ subject: "1. Consult Metis for gap analysis (auto-proceed)", metadata: { priority: "high" } })
+// response1 = { "task": { "id": "T-abc123", "subject": "..." } }
+task_update({ id: "T-abc123", status: "in_progress" })
 \`\`\`
 
 ### Using TodoWrite (Fallback when task_system disabled)
 
+**For flat linear workflows:**
 \`\`\`typescript
-// IMMEDIATELY upon trigger detection - use TodoWrite as fallback
+// Flat workflow - sequential numbering
 todoWrite([
-  { id: "plan-1", content: "Consult Metis for gap analysis (auto-proceed)", status: "pending", priority: "high" },
-  { id: "plan-2", content: "Generate work plan to .sisyphus/plans/{name}.md", status: "pending", priority: "high" },
-  { id: "plan-3", content: "Self-review: classify gaps (critical/minor/ambiguous)", status: "pending", priority: "high" },
-  { id: "plan-4", content: "Present summary with auto-resolved items and decisions needed", status: "pending", priority: "high" },
-  { id: "plan-5", content: "If decisions needed: wait for user, update plan", status: "pending", priority: "high" },
-  { id: "plan-6", content: "Ask user about high accuracy mode (Momus review)", status: "pending", priority: "high" },
-  { id: "plan-7", content: "If high accuracy: Submit to Momus and iterate until OKAY", status: "pending", priority: "medium" },
-  { id: "plan-8", content: "Delete draft file and guide user to /start-work {name}", status: "pending", priority: "medium" }
+  { content: "1. Consult Metis for gap analysis (auto-proceed)", status: "pending", priority: "high" },
+  { content: "2. Generate work plan to .sisyphus/plans/{name}.md", status: "pending", priority: "high" },
+  { content: "3. Self-review: classify gaps (critical/minor/ambiguous)", status: "pending", priority: "high" },
+  { content: "4. Present summary with auto-resolved items and decisions needed", status: "pending", priority: "high" },
+  { content: "5. If decisions needed: wait for user, update plan", status: "pending", priority: "high" },
+  { content: "6. Ask user about high accuracy mode (Momus review)", status: "pending", priority: "high" },
+  { content: "7. If high accuracy: Submit to Momus and iterate until OKAY", status: "pending", priority: "medium" },
+  { content: "8. Delete draft file and guide user to /start-work", status: "pending", priority: "medium" }
+])
+```
+
+**For hierarchical workflows:**
+```typescript
+// Hierarchical workflow - nested numbering: 1., 1.1., 1.1.1.
+// TodoWrite displays hierarchy through numbering prefix (visual hierarchy)
+todoWrite([
+  // Parent 1 and its children
+  { content: "1. Setup authentication system", status: "pending", priority: "high" },
+  { content: "1.1. Implement JWT token generation", status: "pending", priority: "high" },
+  { content: "1.2. Create login endpoint", status: "pending", priority: "high" },
+  { content: "1.3. Add password hashing", status: "pending", priority: "high" },
+  // Parent 2 and its children
+  { content: "2. Build user management", status: "pending", priority: "high" },
+  { content: "2.1. User CRUD operations", status: "pending", priority: "high" },
+  { content: "2.1.1. Create user endpoint", status: "pending", priority: "high" },
+  { content: "2.1.2. Update user endpoint", status: "pending", priority: "high" },
+  { content: "2.2. Role-based permissions", status: "pending", priority: "medium" }
 ])
 \`\`\`
 
@@ -74,24 +118,24 @@ todoWrite([
 - Enables recovery if session is interrupted
 
 **WORKFLOW (with task tools):**
-1. Trigger detected → **IMMEDIATELY** fire task_create for all 8 steps
-2. Mark first task as \`in_progress\` via task_update → Consult Metis (auto-proceed, no questions)
-3. Mark task-2 as \`in_progress\` → Generate plan immediately
-4. Mark task-3 as \`in_progress\` → Self-review and classify gaps
-5. Mark task-4 as \`in_progress\` → Present summary (with auto-resolved/defaults/decisions)
-6. Mark task-5 as \`in_progress\` → If decisions needed, wait for user and update plan
-7. Mark task-6 as \`in_progress\` → Ask high accuracy question
+1. Trigger detected → **IMMEDIATELY** fire task_create for all 8 steps (with 1., 2., 3., etc. prefix)
+2. Mark task "1." as \`in_progress\` via task_update → Consult Metis (auto-proceed, no questions)
+3. Mark task "2." as \`in_progress\` → Generate plan immediately
+4. Mark task "3." as \`in_progress\` → Self-review and classify gaps
+5. Mark task "4." as \`in_progress\` → Present summary (with auto-resolved/defaults/decisions)
+6. Mark task "5." as \`in_progress\` → If decisions needed, wait for user and update plan
+7. Mark task "6." as \`in_progress\` → Ask high accuracy question
 8. Continue marking tasks as you progress
 9. NEVER skip a task. NEVER proceed without updating status.
 
 **WORKFLOW (with TodoWrite fallback):**
-1. Trigger detected → **IMMEDIATELY** TodoWrite (plan-1 through plan-8)
-2. Mark plan-1 as \`in_progress\` → Consult Metis (auto-proceed, no questions)
-3. Mark plan-2 as \`in_progress\` → Generate plan immediately
-4. Mark plan-3 as \`in_progress\` → Self-review and classify gaps
-5. Mark plan-4 as \`in_progress\` → Present summary (with auto-resolved/defaults/decisions)
-6. Mark plan-5 as \`in_progress\` → If decisions needed, wait for user and update plan
-7. Mark plan-6 as \`in_progress\` → Ask high accuracy question
+1. Trigger detected → **IMMEDIATELY** TodoWrite (tasks 1. through 8.)
+2. Mark todo "1." as \`in_progress\` → Consult Metis (auto-proceed, no questions)
+3. Mark todo "2." as \`in_progress\` → Generate plan immediately
+4. Mark todo "3." as \`in_progress\` → Self-review and classify gaps
+5. Mark todo "4." as \`in_progress\` → Present summary (with auto-resolved/defaults/decisions)
+6. Mark todo "5." as \`in_progress\` → If decisions needed, wait for user and update plan
+7. Mark todo "6." as \`in_progress\` → Ask high accuracy question
 8. Continue marking todos as you progress
 9. NEVER skip a todo. NEVER proceed without updating status.
 
@@ -283,30 +327,94 @@ Add this comment at the top of hierarchical plans:
 <!-- Plan-Format: 2 -->
 \`\`\`
 
+### CRITICAL: Waves → Parent Tasks Mapping
+
+**Execution Waves from the "Execution Strategy" section MUST become parent tasks in the TODOs section.**
+
+| Execution Strategy | TODOs Section |
+|-------------------|---------------|
+| Wave 1 (Foundation) | \`1. Wave 1: Foundation [0/N]\` |
+| Wave 2 (Authentication) | \`2. Wave 2: Authentication [0/N]\` |
+| Wave 3 (Features) | \`3. Wave 3: Features [0/N]\` |
+| Task within Wave 1 | \`1.1. Initialize Project\`, \`1.2. Database Setup\` |
+| Task within Wave 2 | \`2.1. JWT Strategy\`, \`2.2. Login Endpoint\` |
+
+**This is NOT optional.** If your plan has waves, those waves MUST be parent tasks with children.
+
+**WRONG (flat numbering despite having waves):**
+\`\`\`markdown
+## TODOs
+- [ ] 1. Initialize Project [0/1]
+- [ ] 2. Database Setup [0/1]
+- [ ] 3. JWT Strategy [0/1]
+- [ ] 4. Login Endpoint [0/1]
+\`\`\`
+
+**CORRECT (waves as parents with hierarchical children):**
+\`\`\`markdown
+## TODOs
+- [ ] 1. Wave 1: Foundation [0/2]
+  - [ ] 1.1. Initialize Project
+  - [ ] 1.2. Database Setup
+- [ ] 2. Wave 2: Authentication [0/2]
+  - [ ] 2.1. JWT Strategy
+  - [ ] 2.2. Login Endpoint
+\`\`\`
+
 ### Task Hierarchy Format
 
 \`\`\`markdown
 ## TODOs
 
-- [ ] 1. Parent Task [0/2]
+- [ ] 1. Wave 1: Foundation [0/3]
 
-  - [ ] 1.1. Child Task A
-
-    **What to do**:
-    - Step 1
-    - Step 2
-
-    **Acceptance Criteria**:
-    - [ ] Criterion 1
-    - [ ] Criterion 2
-
-  - [ ] 1.2. Child Task B
+  - [ ] 1.1. Initialize Project
 
     **What to do**:
-    - Step 1
+    - Create project structure
+    - Install dependencies
 
     **Acceptance Criteria**:
-    - [ ] Criterion 1
+    - [ ] Project builds successfully
+    - [ ] Dependencies installed
+
+  - [ ] 1.2. Database Configuration
+
+    **What to do**:
+    - Configure connection
+    - Create schemas
+
+    **Acceptance Criteria**:
+    - [ ] Database connects
+    - [ ] Migrations run
+
+  - [ ] 1.3. Basic App Setup
+
+    **What to do**:
+    - Configure app module
+    - Setup validation
+
+    **Acceptance Criteria**:
+    - [ ] App starts
+    - [ ] Validation works
+
+- [ ] 2. Wave 2: Core Features [0/2]
+
+  - [ ] 2.1. Authentication Module
+
+    **What to do**:
+    - Implement JWT strategy
+
+    **Acceptance Criteria**:
+    - [ ] JWT tokens generated
+
+  - [ ] 2.2. User Registration
+
+    **What to do**:
+    - Create registration endpoint
+
+    **Acceptance Criteria**:
+    - [ ] Users can register
 \`\`\`
 
 ### Hierarchy Rules

--- a/src/agents/prometheus/plan-template-v2.ts
+++ b/src/agents/prometheus/plan-template-v2.ts
@@ -228,7 +228,15 @@ Parallel Speedup: ~40% faster than sequential
 > EVERY task MUST have: Recommended Agent Profile + Parallelization info.
 > Support hierarchical structures: parent tasks aggregate child completion.
 
-**CRITICAL: Hierarchical Numbering Rules**
+**CRITICAL: Waves → Parent Tasks Mapping**
+
+Execution Waves from the "Execution Strategy" section MUST become parent tasks here:
+- Wave 1 → \`1. Wave 1: [Description] [0/N]\`
+- Wave 2 → \`2. Wave 2: [Description] [0/N]\`
+- Tasks within Wave 1 → \`1.1.\`, \`1.2.\`, \`1.3.\`, etc.
+- Tasks within Wave 2 → \`2.1.\`, \`2.2.\`, \`2.3.\`, etc.
+
+**Hierarchical Numbering Rules**
 
 1. **If a task shows \`[0/N]\` with N > 0, it MUST have exactly N child tasks below it**
 2. **Child tasks MUST use hierarchical numbering**: \`1.1\`, \`1.2\`, \`2.1\`, \`2.2.1\`, etc.
@@ -238,9 +246,9 @@ Parallel Speedup: ~40% faster than sequential
 
 **Examples follow these rules strictly:**
 
-- [ ] 1. Parent Task [0/2]
+- [ ] 1. Wave 1: Foundation [0/2]
 
-  **What to do**: [High-level work package]
+  **What to do**: [High-level work package for foundation setup]
   
   **Recommended Agent Profile**:
   > Select category + skills based on task domain. Justify each choice.
@@ -252,13 +260,13 @@ Parallel Speedup: ~40% faster than sequential
 
   **Parallelization**:
   - **Can Run In Parallel**: YES | NO
-  - **Parallel Group**: Wave N (with Tasks X, Y) | Sequential
+  - **Parallel Group**: Wave 1 (with Tasks 1.1, 1.2)
   - **Blocks**: [Child tasks 1.1, 1.2]
   - **Blocked By**: None (can start immediately)
 
   ---
 
-  - [ ] 1.1. Child Task A
+  - [ ] 1.1. Initialize Project
 
     **What to do**:
     - [Clear implementation steps]
@@ -323,7 +331,7 @@ Parallel Speedup: ~40% faster than sequential
 
   ---
 
-  - [ ] 1.2. Child Task B
+  - [ ] 1.2. Database Configuration
 
     **What to do**:
     - [Clear implementation steps]
@@ -334,8 +342,8 @@ Parallel Speedup: ~40% faster than sequential
     - **Skills**: [\`skill-name\`]
 
     **Parallelization**:
-    - **Can Run In Parallel**: NO
-    - **Blocked By**: Child task 1.1
+    - **Can Run In Parallel**: YES (with 1.1)
+    - **Blocked By**: None (Wave 1 tasks can run in parallel)
     - **Blocks**: None
 
     **References**:
@@ -348,21 +356,22 @@ Parallel Speedup: ~40% faster than sequential
 
 ---
 
-- [ ] 2. Independent Task [0/1]
+- [ ] 2. Wave 2: Core Features [0/1]
 
-  **What to do**: [Standalone work]
+  **What to do**: [Core feature implementation after foundation]
 
   **Recommended Agent Profile**:
   - **Category**: \`quick\`
   - **Skills**: [\`git-master\`]
 
   **Parallelization**:
-  - **Can Run In Parallel**: YES (with Task 1)
-  - **Parallel Group**: Wave 1
+  - **Can Run In Parallel**: NO (depends on Wave 1)
+  - **Parallel Group**: Wave 2
+  - **Blocked By**: Wave 1 completion
 
   ---
 
-  - [ ] 2.1. Subtask
+  - [ ] 2.1. Authentication Module
 
     **What to do**: [Implementation details]
 

--- a/src/agents/prometheus/plan-template-v2.ts
+++ b/src/agents/prometheus/plan-template-v2.ts
@@ -1,0 +1,396 @@
+/**
+ * Prometheus Plan Template V2
+ *
+ * Enhanced markdown template structure for hierarchical work plans.
+ * Supports nested task structures with parent/child relationships.
+ * Format identifier: <!-- Plan-Format: 2 -->
+ */
+
+export const PROMETHEUS_PLAN_TEMPLATE_V2 = `<!-- Plan-Format: 2 -->
+
+# {Plan Title}
+
+## TL;DR
+
+> **Quick Summary**: [1-2 sentences capturing the core objective and approach]
+> 
+> **Deliverables**: [Bullet list of concrete outputs]
+> - [Output 1]
+> - [Output 2]
+> 
+> **Estimated Effort**: [Quick | Short | Medium | Large | XL]
+> **Parallel Execution**: [YES - N waves | NO - sequential]
+> **Critical Path**: [Task X → Task Y → Task Z]
+
+---
+
+## Context
+
+### Original Request
+[User's initial description]
+
+### Interview Summary
+**Key Discussions**:
+- [Point 1]: [User's decision/preference]
+- [Point 2]: [Agreed approach]
+
+**Research Findings**:
+- [Finding 1]: [Implication]
+- [Finding 2]: [Recommendation]
+
+### Metis Review
+**Identified Gaps** (addressed):
+- [Gap 1]: [How resolved]
+- [Gap 2]: [How resolved]
+
+---
+
+## Work Objectives
+
+### Core Objective
+[1-2 sentences: what we're achieving]
+
+### Concrete Deliverables
+- [Exact file/endpoint/feature]
+
+### Definition of Done
+- [ ] [Verifiable condition with command]
+
+### Must Have
+- [Non-negotiable requirement]
+
+### Must NOT Have (Guardrails)
+- [Explicit exclusion from Metis review]
+- [AI slop pattern to avoid]
+- [Scope boundary]
+
+---
+
+## Task Hierarchy
+
+\`\`\`
+Work Plan Structure:
+├── 1. Parent Task [0/2]
+│   ├── 1.1. Child Task A
+│   │   └── Subtask details
+│   └── 1.2. Child Task B
+│       └── Subtask details
+└── 2. Independent Task [0/1]
+    └── 2.1. Subtask
+\`\`\`
+
+### Hierarchy Rules
+- **Parent tasks**: Represent major work packages with sub-tasks
+- **Child tasks**: Atomic, executable units (implementation + tests)
+- **Progress tracking**: Parent shows [N/Total] where N = completed children
+- **Dependencies**: Parent tasks block child execution; children don't cross-block
+
+---
+
+## Verification Strategy (MANDATORY)
+
+> **UNIVERSAL RULE: ZERO HUMAN INTERVENTION**
+>
+> ALL tasks in this plan MUST be verifiable WITHOUT any human action.
+> This is NOT conditional — it applies to EVERY task, regardless of test strategy.
+>
+> **FORBIDDEN** — acceptance criteria that require:
+> - "User manually tests..." / "사용자가 직접 테스트..."
+> - "User visually confirms..." / "사용자가 눈으로 확인..."
+> - "User interacts with..." / "사용자가 직접 조작..."
+> - "Ask user to verify..." / "사용자에게 확인 요청..."
+> - ANY step where a human must perform an action
+>
+> **ALL verification is executed by the agent** using tools (Playwright, interactive_bash, curl, etc.). No exceptions.
+
+### Test Decision
+- **Infrastructure exists**: [YES/NO]
+- **Automated tests**: [TDD / Tests-after / None]
+- **Framework**: [bun test / vitest / jest / pytest / none]
+
+### If TDD Enabled
+
+Each TODO follows RED-GREEN-REFACTOR:
+
+**Task Structure:**
+1. **RED**: Write failing test first
+   - Test file: \`[path].test.ts\`
+   - Test command: \`bun test [file]\`
+   - Expected: FAIL (test exists, implementation doesn't)
+2. **GREEN**: Implement minimum code to pass
+   - Command: \`bun test [file]\`
+   - Expected: PASS
+3. **REFACTOR**: Clean up while keeping green
+   - Command: \`bun test [file]\`
+   - Expected: PASS (still)
+
+**Test Setup Task (if infrastructure doesn't exist):**
+- [ ] 0. Setup Test Infrastructure
+  - Install: \`bun add -d [test-framework]\`
+  - Config: Create \`[config-file]\`
+  - Verify: \`bun test --help\` → shows help
+  - Example: Create \`src/__tests__/example.test.ts\`
+  - Verify: \`bun test\` → 1 test passes
+
+### Agent-Executed QA Scenarios (MANDATORY — ALL tasks)
+
+> Whether TDD is enabled or not, EVERY task MUST include Agent-Executed QA Scenarios.
+> - **With TDD**: QA scenarios complement unit tests at integration/E2E level
+> - **Without TDD**: QA scenarios are the PRIMARY verification method
+>
+> These describe how the executing agent DIRECTLY verifies the deliverable
+> by running it — opening browsers, executing commands, sending API requests.
+> The agent performs what a human tester would do, but automated via tools.
+
+**Verification Tool by Deliverable Type:**
+
+| Type | Tool | How Agent Verifies |
+|------|------|-------------------|
+| **Frontend/UI** | Playwright (playwright skill) | Navigate, interact, assert DOM, screenshot |
+| **TUI/CLI** | interactive_bash (tmux) | Run command, send keystrokes, validate output |
+| **API/Backend** | Bash (curl/httpie) | Send requests, parse responses, assert fields |
+| **Library/Module** | Bash (bun/node REPL) | Import, call functions, compare output |
+| **Config/Infra** | Bash (shell commands) | Apply config, run state checks, validate |
+
+**Each Scenario MUST Follow This Format:**
+
+\`\`\`
+Scenario: [Descriptive name — what user action/flow is being verified]
+  Tool: [Playwright / interactive_bash / Bash]
+  Preconditions: [What must be true before this scenario runs]
+  Steps:
+    1. [Exact action with specific selector/command/endpoint]
+    2. [Next action with expected intermediate state]
+    3. [Assertion with exact expected value]
+  Expected Result: [Concrete, observable outcome]
+  Failure Indicators: [What would indicate failure]
+  Evidence: [Screenshot path / output capture / response body path]
+\`\`\`
+
+**Scenario Detail Requirements:**
+- **Selectors**: Specific CSS selectors (\`.login-button\`, not "the login button")
+- **Data**: Concrete test data (\`"test@example.com"\`, not \`"[email]"\`)
+- **Assertions**: Exact values (\`text contains "Welcome back"\`, not "verify it works")
+- **Timing**: Include wait conditions where relevant (\`Wait for .dashboard (timeout: 10s)\`)
+- **Negative Scenarios**: At least ONE failure/error scenario per feature
+- **Evidence Paths**: Specific file paths (\`.sisyphus/evidence/task-N-scenario-name.png\`)
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+> Maximize throughput by grouping independent tasks into parallel waves.
+> Each wave completes before the next begins.
+
+\`\`\`
+Wave 1 (Start Immediately):
+├── Task 1: [no dependencies]
+└── Task 5: [no dependencies]
+
+Wave 2 (After Wave 1):
+├── Task 2: [depends: 1]
+├── Task 3: [depends: 1]
+└── Task 6: [depends: 5]
+
+Wave 3 (After Wave 2):
+└── Task 4: [depends: 2, 3]
+
+Critical Path: Task 1 → Task 2 → Task 4
+Parallel Speedup: ~40% faster than sequential
+\`\`\`
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Can Parallelize With |
+|------|------------|--------|---------------------|
+| 1 | None | 2, 3 | 5 |
+| 2 | 1 | 4 | 3, 6 |
+| 3 | 1 | 4 | 2, 6 |
+| 4 | 2, 3 | None | None (final) |
+| 5 | None | 6 | 1 |
+| 6 | 5 | None | 2, 3 |
+
+### Agent Dispatch Summary
+
+| Wave | Tasks | Recommended Agents |
+|------|-------|-------------------|
+| 1 | 1, 5 | task(category="...", load_skills=[...], run_in_background=false) |
+| 2 | 2, 3, 6 | dispatch parallel after Wave 1 completes |
+| 3 | 4 | final integration task |
+
+---
+
+## TODOs
+
+> Implementation + Test = ONE Task. Never separate.
+> EVERY task MUST have: Recommended Agent Profile + Parallelization info.
+> Support hierarchical structures: parent tasks aggregate child completion.
+
+**CRITICAL: Hierarchical Numbering Rules**
+
+1. **If a task shows \`[0/N]\` with N > 0, it MUST have exactly N child tasks below it**
+2. **Child tasks MUST use hierarchical numbering**: \`1.1\`, \`1.2\`, \`2.1\`, \`2.2.1\`, etc.
+3. **Parent tasks with children ONLY contain metadata** — all implementation details go into child tasks
+4. **WRONG**: \`- [ ] 2. Task [0/1]\` followed by \`**What to do**: ...\` with no \`2.1\` child
+5. **CORRECT**: \`- [ ] 2. Task [0/1]\` followed by \`---\` and \`- [ ] 2.1. Subtask\` with implementation details
+
+**Examples follow these rules strictly:**
+
+- [ ] 1. Parent Task [0/2]
+
+  **What to do**: [High-level work package]
+  
+  **Recommended Agent Profile**:
+  > Select category + skills based on task domain. Justify each choice.
+  - **Category**: \`[visual-engineering | ultrabrain | artistry | quick | unspecified-low | unspecified-high | writing]\`
+    - Reason: [Why this category fits the task domain]
+  - **Skills**: [\`skill-1\`, \`skill-2\`]
+    - \`skill-1\`: [Why needed - domain overlap explanation]
+    - \`skill-2\`: [Why needed - domain overlap explanation]
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES | NO
+  - **Parallel Group**: Wave N (with Tasks X, Y) | Sequential
+  - **Blocks**: [Child tasks 1.1, 1.2]
+  - **Blocked By**: None (can start immediately)
+
+  ---
+
+  - [ ] 1.1. Child Task A
+
+    **What to do**:
+    - [Clear implementation steps]
+    - [Test cases to cover]
+
+    **Must NOT do**:
+    - [Specific exclusions from guardrails]
+
+    **Recommended Agent Profile**:
+    - **Category**: \`quick\`
+      - Reason: Atomic, well-scoped implementation
+    - **Skills**: [\`git-master\`]
+      - \`git-master\`: [Why needed]
+
+    **Parallelization**:
+    - **Can Run In Parallel**: NO
+    - **Blocked By**: Parent task 1 started
+    - **Blocks**: None
+
+    **References** (CRITICAL - Be Exhaustive):
+
+    > The executor has NO context from your interview. References are their ONLY guide.
+    > Each reference must answer: "What should I look at and WHY?"
+
+    **Pattern References** (existing code to follow):
+    - \`src/services/auth.ts:45-78\` - Authentication flow pattern (JWT creation, refresh token handling)
+    - \`src/hooks/useForm.ts:12-34\` - Form validation pattern (Zod schema + react-hook-form integration)
+
+    **Acceptance Criteria**:
+
+    > **AGENT-EXECUTABLE VERIFICATION ONLY** — No human action permitted.
+    > Every criterion MUST be verifiable by running a command or using a tool.
+
+    **If TDD (tests enabled):**
+    - [ ] Test file created: src/auth/login.test.ts
+    - [ ] Test covers: successful login returns JWT token
+    - [ ] bun test src/auth/login.test.ts → PASS (3 tests, 0 failures)
+
+    **Agent-Executed QA Scenarios (MANDATORY):**
+
+    \\\`\\\`\\\`
+    Scenario: Successful operation
+      Tool: Bash
+      Preconditions: [Setup state]
+      Steps:
+        1. [Run command or interact]
+        2. [Verify intermediate state]
+        3. [Assert final outcome]
+      Expected Result: [Observable outcome]
+      Evidence: [Evidence path]
+    \\\`\\\`\\\`
+
+    **Evidence to Capture:**
+    - [ ] Screenshots in .sisyphus/evidence/ for UI scenarios
+    - [ ] Terminal output for CLI/TUI scenarios
+    - [ ] Response bodies for API scenarios
+
+    **Commit**: YES | NO (groups with N)
+    - Message: \`type(scope): desc\`
+    - Files: \`path/to/file\`
+    - Pre-commit: \`test command\`
+
+  ---
+
+  - [ ] 1.2. Child Task B
+
+    **What to do**:
+    - [Clear implementation steps]
+    - [Test cases to cover]
+
+    **Recommended Agent Profile**:
+    - **Category**: \`quick\`
+    - **Skills**: [\`skill-name\`]
+
+    **Parallelization**:
+    - **Can Run In Parallel**: NO
+    - **Blocked By**: Child task 1.1
+    - **Blocks**: None
+
+    **References**:
+    - [Similar to 1.1]
+
+    **Acceptance Criteria**:
+    - [ ] [Criterion with verification command]
+
+    **Commit**: YES | NO
+
+---
+
+- [ ] 2. Independent Task [0/1]
+
+  **What to do**: [Standalone work]
+
+  **Recommended Agent Profile**:
+  - **Category**: \`quick\`
+  - **Skills**: [\`git-master\`]
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 1)
+  - **Parallel Group**: Wave 1
+
+  ---
+
+  - [ ] 2.1. Subtask
+
+    **What to do**: [Implementation details]
+
+    **Acceptance Criteria**:
+    - [ ] [Verifiable criterion]
+
+---
+
+## Commit Strategy
+
+| After Task | Message | Files | Verification |
+|------------|---------|-------|--------------|
+| 1 | \`type(scope): desc\` | file.ts | npm test |
+
+---
+
+## Success Criteria
+
+### Verification Commands
+\`\`\`bash
+command  # Expected: output
+\`\`\`
+
+### Final Checklist
+- [ ] All "Must Have" present
+- [ ] All "Must NOT Have" absent
+- [ ] All tests pass
+- [ ] Hierarchical structure valid (parents = sum of children)
+
+---
+`

--- a/src/agents/prometheus/system-prompt.ts
+++ b/src/agents/prometheus/system-prompt.ts
@@ -1,8 +1,38 @@
-import { loadPromptSync, prometheusPromptVariants } from "@oh-my-opencode/prompts-core"
+import { PROMETHEUS_IDENTITY_CONSTRAINTS } from "./identity-constraints"
+import { PROMETHEUS_INTERVIEW_MODE } from "./interview-mode"
+import { PROMETHEUS_PLAN_GENERATION } from "./plan-generation"
+import { PROMETHEUS_SPEC_DRIVEN_MODE } from "./spec-driven-mode"
+import { PROMETHEUS_HIGH_ACCURACY_MODE } from "./high-accuracy-mode"
+import { PROMETHEUS_PLAN_TEMPLATE } from "./plan-template"
+import { PROMETHEUS_PLAN_TEMPLATE_V2 } from "./plan-template-v2"
+import { PROMETHEUS_BEHAVIORAL_SUMMARY } from "./behavioral-summary"
+import { getGptPrometheusPrompt } from "./gpt"
+import { getGeminiPrometheusPrompt } from "./gemini"
 import { isGptModel, isGeminiModel } from "../types"
 
-export type PrometheusPromptSource = "default" | "gpt" | "gemini"
+/**
+ * Combined Prometheus system prompt (Claude-optimized, default).
+ * Assembled from modular sections for maintainability.
+ */
+export const PROMETHEUS_SYSTEM_PROMPT = `${PROMETHEUS_IDENTITY_CONSTRAINTS}
+${PROMETHEUS_INTERVIEW_MODE}
+${PROMETHEUS_PLAN_GENERATION}
+${PROMETHEUS_SPEC_DRIVEN_MODE}
+${PROMETHEUS_HIGH_ACCURACY_MODE}
+${PROMETHEUS_PLAN_TEMPLATE}
 
+# Hierarchical Plan Template (V2)
+
+When generating hierarchical plans, use the following template structure:
+
+${PROMETHEUS_PLAN_TEMPLATE_V2}
+${PROMETHEUS_BEHAVIORAL_SUMMARY}`
+
+/**
+ * Prometheus planner permission configuration.
+ * Allows write/edit for plan files (.md only, enforced by prometheus-md-only hook).
+ * Question permission allows agent to ask user questions via OpenCode's QuestionTool.
+ */
 export const PROMETHEUS_PERMISSION = {
   edit: "allow" as const,
   bash: "allow" as const,
@@ -10,26 +40,55 @@ export const PROMETHEUS_PERMISSION = {
   question: "allow" as const,
 }
 
-const QUESTION_TOOL_BLOCK_RE = /```typescript\n\s*Question\(\{[\s\S]*?\}\)\s*\n```/g
+export type PrometheusPromptSource = "default" | "gpt" | "gemini"
 
-function loadPrometheusVariant(variant: PrometheusPromptSource): string {
-  return loadPromptSync({
-    source: prometheusPromptVariants[variant],
-    name: "prometheus",
-    variant,
-  }).body
-}
-
-export const PROMETHEUS_SYSTEM_PROMPT = loadPrometheusVariant("default")
-
+/**
+ * Determines which Prometheus prompt to use based on model.
+ */
 export function getPrometheusPromptSource(model?: string): PrometheusPromptSource {
-  if (model && isGptModel(model)) return "gpt"
-  if (model && isGeminiModel(model)) return "gemini"
+  if (model && isGptModel(model)) {
+    return "gpt"
+  }
+  if (model && isGeminiModel(model)) {
+    return "gemini"
+  }
   return "default"
 }
 
+/**
+ * Gets the appropriate Prometheus prompt based on model.
+ * GPT models → GPT-5.4 optimized prompt (XML-tagged, principle-driven)
+ * Gemini models → Gemini-optimized prompt (aggressive tool-call enforcement, thinking checkpoints)
+ * Default (Claude, etc.) → Claude-optimized prompt (modular sections)
+ */
 export function getPrometheusPrompt(model?: string, disabledTools?: readonly string[]): string {
-  const variant = getPrometheusPromptSource(model)
-  const body = loadPrometheusVariant(variant)
-  return disabledTools?.includes("question") ? body.replace(QUESTION_TOOL_BLOCK_RE, "") : body
+  const source = getPrometheusPromptSource(model)
+  const isQuestionDisabled = disabledTools?.includes("question") ?? false
+
+  let prompt: string
+  switch (source) {
+    case "gpt":
+      prompt = getGptPrometheusPrompt()
+      break
+    case "gemini":
+      prompt = getGeminiPrometheusPrompt()
+      break
+    case "default":
+    default:
+      prompt = PROMETHEUS_SYSTEM_PROMPT
+  }
+
+  if (isQuestionDisabled) {
+    prompt = stripQuestionToolReferences(prompt)
+  }
+
+  return prompt
+}
+
+/**
+ * Removes Question tool usage examples from prompt text when question tool is disabled.
+ */
+function stripQuestionToolReferences(prompt: string): string {
+  // Remove Question({...}) code blocks (multi-line)
+  return prompt.replace(/```typescript\n\s*Question\(\{[\s\S]*?\}\)\s*\n```/g, "")
 }

--- a/src/agents/prometheus/system-prompt.ts
+++ b/src/agents/prometheus/system-prompt.ts
@@ -3,6 +3,7 @@ import { PROMETHEUS_INTERVIEW_MODE } from "./interview-mode"
 import { PROMETHEUS_PLAN_GENERATION } from "./plan-generation"
 import { PROMETHEUS_HIGH_ACCURACY_MODE } from "./high-accuracy-mode"
 import { PROMETHEUS_PLAN_TEMPLATE } from "./plan-template"
+import { PROMETHEUS_PLAN_TEMPLATE_V2 } from "./plan-template-v2"
 import { PROMETHEUS_BEHAVIORAL_SUMMARY } from "./behavioral-summary"
 import { getGptPrometheusPrompt } from "./gpt"
 import { getGeminiPrometheusPrompt } from "./gemini"
@@ -17,6 +18,12 @@ ${PROMETHEUS_INTERVIEW_MODE}
 ${PROMETHEUS_PLAN_GENERATION}
 ${PROMETHEUS_HIGH_ACCURACY_MODE}
 ${PROMETHEUS_PLAN_TEMPLATE}
+
+# Hierarchical Plan Template (V2)
+
+When generating hierarchical plans, use the following template structure:
+
+${PROMETHEUS_PLAN_TEMPLATE_V2}
 ${PROMETHEUS_BEHAVIORAL_SUMMARY}`
 
 /**

--- a/src/features/claude-tasks/index.ts
+++ b/src/features/claude-tasks/index.ts
@@ -1,0 +1,5 @@
+export * from "./types"
+export * from "./storage"
+export * from "./session-storage"
+export * from "./tree-numbering"
+export * from "./tree-utils"

--- a/src/features/claude-tasks/storage.ts
+++ b/src/features/claude-tasks/storage.ts
@@ -4,6 +4,11 @@ import { randomUUID } from "crypto"
 import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { z } from "zod"
 import type { OhMyOpenCodeConfig } from "../../config/schema"
+import type { Task } from "../../tools/task/types"
+import { TaskObjectSchema } from "../../tools/task/types"
+
+/** Maximum depth for hierarchical task trees */
+export const TASK_MAX_DEPTH = 6
 
 export function getTaskDir(config: Partial<OhMyOpenCodeConfig> = {}): string {
   const tasksConfig = config.sisyphus?.tasks
@@ -166,4 +171,28 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
       }
     },
   }
+}
+
+export function loadAllTasks(taskDir: string): Task[] {
+  if (!existsSync(taskDir)) return []
+
+  const files = readdirSync(taskDir).filter(
+    (f) => f.endsWith(".json") && f.startsWith("T-")
+  )
+
+  const tasks: Task[] = []
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(taskDir, file), "utf-8")
+      const parsed = JSON.parse(content)
+      const validated = TaskObjectSchema.safeParse(parsed)
+      if (validated.success) {
+        tasks.push(validated.data)
+      }
+    } catch {
+      // Skip malformed files
+    }
+  }
+
+  return tasks
 }

--- a/src/features/claude-tasks/tree-numbering.test.ts
+++ b/src/features/claude-tasks/tree-numbering.test.ts
@@ -414,4 +414,87 @@ describe("buildNumberedTree", () => {
     const bChildren = result.childrenByParent.get("T-b-child") || []
     expect(bChildren.map((t) => t.id)).toEqual(["T-b-grandchild"])
   })
+
+  it("should number deleted root tasks correctly", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-deleted-root",
+        subject: "Deleted Root",
+        description: "",
+        status: "deleted",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-active-root",
+        subject: "Active Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+    
+    // Should be numbered based on sorted ID order:
+    // T-active-root (1)
+    // T-deleted-root (2)
+    
+    expect(result.taskNumbers.has("T-deleted-root")).toBe(true)
+    const numbering = result.taskNumbers.get("T-deleted-root")
+    expect(numbering).toBeDefined()
+    expect(numbering?.numberingPath).toEqual([2])
+  })
+
+  it("should assign unique indices to multiple deleted siblings", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-1-deleted",
+        subject: "Deleted Child 1",
+        description: "",
+        status: "deleted",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-2-deleted",
+        subject: "Deleted Child 2",
+        description: "",
+        status: "deleted",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+    
+    const child1Num = result.taskNumbers.get("T-child-1-deleted")
+    const child2Num = result.taskNumbers.get("T-child-2-deleted")
+
+    expect(child1Num).toBeDefined()
+    expect(child2Num).toBeDefined()
+
+    // Sorted by ID: T-child-1-deleted, T-child-2-deleted
+    expect(child1Num?.numberingPath).toEqual([1, 1])
+    expect(child2Num?.numberingPath).toEqual([1, 2])
+    
+    // Explicit check against duplicate indices
+    expect(child1Num?.numberingPath).not.toEqual(child2Num?.numberingPath)
+  })
 })

--- a/src/features/claude-tasks/tree-numbering.test.ts
+++ b/src/features/claude-tasks/tree-numbering.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect } from "bun:test"
+import type { Task } from "../../tools/task/types"
+import { buildNumberedTree } from "./tree-numbering"
+
+describe("buildNumberedTree", () => {
+  //#given a set of tasks with parent-child relationships
+  //#when buildNumberedTree is called
+  //#then it builds a deterministic tree with lexical sibling ordering
+
+  it("should return empty result for empty task list", () => {
+    const result = buildNumberedTree([])
+    const rootChildren = result.childrenByParent.get(undefined) ?? []
+    expect(rootChildren).toEqual([])
+    expect(result.taskNumbers.size).toBe(0)
+    expect(result.orphans).toEqual([])
+  })
+
+  it("should build single root task with no children", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-001",
+        subject: "Root task",
+        description: "A root",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+    expect(result.taskNumbers.get("T-001")).toEqual({
+      depth: 0,
+      numberingPath: [1],
+    })
+    const rootChildren = result.childrenByParent.get(undefined) ?? []
+    expect(rootChildren).toHaveLength(1)
+  })
+
+  it("should order siblings lexically by task ID", () => {
+    //#given three root tasks with IDs that are intentionally out of alphabetical order
+    const tasks: Task[] = [
+      {
+        id: "T-zebra",
+        subject: "Z task",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-apple",
+        subject: "A task",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-banana",
+        subject: "B task",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    //#then siblings should be sorted lexically by ID regardless of input order
+    const rootChildren = result.childrenByParent.get(undefined) || []
+    expect(rootChildren.map((t) => t.id)).toEqual(["T-apple", "T-banana", "T-zebra"])
+
+    //#and numbering should reflect lexical order
+    expect(result.taskNumbers.get("T-apple")?.numberingPath).toEqual([1])
+    expect(result.taskNumbers.get("T-banana")?.numberingPath).toEqual([2])
+    expect(result.taskNumbers.get("T-zebra")?.numberingPath).toEqual([3])
+  })
+
+  it("should produce deterministic output regardless of input order", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-003",
+        subject: "Task 3",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-001",
+        subject: "Task 1",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-002",
+        subject: "Task 2",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    //#given the same tasks in different orders
+    const result1 = buildNumberedTree(tasks)
+    const shuffled = [tasks[2], tasks[0], tasks[3], tasks[1]]
+    const result2 = buildNumberedTree(shuffled)
+
+    //#then numbering should be identical
+    expect(result1.taskNumbers.get("T-001")).toEqual(result2.taskNumbers.get("T-001"))
+    expect(result1.taskNumbers.get("T-002")).toEqual(result2.taskNumbers.get("T-002"))
+    expect(result1.taskNumbers.get("T-003")).toEqual(result2.taskNumbers.get("T-003"))
+  })
+
+  it("should assign correct depth to nested tasks", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child",
+        subject: "Child",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-grandchild",
+        subject: "Grandchild",
+        description: "",
+        status: "pending",
+        parentID: "T-child",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    expect(result.taskNumbers.get("T-root")?.depth).toBe(0)
+    expect(result.taskNumbers.get("T-child")?.depth).toBe(1)
+    expect(result.taskNumbers.get("T-grandchild")?.depth).toBe(2)
+  })
+
+  it("should assign correct numbering path for nested tasks", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-a",
+        subject: "Child A",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-b",
+        subject: "Child B",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-grandchild",
+        subject: "Grandchild of A",
+        description: "",
+        status: "pending",
+        parentID: "T-child-a",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    expect(result.taskNumbers.get("T-root")?.numberingPath).toEqual([1])
+    expect(result.taskNumbers.get("T-child-a")?.numberingPath).toEqual([1, 1])
+    expect(result.taskNumbers.get("T-child-b")?.numberingPath).toEqual([1, 2])
+    expect(result.taskNumbers.get("T-grandchild")?.numberingPath).toEqual([1, 1, 1])
+  })
+
+  it("should detect orphaned tasks (missing parent)", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-orphan",
+        subject: "Orphan",
+        description: "",
+        status: "pending",
+        parentID: "T-nonexistent",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    expect(result.orphans).toHaveLength(1)
+    expect(result.orphans[0].id).toBe("T-orphan")
+  })
+
+  it("should handle multiple orphans", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-orphan1",
+        subject: "Orphan 1",
+        description: "",
+        status: "pending",
+        parentID: "T-missing-1",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-orphan2",
+        subject: "Orphan 2",
+        description: "",
+        status: "pending",
+        parentID: "T-missing-2",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    expect(result.orphans).toHaveLength(2)
+  })
+
+  it("should exclude deleted tasks from tree numbering", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-deleted",
+        subject: "Deleted child",
+        description: "",
+        status: "deleted",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-child-active",
+        subject: "Active child",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    //#then deleted task should not appear in childrenByParent
+    const rootChildren = result.childrenByParent.get("T-root") || []
+    expect(rootChildren.map((t) => t.id)).toEqual(["T-child-active"])
+
+    //#but deleted task should still have numbering data (for reference)
+    expect(result.taskNumbers.has("T-child-deleted")).toBe(true)
+  })
+
+  it("should enforce max depth of 6 and report violations", () => {
+    let tasks: Task[] = [
+      {
+        id: "T-level-0",
+        subject: "Level 0",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    //#given a chain of 7 nested tasks (depth 0-6)
+    for (let i = 1; i <= 7; i++) {
+      tasks.push({
+        id: `T-level-${i}`,
+        subject: `Level ${i}`,
+        description: "",
+        status: "pending",
+        parentID: `T-level-${i - 1}`,
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      })
+    }
+
+    const result = buildNumberedTree(tasks)
+
+    //#then depth 7 (index 7) should be recorded as exceeded
+    expect(result.depthExceeded.length).toBeGreaterThan(0)
+    expect(result.depthExceeded).toContain("T-level-7")
+  })
+
+  it("should include multi-level siblings in childrenByParent", () => {
+    const tasks: Task[] = [
+      {
+        id: "T-root",
+        subject: "Root",
+        description: "",
+        status: "pending",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-b-child",
+        subject: "B Child",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-a-child",
+        subject: "A Child",
+        description: "",
+        status: "pending",
+        parentID: "T-root",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-b-grandchild",
+        subject: "B Grandchild",
+        description: "",
+        status: "pending",
+        parentID: "T-b-child",
+        blocks: [],
+        blockedBy: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    const result = buildNumberedTree(tasks)
+
+    //#then root's children should be sorted lexically
+    const rootChildren = result.childrenByParent.get("T-root") || []
+    expect(rootChildren.map((t) => t.id)).toEqual(["T-a-child", "T-b-child"])
+
+    //#and B-child's children should be present
+    const bChildren = result.childrenByParent.get("T-b-child") || []
+    expect(bChildren.map((t) => t.id)).toEqual(["T-b-grandchild"])
+  })
+})

--- a/src/features/claude-tasks/tree-numbering.ts
+++ b/src/features/claude-tasks/tree-numbering.ts
@@ -1,0 +1,113 @@
+import type { Task } from "../../tools/task/types"
+import { TASK_MAX_DEPTH } from "./storage"
+import { createTaskIndex, getAncestors, calculateDepth } from "./tree-utils"
+
+export interface NumberingInfo {
+  depth: number
+  numberingPath: number[]
+}
+
+export interface NumberedTreeResult {
+  childrenByParent: Map<string | undefined, Task[]>
+  taskNumbers: Map<string, NumberingInfo>
+  orphans: Task[]
+  depthExceeded: string[]
+}
+
+export function buildNumberedTree(tasks: Task[]): NumberedTreeResult {
+  const byId = createTaskIndex(tasks)
+  const childrenByParent = new Map<string | undefined, Task[]>()
+  const taskNumbers = new Map<string, NumberingInfo>()
+  const orphans: Task[] = []
+  const depthExceeded: string[] = []
+
+  for (const task of tasks) {
+    if (!task.parentID) {
+      const rootChildren = childrenByParent.get(undefined) ?? []
+      rootChildren.push(task)
+      childrenByParent.set(undefined, rootChildren)
+    } else if (!byId.has(task.parentID)) {
+      orphans.push(task)
+    }
+  }
+
+  const activeRoots = (childrenByParent.get(undefined) ?? []).filter(
+    (t) => t.status !== "deleted"
+  )
+  activeRoots.sort((a, b) => a.id.localeCompare(b.id))
+  childrenByParent.set(undefined, activeRoots)
+
+  for (let i = 0; i < activeRoots.length; i++) {
+    taskNumbers.set(activeRoots[i].id, {
+      depth: 0,
+      numberingPath: [i + 1],
+    })
+  }
+
+  const processChildren = (parentId: string, parentPath: number[], parentDepth: number) => {
+    const children = tasks.filter(
+      (t) => t.parentID === parentId && t.status !== "deleted" && byId.has(t.id)
+    )
+
+    children.sort((a, b) => a.id.localeCompare(b.id))
+    childrenByParent.set(parentId, children)
+
+    const newDepth = parentDepth + 1
+    if (newDepth > TASK_MAX_DEPTH) {
+      for (const child of children) {
+        depthExceeded.push(child.id)
+      }
+      return
+    }
+
+    for (let i = 0; i < children.length; i++) {
+      const childPath = [...parentPath, i + 1]
+      taskNumbers.set(children[i].id, {
+        depth: newDepth,
+        numberingPath: childPath,
+      })
+    }
+
+    for (const child of children) {
+      const childPath = taskNumbers.get(child.id)!.numberingPath
+      processChildren(child.id, childPath, newDepth)
+    }
+  }
+
+  for (const root of activeRoots) {
+    processChildren(root.id, [activeRoots.indexOf(root) + 1], 0)
+  }
+
+  for (const task of tasks) {
+    if (!taskNumbers.has(task.id) && task.status === "deleted") {
+      const depth = calculateDepth(task.id, tasks)
+      const ancestors = getAncestors(task.id, tasks).reverse()
+
+      if (ancestors.length === 0) {
+        const index = activeRoots.findIndex((r) => r.id === task.id)
+        if (index >= 0) {
+          taskNumbers.set(task.id, {
+            depth: 0,
+            numberingPath: [index + 1],
+          })
+        }
+      } else {
+        const parentPath = taskNumbers.get(ancestors[ancestors.length - 1].id)
+        if (parentPath) {
+          const siblingIndex = tasks.filter((t) => t.parentID === task.parentID).length - 1
+          taskNumbers.set(task.id, {
+            depth: depth,
+            numberingPath: [...parentPath.numberingPath, siblingIndex + 1],
+          })
+        }
+      }
+    }
+  }
+
+  return {
+    childrenByParent,
+    taskNumbers,
+    orphans,
+    depthExceeded,
+  }
+}

--- a/src/features/claude-tasks/tree-numbering.ts
+++ b/src/features/claude-tasks/tree-numbering.ts
@@ -84,7 +84,9 @@ export function buildNumberedTree(tasks: Task[]): NumberedTreeResult {
       const ancestors = getAncestors(task.id, tasks).reverse()
 
       if (ancestors.length === 0) {
-        const index = activeRoots.findIndex((r) => r.id === task.id)
+        const allRoots = tasks.filter((t) => !t.parentID)
+        allRoots.sort((a, b) => a.id.localeCompare(b.id))
+        const index = allRoots.findIndex((r) => r.id === task.id)
         if (index >= 0) {
           taskNumbers.set(task.id, {
             depth: 0,
@@ -94,7 +96,10 @@ export function buildNumberedTree(tasks: Task[]): NumberedTreeResult {
       } else {
         const parentPath = taskNumbers.get(ancestors[ancestors.length - 1].id)
         if (parentPath) {
-          const siblingIndex = tasks.filter((t) => t.parentID === task.parentID).length - 1
+          const allSiblings = tasks.filter((t) => t.parentID === task.parentID)
+          allSiblings.sort((a, b) => a.id.localeCompare(b.id))
+          const siblingIndex = allSiblings.findIndex((s) => s.id === task.id)
+          
           taskNumbers.set(task.id, {
             depth: depth,
             numberingPath: [...parentPath.numberingPath, siblingIndex + 1],

--- a/src/features/claude-tasks/tree-utils.test.ts
+++ b/src/features/claude-tasks/tree-utils.test.ts
@@ -1,0 +1,740 @@
+import { describe, test, expect } from "bun:test"
+import type { Task } from "../../tools/task/types"
+import {
+  buildTaskTree,
+  getDescendants,
+  getAncestors,
+  detectCycles,
+  detectOrphans,
+  calculateDepth,
+  calculateProgress,
+} from "./tree-utils"
+
+//#region Test Helpers
+const createTask = (
+  id: string,
+  parentID?: string,
+  status: Task["status"] = "pending"
+): Task => ({
+  id,
+  subject: `Task ${id}`,
+  description: `Description for ${id}`,
+  status,
+  blocks: [],
+  blockedBy: [],
+  threadID: "thread-1",
+  parentID,
+})
+//#endregion
+
+describe("buildTaskTree", () => {
+  test("builds tree from flat task array with valid parent-child relationships", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child1", "T-root"),
+      createTask("T-child2", "T-root"),
+      createTask("T-grandchild", "T-child1"),
+    ]
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots).toHaveLength(1)
+    expect(result.roots[0].id).toBe("T-root")
+    expect(result.byId.size).toBe(4)
+    expect(result.childrenByParent.get("T-root")).toHaveLength(2)
+    expect(result.childrenByParent.get("T-child1")).toHaveLength(1)
+  })
+
+  test("handles multiple root tasks", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root1"),
+      createTask("T-root2"),
+      createTask("T-child", "T-root1"),
+    ]
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots).toHaveLength(2)
+    expect(result.roots.map((t) => t.id).sort()).toEqual(["T-root1", "T-root2"])
+  })
+
+  test("handles empty task array", () => {
+    //#given
+    const tasks: Task[] = []
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots).toHaveLength(0)
+    expect(result.byId.size).toBe(0)
+    expect(result.childrenByParent.size).toBe(0)
+  })
+
+  test("handles single task with no parent", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-single")]
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots).toHaveLength(1)
+    expect(result.roots[0].id).toBe("T-single")
+    expect(result.byId.size).toBe(1)
+  })
+
+  test("treats orphan tasks as roots", () => {
+    //#given - task with parentID pointing to non-existent parent
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-orphan", "T-nonexistent"),
+    ]
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then - orphan should be treated as root
+    expect(result.roots).toHaveLength(2)
+    expect(result.roots.map((t) => t.id).sort()).toEqual(["T-orphan", "T-root"])
+  })
+})
+
+describe("getDescendants", () => {
+  test("returns all descendants of a task", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child1", "T-root"),
+      createTask("T-child2", "T-root"),
+      createTask("T-grandchild1", "T-child1"),
+      createTask("T-grandchild2", "T-child1"),
+    ]
+
+    //#when
+    const result = getDescendants("T-root", tasks)
+
+    //#then
+    expect(result).toHaveLength(4)
+    expect(result.map((t) => t.id).sort()).toEqual([
+      "T-child1",
+      "T-child2",
+      "T-grandchild1",
+      "T-grandchild2",
+    ])
+  })
+
+  test("returns empty array for leaf task", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-leaf", "T-root"),
+    ]
+
+    //#when
+    const result = getDescendants("T-leaf", tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("returns empty array for non-existent task", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-root")]
+
+    //#when
+    const result = getDescendants("T-nonexistent", tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("returns empty array for empty task list", () => {
+    //#given
+    const tasks: Task[] = []
+
+    //#when
+    const result = getDescendants("T-any", tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe("getAncestors", () => {
+  test("returns all ancestors in order from immediate parent to root", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child", "T-root"),
+      createTask("T-grandchild", "T-child"),
+      createTask("T-greatgrandchild", "T-grandchild"),
+    ]
+
+    //#when
+    const result = getAncestors("T-greatgrandchild", tasks)
+
+    //#then
+    expect(result).toHaveLength(3)
+    expect(result.map((t) => t.id)).toEqual(["T-grandchild", "T-child", "T-root"])
+  })
+
+  test("returns empty array for root task", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child", "T-root"),
+    ]
+
+    //#when
+    const result = getAncestors("T-root", tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("returns empty array for non-existent task", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-root")]
+
+    //#when
+    const result = getAncestors("T-nonexistent", tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("stops at orphan (missing parent)", () => {
+    //#given - T-orphan has parentID but parent doesn't exist
+    const tasks: Task[] = [
+      createTask("T-orphan", "T-nonexistent"),
+      createTask("T-child", "T-orphan"),
+    ]
+
+    //#when
+    const result = getAncestors("T-child", tasks)
+
+    //#then - should only return T-orphan, not follow broken chain
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("T-orphan")
+  })
+})
+
+describe("detectCycles", () => {
+  test("detects simple cycle A->B->C->A", () => {
+    //#given
+    const tasks: Task[] = [
+      { ...createTask("T-A"), parentID: "T-C" },
+      { ...createTask("T-B"), parentID: "T-A" },
+      { ...createTask("T-C"), parentID: "T-B" },
+    ]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result.length).toBeGreaterThan(0)
+    const cycleIds = result[0]
+    expect(cycleIds).toContain("T-A")
+    expect(cycleIds).toContain("T-B")
+    expect(cycleIds).toContain("T-C")
+  })
+
+  test("returns empty array for valid tree (no cycles)", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child1", "T-root"),
+      createTask("T-child2", "T-root"),
+      createTask("T-grandchild", "T-child1"),
+    ]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("returns empty array for empty task list", () => {
+    //#given
+    const tasks: Task[] = []
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("detects self-referencing task", () => {
+    //#given - task pointing to itself
+    const tasks: Task[] = [{ ...createTask("T-self"), parentID: "T-self" }]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0]).toContain("T-self")
+  })
+
+  test("handles multiple separate cycles", () => {
+    //#given
+    const tasks: Task[] = [
+      { ...createTask("T-A1"), parentID: "T-B1" },
+      { ...createTask("T-B1"), parentID: "T-A1" },
+      { ...createTask("T-C1"), parentID: "T-D1" },
+      { ...createTask("T-D1"), parentID: "T-C1" },
+      createTask("T-normal"),
+    ]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe("detectOrphans", () => {
+  test("detects tasks with invalid parentID", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-valid-child", "T-root"),
+      createTask("T-orphan1", "T-nonexistent1"),
+      createTask("T-orphan2", "T-nonexistent2"),
+    ]
+
+    //#when
+    const result = detectOrphans(tasks)
+
+    //#then
+    expect(result).toHaveLength(2)
+    expect(result.map((t) => t.id).sort()).toEqual(["T-orphan1", "T-orphan2"])
+  })
+
+  test("returns empty array when all parents are valid", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child1", "T-root"),
+      createTask("T-child2", "T-root"),
+    ]
+
+    //#when
+    const result = detectOrphans(tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("returns empty array for empty task list", () => {
+    //#given
+    const tasks: Task[] = []
+
+    //#when
+    const result = detectOrphans(tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+
+  test("does not treat root tasks (no parentID) as orphans", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root1"),
+      createTask("T-root2"),
+    ]
+
+    //#when
+    const result = detectOrphans(tasks)
+
+    //#then
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe("calculateDepth", () => {
+  test("returns 0 for root task", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child", "T-root"),
+    ]
+
+    //#when
+    const result = calculateDepth("T-root", tasks)
+
+    //#then
+    expect(result).toBe(0)
+  })
+
+  test("returns 1 for immediate child of root", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child", "T-root"),
+    ]
+
+    //#when
+    const result = calculateDepth("T-child", tasks)
+
+    //#then
+    expect(result).toBe(1)
+  })
+
+  test("returns correct depth for deeply nested task", () => {
+    //#given - 7 levels deep
+    const tasks: Task[] = [
+      createTask("T-0"),
+      createTask("T-1", "T-0"),
+      createTask("T-2", "T-1"),
+      createTask("T-3", "T-2"),
+      createTask("T-4", "T-3"),
+      createTask("T-5", "T-4"),
+      createTask("T-6", "T-5"),
+    ]
+
+    //#when
+    const result = calculateDepth("T-6", tasks)
+
+    //#then
+    expect(result).toBe(6)
+  })
+
+  test("returns -1 for non-existent task", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-root")]
+
+    //#when
+    const result = calculateDepth("T-nonexistent", tasks)
+
+    //#then
+    expect(result).toBe(-1)
+  })
+
+  test("handles orphan task (counts from orphan, not missing parent)", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-orphan", "T-nonexistent"),
+      createTask("T-child", "T-orphan"),
+    ]
+
+    //#when
+    const result = calculateDepth("T-child", tasks)
+
+    //#then
+    expect(result).toBe(1)
+  })
+})
+
+describe("calculateProgress", () => {
+  test("returns 0/0 for leaf task with pending status", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-leaf", undefined, "pending")]
+
+    //#when
+    const result = calculateProgress("T-leaf", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 0, total: 1 })
+  })
+
+  test("returns 1/1 for leaf task with completed status", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-leaf", undefined, "completed")]
+
+    //#when
+    const result = calculateProgress("T-leaf", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 1, total: 1 })
+  })
+
+  test("calculates progress from children for parent task", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-parent", undefined, "pending"),
+      createTask("T-child1", "T-parent", "completed"),
+      createTask("T-child2", "T-parent", "completed"),
+      createTask("T-child3", "T-parent", "pending"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-parent", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 2, total: 3 })
+  })
+
+  test("calculates progress recursively from all descendants", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root", undefined, "pending"),
+      createTask("T-child1", "T-root", "pending"),
+      createTask("T-child2", "T-root", "pending"),
+      createTask("T-grandchild1", "T-child1", "completed"),
+      createTask("T-grandchild2", "T-child1", "completed"),
+      createTask("T-grandchild3", "T-child2", "pending"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-root", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 2, total: 3 })
+  })
+
+  test("returns 0/0 for non-existent task", () => {
+    //#given
+    const tasks: Task[] = [createTask("T-root")]
+
+    //#when
+    const result = calculateProgress("T-nonexistent", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 0, total: 0 })
+  })
+
+  test("returns 0/0 for empty task list", () => {
+    //#given
+    const tasks: Task[] = []
+
+    //#when
+    const result = calculateProgress("T-any", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 0, total: 0 })
+  })
+
+  test("ignores deleted tasks in progress calculation", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-parent", undefined, "pending"),
+      createTask("T-child1", "T-parent", "completed"),
+      createTask("T-child2", "T-parent", "deleted"),
+      createTask("T-child3", "T-parent", "pending"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-parent", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 1, total: 2 })
+  })
+
+  test("handles in_progress status as incomplete", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-parent", undefined, "pending"),
+      createTask("T-child1", "T-parent", "completed"),
+      createTask("T-child2", "T-parent", "in_progress"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-parent", tasks)
+
+    //#then
+    expect(result).toEqual({ completed: 1, total: 2 })
+  })
+
+  test("treats parent as leaf when all children are deleted", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-parent", undefined, "pending"),
+      createTask("T-child1", "T-parent", "deleted"),
+      createTask("T-child2", "T-parent", "deleted"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-parent", tasks)
+
+    //#then - parent becomes leaf, counts as 1 pending task
+    expect(result).toEqual({ completed: 0, total: 1 })
+  })
+
+  test("calculates progress with mixed nested and leaf children", () => {
+    //#given - T-parent has T-child1 (leaf, completed), T-child2 (parent with grandchildren)
+    const tasks: Task[] = [
+      createTask("T-parent", undefined, "pending"),
+      createTask("T-child1", "T-parent", "completed"),
+      createTask("T-child2", "T-parent", "pending"),
+      createTask("T-grandchild1", "T-child2", "completed"),
+      createTask("T-grandchild2", "T-child2", "completed"),
+      createTask("T-grandchild3", "T-child2", "pending"),
+    ]
+
+    //#when
+    const result = calculateProgress("T-parent", tasks)
+
+    //#then - should count: T-child1 (1 completed), T-grandchild1,2,3 (2 completed, 1 pending) = 3/4
+    expect(result).toEqual({ completed: 3, total: 4 })
+  })
+})
+
+describe("buildTaskTree edge cases", () => {
+  test("handles tasks with same subject but different IDs", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-1"),
+      createTask("T-2"),
+    ]
+    // Give them the same subject
+    tasks[0].subject = "Same Subject"
+    tasks[1].subject = "Same Subject"
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then - both should be separate roots
+    expect(result.roots).toHaveLength(2)
+    expect(result.byId.size).toBe(2)
+  })
+
+  test("maintains insertion order for roots", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-first"),
+      createTask("T-second"),
+      createTask("T-third"),
+    ]
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots[0].id).toBe("T-first")
+    expect(result.roots[1].id).toBe("T-second")
+    expect(result.roots[2].id).toBe("T-third")
+  })
+
+  test("handles deeply nested structure (10 levels)", () => {
+    //#given - 10 levels deep
+    const tasks: Task[] = []
+    let parentID: string | undefined
+    for (let i = 0; i < 10; i++) {
+      tasks.push(createTask(`T-${i}`, parentID))
+      parentID = `T-${i}`
+    }
+
+    //#when
+    const result = buildTaskTree(tasks)
+
+    //#then
+    expect(result.roots).toHaveLength(1)
+    expect(result.roots[0].id).toBe("T-0")
+    expect(result.byId.size).toBe(10)
+  })
+})
+
+describe("getDescendants edge cases", () => {
+  test("returns descendants in depth-first order", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child1", "T-root"),
+      createTask("T-child2", "T-root"),
+      createTask("T-grandchild1", "T-child1"),
+    ]
+
+    //#when
+    const result = getDescendants("T-root", tasks)
+
+    //#then - order may vary due to stack-based traversal, but all descendants should be present
+    expect(result).toHaveLength(3)
+    const ids = result.map((t) => t.id)
+    expect(ids).toContain("T-child1")
+    expect(ids).toContain("T-child2")
+    expect(ids).toContain("T-grandchild1")
+  })
+
+  test("does not include the task itself in descendants", () => {
+    //#given
+    const tasks: Task[] = [
+      createTask("T-root"),
+      createTask("T-child", "T-root"),
+    ]
+
+    //#when
+    const result = getDescendants("T-root", tasks)
+
+    //#then
+    expect(result.map((t) => t.id)).not.toContain("T-root")
+  })
+})
+
+describe("detectCycles edge cases", () => {
+  test("handles long cycle chain (5 nodes)", () => {
+    //#given - A -> B -> C -> D -> E -> A
+    const tasks: Task[] = [
+      { ...createTask("T-A"), parentID: "T-E" },
+      { ...createTask("T-B"), parentID: "T-A" },
+      { ...createTask("T-C"), parentID: "T-B" },
+      { ...createTask("T-D"), parentID: "T-C" },
+      { ...createTask("T-E"), parentID: "T-D" },
+    ]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result.length).toBeGreaterThan(0)
+    const cycle = result[0]
+    expect(cycle.length).toBe(5)
+  })
+
+  test("detects cycle even with non-cyclic siblings", () => {
+    //#given - mix of cyclic and non-cyclic tasks
+    const tasks: Task[] = [
+      createTask("T-normal-root"),
+      createTask("T-normal-child", "T-normal-root"),
+      { ...createTask("T-cycle-A"), parentID: "T-cycle-B" },
+      { ...createTask("T-cycle-B"), parentID: "T-cycle-A" },
+    ]
+
+    //#when
+    const result = detectCycles(tasks)
+
+    //#then
+    expect(result.length).toBe(1)
+    const cycleIds = result[0]
+    expect(cycleIds).toContain("T-cycle-A")
+    expect(cycleIds).toContain("T-cycle-B")
+  })
+})
+
+describe("calculateDepth edge cases", () => {
+  test("returns 0 for task with undefined parentID", () => {
+    //#given
+    const tasks: Task[] = [
+      { ...createTask("T-root"), parentID: undefined },
+    ]
+
+    //#when
+    const result = calculateDepth("T-root", tasks)
+
+    //#then
+    expect(result).toBe(0)
+  })
+
+  test("returns 0 for task with empty string parentID (treated as no parent)", () => {
+    //#given
+    const task = createTask("T-root")
+    task.parentID = ""
+    const tasks: Task[] = [task]
+
+    //#when
+    const result = calculateDepth("T-root", tasks)
+
+    //#then - empty string is falsy, so treated as root
+    expect(result).toBe(0)
+  })
+})

--- a/src/features/claude-tasks/tree-utils.ts
+++ b/src/features/claude-tasks/tree-utils.ts
@@ -1,0 +1,162 @@
+import type { Task } from "../../tools/task/types"
+
+export interface TaskTree {
+  roots: Task[]
+  byId: Map<string, Task>
+  childrenByParent: Map<string, Task[]>
+}
+
+export interface Progress {
+  completed: number
+  total: number
+}
+
+export function createTaskIndex(tasks: Task[]): Map<string, Task> {
+  const byId = new Map<string, Task>()
+  for (const task of tasks) {
+    byId.set(task.id, task)
+  }
+  return byId
+}
+
+export function buildTaskTree(tasks: Task[]): TaskTree {
+  const byId = createTaskIndex(tasks)
+  const childrenByParent = new Map<string, Task[]>()
+  const roots: Task[] = []
+
+  for (const task of tasks) {
+    if (!task.parentID || !byId.has(task.parentID)) {
+      roots.push(task)
+    } else {
+      const children = childrenByParent.get(task.parentID) ?? []
+      children.push(task)
+      childrenByParent.set(task.parentID, children)
+    }
+  }
+
+  return { roots, byId, childrenByParent }
+}
+
+export function getDescendants(taskId: string, tasks: Task[]): Task[] {
+  const { byId, childrenByParent } = buildTaskTree(tasks)
+  if (!byId.has(taskId)) return []
+
+  const result: Task[] = []
+  const stack = childrenByParent.get(taskId) ?? []
+
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    result.push(current)
+    const children = childrenByParent.get(current.id) ?? []
+    stack.push(...children)
+  }
+
+  return result
+}
+
+export function getAncestors(taskId: string, tasks: Task[]): Task[] {
+  const byId = createTaskIndex(tasks)
+
+  const task = byId.get(taskId)
+  if (!task) return []
+
+  const result: Task[] = []
+  let currentParentId = task.parentID
+
+  while (currentParentId) {
+    const parent = byId.get(currentParentId)
+    if (!parent) break
+    result.push(parent)
+    currentParentId = parent.parentID
+  }
+
+  return result
+}
+
+export function detectCycles(tasks: Task[]): string[][] {
+  const byId = createTaskIndex(tasks)
+
+  const visited = new Set<string>()
+  const cycles: string[][] = []
+
+  for (const task of tasks) {
+    if (visited.has(task.id)) continue
+
+    const path: string[] = []
+    const pathSet = new Set<string>()
+    let current: Task | undefined = task
+
+    while (current && !visited.has(current.id)) {
+      if (pathSet.has(current.id)) {
+        const cycleStart = path.indexOf(current.id)
+        cycles.push(path.slice(cycleStart))
+        break
+      }
+
+      path.push(current.id)
+      pathSet.add(current.id)
+
+      if (!current.parentID) break
+      current = byId.get(current.parentID)
+    }
+
+    for (const id of path) {
+      visited.add(id)
+    }
+  }
+
+  return cycles
+}
+
+export function detectOrphans(tasks: Task[]): Task[] {
+  const byId = createTaskIndex(tasks)
+
+  return tasks.filter((task) => task.parentID && !byId.has(task.parentID))
+}
+
+export function calculateDepth(taskId: string, tasks: Task[]): number {
+  const byId = createTaskIndex(tasks)
+
+  const task = byId.get(taskId)
+  if (!task) return -1
+
+  let depth = 0
+  let currentParentId = task.parentID
+
+  while (currentParentId) {
+    const parent = byId.get(currentParentId)
+    if (!parent) break
+    depth++
+    currentParentId = parent.parentID
+  }
+
+  return depth
+}
+
+export function calculateProgress(taskId: string, tasks: Task[]): Progress {
+  const { byId, childrenByParent } = buildTaskTree(tasks)
+  const task = byId.get(taskId)
+  if (!task) return { completed: 0, total: 0 }
+
+  const getLeafProgress = (id: string): Progress => {
+    const children = childrenByParent.get(id) ?? []
+    const activeChildren = children.filter((c) => c.status !== "deleted")
+
+    if (activeChildren.length === 0) {
+      const t = byId.get(id)!
+      if (t.status === "deleted") return { completed: 0, total: 0 }
+      return { completed: t.status === "completed" ? 1 : 0, total: 1 }
+    }
+
+    let completed = 0
+    let total = 0
+    for (const child of activeChildren) {
+      const childProgress = getLeafProgress(child.id)
+      completed += childProgress.completed
+      total += childProgress.total
+    }
+    return { completed, total }
+  }
+
+  return getLeafProgress(taskId)
+}

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -39,6 +39,7 @@ import {
   createTaskCreateTool,
   createTaskGetTool,
   createTaskList,
+  createTaskTree,
   createTaskUpdateTool,
   createHashlineEditTool,
 } from "../tools"
@@ -293,6 +294,7 @@ export function createToolRegistry(args: {
         task_create: factories.createTaskCreateTool(pluginConfig, ctx),
         task_get: factories.createTaskGetTool(pluginConfig),
         task_list: factories.createTaskList(pluginConfig),
+        task_tree: factories.createTaskTree(pluginConfig),
         task_update: factories.createTaskUpdateTool(pluginConfig, ctx),
       }
     : {}

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -24,6 +24,7 @@ import {
   createTaskCreateTool,
   createTaskGetTool,
   createTaskList,
+  createTaskTree,
   createTaskUpdateTool,
   createHashlineEditTool,
 } from "../tools"
@@ -182,6 +183,7 @@ export function createToolRegistry(args: {
         task_create: createTaskCreateTool(pluginConfig, ctx),
         task_get: createTaskGetTool(pluginConfig),
         task_list: createTaskList(pluginConfig),
+        task_tree: createTaskTree(pluginConfig),
         task_update: createTaskUpdateTool(pluginConfig, ctx),
       }
     : {}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,6 +28,7 @@ export {
   createTaskCreateTool,
   createTaskGetTool,
   createTaskList,
+  createTaskTree,
   createTaskUpdateTool,
 } from "./task"
 export { createHashlineEditTool } from "./hashline-edit"

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -41,6 +41,7 @@ export {
   createTaskCreateTool,
   createTaskGetTool,
   createTaskList,
+  createTaskTree,
   createTaskUpdateTool,
 } from "./task"
 export { createHashlineEditTool } from "./hashline-edit"

--- a/src/tools/task/__snapshots__/task-tree.test.ts.snap
+++ b/src/tools/task/__snapshots__/task-tree.test.ts.snap
@@ -1,0 +1,13 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`createTaskTree snapshot test: complex hierarchy with mixed statuses 1`] = `
+"## Task Tree
+
+- [x] 1. Setup infrastructure (completed)
+- [ ] 2. Implement auth (in_progress)
+  - [x] 2.1. JWT implementation (completed)
+  - [ ] 2.2. OAuth2 integration (in_progress)
+    - [ ] 2.2.1. Google provider (pending)
+    - [x] 2.2.2. GitHub provider (completed)
+- [ ] 3. Write tests (pending)"
+`;

--- a/src/tools/task/index.ts
+++ b/src/tools/task/index.ts
@@ -1,6 +1,7 @@
 export { createTaskCreateTool } from "./task-create"
 export { createTaskGetTool } from "./task-get"
 export { createTaskList } from "./task-list"
+export { createTaskTree } from "./task-tree"
 export { createTaskUpdateTool } from "./task-update"
 export { syncTaskToTodo, syncAllTasksToTodos } from "./todo-sync"
 export type { TaskObject, TaskStatus, TaskCreateInput, TaskListInput, TaskGetInput, TaskUpdateInput, TaskDeleteInput } from "./types"

--- a/src/tools/task/task-tree.test.ts
+++ b/src/tools/task/task-tree.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { createTaskTree } from "./task-tree"
+import { writeJsonAtomic } from "../../features/claude-tasks/storage"
+import type { TaskObject } from "./types"
+import { join } from "path"
+import { existsSync, rmSync } from "fs"
+
+const testProjectDir = "/tmp/task-tree-test"
+const taskDir = join(testProjectDir, ".sisyphus/tasks")
+
+describe("createTaskTree", () => {
+  beforeEach(() => {
+    if (existsSync(taskDir)) {
+      rmSync(taskDir, { recursive: true })
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(taskDir)) {
+      rmSync(taskDir, { recursive: true })
+    }
+  })
+
+  it("returns empty message when no tasks exist", async () => {
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("No tasks found")
+  })
+
+  it("renders flat tasks with numbering", async () => {
+    const task1: TaskObject = {
+      id: "T-1",
+      subject: "First task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const task2: TaskObject = {
+      id: "T-2",
+      subject: "Second task",
+      description: "",
+      status: "completed",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+
+    writeJsonAtomic(join(taskDir, "T-1.json"), task1)
+    writeJsonAtomic(join(taskDir, "T-2.json"), task2)
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("1. First task")
+    expect(result).toContain("2. Second task")
+    expect(result).toContain("[ ] 1. First task (pending)")
+    expect(result).toContain("[x] 2. Second task (completed)")
+  })
+
+  it("renders nested hierarchy with dot numbering", async () => {
+    const parent: TaskObject = {
+      id: "T-parent",
+      subject: "Parent Task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const child1: TaskObject = {
+      id: "T-child1",
+      subject: "Child A",
+      description: "",
+      status: "completed",
+      blockedBy: [],
+      blocks: [],
+      parentID: "T-parent",
+      threadID: "thread-1",
+    }
+    const child2: TaskObject = {
+      id: "T-child2",
+      subject: "Child B",
+      description: "",
+      status: "in_progress",
+      blockedBy: [],
+      blocks: [],
+      parentID: "T-parent",
+      threadID: "thread-1",
+    }
+    const grandchild: TaskObject = {
+      id: "T-grandchild",
+      subject: "Grandchild",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      parentID: "T-child2",
+      threadID: "thread-1",
+    }
+
+    writeJsonAtomic(join(taskDir, "T-parent.json"), parent)
+    writeJsonAtomic(join(taskDir, "T-child1.json"), child1)
+    writeJsonAtomic(join(taskDir, "T-child2.json"), child2)
+    writeJsonAtomic(join(taskDir, "T-grandchild.json"), grandchild)
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("1. Parent Task (pending)")
+    expect(result).toContain("1.1. Child A (completed)")
+    expect(result).toContain("1.2. Child B (in_progress)")
+    expect(result).toContain("1.2.1. Grandchild (pending)")
+    expect(result).toMatch(/^  - \[x\] 1\.1\./m)
+  })
+
+  it("excludes deleted tasks", async () => {
+    const task1: TaskObject = {
+      id: "T-1",
+      subject: "Active task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const task2: TaskObject = {
+      id: "T-2",
+      subject: "Deleted task",
+      description: "",
+      status: "deleted",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+
+    writeJsonAtomic(join(taskDir, "T-1.json"), task1)
+    writeJsonAtomic(join(taskDir, "T-2.json"), task2)
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("1. Active task")
+    expect(result).not.toContain("Deleted task")
+  })
+
+  it("includes orphaned tasks in dedicated section", async () => {
+    const rootTask: TaskObject = {
+      id: "T-root",
+      subject: "Root Task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const orphan: TaskObject = {
+      id: "T-orphan",
+      subject: "Orphan Task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      parentID: "T-nonexistent",
+      threadID: "thread-1",
+    }
+
+    writeJsonAtomic(join(taskDir, "T-root.json"), rootTask)
+    writeJsonAtomic(join(taskDir, "T-orphan.json"), orphan)
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("## Orphaned Tasks")
+    expect(result).toContain("Orphan Task")
+    expect(result).toContain("parent 'T-nonexistent' not found")
+  })
+
+  it("uses correct checkbox for status", async () => {
+    const pending: TaskObject = {
+      id: "T-pending",
+      subject: "Pending Task",
+      description: "",
+      status: "pending",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const inProgress: TaskObject = {
+      id: "T-in-progress",
+      subject: "In Progress Task",
+      description: "",
+      status: "in_progress",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+    const completed: TaskObject = {
+      id: "T-completed",
+      subject: "Completed Task",
+      description: "",
+      status: "completed",
+      blockedBy: [],
+      blocks: [],
+      threadID: "thread-1",
+    }
+
+    writeJsonAtomic(join(taskDir, "T-pending.json"), pending)
+    writeJsonAtomic(join(taskDir, "T-in-progress.json"), inProgress)
+    writeJsonAtomic(join(taskDir, "T-completed.json"), completed)
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toContain("[x] 1. Completed Task (completed)")
+    expect(result).toContain("[ ] 2. In Progress Task (in_progress)")
+    expect(result).toContain("[ ] 3. Pending Task (pending)")
+  })
+
+  it("snapshot test: complex hierarchy with mixed statuses", async () => {
+    const tasks: TaskObject[] = [
+      {
+        id: "T-task1",
+        subject: "Setup infrastructure",
+        description: "",
+        status: "completed",
+        blockedBy: [],
+        blocks: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task2",
+        subject: "Implement auth",
+        description: "",
+        status: "in_progress",
+        blockedBy: [],
+        blocks: [],
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task2a",
+        subject: "JWT implementation",
+        description: "",
+        status: "completed",
+        blockedBy: [],
+        blocks: [],
+        parentID: "T-task2",
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task2b",
+        subject: "OAuth2 integration",
+        description: "",
+        status: "in_progress",
+        blockedBy: [],
+        blocks: [],
+        parentID: "T-task2",
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task2b1",
+        subject: "Google provider",
+        description: "",
+        status: "pending",
+        blockedBy: [],
+        blocks: [],
+        parentID: "T-task2b",
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task2b2",
+        subject: "GitHub provider",
+        description: "",
+        status: "completed",
+        blockedBy: [],
+        blocks: [],
+        parentID: "T-task2b",
+        threadID: "thread-1",
+      },
+      {
+        id: "T-task3",
+        subject: "Write tests",
+        description: "",
+        status: "pending",
+        blockedBy: [],
+        blocks: [],
+        threadID: "thread-1",
+      },
+    ]
+
+    for (const task of tasks) {
+      writeJsonAtomic(join(taskDir, `${task.id}.json`), task)
+    }
+
+    const config = {
+      sisyphus: {
+        tasks: {
+          storage_path: taskDir,
+          claude_code_compat: false,
+        },
+      },
+    }
+    const tool = createTaskTree(config)
+
+    const result = await tool.execute({}, { sessionID: "test-session", messageID: "", agent: "", abort: new AbortController().signal })
+
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/src/tools/task/task-tree.ts
+++ b/src/tools/task/task-tree.ts
@@ -1,0 +1,112 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { join } from "path"
+import { existsSync, readdirSync } from "fs"
+import type { OhMyOpenCodeConfig } from "../../config/schema"
+import type { TaskObject } from "./types"
+import { TaskObjectSchema } from "./types"
+import { readJsonSafe, getTaskDir } from "../../features/claude-tasks/storage"
+import { buildNumberedTree } from "../../features/claude-tasks/tree-numbering"
+
+function formatCheckbox(status: string): string {
+  if (status === "completed") {
+    return "[x]"
+  }
+  return "[ ]"
+}
+
+function renderTreeNode(
+  taskId: string,
+  tasks: Map<string, TaskObject>,
+  taskNumbers: Map<string, { depth: number; numberingPath: number[] }>,
+  childrenByParent: Map<string | undefined, TaskObject[]>
+): string {
+  const task = tasks.get(taskId)
+  if (!task) return ""
+
+  const numberInfo = taskNumbers.get(taskId)
+  if (!numberInfo) return ""
+
+  const indent = "  ".repeat(numberInfo.depth)
+  const numberStr = numberInfo.numberingPath.join(".")
+  const checkbox = formatCheckbox(task.status)
+  const line = `${indent}- ${checkbox} ${numberStr}. ${task.subject} (${task.status})`
+
+  const children = childrenByParent.get(taskId) ?? []
+  const childLines = children.map((child) => renderTreeNode(child.id, tasks, taskNumbers, childrenByParent))
+
+  return [line, ...childLines].filter((l) => l.length > 0).join("\n")
+}
+
+export function createTaskTree(config: Partial<OhMyOpenCodeConfig>): ToolDefinition {
+  return tool({
+    description: `Render a Markdown task tree with hierarchical numbering (1., 1.1., 1.1.1.).
+    
+Displays tasks in a nested tree structure with:
+- Checkbox: [x] for completed, [ ] for pending/in_progress
+- Status label: (pending), (in_progress), (completed)
+- 2-space indentation per depth level
+- Deleted tasks excluded
+- Orphaned tasks shown in separate section with parent reference`,
+    args: {},
+    execute: async (): Promise<string> => {
+      const taskDir = getTaskDir(config)
+
+      if (!existsSync(taskDir)) {
+        return "No tasks found."
+      }
+
+      const files = readdirSync(taskDir)
+        .filter((f) => f.endsWith(".json") && f.startsWith("T-"))
+        .map((f) => f.replace(".json", ""))
+
+      if (files.length === 0) {
+        return "No tasks found."
+      }
+
+      const allTasks: TaskObject[] = []
+      for (const fileId of files) {
+        const task = readJsonSafe(join(taskDir, `${fileId}.json`), TaskObjectSchema)
+        if (task) {
+          allTasks.push(task)
+        }
+      }
+
+      const { childrenByParent, taskNumbers, orphans } = buildNumberedTree(allTasks)
+
+      const tasksMap = new Map<string, TaskObject>()
+      for (const task of allTasks) {
+        tasksMap.set(task.id, task)
+      }
+
+      const rootTasks = childrenByParent.get(undefined) ?? []
+      const treeLines: string[] = []
+
+      if (rootTasks.length > 0) {
+        treeLines.push("## Task Tree")
+        treeLines.push("")
+        for (const rootTask of rootTasks) {
+          const rendered = renderTreeNode(rootTask.id, tasksMap, taskNumbers, childrenByParent)
+          if (rendered) {
+            treeLines.push(rendered)
+          }
+        }
+      }
+
+      if (orphans.length > 0) {
+        treeLines.push("")
+        treeLines.push("## Orphaned Tasks")
+        treeLines.push("")
+        for (const orphan of orphans) {
+          const checkbox = formatCheckbox(orphan.status)
+          treeLines.push(`- ${checkbox} ${orphan.subject} (parent '${orphan.parentID}' not found)`)
+        }
+      }
+
+      if (treeLines.length === 0) {
+        return "No tasks found."
+      }
+
+      return treeLines.join("\n")
+    },
+  })
+}

--- a/src/tools/task/todo-content-builder.ts
+++ b/src/tools/task/todo-content-builder.ts
@@ -1,0 +1,9 @@
+import type { NumberingInfo } from "../../features/claude-tasks/tree-numbering";
+
+const INDENT = "  ";
+
+export function buildTodoContent(subject: string, numbering: NumberingInfo): string {
+  const indent = INDENT.repeat(numbering.depth);
+  const numberingStr = numbering.numberingPath.join(".");
+  return `${indent}${numberingStr}. ${subject}`;
+}

--- a/src/tools/task/todo-sync.test.ts
+++ b/src/tools/task/todo-sync.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="bun-types/test-globals" />
-import type { Task } from "../../features/claude-tasks/types";
+import type { Task } from "./types";
+import type { NumberingInfo } from "../../features/claude-tasks/tree-numbering";
 import {
   syncTaskToTodo,
   syncAllTasksToTodos,
@@ -7,25 +8,107 @@ import {
   type TodoInfo,
 } from "./todo-sync";
 
-describe("syncTaskToTodo", () => {
+describe("syncTaskToTodo with tree numbering", () => {
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
+
+  it("numbers root task as '1. Root Task'", () => {
+    // given
+    const task = createTask({
+      id: "T-root",
+      subject: "Root Task",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
+
+    // then
+    expect(result?.content).toBe("1. Root Task");
+  });
+
+  it("numbers child task as '  1.1. Child Task' with 2-space indent", () => {
+    // given
+    const task = createTask({
+      id: "T-child",
+      subject: "Child Task",
+      parentID: "T-root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 1, numberingPath: [1, 1] });
+
+    // then
+    expect(result?.content).toBe("  1.1. Child Task");
+  });
+
+  it("numbers grandchild task as '    1.1.1. Grandchild' with 4-space indent", () => {
+    // given
+    const task = createTask({
+      id: "T-grandchild",
+      subject: "Grandchild",
+      parentID: "T-child",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 2, numberingPath: [1, 1, 1] });
+
+    // then
+    expect(result?.content).toBe("    1.1.1. Grandchild");
+  });
+
+  it("handles multiple siblings at root level", () => {
+    // given
+    const task = createTask({
+      id: "T-root-2",
+      subject: "Second Root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [2] });
+
+    // then
+    expect(result?.content).toBe("2. Second Root");
+  });
+
+  it("handles nested siblings (1.2, 1.3)", () => {
+    // given
+    const task = createTask({
+      id: "T-sibling",
+      subject: "Second Child",
+      parentID: "T-root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 1, numberingPath: [1, 2] });
+
+    // then
+    expect(result?.content).toBe("  1.2. Second Child");
+  });
+
   it("converts pending task to pending todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-123",
       subject: "Fix bug",
       description: "Fix critical bug",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result).toEqual({
       id: "T-123",
-      content: "Fix bug",
+      content: "1. Fix bug",
       status: "pending",
       priority: "medium",
     });
@@ -33,36 +116,32 @@ describe("syncTaskToTodo", () => {
 
   it("converts in_progress task to in_progress todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-456",
       subject: "Implement feature",
       description: "Add new feature",
       status: "in_progress",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.status).toBe("in_progress");
-    expect(result?.content).toBe("Implement feature");
+    expect(result?.content).toBe("1. Implement feature");
   });
 
   it("converts completed task to completed todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-789",
       subject: "Review PR",
       description: "Review pull request",
       status: "completed",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.status).toBe("completed");
@@ -70,17 +149,15 @@ describe("syncTaskToTodo", () => {
 
   it("returns null for deleted task", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-del",
       subject: "Deleted task",
       description: "This task is deleted",
       status: "deleted",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result).toBeNull();
@@ -88,18 +165,16 @@ describe("syncTaskToTodo", () => {
 
   it("extracts priority from metadata", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-high",
       subject: "Critical task",
       description: "High priority task",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "high" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("high");
@@ -107,18 +182,16 @@ describe("syncTaskToTodo", () => {
 
   it("handles medium priority", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-med",
       subject: "Medium task",
       description: "Medium priority",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "medium" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
@@ -126,18 +199,16 @@ describe("syncTaskToTodo", () => {
 
   it("handles low priority", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-low",
       subject: "Low task",
       description: "Low priority",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "low" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("low");
@@ -145,18 +216,16 @@ describe("syncTaskToTodo", () => {
 
   it("ignores invalid priority values", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-invalid",
       subject: "Invalid priority",
       description: "Invalid priority value",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "urgent" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
@@ -164,43 +233,49 @@ describe("syncTaskToTodo", () => {
 
   it("handles missing metadata", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-no-meta",
       subject: "No metadata",
       description: "Task without metadata",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
   });
 
-  it("uses subject as todo content", () => {
+  it("uses subject as todo content (with numbering)", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-content",
       subject: "This is the subject",
       description: "This is the description",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
-    expect(result?.content).toBe("This is the subject");
+    expect(result?.content).toBe("1. This is the subject");
   });
 });
 
 describe("syncTaskTodoUpdate", () => {
   let mockCtx: any;
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
 
   beforeEach(() => {
     mockCtx = {
@@ -214,14 +289,11 @@ describe("syncTaskTodoUpdate", () => {
 
   it("writes updated todo and preserves existing items", async () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-1",
       subject: "Updated task",
-      description: "",
       status: "in_progress",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
     const currentTodos: TodoInfo[] = [
       { id: "T-1", content: "Old task", status: "pending" },
       { id: "T-2", content: "Keep task", status: "pending" },
@@ -234,7 +306,7 @@ describe("syncTaskTodoUpdate", () => {
       expect(input.todos.length).toBe(2);
       expect(
         input.todos.find((todo: TodoInfo) => todo.id === "T-1")?.content,
-      ).toBe("Updated task");
+      ).toBe("1. Updated task");
       expect(input.todos.some((todo: TodoInfo) => todo.id === "T-2")).toBe(
         true,
       );
@@ -249,14 +321,11 @@ describe("syncTaskTodoUpdate", () => {
 
   it("removes deleted task from todos", async () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-1",
       subject: "Deleted task",
-      description: "",
       status: "deleted",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
     const currentTodos: TodoInfo[] = [
       { id: "T-1", content: "Old task", status: "pending" },
       { id: "T-2", content: "Keep task", status: "pending" },
@@ -284,6 +353,16 @@ describe("syncTaskTodoUpdate", () => {
 
 describe("syncAllTasksToTodos", () => {
   let mockCtx: any;
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
 
   beforeEach(() => {
     mockCtx = {
@@ -298,14 +377,12 @@ describe("syncAllTasksToTodos", () => {
   it("fetches current todos from OpenCode", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -349,14 +426,12 @@ describe("syncAllTasksToTodos", () => {
   it("gracefully handles fetch failure", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockRejectedValue(new Error("API error"));
 
@@ -370,24 +445,20 @@ describe("syncAllTasksToTodos", () => {
   it("converts multiple tasks to todos", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
         metadata: { priority: "high" },
-      },
-      {
+      }),
+      createTask({
         id: "T-2",
         subject: "Task 2",
         description: "Description 2",
         status: "in_progress",
-        blocks: [],
-        blockedBy: [],
         metadata: { priority: "low" },
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockResolvedValue([]);
 
@@ -401,14 +472,12 @@ describe("syncAllTasksToTodos", () => {
   it("removes deleted tasks from todo list", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "deleted",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -433,14 +502,12 @@ describe("syncAllTasksToTodos", () => {
   it("preserves existing todos not in task list", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -465,7 +532,7 @@ describe("syncAllTasksToTodos", () => {
 
     // then
     expect(writtenTodos.some((t: TodoInfo) => t.id === "T-existing")).toBe(true);
-    expect(writtenTodos.some((t: TodoInfo) => t.content === "Task 1")).toBe(true);
+    expect(writtenTodos.some((t: TodoInfo) => t.content === "1. Task 1")).toBe(true);
   });
 
   it("handles empty task list", async () => {
@@ -483,14 +550,12 @@ describe("syncAllTasksToTodos", () => {
   it("calls writer with final todos", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockResolvedValue([]);
     let writerCalled = false;
@@ -498,7 +563,7 @@ describe("syncAllTasksToTodos", () => {
       writerCalled = true;
       expect(input.sessionID).toBe("session-1");
       expect(input.todos.length).toBe(1);
-      expect(input.todos[0].content).toBe("Task 1");
+      expect(input.todos[0].content).toBe("1. Task 1");
     };
 
     // when
@@ -518,11 +583,12 @@ describe("syncAllTasksToTodos", () => {
         status: "in_progress",
         blocks: [],
         blockedBy: [],
+        threadID: "session-1",
       },
     ];
     const currentTodos: TodoInfo[] = [
       {
-        content: "Task 1 (updated)",
+        content: "1. Task 1 (updated)",
         status: "pending",
       },
     ];
@@ -535,8 +601,8 @@ describe("syncAllTasksToTodos", () => {
     // when
     await syncAllTasksToTodos(mockCtx, tasks, "session-1", writer);
 
-      // then, no duplicates
-    const matching = writtenTodos.filter((t: TodoInfo) => t.content === "Task 1 (updated)");
+    // then — no duplicates
+    const matching = writtenTodos.filter((t: TodoInfo) => t.content === "1. Task 1 (updated)");
     expect(matching.length).toBe(1);
     expect(matching[0].status).toBe("in_progress");
   });
@@ -551,6 +617,7 @@ describe("syncAllTasksToTodos", () => {
         status: "pending",
         blocks: [],
         blockedBy: [],
+        threadID: "session-1",
       },
     ];
     const currentTodos: TodoInfo[] = [

--- a/src/tools/task/todo-sync.test.ts
+++ b/src/tools/task/todo-sync.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="bun-types/test-globals" />
-import type { Task } from "../../features/claude-tasks/types";
+import type { Task } from "./types";
+import type { NumberingInfo } from "../../features/claude-tasks/tree-numbering";
 import {
   syncTaskToTodo,
   syncAllTasksToTodos,
@@ -7,25 +8,107 @@ import {
   type TodoInfo,
 } from "./todo-sync";
 
-describe("syncTaskToTodo", () => {
+describe("syncTaskToTodo with tree numbering", () => {
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
+
+  it("numbers root task as '1. Root Task'", () => {
+    // given
+    const task = createTask({
+      id: "T-root",
+      subject: "Root Task",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
+
+    // then
+    expect(result?.content).toBe("1. Root Task");
+  });
+
+  it("numbers child task as '  1.1. Child Task' with 2-space indent", () => {
+    // given
+    const task = createTask({
+      id: "T-child",
+      subject: "Child Task",
+      parentID: "T-root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 1, numberingPath: [1, 1] });
+
+    // then
+    expect(result?.content).toBe("  1.1. Child Task");
+  });
+
+  it("numbers grandchild task as '    1.1.1. Grandchild' with 4-space indent", () => {
+    // given
+    const task = createTask({
+      id: "T-grandchild",
+      subject: "Grandchild",
+      parentID: "T-child",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 2, numberingPath: [1, 1, 1] });
+
+    // then
+    expect(result?.content).toBe("    1.1.1. Grandchild");
+  });
+
+  it("handles multiple siblings at root level", () => {
+    // given
+    const task = createTask({
+      id: "T-root-2",
+      subject: "Second Root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [2] });
+
+    // then
+    expect(result?.content).toBe("2. Second Root");
+  });
+
+  it("handles nested siblings (1.2, 1.3)", () => {
+    // given
+    const task = createTask({
+      id: "T-sibling",
+      subject: "Second Child",
+      parentID: "T-root",
+    });
+
+    // when
+    const result = syncTaskToTodo(task, { depth: 1, numberingPath: [1, 2] });
+
+    // then
+    expect(result?.content).toBe("  1.2. Second Child");
+  });
+
   it("converts pending task to pending todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-123",
       subject: "Fix bug",
       description: "Fix critical bug",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result).toEqual({
       id: "T-123",
-      content: "Fix bug",
+      content: "1. Fix bug",
       status: "pending",
       priority: "medium",
     });
@@ -33,36 +116,32 @@ describe("syncTaskToTodo", () => {
 
   it("converts in_progress task to in_progress todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-456",
       subject: "Implement feature",
       description: "Add new feature",
       status: "in_progress",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.status).toBe("in_progress");
-    expect(result?.content).toBe("Implement feature");
+    expect(result?.content).toBe("1. Implement feature");
   });
 
   it("converts completed task to completed todo", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-789",
       subject: "Review PR",
       description: "Review pull request",
       status: "completed",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.status).toBe("completed");
@@ -70,17 +149,15 @@ describe("syncTaskToTodo", () => {
 
   it("returns null for deleted task", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-del",
       subject: "Deleted task",
       description: "This task is deleted",
       status: "deleted",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result).toBeNull();
@@ -88,18 +165,16 @@ describe("syncTaskToTodo", () => {
 
   it("extracts priority from metadata", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-high",
       subject: "Critical task",
       description: "High priority task",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "high" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("high");
@@ -107,18 +182,16 @@ describe("syncTaskToTodo", () => {
 
   it("handles medium priority", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-med",
       subject: "Medium task",
       description: "Medium priority",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "medium" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
@@ -126,18 +199,16 @@ describe("syncTaskToTodo", () => {
 
   it("handles low priority", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-low",
       subject: "Low task",
       description: "Low priority",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "low" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("low");
@@ -145,18 +216,16 @@ describe("syncTaskToTodo", () => {
 
   it("ignores invalid priority values", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-invalid",
       subject: "Invalid priority",
       description: "Invalid priority value",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
       metadata: { priority: "urgent" },
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
@@ -164,43 +233,49 @@ describe("syncTaskToTodo", () => {
 
   it("handles missing metadata", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-no-meta",
       subject: "No metadata",
       description: "Task without metadata",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
     expect(result?.priority).toBe("medium");
   });
 
-  it("uses subject as todo content", () => {
+  it("uses subject as todo content (with numbering)", () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-content",
       subject: "This is the subject",
       description: "This is the description",
       status: "pending",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
 
     // when
-    const result = syncTaskToTodo(task);
+    const result = syncTaskToTodo(task, { depth: 0, numberingPath: [1] });
 
     // then
-    expect(result?.content).toBe("This is the subject");
+    expect(result?.content).toBe("1. This is the subject");
   });
 });
 
 describe("syncTaskTodoUpdate", () => {
   let mockCtx: any;
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
 
   beforeEach(() => {
     mockCtx = {
@@ -214,14 +289,11 @@ describe("syncTaskTodoUpdate", () => {
 
   it("writes updated todo and preserves existing items", async () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-1",
       subject: "Updated task",
-      description: "",
       status: "in_progress",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
     const currentTodos: TodoInfo[] = [
       { id: "T-1", content: "Old task", status: "pending" },
       { id: "T-2", content: "Keep task", status: "pending" },
@@ -234,7 +306,7 @@ describe("syncTaskTodoUpdate", () => {
       expect(input.todos.length).toBe(2);
       expect(
         input.todos.find((todo: TodoInfo) => todo.id === "T-1")?.content,
-      ).toBe("Updated task");
+      ).toBe("1. Updated task");
       expect(input.todos.some((todo: TodoInfo) => todo.id === "T-2")).toBe(
         true,
       );
@@ -249,14 +321,11 @@ describe("syncTaskTodoUpdate", () => {
 
   it("removes deleted task from todos", async () => {
     // given
-    const task: Task = {
+    const task = createTask({
       id: "T-1",
       subject: "Deleted task",
-      description: "",
       status: "deleted",
-      blocks: [],
-      blockedBy: [],
-    };
+    });
     const currentTodos: TodoInfo[] = [
       { id: "T-1", content: "Old task", status: "pending" },
       { id: "T-2", content: "Keep task", status: "pending" },
@@ -284,6 +353,16 @@ describe("syncTaskTodoUpdate", () => {
 
 describe("syncAllTasksToTodos", () => {
   let mockCtx: any;
+  const createTask = (overrides: Partial<Task> = {}): Task => ({
+    id: "T-test",
+    subject: "Test Task",
+    description: "",
+    status: "pending",
+    blocks: [],
+    blockedBy: [],
+    threadID: "session-1",
+    ...overrides,
+  });
 
   beforeEach(() => {
     mockCtx = {
@@ -298,14 +377,12 @@ describe("syncAllTasksToTodos", () => {
   it("fetches current todos from OpenCode", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -349,14 +426,12 @@ describe("syncAllTasksToTodos", () => {
   it("gracefully handles fetch failure", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockRejectedValue(new Error("API error"));
 
@@ -370,24 +445,20 @@ describe("syncAllTasksToTodos", () => {
   it("converts multiple tasks to todos", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
         metadata: { priority: "high" },
-      },
-      {
+      }),
+      createTask({
         id: "T-2",
         subject: "Task 2",
         description: "Description 2",
         status: "in_progress",
-        blocks: [],
-        blockedBy: [],
         metadata: { priority: "low" },
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockResolvedValue([]);
 
@@ -401,14 +472,12 @@ describe("syncAllTasksToTodos", () => {
   it("removes deleted tasks from todo list", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "deleted",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -433,14 +502,12 @@ describe("syncAllTasksToTodos", () => {
   it("preserves existing todos not in task list", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     const currentTodos: TodoInfo[] = [
       {
@@ -465,7 +532,7 @@ describe("syncAllTasksToTodos", () => {
 
     // then
     expect(writtenTodos.some((t: TodoInfo) => t.id === "T-existing")).toBe(true);
-    expect(writtenTodos.some((t: TodoInfo) => t.content === "Task 1")).toBe(true);
+    expect(writtenTodos.some((t: TodoInfo) => t.content === "1. Task 1")).toBe(true);
   });
 
   it("handles empty task list", async () => {
@@ -483,14 +550,12 @@ describe("syncAllTasksToTodos", () => {
   it("calls writer with final todos", async () => {
     // given
     const tasks: Task[] = [
-      {
+      createTask({
         id: "T-1",
         subject: "Task 1",
         description: "Description 1",
         status: "pending",
-        blocks: [],
-        blockedBy: [],
-      },
+      }),
     ];
     mockCtx.client.session.todo.mockResolvedValue([]);
     let writerCalled = false;
@@ -498,7 +563,7 @@ describe("syncAllTasksToTodos", () => {
       writerCalled = true;
       expect(input.sessionID).toBe("session-1");
       expect(input.todos.length).toBe(1);
-      expect(input.todos[0].content).toBe("Task 1");
+      expect(input.todos[0].content).toBe("1. Task 1");
     };
 
     // when
@@ -518,11 +583,12 @@ describe("syncAllTasksToTodos", () => {
         status: "in_progress",
         blocks: [],
         blockedBy: [],
+        threadID: "session-1",
       },
     ];
     const currentTodos: TodoInfo[] = [
       {
-        content: "Task 1 (updated)",
+        content: "1. Task 1 (updated)",
         status: "pending",
       },
     ];
@@ -536,7 +602,7 @@ describe("syncAllTasksToTodos", () => {
     await syncAllTasksToTodos(mockCtx, tasks, "session-1", writer);
 
     // then — no duplicates
-    const matching = writtenTodos.filter((t: TodoInfo) => t.content === "Task 1 (updated)");
+    const matching = writtenTodos.filter((t: TodoInfo) => t.content === "1. Task 1 (updated)");
     expect(matching.length).toBe(1);
     expect(matching[0].status).toBe("in_progress");
   });
@@ -551,6 +617,7 @@ describe("syncAllTasksToTodos", () => {
         status: "pending",
         blocks: [],
         blockedBy: [],
+        threadID: "session-1",
       },
     ];
     const currentTodos: TodoInfo[] = [

--- a/src/tools/task/todo-sync.ts
+++ b/src/tools/task/todo-sync.ts
@@ -1,6 +1,10 @@
 import type { PluginInput } from "@opencode-ai/plugin";
 import { log } from "../../shared/logger";
-import type { Task } from "../../features/claude-tasks/types.ts";
+import type { Task } from "./types";
+import type { NumberingInfo } from "../../features/claude-tasks/tree-numbering";
+import { buildNumberedTree } from "../../features/claude-tasks/tree-numbering";
+import { buildTodoContent } from "./todo-content-builder";
+import { getTaskDir, loadAllTasks } from "../../features/claude-tasks/storage";
 
 export interface TodoInfo {
   id?: string;
@@ -54,7 +58,7 @@ function todosMatch(todo1: TodoInfo, todo2: TodoInfo): boolean {
   return todo1.content === todo2.content;
 }
 
-export function syncTaskToTodo(task: Task): TodoInfo | null {
+export function syncTaskToTodo(task: Task, numbering: NumberingInfo): TodoInfo | null {
   const todoStatus = mapTaskStatusToTodoStatus(task.status);
 
   if (todoStatus === null) {
@@ -63,7 +67,7 @@ export function syncTaskToTodo(task: Task): TodoInfo | null {
 
   return {
     id: task.id,
-    content: task.subject,
+    content: buildTodoContent(task.subject, numbering),
     status: todoStatus,
     priority: extractPriority(task.metadata) ?? "medium",
   };
@@ -99,34 +103,50 @@ export async function syncTaskTodoUpdate(
   task: Task,
   sessionID: string,
   writer?: TodoWriter,
+  taskDir?: string,
 ): Promise<void> {
   if (!ctx) return;
 
   try {
+    const allTasks = loadAllTasks(taskDir || getTaskDir({}));
+
     const response = await ctx.client.session.todo({
       path: { id: sessionID },
     });
     const currentTodos = extractTodos(response);
-    const taskTodo = syncTaskToTodo(task);
-    const nextTodos = currentTodos.filter((todo) => {
-      if (taskTodo) {
-        return !todosMatch(todo, taskTodo);
-      }
-      // Deleted task: match by id if present, otherwise by content
-      if (todo.id) {
-        return todo.id !== task.id;
-      }
-      return todo.content !== task.subject;
-    });
-    const todo = taskTodo;
 
-    if (todo) {
-      nextTodos.push(todo);
+    const treeResult = buildNumberedTree(allTasks);
+
+    const newTodos: TodoInfo[] = [];
+    const syncedTaskIds = new Set<string>();
+
+    for (const t of allTasks) {
+      const numbering = treeResult.taskNumbers.get(t.id);
+      if (!numbering) {
+        continue;
+      }
+
+      const todo = syncTaskToTodo(t, numbering);
+      if (todo) {
+        newTodos.push(todo);
+        syncedTaskIds.add(t.id);
+      }
     }
+
+    const finalTodos: TodoInfo[] = [];
+    const newTodoIds = new Set(newTodos.map((t) => t.id));
+
+    for (const existing of currentTodos) {
+      if (!newTodoIds.has(existing.id)) {
+        finalTodos.push(existing);
+      }
+    }
+
+    finalTodos.push(...newTodos);
 
     const resolvedWriter = writer ?? (await resolveTodoWriter());
     if (!resolvedWriter) return;
-    await resolvedWriter({ sessionID, todos: nextTodos });
+    await resolvedWriter({ sessionID, todos: finalTodos });
   } catch (err) {
     log("[todo-sync] Failed to sync task todo", {
       error: String(err),
@@ -140,6 +160,7 @@ export async function syncAllTasksToTodos(
   tasks: Task[],
   sessionID?: string,
   writer?: TodoWriter,
+  taskDir?: string,
 ): Promise<void> {
   try {
     let currentTodos: TodoInfo[] = [];
@@ -155,13 +176,23 @@ export async function syncAllTasksToTodos(
       });
     }
 
+    // Build tree from the passed-in tasks (not from disk) so tests work without mocking fs
+    const treeResult = buildNumberedTree(tasks);
+
     const newTodos: TodoInfo[] = [];
     const tasksToRemove = new Set<string>();
     const allTaskSubjects = new Set<string>();
 
-    for (const task of tasks) {
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      // Use tree numbering if available, otherwise fallback to simple index-based numbering
+      const numbering = treeResult.taskNumbers.get(task.id) ?? {
+        depth: 0,
+        numberingPath: [i + 1],
+      };
+
       allTaskSubjects.add(task.subject);
-      const todo = syncTaskToTodo(task);
+      const todo = syncTaskToTodo(task, numbering);
       if (todo === null) {
         tasksToRemove.add(task.id);
       } else {

--- a/src/tools/task/validation.test.ts
+++ b/src/tools/task/validation.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "bun:test"
+import type { Task } from "./types"
+import {
+  validateParentExists,
+  validateNoCycles,
+  validateMaxDepth,
+  validateReparentingDepth,
+} from "./validation"
+
+describe("Task Validation", () => {
+  //#given a set of tasks
+  describe("validateParentExists", () => {
+    //#when parent is null/unset
+    it("should return null when parentID is unset", () => {
+      const tasks: Task[] = []
+      const result = validateParentExists(undefined, tasks)
+      expect(result).toBeNull()
+    })
+
+    //#when parent exists in task list
+    it("should return null when parent exists", () => {
+      const tasks: Task[] = [
+        {
+          id: "T-parent",
+          subject: "Parent",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+        },
+        {
+          id: "T-child",
+          subject: "Child",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-parent",
+        },
+      ]
+      const result = validateParentExists("T-parent", tasks)
+      expect(result).toBeNull()
+    })
+
+    //#when parent does not exist
+    it("should return error when parent does not exist", () => {
+      const tasks: Task[] = []
+      const result = validateParentExists("T-nonexistent", tasks)
+      expect(result).toEqual({ error: "task_parent_not_found" })
+    })
+  })
+
+  describe("validateNoCycles", () => {
+    //#given a linear chain
+    it("should return null for valid chain A -> B -> C", () => {
+      const tasks: Task[] = [
+        {
+          id: "T-a",
+          subject: "A",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+        },
+        {
+          id: "T-b",
+          subject: "B",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-a",
+        },
+        {
+          id: "T-c",
+          subject: "C",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-b",
+        },
+      ]
+      const result = validateNoCycles("T-c", "T-b", tasks)
+      expect(result).toBeNull()
+    })
+
+    //#when creating A -> B and B -> A (direct cycle)
+    it("should reject direct cycle A <- B <- A", () => {
+      const tasks: Task[] = [
+        {
+          id: "T-a",
+          subject: "A",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-b",
+        },
+        {
+          id: "T-b",
+          subject: "B",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+        },
+      ]
+      // Try to set B's parent to A (which has parent B) = cycle
+      const result = validateNoCycles("T-b", "T-a", tasks)
+      expect(result).toEqual({ error: "task_cycle_detected" })
+    })
+
+    //#when creating A -> B -> C -> A (indirect cycle)
+    it("should reject indirect cycle A <- C <- B <- A", () => {
+      const tasks: Task[] = [
+        {
+          id: "T-a",
+          subject: "A",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+        },
+        {
+          id: "T-b",
+          subject: "B",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-a",
+        },
+        {
+          id: "T-c",
+          subject: "C",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+          parentID: "T-b",
+        },
+      ]
+      // Try to set A's parent to C = cycle
+      const result = validateNoCycles("T-a", "T-c", tasks)
+      expect(result).toEqual({ error: "task_cycle_detected" })
+    })
+
+    //#when parent is self
+    it("should reject self-cycle", () => {
+      const tasks: Task[] = [
+        {
+          id: "T-a",
+          subject: "A",
+          description: "",
+          status: "pending",
+          threadID: "test",
+          blocks: [],
+          blockedBy: [],
+        },
+      ]
+      // Try to set A's parent to A = cycle
+      const result = validateNoCycles("T-a", "T-a", tasks)
+      expect(result).toEqual({ error: "task_cycle_detected" })
+    })
+  })
+
+  describe("validateMaxDepth", () => {
+    //#when task is within max depth (6)
+    it("should return null for depth 0 (root)", () => {
+      const tasks: Task[] = []
+      const result = validateMaxDepth("T-root", tasks)
+      expect(result).toBeNull()
+    })
+
+    it("should return null for depth 5", () => {
+      const tasks: Task[] = [
+        { id: "T-1", subject: "1", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [] },
+        { id: "T-2", subject: "2", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-1" },
+        { id: "T-3", subject: "3", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-2" },
+        { id: "T-4", subject: "4", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-3" },
+        { id: "T-5", subject: "5", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-4" },
+        { id: "T-6", subject: "6", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-5" },
+      ]
+      const result = validateMaxDepth("T-6", tasks)
+      expect(result).toBeNull()
+    })
+
+    //#when task exceeds max depth (6)
+    it("should reject depth 6 (7th level in 0-indexed)", () => {
+      const tasks: Task[] = [
+        { id: "T-1", subject: "1", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [] },
+        { id: "T-2", subject: "2", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-1" },
+        { id: "T-3", subject: "3", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-2" },
+        { id: "T-4", subject: "4", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-3" },
+        { id: "T-5", subject: "5", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-4" },
+        { id: "T-6", subject: "6", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-5" },
+        { id: "T-7", subject: "7", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-6" },
+      ]
+      const result = validateMaxDepth("T-7", tasks)
+      expect(result).toEqual({ error: "task_max_depth_exceeded" })
+    })
+  })
+
+  describe("validateReparentingDepth", () => {
+    //#when reparenting doesn't push descendants beyond max depth
+    it("should return null when reparenting stays within limit", () => {
+      const tasks: Task[] = [
+        { id: "T-1", subject: "1", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [] },
+        { id: "T-2", subject: "2", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-1" },
+        { id: "T-3", subject: "3", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-2" },
+        { id: "T-child", subject: "C", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-3" },
+        { id: "T-grandchild", subject: "GC", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-child" },
+      ]
+      // Move T-3 (at depth 2) under T-1 (at depth 0) = T-3 becomes depth 1, T-child = 2, T-grandchild = 3 ✓
+      const result = validateReparentingDepth("T-3", "T-1", tasks)
+      expect(result).toBeNull()
+    })
+
+    //#when reparenting pushes descendants beyond max depth
+    it("should reject reparenting that exceeds max depth for descendants", () => {
+      const tasks: Task[] = [
+        { id: "T-1", subject: "1", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [] },
+        { id: "T-2", subject: "2", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-1" },
+        { id: "T-3", subject: "3", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-2" },
+        { id: "T-4", subject: "4", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-3" },
+        { id: "T-5", subject: "5", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-4" },
+        { id: "T-6", subject: "6", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-5" },
+        { id: "T-child", subject: "C", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-6" },
+        { id: "T-grandchild", subject: "GC", description: "", status: "pending", threadID: "test", blocks: [], blockedBy: [], parentID: "T-child" },
+      ]
+      // Try to move T-1 (depth 0) to parent of T-6 (depth 5)
+      // T-6 becomes depth 6, T-child = 7, T-grandchild = 8 ✗
+      const result = validateReparentingDepth("T-1", "T-6", tasks)
+      expect(result).toEqual({ error: "task_max_depth_exceeded" })
+    })
+  })
+})

--- a/src/tools/task/validation.ts
+++ b/src/tools/task/validation.ts
@@ -1,0 +1,74 @@
+import type { Task } from "./types"
+import { calculateDepth, getAncestors, getDescendants } from "../../features/claude-tasks/tree-utils"
+import { TASK_MAX_DEPTH } from "../../features/claude-tasks/storage"
+
+export interface ValidationError {
+  error: "task_parent_not_found" | "task_cycle_detected" | "task_max_depth_exceeded"
+}
+
+export function validateParentExists(parentID: string | undefined, tasks: Task[]): ValidationError | null {
+  if (!parentID) {
+    return null
+  }
+
+  const parentExists = tasks.some((t) => t.id === parentID)
+  if (!parentExists) {
+    return { error: "task_parent_not_found" }
+  }
+
+  return null
+}
+
+export function validateNoCycles(taskId: string, newParentID: string | undefined, tasks: Task[]): ValidationError | null {
+  if (!newParentID) {
+    return null
+  }
+
+  if (taskId === newParentID) {
+    return { error: "task_cycle_detected" }
+  }
+
+  const ancestors = getAncestors(newParentID, tasks)
+  if (ancestors.some((a) => a.id === taskId)) {
+    return { error: "task_cycle_detected" }
+  }
+
+  return null
+}
+
+export function validateMaxDepth(taskId: string, tasks: Task[]): ValidationError | null {
+  const depth = calculateDepth(taskId, tasks)
+
+  if (depth >= TASK_MAX_DEPTH) {
+    return { error: "task_max_depth_exceeded" }
+  }
+
+  return null
+}
+
+export function validateReparentingDepth(
+  taskId: string,
+  newParentID: string | undefined,
+  tasks: Task[]
+): ValidationError | null {
+  if (!newParentID) {
+    return null
+  }
+
+  const newParentDepth = calculateDepth(newParentID, tasks)
+  if (newParentDepth >= TASK_MAX_DEPTH - 1) {
+    return { error: "task_max_depth_exceeded" }
+  }
+
+  const descendants = getDescendants(taskId, tasks)
+  for (const descendant of descendants) {
+    const descendantDepth = calculateDepth(descendant.id, tasks)
+    const newDescendantDepth = descendantDepth - calculateDepth(taskId, tasks) + newParentDepth + 1
+
+    if (newDescendantDepth >= TASK_MAX_DEPTH) {
+      return { error: "task_max_depth_exceeded" }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
- Update system-prompt.ts to include PROMETHEUS_PLAN_TEMPLATE_V2
- Prometheus now generates v2 hierarchical plans for complex tasks
- Update plan-generation.ts to conditionally use task_create/task_update when available
- Fall back to TodoWrite when task_system disabled
- Add step-by-step guidance for both tooling paths
- Maintain V2 hierarchical TODO format requirement
- Resolve conflicts with tasks-todowrite-disabler hook expectations



## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  <img width="140" height="200"  alt="image" src="https://github.com/user-attachments/assets/f36fcf40-a8e5-4e9e-949b-25e717456ce0" />|


input: 
``` 
Plan the implementation of a user management system with:
- User registration with email verification
- Login with JWT tokens
- Profile management
- Admin panel for user oversight
```
plan md file: 
[user-management-system.md](https://github.com/user-attachments/files/25456561/user-management-system.md)

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues
Closes #1785
<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hierarchical plan generation (V2) to Prometheus with N.x task IDs, a fast `markdown-renderer-v2`, and a `task_tree` tool. V2 is default with v1 fallback via plan-format detection; TODO sync now uses tree numbering. Closes #1785.

- **New Features**
  - Added `PROMETHEUS_PLAN_TEMPLATE_V2` with `<!-- Plan-Format: 2 -->`; detector auto-falls back to v1 when missing.
  - Planner prefers `task_create`/`task_update` (+ `task_list`/`task_get`), with `TodoWrite` fallback; includes step-by-step guidance for both paths.
  - New `task_tree` tool and `markdown-renderer-v2` render numbered hierarchies; collapse past depth 6; tree utils add numbering, progress, validation; `todo-sync` builds numbered content.

- **Bug Fixes**
  - Aligned tool examples and APIs: use `metadata: { priority }`, capture IDs correctly; added hierarchical parent-child examples for `task_create` and `TodoWrite`.
  - Fixed numbering edge cases (deleted-root lookup, duplicate sibling indices) with regression tests; removed O(N²) reconstruction in `markdown-renderer-v2`; resolved `tasks-todowrite-disabler` conflicts.

<sup>Written for commit 3fa58d109b23c9709d15436078f72eb45673413e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/1889?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



