### PR TITLE
fix(config): resolve Antigravity/Native Gemini config conflict

### DIFF
--- a/src/cli/config-manager/add-provider-config.ts
+++ b/src/cli/config-manager/add-provider-config.ts
@@ -40,7 +40,17 @@ export function addProviderConfig(config: InstallConfig): ConfigMergeResult {
     const providers = (newConfig.provider ?? {}) as Record<string, unknown>
 
     if (config.hasGemini) {
-      providers.google = ANTIGRAVITY_PROVIDER_CONFIG.google
+      const existingGoogle = (providers.google ?? {}) as Record<string, unknown>
+      const antigravityGoogle = ANTIGRAVITY_PROVIDER_CONFIG.google as Record<string, unknown>
+
+      providers.google = {
+        ...existingGoogle,
+        ...antigravityGoogle,
+        models: {
+          ...((existingGoogle.models ?? {}) as Record<string, unknown>),
+          ...((antigravityGoogle.models ?? {}) as Record<string, unknown>),
+        },
+      }
     }
 
     if (Object.keys(providers).length > 0) {

--- a/src/cli/fallback-chain-resolution.ts
+++ b/src/cli/fallback-chain-resolution.ts
@@ -13,7 +13,9 @@ export function resolveModelFromChain(
 	for (const entry of fallbackChain) {
 		for (const provider of entry.providers) {
 			if (isProviderAvailable(provider, availability)) {
-				const transformedModel = transformModelForProvider(provider, entry.model)
+				const transformedModel = transformModelForProvider(provider, entry.model, {
+					hasAntigravity: availability.native.gemini,
+				})
 				return {
 					model: `${provider}/${transformedModel}`,
 					variant: entry.variant,

--- a/src/cli/provider-model-id-transform.ts
+++ b/src/cli/provider-model-id-transform.ts
@@ -1,4 +1,14 @@
-export function transformModelForProvider(provider: string, model: string): string {
+export function transformModelForProvider(
+	provider: string,
+	model: string,
+	options: { hasAntigravity?: boolean } = {}
+): string {
+	if (provider === "google" && options.hasAntigravity) {
+		if (model.startsWith("gemini-")) {
+			return `antigravity-${model}`
+		}
+	}
+
 	if (provider === "github-copilot") {
 		return model
 			.replace("claude-opus-4-6", "claude-opus-4.6")


### PR DESCRIPTION
This PR fixes a conflict where enabling Antigravity auth would overwrite existing native Gemini CLI configurations.

**Changes:**
1. **Deep Merge for Google Provider:** Modified `add-provider-config.ts` to merge Antigravity settings with existing Google provider configuration instead of replacing it. This preserves API keys and other custom settings.
2. **Model ID Prefix Injection:** Updated `provider-model-id-transform.ts` and `fallback-chain-resolution.ts` to automatically inject the `antigravity-` prefix into model IDs when Antigravity integration is active. This ensures the correct model IDs (e.g., `antigravity-gemini-3-pro`) are used in the generated agent configuration while still allowing fallback to native IDs if needed.

**Why:**
Users utilizing both Antigravity auth (for high-tier tasks) and native Gemini CLI auth (for other tasks or fallbacks) were experiencing configuration overrides and incorrect model ID usage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the conflict between Antigravity auth and native Gemini config. Preserves existing Google provider settings and uses Antigravity-prefixed model IDs only when Antigravity is active.

- **Bug Fixes**
  - Deep-merge Antigravity Google provider config with existing values to keep API keys and custom settings.
  - Auto-prefix Gemini model IDs with antigravity- for Google when Antigravity is enabled; keep native IDs otherwise.
  - Align fallback chain resolution with the same model ID logic to ensure valid provider/model pairs.

<sup>Written for commit 8263ddae49c6f6cb614e42d5079a34f43efbe182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

