### PR TITLE
feat: allow custom subagents to delegate tasks via task()

### DIFF
--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -72,7 +72,7 @@ export const AgentOverridesSchema = z.object({
   explore: AgentOverrideConfigSchema.optional(),
   "multimodal-looker": AgentOverrideConfigSchema.optional(),
   atlas: AgentOverrideConfigSchema.optional(),
-})
+}).catchall(AgentOverrideConfigSchema)
 
 export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>
 export type AgentOverrides = z.infer<typeof AgentOverridesSchema>

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -8,7 +8,7 @@ import type {
 import { TaskHistory } from "./task-history"
 import {
   log,
-  getAgentToolRestrictions,
+  buildSubagentTools,
   normalizePromptTools,
   normalizeSDKResponse,
   promptWithModelSuggestionRetry,
@@ -356,12 +356,7 @@ export class BackgroundManager {
         ...(launchVariant ? { variant: launchVariant } : {}),
         system: input.skillContent,
         tools: (() => {
-          const tools = {
-            task: false,
-            call_omo_agent: true,
-            question: false,
-            ...getAgentToolRestrictions(input.agent),
-          }
+          const tools = buildSubagentTools(input.agent)
           setSessionTools(sessionID, tools)
           return tools
         })(),
@@ -629,12 +624,7 @@ export class BackgroundManager {
         ...(resumeModel ? { model: resumeModel } : {}),
         ...(resumeVariant ? { variant: resumeVariant } : {}),
         tools: (() => {
-          const tools = {
-            task: false,
-            call_omo_agent: true,
-            question: false,
-            ...getAgentToolRestrictions(existingTask.agent),
-          }
+          const tools = buildSubagentTools(existingTask.agent)
           setSessionTools(existingTask.sessionID!, tools)
           return tools
         })(),

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -1,7 +1,7 @@
 import type { BackgroundTask, LaunchInput, ResumeInput } from "./types"
 import type { OpencodeClient, OnSubagentSessionCreated, QueueItem } from "./constants"
 import { TMUX_CALLBACK_DELAY_MS } from "./constants"
-import { log, getAgentToolRestrictions, promptWithModelSuggestionRetry, createInternalAgentTextPart } from "../../shared"
+import { log, buildSubagentTools, promptWithModelSuggestionRetry, createInternalAgentTextPart } from "../../shared"
 import { subagentSessions } from "../claude-code-session-state"
 import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
@@ -138,12 +138,7 @@ export async function startTask(
       ...(launchModel ? { model: launchModel } : {}),
       ...(launchVariant ? { variant: launchVariant } : {}),
       system: input.skillContent,
-      tools: {
-        task: false,
-        call_omo_agent: true,
-        question: false,
-        ...getAgentToolRestrictions(input.agent),
-      },
+      tools: buildSubagentTools(input.agent),
       parts: [createInternalAgentTextPart(input.prompt)],
     },
   }).catch((error) => {
@@ -222,12 +217,7 @@ export async function resumeTask(
       agent: task.agent,
       ...(resumeModel ? { model: resumeModel } : {}),
       ...(resumeVariant ? { variant: resumeVariant } : {}),
-      tools: {
-        task: false,
-        call_omo_agent: true,
-        question: false,
-        ...getAgentToolRestrictions(task.agent),
-      },
+      tools: buildSubagentTools(task.agent),
       parts: [createInternalAgentTextPart(input.prompt)],
     },
   }).catch((error) => {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -31,6 +31,23 @@ function getConfiguredDefaultAgent(config: Record<string, unknown>): string | un
   return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
 }
 
+function addCustomAgentsFromConfig(params: {
+  config: Record<string, unknown>;
+  pluginConfig: OhMyOpenCodeConfig;
+}): void {
+  const agents = params.pluginConfig.agents;
+  if (!agents) return;
+
+  const configAgent = params.config.agent as Record<string, unknown> | undefined;
+  if (!configAgent) return;
+
+  for (const [name, agentCfg] of Object.entries(agents)) {
+    if (agentCfg && !configAgent[name]) {
+      configAgent[name] = migrateAgentConfig(agentCfg as Record<string, unknown>);
+    }
+  }
+}
+
 export async function applyAgentConfig(params: {
   config: Record<string, unknown>;
   pluginConfig: OhMyOpenCodeConfig;
@@ -210,6 +227,8 @@ export async function applyAgentConfig(params: {
       build: { ...migratedBuild, mode: "subagent", hidden: true },
       ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
     };
+
+    addCustomAgentsFromConfig(params);
   } else {
     params.config.agent = {
       ...builtinAgents,
@@ -218,6 +237,8 @@ export async function applyAgentConfig(params: {
       ...filterDisabledAgents(pluginAgents),
       ...configAgent,
     };
+
+    addCustomAgentsFromConfig(params);
   }
 
   if (params.config.agent) {

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,5 +1,6 @@
 import type { OhMyOpenCodeConfig } from "../config";
 import { getAgentDisplayName } from "../shared/agent-display-names";
+import { getAgentToolRestrictions } from "../shared/agent-tool-restrictions";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
@@ -96,6 +97,15 @@ export function applyToolConfig(params: {
       teammate: "allow",
       ...denyTodoTools,
     };
+  }
+
+  for (const customAgent of Object.keys(params.agentResult)) {
+    const agent = params.agentResult[customAgent] as AgentWithPermission | undefined;
+    if (!agent) continue;
+    const restrictions = getAgentToolRestrictions(customAgent);
+    if (!("task" in restrictions) && !agent.permission?.task) {
+      agent.permission = { ...agent.permission, task: "allow" };
+    }
   }
 
   params.config.permission = {

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -55,3 +55,21 @@ export function hasAgentToolRestrictions(agentName: string): boolean {
     ?? Object.entries(AGENT_RESTRICTIONS).find(([key]) => key.toLowerCase() === agentName.toLowerCase())?.[1]
   return restrictions !== undefined && Object.keys(restrictions).length > 0
 }
+
+/**
+ * Build the tools restriction object for a subagent.
+ *
+ * - Gets base restrictions from AGENT_RESTRICTIONS via getAgentToolRestrictions().
+ * - If restrictions already define `task`, uses that value (built-in agents stay restricted).
+ * - If restrictions do NOT define `task` (custom/unknown agents), defaults to `task: true` (allow).
+ * - Always sets `call_omo_agent: true` and `question: false`.
+ */
+export function buildSubagentTools(agentName: string): Record<string, boolean> {
+  const restrictions = getAgentToolRestrictions(agentName)
+  return {
+    ...restrictions,
+    ...("task" in restrictions ? {} : { task: true }),
+    call_omo_agent: true,
+    question: false,
+  }
+}

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -1,7 +1,7 @@
 import type { CallOmoAgentArgs } from "./types"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { log } from "../../shared"
-import { getAgentToolRestrictions } from "../../shared"
+import { buildSubagentTools } from "../../shared"
 import { createOrGetSession } from "./session-creator"
 import { waitForCompletion } from "./completion-poller"
 import { processMessages } from "./message-processor"
@@ -49,11 +49,7 @@ export async function executeSync(
       path: { id: sessionID },
       body: {
         agent: args.subagent_type,
-        tools: {
-          ...getAgentToolRestrictions(args.subagent_type),
-          task: false,
-          question: false,
-        },
+        tools: buildSubagentTools(args.subagent_type),
         parts: [{ type: "text", text: args.prompt }],
       },
     })

--- a/src/tools/delegate-task/sync-continuation.ts
+++ b/src/tools/delegate-task/sync-continuation.ts
@@ -1,9 +1,8 @@
 import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 import type { ExecutorContext, SessionMessage } from "./executor-types"
-import { isPlanFamily } from "./constants"
 import { storeToolMetadata } from "../../features/tool-metadata-store"
 import { getTaskToastManager } from "../../features/task-toast-manager"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { buildSubagentTools } from "../../shared/agent-tool-restrictions"
 import { getMessageDir } from "../../shared"
 import { promptWithModelSuggestionRetry } from "../../shared/model-suggestion-retry"
 import { findNearestMessageWithFields } from "../../features/hook-message-injector"
@@ -78,13 +77,7 @@ export async function executeSyncContinuation(
       resumeVariant = resumeMessage?.model?.variant
     }
 
-    const allowTask = isPlanFamily(resumeAgent)
-    const tools = {
-      ...(resumeAgent ? getAgentToolRestrictions(resumeAgent) : {}),
-      task: allowTask,
-      call_omo_agent: true,
-      question: false,
-    }
+    const tools = buildSubagentTools(resumeAgent ?? "")
     setSessionTools(args.session_id!, tools)
 
     await promptWithModelSuggestionRetry(client, {

--- a/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,11 +1,10 @@
 import type { DelegateTaskArgs, OpencodeClient } from "./types"
-import { isPlanFamily } from "./constants"
 import {
   promptSyncWithModelSuggestionRetry,
   promptWithModelSuggestionRetry,
 } from "../../shared/model-suggestion-retry"
 import { formatDetailedError } from "./error-formatting"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { buildSubagentTools } from "../../shared/agent-tool-restrictions"
 import { setSessionTools } from "../../shared/session-tools-store"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 
@@ -42,13 +41,7 @@ export async function sendSyncPrompt(
   },
   deps: SendSyncPromptDeps = sendSyncPromptDeps
 ): Promise<string | null> {
-  const allowTask = isPlanFamily(input.agentToUse)
-  const tools = {
-    task: allowTask,
-    call_omo_agent: true,
-    question: false,
-    ...getAgentToolRestrictions(input.agentToUse),
-  }
+  const tools = buildSubagentTools(input.agentToUse)
   setSessionTools(input.sessionID, tools)
 
   const promptArgs = {


### PR DESCRIPTION
## Summary

Custom subagents defined in `oh-my-opencode.json` cannot use `task()` to delegate work to other agents. This PR fixes three independent issues that collectively prevent the pipeline from working.

## Problem

When a user defines custom agents (e.g., `critic`, `breaker`, `type-sentinel`) in `oh-my-opencode.json`, those agents:

1. **Cannot call `task()`** — `buildSubagentTools()` hardcodes `task: false` for background tasks and only allows `task` for plan-family agents in sync flows
2. **Are never registered with opencode** — `applyAgentConfig()` passes custom agents as overrides to `createBuiltinAgents()`, which only processes known builtin names
3. **Are blocked by global permission deny** — `applyToolConfig()` sets `config.permission.task = "deny"` globally, then only whitelists hardcoded agents

## Changes

**Commit 1** (`agent-tool-restrictions.ts`): Check `AGENT_RESTRICTIONS` instead of hardcoding `task: false`. 4 code paths fixed.

**Commit 2** (`agent-config-handler.ts`, `tool-config-handler.ts`): Register custom agents from config. Grant `task: "allow"` to non-restricted agents.