### PR TITLE
feat(background): optional tool-output completion notifications for delegated tasks

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -100,7 +100,8 @@
           "tasks-todowrite-disabler",
           "write-existing-file-guard",
           "anthropic-effort",
-          "hashline-read-enhancer"
+          "hashline-read-enhancer",
+          "background-tool-output-notifier"
         ]
       }
     },
@@ -164,9 +165,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -212,9 +210,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -302,9 +297,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -346,9 +338,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -394,9 +383,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -484,9 +470,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -528,9 +511,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -576,9 +556,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -666,9 +643,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -710,9 +684,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -758,9 +729,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -848,9 +816,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -892,9 +857,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -940,9 +902,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1030,9 +989,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1074,9 +1030,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1122,9 +1075,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1212,9 +1162,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1256,9 +1203,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1304,9 +1248,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1394,9 +1335,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1438,9 +1376,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1486,9 +1421,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1576,9 +1508,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1620,9 +1549,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1668,9 +1594,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1758,9 +1681,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1802,9 +1722,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1850,9 +1767,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1940,9 +1854,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1984,9 +1895,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2032,9 +1940,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2122,9 +2027,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2166,9 +2068,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2214,9 +2113,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2304,9 +2200,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2348,9 +2241,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2396,9 +2286,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2486,9 +2373,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2530,9 +2414,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2578,9 +2459,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2668,9 +2546,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2681,9 +2556,6 @@
     },
     "categories": {
       "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -2747,9 +2619,6 @@
           },
           "tools": {
             "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
             "additionalProperties": {
               "type": "boolean"
             }
@@ -2790,9 +2659,6 @@
         },
         "plugins_override": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "boolean"
           }
@@ -2970,6 +2836,9 @@
         },
         "hashline_edit": {
           "type": "boolean"
+        },
+        "background_notifications_via_tool_output": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -3066,9 +2935,6 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
                     "additionalProperties": {}
                   },
                   "allowed-tools": {
@@ -3120,9 +2986,6 @@
         },
         "providerConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0
@@ -3130,9 +2993,6 @@
         },
         "modelConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1131,6 +1131,7 @@ Opt-in experimental features that may change or be removed in future versions. U
     "truncate_all_tool_outputs": true,
     "aggressive_truncation": true,
     "auto_resume": true,
+    "background_notifications_via_tool_output": true,
     "dynamic_context_pruning": {
       "enabled": false,
       "notification": "detailed",
@@ -1162,6 +1163,7 @@ Opt-in experimental features that may change or be removed in future versions. U
 | `truncate_all_tool_outputs` | `false` | Truncates ALL tool outputs instead of just whitelisted tools (Grep, Glob, LSP, AST-grep). Tool output truncator is enabled by default - disable via `disabled_hooks`.                         |
 | `aggressive_truncation`     | `false` | When token limit is exceeded, aggressively truncates tool outputs to fit within limits. More aggressive than the default truncation behavior. Falls back to summarize/revert if insufficient. |
 | `auto_resume`               | `false` | Automatically resumes session after successful recovery from thinking block errors or thinking disabled violations. Extracts last user message and continues.                             |
+| `background_notifications_via_tool_output` | `false` | Appends background completion summaries to normal `tool.execute.after` outputs (same session) and clears queued notifications, avoiding synthetic parent `session.prompt` injection turns. |
 | `dynamic_context_pruning`    | See below | Dynamic context pruning configuration for managing context window usage automatically. See [Dynamic Context Pruning](#dynamic-context-pruning) below.                              |
 
 ### Dynamic Context Pruning

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -699,6 +699,20 @@ describe("ExperimentalConfigSchema feature flags", () => {
     }
   })
 
+  test("accepts background_notifications_via_tool_output as boolean", () => {
+    //#given
+    const config = { background_notifications_via_tool_output: true }
+
+    //#when
+    const result = ExperimentalConfigSchema.safeParse(config)
+
+    //#then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.background_notifications_via_tool_output).toBe(true)
+    }
+  })
+
   test("accepts hashline_edit as true", () => {
     //#given
     const config = { hashline_edit: true }

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -17,6 +17,7 @@ export const ExperimentalConfigSchema = z.object({
   safe_hook_creation: z.boolean().optional(),
   /** Enable hashline_edit tool for improved file editing with hash-based line anchors */
   hashline_edit: z.boolean().optional(),
+  background_notifications_via_tool_output: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -47,6 +47,7 @@ export const HookNameSchema = z.enum([
   "write-existing-file-guard",
   "anthropic-effort",
   "hashline-read-enhancer",
+  "background-tool-output-notifier",
 ])
 
 export type HookName = z.infer<typeof HookNameSchema>

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -26,6 +26,9 @@ export function createManagers(args: {
 }): Managers {
   const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled } = args
 
+  const useToolOutputBackgroundNotifications =
+    pluginConfig.experimental?.background_notifications_via_tool_output === true
+
   const tmuxSessionManager = new TmuxSessionManager(ctx, tmuxConfig)
 
   const backgroundManager = new BackgroundManager(
@@ -58,7 +61,8 @@ export function createManagers(args: {
           log("[index] tmux cleanup error during shutdown:", error)
         })
       },
-      enableParentSessionNotifications: backgroundNotificationHookEnabled,
+      enableParentSessionNotifications:
+        backgroundNotificationHookEnabled && !useToolOutputBackgroundNotifications,
     },
   )
 

--- a/src/hooks/auto-update-checker/hook/background-update-check.test.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.test.ts
@@ -1,56 +1,47 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
-// Mock modules before importing
-const mockFindPluginEntry = mock(() => null as any)
+const mockFindPluginEntry = mock(() => null as unknown)
 const mockGetCachedVersion = mock(() => null as string | null)
 const mockGetLatestVersion = mock(async () => null as string | null)
-const mockUpdatePinnedVersion = mock(() => false)
 const mockExtractChannel = mock(() => "latest")
 const mockInvalidatePackage = mock(() => {})
 const mockRunBunInstall = mock(async () => true)
 const mockShowUpdateAvailableToast = mock(async () => {})
 const mockShowAutoUpdatedToast = mock(async () => {})
 
-mock.module("../checker", () => ({
+const deps = {
   findPluginEntry: mockFindPluginEntry,
   getCachedVersion: mockGetCachedVersion,
   getLatestVersion: mockGetLatestVersion,
-  updatePinnedVersion: mockUpdatePinnedVersion,
-}))
-
-mock.module("../version-channel", () => ({
   extractChannel: mockExtractChannel,
-}))
-
-mock.module("../cache", () => ({
   invalidatePackage: mockInvalidatePackage,
-}))
-
-mock.module("../../../cli/config-manager", () => ({
   runBunInstall: mockRunBunInstall,
-}))
-
-mock.module("./update-toasts", () => ({
   showUpdateAvailableToast: mockShowUpdateAvailableToast,
   showAutoUpdatedToast: mockShowAutoUpdatedToast,
-}))
+}
 
-mock.module("../../../shared/logger", () => ({
-  log: () => {},
-}))
-
-const { runBackgroundUpdateCheck } = await import("./background-update-check")
+async function runWithFreshModule(
+  autoUpdate: boolean,
+  getToastMessage: (isUpdate: boolean, latestVersion?: string) => string,
+): Promise<void> {
+  const modulePath = `./background-update-check?test=${Date.now()}-${Math.random()}`
+  const imported = await import(modulePath)
+  await imported.runBackgroundUpdateCheck(
+    { directory: "/test" } as never,
+    autoUpdate,
+    getToastMessage,
+    deps as never,
+  )
+}
 
 describe("runBackgroundUpdateCheck", () => {
-  const mockCtx = { directory: "/test" } as any
-  const mockGetToastMessage = (isUpdate: boolean, version?: string) =>
+  const getToastMessage = (isUpdate: boolean, version?: string) =>
     isUpdate ? `Update to ${version}` : "Up to date"
 
   beforeEach(() => {
     mockFindPluginEntry.mockReset()
     mockGetCachedVersion.mockReset()
     mockGetLatestVersion.mockReset()
-    mockUpdatePinnedVersion.mockReset()
     mockExtractChannel.mockReset()
     mockInvalidatePackage.mockReset()
     mockRunBunInstall.mockReset()
@@ -61,114 +52,84 @@ describe("runBackgroundUpdateCheck", () => {
     mockRunBunInstall.mockResolvedValue(true)
   })
 
-  describe("#given user has pinned a specific version", () => {
-    beforeEach(() => {
-      mockFindPluginEntry.mockReturnValue({
-        entry: "oh-my-opencode@3.4.0",
-        isPinned: true,
-        pinnedVersion: "3.4.0",
-        configPath: "/test/opencode.json",
-      })
-      mockGetCachedVersion.mockReturnValue("3.4.0")
-      mockGetLatestVersion.mockResolvedValue("3.5.0")
+  it("uses notification-only flow for pinned versions", async () => {
+    mockFindPluginEntry.mockReturnValue({
+      entry: "oh-my-opencode@3.4.0",
+      isPinned: true,
+      pinnedVersion: "3.4.0",
+      configPath: "/test/opencode.json",
     })
+    mockGetCachedVersion.mockReturnValue("3.4.0")
+    mockGetLatestVersion.mockResolvedValue("3.5.0")
 
-    it("#then should NOT call updatePinnedVersion", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
+    await runWithFreshModule(true, getToastMessage)
 
-      expect(mockUpdatePinnedVersion).not.toHaveBeenCalled()
-    })
-
-    it("#then should show update-available toast instead", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
-
-      expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(
-        mockCtx,
-        "3.5.0",
-        mockGetToastMessage
-      )
-    })
-
-    it("#then should NOT run bun install", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
-
-      expect(mockRunBunInstall).not.toHaveBeenCalled()
-    })
-
-    it("#then should NOT invalidate package cache", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
-
-      expect(mockInvalidatePackage).not.toHaveBeenCalled()
-    })
+    expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(
+      { directory: "/test" },
+      "3.5.0",
+      getToastMessage,
+    )
+    expect(mockInvalidatePackage).not.toHaveBeenCalled()
+    expect(mockRunBunInstall).not.toHaveBeenCalled()
   })
 
-  describe("#given user has NOT pinned a version (unpinned)", () => {
-    beforeEach(() => {
-      mockFindPluginEntry.mockReturnValue({
-        entry: "oh-my-opencode",
-        isPinned: false,
-        pinnedVersion: null,
-        configPath: "/test/opencode.json",
-      })
-      mockGetCachedVersion.mockReturnValue("3.4.0")
-      mockGetLatestVersion.mockResolvedValue("3.5.0")
+  it("runs auto-update for unpinned versions", async () => {
+    mockFindPluginEntry.mockReturnValue({
+      entry: "oh-my-opencode",
+      isPinned: false,
+      pinnedVersion: null,
+      configPath: "/test/opencode.json",
     })
+    mockGetCachedVersion.mockReturnValue("3.4.0")
+    mockGetLatestVersion.mockResolvedValue("3.5.0")
+    mockRunBunInstall.mockResolvedValue(true)
 
-    it("#then should proceed with auto-update", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
+    await runWithFreshModule(true, getToastMessage)
 
-      expect(mockInvalidatePackage).toHaveBeenCalled()
-      expect(mockRunBunInstall).toHaveBeenCalled()
-    })
-
-    it("#then should show auto-updated toast on success", async () => {
-      mockRunBunInstall.mockResolvedValue(true)
-
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
-
-      expect(mockShowAutoUpdatedToast).toHaveBeenCalled()
-    })
+    expect(mockInvalidatePackage).toHaveBeenCalled()
+    expect(mockRunBunInstall).toHaveBeenCalled()
+    expect(mockShowAutoUpdatedToast).toHaveBeenCalledWith(
+      { directory: "/test" },
+      "3.4.0",
+      "3.5.0",
+    )
   })
 
-  describe("#given autoUpdate is false", () => {
-    beforeEach(() => {
-      mockFindPluginEntry.mockReturnValue({
-        entry: "oh-my-opencode",
-        isPinned: false,
-        pinnedVersion: null,
-        configPath: "/test/opencode.json",
-      })
-      mockGetCachedVersion.mockReturnValue("3.4.0")
-      mockGetLatestVersion.mockResolvedValue("3.5.0")
+  it("shows update-available only when autoUpdate=false", async () => {
+    mockFindPluginEntry.mockReturnValue({
+      entry: "oh-my-opencode",
+      isPinned: false,
+      pinnedVersion: null,
+      configPath: "/test/opencode.json",
     })
+    mockGetCachedVersion.mockReturnValue("3.4.0")
+    mockGetLatestVersion.mockResolvedValue("3.5.0")
 
-    it("#then should only show notification toast", async () => {
-      await runBackgroundUpdateCheck(mockCtx, false, mockGetToastMessage)
+    await runWithFreshModule(false, getToastMessage)
 
-      expect(mockShowUpdateAvailableToast).toHaveBeenCalled()
-      expect(mockRunBunInstall).not.toHaveBeenCalled()
-      expect(mockUpdatePinnedVersion).not.toHaveBeenCalled()
-    })
+    expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(
+      { directory: "/test" },
+      "3.5.0",
+      getToastMessage,
+    )
+    expect(mockInvalidatePackage).not.toHaveBeenCalled()
+    expect(mockRunBunInstall).not.toHaveBeenCalled()
   })
 
-  describe("#given already on latest version", () => {
-    beforeEach(() => {
-      mockFindPluginEntry.mockReturnValue({
-        entry: "oh-my-opencode@3.5.0",
-        isPinned: true,
-        pinnedVersion: "3.5.0",
-        configPath: "/test/opencode.json",
-      })
-      mockGetCachedVersion.mockReturnValue("3.5.0")
-      mockGetLatestVersion.mockResolvedValue("3.5.0")
+  it("does nothing when already up to date", async () => {
+    mockFindPluginEntry.mockReturnValue({
+      entry: "oh-my-opencode@3.5.0",
+      isPinned: true,
+      pinnedVersion: "3.5.0",
+      configPath: "/test/opencode.json",
     })
+    mockGetCachedVersion.mockReturnValue("3.5.0")
+    mockGetLatestVersion.mockResolvedValue("3.5.0")
 
-    it("#then should not update or show toast", async () => {
-      await runBackgroundUpdateCheck(mockCtx, true, mockGetToastMessage)
+    await runWithFreshModule(true, getToastMessage)
 
-      expect(mockUpdatePinnedVersion).not.toHaveBeenCalled()
-      expect(mockShowUpdateAvailableToast).not.toHaveBeenCalled()
-      expect(mockShowAutoUpdatedToast).not.toHaveBeenCalled()
-    })
+    expect(mockShowUpdateAvailableToast).not.toHaveBeenCalled()
+    expect(mockShowAutoUpdatedToast).not.toHaveBeenCalled()
+    expect(mockInvalidatePackage).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/auto-update-checker/hook/background-update-check.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.ts
@@ -4,12 +4,34 @@ import { log } from "../../../shared/logger"
 import { invalidatePackage } from "../cache"
 import { PACKAGE_NAME } from "../constants"
 import { extractChannel } from "../version-channel"
-import { findPluginEntry, getCachedVersion, getLatestVersion, revertPinnedVersion } from "../checker"
+import { findPluginEntry, getCachedVersion, getLatestVersion } from "../checker"
 import { showAutoUpdatedToast, showUpdateAvailableToast } from "./update-toasts"
 
-async function runBunInstallSafe(): Promise<boolean> {
+type BackgroundUpdateCheckDeps = {
+  findPluginEntry: typeof findPluginEntry
+  getCachedVersion: typeof getCachedVersion
+  getLatestVersion: typeof getLatestVersion
+  extractChannel: typeof extractChannel
+  invalidatePackage: typeof invalidatePackage
+  runBunInstall: typeof runBunInstall
+  showUpdateAvailableToast: typeof showUpdateAvailableToast
+  showAutoUpdatedToast: typeof showAutoUpdatedToast
+}
+
+const defaultDeps: BackgroundUpdateCheckDeps = {
+  findPluginEntry,
+  getCachedVersion,
+  getLatestVersion,
+  extractChannel,
+  invalidatePackage,
+  runBunInstall,
+  showUpdateAvailableToast,
+  showAutoUpdatedToast,
+}
+
+async function runBunInstallSafe(runInstall: () => Promise<boolean>): Promise<boolean> {
   try {
-    return await runBunInstall()
+    return await runInstall()
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err)
     log("[auto-update-checker] bun install error:", errorMessage)
@@ -20,23 +42,26 @@ async function runBunInstallSafe(): Promise<boolean> {
 export async function runBackgroundUpdateCheck(
   ctx: PluginInput,
   autoUpdate: boolean,
-  getToastMessage: (isUpdate: boolean, latestVersion?: string) => string
+  getToastMessage: (isUpdate: boolean, latestVersion?: string) => string,
+  overrides?: Partial<BackgroundUpdateCheckDeps>,
 ): Promise<void> {
-  const pluginInfo = findPluginEntry(ctx.directory)
+  const deps: BackgroundUpdateCheckDeps = { ...defaultDeps, ...overrides }
+
+  const pluginInfo = deps.findPluginEntry(ctx.directory)
   if (!pluginInfo) {
     log("[auto-update-checker] Plugin not found in config")
     return
   }
 
-  const cachedVersion = getCachedVersion()
+  const cachedVersion = deps.getCachedVersion()
   const currentVersion = cachedVersion ?? pluginInfo.pinnedVersion
   if (!currentVersion) {
     log("[auto-update-checker] No version found (cached or pinned)")
     return
   }
 
-  const channel = extractChannel(pluginInfo.pinnedVersion ?? currentVersion)
-  const latestVersion = await getLatestVersion(channel)
+  const channel = deps.extractChannel(pluginInfo.pinnedVersion ?? currentVersion)
+  const latestVersion = await deps.getLatestVersion(channel)
   if (!latestVersion) {
     log("[auto-update-checker] Failed to fetch latest version for channel:", channel)
     return
@@ -50,32 +75,27 @@ export async function runBackgroundUpdateCheck(
   log(`[auto-update-checker] Update available (${channel}): ${currentVersion} → ${latestVersion}`)
 
   if (!autoUpdate) {
-    await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+    await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
     log("[auto-update-checker] Auto-update disabled, notification only")
     return
   }
 
   if (pluginInfo.isPinned) {
-    await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+    await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
     log(`[auto-update-checker] User-pinned version detected (${pluginInfo.entry}), skipping auto-update. Notification only.`)
     return
   }
 
-  invalidatePackage(PACKAGE_NAME)
+  deps.invalidatePackage(PACKAGE_NAME)
 
-  const installSuccess = await runBunInstallSafe()
+  const installSuccess = await runBunInstallSafe(deps.runBunInstall)
 
   if (installSuccess) {
-    await showAutoUpdatedToast(ctx, currentVersion, latestVersion)
+    await deps.showAutoUpdatedToast(ctx, currentVersion, latestVersion)
     log(`[auto-update-checker] Update installed: ${currentVersion} → ${latestVersion}`)
     return
   }
 
-  if (pluginInfo.isPinned) {
-    revertPinnedVersion(pluginInfo.configPath, latestVersion, pluginInfo.entry)
-    log("[auto-update-checker] Config reverted due to install failure")
-  }
-
-  await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+  await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
   log("[auto-update-checker] bun install failed; update not installed (falling back to notification-only)")
 }

--- a/src/hooks/background-tool-output-notifier/hook.ts
+++ b/src/hooks/background-tool-output-notifier/hook.ts
@@ -1,0 +1,77 @@
+import type { BackgroundTask } from "../../features/background-agent"
+
+type ToolExecuteInput = {
+  tool: string
+  sessionID: string
+  callID: string
+}
+
+type ToolExecuteOutput = {
+  title: string
+  output: string
+  metadata: unknown
+}
+
+type BackgroundNotificationStore = {
+  getPendingNotifications: (sessionID: string) => BackgroundTask[]
+  clearNotifications: (sessionID: string) => void
+}
+
+function formatStatus(task: BackgroundTask): string {
+  if (task.status === "completed") return "COMPLETED"
+  if (task.status === "interrupt") return "INTERRUPTED"
+  if (task.status === "error") return "ERROR"
+  return "CANCELLED"
+}
+
+function sanitizeTaskText(value: string | undefined, maxLength = 500): string {
+  if (!value) return ""
+
+  let sanitized = value.replace(/[\r\n]+/g, " ")
+  sanitized = sanitized.replace(/\s+/g, " ").trim()
+
+  if (sanitized.length > maxLength) {
+    return `${sanitized.slice(0, maxLength - 3)}...`
+  }
+
+  return sanitized
+}
+
+function buildNotificationBlock(tasks: BackgroundTask[]): string {
+  const lines = [
+    "[BACKGROUND TASK UPDATES]",
+    "",
+    ...tasks.map((task) => {
+      const description = sanitizeTaskText(task.description)
+      const error = sanitizeTaskText(task.error)
+      const errorSuffix = error ? ` | error: ${error}` : ""
+      return `- ${formatStatus(task)} | ${task.id} | ${description}${errorSuffix}`
+    }),
+    "",
+    "Use background_output(task_id=\"<id>\") to retrieve results.",
+  ]
+
+  return lines.join("\n")
+}
+
+export function createBackgroundToolOutputNotifierHook(backgroundManager: BackgroundNotificationStore) {
+  const toolExecuteAfter = async (
+    input: ToolExecuteInput,
+    output: ToolExecuteOutput,
+  ): Promise<void> => {
+    const notifications = backgroundManager.getPendingNotifications(input.sessionID)
+    if (notifications.length === 0) {
+      return
+    }
+
+    const block = buildNotificationBlock(notifications)
+    const current = output.output ?? ""
+    output.output = current.trim().length > 0 ? `${block}\n\n${current}` : block
+
+    backgroundManager.clearNotifications(input.sessionID)
+  }
+
+  return {
+    "tool.execute.after": toolExecuteAfter,
+  }
+}

--- a/src/hooks/background-tool-output-notifier/index.test.ts
+++ b/src/hooks/background-tool-output-notifier/index.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test"
+
+import type { BackgroundTask, BackgroundTaskStatus } from "../../features/background-agent"
+import { createBackgroundToolOutputNotifierHook } from "./hook"
+
+function createTask(args: {
+  id: string
+  description: string
+  status: BackgroundTaskStatus
+  error?: string
+}): BackgroundTask {
+  return {
+    id: args.id,
+    parentSessionID: "ses_main",
+    parentMessageID: "msg_1",
+    description: args.description,
+    prompt: "",
+    agent: "explore",
+    status: args.status,
+    ...(args.error ? { error: args.error } : {}),
+  }
+}
+
+describe("createBackgroundToolOutputNotifierHook", () => {
+  test("does nothing when no pending notifications", async () => {
+    const manager = {
+      getPendingNotifications: (_sessionID: string) => [] as BackgroundTask[],
+      clearNotifications: (_sessionID: string) => {},
+    }
+
+    const hook = createBackgroundToolOutputNotifierHook(manager)
+    const output = { title: "bash", output: "ok", metadata: {} }
+
+    await hook["tool.execute.after"]({
+      tool: "bash",
+      sessionID: "ses_main",
+      callID: "call_1",
+    }, output)
+
+    expect(output.output).toBe("ok")
+  })
+
+  test("prepends summary and clears notifications", async () => {
+    const pending = [
+      createTask({ id: "bg_1", description: "Collect API docs", status: "completed" }),
+    ]
+    const cleared: string[] = []
+
+    const manager = {
+      getPendingNotifications: (_sessionID: string) => pending,
+      clearNotifications: (sessionID: string) => {
+        cleared.push(sessionID)
+      },
+    }
+
+    const hook = createBackgroundToolOutputNotifierHook(manager)
+    const output = { title: "read", output: "result", metadata: {} }
+
+    await hook["tool.execute.after"]({
+      tool: "read",
+      sessionID: "ses_main",
+      callID: "call_2",
+    }, output)
+
+    expect(output.output.startsWith("[BACKGROUND TASK UPDATES]")).toBe(true)
+    expect(output.output).toContain("COMPLETED | bg_1 | Collect API docs")
+    expect(output.output).toContain('background_output(task_id="<id>")')
+    expect(output.output.endsWith("result")).toBe(true)
+    expect(cleared).toEqual(["ses_main"])
+  })
+
+  test("includes multiple tasks and error details", async () => {
+    const pending = [
+      createTask({ id: "bg_1", description: "Run tests", status: "completed" }),
+      createTask({ id: "bg_2", description: "Build app", status: "error", error: "Build failed" }),
+      createTask({ id: "bg_3", description: "Lint", status: "cancelled" }),
+    ]
+
+    const manager = {
+      getPendingNotifications: (_sessionID: string) => pending,
+      clearNotifications: (_sessionID: string) => {},
+    }
+
+    const hook = createBackgroundToolOutputNotifierHook(manager)
+    const output = { title: "bash", output: "done", metadata: {} }
+
+    await hook["tool.execute.after"]({
+      tool: "bash",
+      sessionID: "ses_main",
+      callID: "call_3",
+    }, output)
+
+    expect(output.output).toContain("COMPLETED | bg_1 | Run tests")
+    expect(output.output).toContain("ERROR | bg_2 | Build app | error: Build failed")
+    expect(output.output).toContain("CANCELLED | bg_3 | Lint")
+  })
+
+  test("handles empty output by writing notification block only", async () => {
+    const pending = [
+      createTask({ id: "bg_9", description: "Sync branch", status: "interrupt" }),
+    ]
+
+    const manager = {
+      getPendingNotifications: (_sessionID: string) => pending,
+      clearNotifications: (_sessionID: string) => {},
+    }
+
+    const hook = createBackgroundToolOutputNotifierHook(manager)
+    const output = { title: "task", output: "", metadata: {} }
+
+    await hook["tool.execute.after"]({
+      tool: "task",
+      sessionID: "ses_main",
+      callID: "call_4",
+    }, output)
+
+    expect(output.output.startsWith("[BACKGROUND TASK UPDATES]")).toBe(true)
+    expect(output.output).toContain("INTERRUPTED | bg_9 | Sync branch")
+  })
+
+  test("sanitizes multiline task text and truncates long fields", async () => {
+    const longSuffix = "x".repeat(800)
+    const pending = [
+      createTask({
+        id: "bg_10",
+        description: `Run\nmultiline\ttask ${longSuffix}`,
+        status: "error",
+        error: "line1\r\nline2\nline3",
+      }),
+    ]
+
+    const manager = {
+      getPendingNotifications: (_sessionID: string) => pending,
+      clearNotifications: (_sessionID: string) => {},
+    }
+
+    const hook = createBackgroundToolOutputNotifierHook(manager)
+    const output = { title: "task", output: "ok", metadata: {} }
+
+    await hook["tool.execute.after"]({
+      tool: "task",
+      sessionID: "ses_main",
+      callID: "call_5",
+    }, output)
+
+    expect(output.output).toContain("ERROR | bg_10 | Run multiline task")
+    expect(output.output).toContain("| error: line1 line2 line3")
+    expect(output.output).toContain("...")
+    expect(output.output).not.toContain("\nmultiline")
+    expect(output.output).not.toContain("\r\n")
+  })
+})

--- a/src/hooks/background-tool-output-notifier/index.ts
+++ b/src/hooks/background-tool-output-notifier/index.ts
@@ -1,0 +1,1 @@
+export { createBackgroundToolOutputNotifierHook } from "./hook"

--- a/src/hooks/comment-checker/hook.apply-patch.test.ts
+++ b/src/hooks/comment-checker/hook.apply-patch.test.ts
@@ -80,4 +80,18 @@ describe("comment-checker apply_patch integration", () => {
     // then
     expect(processApplyPatchEditsWithCli).toHaveBeenCalledTimes(0)
   })
+
+  it("returns early for non-apply_patch tools without pending call", async () => {
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "read", sessionID: "ses_test", callID: "call_without_pending" }
+    const output = {
+      title: "ok",
+      output: "x".repeat(2000),
+      metadata: {},
+    }
+
+    await hooks["tool.execute.after"](input, output)
+
+    expect(processApplyPatchEditsWithCli).toHaveBeenCalledTimes(0)
+  })
 })

--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -91,6 +91,17 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
 
       const toolLower = input.tool.toLowerCase()
 
+      const isApplyPatch = toolLower === "apply_patch"
+      let pendingCall: PendingCall | null = null
+      if (!isApplyPatch) {
+        pendingCall = takePendingCall(input.callID) ?? null
+      }
+
+      if (!isApplyPatch && !pendingCall) {
+        debugLog("no pendingCall found for:", input.callID)
+        return
+      }
+
       // Only skip if the output indicates a tool execution failure
       const outputLower = (output.output ?? "").toLowerCase()
       const isToolFailure =
@@ -116,7 +127,7 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
         ),
       })
 
-      if (toolLower === "apply_patch") {
+      if (isApplyPatch) {
         const parsed = ApplyPatchMetadataSchema.safeParse(output.metadata)
         if (!parsed.success) {
           debugLog("apply_patch metadata schema mismatch, skipping")
@@ -158,9 +169,8 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
         return
       }
 
-      const pendingCall = takePendingCall(input.callID)
       if (!pendingCall) {
-        debugLog("no pendingCall found for:", input.callID)
+        debugLog("no pendingCall available after checks")
         return
       }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,6 +17,7 @@ export { createThinkModeHook } from "./think-mode";
 export { createClaudeCodeHooksHook } from "./claude-code-hooks";
 export { createRulesInjectorHook } from "./rules-injector";
 export { createBackgroundNotificationHook } from "./background-notification"
+export { createBackgroundToolOutputNotifierHook } from "./background-tool-output-notifier"
 export { createAutoUpdateCheckerHook } from "./auto-update-checker";
 
 export { createAgentUsageReminderHook } from "./agent-usage-reminder";

--- a/src/plugin/hooks/create-continuation-hooks.ts
+++ b/src/plugin/hooks/create-continuation-hooks.ts
@@ -9,6 +9,7 @@ import {
   createCompactionContextInjector,
   createCompactionTodoPreserverHook,
   createAtlasHook,
+  createBackgroundToolOutputNotifierHook,
 } from "../../hooks"
 import { safeCreateHook } from "../../shared/safe-create-hook"
 import { createUnstableAgentBabysitter } from "../unstable-agent-babysitter"
@@ -20,6 +21,7 @@ export type ContinuationHooks = {
   todoContinuationEnforcer: ReturnType<typeof createTodoContinuationEnforcer> | null
   unstableAgentBabysitter: ReturnType<typeof createUnstableAgentBabysitter> | null
   backgroundNotificationHook: ReturnType<typeof createBackgroundNotificationHook> | null
+  backgroundToolOutputNotifier: ReturnType<typeof createBackgroundToolOutputNotifierHook> | null
   atlasHook: ReturnType<typeof createAtlasHook> | null
 }
 
@@ -100,6 +102,13 @@ export function createContinuationHooks(args: {
     ? safeHook("background-notification", () => createBackgroundNotificationHook(backgroundManager))
     : null
 
+  const backgroundToolOutputNotifier =
+    pluginConfig.experimental?.background_notifications_via_tool_output &&
+    isHookEnabled("background-tool-output-notifier")
+      ? safeHook("background-tool-output-notifier", () =>
+          createBackgroundToolOutputNotifierHook(backgroundManager))
+      : null
+
   const atlasHook = isHookEnabled("atlas")
     ? safeHook("atlas", () =>
         createAtlasHook(ctx, {
@@ -118,6 +127,7 @@ export function createContinuationHooks(args: {
     todoContinuationEnforcer,
     unstableAgentBabysitter,
     backgroundNotificationHook,
+    backgroundToolOutputNotifier,
     atlasHook,
   }
 }

--- a/src/plugin/tool-execute-after.test.ts
+++ b/src/plugin/tool-execute-after.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+
+import type { CreatedHooks } from "../create-hooks"
+import { createToolExecuteAfterHandler } from "./tool-execute-after"
+
+describe("createToolExecuteAfterHandler", () => {
+  test("runs background tool output notifier in tool.execute.after pipeline", async () => {
+    const hooks = {
+      backgroundToolOutputNotifier: {
+        "tool.execute.after": async (
+          _input: { tool: string; sessionID: string; callID: string },
+          output: { title: string; output: string; metadata: Record<string, unknown> },
+        ) => {
+          output.output = `${output.output}\n\n[BACKGROUND TASK UPDATES]`
+        },
+      },
+    } as unknown as CreatedHooks
+
+    const handler = createToolExecuteAfterHandler({ hooks })
+    const output = { title: "bash", output: "ok", metadata: {} }
+
+    await handler(
+      { tool: "bash", sessionID: "ses_main", callID: "call_1" },
+      output,
+    )
+
+    expect(output.output).toContain("[BACKGROUND TASK UPDATES]")
+  })
+
+  test("keeps output unchanged when background notifier hook is absent", async () => {
+    const hooks = {} as unknown as CreatedHooks
+    const handler = createToolExecuteAfterHandler({ hooks })
+    const output = { title: "read", output: "stable-output", metadata: {} }
+
+    await handler(
+      { tool: "read", sessionID: "ses_main", callID: "call_2" },
+      output,
+    )
+
+    expect(output.output).toBe("stable-output")
+  })
+})

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -28,9 +28,6 @@ export function createToolExecuteAfterHandler(args: {
     }
 
     await hooks.claudeCodeHooks?.["tool.execute.after"]?.(input, output)
-    await hooks.toolOutputTruncator?.["tool.execute.after"]?.(input, output)
-    await hooks.preemptiveCompaction?.["tool.execute.after"]?.(input, output)
-    await hooks.contextWindowMonitor?.["tool.execute.after"]?.(input, output)
     await hooks.commentChecker?.["tool.execute.after"]?.(input, output)
     await hooks.directoryAgentsInjector?.["tool.execute.after"]?.(input, output)
     await hooks.directoryReadmeInjector?.["tool.execute.after"]?.(input, output)
@@ -44,6 +41,10 @@ export function createToolExecuteAfterHandler(args: {
     await hooks.delegateTaskRetry?.["tool.execute.after"]?.(input, output)
     await hooks.atlasHook?.["tool.execute.after"]?.(input, output)
     await hooks.taskResumeInfo?.["tool.execute.after"]?.(input, output)
+    await hooks.backgroundToolOutputNotifier?.["tool.execute.after"]?.(input, output)
     await hooks.hashlineReadEnhancer?.["tool.execute.after"]?.(input, output)
+    await hooks.toolOutputTruncator?.["tool.execute.after"]?.(input, output)
+    await hooks.preemptiveCompaction?.["tool.execute.after"]?.(input, output)
+    await hooks.contextWindowMonitor?.["tool.execute.after"]?.(input, output)
   }
 }


### PR DESCRIPTION
## Summary
- Add an experimental alternative to the `background-notification` prompt-injection path: `experimental.background_notifications_via_tool_output`.
- When enabled, background task completion updates are appended to the next regular `tool.execute.after` output in the same session, then cleared from queue.
- Disable parent `session.prompt` injection while this mode is active, preserving toast notifications.
- Add integration coverage for the `tool.execute.after` pipeline and stabilize `background-update-check` tests so full suite remains green.

## Why
This provides a practical option for GitHub Copilot users on metered/premium plans: delegated-task status can be surfaced without synthetic reminder prompts that consume premium requests.

## Trade-off
This mode can delay agent awareness of delegated-task completion until the next tool execution in the parent session. It saves premium requests at the cost of potentially delayed status visibility.

## Config
Enable in `oh-my-opencode.jsonc`:

```json
{
  "experimental": {
    "background_notifications_via_tool_output": true
  }
}
```

## Validation
- `bun test` (full suite)
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental mode that appends background task updates to the next tool.execute.after output instead of injecting reminder prompts. Preserves updates under truncation via pipeline ordering while keeping toast notifications.

- **New Features**
  - Added experimental.background_notifications_via_tool_output to append queued updates to the next tool.execute.after output and then clear them; disables parent session prompt-injection notifications while enabled (toasts remain).
  - Introduced background-tool-output-notifier hook and wired it into the tool.execute.after pipeline; updated schema and docs.

- **Bug Fixes**
  - Reordered tool.execute.after so updates are appended before truncation/compaction/context monitoring; sanitizes multiline text, truncates long fields, and writes only the notification block when tool output is empty.
  - Auto-update checker: pinned versions and install failures now fall back to notification-only; improved dependency injection and stabilized tests with fresh module imports.
  - Comment-checker: returns early for non-apply_patch tools without a pending call to avoid unnecessary processing.

<sup>Written for commit de5c279290c71aa74168c74e1b281f3852706bb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

