### PR TITLE
fix(ralph-loop): prevent bypass via minimum work verification before accepting completion promise (#1921)

### DIFF
--- a/src/features/builtin-commands/templates/ralph-loop.ts
+++ b/src/features/builtin-commands/templates/ralph-loop.ts
@@ -10,6 +10,9 @@ export const RALPH_LOOP_TEMPLATE = `You are starting a Ralph Loop - a self-refer
 ## Rules
 
 - Focus on completing the task fully, not partially
+- **You MUST make at least one tool call before outputting the completion promise**
+- The loop will REJECT your completion promise if no tool calls (file reads, edits, commands) were detected
+- An immediate promise without work will be treated as a bypass attempt and rejected
 - Don't output the completion promise until the task is truly done
 - Each iteration should make meaningful progress toward the goal
 - If stuck, try different approaches

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -14,6 +14,20 @@ IMPORTANT:
 Original task:
 {{PROMPT}}`
 
+const NO_WORK_REJECTION_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - RALPH LOOP {{ITERATION}}/{{MAX}} - WORK REQUIRED]
+
+⚠️ Your completion promise was REJECTED because no tool calls were detected.
+
+You output <promise>{{PROMISE}}</promise> without performing any actual work (no file reads, edits, bash commands, or other tool calls).
+
+The Ralph Loop requires you to ACTUALLY WORK on the task before declaring completion. You MUST:
+1. Use tools to investigate, implement, or verify the task
+2. Make meaningful progress (read files, edit code, run commands, etc.)
+3. Only THEN output the completion promise when the task is truly done
+
+Continue working on the original task:
+{{PROMPT}}`
+
 export function buildContinuationPrompt(state: RalphLoopState): string {
 	const continuationPrompt = CONTINUATION_PROMPT.replace(
 		"{{ITERATION}}",
@@ -24,4 +38,16 @@ export function buildContinuationPrompt(state: RalphLoopState): string {
 		.replace("{{PROMPT}}", state.prompt)
 
 	return state.ultrawork ? `ultrawork ${continuationPrompt}` : continuationPrompt
+}
+
+export function buildNoWorkRejectionPrompt(state: RalphLoopState): string {
+	const rejectionPrompt = NO_WORK_REJECTION_PROMPT.replace(
+		"{{ITERATION}}",
+		String(state.iteration),
+	)
+		.replace("{{MAX}}", String(state.max_iterations))
+		.replace("{{PROMISE}}", state.completion_promise)
+		.replace("{{PROMPT}}", state.prompt)
+
+	return state.ultrawork ? `ultrawork ${rejectionPrompt}` : rejectionPrompt
 }

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -489,7 +489,14 @@ describe("ralph-loop", () => {
       // given - active loop with assistant message containing completion promise
       mockSessionMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
-        { info: { role: "assistant" }, parts: [{ type: "text", text: "I have completed the task. <promise>API_DONE</promise>" }] },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "tool_use", text: "read file" },
+            { type: "tool_result", text: "contents" },
+            { type: "text", text: "I have completed the task. <promise>API_DONE</promise>" },
+          ],
+        },
       ]
       const hook = createRalphLoopHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
@@ -510,7 +517,7 @@ describe("ralph-loop", () => {
       expect(hook.getState()).toBeNull()
 
       // then - messages API was called with correct session ID
-      expect(messagesCalls.length).toBe(1)
+      expect(messagesCalls.length).toBe(2)
       expect(messagesCalls[0].sessionID).toBe("session-123")
     })
 
@@ -519,7 +526,14 @@ describe("ralph-loop", () => {
       mockMessagesApiResponseShape = "array"
       mockSessionMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
-        { info: { role: "assistant" }, parts: [{ type: "text", text: "I have completed the task. <promise>API_DONE</promise>" }] },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "tool_use", text: "read file" },
+            { type: "tool_result", text: "contents" },
+            { type: "text", text: "I have completed the task. <promise>API_DONE</promise>" },
+          ],
+        },
       ]
       const hook = createRalphLoopHook(createMockPluginInput(), {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
@@ -540,8 +554,96 @@ describe("ralph-loop", () => {
       expect(hook.getState()).toBeNull()
 
       // then - messages API was called with correct session ID
-      expect(messagesCalls.length).toBe(1)
+      expect(messagesCalls.length).toBe(2)
       expect(messagesCalls[0].sessionID).toBe("session-123")
+    })
+
+    test("should reject completion promise when no tool calls were made (bypass prevention)", async () => {
+      // given - active loop, assistant message with promise but NO tool_use parts
+      mockSessionMessages = [
+        { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
+        { info: { role: "assistant" }, parts: [{ type: "text", text: "Done! <promise>DONE</promise>" }] },
+      ]
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
+      })
+      hook.startLoop("session-123", "Build something", { completionPromise: "DONE", maxIterations: 10 })
+
+      // when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // then - promise should be REJECTED (continuation injected instead of completion)
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("WORK REQUIRED")
+      expect(promptCalls[0].text).toContain("REJECTED")
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(false)
+      expect(hook.getState()?.iteration).toBe(2)
+    })
+
+    test("should accept completion promise when tool calls were made", async () => {
+      // given - assistant message with promise AND tool_use parts
+      mockSessionMessages = [
+        { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "tool_use", text: "read file" },
+            { type: "tool_result", text: "file contents" },
+            { type: "text", text: "Done! <promise>DONE</promise>" },
+          ],
+        },
+      ]
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
+      })
+      hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
+
+      // when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // then - promise should be ACCEPTED (work was done)
+      expect(promptCalls.length).toBe(0)
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
+      expect(hook.getState()).toBeNull()
+    })
+
+    test("should fail open when work verification API errors", async () => {
+      // given - API that throws during work verification
+      let apiCallCount = 0
+      const errorMock = createMockPluginInput()
+      Object.defineProperty(errorMock.client.session, "messages", {
+        value: async () => {
+          apiCallCount++
+          if (apiCallCount > 1) throw new Error("API error")
+          // First call for promise detection succeeds
+          return {
+            data: [
+              {
+                info: { role: "assistant" },
+                parts: [{ type: "text", text: "<promise>DONE</promise>" }],
+              },
+            ],
+          }
+        },
+      })
+      const hook = createRalphLoopHook(errorMock, {
+        getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
+        apiTimeout: 100,
+      })
+      hook.startLoop("session-123", "Build something")
+
+      // when - session goes idle (work verification will fail)
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // then - should fail open (accept the promise since we can't verify)
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
+      expect(hook.getState()).toBeNull()
     })
 
     test("should ignore completion promise in reasoning part via session messages API", async () => {
@@ -671,7 +773,14 @@ describe("ralph-loop", () => {
         { info: { role: "user" }, parts: [{ type: "text", text: "Start task" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "Working on it." }] },
         { info: { role: "user" }, parts: [{ type: "text", text: "Continue" }] },
-        { info: { role: "assistant" }, parts: [{ type: "text", text: "Nearly there... <promise>DONE</promise>" }] },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "tool_use", text: "edit file" },
+            { type: "tool_result", text: "updated" },
+            { type: "text", text: "Nearly there... <promise>DONE</promise>" },
+          ],
+        },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "(extra output after promise)" }] },
       ]
       const hook = createRalphLoopHook(createMockPluginInput(), {
@@ -972,20 +1081,14 @@ Original task: Build something`
     test("should not hang when session.messages() throws", async () => {
       // given - API that throws (simulates timeout error)
       let apiCallCount = 0
-      const errorMock = {
-        ...createMockPluginInput(),
-        client: {
-          ...createMockPluginInput().client,
-          session: {
-            ...createMockPluginInput().client.session,
-            messages: async () => {
-              apiCallCount++
-              throw new Error("API timeout")
-            },
-          },
+      const errorMock = createMockPluginInput()
+      Object.defineProperty(errorMock.client.session, "messages", {
+        value: async () => {
+          apiCallCount++
+          throw new Error("API timeout")
         },
-      }
-      const hook = createRalphLoopHook(errorMock as any, {
+      })
+      const hook = createRalphLoopHook(errorMock, {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
         apiTimeout: 100,
       })

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -4,3 +4,4 @@ export { readState, writeState, clearState, incrementIteration } from "./storage
 
 export { createRalphLoopHook } from "./ralph-loop-hook"
 export type { RalphLoopHook } from "./ralph-loop-hook"
+export { countToolCallsInCurrentIteration } from "./work-verifier"

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -6,8 +6,12 @@ import {
 	detectCompletionInSessionMessages,
 	detectCompletionInTranscript,
 } from "./completion-promise-detector"
-import { buildContinuationPrompt } from "./continuation-prompt-builder"
+import {
+	buildContinuationPrompt,
+	buildNoWorkRejectionPrompt,
+} from "./continuation-prompt-builder"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
+import { countToolCallsInCurrentIteration } from "./work-verifier"
 
 type SessionRecovery = {
 	isRecovering: (sessionID: string) => boolean
@@ -72,6 +76,66 @@ export function createRalphLoopEventHandler(
 				})
 
 			if (completionViaTranscript || completionViaApi) {
+				if (completionViaApi) {
+					const toolCallCount = await countToolCallsInCurrentIteration(ctx, {
+						sessionID,
+						apiTimeoutMs: options.apiTimeoutMs,
+						directory: options.directory,
+					})
+
+					if (toolCallCount === 0) {
+					log(`[${HOOK_NAME}] Promise detected but no tool calls found - rejecting`, {
+						sessionID,
+						iteration: state.iteration,
+						promise: state.completion_promise,
+					})
+
+						if (state.iteration >= state.max_iterations) {
+							options.loopState.clear()
+							await ctx.client.tui
+								.showToast({
+									body: {
+										title: "Ralph Loop Stopped",
+										message: `Max iterations (${state.max_iterations}) reached - promise was rejected due to no work performed`,
+										variant: "warning",
+										duration: 5000,
+									},
+								})
+								.catch(() => {})
+							return
+						}
+
+						const newState = options.loopState.incrementIteration()
+						if (!newState) return
+
+						await ctx.client.tui
+							.showToast({
+								body: {
+									title: "Ralph Loop",
+									message: `Promise rejected - no work detected. Iteration ${newState.iteration}/${newState.max_iterations}`,
+									variant: "warning",
+									duration: 3000,
+								},
+							})
+							.catch(() => {})
+
+						try {
+							await injectContinuationPrompt(ctx, {
+								sessionID,
+								prompt: buildNoWorkRejectionPrompt(newState),
+								directory: options.directory,
+								apiTimeoutMs: options.apiTimeoutMs,
+							})
+						} catch (err) {
+							log(`[${HOOK_NAME}] Failed to inject no-work rejection`, {
+								sessionID,
+								error: String(err),
+							})
+						}
+						return
+					}
+				}
+
 				log(`[${HOOK_NAME}] Completion detected!`, {
 					sessionID,
 					iteration: state.iteration,

--- a/src/hooks/ralph-loop/work-verifier.ts
+++ b/src/hooks/ralph-loop/work-verifier.ts
@@ -1,0 +1,74 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { log } from "../../shared/logger"
+import { HOOK_NAME } from "./constants"
+import { withTimeout } from "./with-timeout"
+
+interface OpenCodeSessionMessage {
+	info?: { role?: string }
+	parts?: Array<{ type: string; text?: string }>
+}
+
+export async function countToolCallsInCurrentIteration(
+	ctx: PluginInput,
+	options: {
+		sessionID: string
+		apiTimeoutMs: number
+		directory: string
+	},
+): Promise<number> {
+	try {
+		const response = await withTimeout(
+			ctx.client.session.messages({
+				path: { id: options.sessionID },
+				query: { directory: options.directory },
+			}),
+			options.apiTimeoutMs,
+		)
+
+		const messagesResponse: unknown = response
+		const responseData =
+			typeof messagesResponse === "object" && messagesResponse !== null && "data" in messagesResponse
+				? (messagesResponse as { data?: unknown }).data
+				: undefined
+
+		const messageArray: unknown[] = Array.isArray(messagesResponse)
+			? messagesResponse
+			: Array.isArray(responseData)
+				? responseData
+				: []
+
+		const messages = messageArray as OpenCodeSessionMessage[]
+		let lastUserIndex = -1
+
+		for (let i = messages.length - 1; i >= 0; i--) {
+			if (messages[i].info?.role === "user") {
+				lastUserIndex = i
+				break
+			}
+		}
+
+		let toolCallCount = 0
+		const startIndex = lastUserIndex + 1
+
+		for (let i = startIndex; i < messages.length; i++) {
+			const message = messages[i]
+			if (message.info?.role !== "assistant" || !message.parts) continue
+
+			for (const part of message.parts) {
+				if (part.type === "tool_use" || part.type === "tool_result") {
+					toolCallCount++
+				}
+			}
+		}
+
+		return toolCallCount
+	} catch (err) {
+		setTimeout(() => {
+			log(`[${HOOK_NAME}] Work verification check failed`, {
+				sessionID: options.sessionID,
+				error: String(err),
+			})
+		}, 0)
+		return -1
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1921.

- Add minimum tool-call verification before accepting completion promise — rejects zero-work bypass attempts
- Strengthen the `RALPH_LOOP_TEMPLATE` prompt with explicit anti-bypass rules
- Fail-open design: verification API errors don't block legitimate completions

---

## The Problem

AI agents can trivially bypass the Ralph Loop by immediately outputting `<promise>DONE</promise>` without performing any actual work (no tool calls, no file operations, nothing). The loop detects the promise and exits with "Task completed after 1 iteration(s)" — but zero work was done.

This is the **inverse** of #1233 (promise not detected). Here, the promise IS detected correctly — but it shouldn't be accepted because no work was performed.

## The Solution

### New: `work-verifier.ts`

`countToolCallsInCurrentIteration()` inspects the session messages for `tool_use` and `tool_result` parts in assistant messages since the last user message. Returns:
- `N > 0`: Number of tool calls found (work verified)
- `0`: No tool calls found (bypass detected)
- `-1`: API error (fail-open — don't block legitimate completions)

### Modified: `ralph-loop-event-handler.ts`

After completion promise is detected via session messages API:
1. Call `countToolCallsInCurrentIteration()` to verify work
2. If `toolCallCount === 0`: reject the promise, increment iteration, inject a "WORK REQUIRED" continuation prompt
3. If `toolCallCount > 0` or `-1` (error): accept the promise normally

Transcript-detected completions skip the work check — transcript entries already contain tool_result data proving work was done.

### Modified: `continuation-prompt-builder.ts`

New `buildNoWorkRejectionPrompt()` that explicitly tells the agent its promise was rejected because no tool calls were detected, and instructs it to actually work before declaring completion.

### Modified: `ralph-loop.ts` template

Added three anti-bypass rules to the prompt template:
```
- **You MUST make at least one tool call before outputting the completion promise**
- The loop will REJECT your completion promise if no tool calls (file reads, edits, commands) were detected
- An immediate promise without work will be treated as a bypass attempt and rejected
```

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Work check only for API-detected completions | Transcript completions already contain tool_result entries |
| Fail-open on API error (`-1`) | Don't block legitimate completions due to transient API failures |
| Count since last user message | Current iteration only — previous iterations' work doesn't count |
| Both `tool_use` and `tool_result` counted | Different API response shapes may include either |

## Tests

3 new test cases added (43 total, 0 failures):

| Test | What it verifies |
|------|-----------------|
| `should reject completion promise when no tool calls were made (bypass prevention)` | Promise with text-only response → rejected, continuation injected with "WORK REQUIRED" |
| `should accept completion promise when tool calls were made` | Promise with tool_use parts → accepted normally |
| `should fail open when work verification API errors` | API error during verification → promise accepted (fail-open) |

```
bun test v1.3.9
 43 pass
 0 fail
 126 expect() calls
```

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/ralph-loop/work-verifier.ts` | **New** — tool call counting logic |
| `src/hooks/ralph-loop/ralph-loop-event-handler.ts` | **Modified** — integrate work verification |
| `src/hooks/ralph-loop/continuation-prompt-builder.ts` | **Modified** — add no-work rejection prompt |
| `src/hooks/ralph-loop/index.ts` | **Modified** — re-export work-verifier |
| `src/hooks/ralph-loop/index.test.ts` | **Modified** — 3 new test cases |
| `src/features/builtin-commands/templates/ralph-loop.ts` | **Modified** — anti-bypass rules in template |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Ralph Loop bypasses by requiring at least one tool call before accepting a completion promise. Closes #1921 by rejecting zero‑work “DONE” outputs.

- **Bug Fixes**
  - Verify minimum work on API-detected completions; reject if no tool_use/tool_result since the last user message.
  - Inject a “WORK REQUIRED” continuation and increment the iteration on rejection; stop at max iterations with a warning.
  - Fail-open on verification API errors to avoid blocking legitimate completions.
  - Skip verification for transcript-based completions (work already proven).

- **New Features**
  - Added work-verifier.ts to count tool calls in the current iteration.
  - Added buildNoWorkRejectionPrompt to guide the agent after a rejected promise.
  - Strengthened RALPH_LOOP_TEMPLATE with explicit anti-bypass rules.

<sup>Written for commit 29203b485caa3304dae01944a5f331060e3caf49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

