### PR TITLE
fix: retain original agent keys in remapAgentKeysToDisplayNames

### DIFF
--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -12,10 +12,10 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then known agents get display name keys
+    // then known agents get display name keys, and original keys are preserved
     expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
     expect(result["oracle"]).toBeDefined()
-    expect(result["sisyphus"]).toBeUndefined()
+    expect(result["sisyphus"]).toBeDefined()
   })
 
   it("preserves unknown agent keys unchanged", () => {
@@ -46,15 +46,20 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then all get display name keys
-    expect(Object.keys(result)).toEqual([
-      "Sisyphus (Ultraworker)",
-      "Hephaestus (Deep Agent)",
-      "Prometheus (Plan Builder)",
-      "Atlas (Plan Executor)",
-      "Metis (Plan Consultant)",
-      "Momus (Plan Critic)",
-      "Sisyphus-Junior",
-    ])
+    // then all get display name keys while preserving original keys
+    expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
+    expect(result["sisyphus"]).toBeDefined()
+    expect(result["Hephaestus (Deep Agent)"]).toBeDefined()
+    expect(result["hephaestus"]).toBeDefined()
+    expect(result["Prometheus (Plan Builder)"]).toBeDefined()
+    expect(result["prometheus"]).toBeDefined()
+    expect(result["Atlas (Plan Executor)"]).toBeDefined()
+    expect(result["atlas"]).toBeDefined()
+    expect(result["Metis (Plan Consultant)"]).toBeDefined()
+    expect(result["metis"]).toBeDefined()
+    expect(result["Momus (Plan Critic)"]).toBeDefined()
+    expect(result["momus"]).toBeDefined()
+    expect(result["Sisyphus-Junior"]).toBeDefined()
+    expect(result["sisyphus-junior"]).toBeDefined()
   })
 })

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -9,6 +9,7 @@ export function remapAgentKeysToDisplayNames(
     const displayName = AGENT_DISPLAY_NAMES[key]
     if (displayName && displayName !== key) {
       result[displayName] = value
+      result[key] = value
     } else {
       result[key] = value
     }


### PR DESCRIPTION
## Summary

- Fixes `remapAgentKeysToDisplayNames()` dropping original agent keys, which causes upstream opencode's `Agent.get()` to return `undefined` → `TypeError: undefined is not an object (evaluating 'agent.name')`
- Both display name and original key are now preserved in the agent map

Fixes #1922

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves original agent keys when remapping to display names so Agent.get() can look up by the original key without crashing. The agent map now contains both the display name and original key for each known agent.

- **Bug Fixes**
  - remapAgentKeysToDisplayNames now adds both display name and original key entries; unknown keys remain unchanged.
  - Updated tests to assert presence of both keys.
  - Fixes #1922.

<sup>Written for commit 996554981c66e7bf644718c1ecb28c6cc35fdd5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

