### PR TITLE
fix: replace non-existent gpt-5.3-codex with gpt-5.2-codex in fallback chains

### DIFF
--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -209,35 +209,35 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
 })
 
 describe("CATEGORY_MODEL_REQUIREMENTS", () => {
-  test("ultrabrain has valid fallbackChain with gpt-5.3-codex as primary", () => {
+  test("ultrabrain has valid fallbackChain with gpt-5.2-codex as primary", () => {
     // given - ultrabrain category requirement
     const ultrabrain = CATEGORY_MODEL_REQUIREMENTS["ultrabrain"]
 
     // when - accessing ultrabrain requirement
-    // then - fallbackChain exists with gpt-5.3-codex as first entry
+    // then - fallbackChain exists with gpt-5.2-codex as first entry
     expect(ultrabrain).toBeDefined()
     expect(ultrabrain.fallbackChain).toBeArray()
     expect(ultrabrain.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = ultrabrain.fallbackChain[0]
     expect(primary.variant).toBe("xhigh")
-    expect(primary.model).toBe("gpt-5.3-codex")
+    expect(primary.model).toBe("gpt-5.2-codex")
     expect(primary.providers[0]).toBe("openai")
   })
 
-  test("deep has valid fallbackChain with gpt-5.3-codex as primary", () => {
+  test("deep has valid fallbackChain with gpt-5.2-codex as primary", () => {
     // given - deep category requirement
     const deep = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
     // when - accessing deep requirement
-    // then - fallbackChain exists with gpt-5.3-codex as first entry, medium variant
+    // then - fallbackChain exists with gpt-5.2-codex as first entry, medium variant
     expect(deep).toBeDefined()
     expect(deep.fallbackChain).toBeArray()
     expect(deep.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = deep.fallbackChain[0]
     expect(primary.variant).toBe("medium")
-    expect(primary.model).toBe("gpt-5.3-codex")
+    expect(primary.model).toBe("gpt-5.2-codex")
     expect(primary.providers[0]).toBe("openai")
   })
 
@@ -477,12 +477,12 @@ describe("ModelRequirement type", () => {
 })
 
 describe("requiresModel field in categories", () => {
-  test("deep category has requiresModel set to gpt-5.3-codex", () => {
+  test("deep category has requiresModel set to gpt-5.2-codex", () => {
     // given
     const deep = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
     // when / #then
-    expect(deep.requiresModel).toBe("gpt-5.3-codex")
+    expect(deep.requiresModel).toBe("gpt-5.2-codex")
   })
 
   test("artistry category has requiresModel set to gemini-3-pro", () => {

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -25,7 +25,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
     ],
     requiresProvider: ["openai", "github-copilot", "opencode"],
   },
@@ -108,18 +108,18 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   ultrabrain: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "xhigh" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],
   },
   deep: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
-    requiresModel: "gpt-5.3-codex",
+    requiresModel: "gpt-5.2-codex",
   },
   artistry: {
     fallbackChain: [
@@ -139,7 +139,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "unspecified-low": {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
     ],
   },


### PR DESCRIPTION
## Summary

- `gpt-5.3-codex` does not exist on the GitHub Copilot provider (only `gpt-5.2-codex` is available), causing model resolution failures for users who rely on GitHub Copilot as their provider.

## Problem

The following agents/categories reference `gpt-5.3-codex` which isn't available:
- **hephaestus agent** — sole fallback model, so the agent never activates
- **ultrabrain category** — first fallback fails
- **deep category** — first fallback fails AND `requiresModel: "gpt-5.3-codex"` prevents the entire category from activating
- **unspecified-low category** — second fallback fails

## Fix

Replace all 5 occurrences of `gpt-5.3-codex` with `gpt-5.2-codex` (the latest available codex model on GitHub Copilot) in `model-requirements.ts` and update corresponding test assertions.

## Changes

- `src/shared/model-requirements.ts` — 5 replacements (hephaestus fallback, ultrabrain fallback, deep fallback + requiresModel, unspecified-low fallback)
- `src/shared/model-requirements.test.ts` — Updated test descriptions and assertions to match

## Verification

- All 28 tests in `model-requirements.test.ts` pass
- `bun run build` succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced references to gpt-5.3-codex with gpt-5.2-codex to restore model resolution on the GitHub Copilot provider. This fixes activation for affected agents and categories.

- **Bug Fixes**
  - Updated fallback chains and requiresModel for hephaestus, ultrabrain, deep, and unspecified-low to use gpt-5.2-codex.
  - Adjusted unit tests to reflect the new model.
  - All model-requirements tests pass; build succeeds.

<sup>Written for commit 22031af408200546b7e4b68303c67b2ed173672b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

