### PR TITLE
fix(config): respect user's external_directory permission setting

### DIFF
--- a/src/cli/run/events.test.ts
+++ b/src/cli/run/events.test.ts
@@ -318,14 +318,8 @@ describe("event handling", () => {
     // given
     const ctx = createMockContext("my-session")
     const state: EventState = {
+      ...createEventState(),
       mainSessionIdle: true,
-      mainSessionError: false,
-      lastError: null,
-      lastOutput: "",
-      lastPartText: "",
-      currentTool: null,
-      hasReceivedMeaningfulWork: false,
-      messageCount: 0,
     }
 
     const payload: EventPayload = {

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -99,9 +99,9 @@ export function applyToolConfig(params: {
   }
 
   params.config.permission = {
-    ...(params.config.permission as Record<string, unknown>),
     webfetch: "allow",
     external_directory: "allow",
+    ...(params.config.permission as Record<string, unknown>),
     task: "deny",
   };
 }


### PR DESCRIPTION
## Summary

- Fixes `applyToolConfig()` forcibly overriding the user's `external_directory` permission to `"allow"`, making it impossible to configure `"ask"` or `"deny"` for external directory access.

## Problem

In `src/plugin-handlers/tool-config-handler.ts`, the permission object was constructed by spreading the user's config first, then overwriting with OMO defaults:

```typescript
params.config.permission = {
  ...(params.config.permission as Record<string, unknown>),
  webfetch: "allow",
  external_directory: "allow",   // forcibly overrides user config
  task: "deny",
};
```

Since `external_directory: "allow"` came **after** the user spread, any user setting (e.g., `"ask"` or `"deny"`) was silently discarded.

## Fix

Reorder so OMO defaults come first and the user config spreads on top:

```typescript
params.config.permission = {
  webfetch: "allow",             // OMO default (overridable)
  external_directory: "allow",   // OMO default (overridable)
  ...(params.config.permission as Record<string, unknown>),  // user wins
  task: "deny",                  // forced after spread (security)
};
```

- `webfetch` and `external_directory` are now defaults that users can override
- `task: "deny"` remains forced after the spread for security (prevents agents from self-granting task permissions globally)

## Testing

- `bun test src/plugin-handlers/config-handler.test.ts` — **39 pass, 0 fail**
- LSP diagnostics clean

Closes #1973

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respects the user's external_directory permission by reordering applyToolConfig: set OMO defaults first, then merge the user's settings; task remains forced to "deny" for security. Updates the session.status test to spread createEventState() so new required EventState fields are included.

<sup>Written for commit 8d66ab742bab6ed4bac977eaa0c99c4544da4eab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

