### PR TITLE
fix(installer): write unpinned plugin entry to enable auto-update

### DIFF
--- a/src/cli/config-manager.test.ts
+++ b/src/cli/config-manager.test.ts
@@ -58,7 +58,7 @@ describe("getPluginNameWithVersion", () => {
     expect(result).toBe("oh-my-opencode@next")
   })
 
-  test("returns pinned version when no tag matches", async () => {
+  test("returns unpinned package name when no tag matches", async () => {
     // #given npm dist-tags with beta=3.0.0-beta.3
     globalThis.fetch = mock(() =>
       Promise.resolve({
@@ -70,22 +70,22 @@ describe("getPluginNameWithVersion", () => {
     // #when current version is old beta 3.0.0-beta.2
     const result = await getPluginNameWithVersion("3.0.0-beta.2")
 
-    // #then should pin to specific version
-    expect(result).toBe("oh-my-opencode@3.0.0-beta.2")
+    // #then should return unpinned package name for auto-update
+    expect(result).toBe("oh-my-opencode")
   })
 
-  test("returns pinned version when fetch fails", async () => {
+  test("returns unpinned package name when fetch fails", async () => {
     // #given network failure
     globalThis.fetch = mock(() => Promise.reject(new Error("Network error"))) as unknown as typeof fetch
 
     // #when current version is 3.0.0-beta.3
     const result = await getPluginNameWithVersion("3.0.0-beta.3")
 
-    // #then should fall back to pinned version
-    expect(result).toBe("oh-my-opencode@3.0.0-beta.3")
+    // #then should fall back to unpinned package name for auto-update
+    expect(result).toBe("oh-my-opencode")
   })
 
-  test("returns pinned version when npm returns non-ok response", async () => {
+  test("returns unpinned package name when npm returns non-ok response", async () => {
     // #given npm returns 404
     globalThis.fetch = mock(() =>
       Promise.resolve({
@@ -97,8 +97,8 @@ describe("getPluginNameWithVersion", () => {
     // #when current version is 2.14.0
     const result = await getPluginNameWithVersion("2.14.0")
 
-    // #then should fall back to pinned version
-    expect(result).toBe("oh-my-opencode@2.14.0")
+    // #then should fall back to unpinned package name for auto-update
+    expect(result).toBe("oh-my-opencode")
   })
 
   test("prioritizes latest over other tags when version matches multiple", async () => {

--- a/src/cli/config-manager/plugin-name-with-version.ts
+++ b/src/cli/config-manager/plugin-name-with-version.ts
@@ -15,5 +15,5 @@ export async function getPluginNameWithVersion(currentVersion: string): Promise<
     }
   }
 
-  return `${PACKAGE_NAME}@${currentVersion}`
+  return PACKAGE_NAME
 }

--- a/src/cli/config-manager/plugin-name-with-version.ts
+++ b/src/cli/config-manager/plugin-name-with-version.ts
@@ -15,5 +15,15 @@ export async function getPluginNameWithVersion(currentVersion: string): Promise<
     }
   }
 
+  const prereleaseChannel = extractPrereleaseChannel(currentVersion)
+  if (prereleaseChannel) {
+    return `${PACKAGE_NAME}@${prereleaseChannel}`
+  }
+
   return PACKAGE_NAME
+}
+
+function extractPrereleaseChannel(version: string): string | null {
+  const match = version.match(/^\d+\.\d+\.\d+-([a-z]+)/)
+  return match ? match[1] : null
 }

--- a/src/cli/run/events.test.ts
+++ b/src/cli/run/events.test.ts
@@ -312,14 +312,8 @@ describe("event handling", () => {
     // given
     const ctx = createMockContext("my-session")
     const state: EventState = {
+      ...createEventState(),
       mainSessionIdle: true,
-      mainSessionError: false,
-      lastError: null,
-      lastOutput: "",
-      lastPartText: "",
-      currentTool: null,
-      hasReceivedMeaningfulWork: false,
-      messageCount: 0,
     }
 
     const payload: EventPayload = {


### PR DESCRIPTION
## Summary

- Fixes installer-pinned versions being treated as user-pinned, preventing auto-update for all installer users.

## Problem

The installer's `getPluginNameWithVersion()` function tries to resolve the current version to a dist tag (like `latest`). When this fails — due to network errors, npm outages, or the version not matching any tag — it falls back to writing an exact version:

```typescript
return `${PACKAGE_NAME}@${currentVersion}`  // e.g., "oh-my-opencode@3.5.2"
```

The auto-updater in `plugin-entry.ts` then sees:
```typescript
const isPinned = pinnedVersion !== "latest"  // "3.5.2" !== "latest" → true
```

Since `isPinned = true`, the auto-updater skips the update entirely, only showing a misleading "Restart to apply" toast that does nothing.

**Timeline:**
| Issue | Effect |
|-------|--------|
| #402 | Auto-update implemented (overwrites all versions) |
| #1745 | Overwrite bug fixed by skipping `isPinned=true` |
| **#1920** | Side effect: installer-pinned users also skipped |

## Fix

Change the fallback in `getPluginNameWithVersion()` to return the bare package name:

```typescript
// Before:
return `${PACKAGE_NAME}@${currentVersion}`  // "oh-my-opencode@3.5.2"

// After:
return PACKAGE_NAME  // "oh-my-opencode"
```

The `findPluginEntry()` function already handles bare entries correctly:
```typescript
if (entry === PACKAGE_NAME) {
  return { entry, isPinned: false, pinnedVersion: null, configPath }
}
```

**Result:**
- Installer users → `oh-my-opencode` (unpinned) → auto-update works
- Manual pinners → `oh-my-opencode@3.5.2` (pinned) → still respected
- Tag-matched installs → `oh-my-opencode@latest` (unpinned) → auto-update works

## Testing

- `bun test src/cli/config-manager.test.ts` — **19 pass, 0 fail** (3 test expectations updated)
- `bun test src/hooks/auto-update-checker/` — **41 pass, 0 fail**
- LSP diagnostics clean

Closes #1920

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the installer fallback to restore auto-update for all users and preserves prerelease channels when dist-tag lookup fails, so beta/next users stay on their track.

- **Bug Fixes**
  - getPluginNameWithVersion now falls back to PACKAGE_NAME for stable versions; for prerelease versions, it falls back to PACKAGE_NAME@channel (e.g., beta/next).
  - Manual pinned versions are still respected.
  - Tests updated: config-manager expectations reflect the new fallback, and session.status uses createEventState() to satisfy new required fields.

<sup>Written for commit 778a72e97aedf227cf0faf6c06826c80a127818e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

