### PR TITLE
fix(hashline-edit): guard context.metadata call for SDK compatibility

### DIFF
--- a/src/tools/hashline-edit/tools.ts
+++ b/src/tools/hashline-edit/tools.ts
@@ -179,7 +179,9 @@ Use \\n in text to represent literal newlines.`,
           },
         }
 
-        context.metadata(meta)
+        if ("metadata" in context && typeof context.metadata === "function") {
+          context.metadata(meta)
+        }
 
         const callID = resolveToolCallID(context)
         if (callID) {


### PR DESCRIPTION
## Summary

- Fixes typecheck failure on dev: `Property 'metadata' does not exist on type 'ToolContext'`

## Problem

`context.metadata()` was added in commit `3adade46` but `ToolContext` from `@opencode-ai/plugin` does not include a `metadata` method in its type definition:

```typescript
// @opencode-ai/plugin/tool.d.ts
export type ToolContext = {
    sessionID: string;
    messageID: string;
    agent: string;
    abort: AbortSignal;
};
```

This causes `tsc --noEmit` to fail, blocking all CI typecheck jobs on dev and any PR branches.

## Fix

Add a runtime guard before calling `context.metadata()`:

```typescript
// Before:
context.metadata(meta)

// After:
if ("metadata" in context && typeof context.metadata === "function") {
  context.metadata(meta)
}
```

This preserves the runtime behavior (OpenCode extends `ToolContext` with `metadata` at runtime) while satisfying TypeScript's type checker.

## Testing

- `bun run typecheck` — **passes** (was failing before)
- `bun test src/tools/hashline-edit/` — **63 pass, 0 fail**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the context.metadata() call in hashline-edit tools to align with @opencode-ai/plugin ToolContext and fix TypeScript typecheck failures. This keeps metadata behavior when available and unblocks CI on dev.

- **Bug Fixes**
  - Call metadata only when present and a function on context.
  - Resolves the TypeScript error where ToolContext lacks metadata.
  - Typecheck and hashline-edit tests now pass.

<sup>Written for commit 922498301b800aee579b1e3f60e40cc20dd463f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

