### PR TITLE
feat(hooks): strip ANSI escape sequences from tool results in messages.transform

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -50,6 +50,8 @@ export const HookNameSchema = z.enum([
   "anthropic-effort",
   "hashline-read-enhancer",
   "read-image-resizer",
+  "hashline-edit-diff-enhancer",
+  "ansi-stripper",
 ])
 
 export type HookName = z.infer<typeof HookNameSchema>

--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -50,7 +50,6 @@ export const HookNameSchema = z.enum([
   "anthropic-effort",
   "hashline-read-enhancer",
   "read-image-resizer",
-  "hashline-edit-diff-enhancer",
   "ansi-stripper",
 ])
 

--- a/src/hooks/ansi-stripper/hook.ts
+++ b/src/hooks/ansi-stripper/hook.ts
@@ -1,0 +1,56 @@
+import type { Message, Part } from "@opencode-ai/sdk"
+
+import { stripAnsi } from "./strip-ansi"
+
+interface MessageWithParts {
+  info: Message
+  parts: Part[]
+}
+
+interface SDKToolPart {
+  type: string
+  state?: {
+    output?: string
+    error?: string
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+type MessagesTransformHook = {
+  "experimental.chat.messages.transform"?: (
+    input: Record<string, never>,
+    output: { messages: MessageWithParts[] },
+  ) => Promise<void>
+}
+
+function stripToolPartAnsi(part: SDKToolPart): void {
+  if (!part.state) return
+
+  if (typeof part.state.output === "string") {
+    part.state.output = stripAnsi(part.state.output)
+  }
+  if (typeof part.state.error === "string") {
+    part.state.error = stripAnsi(part.state.error)
+  }
+}
+
+export function createAnsiStripperHook(): MessagesTransformHook {
+  return {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const { messages } = output
+      if (!messages || messages.length === 0) return
+
+      for (const msg of messages) {
+        if (!msg.parts) continue
+
+        for (const part of msg.parts) {
+          const type = part.type as string
+          if (type === "tool" || type === "tool_use") {
+            stripToolPartAnsi(part as unknown as SDKToolPart)
+          }
+        }
+      }
+    },
+  }
+}

--- a/src/hooks/ansi-stripper/hook.ts
+++ b/src/hooks/ansi-stripper/hook.ts
@@ -1,20 +1,10 @@
-import type { Message, Part } from "@opencode-ai/sdk"
+import type { Message, Part, ToolPart } from "@opencode-ai/sdk"
 
 import { stripAnsi } from "./strip-ansi"
 
 interface MessageWithParts {
   info: Message
   parts: Part[]
-}
-
-interface SDKToolPart {
-  type: string
-  state?: {
-    output?: string
-    error?: string
-    [key: string]: unknown
-  }
-  [key: string]: unknown
 }
 
 type MessagesTransformHook = {
@@ -24,13 +14,10 @@ type MessagesTransformHook = {
   ) => Promise<void>
 }
 
-function stripToolPartAnsi(part: SDKToolPart): void {
-  if (!part.state) return
-
-  if (typeof part.state.output === "string") {
+function stripToolPartAnsi(part: ToolPart): void {
+  if (part.state.status === "completed") {
     part.state.output = stripAnsi(part.state.output)
-  }
-  if (typeof part.state.error === "string") {
+  } else if (part.state.status === "error") {
     part.state.error = stripAnsi(part.state.error)
   }
 }
@@ -45,9 +32,8 @@ export function createAnsiStripperHook(): MessagesTransformHook {
         if (!msg.parts) continue
 
         for (const part of msg.parts) {
-          const type = part.type as string
-          if (type === "tool" || type === "tool_use") {
-            stripToolPartAnsi(part as unknown as SDKToolPart)
+          if (part.type === "tool") {
+            stripToolPartAnsi(part)
           }
         }
       }

--- a/src/hooks/ansi-stripper/index.ts
+++ b/src/hooks/ansi-stripper/index.ts
@@ -1,0 +1,1 @@
+export { createAnsiStripperHook } from "./hook"

--- a/src/hooks/ansi-stripper/strip-ansi.test.ts
+++ b/src/hooks/ansi-stripper/strip-ansi.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "bun:test"
+
+import { stripAnsi, containsAnsi } from "./strip-ansi"
+
+describe("stripAnsi", () => {
+  it("removes basic color codes", () => {
+    // given
+    const input = "\x1b[31mERROR\x1b[0m: something failed"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("ERROR: something failed")
+  })
+
+  it("removes bold and underline codes", () => {
+    // given
+    const input = "\x1b[1mBold\x1b[22m \x1b[4mUnderline\x1b[24m"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("Bold Underline")
+  })
+
+  it("removes 256-color codes", () => {
+    // given
+    const input = "\x1b[38;5;196mRed text\x1b[0m"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("Red text")
+  })
+
+  it("removes RGB color codes", () => {
+    // given
+    const input = "\x1b[38;2;255;0;0mRed\x1b[0m"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("Red")
+  })
+
+  it("returns plain text unchanged", () => {
+    // given
+    const input = "no ansi codes here"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("no ansi codes here")
+  })
+
+  it("returns empty string unchanged", () => {
+    // given / when
+    const result = stripAnsi("")
+
+    // then
+    expect(result).toBe("")
+  })
+
+  it("handles multiple escape sequences in one line", () => {
+    // given
+    const input = "\x1b[32m✓\x1b[0m \x1b[2mtest passed\x1b[22m in \x1b[33m5ms\x1b[0m"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("✓ test passed in 5ms")
+  })
+
+  it("strips cursor movement sequences", () => {
+    // given
+    const input = "\x1b[2Ahello\x1b[K"
+
+    // when
+    const result = stripAnsi(input)
+
+    // then
+    expect(result).toBe("hello")
+  })
+})
+
+describe("containsAnsi", () => {
+  it("returns true for text with ANSI codes", () => {
+    expect(containsAnsi("\x1b[31mred\x1b[0m")).toBe(true)
+  })
+
+  it("returns false for plain text", () => {
+    expect(containsAnsi("plain text")).toBe(false)
+  })
+
+  it("returns false for empty string", () => {
+    expect(containsAnsi("")).toBe(false)
+  })
+})

--- a/src/hooks/ansi-stripper/strip-ansi.ts
+++ b/src/hooks/ansi-stripper/strip-ansi.ts
@@ -1,10 +1,10 @@
-const ANSI_REGEX =
+const ANSI_PATTERN =
   /[\x1b\x9b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
 
 export function stripAnsi(text: string): string {
-  return text.replace(ANSI_REGEX, "")
+  return text.replace(ANSI_PATTERN, "")
 }
 
 export function containsAnsi(text: string): boolean {
-  return ANSI_REGEX.test(text)
+  return /[\x1b\x9b]/.test(text)
 }

--- a/src/hooks/ansi-stripper/strip-ansi.ts
+++ b/src/hooks/ansi-stripper/strip-ansi.ts
@@ -1,0 +1,10 @@
+const ANSI_REGEX =
+  /[\x1b\x9b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, "")
+}
+
+export function containsAnsi(text: string): boolean {
+  return ANSI_REGEX.test(text)
+}

--- a/src/hooks/ansi-stripper/strip-ansi.ts
+++ b/src/hooks/ansi-stripper/strip-ansi.ts
@@ -2,6 +2,7 @@ const ANSI_PATTERN =
   /[\x1b\x9b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
 
 export function stripAnsi(text: string): string {
+  ANSI_PATTERN.lastIndex = 0
   return text.replace(ANSI_PATTERN, "")
 }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -51,3 +51,5 @@ export { createWriteExistingFileGuardHook } from "./write-existing-file-guard";
 export { createHashlineReadEnhancerHook } from "./hashline-read-enhancer";
 export { createJsonErrorRecoveryHook, JSON_ERROR_TOOL_EXCLUDE_LIST, JSON_ERROR_PATTERNS, JSON_ERROR_REMINDER } from "./json-error-recovery";
 export { createReadImageResizerHook } from "./read-image-resizer"
+export { createHashlineEditDiffEnhancerHook } from "./hashline-edit-diff-enhancer";
+export { createAnsiStripperHook } from "./ansi-stripper";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -51,5 +51,4 @@ export { createWriteExistingFileGuardHook } from "./write-existing-file-guard";
 export { createHashlineReadEnhancerHook } from "./hashline-read-enhancer";
 export { createJsonErrorRecoveryHook, JSON_ERROR_TOOL_EXCLUDE_LIST, JSON_ERROR_PATTERNS, JSON_ERROR_REMINDER } from "./json-error-recovery";
 export { createReadImageResizerHook } from "./read-image-resizer"
-export { createHashlineEditDiffEnhancerHook } from "./hashline-edit-diff-enhancer";
 export { createAnsiStripperHook } from "./ansi-stripper";

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -5,6 +5,7 @@ import {
   createClaudeCodeHooksHook,
   createKeywordDetectorHook,
   createThinkingBlockValidatorHook,
+  createAnsiStripperHook,
 } from "../../hooks"
 import {
   contextCollector,
@@ -17,6 +18,7 @@ export type TransformHooks = {
   keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null
   contextInjectorMessagesTransform: ReturnType<typeof createContextInjectorMessagesTransformHook>
   thinkingBlockValidator: ReturnType<typeof createThinkingBlockValidatorHook> | null
+  ansiStripper: ReturnType<typeof createAnsiStripperHook> | null
 }
 
 export function createTransformHooks(args: {
@@ -63,10 +65,19 @@ export function createTransformHooks(args: {
       )
     : null
 
+  const ansiStripper = isHookEnabled("ansi-stripper")
+    ? safeCreateHook(
+        "ansi-stripper",
+        () => createAnsiStripperHook(),
+        { enabled: safeHookEnabled },
+      )
+    : null
+
   return {
     claudeCodeHooks,
     keywordDetector,
     contextInjectorMessagesTransform,
     thinkingBlockValidator,
+    ansiStripper,
   }
 }

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -20,5 +20,9 @@ export function createMessagesTransformHandler(args: {
     await args.hooks.thinkingBlockValidator?.[
       "experimental.chat.messages.transform"
     ]?.(input, output)
+
+    await args.hooks.ansiStripper?.[
+      "experimental.chat.messages.transform"
+    ]?.(input, output)
   }
 }


### PR DESCRIPTION
## Summary

Closes #1796

Add a new `ansi-stripper` transform hook that strips ANSI escape sequences (color codes, cursor movement, etc.) from tool result outputs before they enter the LLM context window.

## Problem

Tool outputs (e.g., from Bash, test runners, build tools) often contain ANSI escape sequences for terminal coloring. These raw escape codes waste context window tokens and can confuse the model's understanding of the output.

## Solution

- **`src/hooks/ansi-stripper/strip-ansi.ts`** — Pure function to strip ANSI escape sequences using a comprehensive regex covering SGR, cursor movement, 256-color, and RGB codes
- **`src/hooks/ansi-stripper/hook.ts`** — Transform hook that iterates over all `tool`/`tool_use` parts in messages and strips ANSI from `state.output` and `state.error` fields
- **`src/hooks/ansi-stripper/index.ts`** — Barrel export
- **`src/hooks/ansi-stripper/strip-ansi.test.ts`** — 11 tests covering basic colors, bold/underline, 256-color, RGB, cursor movement, multi-sequence lines, and edge cases

## Registration

- Added `"ansi-stripper"` to `HookNameSchema` in `src/config/schema/hooks.ts`
- Registered in `src/plugin/hooks/create-transform-hooks.ts` with `safeCreateHook` + `isHookEnabled` gate
- Invoked in `src/plugin/messages-transform.ts` after `thinkingBlockValidator`
- Exported from `src/hooks/index.ts`

The hook is **enabled by default** and can be disabled via `disabled_hooks: ["ansi-stripper"]` in config.

## Testing

- 11 unit tests pass (strip-ansi.test.ts)
- TypeScript typecheck passes
- All existing tests unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips ANSI escape sequences from tool_result parts during messages.transform to reduce token waste and prevent garbled text in the LLM context.

- **New Features**
  - Added `ansi-stripper` transform that cleans ANSI codes from tool parts (`state.output`, `state.error`); enabled by default (disable via `disabled_hooks: ["ansi-stripper"]`).

- **Bug Fixes**
  - Reset regex lastIndex before replace and use a non-global `containsAnsi` regex to avoid stateful `/g` issues.
  - Use `state.status` discriminant with SDK `ToolPart` for safe field access.
  - Removed stale `hashline-edit-diff-enhancer` references.

<sup>Written for commit abd22c55c669aabae18f8c3cdb6376c4edf5698e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

