### PR TITLE
fix: add Antigravity proxy model entries to HIGH_VARIANT_MAP

### DIFF
--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -109,6 +109,13 @@ const HIGH_VARIANT_MAP: Record<string, string> = {
   "gpt-5-2": "gpt-5-2-high",
   "gpt-5-2-chat-latest": "gpt-5-2-chat-latest-high",
   "gpt-5-2-pro": "gpt-5-2-pro-high",
+  // Antigravity (opencode-antigravity-auth) — proxy models routed through google provider
+  "antigravity-gemini-3-flash": "antigravity-gemini-3-flash-high",
+  "antigravity-gemini-3-pro": "antigravity-gemini-3-pro-high",
+  "antigravity-gemini-3-pro-low": "antigravity-gemini-3-pro-high",
+  "antigravity-gemini-3-1-pro": "antigravity-gemini-3-1-pro-high",
+  "antigravity-gemini-3-1-pro-low": "antigravity-gemini-3-1-pro-high",
+  "antigravity-claude-opus-4-6-thinking": "antigravity-claude-opus-4-6-thinking-high",
 }
 
 const ALREADY_HIGH: Set<string> = new Set(Object.values(HIGH_VARIANT_MAP))


### PR DESCRIPTION
## Summary

Fixes #1992

The `opencode-antigravity-auth` plugin routes models through the `google` provider with an `antigravity-` prefix. After `extractModelPrefix()`, the base becomes e.g. `antigravity-gemini-3-flash`, which has no entry in `HIGH_VARIANT_MAP` — so `getHighVariant()` always returns `null` for these models, and think-mode keywords never trigger model upgrades.

### Changes

Added 6 entries to `HIGH_VARIANT_MAP` for Antigravity models:

| Base model | High variant |
|---|---|
| `antigravity-gemini-3-flash` | `antigravity-gemini-3-flash-high` |
| `antigravity-gemini-3-pro` | `antigravity-gemini-3-pro-high` |
| `antigravity-gemini-3-pro-low` | `antigravity-gemini-3-pro-high` |
| `antigravity-gemini-3-1-pro` | `antigravity-gemini-3-1-pro-high` |
| `antigravity-gemini-3-1-pro-low` | `antigravity-gemini-3-1-pro-high` |
| `antigravity-claude-opus-4-6-thinking` | `antigravity-claude-opus-4-6-thinking-high` |

### Design notes

- **Sonnet 4.6 intentionally excluded**: The Antigravity platform does not support extended thinking for Claude Sonnet 4.6 — injecting `thinkingLevel: "HIGH"` causes API errors.
- **`getThinkingConfig()` already works**: Since Antigravity Gemini base names contain `"gemini-3"`, they match `THINKING_CAPABLE_MODELS.google` patterns without changes. Only `HIGH_VARIANT_MAP` needs the new entries.
- **Long-term suggestion**: A more scalable approach might be to strip known proxy prefixes (like `antigravity-`) before lookup, so new Antigravity models are automatically supported. Happy to implement this if preferred.

## Test plan

- [x] Verified `getHighVariant("google/antigravity-gemini-3-flash")` returns `"google/antigravity-gemini-3-flash-high"`
- [x] Verified `getHighVariant("google/antigravity-gemini-3.1-pro")` returns `"google/antigravity-gemini-3-1-pro-high"` (dot normalization works)
- [x] Verified `getHighVariant("google/antigravity-claude-opus-4-6-thinking")` returns `"google/antigravity-claude-opus-4-6-thinking-high"`
- [x] Verified `getHighVariant("google/antigravity-claude-sonnet-4-6")` returns `null` (correct — no entry)
- [x] Verified `getHighVariant("google/antigravity-gemini-3-flash-high")` returns `null` (already high)
- [x] Verified existing non-antigravity models still work correctly
- [x] Verified `getThinkingConfig()` injects Google thinking config for Antigravity Gemini models
- [x] Verified `getThinkingConfig()` does NOT inject config for Antigravity Claude models (safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores think‑mode upgrades for Antigravity proxy models by adding them to HIGH_VARIANT_MAP. Gemini 3 and Claude Opus models routed via opencode-antigravity-auth now auto-upgrade when think keywords are present.

- **Bug Fixes**
  - Added high-variant mappings for antigravity-gemini-3-(flash|pro|3-1-pro) (including -low) and antigravity-claude-opus-4-6-thinking.
  - Intentionally excluded Claude Sonnet 4.6 (Antigravity doesn’t support extended thinking).

<sup>Written for commit d815d9b1dff76f72d4dd8773f5a31919063ec644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

