### PR TITLE
feat(cli): add --project flag for project-level config generation

### DIFF
--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -100,7 +100,7 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
   }
 
   printStep(step++, totalSteps, "Writing oh-my-opencode configuration...")
-  const omoResult = writeOmoConfig(config)
+  const omoResult = writeOmoConfig(config, { project: config.project })
   if (!omoResult.success) {
     printError(`Failed: ${omoResult.error}`)
     return 1

--- a/src/cli/cli-program.test.ts
+++ b/src/cli/cli-program.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const INSTALL_ARGS = [
+  "install",
+  "--no-tui",
+  "--claude=yes",
+  "--gemini=no",
+  "--copilot=no",
+  "--openai=no",
+  "--opencode-zen=no",
+  "--zai-coding-plan=no",
+  "--kimi-for-coding=no",
+  "--skip-auth",
+]
+
+const CLI_ENTRY = fileURLToPath(new URL("./index.ts", import.meta.url))
+
+function getSpawnEnv(globalDir: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value
+    }
+  }
+  env.OPENCODE_CONFIG_DIR = globalDir
+  return env
+}
+
+function runInstall(extraArgs: string[], installArgs: string[] = INSTALL_ARGS): {
+  tempDir: string
+  globalConfigPath: string
+  globalOpenCodeConfigPath: string
+  projectConfigPath: string
+  exitCode: number
+} {
+  const tempDir = join(tmpdir(), `omo-cli-program-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  const projectDir = join(tempDir, "project")
+  const globalDir = join(tempDir, "global")
+  const globalConfigPath = join(globalDir, "oh-my-opencode.json")
+  const globalOpenCodeConfigPath = join(globalDir, "opencode.json")
+  const projectConfigPath = join(projectDir, ".opencode", "oh-my-opencode.json")
+
+  mkdirSync(projectDir, { recursive: true })
+
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, CLI_ENTRY, ...installArgs, ...extraArgs],
+    cwd: projectDir,
+    env: getSpawnEnv(globalDir),
+    stdout: "ignore",
+    stderr: "pipe",
+  })
+
+  return {
+    tempDir,
+    globalConfigPath,
+    globalOpenCodeConfigPath,
+    projectConfigPath,
+    exitCode: result.exitCode,
+  }
+}
+
+describe("cli-program install options", () => {
+  it("parses --project for install command", () => {
+    // #given install command with --project
+    const result = runInstall(["--project"])
+
+    try {
+      // #then writes project-level config and exits successfully
+      expect(result.exitCode).toBe(0)
+      expect(existsSync(result.projectConfigPath)).toBe(true)
+      expect(existsSync(result.globalConfigPath)).toBe(false)
+      expect(existsSync(result.globalOpenCodeConfigPath)).toBe(true)
+
+      const openCodeConfig = JSON.parse(readFileSync(result.globalOpenCodeConfigPath, "utf-8")) as {
+        plugin?: string[]
+      }
+      expect(openCodeConfig.plugin?.some((plugin) => plugin.startsWith("oh-my-opencode"))).toBe(true)
+    } finally {
+      rmSync(result.tempDir, { recursive: true, force: true })
+    }
+  }, { timeout: 20000 })
+
+  it("keeps provider configuration in global opencode.json when --project is enabled", () => {
+    // #given install command with --project and Gemini enabled
+    const geminiInstallArgs = INSTALL_ARGS.map((arg) => (arg === "--gemini=no" ? "--gemini=yes" : arg))
+    const result = runInstall(["--project"], geminiInstallArgs)
+
+    try {
+      // #then provider config is written to global opencode config
+      expect(result.exitCode).toBe(0)
+      expect(existsSync(result.projectConfigPath)).toBe(true)
+      expect(existsSync(result.globalOpenCodeConfigPath)).toBe(true)
+
+      const openCodeConfig = JSON.parse(readFileSync(result.globalOpenCodeConfigPath, "utf-8")) as {
+        provider?: Record<string, unknown>
+      }
+      expect(openCodeConfig.provider).toHaveProperty("google")
+    } finally {
+      rmSync(result.tempDir, { recursive: true, force: true })
+    }
+  }, { timeout: 20000 })
+})

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -24,6 +24,7 @@ program
   .command("install")
   .description("Install and configure oh-my-opencode with interactive setup")
   .option("--no-tui", "Run in non-interactive mode (requires all options)")
+  .option("--project", "Write config to .opencode/oh-my-opencode.json in the current directory instead of global config")
   .option("--claude <value>", "Claude subscription: no, yes, max20")
   .option("--openai <value>", "OpenAI/ChatGPT subscription: no, yes (default: no)")
   .option("--gemini <value>", "Gemini integration: no, yes")
@@ -50,6 +51,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   .action(async (options) => {
     const args: InstallArgs = {
       tui: options.tui !== false,
+      project: options.project ?? false,
       claude: options.claude,
       openai: options.openai,
       gemini: options.gemini,

--- a/src/cli/config-manager/write-omo-config.test.ts
+++ b/src/cli/config-manager/write-omo-config.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { getProjectOmoConfigPath } from "../../shared"
+import type { InstallConfig } from "../types"
+import { getOmoConfigPath, initConfigContext, resetConfigContext } from "./config-context"
+import { writeOmoConfig } from "./write-omo-config"
+
+describe("writeOmoConfig", () => {
+  let tempRoot: string
+  let projectDir: string
+  let globalConfigDir: string
+  let originalCwd: string
+  let originalConfigDir: string | undefined
+
+  const baseInstallConfig: InstallConfig = {
+    project: false,
+    hasClaude: true,
+    isMax20: false,
+    hasOpenAI: false,
+    hasGemini: false,
+    hasCopilot: false,
+    hasOpencodeZen: false,
+    hasZaiCodingPlan: false,
+    hasKimiForCoding: false,
+  }
+
+  beforeEach(() => {
+    tempRoot = join(tmpdir(), `omo-write-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    projectDir = join(tempRoot, "project")
+    globalConfigDir = join(tempRoot, "global")
+    mkdirSync(projectDir, { recursive: true })
+
+    originalCwd = process.cwd()
+    originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+
+    process.chdir(projectDir)
+    process.env.OPENCODE_CONFIG_DIR = globalConfigDir
+    resetConfigContext()
+    initConfigContext("opencode", null)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+
+    if (originalConfigDir !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
+
+    resetConfigContext()
+
+    if (existsSync(tempRoot)) {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("writes project config and creates the .opencode directory when missing", () => {
+    // #given no .opencode directory exists yet
+    const projectConfigPath = getProjectOmoConfigPath()
+    expect(existsSync(join(projectDir, ".opencode"))).toBe(false)
+
+    // #when writing in project mode
+    const result = writeOmoConfig(baseInstallConfig, { project: true })
+
+    // #then writes to project config path
+    expect(result.success).toBe(true)
+    expect(result.configPath).toBe(projectConfigPath)
+    expect(existsSync(projectConfigPath)).toBe(true)
+
+    const parsed = JSON.parse(readFileSync(projectConfigPath, "utf-8")) as Record<string, unknown>
+    expect(parsed).toHaveProperty("$schema")
+  })
+
+  it("does not modify global config when project mode is enabled", () => {
+    // #given an existing global config file
+    mkdirSync(globalConfigDir, { recursive: true })
+    const globalConfigPath = getOmoConfigPath()
+    const originalGlobal = '{\n  "custom": "keep"\n}\n'
+    writeFileSync(globalConfigPath, originalGlobal)
+
+    // #when writing in project mode
+    const result = writeOmoConfig(baseInstallConfig, { project: true })
+
+    // #then global config remains unchanged
+    expect(result.success).toBe(true)
+    expect(readFileSync(globalConfigPath, "utf-8")).toBe(originalGlobal)
+  })
+
+  it("writes to global config when project mode is disabled", () => {
+    // #given no existing config files
+    const globalConfigPath = getOmoConfigPath()
+    const projectConfigPath = getProjectOmoConfigPath()
+    expect(existsSync(globalConfigPath)).toBe(false)
+    expect(existsSync(projectConfigPath)).toBe(false)
+
+    // #when writing with default mode
+    const result = writeOmoConfig(baseInstallConfig)
+
+    // #then writes global config and does not create project config
+    expect(result.success).toBe(true)
+    expect(result.configPath).toBe(globalConfigPath)
+    expect(existsSync(globalConfigPath)).toBe(true)
+    expect(existsSync(projectConfigPath)).toBe(false)
+  })
+})

--- a/src/cli/config-manager/write-omo-config.ts
+++ b/src/cli/config-manager/write-omo-config.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { parseJsonc } from "../../shared"
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+import { getProjectOmoConfigPath, parseJsonc } from "../../shared"
 import type { ConfigMergeResult, InstallConfig } from "../types"
 import { getConfigDir, getOmoConfigPath } from "./config-context"
 import { deepMergeRecord } from "./deep-merge-record"
@@ -11,18 +12,32 @@ function isEmptyOrWhitespace(content: string): boolean {
   return content.trim().length === 0
 }
 
-export function writeOmoConfig(installConfig: InstallConfig): ConfigMergeResult {
+export interface WriteOmoConfigOptions {
+  project?: boolean
+}
+
+function getTargetPath(installConfig: InstallConfig, options?: WriteOmoConfigOptions): string {
+  const shouldWriteProject = options?.project ?? installConfig.project ?? false
+  return shouldWriteProject ? getProjectOmoConfigPath() : getOmoConfigPath()
+}
+
+export function writeOmoConfig(installConfig: InstallConfig, options?: WriteOmoConfigOptions): ConfigMergeResult {
+  const omoConfigPath = getTargetPath(installConfig, options)
+  const shouldWriteProject = options?.project ?? installConfig.project ?? false
+
   try {
-    ensureConfigDirectoryExists()
+    if (shouldWriteProject) {
+      mkdirSync(dirname(omoConfigPath), { recursive: true })
+    } else {
+      ensureConfigDirectoryExists()
+    }
   } catch (err) {
     return {
       success: false,
-      configPath: getConfigDir(),
+      configPath: shouldWriteProject ? dirname(omoConfigPath) : getConfigDir(),
       error: formatErrorWithSuggestion(err, "create config directory"),
     }
   }
-
-  const omoConfigPath = getOmoConfigPath()
 
   try {
     const newConfig = generateOmoConfig(installConfig)

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -152,6 +152,7 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
 
 export function argsToConfig(args: InstallArgs): InstallConfig {
   return {
+    project: args.project ?? false,
     hasClaude: args.claude !== "no",
     isMax20: args.claude === "max20",
     hasOpenAI: args.openai === "yes",

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -45,6 +45,32 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   const config = await promptInstallConfig(detected)
   if (!config) return 1
 
+  const configScope = await p.select<"global" | "project">({
+    message: "Where should model assignments be saved?",
+    options: [
+      {
+        value: "global",
+        label: "Global",
+        hint: "~/.config/opencode/oh-my-opencode.json",
+      },
+      {
+        value: "project",
+        label: "Project",
+        hint: ".opencode/oh-my-opencode.json in current directory",
+      },
+    ],
+    initialValue: args.project ? "project" : "global",
+  })
+  if (p.isCancel(configScope)) {
+    p.cancel("Installation cancelled.")
+    return 1
+  }
+
+  const installConfig = {
+    ...config,
+    project: configScope === "project",
+  }
+
   spinner.start("Adding oh-my-opencode to OpenCode config")
   const pluginResult = await addPluginToOpenCodeConfig(version)
   if (!pluginResult.success) {
@@ -54,9 +80,9 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   }
   spinner.stop(`Plugin added to ${color.cyan(pluginResult.configPath)}`)
 
-  if (config.hasGemini) {
+  if (installConfig.hasGemini) {
     spinner.start("Adding auth plugins (fetching latest versions)")
-    const authResult = await addAuthPlugins(config)
+    const authResult = await addAuthPlugins(installConfig)
     if (!authResult.success) {
       spinner.stop(`Failed to add auth plugins: ${authResult.error}`)
       p.outro(color.red("Installation failed."))
@@ -65,7 +91,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     spinner.stop(`Auth plugins added to ${color.cyan(authResult.configPath)}`)
 
     spinner.start("Adding provider configurations")
-    const providerResult = addProviderConfig(config)
+    const providerResult = addProviderConfig(installConfig)
     if (!providerResult.success) {
       spinner.stop(`Failed to add provider config: ${providerResult.error}`)
       p.outro(color.red("Installation failed."))
@@ -75,7 +101,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   }
 
   spinner.start("Writing oh-my-opencode configuration")
-  const omoResult = writeOmoConfig(config)
+  const omoResult = writeOmoConfig(installConfig, { project: installConfig.project })
   if (!omoResult.success) {
     spinner.stop(`Failed to write config: ${omoResult.error}`)
     p.outro(color.red("Installation failed."))
@@ -83,7 +109,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   }
   spinner.stop(`Config written to ${color.cyan(omoResult.configPath)}`)
 
-  if (!config.hasClaude) {
+  if (!installConfig.hasClaude) {
     console.log()
     console.log(color.bgRed(color.white(color.bold(" CRITICAL WARNING "))))
     console.log()
@@ -97,11 +123,17 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     console.log()
   }
 
-  if (!config.hasClaude && !config.hasOpenAI && !config.hasGemini && !config.hasCopilot && !config.hasOpencodeZen) {
+  if (
+    !installConfig.hasClaude &&
+    !installConfig.hasOpenAI &&
+    !installConfig.hasGemini &&
+    !installConfig.hasCopilot &&
+    !installConfig.hasOpencodeZen
+  ) {
     p.log.warn("No model providers configured. Using opencode/big-pickle as fallback.")
   }
 
-  p.note(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")
+  p.note(formatConfigSummary(installConfig), isUpdate ? "Updated Configuration" : "Installation Complete")
 
   p.log.success(color.bold(isUpdate ? "Configuration updated!" : "Installation complete!"))
   p.log.message(`Run ${color.cyan("opencode")} to start!`)
@@ -120,11 +152,11 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
 
   p.outro(color.green("oMoMoMoMo... Enjoy!"))
 
-  if ((config.hasClaude || config.hasGemini || config.hasCopilot) && !args.skipAuth) {
+  if ((installConfig.hasClaude || installConfig.hasGemini || installConfig.hasCopilot) && !args.skipAuth) {
     const providers: string[] = []
-    if (config.hasClaude) providers.push(`Anthropic ${color.gray("→ Claude Pro/Max")}`)
-    if (config.hasGemini) providers.push(`Google ${color.gray("→ OAuth with Antigravity")}`)
-    if (config.hasCopilot) providers.push(`GitHub ${color.gray("→ Copilot")}`)
+    if (installConfig.hasClaude) providers.push(`Anthropic ${color.gray("→ Claude Pro/Max")}`)
+    if (installConfig.hasGemini) providers.push(`Google ${color.gray("→ OAuth with Antigravity")}`)
+    if (installConfig.hasCopilot) providers.push(`GitHub ${color.gray("→ Copilot")}`)
 
     console.log()
     console.log(color.bold("Authenticate Your Providers"))

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -3,6 +3,7 @@ export type BooleanArg = "no" | "yes"
 
 export interface InstallArgs {
   tui: boolean
+  project?: boolean
   claude?: ClaudeSubscription
   openai?: BooleanArg
   gemini?: BooleanArg
@@ -14,6 +15,7 @@ export interface InstallArgs {
 }
 
 export interface InstallConfig {
+  project?: boolean
   hasClaude: boolean
   isMax20: boolean
   hasOpenAI: boolean

--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path"
 import {
   getOpenCodeConfigDir,
   getOpenCodeConfigPaths,
+  getProjectOmoConfigPath,
   isDevBuild,
   detectExistingConfigDir,
   TAURI_APP_IDENTIFIER,
@@ -289,6 +290,19 @@ describe("opencode-config-dir", () => {
       expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"))
       expect(paths.packageJson).toBe(join(expectedDir, "package.json"))
       expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-opencode.json"))
+    })
+  })
+
+  describe("getProjectOmoConfigPath", () => {
+    test("returns .opencode/oh-my-opencode.json in the provided directory", () => {
+      // given a project directory
+      const projectDir = "/tmp/my-project"
+
+      // when resolving the project config path
+      const result = getProjectOmoConfigPath(projectDir)
+
+      // then returns the project-level config location
+      expect(result).toBe(join(projectDir, ".opencode", "oh-my-opencode.json"))
     })
   })
 

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -136,3 +136,7 @@ export function detectExistingConfigDir(binary: OpenCodeBinaryType, version?: st
 
   return null
 }
+
+export function getProjectOmoConfigPath(directory: string = process.cwd()): string {
+  return join(directory, ".opencode", "oh-my-opencode.json")
+}


### PR DESCRIPTION
## Summary

- Adds `--project` flag to the installer that writes model assignments to `.opencode/oh-my-opencode.json` in the current directory instead of `~/.config/opencode/oh-my-opencode.json`
- Plugin registration and provider configs remain global (only model assignments go project-level)
- TUI installer gets a "Global vs Project" scope prompt when running interactively
- Creates `.opencode/` directory automatically if it doesn't exist

Closes #2022

## Changes

| File | Change |
|------|--------|
| `src/cli/types.ts` | Added `project?: boolean` to `InstallArgs` and `InstallConfig` |
| `src/cli/cli-program.ts` | Added `--project` option to install command |
| `src/shared/opencode-config-dir.ts` | Added `getProjectOmoConfigPath()` helper |
| `src/cli/install-validators.ts` | Threaded `project` flag through `argsToConfig()` |
| `src/cli/config-manager/write-omo-config.ts` | Added `WriteOmoConfigOptions`, project path routing, `.opencode/` dir creation |
| `src/cli/cli-installer.ts` | Passed `{ project }` to `writeOmoConfig()` |
| `src/cli/tui-installer.ts` | Added interactive config scope prompt (Global/Project) |

## Usage

```bash
# Non-interactive: generate project-level config
bunx oh-my-opencode install --project --no-tui --claude=max20 --gemini=yes

# Interactive: prompted to choose Global vs Project
bunx oh-my-opencode install --project
```

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] New unit tests for `writeOmoConfig` project mode (3 tests)
- [x] New integration tests for `--project` CLI flag (2 tests)
- [x] New unit test for `getProjectOmoConfigPath` helper
- [x] Verified `--project` writes to `.opencode/oh-my-opencode.json` in CWD
- [x] Verified global `oh-my-opencode.json` is NOT modified with `--project`
- [x] Verified plugin registration in global `opencode.json` still happens with `--project`
- [x] Verified install without `--project` still writes to global config (no regression)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --project flag to the CLI installer to save model assignments to .opencode/oh-my-opencode.json in the current project. Enables per-project agent config while keeping plugins/providers global, aligning with Linear #2022.

- **New Features**
  - --project routes writeOmoConfig to the project path and auto-creates .opencode/.
  - TUI adds a Global vs Project scope prompt; preselects Project when --project is passed.
  - Provider configs and plugin registration remain in the global opencode.json.

- **Migration**
  - Non-interactive: bunx oh-my-opencode install --project --no-tui …
  - Interactive: bunx oh-my-opencode install and choose Project when prompted.

<sup>Written for commit 0352ae75f32b01abe1cd53f1ca415de83f33b1de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

