### PR TITLE
feat(cli): add local model provider support (LMStudio, Ollama, vLLM)

### DIFF
--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -1,5 +1,7 @@
 import color from "picocolors"
 import type { InstallArgs } from "./types"
+import { mapProbeResultsToLocalProviderModels } from "./local-model-capabilities"
+import { probeLocalProviders } from "./local-provider-probe"
 import {
   addAuthPlugins,
   addPluginToOpenCodeConfig,
@@ -24,6 +26,12 @@ import {
   validateNonTuiArgs,
 } from "./install-validators"
 
+function localProviderLabel(provider: "lmstudio" | "ollama" | "vllm"): string {
+  if (provider === "lmstudio") return "LMStudio"
+  if (provider === "vllm") return "vLLM"
+  return "Ollama"
+}
+
 export async function runCliInstaller(args: InstallArgs, version: string): Promise<number> {
   const validation = validateNonTuiArgs(args)
   if (!validation.valid) {
@@ -34,7 +42,7 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     }
     console.log()
     printInfo(
-      "Usage: bunx oh-my-opencode install --no-tui --claude=<no|yes|max20> --gemini=<no|yes> --copilot=<no|yes>",
+      "Usage: bunx oh-my-opencode install --no-tui --claude=<no|yes|max20> [provider options]",
     )
     console.log()
     return 1
@@ -67,6 +75,34 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
 
   const config = argsToConfig(args)
 
+  printStep(step++, totalSteps, "Probing local model providers...")
+  if (config.hasLmstudio || config.hasOllama || config.hasVllm) {
+    const probeResults = await probeLocalProviders({
+      lmstudioUrl: config.lmstudioUrl,
+      ollamaUrl: config.ollamaUrl,
+      vllmUrl: config.vllmUrl,
+    })
+
+    config.localProviderModels = mapProbeResultsToLocalProviderModels(probeResults)
+
+    for (const result of probeResults) {
+      const label = localProviderLabel(result.provider)
+      if (result.warning) {
+        printWarning(`${label} probe failed (${result.url}): ${result.warning}`)
+        continue
+      }
+
+      if (result.models.length === 0) {
+        printWarning(`${label} probe returned no models (${result.url})`)
+      } else {
+        const preview = result.models.slice(0, 3).map((model) => model.id).join(", ")
+        printSuccess(`${label}: found ${result.models.length} model(s)${preview ? ` (${preview})` : ""}`)
+      }
+    }
+  } else {
+    printInfo("No local provider URLs provided. Skipping local probe.")
+  }
+
   printStep(step++, totalSteps, "Adding oh-my-opencode plugin...")
   const pluginResult = await addPluginToOpenCodeConfig(version)
   if (!pluginResult.success) {
@@ -77,9 +113,10 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     `Plugin ${isUpdate ? "verified" : "added"} ${SYMBOLS.arrow} ${color.dim(pluginResult.configPath)}`,
   )
 
-  const needsProviderSetup = config.hasGemini || config.hasOpenAI || config.hasCopilot
+  const needsAuthSetup = config.hasGemini || config.hasOpenAI || config.hasCopilot
+  const needsProviderSetup = needsAuthSetup || config.hasLmstudio || config.hasOllama || config.hasVllm
 
-  if (needsProviderSetup) {
+  if (needsAuthSetup) {
     printStep(step++, totalSteps, "Adding auth plugins...")
     const authResult = await addAuthPlugins(config)
     if (!authResult.success) {
@@ -87,7 +124,12 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
       return 1
     }
     printSuccess(`Auth plugins configured ${SYMBOLS.arrow} ${color.dim(authResult.configPath)}`)
+  } else {
+    printStep(step++, totalSteps, "Skipping auth plugins...")
+    printInfo("No cloud provider auth plugins required.")
+  }
 
+  if (needsProviderSetup) {
     printStep(step++, totalSteps, "Adding provider configurations...")
     const providerResult = addProviderConfig(config)
     if (!providerResult.success) {
@@ -96,7 +138,8 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     }
     printSuccess(`Providers configured ${SYMBOLS.arrow} ${color.dim(providerResult.configPath)}`)
   } else {
-    step += 2
+    printStep(step++, totalSteps, "Skipping provider configurations...")
+    printInfo("No provider configuration changes required.")
   }
 
   printStep(step++, totalSteps, "Writing oh-my-opencode configuration...")
@@ -128,7 +171,10 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     !config.hasOpenAI &&
     !config.hasGemini &&
     !config.hasCopilot &&
-    !config.hasOpencodeZen
+    !config.hasOpencodeZen &&
+    !config.hasLmstudio &&
+    !config.hasOllama &&
+    !config.hasVllm
   ) {
     printWarning("No model providers configured. Using opencode/big-pickle as fallback.")
   }

--- a/src/cli/cli-program.test.ts
+++ b/src/cli/cli-program.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+
+describe("cli-program install command flags", () => {
+  const originalArgv = [...process.argv]
+
+  afterEach(() => {
+    process.argv = [...originalArgv]
+    mock.restore()
+  })
+
+  async function runInstallCommandAndCaptureArgs(argv: string[]): Promise<Record<string, unknown>> {
+    const installMock = mock(async () => 0)
+    mock.module("./install", () => ({ install: installMock }))
+
+    const exitCodes: number[] = []
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0)
+      return undefined as never
+    }) as never)
+
+    process.argv = ["bun", "oh-my-opencode", ...argv]
+
+    const { runCli } = await import(`./cli-program?test=${Date.now()}-${Math.random()}`)
+
+    runCli()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    exitSpy.mockRestore()
+    expect(exitCodes).toEqual([0])
+    expect(installMock).toHaveBeenCalledTimes(1)
+    return installMock.mock.calls[0][0] as Record<string, unknown>
+  }
+
+  it("parses --lmstudio URL value", async () => {
+    //#given / #when
+    const parsedArgs = await runInstallCommandAndCaptureArgs([
+      "install",
+      "--no-tui",
+      "--claude=yes",
+      "--openai=no",
+      "--gemini=no",
+      "--copilot=no",
+      "--opencode-zen=no",
+      "--zai-coding-plan=no",
+      "--kimi-for-coding=no",
+      "--lmstudio=http://localhost:1234/v1",
+    ])
+
+    //#then
+    expect(parsedArgs.lmstudio).toBe("http://localhost:1234/v1")
+  })
+
+  it("parses --ollama URL value", async () => {
+    //#given / #when
+    const parsedArgs = await runInstallCommandAndCaptureArgs([
+      "install",
+      "--no-tui",
+      "--claude=yes",
+      "--openai=no",
+      "--gemini=no",
+      "--copilot=no",
+      "--opencode-zen=no",
+      "--zai-coding-plan=no",
+      "--kimi-for-coding=no",
+      "--ollama=http://localhost:11434",
+    ])
+
+    //#then
+    expect(parsedArgs.ollama).toBe("http://localhost:11434")
+  })
+
+  it("parses --vllm URL value", async () => {
+    //#given / #when
+    const parsedArgs = await runInstallCommandAndCaptureArgs([
+      "install",
+      "--no-tui",
+      "--claude=yes",
+      "--openai=no",
+      "--gemini=no",
+      "--copilot=no",
+      "--opencode-zen=no",
+      "--zai-coding-plan=no",
+      "--kimi-for-coding=no",
+      "--vllm=http://localhost:8000/v1",
+    ])
+
+    //#then
+    expect(parsedArgs.vllm).toBe("http://localhost:8000/v1")
+  })
+
+  it("keeps local provider args undefined when local flags are omitted", async () => {
+    //#given / #when
+    const parsedArgs = await runInstallCommandAndCaptureArgs([
+      "install",
+      "--no-tui",
+      "--claude=yes",
+      "--openai=no",
+      "--gemini=no",
+      "--copilot=no",
+      "--opencode-zen=no",
+      "--zai-coding-plan=no",
+      "--kimi-for-coding=no",
+    ])
+
+    //#then
+    expect(parsedArgs.lmstudio).toBeUndefined()
+    expect(parsedArgs.ollama).toBeUndefined()
+    expect(parsedArgs.vllm).toBeUndefined()
+  })
+})

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -23,7 +23,7 @@ program
 program
   .command("install")
   .description("Install and configure oh-my-opencode with interactive setup")
-  .option("--no-tui", "Run in non-interactive mode (requires all options)")
+  .option("--no-tui", "Run in non-interactive mode")
   .option("--claude <value>", "Claude subscription: no, yes, max20")
   .option("--openai <value>", "OpenAI/ChatGPT subscription: no, yes (default: no)")
   .option("--gemini <value>", "Gemini integration: no, yes")
@@ -31,14 +31,18 @@ program
   .option("--opencode-zen <value>", "OpenCode Zen access: no, yes (default: no)")
   .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
   .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
+  .option("--lmstudio <url>", "LMStudio endpoint URL (e.g., http://localhost:1234/v1)")
+  .option("--ollama <url>", "Ollama endpoint URL (e.g., http://localhost:11434)")
+  .option("--vllm <url>", "vLLM endpoint URL (e.g., http://localhost:8000/v1)")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
   $ bunx oh-my-opencode install
   $ bunx oh-my-opencode install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no
   $ bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes --opencode-zen=yes
+  $ bunx oh-my-opencode install --no-tui --claude=yes --gemini=no --copilot=no --lmstudio=http://localhost:1234/v1
 
-Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
+Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Local):
   Claude        Native anthropic/ models (Opus, Sonnet, Haiku)
   OpenAI        Native openai/ models (GPT-5.2 for Oracle)
   Gemini        Native google/ models (Gemini 3 Pro, Flash)
@@ -46,6 +50,9 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)
   Kimi          kimi-for-coding/k2p5 (Sisyphus/Prometheus fallback)
+  LMStudio      lmstudio/ models (local low-priority fallback)
+  Ollama        ollama/ models (local low-priority fallback)
+  vLLM          vllm/ models (local low-priority fallback)
 `)
   .action(async (options) => {
     const args: InstallArgs = {
@@ -57,6 +64,9 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
       opencodeZen: options.opencodeZen,
       zaiCodingPlan: options.zaiCodingPlan,
       kimiForCoding: options.kimiForCoding,
+      lmstudio: options.lmstudio,
+      ollama: options.ollama,
+      vllm: options.vllm,
       skipAuth: options.skipAuth ?? false,
     }
     const exitCode = await install(args)

--- a/src/cli/config-manager.test.ts
+++ b/src/cli/config-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, mock, afterEach } from "bun:test"
 
 import { ANTIGRAVITY_PROVIDER_CONFIG, getPluginNameWithVersion, fetchNpmDistTags, generateOmoConfig } from "./config-manager"
 import type { InstallConfig } from "./types"
+import { createEmptyLocalProviderModels } from "./local-model-capabilities"
 
 describe("getPluginNameWithVersion", () => {
   const originalFetch = globalThis.fetch
@@ -251,6 +252,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config
@@ -271,6 +276,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config
@@ -292,6 +301,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: true,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config
@@ -314,6 +327,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config
@@ -338,6 +355,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config
@@ -358,6 +379,10 @@ describe("generateOmoConfig - model fallback system", () => {
       hasOpencodeZen: false,
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+      localProviderModels: createEmptyLocalProviderModels(),
     }
 
     // #when generating config

--- a/src/cli/config-manager/add-provider-config.test.ts
+++ b/src/cli/config-manager/add-provider-config.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { modifyProviderInJsonc } from "./jsonc-provider-editor"
 import { parseJsonc } from "../../shared/jsonc-parser"
+import { addProviderConfig } from "./add-provider-config"
+import { resetConfigContext } from "./config-context"
+import type { InstallConfig } from "../types"
+import { createEmptyLocalProviderModels } from "../local-model-capabilities"
 
 describe("modifyProviderInJsonc", () => {
   describe("Test 1: Basic JSONC with existing provider", () => {
@@ -201,5 +208,150 @@ describe("modifyProviderInJsonc", () => {
       expect(parsed).toHaveProperty('plugin')
       expect(parsed.plugin).toEqual(['foo'])
     })
+  })
+})
+
+function createInstallConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
+  return {
+    hasClaude: false,
+    isMax20: false,
+    hasOpenAI: false,
+    hasGemini: false,
+    hasCopilot: false,
+    hasOpencodeZen: false,
+    hasZaiCodingPlan: false,
+    hasKimiForCoding: false,
+    hasLmstudio: false,
+    hasOllama: false,
+    hasVllm: false,
+    localProviderModels: createEmptyLocalProviderModels(),
+    ...overrides,
+  }
+}
+
+describe("addProviderConfig local provider support", () => {
+  let configDir = ""
+  let originalConfigDir: string | undefined
+
+  beforeEach(() => {
+    configDir = join(tmpdir(), `omo-provider-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(configDir, { recursive: true })
+    originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    process.env.OPENCODE_CONFIG_DIR = configDir
+    resetConfigContext()
+  })
+
+  afterEach(() => {
+    resetConfigContext()
+    if (originalConfigDir === undefined) {
+      delete process.env.OPENCODE_CONFIG_DIR
+    } else {
+      process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+    }
+    rmSync(configDir, { recursive: true, force: true })
+  })
+
+  it("generates LMStudio local provider config with discovered models", () => {
+    //#given
+    const configPath = join(configDir, "opencode.jsonc")
+    writeFileSync(configPath, `{\n  \"plugin\": [\"oh-my-opencode\"]\n}\n`)
+
+    const installConfig = createInstallConfig({
+      hasLmstudio: true,
+      lmstudioUrl: "http://192.168.1.254:1234/v1",
+      localProviderModels: {
+        lmstudio: [
+          {
+            id: "devstral-small",
+            name: "Devstral Small",
+            contextLength: 32768,
+            outputLength: 4096,
+            capabilities: ["multimodal", "coding", "general"],
+            targets: ["explore", "librarian", "atlas", "multimodal-looker", "quick", "unspecified-low"],
+          },
+        ],
+        ollama: [],
+        vllm: [],
+      },
+    })
+
+    //#when
+    const result = addProviderConfig(installConfig)
+
+    //#then
+    expect(result.success).toBe(true)
+
+    const parsed = parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
+    const provider = parsed.provider as Record<string, any>
+    expect(provider.lmstudio.type).toBe("openai")
+    expect(provider.lmstudio.url).toBe("http://192.168.1.254:1234/v1")
+    expect(provider.lmstudio.name).toBe("LMStudio Local")
+    expect(provider.lmstudio.models["devstral-small"].name).toBe("Devstral Small")
+    expect(provider.lmstudio.models["devstral-small"].limit.context).toBe(32768)
+    expect(provider.lmstudio.models["devstral-small"].limit.output).toBe(4096)
+  })
+
+  it("writes local provider config alongside existing providers", () => {
+    //#given
+    const configPath = join(configDir, "opencode.jsonc")
+    writeFileSync(
+      configPath,
+      `{\n  \"provider\": {\n    \"openai\": { \"type\": \"openai\", \"url\": \"https://api.openai.com/v1\" }\n  }\n}\n`
+    )
+
+    const installConfig = createInstallConfig({
+      hasOllama: true,
+      ollamaUrl: "http://localhost:11434",
+      localProviderModels: {
+        lmstudio: [],
+        ollama: [
+          {
+            id: "qwen3-coder:32b",
+            name: "Qwen3 Coder",
+            contextLength: 65536,
+            outputLength: 8192,
+            capabilities: ["coding", "general"],
+            targets: ["explore", "librarian", "atlas", "quick", "unspecified-low"],
+          },
+        ],
+        vllm: [],
+      },
+    })
+
+    //#when
+    const result = addProviderConfig(installConfig)
+
+    //#then
+    expect(result.success).toBe(true)
+
+    const parsed = parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
+    const provider = parsed.provider as Record<string, any>
+    expect(provider.openai).toBeTruthy()
+    expect(provider.ollama.type).toBe("ollama")
+    expect(provider.ollama.url).toBe("http://localhost:11434")
+    expect(provider.ollama.models["qwen3-coder:32b"]).toBeTruthy()
+  })
+
+  it("does not add local provider config when local flags are omitted", () => {
+    //#given
+    const configPath = join(configDir, "opencode.jsonc")
+    writeFileSync(configPath, `{\n  \"provider\": {}\n}\n`)
+
+    const installConfig = createInstallConfig({
+      hasGemini: true,
+    })
+
+    //#when
+    const result = addProviderConfig(installConfig)
+
+    //#then
+    expect(result.success).toBe(true)
+
+    const parsed = parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
+    const provider = parsed.provider as Record<string, any>
+    expect(provider.google).toBeTruthy()
+    expect(provider.lmstudio).toBeUndefined()
+    expect(provider.ollama).toBeUndefined()
+    expect(provider.vllm).toBeUndefined()
   })
 })

--- a/src/cli/config-manager/add-provider-config.ts
+++ b/src/cli/config-manager/add-provider-config.ts
@@ -9,6 +9,42 @@ import { ANTIGRAVITY_PROVIDER_CONFIG } from "./antigravity-provider-configuratio
 import { modifyProviderInJsonc } from "./jsonc-provider-editor"
 import { parseJsonc } from "../../shared/jsonc-parser"
 
+const DEFAULT_LOCAL_CONTEXT_LIMIT = 32768
+const DEFAULT_LOCAL_OUTPUT_LIMIT = 4096
+
+function toLocalProviderModels(config: InstallConfig["localProviderModels"][keyof InstallConfig["localProviderModels"]]): Record<string, unknown> {
+  return Object.fromEntries(
+    config.map((model) => [
+      model.id,
+      {
+        name: model.name,
+        limit: {
+          context: model.contextLength ?? DEFAULT_LOCAL_CONTEXT_LIMIT,
+          output: model.outputLength ?? DEFAULT_LOCAL_OUTPUT_LIMIT,
+        },
+      },
+    ])
+  )
+}
+
+function buildOpenAiCompatibleLocalProvider(name: string, url: string, models: InstallConfig["localProviderModels"]["lmstudio"]): Record<string, unknown> {
+  return {
+    type: "openai",
+    url,
+    name,
+    models: toLocalProviderModels(models),
+  }
+}
+
+function buildOllamaProvider(url: string, models: InstallConfig["localProviderModels"]["ollama"]): Record<string, unknown> {
+  return {
+    type: "ollama",
+    url,
+    name: "Ollama Local",
+    models: toLocalProviderModels(models),
+  }
+}
+
 export function addProviderConfig(config: InstallConfig): ConfigMergeResult {
   try {
     ensureConfigDirectoryExists()
@@ -41,6 +77,26 @@ export function addProviderConfig(config: InstallConfig): ConfigMergeResult {
 
     if (config.hasGemini) {
       providers.google = ANTIGRAVITY_PROVIDER_CONFIG.google
+    }
+
+    if (config.hasLmstudio && config.lmstudioUrl) {
+      providers.lmstudio = buildOpenAiCompatibleLocalProvider(
+        "LMStudio Local",
+        config.lmstudioUrl,
+        config.localProviderModels.lmstudio
+      )
+    }
+
+    if (config.hasOllama && config.ollamaUrl) {
+      providers.ollama = buildOllamaProvider(config.ollamaUrl, config.localProviderModels.ollama)
+    }
+
+    if (config.hasVllm && config.vllmUrl) {
+      providers.vllm = buildOpenAiCompatibleLocalProvider(
+        "vLLM Local",
+        config.vllmUrl,
+        config.localProviderModels.vllm
+      )
     }
 
     if (Object.keys(providers).length > 0) {

--- a/src/cli/config-manager/auth-plugins.test.ts
+++ b/src/cli/config-manager/auth-plugins.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from "node:fs"
 import { parseJsonc } from "../../shared/jsonc-parser"
 import type { InstallConfig } from "../types"
+import { createEmptyLocalProviderModels } from "../local-model-capabilities"
 import { resetConfigContext } from "./config-context"
 
 let testConfigPath: string
@@ -39,6 +40,10 @@ const testConfig: InstallConfig = {
   hasOpencodeZen: false,
   hasZaiCodingPlan: false,
   hasKimiForCoding: false,
+  hasLmstudio: false,
+  hasOllama: false,
+  hasVllm: false,
+  localProviderModels: createEmptyLocalProviderModels(),
 }
 
 describe("addAuthPlugins", () => {

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -35,6 +35,46 @@ function detectProvidersFromOmoConfig(): {
   }
 }
 
+function detectLocalProvidersFromOpenCodeConfig(openCodeConfig: Record<string, unknown>): {
+  hasLmstudio: boolean
+  lmstudioUrl?: string
+  hasOllama: boolean
+  ollamaUrl?: string
+  hasVllm: boolean
+  vllmUrl?: string
+} {
+  const providers = openCodeConfig.provider
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) {
+    return {
+      hasLmstudio: false,
+      hasOllama: false,
+      hasVllm: false,
+    }
+  }
+
+  const readUrl = (providerName: string): string | undefined => {
+    const providerValue = (providers as Record<string, unknown>)[providerName]
+    if (!providerValue || typeof providerValue !== "object" || Array.isArray(providerValue)) {
+      return undefined
+    }
+    const url = (providerValue as Record<string, unknown>).url
+    return typeof url === "string" && url.length > 0 ? url : undefined
+  }
+
+  const lmstudioUrl = readUrl("lmstudio")
+  const ollamaUrl = readUrl("ollama")
+  const vllmUrl = readUrl("vllm")
+
+  return {
+    hasLmstudio: lmstudioUrl !== undefined,
+    lmstudioUrl,
+    hasOllama: ollamaUrl !== undefined,
+    ollamaUrl,
+    hasVllm: vllmUrl !== undefined,
+    vllmUrl,
+  }
+}
+
 export function detectCurrentConfig(): DetectedConfig {
   const result: DetectedConfig = {
     isInstalled: false,
@@ -46,6 +86,9 @@ export function detectCurrentConfig(): DetectedConfig {
     hasOpencodeZen: true,
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
+    hasLmstudio: false,
+    hasOllama: false,
+    hasVllm: false,
   }
 
   const { format, path } = detectConfigFormat()
@@ -73,6 +116,14 @@ export function detectCurrentConfig(): DetectedConfig {
   result.hasOpencodeZen = hasOpencodeZen
   result.hasZaiCodingPlan = hasZaiCodingPlan
   result.hasKimiForCoding = hasKimiForCoding
+
+  const localProviders = detectLocalProvidersFromOpenCodeConfig(openCodeConfig as Record<string, unknown>)
+  result.hasLmstudio = localProviders.hasLmstudio
+  result.lmstudioUrl = localProviders.lmstudioUrl
+  result.hasOllama = localProviders.hasOllama
+  result.ollamaUrl = localProviders.ollamaUrl
+  result.hasVllm = localProviders.hasVllm
+  result.vllmUrl = localProviders.vllmUrl
 
   return result
 }

--- a/src/cli/fallback-chain-resolution.ts
+++ b/src/cli/fallback-chain-resolution.ts
@@ -1,8 +1,20 @@
 import type { FallbackEntry } from "../shared/model-requirements"
+import { resolveLocalModelForSelector } from "./local-model-capabilities"
 import type { ProviderAvailability } from "./model-fallback-types"
 import { CLI_AGENT_MODEL_REQUIREMENTS } from "./model-fallback-requirements"
 import { isProviderAvailable } from "./provider-availability"
 import { transformModelForProvider } from "./provider-model-id-transform"
+
+function resolveEntryModelForProvider(
+	provider: string,
+	model: string,
+	availability: ProviderAvailability
+): string | null {
+	if (provider === "lmstudio" || provider === "ollama" || provider === "vllm") {
+		return resolveLocalModelForSelector(provider, model, availability.localProviderModels)
+	}
+	return model
+}
 
 export function resolveModelFromChain(
 	fallbackChain: FallbackEntry[],
@@ -11,7 +23,11 @@ export function resolveModelFromChain(
 	for (const entry of fallbackChain) {
 		for (const provider of entry.providers) {
 			if (isProviderAvailable(provider, availability)) {
-				const transformedModel = transformModelForProvider(provider, entry.model)
+				const resolvedModel = resolveEntryModelForProvider(provider, entry.model, availability)
+				if (!resolvedModel) {
+					continue
+				}
+				const transformedModel = transformModelForProvider(provider, resolvedModel)
 				return {
 					model: `${provider}/${transformedModel}`,
 					variant: entry.variant,

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -1,4 +1,5 @@
 import color from "picocolors"
+import { createEmptyLocalProviderModels } from "./local-model-capabilities"
 import type {
   BooleanArg,
   ClaudeSubscription,
@@ -38,6 +39,9 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))
   lines.push(formatProvider("Z.ai Coding Plan", config.hasZaiCodingPlan, "Librarian/Multimodal"))
   lines.push(formatProvider("Kimi For Coding", config.hasKimiForCoding, "Sisyphus/Prometheus fallback"))
+  lines.push(formatProvider("LMStudio", config.hasLmstudio, config.lmstudioUrl))
+  lines.push(formatProvider("Ollama", config.hasOllama, config.ollamaUrl))
+  lines.push(formatProvider("vLLM", config.hasVllm, config.vllmUrl))
 
   lines.push("")
   lines.push(color.dim("─".repeat(40)))
@@ -46,7 +50,7 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(color.bold(color.white("Model Assignment")))
   lines.push("")
   lines.push(`  ${SYMBOLS.info} Models auto-configured based on provider priority`)
-  lines.push(`  ${SYMBOLS.bullet} Priority: Native > Copilot > OpenCode Zen > Z.ai`)
+  lines.push(`  ${SYMBOLS.bullet} Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Local`)
 
   return lines.join("\n")
 }
@@ -119,15 +123,11 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --claude value: ${args.claude} (expected: no, yes, max20)`)
   }
 
-  if (args.gemini === undefined) {
-    errors.push("--gemini is required (values: no, yes)")
-  } else if (!["no", "yes"].includes(args.gemini)) {
+  if (args.gemini !== undefined && !["no", "yes"].includes(args.gemini)) {
     errors.push(`Invalid --gemini value: ${args.gemini} (expected: no, yes)`)
   }
 
-  if (args.copilot === undefined) {
-    errors.push("--copilot is required (values: no, yes)")
-  } else if (!["no", "yes"].includes(args.copilot)) {
+  if (args.copilot !== undefined && !["no", "yes"].includes(args.copilot)) {
     errors.push(`Invalid --copilot value: ${args.copilot} (expected: no, yes)`)
   }
 
@@ -147,10 +147,35 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --kimi-for-coding value: ${args.kimiForCoding} (expected: no, yes)`)
   }
 
+  const localProviderUrls = [
+    { flag: "--lmstudio", value: args.lmstudio },
+    { flag: "--ollama", value: args.ollama },
+    { flag: "--vllm", value: args.vllm },
+  ]
+
+  for (const localProvider of localProviderUrls) {
+    if (localProvider.value !== undefined && !isValidHttpUrl(localProvider.value)) {
+      errors.push(`Invalid ${localProvider.flag} value: ${localProvider.value} (expected: http://... or https://...)`)
+    }
+  }
+
   return { valid: errors.length === 0, errors }
 }
 
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
 export function argsToConfig(args: InstallArgs): InstallConfig {
+  const lmstudioUrl = args.lmstudio?.trim() || undefined
+  const ollamaUrl = args.ollama?.trim() || undefined
+  const vllmUrl = args.vllm?.trim() || undefined
+
   return {
     hasClaude: args.claude !== "no",
     isMax20: args.claude === "max20",
@@ -160,6 +185,13 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasOpencodeZen: args.opencodeZen === "yes",
     hasZaiCodingPlan: args.zaiCodingPlan === "yes",
     hasKimiForCoding: args.kimiForCoding === "yes",
+    hasLmstudio: lmstudioUrl !== undefined,
+    lmstudioUrl,
+    hasOllama: ollamaUrl !== undefined,
+    ollamaUrl,
+    hasVllm: vllmUrl !== undefined,
+    vllmUrl,
+    localProviderModels: createEmptyLocalProviderModels(),
   }
 }
 

--- a/src/cli/local-model-capabilities.test.ts
+++ b/src/cli/local-model-capabilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test"
+import {
+  mapProbeResultsToLocalProviderModels,
+  resolveLocalModelForSelector,
+} from "./local-model-capabilities"
+import type { LocalProviderProbeResult } from "./local-provider-probe"
+
+describe("local-model-capabilities", () => {
+  it("detects devstral models as multimodal and routes to multimodal-looker", () => {
+    //#given
+    const probeResults: LocalProviderProbeResult[] = [
+      {
+        provider: "lmstudio",
+        url: "http://localhost:1234/v1",
+        models: [{ id: "devstral-small", name: "devstral-small", contextLength: 65536 }],
+      },
+    ]
+
+    //#when
+    const mapped = mapProbeResultsToLocalProviderModels(probeResults)
+
+    //#then
+    expect(mapped.lmstudio[0].capabilities).toContain("multimodal")
+    expect(mapped.lmstudio[0].targets).toContain("multimodal-looker")
+    expect(resolveLocalModelForSelector("lmstudio", "local:multimodal-looker", mapped)).toBe("devstral-small")
+  })
+
+  it("detects qwen and deepseek models as coding-capable", () => {
+    //#given
+    const probeResults: LocalProviderProbeResult[] = [
+      {
+        provider: "ollama",
+        url: "http://localhost:11434",
+        models: [
+          { id: "qwen3-coder:32b", name: "qwen3-coder:32b" },
+          { id: "deepseek-coder:16b", name: "deepseek-coder:16b" },
+        ],
+      },
+    ]
+
+    //#when
+    const mapped = mapProbeResultsToLocalProviderModels(probeResults)
+
+    //#then
+    expect(mapped.ollama[0].capabilities).toContain("coding")
+    expect(mapped.ollama[1].capabilities).toContain("coding")
+    expect(["qwen3-coder:32b", "deepseek-coder:16b"]).toContain(
+      resolveLocalModelForSelector("ollama", "local:librarian", mapped)
+    )
+  })
+
+  it("assigns unknown models to explore-only fallback", () => {
+    //#given
+    const probeResults: LocalProviderProbeResult[] = [
+      {
+        provider: "vllm",
+        url: "http://localhost:8000/v1",
+        models: [{ id: "my-custom-model", name: "my-custom-model" }],
+      },
+    ]
+
+    //#when
+    const mapped = mapProbeResultsToLocalProviderModels(probeResults)
+
+    //#then
+    expect(mapped.vllm[0].targets).toEqual(["explore"])
+    expect(resolveLocalModelForSelector("vllm", "local:explore", mapped)).toBe("my-custom-model")
+    expect(resolveLocalModelForSelector("vllm", "local:librarian", mapped)).toBeNull()
+  })
+
+  it("preserves context length from probe metadata", () => {
+    //#given
+    const probeResults: LocalProviderProbeResult[] = [
+      {
+        provider: "lmstudio",
+        url: "http://localhost:1234/v1",
+        models: [{ id: "codestral-22b", name: "codestral-22b", contextLength: 131072 }],
+      },
+    ]
+
+    //#when
+    const mapped = mapProbeResultsToLocalProviderModels(probeResults)
+
+    //#then
+    expect(mapped.lmstudio[0].contextLength).toBe(131072)
+    expect(mapped.lmstudio[0].outputLength).toBe(8192)
+  })
+})

--- a/src/cli/local-model-capabilities.ts
+++ b/src/cli/local-model-capabilities.ts
@@ -1,0 +1,175 @@
+import type { LocalProvider, LocalProviderModels, LocalModelConfig, LocalModelTarget } from "./types"
+import type { LocalProviderProbeResult, ProbedLocalModel } from "./local-provider-probe"
+
+const LOCAL_SELECTOR_PREFIX = "local:"
+
+const LOCAL_MODEL_TARGETS: LocalModelTarget[] = [
+  "explore",
+  "librarian",
+  "atlas",
+  "multimodal-looker",
+  "quick",
+  "unspecified-low",
+]
+
+const DEFAULT_OUTPUT_TOKENS = 4096
+
+function parseKNotation(value: string): number | undefined {
+  const match = value.match(/(\d+)\s*k/i)
+  if (!match) return undefined
+
+  const amount = Number.parseInt(match[1], 10)
+  if (!Number.isFinite(amount) || amount <= 0) return undefined
+
+  return amount * 1024
+}
+
+function estimateContextLength(model: ProbedLocalModel): number | undefined {
+  if (typeof model.contextLength === "number" && Number.isFinite(model.contextLength) && model.contextLength > 0) {
+    return Math.floor(model.contextLength)
+  }
+
+  return parseKNotation(model.id) ?? parseKNotation(model.name)
+}
+
+function estimateOutputLength(model: ProbedLocalModel, contextLength?: number): number {
+  if (typeof model.outputLength === "number" && Number.isFinite(model.outputLength) && model.outputLength > 0) {
+    return Math.floor(model.outputLength)
+  }
+
+  if (contextLength) {
+    return Math.max(2048, Math.min(8192, Math.floor(contextLength / 8)))
+  }
+
+  return DEFAULT_OUTPUT_TOKENS
+}
+
+function detectCapabilities(model: ProbedLocalModel): {
+  capabilities: LocalModelConfig["capabilities"]
+  targets: LocalModelConfig["targets"]
+} {
+  const name = `${model.id} ${model.name}`.toLowerCase()
+
+  if (name.includes("devstral")) {
+    return {
+      capabilities: ["multimodal", "coding", "general"],
+      targets: ["explore", "librarian", "atlas", "multimodal-looker", "quick", "unspecified-low"],
+    }
+  }
+
+  if (name.includes("codestral") || name.includes("qwen") || name.includes("deepseek")) {
+    return {
+      capabilities: ["coding", "general"],
+      targets: ["explore", "librarian", "atlas", "quick", "unspecified-low"],
+    }
+  }
+
+  if (name.includes("llama") || name.includes("mistral")) {
+    return {
+      capabilities: ["general"],
+      targets: ["explore", "atlas", "quick", "unspecified-low"],
+    }
+  }
+
+  return {
+    capabilities: ["general"],
+    targets: ["explore"],
+  }
+}
+
+function capabilityRank(model: LocalModelConfig): number {
+  if (model.capabilities.includes("multimodal")) return 3
+  if (model.capabilities.includes("coding")) return 2
+  if (model.targets.length > 1) return 1
+  return 0
+}
+
+function sortByUsefulness(models: LocalModelConfig[]): LocalModelConfig[] {
+  return [...models].sort((a, b) => {
+    const rankDiff = capabilityRank(b) - capabilityRank(a)
+    if (rankDiff !== 0) return rankDiff
+
+    const contextDiff = (b.contextLength ?? 0) - (a.contextLength ?? 0)
+    if (contextDiff !== 0) return contextDiff
+
+    return a.id.localeCompare(b.id)
+  })
+}
+
+export function createEmptyLocalProviderModels(): LocalProviderModels {
+  return {
+    lmstudio: [],
+    ollama: [],
+    vllm: [],
+  }
+}
+
+function mapProbeModel(model: ProbedLocalModel): LocalModelConfig {
+  const contextLength = estimateContextLength(model)
+  const outputLength = estimateOutputLength(model, contextLength)
+  const { capabilities, targets } = detectCapabilities(model)
+
+  return {
+    id: model.id,
+    name: model.name,
+    contextLength,
+    outputLength,
+    capabilities,
+    targets,
+  }
+}
+
+function dedupeById(models: LocalModelConfig[]): LocalModelConfig[] {
+  const deduped = new Map<string, LocalModelConfig>()
+  for (const model of models) {
+    if (!deduped.has(model.id)) {
+      deduped.set(model.id, model)
+    }
+  }
+  return [...deduped.values()]
+}
+
+export function mapProbeResultsToLocalProviderModels(results: LocalProviderProbeResult[]): LocalProviderModels {
+  const mapped = createEmptyLocalProviderModels()
+
+  for (const result of results) {
+    const converted = dedupeById(result.models.map(mapProbeModel))
+    mapped[result.provider] = sortByUsefulness(converted)
+  }
+
+  return mapped
+}
+
+export function toLocalModelSelector(target: LocalModelTarget): string {
+  return `${LOCAL_SELECTOR_PREFIX}${target}`
+}
+
+export function isLocalModelSelector(model: string): boolean {
+  return model.startsWith(LOCAL_SELECTOR_PREFIX)
+}
+
+function isLocalTarget(value: string): value is LocalModelTarget {
+  return LOCAL_MODEL_TARGETS.includes(value as LocalModelTarget)
+}
+
+export function resolveLocalModelForSelector(
+  provider: LocalProvider,
+  selector: string,
+  localProviderModels: LocalProviderModels,
+): string | null {
+  if (!isLocalModelSelector(selector)) {
+    return selector
+  }
+
+  const target = selector.slice(LOCAL_SELECTOR_PREFIX.length)
+  if (!isLocalTarget(target)) {
+    return null
+  }
+
+  const matched = localProviderModels[provider].find((model) => model.targets.includes(target))
+  return matched?.id ?? null
+}
+
+export function getDiscoveredModelNames(result: LocalProviderProbeResult): string[] {
+  return result.models.map((model) => model.id)
+}

--- a/src/cli/local-provider-probe.test.ts
+++ b/src/cli/local-provider-probe.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, mock } from "bun:test"
+import { probeLocalProviders } from "./local-provider-probe"
+
+describe("probeLocalProviders", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("parses LMStudio OpenAI-compatible /models response", async () => {
+    //#given
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              { id: "devstral-small", context_length: 32768, max_output_tokens: 4096 },
+              { id: "qwen3-coder" },
+            ],
+          }),
+      } as Response)
+    ) as unknown as typeof fetch
+
+    //#when
+    const result = await probeLocalProviders({
+      lmstudioUrl: "http://127.0.0.1:1234/v1",
+    })
+
+    //#then
+    expect(result).toHaveLength(1)
+    expect(result[0].provider).toBe("lmstudio")
+    expect(result[0].warning).toBeUndefined()
+    expect(result[0].models.map((model) => model.id)).toEqual(["devstral-small", "qwen3-coder"])
+    expect(result[0].models[0].contextLength).toBe(32768)
+    expect(result[0].models[0].outputLength).toBe(4096)
+  })
+
+  it("parses Ollama /api/tags response", async () => {
+    //#given
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            models: [
+              {
+                name: "qwen3-coder:32b",
+                details: {
+                  parameter_size: "32B",
+                  context_length: 65536,
+                },
+              },
+            ],
+          }),
+      } as Response)
+    ) as unknown as typeof fetch
+
+    //#when
+    const result = await probeLocalProviders({
+      ollamaUrl: "http://localhost:11434",
+    })
+
+    //#then
+    expect(result).toHaveLength(1)
+    expect(result[0].provider).toBe("ollama")
+    expect(result[0].warning).toBeUndefined()
+    expect(result[0].models).toHaveLength(1)
+    expect(result[0].models[0].id).toBe("qwen3-coder:32b")
+    expect(result[0].models[0].parameterSize).toBe("32B")
+    expect(result[0].models[0].contextLength).toBe(65536)
+  })
+
+  it("returns warning and empty model list when endpoint is unreachable", async () => {
+    //#given
+    globalThis.fetch = mock(() => Promise.reject(new Error("connection refused"))) as unknown as typeof fetch
+
+    //#when
+    const result = await probeLocalProviders({
+      vllmUrl: "http://localhost:8000/v1",
+    })
+
+    //#then
+    expect(result).toHaveLength(1)
+    expect(result[0].provider).toBe("vllm")
+    expect(result[0].models).toEqual([])
+    expect(result[0].warning).toContain("connection refused")
+  })
+
+  it("handles malformed responses without throwing", async () => {
+    //#given
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ nope: true }),
+      } as Response)
+    ) as unknown as typeof fetch
+
+    //#when
+    const result = await probeLocalProviders({
+      lmstudioUrl: "http://127.0.0.1:1234/v1",
+    })
+
+    //#then
+    expect(result).toHaveLength(1)
+    expect(result[0].models).toEqual([])
+    expect(result[0].warning).toBe("Malformed model list response")
+  })
+})

--- a/src/cli/local-provider-probe.ts
+++ b/src/cli/local-provider-probe.ts
@@ -1,0 +1,262 @@
+import type { LocalProvider } from "./types"
+
+const LOCAL_PROVIDER_TIMEOUT_MS = 4000
+
+export interface ProbedLocalModel {
+  id: string
+  name: string
+  contextLength?: number
+  outputLength?: number
+  parameterSize?: string
+}
+
+export interface LocalProviderProbeResult {
+  provider: LocalProvider
+  url: string
+  models: ProbedLocalModel[]
+  warning?: string
+}
+
+interface LocalProviderProbeInput {
+  lmstudioUrl?: string
+  ollamaUrl?: string
+  vllmUrl?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "")
+}
+
+function buildOpenAiModelsUrl(url: string): string {
+  return `${normalizeBaseUrl(url)}/models`
+}
+
+function buildVllmModelsUrl(url: string): string {
+  const normalized = normalizeBaseUrl(url)
+  return normalized.endsWith("/v1") ? `${normalized}/models` : `${normalized}/v1/models`
+}
+
+function buildOllamaTagsUrl(url: string): string {
+  const normalized = normalizeBaseUrl(url)
+  return normalized.endsWith("/api/tags") ? normalized : `${normalized}/api/tags`
+}
+
+function parsePositiveNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value)
+  }
+  if (typeof value === "string") {
+    const numeric = Number.parseInt(value, 10)
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric
+    }
+  }
+  return undefined
+}
+
+function parseKNotation(value: string): number | undefined {
+  const match = value.match(/(\d+)\s*k/i)
+  if (!match) return undefined
+  const amount = Number.parseInt(match[1], 10)
+  if (!Number.isFinite(amount) || amount <= 0) return undefined
+  return amount * 1024
+}
+
+function extractContextLength(rawModel: Record<string, unknown>): number | undefined {
+  const contextCandidates = [
+    rawModel.context_length,
+    rawModel.contextLength,
+    rawModel.max_context_length,
+    rawModel.context,
+    rawModel.maxModelLen,
+    rawModel.num_ctx,
+  ]
+
+  const details = isRecord(rawModel.details) ? rawModel.details : null
+  if (details) {
+    contextCandidates.push(details.context_length, details.contextLength, details.num_ctx)
+  }
+
+  for (const candidate of contextCandidates) {
+    const parsed = parsePositiveNumber(candidate)
+    if (parsed) return parsed
+  }
+
+  const id = typeof rawModel.id === "string" ? rawModel.id : ""
+  return parseKNotation(id)
+}
+
+function extractOutputLength(rawModel: Record<string, unknown>): number | undefined {
+  const outputCandidates = [
+    rawModel.max_output_tokens,
+    rawModel.output_length,
+    rawModel.max_completion_tokens,
+    rawModel.max_tokens,
+  ]
+
+  const details = isRecord(rawModel.details) ? rawModel.details : null
+  if (details) {
+    outputCandidates.push(details.max_output_tokens, details.output_length)
+  }
+
+  for (const candidate of outputCandidates) {
+    const parsed = parsePositiveNumber(candidate)
+    if (parsed) return parsed
+  }
+
+  return undefined
+}
+
+async function fetchJson(url: string): Promise<{ data?: unknown; warning?: string }> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(LOCAL_PROVIDER_TIMEOUT_MS) })
+    if (!response.ok) {
+      return {
+        warning: `Endpoint returned ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+      }
+    }
+    return { data: await response.json() }
+  } catch (error) {
+    return {
+      warning: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function parseOpenAiCompatibleModels(payload: unknown): ProbedLocalModel[] | null {
+  if (!isRecord(payload) || !Array.isArray(payload.data)) {
+    return null
+  }
+
+  const parsed: ProbedLocalModel[] = []
+
+  for (const item of payload.data) {
+    if (!isRecord(item) || typeof item.id !== "string" || item.id.trim().length === 0) {
+      continue
+    }
+
+    const contextLength = extractContextLength(item)
+    const outputLength = extractOutputLength(item)
+
+    parsed.push({
+      id: item.id,
+      name: typeof item.name === "string" ? item.name : item.id,
+      contextLength,
+      outputLength,
+    })
+  }
+
+  return parsed
+}
+
+function parseOllamaModels(payload: unknown): ProbedLocalModel[] | null {
+  if (!isRecord(payload) || !Array.isArray(payload.models)) {
+    return null
+  }
+
+  const parsed: ProbedLocalModel[] = []
+
+  for (const item of payload.models) {
+    if (!isRecord(item) || typeof item.name !== "string" || item.name.trim().length === 0) {
+      continue
+    }
+
+    const details = isRecord(item.details) ? item.details : null
+    const parameterSize = typeof details?.parameter_size === "string" ? details.parameter_size : undefined
+
+    const contextLength = extractContextLength(item)
+    const outputLength = extractOutputLength(item)
+
+    parsed.push({
+      id: item.name,
+      name: item.name,
+      contextLength,
+      outputLength,
+      parameterSize,
+    })
+  }
+
+  return parsed
+}
+
+async function probeOpenAiCompatibleProvider(
+  provider: LocalProvider,
+  url: string,
+  modelsUrl: string,
+): Promise<LocalProviderProbeResult> {
+  const result = await fetchJson(modelsUrl)
+  if (result.warning) {
+    return {
+      provider,
+      url,
+      models: [],
+      warning: result.warning,
+    }
+  }
+
+  const models = parseOpenAiCompatibleModels(result.data)
+  if (!models) {
+    return {
+      provider,
+      url,
+      models: [],
+      warning: "Malformed model list response",
+    }
+  }
+
+  return {
+    provider,
+    url,
+    models,
+  }
+}
+
+async function probeOllamaProvider(url: string): Promise<LocalProviderProbeResult> {
+  const result = await fetchJson(buildOllamaTagsUrl(url))
+  if (result.warning) {
+    return {
+      provider: "ollama",
+      url,
+      models: [],
+      warning: result.warning,
+    }
+  }
+
+  const models = parseOllamaModels(result.data)
+  if (!models) {
+    return {
+      provider: "ollama",
+      url,
+      models: [],
+      warning: "Malformed model list response",
+    }
+  }
+
+  return {
+    provider: "ollama",
+    url,
+    models,
+  }
+}
+
+export async function probeLocalProviders(input: LocalProviderProbeInput): Promise<LocalProviderProbeResult[]> {
+  const probes: Array<Promise<LocalProviderProbeResult>> = []
+
+  if (input.lmstudioUrl) {
+    probes.push(probeOpenAiCompatibleProvider("lmstudio", input.lmstudioUrl, buildOpenAiModelsUrl(input.lmstudioUrl)))
+  }
+
+  if (input.ollamaUrl) {
+    probes.push(probeOllamaProvider(input.ollamaUrl))
+  }
+
+  if (input.vllmUrl) {
+    probes.push(probeOpenAiCompatibleProvider("vllm", input.vllmUrl, buildVllmModelsUrl(input.vllmUrl)))
+  }
+
+  return Promise.all(probes)
+}

--- a/src/cli/model-fallback-requirements.ts
+++ b/src/cli/model-fallback-requirements.ts
@@ -33,12 +33,14 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["zai-coding-plan"], model: "glm-4.7" },
       { providers: ["opencode"], model: "glm-4.7-free" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:librarian" },
     ],
   },
   explore: {
     fallbackChain: [
       { providers: ["github-copilot"], model: "grok-code-fast-1" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:explore" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },
@@ -50,6 +52,7 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:multimodal-looker" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },
@@ -85,6 +88,7 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:atlas" },
     ],
   },
 }
@@ -125,6 +129,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:quick" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },
@@ -133,6 +138,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
+      { providers: ["lmstudio", "ollama", "vllm"], model: "local:unspecified-low" },
     ],
   },
   "unspecified-high": {

--- a/src/cli/model-fallback-types.ts
+++ b/src/cli/model-fallback-types.ts
@@ -1,3 +1,5 @@
+import type { LocalProviderModels } from "./types"
+
 export interface ProviderAvailability {
 	native: {
 		claude: boolean
@@ -8,6 +10,10 @@ export interface ProviderAvailability {
 	copilot: boolean
 	zai: boolean
 	kimiForCoding: boolean
+	lmstudio: boolean
+	ollama: boolean
+	vllm: boolean
+	localProviderModels: LocalProviderModels
 	isMaxPlan: boolean
 }
 

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import { generateModelConfig } from "./model-fallback"
 import type { InstallConfig } from "./types"
+import { createEmptyLocalProviderModels } from "./local-model-capabilities"
 
 function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
   return {
@@ -13,6 +14,10 @@ function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
     hasOpencodeZen: false,
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
+    hasLmstudio: false,
+    hasOllama: false,
+    hasVllm: false,
+    localProviderModels: createEmptyLocalProviderModels(),
     ...overrides,
   }
 }

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -21,6 +21,15 @@ const ZAI_MODEL = "zai-coding-plan/glm-4.7"
 const ULTIMATE_FALLBACK = "opencode/glm-4.7-free"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json"
 
+function resolveLocalTargetModel(
+	target: "explore" | "librarian" | "atlas" | "multimodal-looker" | "quick" | "unspecified-low",
+	availability: ReturnType<typeof toProviderAvailability>
+): { model: string; variant?: string } | null {
+	return resolveModelFromChain(
+		[{ providers: ["lmstudio", "ollama", "vllm"], model: `local:${target}` }],
+		availability
+	)
+}
 
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
@@ -32,7 +41,10 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     avail.opencodeZen ||
     avail.copilot ||
     avail.zai ||
-    avail.kimiForCoding
+    avail.kimiForCoding ||
+    avail.lmstudio ||
+    avail.ollama ||
+    avail.vllm
 
   if (!hasAnyProvider) {
     return {
@@ -65,7 +77,27 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       } else if (avail.copilot) {
         agents[role] = { model: "github-copilot/gpt-5-mini" }
       } else {
-        agents[role] = { model: "opencode/gpt-5-nano" }
+        const resolvedLocal = resolveLocalTargetModel("explore", avail)
+        if (resolvedLocal) {
+          agents[role] = { model: resolvedLocal.model }
+        } else {
+          agents[role] = { model: "opencode/gpt-5-nano" }
+        }
+      }
+      continue
+    }
+
+    if (role === "librarian") {
+      const resolved = resolveModelFromChain(req.fallbackChain, avail)
+      const localLibrarian = resolveLocalTargetModel("librarian", avail)
+
+      if (resolved?.model === "opencode/glm-4.7-free" && localLibrarian) {
+        agents[role] = { model: localLibrarian.model }
+      } else if (resolved) {
+        const variant = resolved.variant ?? req.variant
+        agents[role] = variant ? { model: resolved.model, variant } : { model: resolved.model }
+      } else {
+        agents[role] = { model: ULTIMATE_FALLBACK }
       }
       continue
     }
@@ -92,6 +124,12 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
 
     const resolved = resolveModelFromChain(req.fallbackChain, avail)
     if (resolved) {
+      const localMultimodal = role === "multimodal-looker" ? resolveLocalTargetModel("multimodal-looker", avail) : null
+      if (resolved.model === "opencode/gpt-5-nano" && localMultimodal) {
+        agents[role] = { model: localMultimodal.model }
+        continue
+      }
+
       const variant = resolved.variant ?? req.variant
       agents[role] = variant ? { model: resolved.model, variant } : { model: resolved.model }
     } else {
@@ -115,6 +153,12 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
 
     const resolved = resolveModelFromChain(fallbackChain, avail)
     if (resolved) {
+      const localQuick = cat === "quick" ? resolveLocalTargetModel("quick", avail) : null
+      if (resolved.model === "opencode/gpt-5-nano" && localQuick) {
+        categories[cat] = { model: localQuick.model }
+        continue
+      }
+
       const variant = resolved.variant ?? req.variant
       categories[cat] = variant ? { model: resolved.model, variant } : { model: resolved.model }
     } else {

--- a/src/cli/provider-availability.test.ts
+++ b/src/cli/provider-availability.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test"
+import { createEmptyLocalProviderModels } from "./local-model-capabilities"
+import { isProviderAvailable, toProviderAvailability } from "./provider-availability"
+import type { InstallConfig } from "./types"
+
+function createInstallConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
+  return {
+    hasClaude: false,
+    isMax20: false,
+    hasOpenAI: false,
+    hasGemini: false,
+    hasCopilot: false,
+    hasOpencodeZen: false,
+    hasZaiCodingPlan: false,
+    hasKimiForCoding: false,
+    hasLmstudio: false,
+    hasOllama: false,
+    hasVllm: false,
+    localProviderModels: createEmptyLocalProviderModels(),
+    ...overrides,
+  }
+}
+
+describe("provider-availability", () => {
+  it("maps local providers into ProviderAvailability", () => {
+    //#given
+    const installConfig = createInstallConfig({
+      hasLmstudio: true,
+      lmstudioUrl: "http://localhost:1234/v1",
+      hasOllama: true,
+      ollamaUrl: "http://localhost:11434",
+      hasVllm: false,
+    })
+
+    //#when
+    const availability = toProviderAvailability(installConfig)
+
+    //#then
+    expect(availability.lmstudio).toBe(true)
+    expect(availability.ollama).toBe(true)
+    expect(availability.vllm).toBe(false)
+  })
+
+  it("reports local provider availability in isProviderAvailable", () => {
+    //#given
+    const availability = toProviderAvailability(
+      createInstallConfig({
+        hasLmstudio: true,
+        hasOllama: false,
+        hasVllm: true,
+      })
+    )
+
+    //#when / #then
+    expect(isProviderAvailable("lmstudio", availability)).toBe(true)
+    expect(isProviderAvailable("ollama", availability)).toBe(false)
+    expect(isProviderAvailable("vllm", availability)).toBe(true)
+  })
+})

--- a/src/cli/provider-availability.ts
+++ b/src/cli/provider-availability.ts
@@ -1,5 +1,6 @@
 import type { InstallConfig } from "./types"
 import type { ProviderAvailability } from "./model-fallback-types"
+import { createEmptyLocalProviderModels } from "./local-model-capabilities"
 
 export function toProviderAvailability(config: InstallConfig): ProviderAvailability {
 	return {
@@ -12,6 +13,10 @@ export function toProviderAvailability(config: InstallConfig): ProviderAvailabil
 		copilot: config.hasCopilot,
 		zai: config.hasZaiCodingPlan,
 		kimiForCoding: config.hasKimiForCoding,
+		lmstudio: config.hasLmstudio,
+		ollama: config.hasOllama,
+		vllm: config.hasVllm,
+		localProviderModels: config.localProviderModels ?? createEmptyLocalProviderModels(),
 		isMaxPlan: config.isMax20,
 	}
 }
@@ -25,6 +30,9 @@ export function isProviderAvailable(provider: string, availability: ProviderAvai
 		opencode: availability.opencodeZen,
 		"zai-coding-plan": availability.zai,
 		"kimi-for-coding": availability.kimiForCoding,
+		lmstudio: availability.lmstudio,
+		ollama: availability.ollama,
+		vllm: availability.vllm,
 	}
 	return mapping[provider] ?? false
 }

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -1,11 +1,14 @@
 import * as p from "@clack/prompts"
 import type { Option } from "@clack/prompts"
 import type {
+  BooleanArg,
   ClaudeSubscription,
   DetectedConfig,
   InstallConfig,
 } from "./types"
 import { detectedToInitialValues } from "./install-validators"
+import { createEmptyLocalProviderModels, mapProbeResultsToLocalProviderModels } from "./local-model-capabilities"
+import { probeLocalProviders } from "./local-provider-probe"
 
 async function selectOrCancel<TValue extends Readonly<string | boolean | number>>(params: {
   message: string
@@ -24,6 +27,68 @@ async function selectOrCancel<TValue extends Readonly<string | boolean | number>
     return null
   }
   return value as TValue
+}
+
+async function textOrCancel(params: {
+  message: string
+  placeholder: string
+  initialValue?: string
+}): Promise<string | null> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return null
+
+  const value = await p.text({
+    message: params.message,
+    placeholder: params.placeholder,
+    initialValue: params.initialValue,
+    validate: (input) => (isValidHttpUrl(input) ? undefined : "Please enter a valid http(s) URL"),
+  })
+
+  if (p.isCancel(value)) {
+    p.cancel("Installation cancelled.")
+    return null
+  }
+
+  return String(value).trim()
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function localProviderLabel(provider: "lmstudio" | "ollama" | "vllm"): string {
+  if (provider === "lmstudio") return "LMStudio"
+  if (provider === "vllm") return "vLLM"
+  return "Ollama"
+}
+
+async function promptLocalProviderUrl(params: {
+  providerName: string
+  initialEnabled: BooleanArg
+  initialUrl?: string
+  placeholder: string
+}): Promise<string | undefined | null> {
+  const enabled = await selectOrCancel<BooleanArg>({
+    message: `Configure ${params.providerName} local endpoint?`,
+    options: [
+      { value: "no", label: "No (skip)", hint: "Do not probe this local provider" },
+      { value: "yes", label: "Yes", hint: "Probe endpoint and add models to local fallback chain" },
+    ],
+    initialValue: params.initialEnabled,
+  })
+
+  if (!enabled) return null
+  if (enabled === "no") return undefined
+
+  return textOrCancel({
+    message: `${params.providerName} URL`,
+    placeholder: params.placeholder,
+    initialValue: params.initialUrl,
+  })
 }
 
 export async function promptInstallConfig(detected: DetectedConfig): Promise<InstallConfig | null> {
@@ -100,6 +165,59 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
   })
   if (!kimiForCoding) return null
 
+  const lmstudioUrl = await promptLocalProviderUrl({
+    providerName: "LMStudio",
+    initialEnabled: detected.hasLmstudio ? "yes" : "no",
+    initialUrl: detected.lmstudioUrl,
+    placeholder: "http://localhost:1234/v1",
+  })
+  if (lmstudioUrl === null) return null
+
+  const ollamaUrl = await promptLocalProviderUrl({
+    providerName: "Ollama",
+    initialEnabled: detected.hasOllama ? "yes" : "no",
+    initialUrl: detected.ollamaUrl,
+    placeholder: "http://localhost:11434",
+  })
+  if (ollamaUrl === null) return null
+
+  const vllmUrl = await promptLocalProviderUrl({
+    providerName: "vLLM",
+    initialEnabled: detected.hasVllm ? "yes" : "no",
+    initialUrl: detected.vllmUrl,
+    placeholder: "http://localhost:8000/v1",
+  })
+  if (vllmUrl === null) return null
+
+  const probeResults =
+    lmstudioUrl || ollamaUrl || vllmUrl
+      ? await probeLocalProviders({
+          lmstudioUrl,
+          ollamaUrl,
+          vllmUrl,
+        })
+      : []
+  const localProviderModels =
+    probeResults.length > 0
+      ? mapProbeResultsToLocalProviderModels(probeResults)
+      : createEmptyLocalProviderModels()
+
+  for (const result of probeResults) {
+    const label = localProviderLabel(result.provider)
+    if (result.warning) {
+      p.log.warn(`${label} probe failed (${result.url}): ${result.warning}`)
+      continue
+    }
+
+    if (result.models.length === 0) {
+      p.log.warn(`${label} probe returned no models (${result.url})`)
+      continue
+    }
+
+    const modelPreview = result.models.slice(0, 4).map((model) => model.id).join(", ")
+    p.log.info(`${label}: found ${result.models.length} model(s)${modelPreview ? ` (${modelPreview})` : ""}`)
+  }
+
   return {
     hasClaude: claude !== "no",
     isMax20: claude === "max20",
@@ -109,5 +227,12 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     hasOpencodeZen: opencodeZen === "yes",
     hasZaiCodingPlan: zaiCodingPlan === "yes",
     hasKimiForCoding: kimiForCoding === "yes",
+    hasLmstudio: lmstudioUrl !== undefined,
+    lmstudioUrl,
+    hasOllama: ollamaUrl !== undefined,
+    ollamaUrl,
+    hasVllm: vllmUrl !== undefined,
+    vllmUrl,
+    localProviderModels,
   }
 }

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -45,6 +45,9 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   const config = await promptInstallConfig(detected)
   if (!config) return 1
 
+  const needsAuthSetup = config.hasGemini || config.hasOpenAI || config.hasCopilot
+  const needsProviderSetup = needsAuthSetup || config.hasLmstudio || config.hasOllama || config.hasVllm
+
   spinner.start("Adding oh-my-opencode to OpenCode config")
   const pluginResult = await addPluginToOpenCodeConfig(version)
   if (!pluginResult.success) {
@@ -54,7 +57,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   }
   spinner.stop(`Plugin added to ${color.cyan(pluginResult.configPath)}`)
 
-  if (config.hasGemini) {
+  if (needsAuthSetup) {
     spinner.start("Adding auth plugins (fetching latest versions)")
     const authResult = await addAuthPlugins(config)
     if (!authResult.success) {
@@ -63,7 +66,9 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
       return 1
     }
     spinner.stop(`Auth plugins added to ${color.cyan(authResult.configPath)}`)
+  }
 
+  if (needsProviderSetup) {
     spinner.start("Adding provider configurations")
     const providerResult = addProviderConfig(config)
     if (!providerResult.success) {
@@ -97,7 +102,16 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     console.log()
   }
 
-  if (!config.hasClaude && !config.hasOpenAI && !config.hasGemini && !config.hasCopilot && !config.hasOpencodeZen) {
+  if (
+    !config.hasClaude &&
+    !config.hasOpenAI &&
+    !config.hasGemini &&
+    !config.hasCopilot &&
+    !config.hasOpencodeZen &&
+    !config.hasLmstudio &&
+    !config.hasOllama &&
+    !config.hasVllm
+  ) {
     p.log.warn("No model providers configured. Using opencode/big-pickle as fallback.")
   }
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,6 +1,33 @@
 export type ClaudeSubscription = "no" | "yes" | "max20"
 export type BooleanArg = "no" | "yes"
 
+export type LocalProvider = "lmstudio" | "ollama" | "vllm"
+
+export type LocalModelCapability = "multimodal" | "coding" | "general"
+
+export type LocalModelTarget =
+  | "explore"
+  | "librarian"
+  | "atlas"
+  | "multimodal-looker"
+  | "quick"
+  | "unspecified-low"
+
+export interface LocalModelConfig {
+  id: string
+  name: string
+  contextLength?: number
+  outputLength?: number
+  capabilities: LocalModelCapability[]
+  targets: LocalModelTarget[]
+}
+
+export interface LocalProviderModels {
+  lmstudio: LocalModelConfig[]
+  ollama: LocalModelConfig[]
+  vllm: LocalModelConfig[]
+}
+
 export interface InstallArgs {
   tui: boolean
   claude?: ClaudeSubscription
@@ -10,6 +37,9 @@ export interface InstallArgs {
   opencodeZen?: BooleanArg
   zaiCodingPlan?: BooleanArg
   kimiForCoding?: BooleanArg
+  lmstudio?: string
+  ollama?: string
+  vllm?: string
   skipAuth?: boolean
 }
 
@@ -22,6 +52,13 @@ export interface InstallConfig {
   hasOpencodeZen: boolean
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
+  hasLmstudio: boolean
+  lmstudioUrl?: string
+  hasOllama: boolean
+  ollamaUrl?: string
+  hasVllm: boolean
+  vllmUrl?: string
+  localProviderModels: LocalProviderModels
 }
 
 export interface ConfigMergeResult {
@@ -40,4 +77,10 @@ export interface DetectedConfig {
   hasOpencodeZen: boolean
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
+  hasLmstudio?: boolean
+  lmstudioUrl?: string
+  hasOllama?: boolean
+  ollamaUrl?: string
+  hasVllm?: boolean
+  vllmUrl?: string
 }


### PR DESCRIPTION
## Summary

- Adds `--lmstudio <url>`, `--ollama <url>`, and `--vllm <url>` flags to the installer for configuring local model providers
- Probes local endpoints to discover available models (best-effort, warns on failure)
- Maps discovered models to agent capabilities (e.g., devstral → multimodal, qwen → coding)
- Integrates local models as low-priority fallbacks in the model assignment chains
- Generates OpenAI-compatible provider configs in `opencode.json`
- TUI installer includes interactive local provider setup section

Closes #2023

## Design Decisions

- **Low-priority fallbacks only**: Local models are placed LAST in fallback chains, after all cloud providers, before the ultimate `opencode/glm-4.7-free` fallback
- **Cost-sensitive agents only**: Local models target `explore`, `librarian`, `atlas`, and `quick` category. High-capability agents (`sisyphus`, `oracle`, `prometheus`, `metis`, `momus`) are never assigned local models
- **Best-effort probing**: If a local endpoint is unreachable, the installer warns but continues without failing
- **No new dependencies**: Uses native `fetch()` (Bun built-in) with 3-5 second timeouts

## Usage

```bash
# LMStudio
bunx oh-my-opencode install --no-tui --claude=yes --lmstudio=http://192.168.1.254:1234/v1

# Ollama
bunx oh-my-opencode install --no-tui --claude=yes --ollama=http://localhost:11434

# vLLM
bunx oh-my-opencode install --no-tui --claude=yes --vllm=http://localhost:8000/v1

# Multiple local providers
bunx oh-my-opencode install --no-tui --claude=yes --lmstudio=http://192.168.1.254:1234/v1 --ollama=http://localhost:11434

# Works with --project flag from #2022
bunx oh-my-opencode install --project --no-tui --claude=yes --lmstudio=http://localhost:1234/v1
```

## New Files

| File | Purpose |
|------|---------|
| `src/cli/local-provider-probe.ts` | Endpoint discovery for LMStudio/Ollama/vLLM |
| `src/cli/local-model-capabilities.ts` | Model-to-capability mapping (devstral→multimodal, qwen→coding, etc.) |

## Changes

| File | Change |
|------|--------|
| `src/cli/types.ts` | Added local provider fields to InstallArgs/InstallConfig |
| `src/cli/cli-program.ts` | Added --lmstudio, --ollama, --vllm flags |
| `src/cli/install-validators.ts` | URL validation and config conversion |
| `src/cli/provider-availability.ts` | Extended isProviderAvailable() |
| `src/cli/model-fallback-types.ts` | Extended ProviderAvailability type |
| `src/cli/model-fallback-requirements.ts` | Added local provider fallback entries |
| `src/cli/model-fallback.ts` | Local provider model generation |
| `src/cli/fallback-chain-resolution.ts` | Extended resolution for local providers |
| `src/cli/config-manager/add-provider-config.ts` | OpenAI-compatible provider config generation |
| `src/cli/config-manager/detect-current-config.ts` | Detect existing local provider configs |
| `src/cli/cli-installer.ts` | Added probing step in CLI flow |
| `src/cli/tui-installer.ts` | Local provider section in TUI |
| `src/cli/tui-install-prompts.ts` | TUI prompts for local provider setup |

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] 64 new/updated tests across 6 test files - all pass
- [x] Local provider probe tests (mock fetch, timeout handling, malformed responses)
- [x] Model capability mapping tests (devstral→multimodal, qwen→coding, unknown→default)
- [x] Provider availability tests for lmstudio/ollama/vllm
- [x] Provider config generation tests
- [x] CLI flag parsing tests
- [x] Install without local flags works identically (regression)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local model provider support to the installer and TUI (LMStudio, Ollama, vLLM) with endpoint probing, capability mapping, and low‑priority fallback integration for cost‑sensitive agents. Implements #2023.

- **New Features**
  - New flags: --lmstudio <url>, --ollama <url>, --vllm <url>
  - Probes local endpoints to list models; warns on failure, continues
  - Maps discovered models to capabilities/targets (e.g., coding, multimodal) and resolves selectors like local:librarian
  - Adds local providers to fallback chains after cloud providers for explore, librarian, atlas, quick, and multimodal-looker
  - Generates provider entries in opencode.json(c): LMStudio/vLLM as OpenAI-compatible, Ollama as native; includes context/output limits
  - TUI flow adds interactive local provider setup and shows probe results; detects existing local configs
  - Updated CLI help/validation and provider availability to include local providers; no new dependencies

- **Migration**
  - Optional: run install with local endpoints, e.g. --lmstudio=http://localhost:1234/v1, --ollama=http://localhost:11434, --vllm=http://localhost:8000/v1
  - No action needed if not using local providers; existing configs are preserved and local providers are added alongside cloud providers

<sup>Written for commit 628f57fd35a5e2c3666a404838d5c9a95c133708. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

