### PR TITLE
feat: register ~/.agents/skills/ as slash commands in config.command

### DIFF
--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -126,3 +126,15 @@ export async function discoverGlobalAgentsSkills(): Promise<LoadedSkill[]> {
   const agentsGlobalDir = join(homedir(), ".agents", "skills")
   return loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
 }
+
+export async function loadGlobalAgentsSkills(): Promise<Record<string, CommandDefinition>> {
+  const agentsGlobalDir = join(homedir(), ".agents", "skills")
+  const skills = await loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
+  return skillsToCommandDefinitionRecord(skills)
+}
+
+export async function loadProjectAgentsSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+  const agentsProjectDir = join(directory ?? process.cwd(), ".agents", "skills")
+  const skills = await loadSkillsFromDir({ skillsDir: agentsProjectDir, scope: "project" })
+  return skillsToCommandDefinitionRecord(skills)
+}

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -13,6 +13,8 @@ import {
   loadProjectSkills,
   loadOpencodeGlobalSkills,
   loadOpencodeProjectSkills,
+  loadGlobalAgentsSkills,
+  loadProjectAgentsSkills,
   skillsToCommandDefinitionRecord,
 } from "../features/opencode-skill-loader";
 import type { PluginComponents } from "./plugin-components-loader";
@@ -39,6 +41,8 @@ export async function applyCommandConfig(params: {
     projectSkills,
     opencodeGlobalSkills,
     opencodeProjectSkills,
+    agentsGlobalSkills,
+    agentsProjectSkills,
   ] = await Promise.all([
     discoverConfigSourceSkills({
       config: params.pluginConfig.skills,
@@ -52,16 +56,20 @@ export async function applyCommandConfig(params: {
     includeClaudeSkills ? loadProjectSkills(params.ctx.directory) : Promise.resolve({}),
     loadOpencodeGlobalSkills(),
     loadOpencodeProjectSkills(params.ctx.directory),
+    loadGlobalAgentsSkills(),
+    loadProjectAgentsSkills(params.ctx.directory),
   ]);
 
   params.config.command = {
     ...builtinCommands,
     ...skillsToCommandDefinitionRecord(configSourceSkills),
+    ...agentsGlobalSkills,
     ...userCommands,
     ...userSkills,
     ...opencodeGlobalCommands,
     ...opencodeGlobalSkills,
     ...systemCommands,
+    ...agentsProjectSkills,
     ...projectCommands,
     ...projectSkills,
     ...opencodeProjectCommands,


### PR DESCRIPTION
## Summary

- Adds `loadGlobalAgentsSkills()` and `loadProjectAgentsSkills()` functions to the skill loader, following the same pattern as existing `loadUserSkills()` / `loadProjectSkills()`
- Integrates them into `command-config-handler.ts` so skills from `~/.agents/skills/` and `.agents/skills/` are registered as slash commands

## Problem

The `dev` branch added `discoverGlobalAgentsSkills()` and `discoverProjectAgentsSkills()` for agent awareness (skill descriptions in system prompts) and skill merging (`skill-context.ts`). However, the **command config handler** was not updated to load agents skills into `config.command`.

This means skills installed via `npx skills add` (skills.sh v3) were:
- ✅ Available via `load_skills=[]` and `proxy_skill()` (through the merging pipeline)
- ❌ **NOT** available as slash commands (e.g., `/my-skill`)

## Changes

### `src/features/opencode-skill-loader/loader.ts`
Added two new functions:
- `loadGlobalAgentsSkills()` — loads from `~/.agents/skills/` with scope `"user"`
- `loadProjectAgentsSkills(directory?)` — loads from `.agents/skills/` with scope `"project"`

Both follow the exact pattern of existing load functions: `loadSkillsFromDir()` → `skillsToCommandDefinitionRecord()`.

### `src/plugin-handlers/command-config-handler.ts`
- Added `loadGlobalAgentsSkills` and `loadProjectAgentsSkills` to imports and Promise.all
- Added `...agentsGlobalSkills` before `...userCommands` (so user-scope skills can override)
- Added `...agentsProjectSkills` before `...projectCommands` (so project-scope skills can override)

Priority ordering in the spread (later wins): `builtin < config < agentsGlobal < user < opencode < system < agentsProject < project < opencode-project < plugin`

## Testing

- 78 tests pass across skill loader and command config handler (0 failures)
- 0 LSP/TypeScript errors on modified files
- 16 pre-existing test failures in unrelated files (session-notification, executor, recovery-deduplication, config-handler todo permission)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers skills from ~/.agents/skills and .agents/skills as slash commands in config.command. This makes skills installed via skills.sh v3 (npx skills add) available as /commands.

- New Features
  - Added loadGlobalAgentsSkills() and loadProjectAgentsSkills() to convert agents skills into CommandDefinition records.
  - Updated command-config-handler to load these skills and merge them into config.command.
  - Precedence updated so agentsGlobal comes before user and agentsProject before project, allowing user/project overrides.

<sup>Written for commit 695e2a23043da752c86952b126048f865789a81c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

