### PR TITLE
fix(hashline-edit): update HASHLINE_OUTPUT_PATTERN separator from : to |

### DIFF
--- a/src/tools/hashline-edit/constants.ts
+++ b/src/tools/hashline-edit/constants.ts
@@ -7,5 +7,5 @@ export const HASHLINE_DICT = Array.from({ length: 256 }, (_, i) => {
 })
 
 export const HASHLINE_REF_PATTERN = /^([0-9]+)#([ZPMQVRWSNKTXJBYH]{2})$/
-export const HASHLINE_OUTPUT_PATTERN = /^([0-9]+)#([ZPMQVRWSNKTXJBYH]{2}):(.*)$/
+export const HASHLINE_OUTPUT_PATTERN = /^([0-9]+)#([ZPMQVRWSNKTXJBYH]{2})\|(.*)$/
 export const HASHLINE_LEGACY_REF_PATTERN = /^([0-9]+):([0-9a-fA-F]{2,})$/


### PR DESCRIPTION
## Summary
- Update `HASHLINE_OUTPUT_PATTERN` regex in `constants.ts` to use `|` separator instead of `:`

## Why
- PR #2079 migrated all hashline format separators from `:` to `|` but missed this exported constant
- `HASHLINE_OUTPUT_PATTERN` is exported as public API for external consumers
- No internal usage, but the inconsistency would break any external code relying on this pattern

## Changes
- `constants.ts`: `/^([0-9]+)#([ZPMQVRWSNKTXJBYH]{2}):(.*)$/` → `/^([0-9]+)#([ZPMQVRWSNKTXJBYH]{2})\|(.*)$/`

## Validation
- `bun test src/tools/hashline-edit` — 70 tests pass
- `tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update HASHLINE_OUTPUT_PATTERN to use the | separator instead of :. This aligns the public API with the hashline format migration and prevents breakage for external consumers.

- **Bug Fixes**
  - Change regex in constants.ts from ...):(.+)$ to ...)\|(.+)$ to match PR #2079.
  - No internal usage affected; tests pass and tsc is clean.

<sup>Written for commit 55c8952668a57f0d6efa8224fe7f8387bf4b3bf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

