### PR TITLE
feat(session-manager): ✨ add offset pagination to session_read tool

### DIFF
--- a/src/tools/session-manager/constants.ts
+++ b/src/tools/session-manager/constants.ts
@@ -27,17 +27,20 @@ Arguments:
 - session_id (required): Session ID to read
 - include_todos (optional): Include todo list if available (default: false)
 - include_transcript (optional): Include transcript log if available (default: false)
+- offset (optional): The message number to start reading from (1-indexed, default: 1)
 - limit (optional): Maximum number of messages to return (default: all)
 
 Example output:
 Session: ses_abc123
-Messages: 45
+Messages: 3-4 of 45
 Date Range: 2025-12-20 to 2025-12-24
 
-[Message 1] user (2025-12-20 10:30:00)
+Showing messages 3-4 of 45
+
+[Message 3] user (2025-12-20 10:35:00)
 Hello, can you help me with...
 
-[Message 2] assistant (2025-12-20 10:30:15)
+[Message 4] assistant (2025-12-20 10:35:15)
 Of course! Let me help you with...`
 
 export const SESSION_SEARCH_DESCRIPTION = `Search for content within OpenCode session messages.

--- a/src/tools/session-manager/session-formatter.ts
+++ b/src/tools/session-manager/session-formatter.ts
@@ -44,7 +44,8 @@ export async function formatSessionList(sessionIDs: string[]): Promise<string> {
 export function formatSessionMessages(
   messages: SessionMessage[],
   includeTodos?: boolean,
-  todos?: Array<{ id?: string; content: string; status: string }>
+  todos?: Array<{ id?: string; content: string; status: string }>,
+  pagination?: { offset: number; totalMessages: number }
 ): string {
   if (messages.length === 0) {
     return "No messages found in this session."
@@ -52,10 +53,18 @@ export function formatSessionMessages(
 
   const lines: string[] = []
 
-  for (const msg of messages) {
+  if (pagination) {
+    const endIndex = pagination.offset + messages.length - 1
+    lines.push(`Showing messages ${pagination.offset}-${endIndex} of ${pagination.totalMessages}`)
+    lines.push("")
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]
+    const messageNumber = pagination ? pagination.offset + i : i + 1
     const timestamp = msg.time?.created ? new Date(msg.time.created).toISOString() : "Unknown time"
     const agent = msg.agent ? ` (${msg.agent})` : ""
-    lines.push(`\n[${msg.role}${agent}] ${timestamp}`)
+    lines.push(`\n[Message ${messageNumber}] ${msg.role}${agent} ${timestamp}`)
 
     for (const part of msg.parts) {
       if (part.type === "text" && part.text) {

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -2,6 +2,9 @@ import { describe, test, expect } from "bun:test"
 import { createSessionManagerTools } from "./tools"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 import type { PluginInput } from "@opencode-ai/plugin"
+import { mock, beforeAll, afterAll } from "bun:test"
+import { formatSessionMessages } from "./session-formatter"
+import type { SessionMessage } from "./types"
 
 const projectDir = "/Users/yeongyu/local-workspaces/oh-my-opencode"
 
@@ -132,5 +135,105 @@ describe("session-manager tools", () => {
     const result = await session_info.execute({ session_id: "ses_test123" }, mockContext)
     
     expect(typeof result).toBe("string")
+  })
+})
+
+describe("session_read offset pagination", () => {
+  const mockMessages: SessionMessage[] = [
+    { id: "msg_1", role: "user", time: { created: 1700000000000 }, parts: [{ id: "p1", type: "text", text: "Hello" }] },
+    { id: "msg_2", role: "assistant", agent: "test-agent", time: { created: 1700000060000 }, parts: [{ id: "p2", type: "text", text: "Hi there" }] },
+    { id: "msg_3", role: "user", time: { created: 1700000120000 }, parts: [{ id: "p3", type: "text", text: "Question" }] },
+    { id: "msg_4", role: "assistant", agent: "test-agent", time: { created: 1700000180000 }, parts: [{ id: "p4", type: "text", text: "Answer" }] },
+    { id: "msg_5", role: "user", time: { created: 1700000240000 }, parts: [{ id: "p5", type: "text", text: "Thanks" }] },
+  ]
+
+  beforeAll(() => {
+    mock.module("./storage", () => ({
+      sessionExists: () => Promise.resolve(true),
+      readSessionMessages: () => Promise.resolve([...mockMessages]),
+      readSessionTodos: () => Promise.resolve([]),
+      setStorageClient: () => {},
+      resetStorageClient: () => {},
+      getMainSessions: () => Promise.resolve([]),
+      getAllSessions: () => Promise.resolve([]),
+      getMessageDir: () => null,
+      readSessionTranscript: () => Promise.resolve(0),
+      getSessionInfo: () => Promise.resolve(null),
+    }))
+  })
+
+  afterAll(() => {
+    mock.restore()
+  })
+
+  describe("#given offset is less than 1", () => {
+    describe("#when session_read is called with offset=0", () => {
+      test("#then returns error that offset must be >= 1", async () => {
+        const result = await session_read.execute({ session_id: "ses_mock", offset: 0 }, mockContext)
+
+        expect(result).toContain("offset must be >= 1")
+        expect(result).toContain("got 0")
+      })
+    })
+  })
+
+  describe("#given offset exceeds total message count", () => {
+    describe("#when session_read is called with offset=10 on a session with 5 messages", () => {
+      test("#then returns error about exceeding total message count", async () => {
+        const result = await session_read.execute({ session_id: "ses_mock", offset: 10 }, mockContext)
+
+        expect(result).toContain("exceeds total message count")
+        expect(result).toContain("(5)")
+      })
+    })
+  })
+
+  describe("#given a session with 5 messages", () => {
+    describe("#when session_read is called with a valid offset=3", () => {
+      test("#then executes without error", async () => {
+        const result = await session_read.execute({ session_id: "ses_mock", offset: 3 }, mockContext)
+
+        expect(result).not.toContain("Error")
+        expect(typeof result).toBe("string")
+      })
+    })
+
+    describe("#when session_read is called with offset=2 and limit=2", () => {
+      test("#then executes without error and returns correct slice", async () => {
+        const result = await session_read.execute({ session_id: "ses_mock", offset: 2, limit: 2 }, mockContext)
+
+        expect(result).not.toContain("Error")
+        expect(typeof result).toBe("string")
+      })
+    })
+
+    describe("#when session_read is called without offset or limit", () => {
+      test("#then returns all messages without pagination header", async () => {
+        const result = await session_read.execute({ session_id: "ses_mock" }, mockContext)
+
+        expect(result).not.toContain("Showing messages")
+        expect(result).not.toContain("Error")
+      })
+    })
+  })
+
+  describe("#given formatSessionMessages is called with pagination info", () => {
+    describe("#when offset is provided", () => {
+      test("#then pagination header shows correct message range", () => {
+        const slicedMessages = mockMessages.slice(2)
+        const result = formatSessionMessages(slicedMessages, false, undefined, { offset: 3, totalMessages: 5 })
+
+        expect(result).toContain("Showing messages 3-5 of 5")
+      })
+    })
+
+    describe("#when only limit is used and offset defaults to 1", () => {
+      test("#then pagination header starts from message 1", () => {
+        const slicedMessages = mockMessages.slice(0, 2)
+        const result = formatSessionMessages(slicedMessages, false, undefined, { offset: 1, totalMessages: 5 })
+
+        expect(result).toContain("Showing messages 1-2 of 5")
+      })
+    })
   })
 })

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -66,6 +66,7 @@ export function createSessionManagerTools(ctx: PluginInput): Record<string, Tool
       session_id: tool.schema.string().describe("Session ID to read"),
       include_todos: tool.schema.boolean().optional().describe("Include todo list if available (default: false)"),
       include_transcript: tool.schema.boolean().optional().describe("Include transcript log if available (default: false)"),
+      offset: tool.schema.number().optional().describe("The message number to start reading from (1-indexed, default: 1)"),
       limit: tool.schema.number().optional().describe("Maximum number of messages to return (default: all)"),
     },
     execute: async (args: SessionReadArgs, _context) => {
@@ -80,13 +81,28 @@ export function createSessionManagerTools(ctx: PluginInput): Record<string, Tool
           return `Session not found: ${args.session_id}`
         }
 
-        if (args.limit && args.limit > 0) {
-          messages = messages.slice(0, args.limit)
+        const totalMessages = messages.length
+
+        if (args.offset !== undefined) {
+          if (args.offset < 1) {
+            return `Error: offset must be >= 1, got ${args.offset}`
+          }
+          if (args.offset > totalMessages) {
+            return `Error: offset ${args.offset} exceeds total message count (${totalMessages})`
+          }
         }
+
+        const startIndex = args.offset !== undefined ? args.offset - 1 : 0
+        const endIndex = args.limit && args.limit > 0 ? startIndex + args.limit : undefined
+        messages = messages.slice(startIndex, endIndex)
 
         const todos = args.include_todos ? await readSessionTodos(args.session_id) : undefined
 
-        return formatSessionMessages(messages, args.include_todos, todos)
+        const shouldPaginate = args.offset !== undefined || (args.limit !== undefined && args.limit > 0)
+        return formatSessionMessages(messages, args.include_todos, todos, shouldPaginate ? {
+          offset: startIndex + 1,
+          totalMessages,
+        } : undefined)
       } catch (e) {
         return `Error: ${e instanceof Error ? e.message : String(e)}`
       }

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -79,6 +79,7 @@ export interface SessionReadArgs {
   session_id: string
   include_todos?: boolean
   include_transcript?: boolean
+  offset?: number
   limit?: number
 }
 


### PR DESCRIPTION
## Summary

- Add 1-indexed `offset` parameter to `session_read` tool for message pagination, similar to how the file `Read` tool works
- Users can now specify which message to start reading from (not just how many from the beginning)
- Clear error messages for invalid offset values (< 1 or > total messages)
- Pagination context header shows "Showing messages X-Y of Z" when offset/limit is used

## Changes

| File | Change |
|------|--------|
| `types.ts` | Added `offset?: number` to `SessionReadArgs` |
| `constants.ts` | Updated tool description with offset parameter docs and usage examples |
| `tools.ts` | Added offset validation, pagination slicing logic, and conditional pagination info |
| `session-formatter.ts` | Added pagination header and message numbering support |
| `tools.test.ts` | Added 7 new test cases covering offset validation, pagination, and edge cases |

## Motivation

The existing `session_read` tool only supports `limit` (read N messages from the beginning), making it inconvenient to read recent messages in long sessions. This change adds `offset` support so users can jump to any position in the message history — useful since the most relevant information is often near the end of a session.

## Testing

- 21 tests pass (7 new + 14 existing), 0 failures
- typecheck clean (`tsc --noEmit`)
- No anti-patterns introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 1-indexed offset pagination to session_read so you can start reading from any message. Output now shows the message range and numbers each message, with clear errors for invalid offsets.

- **New Features**
  - Added offset arg (1-indexed) that works with limit to return slices.
  - Validates offset bounds and returns helpful errors.
  - Shows "Showing messages X–Y of Z" and numbers each message.
  - Updated tool docs and added tests.

<sup>Written for commit c1ff58533bf5285b61ead67ee01df4633ee07c69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

