### PR TITLE
fix: stabilize fallback/notification regressions and add issue delivery docs

### DIFF
--- a/docs/guide/gitlab-issue-regression-delivery-plan.md
+++ b/docs/guide/gitlab-issue-regression-delivery-plan.md
@@ -1,0 +1,81 @@
+# GitLab Issue-Aligned Delivery Plan (Regression Fixes)
+
+## Goal
+
+Ship the current regression fixes with strict issue workflow discipline:
+
+- Lock scope to regression stabilization.
+- Verify with deterministic evidence.
+- Prepare review-ready update/MR materials.
+
+## Scope Lock
+
+This issue only covers the following files:
+
+- `src/hooks/model-fallback/hook.ts`
+- `src/hooks/session-notification-utils.ts`
+- `src/plugin/tool-execute-before-session-notification.test.ts`
+- `docs/guide/gitlab-issue-regression-delivery-plan.md`
+- `docs/guide/gitlab-issue-regression-delivery-template.md`
+
+Out of scope:
+
+- New features
+- Cross-repo architecture changes
+- Unrelated dirty worktree files
+
+## Delivery Phases
+
+### Phase A - Implement
+
+1. Keep fallback provider deterministic for first-step fallback selection.
+2. Remove session-notification command lookup state leakage.
+3. Restore test isolation for session state mocking.
+
+### Phase B - Verify
+
+Run and record:
+
+1. Targeted regression test batch
+2. Extended related test batch
+3. `bun run typecheck`
+4. `bun run build`
+
+### Phase C - Handoff
+
+1. Post issue status update with root cause + fix summary.
+2. Publish MR description with verification evidence and rollback notes.
+
+## Acceptance Criteria
+
+### AC-1 Model Fallback
+
+- Given retryable model errors
+- When fallback is applied
+- Then first-hop provider selection remains stable and tests pass
+
+### AC-2 Session Notification
+
+- Given idle/question/permission notification paths
+- When tests run as a batch
+- Then notification assertions remain stable (no batch-only zero-notification regressions)
+
+### AC-3 Quality Gates
+
+- Regression test suite passes
+- `bun run typecheck` passes
+- `bun run build` passes
+
+## Risk and Rollback
+
+Risk level: low-to-medium.
+
+Rollback strategy:
+
+- Revert only the touched files in this issue scope.
+- Re-run the same verification chain.
+
+## Suggested Commit Slices
+
+1. `fix(hooks): stabilize fallback and notification regression paths`
+2. `docs(guide): add GitLab issue delivery plan and templates`

--- a/docs/guide/gitlab-issue-regression-delivery-template.md
+++ b/docs/guide/gitlab-issue-regression-delivery-template.md
@@ -1,0 +1,78 @@
+# GitLab Issue Update and MR Template
+
+## Issue Update (Paste-ready)
+
+### Status
+
+- `In Progress -> Ready for Review`
+- Type: regression fix only (scope locked)
+
+### Completed
+
+- Stabilized first-hop provider handling in model fallback path.
+- Removed cross-test leakage in session-notification command lookup helper.
+- Restored mock cleanup in session-notification related plugin test.
+
+### Root Cause
+
+- Fallback provider selection behavior varied under retry chains.
+- Notification tests were affected by shared runtime/mock state across files.
+
+### Validation Evidence
+
+```bash
+bun test src/shared/model-error-classifier.test.ts \
+  src/hooks/model-fallback/hook.test.ts \
+  src/plugin/event.model-fallback.test.ts \
+  src/cli/model-fallback.test.ts \
+  src/hooks/session-notification.test.ts \
+  src/hooks/session-notification-input-needed.test.ts \
+  src/plugin/tool-execute-before-session-notification.test.ts \
+  src/cli/mcp-oauth/login.test.ts
+
+bun run typecheck
+bun run build
+```
+
+### Risk and Rollback
+
+- Risk: low-to-medium, localized behavior changes
+- Rollback: revert issue-scoped files only and rerun the same verification chain
+
+---
+
+## MR Description (Paste-ready)
+
+### What
+
+- Fix fallback and notification regression behavior.
+- Improve test isolation for session-notification path.
+- Add issue-aligned delivery docs for consistent workflow.
+
+### Why
+
+- Batch-run instability made regression verification unreliable.
+- Issue delivery needed explicit acceptance criteria and review artifacts.
+
+### Files
+
+- `src/hooks/model-fallback/hook.ts`
+- `src/hooks/session-notification-utils.ts`
+- `src/plugin/tool-execute-before-session-notification.test.ts`
+- `docs/guide/gitlab-issue-regression-delivery-plan.md`
+- `docs/guide/gitlab-issue-regression-delivery-template.md`
+
+### Validation
+
+- Regression tests: pass
+- Typecheck: pass
+- Build: pass
+
+### Risk
+
+- No API shape changes
+- Behavior changes are localized to fallback/notification flows
+
+### Rollback
+
+- Revert touched files and rerun validation commands

--- a/src/hooks/model-fallback/hook.ts
+++ b/src/hooks/model-fallback/hook.ts
@@ -138,7 +138,10 @@ export function getNextFallback(
       continue
     }
 
-    const providerID = selectFallbackProvider(fallback.providers, state.providerID)
+    const preferredProviderID = fallback.providers.find(
+      (provider) => provider.toLowerCase() === state.providerID.toLowerCase(),
+    )
+    const providerID = preferredProviderID ?? selectFallbackProvider(fallback.providers, state.providerID)
     state.pending = false
 
     log("[model-fallback] Using fallback for session: " + sessionID + ", attempt: " + attemptCount + ", model: " + fallback.model)

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -12,7 +12,7 @@ function createCommandFinder(commandName: string): () => Promise<string | null> 
   let cachedPath: string | null = null
   let pending: Promise<string | null> | null = null
 
-  return async () => {
+  return async (): Promise<string | null> => {
     if (cachedPath !== null) return cachedPath
     if (pending) return pending
 
@@ -22,7 +22,11 @@ function createCommandFinder(commandName: string): () => Promise<string | null> 
       return path
     })()
 
-    return pending
+    try {
+      return await pending
+    } finally {
+      pending = null
+    }
   }
 }
 

--- a/src/plugin/tool-execute-before-session-notification.test.ts
+++ b/src/plugin/tool-execute-before-session-notification.test.ts
@@ -15,18 +15,22 @@ describe("createToolExecuteBeforeHandler session notification sessionID", () => 
       },
     }
 
-    const handler = createToolExecuteBeforeHandler({
-      ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
-      hooks,
-    })
+    try {
+      const handler = createToolExecuteBeforeHandler({
+        ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
+        hooks,
+      })
 
-    await handler(
-      { tool: "question", sessionID: "", callID: "call_q" },
-      { args: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] } },
-    )
+      await handler(
+        { tool: "question", sessionID: "", callID: "call_q" },
+        { args: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] } },
+      )
 
-    expect(getMainSessionIDSpy).toHaveBeenCalled()
-    expect(capturedSessionID).toBe(mainSessionID)
+      expect(getMainSessionIDSpy).toHaveBeenCalled()
+      expect(capturedSessionID).toBe(mainSessionID)
+    } finally {
+      getMainSessionIDSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Goal
Deliver a scope-locked regression fix aligned with issue workflow, with deterministic validation evidence and handoff-ready docs.

## Scope Lock
This PR only includes regression stabilization and issue-delivery documentation:
- `src/hooks/model-fallback/hook.ts`
- `src/hooks/session-notification-utils.ts`
- `src/plugin/tool-execute-before-session-notification.test.ts`
- `docs/guide/gitlab-issue-regression-delivery-plan.md`
- `docs/guide/gitlab-issue-regression-delivery-template.md`

Out of scope:
- feature expansion
- cross-repo architecture changes
- unrelated dirty worktree changes

## Commits
- `0a930bea` fix(hooks): stabilize fallback and notification regression paths
- `d8c6b8a0` docs(guide): add GitLab issue regression delivery templates

## What Changed
- Model fallback: keep first-hop provider deterministic by preferring the current session provider when it exists in candidate providers.
- Session notification utils: clear command lookup pending state after each probe to prevent cross-test leakage.
- Test isolation: restore mocked session state in `tool-execute-before-session-notification` test with guaranteed cleanup.
- Delivery docs: add issue-aligned plan/template for repeatable review and handoff.

## Validation
```bash
bun test src/shared/model-error-classifier.test.ts src/hooks/model-fallback/hook.test.ts src/plugin/event.model-fallback.test.ts src/cli/model-fallback.test.ts src/hooks/session-notification.test.ts src/hooks/session-notification-input-needed.test.ts src/plugin/tool-execute-before-session-notification.test.ts src/cli/mcp-oauth/login.test.ts
bun run typecheck
bun run build
```
Result:
- tests: 69 pass / 0 fail
- typecheck: pass
- build: pass

## Acceptance Criteria Mapping
- AC-1 (model fallback): pass
- AC-2 (session notification batch stability): pass
- AC-3 (quality gates): pass

## Risk
- localized behavior changes in fallback/notification paths
- no API shape changes

## Rollback
Revert touched files in this PR scope and rerun the same validation chain.
