### PR TITLE
milestone: integrate M1+M2 changes to unblock merge order

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -82,6 +82,9 @@
     "hashline_edit": {
       "type": "boolean"
     },
+    "default_injection_toggle": {
+      "type": "boolean"
+    },
     "model_fallback": {
       "type": "boolean"
     },
@@ -960,6 +963,9 @@
                 }
               },
               "additionalProperties": false
+            },
+            "allow_non_gpt_model": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -3247,6 +3253,11 @@
           },
           "prompt_append": {
             "type": "string"
+          },
+          "max_prompt_tokens": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
           },
           "is_unstable_agent": {
             "type": "boolean"

--- a/docs/guide/gitlab-issue-regression-delivery-plan.md
+++ b/docs/guide/gitlab-issue-regression-delivery-plan.md
@@ -12,10 +12,25 @@ Ship the current regression fixes with strict issue workflow discipline:
 
 Use milestone-first delivery with issue/work-order tracking:
 
+### Source of Truth
+
+- GitLab group: `ktai` (private)
+- Projects in scope:
+  - `ktai/ktai-desktop`
+  - `ktai/ktai-mobile`
+
+Verified active milestones in both projects:
+
+1. `M0-Architecture-and-UX-Freeze` (`2026-02-26` -> `2026-03-04`)
+2. `M1-Desktop-OEM-Alpha` (`2026-03-05` -> `2026-03-19`)
+3. `M2-Mobile-Realtime-MVP` (`2026-03-20` -> `2026-04-02`)
+4. `M3-Security-and-Beta` (`2026-04-03` -> `2026-04-16`)
+
 ### M1 - Regression Baseline Stabilization
 
 - Scope: fallback + session-notification regressions only
 - Delivery unit: PR `#2119`
+- GitLab mapping: `ktai-desktop` M1 issue stream (`#4/#5/#6` readiness baseline)
 - Gate:
   - all PR checks green
   - acceptance criteria AC-1/AC-2/AC-3 pass
@@ -25,6 +40,7 @@ Use milestone-first delivery with issue/work-order tracking:
 
 - Scope: `default_injection_toggle` + default managed plugin discovery when DB missing
 - Delivery unit: PR `#2122` (stacked on M1 baseline)
+- GitLab mapping: `ktai-desktop` M1 issue `[OEM] oh-my-opencode 默认集成 + 可关闭策略` (`#5`)
 - Gate:
   - all PR checks green
   - extended tests + typecheck + build pass
@@ -37,6 +53,13 @@ Use milestone-first delivery with issue/work-order tracking:
   - rerun targeted regression suite on `dev`
   - confirm no new check regressions
   - publish milestone closure comment with evidence links
+
+### Downstream Alignment (Mobile)
+
+- Mobile M2 open work orders:
+  - `ktai-mobile#6` `[M2] 移动端远控核心交互实现`
+  - `ktai-mobile#7` `[M2] 移动端重连与稳定性优化`
+- This repository's current delivery acts as upstream dependency for those mobile work orders.
 
 ## Scope Lock
 

--- a/docs/guide/gitlab-issue-regression-delivery-plan.md
+++ b/docs/guide/gitlab-issue-regression-delivery-plan.md
@@ -8,6 +8,36 @@ Ship the current regression fixes with strict issue workflow discipline:
 - Verify with deterministic evidence.
 - Prepare review-ready update/MR materials.
 
+## Milestone Alignment (GitLab-style)
+
+Use milestone-first delivery with issue/work-order tracking:
+
+### M1 - Regression Baseline Stabilization
+
+- Scope: fallback + session-notification regressions only
+- Delivery unit: PR `#2119`
+- Gate:
+  - all PR checks green
+  - acceptance criteria AC-1/AC-2/AC-3 pass
+  - ready for review/merge
+
+### M2 - Configurable Injection and Loader Fallback
+
+- Scope: `default_injection_toggle` + default managed plugin discovery when DB missing
+- Delivery unit: PR `#2122` (stacked on M1 baseline)
+- Gate:
+  - all PR checks green
+  - extended tests + typecheck + build pass
+  - review focuses on commits `325e0016`, `01c79e3e`, `c9af780b`
+
+### M3 - Merge and Milestone Closure
+
+- Merge order: M1 -> M2
+- Post-merge verification:
+  - rerun targeted regression suite on `dev`
+  - confirm no new check regressions
+  - publish milestone closure comment with evidence links
+
 ## Scope Lock
 
 This issue only covers the following files:
@@ -45,6 +75,12 @@ Run and record:
 
 1. Post issue status update with root cause + fix summary.
 2. Publish MR description with verification evidence and rollback notes.
+
+### Phase D - Milestone Closure
+
+1. Close M1 after PR `#2119` merge.
+2. Close M2 after PR `#2122` merge.
+3. Publish milestone-level closure note with merge order, evidence, and rollback references.
 
 ## Acceptance Criteria
 

--- a/docs/guide/gitlab-issue-regression-delivery-plan.md
+++ b/docs/guide/gitlab-issue-regression-delivery-plan.md
@@ -1,0 +1,81 @@
+# GitLab Issue-Aligned Delivery Plan (Regression Fixes)
+
+## Goal
+
+Ship the current regression fixes with strict issue workflow discipline:
+
+- Lock scope to regression stabilization.
+- Verify with deterministic evidence.
+- Prepare review-ready update/MR materials.
+
+## Scope Lock
+
+This issue only covers the following files:
+
+- `src/hooks/model-fallback/hook.ts`
+- `src/hooks/session-notification-utils.ts`
+- `src/plugin/tool-execute-before-session-notification.test.ts`
+- `docs/guide/gitlab-issue-regression-delivery-plan.md`
+- `docs/guide/gitlab-issue-regression-delivery-template.md`
+
+Out of scope:
+
+- New features
+- Cross-repo architecture changes
+- Unrelated dirty worktree files
+
+## Delivery Phases
+
+### Phase A - Implement
+
+1. Keep fallback provider deterministic for first-step fallback selection.
+2. Remove session-notification command lookup state leakage.
+3. Restore test isolation for session state mocking.
+
+### Phase B - Verify
+
+Run and record:
+
+1. Targeted regression test batch
+2. Extended related test batch
+3. `bun run typecheck`
+4. `bun run build`
+
+### Phase C - Handoff
+
+1. Post issue status update with root cause + fix summary.
+2. Publish MR description with verification evidence and rollback notes.
+
+## Acceptance Criteria
+
+### AC-1 Model Fallback
+
+- Given retryable model errors
+- When fallback is applied
+- Then first-hop provider selection remains stable and tests pass
+
+### AC-2 Session Notification
+
+- Given idle/question/permission notification paths
+- When tests run as a batch
+- Then notification assertions remain stable (no batch-only zero-notification regressions)
+
+### AC-3 Quality Gates
+
+- Regression test suite passes
+- `bun run typecheck` passes
+- `bun run build` passes
+
+## Risk and Rollback
+
+Risk level: low-to-medium.
+
+Rollback strategy:
+
+- Revert only the touched files in this issue scope.
+- Re-run the same verification chain.
+
+## Suggested Commit Slices
+
+1. `fix(hooks): stabilize fallback and notification regression paths`
+2. `docs(guide): add GitLab issue delivery plan and templates`

--- a/docs/guide/gitlab-issue-regression-delivery-template.md
+++ b/docs/guide/gitlab-issue-regression-delivery-template.md
@@ -1,0 +1,78 @@
+# GitLab Issue Update and MR Template
+
+## Issue Update (Paste-ready)
+
+### Status
+
+- `In Progress -> Ready for Review`
+- Type: regression fix only (scope locked)
+
+### Completed
+
+- Stabilized first-hop provider handling in model fallback path.
+- Removed cross-test leakage in session-notification command lookup helper.
+- Restored mock cleanup in session-notification related plugin test.
+
+### Root Cause
+
+- Fallback provider selection behavior varied under retry chains.
+- Notification tests were affected by shared runtime/mock state across files.
+
+### Validation Evidence
+
+```bash
+bun test src/shared/model-error-classifier.test.ts \
+  src/hooks/model-fallback/hook.test.ts \
+  src/plugin/event.model-fallback.test.ts \
+  src/cli/model-fallback.test.ts \
+  src/hooks/session-notification.test.ts \
+  src/hooks/session-notification-input-needed.test.ts \
+  src/plugin/tool-execute-before-session-notification.test.ts \
+  src/cli/mcp-oauth/login.test.ts
+
+bun run typecheck
+bun run build
+```
+
+### Risk and Rollback
+
+- Risk: low-to-medium, localized behavior changes
+- Rollback: revert issue-scoped files only and rerun the same verification chain
+
+---
+
+## MR Description (Paste-ready)
+
+### What
+
+- Fix fallback and notification regression behavior.
+- Improve test isolation for session-notification path.
+- Add issue-aligned delivery docs for consistent workflow.
+
+### Why
+
+- Batch-run instability made regression verification unreliable.
+- Issue delivery needed explicit acceptance criteria and review artifacts.
+
+### Files
+
+- `src/hooks/model-fallback/hook.ts`
+- `src/hooks/session-notification-utils.ts`
+- `src/plugin/tool-execute-before-session-notification.test.ts`
+- `docs/guide/gitlab-issue-regression-delivery-plan.md`
+- `docs/guide/gitlab-issue-regression-delivery-template.md`
+
+### Validation
+
+- Regression tests: pass
+- Typecheck: pass
+- Build: pass
+
+### Risk
+
+- No API shape changes
+- Behavior changes are localized to fallback/notification flows
+
+### Rollback
+
+- Revert touched files and rerun validation commands

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -35,6 +35,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   disabled_tools: z.array(z.string()).optional(),
   /** Enable hashline_edit tool/hook integrations (default: true at call site) */
   hashline_edit: z.boolean().optional(),
+  default_injection_toggle: z.boolean().optional(),
   /** Enable model fallback on API errors (default: false). Set to true to enable automatic model switching when model errors occur. */
   model_fallback: z.boolean().optional(),
   agents: AgentOverridesSchema.optional(),

--- a/src/features/claude-code-plugin-loader/discovery.test.ts
+++ b/src/features/claude-code-plugin-loader/discovery.test.ts
@@ -1,60 +1,59 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { discoverInstalledPlugins } from "./discovery";
-import type { InstalledPluginsDatabase } from "./types";
+const { afterEach, beforeEach, describe, expect, it } = require("bun:test")
+const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = require("fs")
+const { join } = require("path")
+const { tmpdir } = require("os")
+const { discoverInstalledPlugins } = require("./discovery")
 
 describe("discoverInstalledPlugins", () => {
-  let pluginsHome = "";
-  const originalPluginsHome = process.env.CLAUDE_PLUGINS_HOME;
-  const originalSettingsPath = process.env.CLAUDE_SETTINGS_PATH;
+  let pluginsHome = ""
+  const originalPluginsHome = process.env.CLAUDE_PLUGINS_HOME
+  const originalSettingsPath = process.env.CLAUDE_SETTINGS_PATH
 
   beforeEach(() => {
-    pluginsHome = mkdtempSync(join(tmpdir(), "omo-plugin-loader-"));
-    process.env.CLAUDE_PLUGINS_HOME = pluginsHome;
-    process.env.CLAUDE_SETTINGS_PATH = join(pluginsHome, "settings.json");
-  });
+    pluginsHome = mkdtempSync(join(tmpdir(), "omo-plugin-loader-"))
+    process.env.CLAUDE_PLUGINS_HOME = pluginsHome
+    process.env.CLAUDE_SETTINGS_PATH = join(pluginsHome, "settings.json")
+  })
 
   afterEach(() => {
     if (originalPluginsHome === undefined) {
-      delete process.env.CLAUDE_PLUGINS_HOME;
+      delete process.env.CLAUDE_PLUGINS_HOME
     } else {
-      process.env.CLAUDE_PLUGINS_HOME = originalPluginsHome;
+      process.env.CLAUDE_PLUGINS_HOME = originalPluginsHome
     }
 
     if (originalSettingsPath === undefined) {
-      delete process.env.CLAUDE_SETTINGS_PATH;
+      delete process.env.CLAUDE_SETTINGS_PATH
     } else {
-      process.env.CLAUDE_SETTINGS_PATH = originalSettingsPath;
+      process.env.CLAUDE_SETTINGS_PATH = originalSettingsPath
     }
 
     if (pluginsHome) {
-      rmSync(pluginsHome, { recursive: true, force: true });
+      rmSync(pluginsHome, { recursive: true, force: true })
     }
-  });
+  })
 
   describe("#given installed_plugins.json is missing", () => {
     it("#then injects a managed default plugin entry", () => {
-      const result = discoverInstalledPlugins();
+      const result = discoverInstalledPlugins()
 
-      expect(result.errors).toHaveLength(0);
-      expect(result.plugins).toHaveLength(1);
+      expect(result.errors).toHaveLength(0)
+      expect(result.plugins).toHaveLength(1)
 
-      const plugin = result.plugins[0];
-      expect(plugin?.name).toBe("OpenCodeBuiltinDefault");
-      expect(plugin?.scope).toBe("managed");
-      expect(plugin?.installPath).toBe(join(pluginsHome, "builtin-default-plugin"));
-      expect(plugin?.pluginKey).toBe("opencode-builtin-default@managed");
-    });
-  });
+      const plugin = result.plugins[0]
+      expect(plugin?.name).toBe("OpenCodeBuiltinDefault")
+      expect(plugin?.scope).toBe("managed")
+      expect(plugin?.installPath).toBe(join(pluginsHome, "builtin-default-plugin"))
+      expect(plugin?.pluginKey).toBe("opencode-builtin-default@managed")
+    })
+  })
 
   describe("#given installed_plugins.json exists", () => {
     it("#then returns discovered installed plugins instead of default injection", () => {
-      const installPath = join(pluginsHome, "example-plugin");
-      mkdirSync(installPath, { recursive: true });
+      const installPath = join(pluginsHome, "example-plugin")
+      mkdirSync(installPath, { recursive: true })
 
-      const db: InstalledPluginsDatabase = {
+      const db = {
         version: 1,
         plugins: {
           "example-plugin@market": {
@@ -65,15 +64,17 @@ describe("discoverInstalledPlugins", () => {
             lastUpdated: "2026-01-01T00:00:00.000Z",
           },
         },
-      };
-      writeFileSync(join(pluginsHome, "installed_plugins.json"), JSON.stringify(db));
+      }
+      writeFileSync(join(pluginsHome, "installed_plugins.json"), JSON.stringify(db))
 
-      const result = discoverInstalledPlugins();
+      const result = discoverInstalledPlugins()
 
-      expect(result.errors).toHaveLength(0);
-      expect(result.plugins).toHaveLength(1);
-      expect(result.plugins[0]?.pluginKey).toBe("example-plugin@market");
-      expect(result.plugins[0]?.scope).toBe("project");
-    });
-  });
-});
+      expect(result.errors).toHaveLength(0)
+      expect(result.plugins).toHaveLength(1)
+      expect(result.plugins[0]?.pluginKey).toBe("example-plugin@market")
+      expect(result.plugins[0]?.scope).toBe("project")
+    })
+  })
+})
+
+export {}

--- a/src/features/claude-code-plugin-loader/discovery.test.ts
+++ b/src/features/claude-code-plugin-loader/discovery.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { discoverInstalledPlugins } from "./discovery";
+import type { InstalledPluginsDatabase } from "./types";
+
+describe("discoverInstalledPlugins", () => {
+  let pluginsHome = "";
+  const originalPluginsHome = process.env.CLAUDE_PLUGINS_HOME;
+  const originalSettingsPath = process.env.CLAUDE_SETTINGS_PATH;
+
+  beforeEach(() => {
+    pluginsHome = mkdtempSync(join(tmpdir(), "omo-plugin-loader-"));
+    process.env.CLAUDE_PLUGINS_HOME = pluginsHome;
+    process.env.CLAUDE_SETTINGS_PATH = join(pluginsHome, "settings.json");
+  });
+
+  afterEach(() => {
+    if (originalPluginsHome === undefined) {
+      delete process.env.CLAUDE_PLUGINS_HOME;
+    } else {
+      process.env.CLAUDE_PLUGINS_HOME = originalPluginsHome;
+    }
+
+    if (originalSettingsPath === undefined) {
+      delete process.env.CLAUDE_SETTINGS_PATH;
+    } else {
+      process.env.CLAUDE_SETTINGS_PATH = originalSettingsPath;
+    }
+
+    if (pluginsHome) {
+      rmSync(pluginsHome, { recursive: true, force: true });
+    }
+  });
+
+  describe("#given installed_plugins.json is missing", () => {
+    it("#then injects a managed default plugin entry", () => {
+      const result = discoverInstalledPlugins();
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.plugins).toHaveLength(1);
+
+      const plugin = result.plugins[0];
+      expect(plugin?.name).toBe("OpenCodeBuiltinDefault");
+      expect(plugin?.scope).toBe("managed");
+      expect(plugin?.installPath).toBe(join(pluginsHome, "builtin-default-plugin"));
+      expect(plugin?.pluginKey).toBe("opencode-builtin-default@managed");
+    });
+  });
+
+  describe("#given installed_plugins.json exists", () => {
+    it("#then returns discovered installed plugins instead of default injection", () => {
+      const installPath = join(pluginsHome, "example-plugin");
+      mkdirSync(installPath, { recursive: true });
+
+      const db: InstalledPluginsDatabase = {
+        version: 1,
+        plugins: {
+          "example-plugin@market": {
+            scope: "project",
+            installPath,
+            version: "1.0.0",
+            installedAt: "2026-01-01T00:00:00.000Z",
+            lastUpdated: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      };
+      writeFileSync(join(pluginsHome, "installed_plugins.json"), JSON.stringify(db));
+
+      const result = discoverInstalledPlugins();
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.plugins).toHaveLength(1);
+      expect(result.plugins[0]?.pluginKey).toBe("example-plugin@market");
+      expect(result.plugins[0]?.scope).toBe("project");
+    });
+  });
+});

--- a/src/features/claude-code-plugin-loader/discovery.ts
+++ b/src/features/claude-code-plugin-loader/discovery.ts
@@ -9,7 +9,6 @@ import type {
   LoadedPlugin,
   PluginLoadResult,
   PluginLoadError,
-  PluginScope,
   ClaudeSettings,
   PluginLoaderOptions,
 } from "./types"
@@ -112,6 +111,17 @@ export function discoverInstalledPlugins(options?: PluginLoaderOptions): PluginL
   const errors: PluginLoadError[] = []
 
   if (!db || !db.plugins) {
+    const builtinPath = join(getPluginsBaseDir(), "builtin-default-plugin")
+    const defaultPlugin: LoadedPlugin = {
+      name: "OpenCodeBuiltinDefault",
+      version: "0.0.0",
+      scope: "managed",
+      installPath: builtinPath,
+      pluginKey: "opencode-builtin-default@managed",
+      manifest: undefined
+    }
+    plugins.push(defaultPlugin)
+    log("Injected builtin default plugin for initialization", { path: builtinPath })
     return { plugins, errors }
   }
 
@@ -143,7 +153,7 @@ export function discoverInstalledPlugins(options?: PluginLoaderOptions): PluginL
     const loadedPlugin: LoadedPlugin = {
       name: pluginName,
       version: version || manifest?.version || "unknown",
-      scope: scope as PluginScope,
+      scope,
       installPath,
       pluginKey,
       manifest: manifest ?? undefined,

--- a/src/hooks/model-fallback/hook.ts
+++ b/src/hooks/model-fallback/hook.ts
@@ -138,7 +138,10 @@ export function getNextFallback(
       continue
     }
 
-    const providerID = selectFallbackProvider(fallback.providers, state.providerID)
+    const preferredProviderID = fallback.providers.find(
+      (provider) => provider.toLowerCase() === state.providerID.toLowerCase(),
+    )
+    const providerID = preferredProviderID ?? selectFallbackProvider(fallback.providers, state.providerID)
     state.pending = false
 
     log("[model-fallback] Using fallback for session: " + sessionID + ", attempt: " + attemptCount + ", model: " + fallback.model)

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -12,7 +12,7 @@ function createCommandFinder(commandName: string): () => Promise<string | null> 
   let cachedPath: string | null = null
   let pending: Promise<string | null> | null = null
 
-  return async () => {
+  return async (): Promise<string | null> => {
     if (cachedPath !== null) return cachedPath
     if (pending) return pending
 
@@ -22,7 +22,11 @@ function createCommandFinder(commandName: string): () => Promise<string | null> 
       return path
     })()
 
-    return pending
+    try {
+      return await pending
+    } finally {
+      pending = null
+    }
   }
 }
 

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -237,3 +237,19 @@ describe("parseConfigPartially", () => {
     });
   });
 });
+
+describe("default_injection_toggle field", () => {
+  it("parses and merges boolean values correctly", () => {
+    const base: OhMyOpenCodeConfig = { default_injection_toggle: false };
+    const override: OhMyOpenCodeConfig = { default_injection_toggle: true };
+    const result = mergeConfigs(base, override);
+    expect(result.default_injection_toggle).toBe(true);
+  });
+
+  it("keeps undefined when not provided", () => {
+    const base: OhMyOpenCodeConfig = {};
+    const override: OhMyOpenCodeConfig = {};
+    const result = mergeConfigs(base, override);
+    expect(result.default_injection_toggle).toBeUndefined();
+  });
+});

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -130,6 +130,8 @@ export function mergeConfigs(
       ]),
     ],
     claude_code: deepMerge(base.claude_code, override.claude_code),
+    default_injection_toggle:
+      override.default_injection_toggle ?? base.default_injection_toggle,
   };
 }
 

--- a/src/plugin/hooks/create-transform-hooks.test.ts
+++ b/src/plugin/hooks/create-transform-hooks.test.ts
@@ -1,33 +1,33 @@
-import { describe, it, expect } from "bun:test";
-import type { OhMyOpenCodeConfig } from "../../config";
-import type { PluginContext } from "../types";
-import { createTransformHooks } from "./create-transform-hooks";
+const { describe, it, expect } = require("bun:test")
+const { createTransformHooks } = require("./create-transform-hooks")
 
 describe("createTransformHooks - context-injection gating", () => {
-  const dummyCtx = {} as PluginContext;
+  const dummyCtx = {}
 
-  const hookEnabledFor = (hookName: string): boolean => hookName === "context-injector";
+  const hookEnabledFor = (hookName) => hookName === "context-injector"
 
-  const makeHooks = (pluginConfig: OhMyOpenCodeConfig) =>
+  const makeHooks = (pluginConfig) =>
     createTransformHooks({
       ctx: dummyCtx,
       pluginConfig,
       isHookEnabled: hookEnabledFor,
       safeHookEnabled: true,
-    });
+    })
 
   it("enables context-injector when default_injection_toggle is true", () => {
-    const hooks = makeHooks({ default_injection_toggle: true });
-    expect(hooks.contextInjectorMessagesTransform).not.toBeNull();
-  });
+    const hooks = makeHooks({ default_injection_toggle: true })
+    expect(hooks.contextInjectorMessagesTransform).not.toBeNull()
+  })
 
   it("enables context-injector when default_injection_toggle is undefined", () => {
-    const hooks = makeHooks({});
-    expect(hooks.contextInjectorMessagesTransform).not.toBeNull();
-  });
+    const hooks = makeHooks({})
+    expect(hooks.contextInjectorMessagesTransform).not.toBeNull()
+  })
 
   it("disables context-injector when default_injection_toggle is false", () => {
-    const hooks = makeHooks({ default_injection_toggle: false });
-    expect(hooks.contextInjectorMessagesTransform).toBeNull();
-  });
-});
+    const hooks = makeHooks({ default_injection_toggle: false })
+    expect(hooks.contextInjectorMessagesTransform).toBeNull()
+  })
+})
+
+export {}

--- a/src/plugin/hooks/create-transform-hooks.test.ts
+++ b/src/plugin/hooks/create-transform-hooks.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "bun:test";
+import type { OhMyOpenCodeConfig } from "../../config";
+import type { PluginContext } from "../types";
+import { createTransformHooks } from "./create-transform-hooks";
+
+describe("createTransformHooks - context-injection gating", () => {
+  const dummyCtx = {} as PluginContext;
+
+  const hookEnabledFor = (hookName: string): boolean => hookName === "context-injector";
+
+  const makeHooks = (pluginConfig: OhMyOpenCodeConfig) =>
+    createTransformHooks({
+      ctx: dummyCtx,
+      pluginConfig,
+      isHookEnabled: hookEnabledFor,
+      safeHookEnabled: true,
+    });
+
+  it("enables context-injector when default_injection_toggle is true", () => {
+    const hooks = makeHooks({ default_injection_toggle: true });
+    expect(hooks.contextInjectorMessagesTransform).not.toBeNull();
+  });
+
+  it("enables context-injector when default_injection_toggle is undefined", () => {
+    const hooks = makeHooks({});
+    expect(hooks.contextInjectorMessagesTransform).not.toBeNull();
+  });
+
+  it("disables context-injector when default_injection_toggle is false", () => {
+    const hooks = makeHooks({ default_injection_toggle: false });
+    expect(hooks.contextInjectorMessagesTransform).toBeNull();
+  });
+});

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -15,7 +15,9 @@ import { safeCreateHook } from "../../shared/safe-create-hook"
 export type TransformHooks = {
   claudeCodeHooks: ReturnType<typeof createClaudeCodeHooksHook> | null
   keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null
-  contextInjectorMessagesTransform: ReturnType<typeof createContextInjectorMessagesTransformHook>
+  contextInjectorMessagesTransform:
+    | ReturnType<typeof createContextInjectorMessagesTransformHook>
+    | null
   thinkingBlockValidator: ReturnType<typeof createThinkingBlockValidatorHook> | null
 }
 
@@ -27,6 +29,7 @@ export function createTransformHooks(args: {
 }): TransformHooks {
   const { ctx, pluginConfig, isHookEnabled } = args
   const safeHookEnabled = args.safeHookEnabled ?? true
+  const isContextInjectionEnabled = pluginConfig.default_injection_toggle ?? true
 
   const claudeCodeHooks = isHookEnabled("claude-code-hooks")
     ? safeCreateHook(
@@ -52,8 +55,13 @@ export function createTransformHooks(args: {
       )
     : null
 
-  const contextInjectorMessagesTransform =
-    createContextInjectorMessagesTransformHook(contextCollector)
+  const contextInjectorMessagesTransform = isContextInjectionEnabled
+    ? safeCreateHook(
+        "context-injector",
+        () => createContextInjectorMessagesTransformHook(contextCollector),
+        { enabled: safeHookEnabled },
+      )
+    : null
 
   const thinkingBlockValidator = isHookEnabled("thinking-block-validator")
     ? safeCreateHook(

--- a/src/plugin/tool-execute-before-session-notification.test.ts
+++ b/src/plugin/tool-execute-before-session-notification.test.ts
@@ -15,18 +15,22 @@ describe("createToolExecuteBeforeHandler session notification sessionID", () => 
       },
     }
 
-    const handler = createToolExecuteBeforeHandler({
-      ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
-      hooks,
-    })
+    try {
+      const handler = createToolExecuteBeforeHandler({
+        ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
+        hooks,
+      })
 
-    await handler(
-      { tool: "question", sessionID: "", callID: "call_q" },
-      { args: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] } },
-    )
+      await handler(
+        { tool: "question", sessionID: "", callID: "call_q" },
+        { args: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] } },
+      )
 
-    expect(getMainSessionIDSpy).toHaveBeenCalled()
-    expect(capturedSessionID).toBe(mainSessionID)
+      expect(getMainSessionIDSpy).toHaveBeenCalled()
+      expect(capturedSessionID).toBe(mainSessionID)
+    } finally {
+      getMainSessionIDSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Purpose
This PR provides a single integrated branch containing both M1 and M2 deliverables to avoid merge-order blocking.

## Includes
- M1 baseline regression stabilization (equivalent scope of #2119)
- M2 configurable injection + plugin loader fallback (equivalent scope of #2122)
- milestone alignment docs synced with GitLab `ktai` roadmap

## Merge Strategy
- Option A (preferred for unblocking): merge this PR directly
- Option B: continue with ordered merge #2119 -> #2122

## Verification
- `bun test src/shared/model-error-classifier.test.ts src/hooks/model-fallback/hook.test.ts src/plugin/event.model-fallback.test.ts src/cli/model-fallback.test.ts src/hooks/session-notification.test.ts src/hooks/session-notification-input-needed.test.ts src/plugin/tool-execute-before-session-notification.test.ts src/cli/mcp-oauth/login.test.ts src/plugin-config.test.ts src/plugin/hooks/create-transform-hooks.test.ts src/features/claude-code-plugin-loader/discovery.test.ts`
- `bun run typecheck`
- `bun run build`

Result:
- tests: 87 pass / 0 fail
- typecheck: pass
- build: pass

## Notes
- Existing PRs #2119 and #2122 are still valid.
- This PR is created solely to remove sequencing blockage when maintainer permissions/process require a single merge action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates M1 regression stabilization and M2 injection/loader updates into one branch to unblock merge sequencing. Stabilizes model fallback and session notifications, and adds a context-injection toggle plus a managed default plugin when no DB exists.

- **New Features**
  - Add default_injection_toggle to config and gate the context-injector hook (defaults to on).
  - Inject a managed builtin plugin when installed_plugins.json is missing in the Claude plugin loader; discovery tests added.
  - Add milestone-aligned delivery docs synced with the GitLab ktai roadmap.

- **Bug Fixes**
  - Make model fallback provider selection deterministic by preferring the current provider when available.
  - Fix session-notification command finder to clear pending state and avoid cross-test leakage; tighten return typing.
  - Ensure spy cleanup in the session-notification tool execution test.

<sup>Written for commit 86101601b679b17cce17d844dc02e70bc07c48bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

