### PR TITLE
docs: update Z.ai Coding Plan model from GLM-4.7 to GLM-5

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -21,7 +21,7 @@ It asks about your providers (Claude, OpenAI, Gemini, etc.) and generates optima
   // Override specific agent models
   "agents": {
     "oracle": { "model": "openai/gpt-5.2" },           // Use GPT for debugging
-    "librarian": { "model": "zai-coding-plan/glm-4.7" }, // Cheap model for research
+    "librarian": { "model": "zai-coding-plan/glm-5" }, // Cheap model for research
     "explore": { "model": "opencode/gpt-5-nano" }        // Free model for grep
   },
   

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -194,22 +194,22 @@ When GitHub Copilot is the best available provider, oh-my-opencode uses these mo
 | **Sisyphus**  | `github-copilot/claude-opus-4.5` |
 | **Oracle**    | `github-copilot/gpt-5.2`         |
 | **Explore**   | `opencode/gpt-5-nano`              |
-| **Librarian** | `zai-coding-plan/glm-4.7` (if Z.ai available) or fallback |
+| **Librarian** | `zai-coding-plan/glm-5` (if Z.ai available) or fallback |
 
 GitHub Copilot acts as a proxy provider, routing requests to underlying models based on your subscription.
 
 #### Z.ai Coding Plan
 
-Z.ai Coding Plan provides access to GLM-4.7 models. When enabled, the **Librarian agent always uses `zai-coding-plan/glm-4.7`** regardless of other available providers.
+Z.ai Coding Plan provides access to GLM models (including GLM-5). When enabled, the **Librarian agent always uses `zai-coding-plan/glm-5`** regardless of other available providers.
 
 If Z.ai is the only provider available, all agents will use GLM models:
 
 | Agent         | Model                            |
 | ------------- | -------------------------------- |
-| **Sisyphus**  | `zai-coding-plan/glm-4.7`        |
-| **Oracle**    | `zai-coding-plan/glm-4.7`        |
+| **Sisyphus**  | `zai-coding-plan/glm-5`          |
+| **Oracle**    | `zai-coding-plan/glm-5`          |
 | **Explore**   | `zai-coding-plan/glm-4.7-flash`  |
-| **Librarian** | `zai-coding-plan/glm-4.7`        |
+| **Librarian** | `zai-coding-plan/glm-5`          |
 
 #### OpenCode Zen
 

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -129,14 +129,14 @@ Here's a real-world config for a user with **Claude, OpenAI, Gemini, and Z.ai** 
   "agents": {
     // Override specific agents only - rest use fallback chain
     "atlas": { "model": "anthropic/claude-sonnet-4-5", "variant": "max" },
-    "librarian": { "model": "zai-coding-plan/glm-4.7" },
+    "librarian": { "model": "zai-coding-plan/glm-5" },
     "explore": { "model": "opencode/gpt-5-nano" },
     "multimodal-looker": { "model": "zai-coding-plan/glm-4.6v" }
   },
   "categories": {
     // Override categories for cost optimization
     "quick": { "model": "opencode/gpt-5-nano" },
-    "unspecified-low": { "model": "zai-coding-plan/glm-4.7" }
+    "unspecified-low": { "model": "zai-coding-plan/glm-5" }
   },
   "experimental": {
     "aggressive_truncation": true

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -845,7 +845,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
       "model": "opencode/gpt-5-nano",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "opencode/big-pickle",
@@ -886,7 +886,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
       "model": "opencode/big-pickle",
     },
     "writing": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
   },
 }
@@ -903,7 +903,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/gpt-5-nano",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "opencode/big-pickle",
@@ -921,7 +921,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/big-pickle",
     },
     "sisyphus": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
   },
   "categories": {
@@ -944,7 +944,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/big-pickle",
     },
     "writing": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
   },
 }
@@ -1089,7 +1089,7 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + ZAI combinat
       "model": "anthropic/claude-haiku-4-5",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "anthropic/claude-opus-4-5",
@@ -1216,7 +1216,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "model": "opencode/claude-haiku-4-5",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "github-copilot/claude-opus-4.5",
@@ -1280,7 +1280,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "model": "anthropic/claude-haiku-4-5",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "anthropic/claude-opus-4-5",
@@ -1344,7 +1344,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "model": "anthropic/claude-haiku-4-5",
     },
     "librarian": {
-      "model": "zai-coding-plan/glm-4.7",
+      "model": "zai-coding-plan/glm-5",
     },
     "metis": {
       "model": "anthropic/claude-opus-4-5",

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -391,7 +391,7 @@ describe("generateModelConfig", () => {
       const result = generateModelConfig(config)
 
       // #then librarian should use ZAI_MODEL
-      expect(result.agents?.librarian?.model).toBe("zai-coding-plan/glm-4.7")
+      expect(result.agents?.librarian?.model).toBe("zai-coding-plan/glm-5")
     })
 
     test("librarian uses claude-sonnet when ZAI not available but Claude is", () => {

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -34,7 +34,7 @@ export interface GeneratedOmoConfig {
   [key: string]: unknown
 }
 
-const ZAI_MODEL = "zai-coding-plan/glm-4.7"
+const ZAI_MODEL = "zai-coding-plan/glm-5"
 
 const ULTIMATE_FALLBACK = "opencode/big-pickle"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json"

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -39,19 +39,19 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.variant).toBe("max")
   })
 
-  test("librarian has valid fallbackChain with glm-4.7 as primary", () => {
+  test("librarian has valid fallbackChain with glm-5 as primary", () => {
     // #given - librarian agent requirement
     const librarian = AGENT_MODEL_REQUIREMENTS["librarian"]
 
     // #when - accessing librarian requirement
-    // #then - fallbackChain exists with glm-4.7 as first entry
+    // #then - fallbackChain exists with glm-5 as first entry
     expect(librarian).toBeDefined()
     expect(librarian.fallbackChain).toBeArray()
     expect(librarian.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = librarian.fallbackChain[0]
     expect(primary.providers[0]).toBe("zai-coding-plan")
-    expect(primary.model).toBe("glm-4.7")
+    expect(primary.model).toBe("glm-5")
   })
 
   test("explore has valid fallbackChain with claude-haiku-4-5 as primary", () => {

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -13,7 +13,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-      { providers: ["zai-coding-plan"], model: "glm-4.7" },
+      { providers: ["zai-coding-plan"], model: "glm-5" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
     ],
@@ -27,7 +27,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
    librarian: {
      fallbackChain: [
-       { providers: ["zai-coding-plan"], model: "glm-4.7" },
+       { providers: ["zai-coding-plan"], model: "glm-5" },
        { providers: ["opencode"], model: "big-pickle" },
        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
      ],
@@ -124,7 +124,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
-      { providers: ["zai-coding-plan"], model: "glm-4.7" },
+      { providers: ["zai-coding-plan"], model: "glm-5" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
     ],
   },


### PR DESCRIPTION
## Summary
- Update Z.ai Coding Plan documentation to reflect the latest GLM-5 model
- Update Librarian, Sisyphus, and Oracle agent model references from `glm-4.7` to `glm-5`
- Keep `glm-4.7-flash` for Explore agent (GLM-5 flash variant not yet available)

## Changes
| File | Change |
|------|--------|
| `docs/guide/installation.md` | Updated Z.ai Coding Plan section with GLM-5 models |
| `docs/configurations.md` | Updated librarian example config |
| `docs/guide/overview.md` | Updated example config with glm-5 references |

## Test Plan
- [x] Verified all documentation files are consistent
- [x] Preserved glm-4.7-flash for Explore agent (no glm-5-flash available yet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Z.ai Coding Plan from GLM-4.7 to GLM-5 across docs and defaults. Librarian, Sisyphus, and Oracle now use GLM-5; Explore stays on glm-4.7-flash until a GLM-5 flash variant exists.

- **Bug Fixes**
  - Updated ZAI_MODEL constant and fallback chains (Sisyphus, Librarian, relevant category models) to glm-5.
  - Synced tests and snapshots with the new defaults.
  - Refreshed docs (installation, overview, configurations) to reference glm-5.

<sup>Written for commit b5c00581f4f073c37a160f8e912ec6c3debf8ccc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

