### PR TITLE
[sisyphus-bot] feat(boulder-state): automatically archive completed plans

### DIFF
--- a/src/features/boulder-state/archive.test.ts
+++ b/src/features/boulder-state/archive.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { archivePlan, findCompletedPlans } from "./storage"
+import { PROMETHEUS_PLANS_DIR, COMPLETED_PLANS_DIR, NOTEPAD_BASE_PATH, COMPLETED_NOTEPAD_DIR } from "./constants"
+
+describe("archive functions", () => {
+  const TEST_DIR = join(tmpdir(), "archive-test-" + Date.now())
+
+  beforeEach(() => {
+    if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  describe("archivePlan", () => {
+    test("moves plan to completed dir", () => {
+      const planName = "test-plan"
+      const planDir = join(TEST_DIR, PROMETHEUS_PLANS_DIR)
+      if (!existsSync(planDir)) mkdirSync(planDir, { recursive: true })
+      const sourcePlan = join(planDir, `${planName}.md`)
+      writeFileSync(sourcePlan, "# Test Plan\n- [x] Task 1")
+
+      const result = archivePlan(TEST_DIR, planName)
+
+      const archivedPath = join(TEST_DIR, COMPLETED_PLANS_DIR, `${planName}.md`)
+      expect(result.success).toBe(true)
+      expect(existsSync(archivedPath)).toBe(true)
+      expect(existsSync(sourcePlan)).toBe(false)
+    })
+
+    test("renames on conflict with -2 suffix", () => {
+      const planName = "conflict-plan"
+      const planDir = join(TEST_DIR, PROMETHEUS_PLANS_DIR)
+      if (!existsSync(planDir)) mkdirSync(planDir, { recursive: true })
+      const sourcePlan = join(planDir, `${planName}.md`)
+      writeFileSync(sourcePlan, "# Plan")
+      
+      const completedDir = join(TEST_DIR, COMPLETED_PLANS_DIR)
+      if (!existsSync(completedDir)) mkdirSync(completedDir, { recursive: true })
+      writeFileSync(join(completedDir, `${planName}.md`), "existing")
+
+      const result = archivePlan(TEST_DIR, planName)
+
+      const archivedPath = join(TEST_DIR, COMPLETED_PLANS_DIR, `${planName}-2.md`)
+      expect(result.success).toBe(true)
+      expect(existsSync(archivedPath)).toBe(true)
+    })
+
+    test("moves notepad if exists", () => {
+      const planName = "with-notepad"
+      const planDir = join(TEST_DIR, PROMETHEUS_PLANS_DIR)
+      if (!existsSync(planDir)) mkdirSync(planDir, { recursive: true })
+      writeFileSync(join(planDir, `${planName}.md`), "# Plan")
+      
+      const notepadDir = join(TEST_DIR, NOTEPAD_BASE_PATH)
+      if (!existsSync(notepadDir)) mkdirSync(notepadDir, { recursive: true })
+      writeFileSync(join(notepadDir, `${planName}.md`), "notes")
+
+      const result = archivePlan(TEST_DIR, planName)
+
+      const archivedNotepad = join(TEST_DIR, COMPLETED_NOTEPAD_DIR, `${planName}.md`)
+      expect(result.success).toBe(true)
+      expect(existsSync(archivedNotepad)).toBe(true)
+    })
+
+    test("fails for non-existent plan", () => {
+      const result = archivePlan(TEST_DIR, "non-existent")
+      expect(result.success).toBe(false)
+      expect(result.error).toContain("not found")
+    })
+  })
+
+  describe("findCompletedPlans", () => {
+    test("returns empty array when no completed plans", () => {
+      const result = findCompletedPlans(TEST_DIR)
+      expect(result).toEqual([])
+    })
+
+    test("returns list of completed plans", () => {
+      const completedDir = join(TEST_DIR, COMPLETED_PLANS_DIR)
+      if (!existsSync(completedDir)) mkdirSync(completedDir, { recursive: true })
+      writeFileSync(join(completedDir, "plan-a.md"), "# A")
+      writeFileSync(join(completedDir, "plan-b.md"), "# B")
+
+      const result = findCompletedPlans(TEST_DIR)
+      expect(result.length).toBe(2)
+    })
+  })
+})

--- a/src/features/boulder-state/constants.ts
+++ b/src/features/boulder-state/constants.ts
@@ -9,5 +9,7 @@ export const BOULDER_STATE_PATH = `${BOULDER_DIR}/${BOULDER_FILE}`
 export const NOTEPAD_DIR = "notepads"
 export const NOTEPAD_BASE_PATH = `${BOULDER_DIR}/${NOTEPAD_DIR}`
 
-/** Prometheus plan directory pattern */
 export const PROMETHEUS_PLANS_DIR = ".sisyphus/plans"
+
+export const COMPLETED_PLANS_DIR = `${PROMETHEUS_PLANS_DIR}/completed`
+export const COMPLETED_NOTEPAD_DIR = `${NOTEPAD_BASE_PATH}/completed`

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -4,10 +4,10 @@
  * Handles reading/writing boulder.json for active plan tracking.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, cpSync, rmSync } from "node:fs"
 import { dirname, join, basename } from "node:path"
-import type { BoulderState, PlanProgress } from "./types"
-import { BOULDER_DIR, BOULDER_FILE, PROMETHEUS_PLANS_DIR } from "./constants"
+import type { BoulderState, PlanProgress, ArchiveResult } from "./types"
+import { BOULDER_DIR, BOULDER_FILE, PROMETHEUS_PLANS_DIR, COMPLETED_PLANS_DIR, NOTEPAD_BASE_PATH, COMPLETED_NOTEPAD_DIR } from "./constants"
 
 export function getBoulderFilePath(directory: string): string {
   return join(directory, BOULDER_DIR, BOULDER_FILE)
@@ -146,5 +146,134 @@ export function createBoulderState(
     started_at: new Date().toISOString(),
     session_ids: [sessionId],
     plan_name: getPlanName(planPath),
+  }
+}
+
+/**
+ * Find a unique target path by appending -2, -3, etc. if needed.
+ */
+function findUniqueTargetPath(basePath: string): string {
+  if (!existsSync(basePath)) {
+    return basePath
+  }
+
+  let counter = 2
+  while (true) {
+    const newPath = basePath.replace(/\.md$/, `-${counter}.md`)
+    if (!existsSync(newPath)) {
+      return newPath
+    }
+    counter++
+  }
+}
+
+/**
+ * Archive a completed plan by moving it to the completed directory.
+ * Also moves the corresponding notepad file if it exists.
+ * Handles name conflicts by auto-renaming.
+ */
+export function archivePlan(directory: string, planName: string): ArchiveResult {
+  const sourcePlanPath = join(directory, PROMETHEUS_PLANS_DIR, `${planName}.md`)
+  const sourceNotepadPath = join(directory, NOTEPAD_BASE_PATH, `${planName}.md`)
+
+  if (!existsSync(sourcePlanPath)) {
+    return { success: false, error: `Source plan not found: ${planName}` }
+  }
+
+  const completedPlansDir = join(directory, COMPLETED_PLANS_DIR)
+  const completedNotepadDir = join(directory, COMPLETED_NOTEPAD_DIR)
+
+  try {
+    if (!existsSync(completedPlansDir)) {
+      mkdirSync(completedPlansDir, { recursive: true })
+    }
+  } catch (err) {
+    return { success: false, error: `Failed to create completed plans directory: ${err}` }
+  }
+
+  const targetPlanPath = findUniqueTargetPath(join(completedPlansDir, `${planName}.md`))
+  const hasNotepad = existsSync(sourceNotepadPath)
+  let targetNotepadPath: string | undefined
+
+  if (hasNotepad) {
+    try {
+      if (!existsSync(completedNotepadDir)) {
+        mkdirSync(completedNotepadDir, { recursive: true })
+      }
+    } catch (err) {
+      return { success: false, error: `Failed to create completed notepad directory: ${err}` }
+    }
+    targetNotepadPath = findUniqueTargetPath(join(completedNotepadDir, `${planName}.md`))
+  }
+
+  let planMoved = false
+  let notepadMoved = false
+
+  try {
+    try {
+      renameSync(sourcePlanPath, targetPlanPath)
+      planMoved = true
+    } catch {
+      try {
+        cpSync(sourcePlanPath, targetPlanPath)
+        rmSync(sourcePlanPath)
+        planMoved = true
+      } catch (fallbackErr) {
+        return { success: false, error: `Failed to move plan: ${fallbackErr}` }
+      }
+    }
+
+    if (hasNotepad && targetNotepadPath) {
+      try {
+        renameSync(sourceNotepadPath, targetNotepadPath)
+        notepadMoved = true
+      } catch {
+        try {
+          cpSync(sourceNotepadPath, targetNotepadPath)
+          rmSync(sourceNotepadPath)
+          notepadMoved = true
+        } catch {
+          if (planMoved) {
+            try { renameSync(targetPlanPath, sourcePlanPath) } catch {}
+          }
+          return { success: false, error: "Failed to move notepad, rolled back plan" }
+        }
+      }
+    }
+
+    return {
+      success: true,
+      archivedPlanPath: targetPlanPath,
+      archivedNotepadPath: notepadMoved ? targetNotepadPath : undefined,
+    }
+  } catch (err) {
+    if (planMoved) { try { renameSync(targetPlanPath, sourcePlanPath) } catch {} }
+    if (notepadMoved && targetNotepadPath) { try { renameSync(targetNotepadPath, sourceNotepadPath) } catch {} }
+    return { success: false, error: `Archive failed: ${err}` }
+  }
+}
+
+/**
+ * Find all completed plan files in the completed directory.
+ */
+export function findCompletedPlans(directory: string): string[] {
+  const completedDir = join(directory, COMPLETED_PLANS_DIR)
+
+  if (!existsSync(completedDir)) {
+    return []
+  }
+
+  try {
+    const files = readdirSync(completedDir)
+    return files
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => join(completedDir, f))
+      .sort((a, b) => {
+        const aStat = require("node:fs").statSync(a)
+        const bStat = require("node:fs").statSync(b)
+        return bStat.mtimeMs - aStat.mtimeMs
+      })
+  } catch {
+    return []
   }
 }

--- a/src/features/boulder-state/types.ts
+++ b/src/features/boulder-state/types.ts
@@ -24,3 +24,14 @@ export interface PlanProgress {
   /** Whether all tasks are done */
   isComplete: boolean
 }
+
+export interface ArchiveResult {
+  /** Whether the archive operation succeeded */
+  success: boolean
+  /** Path to the archived plan file (if successful) */
+  archivedPlanPath?: string
+  /** Path to the archived notepad file (if successful and existed) */
+  archivedNotepadPath?: string
+  /** Error message (if failed) */
+  error?: string
+}

--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -6,6 +6,8 @@ import {
   readBoulderState,
   appendSessionId,
   getPlanProgress,
+  archivePlan,
+  clearBoulderState,
 } from "../../features/boulder-state"
 import { getMainSessionID, subagentSessions } from "../../features/claude-code-session-state"
 import { findNearestMessageWithFields, MESSAGE_STORAGE } from "../../features/hook-message-injector"
@@ -578,6 +580,23 @@ export function createAtlasHook(
         const progress = getPlanProgress(boulderState.active_plan)
         if (progress.isComplete) {
           log(`[${HOOK_NAME}] Boulder complete`, { sessionID, plan: boulderState.plan_name })
+
+          // Auto-archive the completed plan
+          const archiveResult = archivePlan(ctx.directory, boulderState.plan_name)
+          if (archiveResult.success) {
+            clearBoulderState(ctx.directory)
+            log(`[${HOOK_NAME}] Plan archived successfully`, {
+              sessionID,
+              plan: boulderState.plan_name,
+              archivedPath: archiveResult.archivedPlanPath
+            })
+          } else {
+            log(`[${HOOK_NAME}] Plan archival failed`, {
+              sessionID,
+              plan: boulderState.plan_name,
+              error: archiveResult.error
+            })
+          }
           return
         }
 


### PR DESCRIPTION
> **⚠️ THIS REPOSITORY IS ENGLISH-ONLY. ALL ISSUE, PR, REVIEW, AND COMMENT COMMUNICATION MUST BE WRITTEN IN ENGLISH. DO NOT POST NON-ENGLISH CONTENT HERE. THIS IS A STRICT PROJECT COMMUNICATION RULE AND MUST BE FOLLOWED FROM NOW ON.**

## Summary

- Add automatic archiving of completed plans to `.sisyphus/plans/completed/`
- Archive the associated notepad directory at the same time
- Handle filename conflicts (automatically rename to `-2.md`, `-3.md`, etc.)
- Comprehensive test coverage (6 test cases)

## Implementation

### Core functions (`src/features/boulder-state/storage.ts`)
- `archivePlan(directory, planName)`: Archive a completed plan
- `findCompletedPlans(directory)`: Find the list of archived plans

### Atlas Hook integration (`src/hooks/atlas/index.ts`)
- Automatically invoke archiving when a plan is detected as complete (all checkboxes checked)
- Clean up the `boulder.json` state file after successful archiving

## Test Coverage

- `archive.test.ts`: 6 test cases for the archiving functions

## File Changes

| File | Purpose |
|------|------|
| `constants.ts` | Add constants for archive directories |
| `types.ts` | Add the `ArchiveResult` type |
| `storage.ts` | Core archiving functions |
| `index.ts` (Atlas hook) | Integrate automatic archiving |
| `archive.test.ts` | Test cases |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic archiving of completed plans to .sisyphus/plans/completed and moves their notepads when all tasks are done. Atlas triggers the archive, resolves filename conflicts, and clears boulder state after success.

- **New Features**
  - archivePlan(directory, planName) moves plan/notepad and auto-renames on conflict (-2, -3).
  - findCompletedPlans(directory) lists completed plans.
  - Added constants for completed dirs; creates them if missing.
  - 6 tests covering success, conflicts, notepad moves, missing plan, and listing.

<sup>Written for commit 95615330cdbccfc9ba060270e3393f8972543606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

