### PR TITLE
fix: silence startup noise from config-context warn and bun install output

### DIFF
--- a/src/cli/config-manager/bun-install.ts
+++ b/src/cli/config-manager/bun-install.ts
@@ -19,8 +19,8 @@ export async function runBunInstallWithDetails(): Promise<BunInstallResult> {
   try {
     const proc = spawnWithWindowsHide(["bun", "install"], {
       cwd: getConfigDir(),
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "pipe",
+      stderr: "pipe",
     })
 
     let timeoutId: ReturnType<typeof setTimeout>

--- a/src/cli/config-manager/config-context.ts
+++ b/src/cli/config-manager/config-context.ts
@@ -1,4 +1,4 @@
-import { getOpenCodeConfigPaths } from "../../shared"
+import { log, getOpenCodeConfigPaths } from "../../shared"
 import type {
   OpenCodeBinaryType,
   OpenCodeConfigPaths,
@@ -19,9 +19,7 @@ export function initConfigContext(binary: OpenCodeBinaryType, version: string | 
 
 export function getConfigContext(): ConfigContext {
   if (!configContext) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[config-context] getConfigContext() called before initConfigContext(); defaulting to CLI paths.")
-    }
+    log("[config-context] getConfigContext() called before initConfigContext(); defaulting to CLI paths.")
     const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
     configContext = { binary: "opencode", version: null, paths }
   }


### PR DESCRIPTION
## Summary

- **config-context.ts**: Replace `console.warn` with internal `log()` so the `[config-context] getConfigContext() called before initConfigContext()` message goes to the log file instead of polluting the user's terminal. The `process.env.NODE_ENV !== "production"` guard was being compiled as `if (true)` in the bundle, causing the warning to always appear.
- **bun-install.ts**: Change `stdout`/`stderr` from `"inherit"` to `"pipe"` so the internal `bun install` output (e.g., `bun install v1.3.9 checked 3 installs across 4 packages`) is suppressed from the user's terminal. The install still runs and errors are still captured via exit code.

## Problem

Every time a user starts OpenCode with oh-my-opencode, two noisy messages appear in the terminal:

```
[config-context] getConfigContext() called before initConfigContext(); defaulting to CLI paths.
bun install v1.3.9 (f2a54014) checked 3 installs across 4 packages (no changes) - 35ms
```

These are internal implementation details that shouldn't be visible to the end user.

## Changes

| File | Change |
|------|--------|
| `src/cli/config-manager/config-context.ts` | `console.warn` → `log()` (writes to log file, not terminal) |
| `src/cli/config-manager/bun-install.ts` | `stdout/stderr: "inherit"` → `"pipe"` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences startup noise by redirecting internal config warnings to the log and piping bun install output, keeping the terminal clean while preserving error handling.

- **Bug Fixes**
  - config-context: console.warn → log() (writes to log file, not terminal).
  - bun-install: stdout/stderr "inherit" → "pipe" to suppress install output; errors still captured via exit code.

<sup>Written for commit 4ec3bb7eb8e8a1e52761bc1598352a4f7bdbaf87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

