### PR TITLE
feat: add OpenCode Zen Go subscription mode

### DIFF
--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -31,6 +31,7 @@ program
   .option("--opencode-zen <value>", "OpenCode Zen access: no, yes (default: no)")
   .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
   .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
+  .option("--opencode-zen-go <value>", "OpenCode Zen Go subscription: no, yes (default: no)")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
@@ -57,6 +58,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
       opencodeZen: options.opencodeZen,
       zaiCodingPlan: options.zaiCodingPlan,
       kimiForCoding: options.kimiForCoding,
+      opencodeZenGo: options.opencodeZenGo,
       skipAuth: options.skipAuth ?? false,
     }
     const exitCode = await install(args)

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -10,17 +10,18 @@ function detectProvidersFromOmoConfig(): {
   hasOpencodeZen: boolean
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
+  hasOpencodeZenGo: boolean
 } {
   const omoConfigPath = getOmoConfigPath()
   if (!existsSync(omoConfigPath)) {
-    return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false }
+    return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false, hasOpencodeZenGo: false }
   }
 
   try {
     const content = readFileSync(omoConfigPath, "utf-8")
     const omoConfig = parseJsonc<Record<string, unknown>>(content)
     if (!omoConfig || typeof omoConfig !== "object") {
-      return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false }
+      return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false, hasOpencodeZenGo: false }
     }
 
     const configStr = JSON.stringify(omoConfig)
@@ -28,10 +29,11 @@ function detectProvidersFromOmoConfig(): {
     const hasOpencodeZen = configStr.includes('"opencode/')
     const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/')
     const hasKimiForCoding = configStr.includes('"kimi-for-coding/')
+    const hasOpencodeZenGo = configStr.includes('"opencode-go/')
 
-    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding }
+    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeZenGo }
   } catch {
-    return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false }
+    return { hasOpenAI: true, hasOpencodeZen: true, hasZaiCodingPlan: false, hasKimiForCoding: false, hasOpencodeZenGo: false }
   }
 }
 
@@ -46,6 +48,7 @@ export function detectCurrentConfig(): DetectedConfig {
     hasOpencodeZen: true,
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
+    hasOpencodeZenGo: false,
   }
 
   const { format, path } = detectConfigFormat()
@@ -68,11 +71,12 @@ export function detectCurrentConfig(): DetectedConfig {
 
   result.hasGemini = plugins.some((p) => p.startsWith("opencode-antigravity-auth"))
 
-  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding } = detectProvidersFromOmoConfig()
+  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeZenGo } = detectProvidersFromOmoConfig()
   result.hasOpenAI = hasOpenAI
   result.hasOpencodeZen = hasOpencodeZen
   result.hasZaiCodingPlan = hasZaiCodingPlan
   result.hasKimiForCoding = hasKimiForCoding
+  result.hasOpencodeZenGo = hasOpencodeZenGo
 
   return result
 }

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -38,6 +38,7 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))
   lines.push(formatProvider("Z.ai Coding Plan", config.hasZaiCodingPlan, "Librarian/Multimodal"))
   lines.push(formatProvider("Kimi For Coding", config.hasKimiForCoding, "Sisyphus/Prometheus fallback"))
+  lines.push(formatProvider("OpenCode Zen Go", config.hasOpencodeZenGo, "GLM-5/Kimi K2.5/MiniMax M2.5"))
 
   lines.push("")
   lines.push(color.dim("─".repeat(40)))
@@ -147,6 +148,10 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --kimi-for-coding value: ${args.kimiForCoding} (expected: no, yes)`)
   }
 
+  if (args.opencodeZenGo !== undefined && !["no", "yes"].includes(args.opencodeZenGo)) {
+    errors.push(`Invalid --opencode-zen-go value: ${args.opencodeZenGo} (expected: no, yes)`)
+  }
+
   return { valid: errors.length === 0, errors }
 }
 
@@ -160,6 +165,7 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasOpencodeZen: args.opencodeZen === "yes",
     hasZaiCodingPlan: args.zaiCodingPlan === "yes",
     hasKimiForCoding: args.kimiForCoding === "yes",
+    hasOpencodeZenGo: args.opencodeZenGo === "yes",
   }
 }
 
@@ -171,6 +177,7 @@ export function detectedToInitialValues(detected: DetectedConfig): {
   opencodeZen: BooleanArg
   zaiCodingPlan: BooleanArg
   kimiForCoding: BooleanArg
+  opencodeZenGo: BooleanArg
 } {
   let claude: ClaudeSubscription = "no"
   if (detected.hasClaude) {
@@ -185,5 +192,6 @@ export function detectedToInitialValues(detected: DetectedConfig): {
     opencodeZen: detected.hasOpencodeZen ? "yes" : "no",
     zaiCodingPlan: detected.hasZaiCodingPlan ? "yes" : "no",
     kimiForCoding: detected.hasKimiForCoding ? "yes" : "no",
+    opencodeZenGo: detected.hasOpencodeZenGo ? "yes" : "no",
   }
 }

--- a/src/cli/model-fallback-types.ts
+++ b/src/cli/model-fallback-types.ts
@@ -5,6 +5,7 @@ export interface ProviderAvailability {
 		gemini: boolean
 	}
 	opencodeZen: boolean
+	opencodeZenGo: boolean
 	copilot: boolean
 	zai: boolean
 	kimiForCoding: boolean

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -22,16 +22,16 @@ const ULTIMATE_FALLBACK = "opencode/glm-4.7-free"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/dev/assets/oh-my-opencode.schema.json"
 
 const OPENCODE_ZEN_GO_AGENT_MODELS: Record<string, string> = {
-  sisyphus: "opencode-go/glm-5",
-  oracle: "opencode-go/glm-5",
-  hephaestus: "opencode-go/minimax-m2.5",
-  librarian: "opencode-go/minimax-m2.5",
-  explore: "opencode-go/minimax-m2.5",
+  sisyphus: "opencode-go/glm-5.1",
+  oracle: "opencode-go/glm-5.1",
+  hephaestus: "opencode-go/minimax-m2.7",
+  librarian: "opencode-go/minimax-m2.7",
+  explore: "opencode-go/minimax-m2.7",
 }
 
 const OPENCODE_ZEN_GO_CATEGORY_MODELS: Record<string, string> = {
-  "visual-engineering": "opencode-go/kimi-k2.5",
-  writing: "opencode-go/kimi-k2.5",
+  "visual-engineering": "opencode-go/kimi-k2.6",
+  writing: "opencode-go/kimi-k2.6",
 }
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -30,8 +30,8 @@ const OPENCODE_ZEN_GO_AGENT_MODELS: Record<string, string> = {
 }
 
 const OPENCODE_ZEN_GO_CATEGORY_MODELS: Record<string, string> = {
-  frontend: "opencode-go/kimi-k2.5",
-  document: "opencode-go/kimi-k2.5",
+  "visual-engineering": "opencode-go/kimi-k2.5",
+  writing: "opencode-go/kimi-k2.5",
 }
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -21,10 +21,29 @@ const ZAI_MODEL = "zai-coding-plan/glm-4.7"
 const ULTIMATE_FALLBACK = "opencode/glm-4.7-free"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/dev/assets/oh-my-opencode.schema.json"
 
-
+const OPENCODE_ZEN_GO_AGENT_MODELS: Record<string, string> = {
+  sisyphus: "opencode-go/glm-5",
+  oracle: "opencode-go/glm-5",
+  hephaestus: "opencode-go/minimax-m2.5",
+  librarian: "opencode-go/minimax-m2.5",
+  explore: "opencode-go/minimax-m2.5",
+  frontend: "opencode-go/kimi-k2.5",
+  document: "opencode-go/kimi-k2.5",
+}
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
   const avail = toProviderAvailability(config)
+
+  if (avail.opencodeZenGo) {
+    const agents: Record<string, AgentConfig> = Object.fromEntries(
+      Object.entries(OPENCODE_ZEN_GO_AGENT_MODELS).map(([role, model]) => [role, { model }])
+    )
+    return {
+      $schema: SCHEMA_URL,
+      agents,
+    }
+  }
+
   const hasAnyProvider =
     avail.native.claude ||
     avail.native.openai ||

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -27,6 +27,9 @@ const OPENCODE_ZEN_GO_AGENT_MODELS: Record<string, string> = {
   hephaestus: "opencode-go/minimax-m2.5",
   librarian: "opencode-go/minimax-m2.5",
   explore: "opencode-go/minimax-m2.5",
+}
+
+const OPENCODE_ZEN_GO_CATEGORY_MODELS: Record<string, string> = {
   frontend: "opencode-go/kimi-k2.5",
   document: "opencode-go/kimi-k2.5",
 }
@@ -38,9 +41,13 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     const agents: Record<string, AgentConfig> = Object.fromEntries(
       Object.entries(OPENCODE_ZEN_GO_AGENT_MODELS).map(([role, model]) => [role, { model }])
     )
+    const categories: Record<string, CategoryConfig> = Object.fromEntries(
+      Object.entries(OPENCODE_ZEN_GO_CATEGORY_MODELS).map(([name, model]) => [name, { model }])
+    )
     return {
       $schema: SCHEMA_URL,
       agents,
+      categories,
     }
   }
 

--- a/src/cli/provider-availability.ts
+++ b/src/cli/provider-availability.ts
@@ -9,6 +9,7 @@ export function toProviderAvailability(config: InstallConfig): ProviderAvailabil
 			gemini: config.hasGemini,
 		},
 		opencodeZen: config.hasOpencodeZen,
+		opencodeZenGo: config.hasOpencodeZenGo,
 		copilot: config.hasCopilot,
 		zai: config.hasZaiCodingPlan,
 		kimiForCoding: config.hasKimiForCoding,
@@ -23,6 +24,7 @@ export function isProviderAvailable(provider: string, availability: ProviderAvai
 		google: availability.native.gemini,
 		"github-copilot": availability.copilot,
 		opencode: availability.opencodeZen,
+		"opencode-go": availability.opencodeZenGo,
 		"zai-coding-plan": availability.zai,
 		"kimi-for-coding": availability.kimiForCoding,
 	}

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -100,6 +100,16 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
   })
   if (!kimiForCoding) return null
 
+  const opencodeZenGo = await selectOrCancel({
+    message: "Do you have an OpenCode Zen Go subscription?",
+    options: [
+      { value: "no", label: "No", hint: "Will use other configured providers" },
+      { value: "yes", label: "OpenCode Zen Go ($10/month)", hint: "GLM-5/Kimi K2.5/MiniMax M2.5 via opencode-go/" },
+    ],
+    initialValue: initial.opencodeZenGo,
+  })
+  if (!opencodeZenGo) return null
+
   return {
     hasClaude: claude !== "no",
     isMax20: claude === "max20",
@@ -109,5 +119,6 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     hasOpencodeZen: opencodeZen === "yes",
     hasZaiCodingPlan: zaiCodingPlan === "yes",
     hasKimiForCoding: kimiForCoding === "yes",
+    hasOpencodeZenGo: opencodeZenGo === "yes",
   }
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -10,6 +10,7 @@ export interface InstallArgs {
   opencodeZen?: BooleanArg
   zaiCodingPlan?: BooleanArg
   kimiForCoding?: BooleanArg
+  opencodeZenGo?: BooleanArg
   skipAuth?: boolean
 }
 
@@ -22,6 +23,7 @@ export interface InstallConfig {
   hasOpencodeZen: boolean
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
+  hasOpencodeZenGo: boolean
 }
 
 export interface ConfigMergeResult {
@@ -40,4 +42,5 @@ export interface DetectedConfig {
   hasOpencodeZen: boolean
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
+  hasOpencodeZenGo: boolean
 }


### PR DESCRIPTION
## Summary

Adds support for **OpenCode Zen Go** (`opencode-go/` provider) as a first-class subscription tier in the installer and model fallback logic. When a user has an OpenCode Zen Go subscription ($10/month), all agents are configured using its curated model set instead of the regular provider fallback chain.

## Why

The existing fallback chain requires users to hold subscriptions to Claude, OpenAI, Gemini, GitHub Copilot, Z.ai, or Kimi individually — which can be expensive. OpenCode Zen Go bundles access to GLM-5, MiniMax M2.5, and Kimi K2.5 under a single affordable subscription, giving users a complete, well-matched set of models without needing any native API keys. This makes oh-my-opencode accessible to a much broader audience.

## Model Assignment Rationale

| Agent(s) | Model | Reasoning |
|---|---|---|
| `sisyphus`, `oracle` | `opencode-go/glm-5` | GLM-5 is a strong reasoning/coding model suitable for the primary orchestrator (Sisyphus) and the high-IQ debugging agent (Oracle) |
| `hephaestus`, `librarian`, `explore` | `opencode-go/minimax-m2.5` | MiniMax M2.5 offers broad capability at moderate cost, ideal for the implementation agent (Hephaestus), knowledge retrieval (Librarian), and lightweight exploration (Explore) |
| `frontend`, `document` | `opencode-go/kimi-k2.5` | Kimi K2.5 has strong multilingual and structured-output capabilities, well-suited for UI generation (Frontend) and documentation writing (Document) |

When `opencodeZenGo` is detected, `generateModelConfig` bypasses the normal provider availability checks entirely and returns this fixed assignment map, ensuring a clean, predictable configuration for Go subscribers.

## Files Changed

- **`src/cli/model-fallback.ts`** — Added `OPENCODE_ZEN_GO_AGENT_MODELS` constant and an early-return branch at the top of `generateModelConfig()` that activates when `avail.opencodeZenGo` is true
- **`src/cli/tui-install-prompts.ts`** — Added the `opencodeZenGo` prompt step and mapped the response to `hasOpencodeZenGo` in the returned `InstallConfig`

## PR Checklist

- [ ] Code follows project conventions
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds
- [ ] Tested locally with OpenCode
- [ ] Updated documentation if needed (README, AGENTS.md)
- [ ] No version changes in `package.json`

---

I agree to the terms of the Contributor License Agreement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode Zen Go subscription mode that uses curated `opencode-go` models and bypasses the standard provider fallback. Enable via CLI, TUI, or auto-detection.

- **New Features**
  - Mapping: Agents—Sisyphus/Oracle → `opencode-go/glm-5.1`; Hephaestus/Librarian/Explore → `opencode-go/minimax-m2.7`. Categories—visual-engineering/writing → `opencode-go/kimi-k2.6`.
  - Activation: `--opencode-zen-go` flag, TUI prompt, and detection of `opencode-go` models in omo config.
  - Behavior: `generateModelConfig` returns the fixed mapping early; updated types, validators, provider availability (`opencode-go`), and install summary.

<sup>Written for commit 4451af57814de97a110e560593fb436a1e6a56d6. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/2221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

