### PR TITLE
fix(win32): wrap toast and sound scripts in try/catch for headless sessions

### DIFF
--- a/src/hooks/session-notification-formatting.ts
+++ b/src/hooks/session-notification-formatting.ts
@@ -10,7 +10,7 @@ export function buildWindowsToastScript(title: string, message: string): string 
   const psTitle = escapePowerShellSingleQuotedText(title)
   const psMessage = escapePowerShellSingleQuotedText(message)
 
-  return `
+  const script = `
 [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
 $Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
 $RawXml = [xml] $Template.GetXml()
@@ -22,4 +22,6 @@ $Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
 $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('OpenCode')
 $Notifier.Show($Toast)
 `.trim().replace(/\n/g, "; ")
+
+  return `try { ${script} } catch { }`
 }

--- a/src/hooks/session-notification-sender.test.ts
+++ b/src/hooks/session-notification-sender.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { buildWindowsToastScript } from "./session-notification-formatting"
+
+// Tests for win32 headless/SSH resilience.
+// The core invariant: the PowerShell script output wraps in try/catch so that
+// WinRT failures (e.g. "notification platform is unavailable" on SSH) don't
+// produce stderr output. JS-level .catch() in the sender already prevents
+// crashes; these tests verify the PowerShell-level protection is in place.
+
+describe("win32 headless/SSH resilience", () => {
+  describe("buildWindowsToastScript", () => {
+    test("wraps toast script in PowerShell try/catch", () => {
+      const script = buildWindowsToastScript("Test Title", "Test Message")
+      expect(script).toStartWith("try {")
+      expect(script).toEndWith("} catch { }")
+      // The WinRT call that fails on headless is still inside the try block
+      expect(script).toContain("CreateToastNotifier")
+    })
+
+    test("still escapes single quotes in title and message", () => {
+      const script = buildWindowsToastScript("It's a title", "It's a message")
+      expect(script).toContain("It''s a title")
+      expect(script).toContain("It''s a message")
+      // Escaping must not break the try/catch wrapper
+      expect(script).toStartWith("try {")
+      expect(script).toEndWith("} catch { }")
+    })
+
+    test("generated script is a single semicolon-joined line (safe for -Command)", () => {
+      const script = buildWindowsToastScript("Title", "Message")
+      // Should not contain raw newlines — the sender passes this to -Command inline
+      expect(script).not.toContain("\n")
+      // But must still have the try/catch structure
+      expect(script).toContain("try {")
+      expect(script).toContain("} catch { }")
+    })
+  })
+})

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -95,7 +95,8 @@ export async function playSessionNotificationSound(
       const powershellPath = await getPowershellPath()
       if (!powershellPath) return
       const escaped = escapePowerShellSingleQuotedText(soundPath)
-      ctx.$`${powershellPath} -Command ${("(New-Object Media.SoundPlayer '" + escaped + "').PlaySync()")}`.catch(() => {})
+      const soundCommand = `try { (New-Object Media.SoundPlayer '${escaped}').PlaySync() } catch { }`
+      ctx.$`${powershellPath} -Command ${soundCommand}`.catch(() => {})
       break
     }
   }

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -95,7 +95,7 @@ export async function playSessionNotificationSound(
       const powershellPath = await getPowershellPath()
       if (!powershellPath) return
       const escaped = escapePowerShellSingleQuotedText(soundPath)
-      const soundCommand = `try { (New-Object Media.SoundPlayer '${escaped}').PlaySync() } catch { }`
+      const soundCommand = `try { (New-Object -ErrorAction Stop Media.SoundPlayer '${escaped}').PlaySync() } catch { }`
       ctx.$`${powershellPath} -Command ${soundCommand}`.catch(() => {})
       break
     }


### PR DESCRIPTION
On SSH or headless Windows, the WinRT APIs for toast notifications aren't available, so CreateToastNotifier returns null and calling .Show() crashes. The JS catch handler prevents the whole thing from exploding, but PowerShell stderr still leaks through. Wrapped the generated toast script in try/catch at the PowerShell level to suppress that noise. Same fix for the sound playback command since it has the same issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress stderr in headless/SSH Windows sessions by wrapping Windows toast and sound PowerShell commands in try/catch and forcing New-Object to throw with -ErrorAction Stop. Keeps notifications from spamming errors when WinRT isn’t available.

- **Bug Fixes**
  - Wrap Windows toast script in PowerShell try/catch to swallow WinRT failures.
  - Wrap SoundPlayer command in try/catch and add -ErrorAction Stop to catch non-terminating errors.
  - Add tests for try/catch wrapping, single-line semicolon output, and proper escaping.

<sup>Written for commit c8e019217e0376ce5750437580a8a81171938ad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

