### PR TITLE
fix: enforce write guard after pre-tool argument mutations

### DIFF
--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -18,9 +18,9 @@ export function createToolExecuteBeforeHandler(args: {
   const { ctx, hooks } = args
 
   return async (input, output): Promise<void> => {
-    await hooks.writeExistingFileGuard?.["tool.execute.before"]?.(input, output)
     await hooks.questionLabelTruncator?.["tool.execute.before"]?.(input, output)
     await hooks.claudeCodeHooks?.["tool.execute.before"]?.(input, output)
+    await hooks.writeExistingFileGuard?.["tool.execute.before"]?.(input, output)
     await hooks.nonInteractiveEnv?.["tool.execute.before"]?.(input, output)
     await hooks.commentChecker?.["tool.execute.before"]?.(input, output)
     await hooks.directoryAgentsInjector?.["tool.execute.before"]?.(input, output)


### PR DESCRIPTION
## What this PR fixes
This PR closes a safety gap in the pre-tool hook pipeline where `writeExistingFileGuard` could validate a stale path.

`claudeCodeHooks` is allowed to mutate tool arguments (`output.args`) via `modifiedInput`. When `writeExistingFileGuard` ran **before** those mutations, a write could be approved for one path and then executed on another.

## Why this matters
The guard exists to prevent accidental overwrites of existing files unless explicit conditions are met.
If path mutation happens after guard validation, that guarantee is broken.

In practice, this can lead to unintended overwrites of important existing files (for example `.env`, `package.json`, workflow/config files) when a pre-hook rewrites `path`/`filePath`.

## Root cause
Pre-tool execution order in `createToolExecuteBeforeHandler` was:
1. `writeExistingFileGuard`
2. `questionLabelTruncator`
3. `claudeCodeHooks`

`claudeCodeHooks` can do:
- `Object.assign(output.args, result.modifiedInput)`

So the guard could check old args, then args changed later.

## Change made
Reordered a single hook call so `writeExistingFileGuard` runs after `claudeCodeHooks`.

New order (relevant part):
1. `questionLabelTruncator`
2. `claudeCodeHooks`
3. `writeExistingFileGuard`

## Before/After (ASCII)
```text
BEFORE (bypass possible)

tool.execute.before
  |
  v
[writeExistingFileGuard]  <-- validates old path
  |
  v
[questionLabelTruncator]
  |
  v
[claudeCodeHooks]         <-- may mutate output.args.path/filePath
  |
  v
[...other pre-hooks...]
  |
  v
[write tool]              <-- executes with mutated path
```

```text
AFTER (fixed)

tool.execute.before
  |
  v
[questionLabelTruncator]
  |
  v
[claudeCodeHooks]         <-- may mutate output.args.path/filePath
  |
  v
[writeExistingFileGuard]  <-- validates final path
  |
  v
[...other pre-hooks...]
  |
  v
[write tool]
```

## Scope
- 1 file changed
- 1-line behavioral change (hook ordering only)

## Validation
Ran targeted tests:
- `bun test src/plugin/tool-execute-before.test.ts`

Result:
- 11 passed, 0 failed.

## Risk assessment
Low risk:
- No schema/API changes
- No data format changes
- Only execution order adjusted to match expected safety semantics


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures writeExistingFileGuard runs after pre-tool argument mutations so it validates the final path. This closes a gap that could allow unintended overwrites when claudeCodeHooks rewrites path/filePath.

<sup>Written for commit 2fc6522284ef21a6337cc69c05f025cc2e96c63a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

