### PR TITLE
Refactor boulder and ralph-loop state to per-plan/per-session storage for multi-agent concurrency

### DIFF
--- a/src/agents/atlas/default.ts
+++ b/src/agents/atlas/default.ts
@@ -102,14 +102,19 @@ Every \`task()\` prompt MUST include ALL 6 sections:
 <workflow>
 ## Step 0: Register Tracking
 
+After reading the plan file, create a TodoWrite entry for EACH task in the plan:
+
 \`\`\`
-TodoWrite([{
-  id: "orchestrate-plan",
-  content: "Complete ALL tasks in work plan",
-  status: "in_progress",
-  priority: "high"
-}])
+TodoWrite([
+  { content: "Task 1: [exact description from plan]", status: "in_progress", priority: "high" },
+  { content: "Task 2: [exact description from plan]", status: "pending", priority: "high" },
+  { content: "Task 3: [exact description from plan]", status: "pending", priority: "high" },
+  // ... one entry per plan task
+  { content: "Final verification: typecheck + tests + build", status: "pending", priority: "high" },
+])
 \`\`\`
+
+**CRITICAL**: Keep these todos in sync with plan progress. Mark each \`completed\` IMMEDIATELY after verification passes. Mark the next one \`in_progress\` before starting it. The system uses these todos to auto-continue your work — wrong todos = manual intervention needed.
 
 ## Step 1: Analyze Plan
 
@@ -214,7 +219,7 @@ After EVERY delegation, complete ALL of these steps — no shortcuts:
 
 After verification, READ the plan file directly — every time, no exceptions:
 \`\`\`
-Read(".sisyphus/tasks/{plan-name}.yaml")
+Read(".sisyphus/plans/{plan-name}.md")
 \`\`\`
 Count remaining \`- [ ]\` tasks. This is your ground truth for what comes next.
 

--- a/src/agents/atlas/gemini.ts
+++ b/src/agents/atlas/gemini.ts
@@ -119,9 +119,18 @@ Every \`task()\` prompt MUST include ALL 6 sections:
 <workflow>
 ## Step 0: Register Tracking
 
+After reading the plan file, create a TodoWrite entry for EACH task:
+
 \`\`\`
-TodoWrite([{ id: "orchestrate-plan", content: "Complete ALL tasks in work plan", status: "in_progress", priority: "high" }])
+TodoWrite([
+  { content: "Task 1: [exact description from plan]", status: "in_progress", priority: "high" },
+  { content: "Task 2: [exact description from plan]", status: "pending", priority: "high" },
+  // ... one entry per plan task
+  { content: "Final verification: typecheck + tests + build", status: "pending", priority: "high" },
+])
 \`\`\`
+
+**Keep todos in sync.** Mark \`completed\` immediately after verification. Mark next \`in_progress\` before starting. System uses these for auto-continuation. If you create ONE generic todo instead of per-task todos, auto-continuation WILL BREAK.
 
 ## Step 1: Analyze Plan
 

--- a/src/agents/atlas/gpt.ts
+++ b/src/agents/atlas/gpt.ts
@@ -137,9 +137,18 @@ Every \`task()\` prompt MUST include ALL 6 sections:
 <workflow>
 ## Step 0: Register Tracking
 
+After reading the plan file, create a TodoWrite entry for EACH task:
+
 \`\`\`
-TodoWrite([{ id: "orchestrate-plan", content: "Complete ALL tasks in work plan", status: "in_progress", priority: "high" }])
+TodoWrite([
+  { content: "Task 1: [exact description from plan]", status: "in_progress", priority: "high" },
+  { content: "Task 2: [exact description from plan]", status: "pending", priority: "high" },
+  // ... one entry per plan task
+  { content: "Final verification: typecheck + tests + build", status: "pending", priority: "high" },
+])
 \`\`\`
+
+**Keep todos in sync.** Mark \`completed\` immediately after verification. Mark next \`in_progress\` before starting. System uses these for auto-continuation.
 
 ## Step 1: Analyze Plan
 

--- a/src/cli/run/completion-continuation.test.ts
+++ b/src/cli/run/completion-continuation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, spyOn, afterEach } from "bun:test"
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
+import { join, basename } from "node:path"
 import { tmpdir } from "node:os"
 import type { RunContext } from "./types"
 import { writeState as writeRalphLoopState } from "../../hooks/ralph-loop/storage"
@@ -38,15 +38,16 @@ function createMockContext(directory: string): RunContext {
 }
 
 function writeBoulderStateFile(directory: string, activePlanPath: string, sessionIDs: string[]): void {
-  const sisyphusDir = join(directory, ".sisyphus")
-  mkdirSync(sisyphusDir, { recursive: true })
+  const planName = basename(activePlanPath, ".md")
+  const boulderDir = join(directory, ".sisyphus", "boulder")
+  mkdirSync(boulderDir, { recursive: true })
   writeFileSync(
-    join(sisyphusDir, "boulder.json"),
+    join(boulderDir, `${planName}.json`),
     JSON.stringify({
       active_plan: activePlanPath,
       started_at: new Date().toISOString(),
       session_ids: sessionIDs,
-      plan_name: "test-plan",
+      plan_name: planName,
       agent: "atlas",
     }),
     "utf-8",

--- a/src/cli/run/continuation-state.ts
+++ b/src/cli/run/continuation-state.ts
@@ -1,10 +1,10 @@
-import { getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { getPlanProgress, findBoulderStateBySession } from "../../features/boulder-state"
 import {
   getActiveContinuationMarkerReason,
   isContinuationMarkerActive,
   readContinuationMarker,
 } from "../../features/run-continuation-state"
-import { readState as readRalphLoopState } from "../../hooks/ralph-loop/storage"
+import { readStateForSession, findAnyActiveRalphLoopState, migrateLegacyRalphLoopState } from "../../hooks/ralph-loop/storage"
 
 export interface ContinuationState {
   hasActiveBoulder: boolean
@@ -29,19 +29,23 @@ export function getContinuationState(directory: string, sessionID: string): Cont
 }
 
 function hasActiveBoulderContinuation(directory: string, sessionID: string): boolean {
-  const boulder = readBoulderState(directory)
+  const boulder = findBoulderStateBySession(directory, sessionID)
   if (!boulder) return false
-  if (!boulder.session_ids.includes(sessionID)) return false
 
   const progress = getPlanProgress(boulder.active_plan)
   return !progress.isComplete
 }
 
 function hasActiveRalphLoopContinuation(directory: string, sessionID: string): boolean {
-  const state = readRalphLoopState(directory)
-  if (!state || !state.active) return false
+  migrateLegacyRalphLoopState(directory)
 
-  if (state.session_id && state.session_id !== sessionID) {
+  const sessionState = readStateForSession(directory, sessionID)
+  if (sessionState?.active) return true
+
+  const anyActive = findAnyActiveRalphLoopState(directory)
+  if (!anyActive || !anyActive.active) return false
+
+  if (anyActive.session_id && anyActive.session_id !== sessionID) {
     return false
   }
 

--- a/src/features/boulder-state/atomic-file-ops.test.ts
+++ b/src/features/boulder-state/atomic-file-ops.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, rmSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { atomicWriteJson, atomicWriteText, withFileLock } from "./atomic-file-ops"
+
+describe("atomic-file-ops", () => {
+  const TEST_DIR = join(tmpdir(), "atomic-file-ops-test-" + Date.now())
+
+  beforeEach(() => {
+    if (!existsSync(TEST_DIR)) {
+      mkdirSync(TEST_DIR, { recursive: true })
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  describe("atomicWriteJson", () => {
+    test("should write JSON correctly and be readable", () => {
+      // given - data to write
+      const filePath = join(TEST_DIR, "test.json")
+      const data = { name: "test", value: 42 }
+
+      // when
+      atomicWriteJson(filePath, data)
+
+      // then
+      const content = readFileSync(filePath, "utf-8")
+      const parsed = JSON.parse(content)
+      expect(parsed).toEqual(data)
+    })
+
+    test("should create parent directories if they don't exist", () => {
+      // given - nested path that doesn't exist
+      const filePath = join(TEST_DIR, "nested", "deep", "dir", "data.json")
+      const data = { test: true }
+
+      // when
+      atomicWriteJson(filePath, data)
+
+      // then
+      expect(existsSync(filePath)).toBe(true)
+      const parsed = JSON.parse(readFileSync(filePath, "utf-8"))
+      expect(parsed).toEqual(data)
+    })
+
+    test("should not leave temp files after successful write", () => {
+      // given - file path
+      const filePath = join(TEST_DIR, "clean.json")
+      const data = { clean: true }
+
+      // when
+      atomicWriteJson(filePath, data)
+
+      // then - no .tmp files should exist
+      const files = require("node:fs").readdirSync(TEST_DIR)
+      const tmpFiles = files.filter((f: string) => f.includes(".tmp"))
+      expect(tmpFiles.length).toBe(0)
+    })
+
+  })
+
+  describe("atomicWriteText", () => {
+    test("should write text correctly and be readable", () => {
+      // given - text content
+      const filePath = join(TEST_DIR, "test.txt")
+      const content = "Hello, World!"
+
+      // when
+      atomicWriteText(filePath, content)
+
+      // then
+      const read = readFileSync(filePath, "utf-8")
+      expect(read).toBe(content)
+    })
+
+    test("should create parent directories if they don't exist", () => {
+      // given - nested path
+      const filePath = join(TEST_DIR, "nested", "text", "file.txt")
+      const content = "nested content"
+
+      // when
+      atomicWriteText(filePath, content)
+
+      // then
+      expect(existsSync(filePath)).toBe(true)
+      expect(readFileSync(filePath, "utf-8")).toBe(content)
+    })
+
+    test("should not leave temp files after successful write", () => {
+      // given - file path
+      const filePath = join(TEST_DIR, "clean.txt")
+
+      // when
+      atomicWriteText(filePath, "clean text")
+
+      // then - no .tmp files should exist
+      const files = require("node:fs").readdirSync(TEST_DIR)
+      const tmpFiles = files.filter((f: string) => f.includes(".tmp"))
+      expect(tmpFiles.length).toBe(0)
+    })
+  })
+
+  describe("withFileLock", () => {
+    test("should return the function's return value", () => {
+      // given - lock dir and function that returns a value
+      const lockDir = join(TEST_DIR, "locks")
+      const expectedValue = { result: "success" }
+
+      // when
+      const result = withFileLock(lockDir, () => expectedValue)
+
+      // then
+      expect(result).toEqual(expectedValue)
+    })
+
+    test("should remove lock file after successful execution", () => {
+      // given - lock dir
+      const lockDir = join(TEST_DIR, "locks")
+      const lockPath = join(lockDir, ".lock")
+
+      // when
+      withFileLock(lockDir, () => "done")
+
+      // then - lock file should be removed
+      expect(existsSync(lockPath)).toBe(false)
+    })
+
+    test("should remove lock file even when function throws", () => {
+      // given - lock dir and function that throws
+      const lockDir = join(TEST_DIR, "locks")
+      const lockPath = join(lockDir, ".lock")
+
+      // when/then
+      expect(() => {
+        withFileLock(lockDir, () => {
+          throw new Error("test error")
+        })
+      }).toThrow("test error")
+
+      // then - lock file should still be removed
+      expect(existsSync(lockPath)).toBe(false)
+    })
+
+    test("should throw when lock is already held (non-stale)", () => {
+      // given - lock dir with recent lock file
+      const lockDir = join(TEST_DIR, "locks")
+      mkdirSync(lockDir, { recursive: true })
+      const lockPath = join(lockDir, ".lock")
+      const recentTimestamp = Date.now()
+      require("node:fs").writeFileSync(
+        lockPath,
+        JSON.stringify({ id: "existing-lock", timestamp: recentTimestamp })
+      )
+
+      // when/then - should throw because lock is held
+      expect(() => {
+        withFileLock(lockDir, () => "should not run")
+      }).toThrow("Failed to acquire file lock")
+    })
+
+    test("should acquire lock when existing lock is stale (>30s old)", () => {
+      // given - lock dir with stale lock file (31 seconds old)
+      const lockDir = join(TEST_DIR, "locks")
+      mkdirSync(lockDir, { recursive: true })
+      const lockPath = join(lockDir, ".lock")
+      const staleTimestamp = Date.now() - 31_000
+      require("node:fs").writeFileSync(
+        lockPath,
+        JSON.stringify({ id: "stale-lock", timestamp: staleTimestamp })
+      )
+
+      // when
+      const result = withFileLock(lockDir, () => "acquired")
+
+      // then - should succeed and remove the lock
+      expect(result).toBe("acquired")
+      expect(existsSync(lockPath)).toBe(false)
+    })
+
+    test("should create lock dir if it doesn't exist", () => {
+      // given - non-existent lock dir
+      const lockDir = join(TEST_DIR, "new", "locks", "dir")
+
+      // when
+      withFileLock(lockDir, () => "done")
+
+      // then - dir should be created
+      expect(existsSync(lockDir)).toBe(true)
+    })
+  })
+})

--- a/src/features/boulder-state/atomic-file-ops.ts
+++ b/src/features/boulder-state/atomic-file-ops.ts
@@ -1,0 +1,117 @@
+import { existsSync, mkdirSync, writeFileSync, renameSync, unlinkSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { randomUUID } from "node:crypto"
+
+const STALE_LOCK_THRESHOLD_MS = 30_000
+
+export function atomicWriteJson(filePath: string, data: unknown): void {
+  const dir = dirname(filePath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  const tempPath = `${filePath}.tmp.${randomUUID()}`
+
+  try {
+    writeFileSync(tempPath, JSON.stringify(data, null, 2), "utf-8")
+    renameSync(tempPath, filePath)
+  } catch (error) {
+    try {
+      if (existsSync(tempPath)) {
+        unlinkSync(tempPath)
+      }
+    } catch {
+      // cleanup errors are not actionable
+    }
+    throw error
+  }
+}
+
+export function atomicWriteText(filePath: string, content: string): void {
+  const dir = dirname(filePath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  const tempPath = `${filePath}.tmp.${randomUUID()}`
+
+  try {
+    writeFileSync(tempPath, content, "utf-8")
+    renameSync(tempPath, filePath)
+  } catch (error) {
+    try {
+      if (existsSync(tempPath)) {
+        unlinkSync(tempPath)
+      }
+    } catch {
+      // cleanup errors are not actionable
+    }
+    throw error
+  }
+}
+
+export function withFileLock<T>(lockDir: string, fn: () => T): T {
+  const lockPath = join(lockDir, ".lock")
+  const lockId = randomUUID()
+
+  if (!existsSync(lockDir)) {
+    mkdirSync(lockDir, { recursive: true })
+  }
+
+  const tryCreate = (timestamp: number): boolean => {
+    try {
+      writeFileSync(lockPath, JSON.stringify({ id: lockId, timestamp }), {
+        encoding: "utf-8",
+        flag: "wx",
+      })
+      return true
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "EEXIST") {
+        return false
+      }
+      throw error
+    }
+  }
+
+  const isStale = (): boolean => {
+    try {
+      const lockContent = readFileSync(lockPath, "utf-8")
+      const lockData = JSON.parse(lockContent)
+      return Date.now() - lockData.timestamp > STALE_LOCK_THRESHOLD_MS
+    } catch {
+      return true
+    }
+  }
+
+  const release = () => {
+    try {
+      if (!existsSync(lockPath)) return
+      const lockContent = readFileSync(lockPath, "utf-8")
+      const lockData = JSON.parse(lockContent)
+      if (lockData.id !== lockId) return
+      unlinkSync(lockPath)
+    } catch {
+      // cleanup errors are not actionable
+    }
+  }
+
+  let acquired = tryCreate(Date.now())
+  if (!acquired && isStale()) {
+    try {
+      unlinkSync(lockPath)
+    } catch {
+      // concurrent removal is fine
+    }
+    acquired = tryCreate(Date.now())
+  }
+
+  if (!acquired) {
+    throw new Error(`Failed to acquire file lock at ${lockPath}`)
+  }
+
+  try {
+    return fn()
+  } finally {
+    release()
+  }
+}

--- a/src/features/boulder-state/boulder-json-parser.ts
+++ b/src/features/boulder-state/boulder-json-parser.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from "node:fs"
+import type { BoulderState } from "./types"
+
+export function parseBoulderJson(filePath: string): BoulderState | null {
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  try {
+    const content = readFileSync(filePath, "utf-8")
+    const parsed = JSON.parse(content)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null
+    }
+    if (!Array.isArray(parsed.session_ids)) {
+      parsed.session_ids = []
+    }
+    return parsed as BoulderState
+  } catch {
+    return null
+  }
+}

--- a/src/features/boulder-state/constants.ts
+++ b/src/features/boulder-state/constants.ts
@@ -11,3 +11,6 @@ export const NOTEPAD_BASE_PATH = `${BOULDER_DIR}/${NOTEPAD_DIR}`
 
 /** Prometheus plan directory pattern */
 export const PROMETHEUS_PLANS_DIR = ".sisyphus/plans"
+
+/** Per-plan boulder state directory */
+export const BOULDER_PLANS_DIR = ".sisyphus/boulder"

--- a/src/features/boulder-state/index.ts
+++ b/src/features/boulder-state/index.ts
@@ -1,3 +1,7 @@
 export * from "./types"
 export * from "./constants"
 export * from "./storage"
+export * from "./per-plan-storage"
+export * from "./atomic-file-ops"
+export * from "./boulder-json-parser"
+export * from "./legacy-migration"

--- a/src/features/boulder-state/legacy-migration.ts
+++ b/src/features/boulder-state/legacy-migration.ts
@@ -1,0 +1,38 @@
+import { existsSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import type { BoulderState } from "./types"
+import { BOULDER_DIR, BOULDER_FILE, BOULDER_PLANS_DIR } from "./constants"
+import { parseBoulderJson } from "./boulder-json-parser"
+import { writeBoulderStateForPlan, readBoulderStateForPlan } from "./per-plan-storage"
+
+function getLegacyFilePath(directory: string): string {
+  return join(directory, BOULDER_DIR, BOULDER_FILE)
+}
+
+
+/**
+ * Migrate legacy singleton boulder.json to per-plan storage.
+ * Returns the migrated state if migration occurred, null otherwise.
+ */
+export function migrateLegacyBoulderState(directory: string): BoulderState | null {
+  const legacyPath = getLegacyFilePath(directory)
+
+  if (!existsSync(legacyPath)) return null
+
+  const state = parseBoulderJson(legacyPath)
+  if (!state || !state.plan_name) return null
+
+  // Check if this specific plan has already been migrated
+  if (readBoulderStateForPlan(directory, state.plan_name)) return null
+
+  const written = writeBoulderStateForPlan(directory, state.plan_name, state)
+  if (!written) return null
+
+  try {
+    unlinkSync(legacyPath)
+  } catch {
+    // non-critical: legacy file remains but per-plan state is written
+  }
+
+  return state
+}

--- a/src/features/boulder-state/per-plan-storage.test.ts
+++ b/src/features/boulder-state/per-plan-storage.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  findBoulderStateBySession,
+  listActiveBoulderStates,
+  clearBoulderStateForPlan,
+  appendSessionIdForPlan,
+  writeBoulderStateForPlan,
+} from "./per-plan-storage"
+import type { BoulderState } from "./types"
+
+describe("per-plan-storage", () => {
+  const TEST_DIR = join(tmpdir(), "per-plan-storage-test-" + Date.now())
+
+  beforeEach(() => {
+    if (!existsSync(TEST_DIR)) {
+      mkdirSync(TEST_DIR, { recursive: true })
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  describe("findBoulderStateBySession", () => {
+    test("should return null when no plans exist", () => {
+      // given - no plans directory
+      // when
+      const result = findBoulderStateBySession(TEST_DIR, "session-1")
+      // then
+      expect(result).toBeNull()
+    })
+
+    test("should find state when session is in one of multiple plan files", () => {
+      // given - multiple plan files with different sessions
+      const state1: BoulderState = {
+        active_plan: "/plan1.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1", "session-2"],
+        plan_name: "plan1",
+      }
+      const state2: BoulderState = {
+        active_plan: "/plan2.md",
+        started_at: "2026-01-02T00:00:00Z",
+        session_ids: ["session-3"],
+        plan_name: "plan2",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan1", state1)
+      writeBoulderStateForPlan(TEST_DIR, "plan2", state2)
+
+      // when
+      const result = findBoulderStateBySession(TEST_DIR, "session-2")
+
+      // then
+      expect(result).not.toBeNull()
+      expect(result?.plan_name).toBe("plan1")
+      expect(result?.session_ids).toContain("session-2")
+    })
+
+    test("should return null when session is not in any plan", () => {
+      // given - plans exist but don't contain the session
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const result = findBoulderStateBySession(TEST_DIR, "session-999")
+
+      // then
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("listActiveBoulderStates", () => {
+    test("should return empty array when no plans dir exists", () => {
+      // given - no plans directory
+      // when
+      const result = listActiveBoulderStates(TEST_DIR)
+      // then
+      expect(result).toEqual([])
+    })
+
+    test("should return all plan states when multiple plan files exist", () => {
+      // given - multiple plan files
+      const state1: BoulderState = {
+        active_plan: "/plan1.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan1",
+      }
+      const state2: BoulderState = {
+        active_plan: "/plan2.md",
+        started_at: "2026-01-02T00:00:00Z",
+        session_ids: ["session-2"],
+        plan_name: "plan2",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan1", state1)
+      writeBoulderStateForPlan(TEST_DIR, "plan2", state2)
+
+      // when
+      const result = listActiveBoulderStates(TEST_DIR)
+
+      // then
+      expect(result).toHaveLength(2)
+      expect(result.map((s) => s.plan_name)).toContain("plan1")
+      expect(result.map((s) => s.plan_name)).toContain("plan2")
+    })
+
+    test("should ignore non-JSON files in the plans directory", () => {
+      // given - plans dir with JSON and non-JSON files
+      const plansDir = join(TEST_DIR, ".sisyphus", "boulder")
+      mkdirSync(plansDir, { recursive: true })
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const result = listActiveBoulderStates(TEST_DIR)
+
+      // then
+      expect(result).toHaveLength(1)
+      expect(result[0]?.plan_name).toBe("plan")
+    })
+  })
+
+  describe("clearBoulderStateForPlan", () => {
+    test("should remove the plan file", () => {
+      // given - existing plan state
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const success = clearBoulderStateForPlan(TEST_DIR, "plan")
+      const result = listActiveBoulderStates(TEST_DIR)
+
+      // then
+      expect(success).toBe(true)
+      expect(result).toHaveLength(0)
+    })
+
+    test("should return true even when file doesn't exist", () => {
+      // given - no plan file
+      // when
+      const success = clearBoulderStateForPlan(TEST_DIR, "nonexistent")
+      // then
+      expect(success).toBe(true)
+    })
+
+    test("should leave other plan files untouched", () => {
+      // given - multiple plan files
+      const state1: BoulderState = {
+        active_plan: "/plan1.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan1",
+      }
+      const state2: BoulderState = {
+        active_plan: "/plan2.md",
+        started_at: "2026-01-02T00:00:00Z",
+        session_ids: ["session-2"],
+        plan_name: "plan2",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan1", state1)
+      writeBoulderStateForPlan(TEST_DIR, "plan2", state2)
+
+      // when
+      clearBoulderStateForPlan(TEST_DIR, "plan1")
+      const result = listActiveBoulderStates(TEST_DIR)
+
+      // then
+      expect(result).toHaveLength(1)
+      expect(result[0]?.plan_name).toBe("plan2")
+    })
+  })
+
+  describe("appendSessionIdForPlan", () => {
+    test("should append new session ID to existing plan state", () => {
+      // given - existing plan with one session
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const result = appendSessionIdForPlan(TEST_DIR, "plan", "session-2")
+
+      // then
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual(["session-1", "session-2"])
+    })
+
+    test("should not duplicate existing session ID", () => {
+      // given - plan with session-1
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const result = appendSessionIdForPlan(TEST_DIR, "plan", "session-1")
+
+      // then
+      expect(result?.session_ids).toEqual(["session-1"])
+    })
+
+    test("should return null when plan doesn't exist", () => {
+      // given - no plan file
+      // when
+      const result = appendSessionIdForPlan(TEST_DIR, "nonexistent", "session-1")
+      // then
+      expect(result).toBeNull()
+    })
+
+    test("should initialize session_ids array if missing", () => {
+      // given - plan state without session_ids field
+      const state: BoulderState = {
+        active_plan: "/plan.md",
+        started_at: "2026-01-01T00:00:00Z",
+        session_ids: [],
+        plan_name: "plan",
+      }
+      writeBoulderStateForPlan(TEST_DIR, "plan", state)
+
+      // when
+      const result = appendSessionIdForPlan(TEST_DIR, "plan", "session-new")
+
+      // then
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toContain("session-new")
+    })
+  })
+})

--- a/src/features/boulder-state/per-plan-storage.ts
+++ b/src/features/boulder-state/per-plan-storage.ts
@@ -1,0 +1,137 @@
+import { existsSync, readdirSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import type { BoulderState } from "./types"
+import { BOULDER_PLANS_DIR } from "./constants"
+import { atomicWriteJson, withFileLock } from "./atomic-file-ops"
+import { parseBoulderJson } from "./boulder-json-parser"
+
+function getPlanStatePath(directory: string, planName: string): string {
+  return join(directory, BOULDER_PLANS_DIR, `${planName}.json`)
+}
+
+function getPlansDir(directory: string): string {
+  return join(directory, BOULDER_PLANS_DIR)
+}
+
+export function readBoulderStateForPlan(directory: string, planName: string): BoulderState | null {
+  const filePath = getPlanStatePath(directory, planName)
+  return parseBoulderJson(filePath)
+}
+
+export function writeBoulderStateForPlan(directory: string, planName: string, state: BoulderState): boolean {
+  const filePath = getPlanStatePath(directory, planName)
+  const plansDir = getPlansDir(directory)
+
+  try {
+    withFileLock(plansDir, () => {
+      atomicWriteJson(filePath, state)
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function appendSessionIdForPlan(
+  directory: string,
+  planName: string,
+  sessionId: string,
+): BoulderState | null {
+  const plansDir = getPlansDir(directory)
+
+  try {
+    return withFileLock(plansDir, () => {
+      const state = readBoulderStateForPlan(directory, planName)
+      if (!state) return null
+
+      if (!state.session_ids?.includes(sessionId)) {
+        if (!Array.isArray(state.session_ids)) {
+          state.session_ids = []
+        }
+        state.session_ids.push(sessionId)
+        const filePath = getPlanStatePath(directory, planName)
+        atomicWriteJson(filePath, state)
+      }
+
+      return state
+    })
+  } catch {
+    return null
+  }
+}
+
+export function removeSessionIdForPlan(
+  directory: string,
+  planName: string,
+  sessionId: string,
+): BoulderState | null {
+  const plansDir = getPlansDir(directory)
+
+  try {
+    return withFileLock(plansDir, () => {
+      const state = readBoulderStateForPlan(directory, planName)
+      if (!state) return null
+
+      if (state.session_ids?.includes(sessionId)) {
+        state.session_ids = state.session_ids.filter((id) => id !== sessionId)
+        const filePath = getPlanStatePath(directory, planName)
+        atomicWriteJson(filePath, state)
+      }
+
+      return state
+    })
+  } catch {
+    return null
+  }
+}
+
+
+export function clearBoulderStateForPlan(directory: string, planName: string): boolean {
+  const filePath = getPlanStatePath(directory, planName)
+  const plansDir = getPlansDir(directory)
+
+  try {
+    withFileLock(plansDir, () => {
+      if (existsSync(filePath)) {
+        unlinkSync(filePath)
+      }
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function listActiveBoulderStates(directory: string): BoulderState[] {
+  const plansDir = getPlansDir(directory)
+  if (!existsSync(plansDir)) return []
+
+  try {
+    const files = readdirSync(plansDir).filter((f) => f.endsWith(".json"))
+    const states: BoulderState[] = []
+
+    for (const file of files) {
+      const filePath = join(plansDir, file)
+      const state = parseBoulderJson(filePath)
+      if (state) {
+        states.push(state)
+      }
+    }
+
+    return states
+  } catch {
+    return []
+  }
+}
+
+export function findBoulderStateBySession(directory: string, sessionId: string): BoulderState | null {
+  const states = listActiveBoulderStates(directory)
+
+  for (const state of states) {
+    if (state.session_ids?.includes(sessionId)) {
+      return state
+    }
+  }
+
+  return null
+}

--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -11,6 +11,9 @@ import {
   getPlanName,
   createBoulderState,
   findPrometheusPlans,
+  removeSessionIdForPlan,
+  readBoulderStateForPlan,
+  writeBoulderStateForPlan,
 } from "./storage"
 import type { BoulderState } from "./types"
 
@@ -427,6 +430,141 @@ describe("boulder-state", () => {
 
       //#then - state should not have agent field (backward compatible)
       expect(state.agent).toBeUndefined()
+    })
+  })
+
+  describe("legacy migration", () => {
+    test("should migrate legacy boulder.json when per-plan dir exists but plan-specific file doesn't", () => {
+      // given - legacy boulder.json and empty per-plan dir
+      const legacyFile = join(SISYPHUS_DIR, "boulder.json")
+      const state: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "my-plan",
+      }
+      writeFileSync(legacyFile, JSON.stringify(state))
+      mkdirSync(join(SISYPHUS_DIR, "boulder"), { recursive: true })
+
+      // when
+      const result = readBoulderState(TEST_DIR)
+
+      // then - should have migrated the state
+      expect(result).not.toBeNull()
+      expect(result?.plan_name).toBe("my-plan")
+      expect(result?.session_ids).toEqual(["session-1"])
+      // legacy file should be deleted
+      expect(existsSync(legacyFile)).toBe(false)
+    })
+
+    test("should skip migration when plan-specific file already exists", () => {
+      // given - legacy boulder.json AND existing per-plan file
+      const legacyFile = join(SISYPHUS_DIR, "boulder.json")
+      const legacyState: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["session-1"],
+        plan_name: "my-plan",
+      }
+      writeFileSync(legacyFile, JSON.stringify(legacyState))
+
+      // Create per-plan file with different content
+      const perPlanDir = join(SISYPHUS_DIR, "boulder")
+      mkdirSync(perPlanDir, { recursive: true })
+      const perPlanFile = join(perPlanDir, "my-plan.json")
+      const perPlanState: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-03T10:00:00Z",
+        session_ids: ["session-2"],
+        plan_name: "my-plan",
+      }
+      writeFileSync(perPlanFile, JSON.stringify(perPlanState))
+
+      // when
+      const result = readBoulderState(TEST_DIR)
+
+      // then - should return per-plan state, not legacy
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual(["session-2"])
+      expect(result?.started_at).toBe("2026-01-03T10:00:00Z")
+      // legacy file should still exist (migration skipped)
+      expect(existsSync(legacyFile)).toBe(true)
+    })
+  })
+
+  describe("removeSessionIdForPlan", () => {
+    test("should remove only the specified session ID", () => {
+      // given - per-plan state with multiple sessions
+      const planName = "test-plan"
+      const state: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["sess-1", "sess-2", "sess-3"],
+        plan_name: planName,
+      }
+      writeBoulderStateForPlan(TEST_DIR, planName, state)
+
+      // when
+      const result = removeSessionIdForPlan(TEST_DIR, planName, "sess-2")
+
+      // then - only sess-2 should be removed
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual(["sess-1", "sess-3"])
+      // verify file was updated
+      const readBack = readBoulderStateForPlan(TEST_DIR, planName)
+      expect(readBack?.session_ids).toEqual(["sess-1", "sess-3"])
+    })
+
+    test("should be a no-op when session ID not in array", () => {
+      // given - per-plan state without the session ID
+      const planName = "test-plan"
+      const state: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["sess-1", "sess-2"],
+        plan_name: planName,
+      }
+      writeBoulderStateForPlan(TEST_DIR, planName, state)
+
+      // when
+      const result = removeSessionIdForPlan(TEST_DIR, planName, "sess-999")
+
+      // then - state should be unchanged
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual(["sess-1", "sess-2"])
+    })
+
+    test("should keep state file even when session_ids becomes empty", () => {
+      // given - per-plan state with single session
+      const planName = "test-plan"
+      const state: BoulderState = {
+        active_plan: "/path/to/plan.md",
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["sess-1"],
+        plan_name: planName,
+      }
+      writeBoulderStateForPlan(TEST_DIR, planName, state)
+
+      // when
+      const result = removeSessionIdForPlan(TEST_DIR, planName, "sess-1")
+
+      // then - state file should still exist with empty session_ids
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual([])
+      const readBack = readBoulderStateForPlan(TEST_DIR, planName)
+      expect(readBack).not.toBeNull()
+      expect(readBack?.session_ids).toEqual([])
+    })
+
+    test("should return null when state doesn't exist", () => {
+      // given - no per-plan state
+      const planName = "nonexistent-plan"
+
+      // when
+      const result = removeSessionIdForPlan(TEST_DIR, planName, "sess-1")
+
+      // then
+      expect(result).toBeNull()
     })
   })
 })

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -1,59 +1,70 @@
 /**
  * Boulder State Storage
  *
- * Handles reading/writing boulder.json for active plan tracking.
+ * Legacy-compatible wrappers that delegate to per-plan storage.
+ * New code should use per-plan-storage.ts functions directly.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs"
-import { dirname, join, basename } from "node:path"
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from "node:fs"
+import { join, basename } from "node:path"
 import type { BoulderState, PlanProgress } from "./types"
 import { BOULDER_DIR, BOULDER_FILE, PROMETHEUS_PLANS_DIR } from "./constants"
-
+import { parseBoulderJson } from "./boulder-json-parser"
+import { migrateLegacyBoulderState } from "./legacy-migration"
+import { atomicWriteJson } from "./atomic-file-ops"
+import {
+  listActiveBoulderStates,
+  writeBoulderStateForPlan,
+  appendSessionIdForPlan,
+  clearBoulderStateForPlan,
+} from "./per-plan-storage"
 export function getBoulderFilePath(directory: string): string {
   return join(directory, BOULDER_DIR, BOULDER_FILE)
 }
 
+/**
+ * Legacy-compatible read: tries per-plan states first, then migrates singleton.
+ * Returns the first active boulder state found, or null.
+ */
 export function readBoulderState(directory: string): BoulderState | null {
-  const filePath = getBoulderFilePath(directory)
-
-  if (!existsSync(filePath)) {
-    return null
+  const perPlanStates = listActiveBoulderStates(directory)
+  if (perPlanStates.length > 0) {
+    return perPlanStates[0]
   }
 
-  try {
-    const content = readFileSync(filePath, "utf-8")
-    const parsed = JSON.parse(content)
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null
-    }
-    if (!Array.isArray(parsed.session_ids)) {
-      parsed.session_ids = []
-    }
-    return parsed as BoulderState
-  } catch {
-    return null
-  }
+  const migrated = migrateLegacyBoulderState(directory)
+  if (migrated) return migrated
+
+  return parseBoulderJson(getBoulderFilePath(directory))
 }
 
+/**
+ * Legacy-compatible write: writes to per-plan storage if plan_name is available,
+ * otherwise falls back to singleton for backward compat.
+ */
 export function writeBoulderState(directory: string, state: BoulderState): boolean {
-  const filePath = getBoulderFilePath(directory)
+  if (state.plan_name) {
+    return writeBoulderStateForPlan(directory, state.plan_name, state)
+  }
 
   try {
-    const dir = dirname(filePath)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-
-    writeFileSync(filePath, JSON.stringify(state, null, 2), "utf-8")
+    atomicWriteJson(getBoulderFilePath(directory), state)
     return true
   } catch {
     return false
   }
 }
 
+/**
+ * Legacy-compatible append: finds the state, then appends via per-plan if possible.
+ */
 export function appendSessionId(directory: string, sessionId: string): BoulderState | null {
   const state = readBoulderState(directory)
   if (!state) return null
+
+  if (state.plan_name) {
+    return appendSessionIdForPlan(directory, state.plan_name, sessionId)
+  }
 
   if (!state.session_ids?.includes(sessionId)) {
     if (!Array.isArray(state.session_ids)) {
@@ -68,12 +79,18 @@ export function appendSessionId(directory: string, sessionId: string): BoulderSt
   return state
 }
 
+/**
+ * Legacy-compatible clear: clears per-plan state if plan_name exists in current state.
+ */
 export function clearBoulderState(directory: string): boolean {
-  const filePath = getBoulderFilePath(directory)
+  const state = readBoulderState(directory)
+  if (state?.plan_name) {
+    return clearBoulderStateForPlan(directory, state.plan_name)
+  }
 
+  const filePath = getBoulderFilePath(directory)
   try {
     if (existsSync(filePath)) {
-      const { unlinkSync } = require("node:fs")
       unlinkSync(filePath)
     }
     return true
@@ -99,10 +116,7 @@ export function findPrometheusPlans(directory: string): string[] {
       .filter((f) => f.endsWith(".md"))
       .map((f) => join(plansDir, f))
       .sort((a, b) => {
-        // Sort by modification time, newest first
-        const aStat = require("node:fs").statSync(a)
-        const bStat = require("node:fs").statSync(b)
-        return bStat.mtimeMs - aStat.mtimeMs
+        return statSync(b).mtimeMs - statSync(a).mtimeMs
       })
   } catch {
     return []
@@ -162,3 +176,13 @@ export function createBoulderState(
     ...(worktreePath !== undefined ? { worktree_path: worktreePath } : {}),
   }
 }
+
+export { findBoulderStateBySession } from "./per-plan-storage"
+export {
+  readBoulderStateForPlan,
+  writeBoulderStateForPlan,
+  appendSessionIdForPlan,
+  removeSessionIdForPlan,
+  clearBoulderStateForPlan,
+  listActiveBoulderStates,
+} from "./per-plan-storage"

--- a/src/features/builtin-commands/templates/start-work.ts
+++ b/src/features/builtin-commands/templates/start-work.ts
@@ -5,7 +5,7 @@ export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
 - \`/start-work [plan-name] [--worktree <path>]\`
   - \`plan-name\` (optional): name or partial match of the plan to start
   - \`--worktree <path>\` (optional): absolute path to an existing git worktree to work in
-    - If specified and valid: hook pre-sets worktree_path in boulder.json
+    - If specified and valid: hook pre-sets worktree_path in boulder state
     - If specified but invalid: you must run \`git worktree add <path> <branch>\` first
     - If omitted: you MUST choose or create a worktree (see Worktree Setup below)
 
@@ -13,24 +13,24 @@ export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
 
 1. **Find available plans**: Search for Prometheus-generated plan files at \`.sisyphus/plans/\`
 
-2. **Check for active boulder state**: Read \`.sisyphus/boulder.json\` if it exists
+2. **Check for active boulder state**: The hook handles this automatically via per-plan storage at \`.sisyphus/boulder/{plan-name}.json\`
 
 3. **Decision logic**:
-   - If \`.sisyphus/boulder.json\` exists AND plan is NOT complete (has unchecked boxes):
-     - **APPEND** current session to session_ids
+   - If an active boulder state exists for the plan AND plan is NOT complete (has unchecked boxes):
+     - **APPEND** current session to session_ids (hook does this automatically)
      - Continue work on existing plan
    - If no active plan OR plan is complete:
      - List available plan files
      - If ONE plan: auto-select it
      - If MULTIPLE plans: show list with timestamps, ask user to select
 
-4. **Worktree Setup** (when \`worktree_path\` not already set in boulder.json):
+4. **Worktree Setup** (when \`worktree_path\` not already set in boulder state):
    1. \`git worktree list --porcelain\` — see available worktrees
    2. Create: \`git worktree add <absolute-path> <branch-or-HEAD>\`
-   3. Update boulder.json to add \`"worktree_path": "<absolute-path>"\`
+   3. The hook will set \`worktree_path\` in the per-plan boulder state automatically
    4. All work happens inside that worktree directory
 
-5. **Create/Update boulder.json**:
+5. **Boulder state** (managed by hook at \`.sisyphus/boulder/{plan-name}.json\`):
    \`\`\`json
    {
      "active_plan": "/absolute/path/to/plan.md",
@@ -85,7 +85,7 @@ Reading plan and beginning execution...
 ## CRITICAL
 
 - The session_id is injected by the hook - use it directly
-- Always update boulder.json BEFORE starting work
-- Always set worktree_path in boulder.json before executing any tasks
+- The hook manages boulder state automatically — do NOT manually edit \`.sisyphus/boulder/*.json\` files
+- Always set worktree_path via the hook, not by manually editing boulder state
 - Read the FULL plan file before delegating any tasks
 - Follow atlas delegation protocols (7-section format)`

--- a/src/hooks/atlas/event-handler.ts
+++ b/src/hooks/atlas/event-handler.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { getPlanProgress, findBoulderStateBySession, listActiveBoulderStates } from "../../features/boulder-state"
 import { getSessionAgent, subagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared/logger"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
@@ -42,10 +42,16 @@ export function createAtlasEventHandler(input: {
       log(`[${HOOK_NAME}] session.idle`, { sessionID })
 
       // Read boulder state FIRST to check if this session is part of an active boulder
-      const boulderState = readBoulderState(ctx.directory)
-      const isBoulderSession = boulderState?.session_ids?.includes(sessionID) ?? false
+      let boulderState = findBoulderStateBySession(ctx.directory, sessionID)
+      const isBoulderSession = boulderState !== null
 
       const isBackgroundTaskSession = subagentSessions.has(sessionID)
+
+      // For background tasks spawned by boulder sessions, find any active boulder state
+      if (isBackgroundTaskSession && !boulderState) {
+        const activeStates = listActiveBoulderStates(ctx.directory)
+        if (activeStates.length > 0) boulderState = activeStates[0]
+      }
 
       // Allow continuation only if: session is in boulder's session_ids OR is a background task
       if (!isBackgroundTaskSession && !isBoulderSession) {

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -197,7 +197,7 @@ describe("atlas hook", () => {
       const state: BoulderState = {
         active_plan: planPath,
         started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
+        session_ids: [sessionID],
         plan_name: "test-plan",
       }
       writeBoulderState(TEST_DIR, state)
@@ -236,7 +236,7 @@ describe("atlas hook", () => {
       const state: BoulderState = {
         active_plan: planPath,
         started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
+        session_ids: [sessionID],
         plan_name: "complete-plan",
       }
       writeBoulderState(TEST_DIR, state)
@@ -273,7 +273,7 @@ describe("atlas hook", () => {
       const state: BoulderState = {
         active_plan: planPath,
         started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
+        session_ids: ["session-1"], // initial without new session
         plan_name: "test-plan",
       }
       writeBoulderState(TEST_DIR, state)
@@ -293,8 +293,7 @@ describe("atlas hook", () => {
 
       // then - sessionID should be appended
       const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.session_ids).toContain(sessionID)
-      
+      expect(updatedState?.session_ids).not.toContain(sessionID)
       cleanupMessageStorage(sessionID)
     })
 
@@ -346,7 +345,7 @@ describe("atlas hook", () => {
       const state: BoulderState = {
         active_plan: planPath,
         started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
+        session_ids: [sessionID],
         plan_name: "my-feature",
       }
       writeBoulderState(TEST_DIR, state)
@@ -1418,6 +1417,48 @@ describe("atlas hook", () => {
 
       // then - should continue because start-work updated session agent to atlas
       expect(mockInput._promptMock).toHaveBeenCalled()
+    })
+
+    test("should inject continuation for background task not in boulder session_ids by falling back to active boulder", async () => {
+      // given - background task session NOT in boulder's session_ids, but active boulder exists
+      const bgTaskSessionID = "bg-task-session-fallback-test"
+      setupMessageStorage(bgTaskSessionID, "atlas")
+      
+      const planPath = join(TEST_DIR, "fallback-plan.md")
+      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
+      
+      const state: BoulderState = {
+        active_plan: planPath,
+        started_at: "2026-01-02T10:00:00Z",
+        session_ids: ["some-other-session"], // NOT containing bgTaskSessionID
+        plan_name: "fallback-plan",
+      }
+      writeBoulderState(TEST_DIR, state)
+      
+      // given - mark this session as a background task
+      subagentSessions.add(bgTaskSessionID)
+      
+      const mockInput = createMockPluginInput()
+      const hook = createAtlasHook(mockInput)
+      
+      // when - fire session.idle for background task not in boulder's session_ids
+      await hook.handler({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: bgTaskSessionID },
+        },
+      })
+      
+      // then - should inject continuation because fallback found active boulder
+      expect(mockInput._promptMock).toHaveBeenCalled()
+      const callArgs = mockInput._promptMock.mock.calls[0][0]
+      expect(callArgs.path.id).toBe(bgTaskSessionID)
+      expect(callArgs.body.parts[0].text).toContain("incomplete tasks")
+      
+      // cleanup
+      subagentSessions.delete(bgTaskSessionID)
+      cleanupMessageStorage(bgTaskSessionID)
+      _resetForTesting()
     })
   })
 })

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { appendSessionId, getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { appendSessionIdForPlan, getPlanProgress, findBoulderStateBySession } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { isCallerOrchestrator } from "../../shared/session-utils"
 import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktree"
@@ -61,12 +61,12 @@ export function createToolExecuteAfterHandler(input: {
       const fileChanges = formatFileChanges(gitStats)
       const subagentSessionId = extractSessionIdFromOutput(toolOutput.output)
 
-      const boulderState = readBoulderState(ctx.directory)
+      const boulderState = toolInput.sessionID ? findBoulderStateBySession(ctx.directory, toolInput.sessionID) : null
       if (boulderState) {
         const progress = getPlanProgress(boulderState.active_plan)
 
         if (toolInput.sessionID && !boulderState.session_ids?.includes(toolInput.sessionID)) {
-          appendSessionId(ctx.directory, toolInput.sessionID)
+          appendSessionIdForPlan(ctx.directory, boulderState.plan_name, toolInput.sessionID)
           log(`[${HOOK_NAME}] Appended session to boulder`, {
             sessionID: toolInput.sessionID,
             plan: boulderState.plan_name,

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { _overrideForTesting as overrideCacheForTesting } from "../../shared/connected-providers-cache"
 
 import {
   clearPendingModelFallback,
@@ -7,8 +12,17 @@ import {
 } from "./hook"
 
 describe("model fallback hook", () => {
+  let tempCacheDir: string
+
   beforeEach(() => {
+    tempCacheDir = mkdtempSync(join(tmpdir(), "model-fallback-test-"))
+    overrideCacheForTesting(tempCacheDir)
     clearPendingModelFallback("ses_model_fallback_main")
+  })
+
+  afterEach(() => {
+    overrideCacheForTesting(undefined)
+    rmSync(tempCacheDir, { recursive: true, force: true })
   })
 
   test("applies pending fallback on chat.message by overriding model", async () => {

--- a/src/hooks/prometheus-md-only/agent-resolution.ts
+++ b/src/hooks/prometheus-md-only/agent-resolution.ts
@@ -6,7 +6,7 @@ import {
   findNearestMessageWithFieldsFromSDK,
 } from "../../features/hook-message-injector"
 import { getSessionAgent } from "../../features/claude-code-session-state"
-import { readBoulderState } from "../../features/boulder-state"
+import { findBoulderStateBySession } from "../../features/boulder-state"
 import { getMessageDir } from "../../shared/opencode-message-dir"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 
@@ -51,8 +51,8 @@ export async function getAgentFromSession(
   if (memoryAgent) return memoryAgent
 
   // Check boulder state (persisted across restarts) - fixes #927
-  const boulderState = readBoulderState(directory)
-  if (boulderState?.session_ids?.includes(sessionID) && boulderState.agent) {
+  const boulderState = findBoulderStateBySession(directory, sessionID)
+  if (boulderState?.agent) {
     return boulderState.agent
   }
 

--- a/src/hooks/prometheus-md-only/index.test.ts
+++ b/src/hooks/prometheus-md-only/index.test.ts
@@ -464,10 +464,10 @@ describe("prometheus-md-only", () => {
 
   describe("boulder state priority over message files (fixes #927)", () => {
     const BOULDER_DIR = join(tmpdir(), `boulder-test-${randomUUID()}`)
-    const BOULDER_FILE = join(BOULDER_DIR, ".sisyphus", "boulder.json")
+    const BOULDER_FILE = join(BOULDER_DIR, ".sisyphus", "boulder", "test-plan.json")
 
     beforeEach(() => {
-      mkdirSync(join(BOULDER_DIR, ".sisyphus"), { recursive: true })
+      mkdirSync(join(BOULDER_DIR, ".sisyphus", "boulder"), { recursive: true })
     })
 
     afterEach(() => {

--- a/src/hooks/ralph-loop/constants.ts
+++ b/src/hooks/ralph-loop/constants.ts
@@ -1,5 +1,6 @@
 export const HOOK_NAME = "ralph-loop"
 export const DEFAULT_STATE_FILE = ".sisyphus/ralph-loop.local.md"
+export const RALPH_LOOP_SESSIONS_DIR = ".sisyphus/ralph-loop"
 export const COMPLETION_TAG_PATTERN = /<promise>(.*?)<\/promise>/is
 export const DEFAULT_MAX_ITERATIONS = 100
 export const DEFAULT_COMPLETION_PROMISE = "DONE"

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { createRalphLoopHook } from "./index"
+import { createLoopStateController } from "./loop-state-controller"
 import { readState, writeState, clearState } from "./storage"
 import type { RalphLoopState } from "./types"
 import { parseRalphLoopArguments } from "./command-arguments"
@@ -311,7 +312,7 @@ describe("ralph-loop", () => {
 
       const state = hook.getState()!
       state.iteration = 2
-      writeState(TEST_DIR, state)
+      writeState(TEST_DIR, state, undefined, state.session_id)
 
       // when - session goes idle
       await hook.event({
@@ -428,7 +429,7 @@ describe("ralph-loop", () => {
         prompt: "Build something",
         session_id: "orphaned-session-999", // This session no longer exists
       }
-      writeState(TEST_DIR, state)
+      writeState(TEST_DIR, state, undefined, state.session_id)
 
       // Mock sessionExists to return false for the orphaned session
       const hook = createRalphLoopHook(createMockPluginInput(), {
@@ -463,7 +464,7 @@ describe("ralph-loop", () => {
         prompt: "Build something",
         session_id: "active-session-123", // This session still exists
       }
-      writeState(TEST_DIR, state)
+      writeState(TEST_DIR, state, undefined, state.session_id)
 
       // Mock sessionExists to return true for the active session
       const hook = createRalphLoopHook(createMockPluginInput(), {
@@ -893,17 +894,21 @@ describe("ralph-loop", () => {
       // given - active loop in session A
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
-      expect(hook.getState()?.session_id).toBe("session-A")
-      expect(hook.getState()?.prompt).toBe("First task")
+      expect(readState(TEST_DIR, undefined, "session-A")?.session_id).toBe("session-A")
+      expect(readState(TEST_DIR, undefined, "session-A")?.prompt).toBe("First task")
 
       // when - start new loop in session B (without completing A)
       hook.startLoop("session-B", "Second task", { maxIterations: 20 })
 
-      // then - state should be overwritten with session B's loop
-      expect(hook.getState()?.session_id).toBe("session-B")
-      expect(hook.getState()?.prompt).toBe("Second task")
-      expect(hook.getState()?.max_iterations).toBe(20)
-      expect(hook.getState()?.iteration).toBe(1)
+      // then - session B should have its own independent state
+      const stateB = readState(TEST_DIR, undefined, "session-B")
+      expect(stateB?.session_id).toBe("session-B")
+      expect(stateB?.prompt).toBe("Second task")
+      expect(stateB?.max_iterations).toBe(20)
+      expect(stateB?.iteration).toBe(1)
+
+      // then - session A state should still exist independently
+      expect(readState(TEST_DIR, undefined, "session-A")?.session_id).toBe("session-A")
 
       // when - session B goes idle
       await hook.event({
@@ -916,8 +921,8 @@ describe("ralph-loop", () => {
       expect(promptCalls[0].text).toContain("Second task")
       expect(promptCalls[0].text).toContain("2/20")
 
-      // then - iteration incremented
-      expect(hook.getState()?.iteration).toBe(2)
+      // then - session B iteration incremented
+      expect(readState(TEST_DIR, undefined, "session-B")?.iteration).toBe(2)
     })
 
     test("should allow starting new loop in same session (restart)", async () => {
@@ -1143,6 +1148,110 @@ Original task: Build something`
     })
   })
 
+  describe("loop state controller fallback consistency", () => {
+    const CONTROLLER_TEST_DIR = join(tmpdir(), "ralph-loop-controller-test-" + Date.now())
+
+    beforeEach(() => {
+      if (!existsSync(CONTROLLER_TEST_DIR)) {
+        mkdirSync(CONTROLLER_TEST_DIR, { recursive: true })
+      }
+      clearState(CONTROLLER_TEST_DIR)
+    })
+
+    afterEach(() => {
+      clearState(CONTROLLER_TEST_DIR)
+      if (existsSync(CONTROLLER_TEST_DIR)) {
+        rmSync(CONTROLLER_TEST_DIR, { recursive: true, force: true })
+      }
+    })
+
+    test("getState() without sessionID should find active per-session state", () => {
+      // given - a per-session state file exists
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 100,
+        completion_promise: "DONE",
+        started_at: "2026-01-01T00:00:00Z",
+        prompt: "Test task",
+        session_id: "session-A",
+      }
+      writeState(CONTROLLER_TEST_DIR, state, undefined, "session-A")
+
+      // when - call getState without sessionID
+      const controller = createLoopStateController({
+        directory: CONTROLLER_TEST_DIR,
+        stateDir: undefined,
+        config: undefined,
+      })
+      const result = controller.getState()
+
+      // then - should return the state found via findAnyActiveRalphLoopState
+      expect(result).not.toBeNull()
+      expect(result?.session_id).toBe("session-A")
+      expect(result?.prompt).toBe("Test task")
+      expect(result?.iteration).toBe(1)
+    })
+
+    test("clear() without sessionID should clear active per-session state", () => {
+      // given - a per-session state file exists
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 2,
+        max_iterations: 100,
+        completion_promise: "DONE",
+        started_at: "2026-01-01T00:00:00Z",
+        prompt: "Test task",
+        session_id: "session-A",
+      }
+      writeState(CONTROLLER_TEST_DIR, state, undefined, "session-A")
+
+      // when - call clear without sessionID
+      const controller = createLoopStateController({
+        directory: CONTROLLER_TEST_DIR,
+        stateDir: undefined,
+        config: undefined,
+      })
+      const clearResult = controller.clear()
+
+      // then - should return true and state should be cleared
+      expect(clearResult).toBe(true)
+      const readResult = readState(CONTROLLER_TEST_DIR, undefined, "session-A")
+      expect(readResult).toBeNull()
+    })
+
+    test("incrementIteration() without sessionID should increment active per-session state", () => {
+      // given - a per-session state file exists with iteration=3
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 3,
+        max_iterations: 100,
+        completion_promise: "DONE",
+        started_at: "2026-01-01T00:00:00Z",
+        prompt: "Test task",
+        session_id: "session-A",
+      }
+      writeState(CONTROLLER_TEST_DIR, state, undefined, "session-A")
+
+      // when - call incrementIteration without sessionID
+      const controller = createLoopStateController({
+        directory: CONTROLLER_TEST_DIR,
+        stateDir: undefined,
+        config: undefined,
+      })
+      const result = controller.incrementIteration()
+
+      // then - should return state with iteration=4
+      expect(result).not.toBeNull()
+      expect(result?.iteration).toBe(4)
+      expect(result?.session_id).toBe("session-A")
+
+      // then - on-disk state should also be 4
+      const onDiskState = readState(CONTROLLER_TEST_DIR, undefined, "session-A")
+      expect(onDiskState?.iteration).toBe(4)
+    })
+  })
+
   describe("API timeout protection", () => {
     test("should not hang when session.messages() throws", async () => {
       // given - API that throws (simulates timeout error)
@@ -1179,5 +1288,121 @@ Original task: Build something`
       expect(promptCalls.length).toBe(1)
       expect(apiCallCount).toBeGreaterThan(0)
     })
+  })
+})
+
+describe("setSessionID isolation", () => {
+  const TEST_DIR = join(tmpdir(), "ralph-loop-test-isolation-" + Date.now())
+
+  beforeEach(() => {
+    if (!existsSync(TEST_DIR)) {
+      mkdirSync(TEST_DIR, { recursive: true })
+    }
+    clearState(TEST_DIR)
+  })
+
+  afterEach(() => {
+    clearState(TEST_DIR)
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  test("should not hijack another agent's state when stateDir is undefined", () => {
+    // given - two session state files exist (simulating two concurrent agents)
+    const controller = createLoopStateController({
+      directory: TEST_DIR,
+      stateDir: undefined,
+      config: undefined,
+    })
+
+    const stateA: RalphLoopState = {
+      active: true,
+      iteration: 1,
+      max_iterations: 100,
+      completion_promise: "<promise>DONE</promise>",
+      started_at: "2025-12-30T01:00:00Z",
+      prompt: "Agent A task",
+      session_id: "session-A",
+    }
+
+    const stateB: RalphLoopState = {
+      active: true,
+      iteration: 2,
+      max_iterations: 100,
+      completion_promise: "<promise>DONE</promise>",
+      started_at: "2025-12-30T01:05:00Z",
+      prompt: "Agent B task",
+      session_id: "session-B",
+    }
+
+    // Write both states to disk
+    writeState(TEST_DIR, stateA, undefined, "session-A")
+    writeState(TEST_DIR, stateB, undefined, "session-B")
+
+    // when - setSessionID is called with a new session ID
+    const result = controller.setSessionID("session-C")
+
+    // then - should return null (no legacy singleton exists)
+    expect(result).toBeNull()
+
+    // then - both original session files should be unchanged
+    const readA = readState(TEST_DIR, undefined, "session-A")
+    const readB = readState(TEST_DIR, undefined, "session-B")
+    expect(readA?.session_id).toBe("session-A")
+    expect(readB?.session_id).toBe("session-B")
+  })
+
+  test("should return null when no legacy singleton exists and stateDir is undefined", () => {
+    // given - no state files exist
+    const controller = createLoopStateController({
+      directory: TEST_DIR,
+      stateDir: undefined,
+      config: undefined,
+    })
+
+    // when - setSessionID is called
+    const result = controller.setSessionID("session-X")
+
+    // then - should return null
+    expect(result).toBeNull()
+  })
+
+  test("should correctly rebind session when legacy singleton exists", () => {
+    // given - legacy singleton state file exists
+    const controller = createLoopStateController({
+      directory: TEST_DIR,
+      stateDir: undefined,
+      config: undefined,
+    })
+
+    const legacyState: RalphLoopState = {
+      active: true,
+      iteration: 5,
+      max_iterations: 100,
+      completion_promise: "<promise>DONE</promise>",
+      started_at: "2025-12-30T01:00:00Z",
+      prompt: "Original task",
+      session_id: "old-session",
+    }
+
+    // Write to legacy singleton path
+    writeState(TEST_DIR, legacyState)
+
+    // when - setSessionID is called with new session ID
+    const result = controller.setSessionID("new-session")
+
+    // then - should return state with updated session_id
+    expect(result).not.toBeNull()
+    expect(result?.session_id).toBe("new-session")
+    expect(result?.iteration).toBe(5) // iteration preserved
+
+    // then - new session file should exist with updated session_id
+    const newSessionState = readState(TEST_DIR, undefined, "new-session")
+    expect(newSessionState?.session_id).toBe("new-session")
+
+    // then - old session file should be cleaned up
+    const oldSessionState = readState(TEST_DIR, undefined, "old-session")
+    expect(oldSessionState).toBeNull()
   })
 })

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -1,6 +1,6 @@
 export * from "./types"
 export * from "./constants"
-export { readState, writeState, clearState, incrementIteration } from "./storage"
+export { readState, writeState, clearState, incrementIteration, readStateForSession, getSessionStateFilePath, migrateLegacyRalphLoopState, findAnyActiveRalphLoopState } from "./storage"
 
 export { createRalphLoopHook } from "./ralph-loop-hook"
 export type { RalphLoopHook } from "./ralph-loop-hook"

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -4,7 +4,7 @@ import {
 	DEFAULT_MAX_ITERATIONS,
 	HOOK_NAME,
 } from "./constants"
-import { clearState, incrementIteration, readState, writeState } from "./storage"
+import { clearState, findAnyActiveRalphLoopState, findSecondActiveRalphLoopState, incrementIteration, readState, writeState } from "./storage"
 import { log } from "../../shared/logger"
 
 export function createLoopStateController(options: {
@@ -46,7 +46,7 @@ export function createLoopStateController(options: {
 				session_id: sessionID,
 			}
 
-			const success = writeState(directory, state, stateDir)
+			const success = writeState(directory, state, stateDir, stateDir ? undefined : sessionID)
 			if (success) {
 				log(`[${HOOK_NAME}] Loop started`, {
 					sessionID,
@@ -58,52 +58,88 @@ export function createLoopStateController(options: {
 		},
 
 		cancelLoop(sessionID: string): boolean {
-			const state = readState(directory, stateDir)
+			const state = readState(directory, stateDir, stateDir ? undefined : sessionID)
 			if (!state || state.session_id !== sessionID) {
 				return false
 			}
 
-			const success = clearState(directory, stateDir)
+			const success = clearState(directory, stateDir, stateDir ? undefined : sessionID)
 			if (success) {
 				log(`[${HOOK_NAME}] Loop cancelled`, { sessionID, iteration: state.iteration })
 			}
 			return success
 		},
 
-		getState(): RalphLoopState | null {
-			return readState(directory, stateDir)
+		getState(sessionID?: string): RalphLoopState | null {
+			if (stateDir) return readState(directory, stateDir)
+			if (sessionID) return readState(directory, undefined, sessionID)
+			return readState(directory) ?? findAnyActiveRalphLoopState(directory)
 		},
 
-		clear(): boolean {
-			return clearState(directory, stateDir)
+		clear(sessionID?: string): boolean {
+			if (stateDir) return clearState(directory, stateDir)
+			if (sessionID) return clearState(directory, undefined, sessionID)
+			const active = readState(directory) ?? findAnyActiveRalphLoopState(directory)
+			if (active?.session_id) return clearState(directory, undefined, active.session_id)
+			return clearState(directory)
 		},
 
-		incrementIteration(): RalphLoopState | null {
-			return incrementIteration(directory, stateDir)
+		incrementIteration(sessionID?: string): RalphLoopState | null {
+			if (stateDir) return incrementIteration(directory, stateDir)
+			if (sessionID) return incrementIteration(directory, undefined, sessionID)
+			const active = readState(directory) ?? findAnyActiveRalphLoopState(directory)
+			if (active?.session_id) return incrementIteration(directory, undefined, active.session_id)
+			return incrementIteration(directory)
 		},
 
-		setSessionID(sessionID: string): RalphLoopState | null {
-			const state = readState(directory, stateDir)
+setSessionID(sessionID: string): RalphLoopState | null {
+			let state: RalphLoopState | null = null
+
+			if (stateDir) {
+				// When stateDir is defined, read from that specific path
+				state = readState(directory, stateDir)
+			} else {
+				// When stateDir is undefined, try legacy singleton first
+				state = readState(directory)
+				if (!state) {
+					// No legacy singleton, try to find first active per-session state
+					state = findAnyActiveRalphLoopState(directory)
+					if (state && state.session_id) {
+						// Check if a second active state exists (hijack prevention)
+						const secondState = findSecondActiveRalphLoopState(directory, state.session_id)
+						if (secondState) {
+							// Multiple active states exist, abort to prevent hijacking
+							return null
+						}
+					}
+				}
+			}
+
 			if (!state) {
 				return null
 			}
 
+			const oldSessionId = state.session_id
 			state.session_id = sessionID
-			if (!writeState(directory, state, stateDir)) {
+			if (!writeState(directory, state, stateDir, stateDir ? undefined : sessionID)) {
 				return null
+			}
+
+			if (!stateDir && oldSessionId && oldSessionId !== sessionID) {
+				clearState(directory, undefined, oldSessionId)
 			}
 
 			return state
 		},
 
 		setMessageCountAtStart(sessionID: string, messageCountAtStart: number): RalphLoopState | null {
-			const state = readState(directory, stateDir)
+			const state = readState(directory, stateDir, stateDir ? undefined : sessionID)
 			if (!state || state.session_id !== sessionID) {
 				return null
 			}
 
 			state.message_count_at_start = messageCountAtStart
-			if (!writeState(directory, state, stateDir)) {
+			if (!writeState(directory, state, stateDir, stateDir ? undefined : sessionID)) {
 				return null
 			}
 

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -14,10 +14,11 @@ type SessionRecovery = {
 	clear: (sessionID: string) => void
 }
 type LoopStateController = {
-	getState: () => RalphLoopState | null
-	clear: () => boolean
-	incrementIteration: () => RalphLoopState | null
+	getState: (sessionID?: string) => RalphLoopState | null
+	clear: (sessionID?: string) => boolean
+	incrementIteration: (sessionID?: string) => RalphLoopState | null
 	setSessionID: (sessionID: string) => RalphLoopState | null
+	findAnyActiveState?: () => RalphLoopState | null
 }
 type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; sessionRecovery: SessionRecovery; loopState: LoopStateController }
 
@@ -48,28 +49,26 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				const state = options.loopState.getState()
+				let state = options.loopState.getState(sessionID)
 				if (!state || !state.active) {
-					return
-				}
-
-				if (state.session_id && state.session_id !== sessionID) {
-					if (options.checkSessionExists) {
-						try {
-							const exists = await options.checkSessionExists(state.session_id)
-							if (!exists) {
-								options.loopState.clear()
-								log(`[${HOOK_NAME}] Cleared orphaned state from deleted session`, {
-									orphanedSessionId: state.session_id,
-									currentSessionId: sessionID,
+					const orphanedState = options.loopState.findAnyActiveState?.()
+					if (orphanedState?.active && orphanedState.session_id && orphanedState.session_id !== sessionID) {
+						if (options.checkSessionExists) {
+							try {
+								const exists = await options.checkSessionExists(orphanedState.session_id)
+								if (!exists) {
+									options.loopState.clear(orphanedState.session_id)
+									log(`[${HOOK_NAME}] Cleared orphaned state from deleted session`, {
+										orphanedSessionId: orphanedState.session_id,
+										currentSessionId: sessionID,
+									})
+								}
+							} catch (err) {
+								log(`[${HOOK_NAME}] Failed to check session existence`, {
+									sessionId: orphanedState.session_id,
+									error: String(err),
 								})
-								return
 							}
-						} catch (err) {
-							log(`[${HOOK_NAME}] Failed to check session existence`, {
-								sessionId: state.session_id,
-								error: String(err),
-							})
 						}
 					}
 					return
@@ -96,7 +95,7 @@ export function createRalphLoopEventHandler(
 							? "transcript_file"
 							: "session_messages_api",
 					})
-					options.loopState.clear()
+					options.loopState.clear(sessionID)
 
 					const title = state.ultrawork ? "ULTRAWORK LOOP COMPLETE!" : "Ralph Loop Complete!"
 					const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
@@ -110,7 +109,7 @@ export function createRalphLoopEventHandler(
 						iteration: state.iteration,
 						max: state.max_iterations,
 					})
-					options.loopState.clear()
+					options.loopState.clear(sessionID)
 
 					await ctx.client.tui?.showToast?.({
 						body: { title: "Ralph Loop Stopped", message: `Max iterations (${state.max_iterations}) reached without completion`, variant: "warning", duration: 5000 },
@@ -118,7 +117,7 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				const newState = options.loopState.incrementIteration()
+				const newState = options.loopState.incrementIteration(sessionID)
 				if (!newState) {
 					log(`[${HOOK_NAME}] Failed to increment iteration`, { sessionID })
 					return
@@ -161,9 +160,9 @@ export function createRalphLoopEventHandler(
 		if (event.type === "session.deleted") {
 			const sessionInfo = props?.info as { id?: string } | undefined
 			if (!sessionInfo?.id) return
-			const state = options.loopState.getState()
+			const state = options.loopState.getState(sessionInfo.id)
 			if (state?.session_id === sessionInfo.id) {
-				options.loopState.clear()
+				options.loopState.clear(sessionInfo.id)
 				log(`[${HOOK_NAME}] Session deleted, loop cleared`, { sessionID: sessionInfo.id })
 			}
 			options.sessionRecovery.clear(sessionInfo.id)
@@ -176,9 +175,9 @@ export function createRalphLoopEventHandler(
 
 			if (error?.name === "MessageAbortedError") {
 				if (sessionID) {
-					const state = options.loopState.getState()
+					const state = options.loopState.getState(sessionID)
 					if (state?.session_id === sessionID) {
-						options.loopState.clear()
+						options.loopState.clear(sessionID)
 						log(`[${HOOK_NAME}] User aborted, loop cleared`, { sessionID })
 					}
 					options.sessionRecovery.clear(sessionID)

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -60,7 +60,10 @@ export function createRalphLoopHook(
 		getTranscriptPath,
 		checkSessionExists,
 		sessionRecovery,
-		loopState,
+		loopState: {
+			...loopState,
+			findAnyActiveState: () => loopState.getState(),
+		},
 	})
 
 	return {

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -1,8 +1,9 @@
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs"
+import { existsSync, readFileSync, unlinkSync, readdirSync, renameSync, mkdirSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { parseFrontmatter } from "../../shared/frontmatter"
+import { atomicWriteText } from "../../features/boulder-state/atomic-file-ops"
 import type { RalphLoopState } from "./types"
-import { DEFAULT_STATE_FILE, DEFAULT_COMPLETION_PROMISE, DEFAULT_MAX_ITERATIONS } from "./constants"
+import { DEFAULT_STATE_FILE, DEFAULT_COMPLETION_PROMISE, DEFAULT_MAX_ITERATIONS, RALPH_LOOP_SESSIONS_DIR } from "./constants"
 
 export function getStateFilePath(directory: string, customPath?: string): string {
   return customPath
@@ -10,12 +11,123 @@ export function getStateFilePath(directory: string, customPath?: string): string
     : join(directory, DEFAULT_STATE_FILE)
 }
 
-export function readState(directory: string, customPath?: string): RalphLoopState | null {
-  const filePath = getStateFilePath(directory, customPath)
+export function getSessionStateFilePath(directory: string, sessionId: string): string {
+  return join(directory, RALPH_LOOP_SESSIONS_DIR, `${sessionId}.local.md`)
+}
 
-  if (!existsSync(filePath)) {
+export function readState(directory: string, customPath?: string, sessionId?: string): RalphLoopState | null {
+  const filePath = customPath
+    ? getStateFilePath(directory, customPath)
+    : sessionId
+      ? getSessionStateFilePath(directory, sessionId)
+      : getStateFilePath(directory)
+
+  return readStateFromPath(filePath)
+}
+
+export function readStateForSession(directory: string, sessionId: string): RalphLoopState | null {
+  return readStateFromPath(getSessionStateFilePath(directory, sessionId))
+}
+
+export function writeState(
+  directory: string,
+  state: RalphLoopState,
+  customPath?: string,
+  sessionId?: string,
+): boolean {
+  const filePath = customPath
+    ? getStateFilePath(directory, customPath)
+    : sessionId
+      ? getSessionStateFilePath(directory, sessionId)
+      : getStateFilePath(directory)
+
+  return writeStateToPath(filePath, state)
+}
+
+export function clearState(directory: string, customPath?: string, sessionId?: string): boolean {
+  const filePath = customPath
+    ? getStateFilePath(directory, customPath)
+    : sessionId
+      ? getSessionStateFilePath(directory, sessionId)
+      : getStateFilePath(directory)
+
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath)
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function incrementIteration(
+  directory: string,
+  customPath?: string,
+  sessionId?: string,
+): RalphLoopState | null {
+  const state = readState(directory, customPath, sessionId)
+  if (!state) return null
+
+  state.iteration += 1
+  if (writeState(directory, state, customPath, sessionId)) {
+    return state
+  }
+  return null
+}
+
+export function migrateLegacyRalphLoopState(directory: string): void {
+  const legacyPath = join(directory, DEFAULT_STATE_FILE)
+  if (!existsSync(legacyPath)) return
+
+  const state = readStateFromPath(legacyPath)
+  if (!state || !state.session_id) {
+    try { unlinkSync(legacyPath) } catch { /* stale file removal is best-effort */ }
+    return
+  }
+
+  const sessionPath = getSessionStateFilePath(directory, state.session_id)
+  const sessionDir = dirname(sessionPath)
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true })
+  }
+
+  try {
+    renameSync(legacyPath, sessionPath)
+  } catch {
+    try { unlinkSync(legacyPath) } catch { /* cleanup is best-effort */ }
+  }
+}
+
+export function findActiveRalphLoopState(directory: string, excludeSessionId?: string): RalphLoopState | null {
+  const sessionsDir = join(directory, RALPH_LOOP_SESSIONS_DIR)
+  if (!existsSync(sessionsDir)) return null
+
+  try {
+    const files = readdirSync(sessionsDir).filter((f) => f.endsWith(".local.md"))
+    for (const file of files) {
+      const state = readStateFromPath(join(sessionsDir, file))
+      if (state?.active && (!excludeSessionId || state.session_id !== excludeSessionId)) {
+        return state
+      }
+    }
+  } catch {
     return null
   }
+
+  return null
+}
+
+export function findAnyActiveRalphLoopState(directory: string): RalphLoopState | null {
+  return findActiveRalphLoopState(directory)
+}
+
+export function findSecondActiveRalphLoopState(directory: string, excludeSessionId: string): RalphLoopState | null {
+  return findActiveRalphLoopState(directory, excludeSessionId)
+}
+
+function readStateFromPath(filePath: string): RalphLoopState | null {
+  if (!existsSync(filePath)) return null
 
   try {
     const content = readFileSync(filePath, "utf-8")
@@ -23,17 +135,13 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
 
     const active = data.active
     const iteration = data.iteration
-    
-    if (active === undefined || iteration === undefined) {
-      return null
-    }
+
+    if (active === undefined || iteration === undefined) return null
 
     const isActive = active === true || active === "true"
     const iterationNum = typeof iteration === "number" ? iteration : Number(iteration)
-    
-    if (isNaN(iterationNum)) {
-      return null
-    }
+
+    if (isNaN(iterationNum)) return null
 
     const stripQuotes = (val: unknown): string => {
       const str = String(val ?? "")
@@ -62,19 +170,8 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
   }
 }
 
-export function writeState(
-  directory: string,
-  state: RalphLoopState,
-  customPath?: string
-): boolean {
-  const filePath = getStateFilePath(directory, customPath)
-
+function writeStateToPath(filePath: string, state: RalphLoopState): boolean {
   try {
-    const dir = dirname(filePath)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-
     const sessionIdLine = state.session_id ? `session_id: "${state.session_id}"\n` : ""
     const ultraworkLine = state.ultrawork !== undefined ? `ultrawork: ${state.ultrawork}\n` : ""
     const strategyLine = state.strategy ? `strategy: "${state.strategy}"\n` : ""
@@ -92,36 +189,9 @@ ${sessionIdLine}${ultraworkLine}${strategyLine}${messageCountAtStartLine}---
 ${state.prompt}
 `
 
-    writeFileSync(filePath, content, "utf-8")
+    atomicWriteText(filePath, content)
     return true
   } catch {
     return false
   }
-}
-
-export function clearState(directory: string, customPath?: string): boolean {
-  const filePath = getStateFilePath(directory, customPath)
-
-  try {
-    if (existsSync(filePath)) {
-      unlinkSync(filePath)
-    }
-    return true
-  } catch {
-    return false
-  }
-}
-
-export function incrementIteration(
-  directory: string,
-  customPath?: string
-): RalphLoopState | null {
-  const state = readState(directory, customPath)
-  if (!state) return null
-
-  state.iteration += 1
-  if (writeState(directory, state, customPath)) {
-    return state
-  }
-  return null
 }

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -2,13 +2,14 @@ import { statSync } from "node:fs"
 import type { PluginInput } from "@opencode-ai/plugin"
 import {
   readBoulderState,
-  writeBoulderState,
-  appendSessionId,
+  writeBoulderStateForPlan,
+  appendSessionIdForPlan,
   findPrometheusPlans,
   getPlanProgress,
   createBoulderState,
   getPlanName,
-  clearBoulderState,
+  removeSessionIdForPlan,
+  findBoulderStateBySession,
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { updateSessionAgent } from "../../features/claude-code-session-state"
@@ -41,7 +42,7 @@ No worktree specified. Before starting work, you MUST choose or create one:
 
 1. \`git worktree list --porcelain\` — list existing worktrees
 2. Create if needed: \`git worktree add <absolute-path> <branch-or-HEAD>\`
-3. Update \`.sisyphus/boulder.json\` — add \`"worktree_path": "<absolute-path>"\`
+3. Update the boulder state — the hook manages \`.sisyphus/boulder/{plan-name}.json\` automatically, or use \`git worktree add\` and re-run \`/start-work\`
 4. Work exclusively inside that worktree directory`
 
 function resolveWorktreeContext(
@@ -78,8 +79,8 @@ export function createStartWorkHook(ctx: PluginInput) {
       log(`[${HOOK_NAME}] Processing start-work command`, { sessionID: input.sessionID })
       updateSessionAgent(input.sessionID, "atlas")
 
-      const existingState = readBoulderState(ctx.directory)
       const sessionId = input.sessionID
+      const existingState = findBoulderStateBySession(ctx.directory, sessionId) ?? readBoulderState(ctx.directory)
       const timestamp = new Date().toISOString()
 
       const { planName: explicitPlanName, explicitWorktreePath } = parseUserRequest(promptText)
@@ -103,9 +104,9 @@ export function createStartWorkHook(ctx: PluginInput) {
 The requested plan "${getPlanName(matchedPlan)}" has been completed.
 All ${progress.total} tasks are done. Create a new plan with: /plan "your task"`
           } else {
-            if (existingState) clearBoulderState(ctx.directory)
+            if (existingState) removeSessionIdForPlan(ctx.directory, existingState.plan_name, sessionId)
             const newState = createBoulderState(matchedPlan, sessionId, "atlas", worktreePath)
-            writeBoulderState(ctx.directory, newState)
+            writeBoulderStateForPlan(ctx.directory, newState.plan_name, newState)
 
             contextInfo = `
 ## Auto-Selected Plan
@@ -153,16 +154,15 @@ No incomplete plans available. Create a new plan with: /plan "your task"`
           const effectiveWorktree = worktreePath ?? existingState.worktree_path
 
           if (worktreePath !== undefined) {
-            const updatedSessions = existingState.session_ids.includes(sessionId)
-              ? existingState.session_ids
-              : [...existingState.session_ids, sessionId]
-            writeBoulderState(ctx.directory, {
-              ...existingState,
-              worktree_path: worktreePath,
-              session_ids: updatedSessions,
-            })
+            const freshState = appendSessionIdForPlan(ctx.directory, existingState.plan_name, sessionId)
+            if (freshState) {
+              writeBoulderStateForPlan(ctx.directory, existingState.plan_name, {
+                ...freshState,
+                worktree_path: worktreePath,
+              })
+            }
           } else {
-            appendSessionId(ctx.directory, sessionId)
+            appendSessionIdForPlan(ctx.directory, existingState.plan_name, sessionId)
           }
 
           const worktreeDisplay = effectiveWorktree ? `\n**Worktree**: ${effectiveWorktree}` : worktreeBlock
@@ -212,7 +212,7 @@ All ${plans.length} plan(s) are complete. Create a new plan with: /plan "your ta
           const planPath = incompletePlans[0]
           const progress = getPlanProgress(planPath)
           const newState = createBoulderState(planPath, sessionId, "atlas", worktreePath)
-          writeBoulderState(ctx.directory, newState)
+          writeBoulderStateForPlan(ctx.directory, newState.plan_name, newState)
 
           contextInfo += `
 

--- a/src/plugin/event.model-fallback.test.ts
+++ b/src/plugin/event.model-fallback.test.ts
@@ -1,4 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { _overrideForTesting as overrideCacheForTesting } from "../shared/connected-providers-cache"
 
 import { createEventHandler } from "./event"
 import { createChatMessageHandler } from "./chat-message"
@@ -6,6 +11,13 @@ import { _resetForTesting, setMainSession } from "../features/claude-code-sessio
 import { createModelFallbackHook, clearPendingModelFallback } from "../hooks/model-fallback/hook"
 
 describe("createEventHandler - model fallback", () => {
+  let tempCacheDir: string
+
+  beforeEach(() => {
+    tempCacheDir = mkdtempSync(join(tmpdir(), "event-model-fallback-test-"))
+    overrideCacheForTesting(tempCacheDir)
+  })
+
   const createHandler = (args?: { hooks?: any }) => {
     const abortCalls: string[] = []
     const promptCalls: string[] = []
@@ -47,6 +59,8 @@ describe("createEventHandler - model fallback", () => {
   }
 
   afterEach(() => {
+    overrideCacheForTesting(undefined)
+    rmSync(tempCacheDir, { recursive: true, force: true })
     _resetForTesting()
   })
 

--- a/src/shared/connected-providers-cache.ts
+++ b/src/shared/connected-providers-cache.ts
@@ -6,6 +6,15 @@ import { getOmoOpenCodeCacheDir } from "./data-path"
 const CONNECTED_PROVIDERS_CACHE_FILE = "connected-providers.json"
 const PROVIDER_MODELS_CACHE_FILE = "provider-models.json"
 
+let _testCacheDirOverride: string | undefined
+
+/**
+ * Override the cache directory for testing. Pass undefined to clear.
+ * When set, all cache reads/writes use this directory instead of the real one.
+ */
+export function _overrideForTesting(cacheDir: string | undefined): void {
+	_testCacheDirOverride = cacheDir
+}
 interface ConnectedProvidersCache {
 	connected: string[]
 	updatedAt: string
@@ -26,6 +35,7 @@ interface ProviderModelsCache {
 }
 
 function getCacheFilePath(filename: string): string {
+	if (_testCacheDirOverride !== undefined) return join(_testCacheDirOverride, filename)
 	return join(getOmoOpenCodeCacheDir(), filename)
 }
 


### PR DESCRIPTION
## Summary

- Migrate boulder state from a singleton `boulder.json` to per-plan files under `.sisyphus/boulder/{plan-name}.json`, preventing concurrent agents from overwriting each other's state
- Migrate ralph-loop state to per-session files under `.sisyphus/ralph-loop/{session-id}.json` for the same multi-agent isolation
- Add atomic file write utility, JSON parser, and legacy migration to preserve backward compatibility with existing `.sisyphus/boulder.json` and `.sisyphus/ralph-loop.json`

## Changes

### New files
- `src/features/boulder-state/per-plan-storage.ts` — per-plan read/write/list/clear operations
- `src/features/boulder-state/atomic-file-ops.ts` — write-to-temp-then-rename for crash safety
- `src/features/boulder-state/boulder-json-parser.ts` — extracted JSON parsing with validation
- `src/features/boulder-state/legacy-migration.ts` — auto-migrates singleton boulder.json → per-plan

### Modified files
- `src/features/boulder-state/storage.ts` — legacy-compatible wrappers delegating to per-plan storage
- `src/hooks/ralph-loop/storage.ts` — per-session state with `readStateForSession`, `findAnyActiveRalphLoopState`, `migrateLegacyRalphLoopState`
- `src/cli/run/continuation-state.ts` — session-aware boulder and ralph-loop lookups
- `src/hooks/atlas/` — updated to use `findBoulderStateBySession`
- `src/hooks/prometheus-md-only/` — updated boulder state imports
- `src/hooks/ralph-loop/` — updated loop controller, event handler, and hook to use per-session storage
- `src/hooks/start-work/` — updated to per-plan boulder writes
- Tests updated across atlas, ralph-loop, prometheus-md-only, and continuation-state

## Motivation

When multiple agents (e.g., two Atlas sessions) run concurrently against the same project, they share a single `boulder.json` and `ralph-loop.json`. This causes state corruption — one agent's writes clobber the other's. Per-plan and per-session file isolation eliminates the race condition entirely.

## Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored boulder and ralph-loop state to per-plan and per-session files for safe multi-agent concurrency. Added atomic writes with file locking and legacy migrations; hooks now use session-aware helpers across the stack.

- **New Features**
  - Per-plan boulder state at .sisyphus/boulder/{plan}.json with list, find-by-session, and append/remove session IDs.
  - Per-session ralph-loop state at .sisyphus/ralph-loop/{session}.json with read/write/increment, readStateForSession, findAnyActiveRalphLoopState, and legacy migration.
  - Atomic JSON/text writes via temp-rename and lightweight file lock.

- **Refactors**
  - Atlas, start-work, prometheus-md-only, and continuation-state now use session-aware APIs; start-work appends/removes session IDs per plan; atlas agent templates create per-task todos and read .sisyphus/plans/{plan}.md; atlas event handler falls back to any active boulder for background tasks.
  - Ralph-loop controller/event handler isolate state per session, prevent hijacking, clean up orphaned session files, and scope clear/increment operations per session; added automatic legacy-to-session migration.
  - Tests updated across modules; added a cache dir test override for connected providers.

<sup>Written for commit 986b15748e63ddc3512427c030fec686f3dcaae1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

