### PR TITLE
feat: support file:// URIs in agent prompt field

### DIFF
--- a/src/agents/builtin-agents/agent-overrides.ts
+++ b/src/agents/builtin-agents/agent-overrides.ts
@@ -44,6 +44,10 @@ export function mergeAgentConfig(
   const { prompt_append, ...rest } = migratedOverride
   const merged = deepMerge(base, rest as Partial<AgentConfig>)
 
+  if (merged.prompt && typeof merged.prompt === 'string' && merged.prompt.startsWith('file://')) {
+    merged.prompt = resolvePromptAppend(merged.prompt, directory)
+  }
+
   if (prompt_append && merged.prompt) {
     merged.prompt = merged.prompt + "\n" + resolvePromptAppend(prompt_append, directory)
   }


### PR DESCRIPTION
## Problem

Currently, `prompt_append` supports `file://` URIs via `resolvePromptAppend()`, allowing users to load prompt content from files. However, the `prompt` field does **not** support `file://` URIs — it goes through `deepMerge()` as a literal string.

This means users can only **append** to a built-in agent's prompt using a file. They cannot **fully replace** a built-in agent's prompt with file-based content. This is a significant limitation for power users who need complete control over agent system prompts.

## Solution

Add a single check in `mergeAgentConfig()` to resolve `file://` URIs in the `prompt` field, reusing the existing `resolvePromptAppend()` function. The check runs **after** `deepMerge()` but **before** `prompt_append` processing, so:

1. `prompt: "file://~/.config/opencode/prompts/my-agent.md"` → file contents become the prompt
2. `prompt_append` still works on top of the resolved prompt (composable)

## Changes

- **`src/agents/builtin-agents/agent-overrides.ts`**: Added 3 lines in `mergeAgentConfig()` to check if `merged.prompt` starts with `file://` and resolve it via `resolvePromptAppend()`.

## Use Case

```json
{
  "agents": {
    "sisyphus": {
      "prompt": "file://~/.config/opencode/prompts/sisyphus.md"
    }
  }
}
```

This allows fully replacing a built-in agent's prompt with a file, while `prompt_append` continues to work for additive modifications.

Zero new dependencies. Zero new functions. Just one additional call to the existing `resolvePromptAppend()`.

Related: #1908