### PR TITLE
fix: add retry status timeout to prevent infinite hang

### DIFF
--- a/src/cli/run/poll-for-completion.ts
+++ b/src/cli/run/poll-for-completion.ts
@@ -136,6 +136,8 @@ export async function pollForCompletion(
           return 1
         }
       }
+    } else if (mainSessionStatus === "busy" || mainSessionStatus === "idle") {
+      retryStatusStartTimestamp = null
     }
 
     if (!eventState.mainSessionIdle) {

--- a/src/cli/run/poll-for-completion.ts
+++ b/src/cli/run/poll-for-completion.ts
@@ -10,6 +10,7 @@ const ERROR_GRACE_CYCLES = 3
 const MIN_STABILIZATION_MS = 1_000
 const DEFAULT_EVENT_WATCHDOG_MS = 30_000 // 30 seconds
 const DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS = 60_000 // 60 seconds
+const DEFAULT_RETRY_STATUS_TIMEOUT_MS = 180_000 // 3 minutes - max time for runtime fallback retries
 
 export interface PollOptions {
   pollIntervalMs?: number
@@ -17,6 +18,7 @@ export interface PollOptions {
   minStabilizationMs?: number
   eventWatchdogMs?: number
   secondaryMeaningfulWorkTimeoutMs?: number
+  retryStatusTimeoutMs?: number
 }
 
 export async function pollForCompletion(
@@ -37,10 +39,13 @@ export async function pollForCompletion(
   const secondaryMeaningfulWorkTimeoutMs =
     options.secondaryMeaningfulWorkTimeoutMs ??
     DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS
+  const retryStatusTimeoutMs =
+    options.retryStatusTimeoutMs ?? DEFAULT_RETRY_STATUS_TIMEOUT_MS
   let consecutiveCompleteChecks = 0
   let errorCycleCount = 0
   let firstWorkTimestamp: number | null = null
   let secondaryTimeoutChecked = false
+  let retryStatusStartTimestamp: number | null = null
   const pollStartTimestamp = Date.now()
 
   while (!abortController.signal.aborted) {
@@ -104,6 +109,33 @@ export async function pollForCompletion(
       eventState.mainSessionIdle = false
     } else if (mainSessionStatus === "idle") {
       eventState.mainSessionIdle = true
+      retryStatusStartTimestamp = null
+    }
+
+    // Track retry status timeout - prevent infinite loop when runtime fallback keeps retrying
+    if (mainSessionStatus === "retry") {
+      if (retryStatusStartTimestamp === null) {
+        retryStatusStartTimestamp = Date.now()
+      } else {
+        const retryDuration = Date.now() - retryStatusStartTimestamp
+        if (retryDuration > retryStatusTimeoutMs) {
+          console.error(
+            pc.red(
+              `\n\nSession stuck in retry status for ${Math.round(
+                retryDuration / 1000
+              )}s - runtime fallback may be failing repeatedly`
+            )
+          )
+          console.error(
+            pc.yellow(
+              `Maximum retry timeout (${Math.round(
+                retryStatusTimeoutMs / 1000
+              )}s) exceeded. Check model availability and network connectivity.`
+            )
+          )
+          return 1
+        }
+      }
     }
 
     if (!eventState.mainSessionIdle) {


### PR DESCRIPTION
## Summary

When runtime fallback triggers on errors like 503, the session status becomes "retry". The poll-for-completion loop treats "retry" the same as "busy", causing it to wait indefinitely without any timeout.

This fix adds a 3-minute timeout (based on `max_fallback_attempts * cooldown_seconds = 3 * 60s`) for the retry status. If the session stays in retry status longer than the timeout, it exits with an error instead of hanging forever (exit code 143).

## Changes

- Added `DEFAULT_RETRY_STATUS_TIMEOUT_MS` constant (180000ms = 3 minutes)
- Added `retryStatusTimeoutMs` option to `PollOptions` interface
- Track when session first enters "retry" status
- Check if retry timeout exceeded and exit with error message if so

## Root Cause

The issue was reported in CloudWaddie/actions-agent#82 where the agent hangs with exit code 143 when 503 errors trigger runtime fallback retry loops. The session gets stuck in "retry" status and the poll loop keeps waiting forever.

## Testing

The fix should be tested by:
1. Triggering a runtime fallback scenario (e.g., 503 error)
2. Verifying the session exits after 3 minutes instead of hanging indefinitely
3. Verifying the error message is helpful

Fixes: CloudWaddie/actions-agent#82

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite hangs when runtime fallback keeps retrying by adding a 3-minute timeout for sessions in "retry". The poll loop now exits with a clear, actionable error instead of waiting forever.

- **Bug Fixes**
  - Add DEFAULT_RETRY_STATUS_TIMEOUT_MS (180000 ms) and retryStatusTimeoutMs option.
  - Track first entry into "retry"; reset timer when status becomes "busy" or "idle".
  - On timeout, exit non-zero and print guidance to check model availability and network connectivity.

<sup>Written for commit e1ce2860d276a376f5a639972a61c6597201ce6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

