### PR TITLE
feat: add default_model config for all agents

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -99,6 +99,9 @@
     "model_fallback": {
       "type": "boolean"
     },
+    "default_model": {
+      "type": "string"
+    },
     "agents": {
       "type": "object",
       "properties": {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,6 +75,7 @@ Here's a practical starting configuration:
 ```jsonc
 {
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "default_model": "anthropic/claude-sonnet-4-6",
 
   "agents": {
     // Main orchestrator: Claude Opus or Kimi K2.6 work best
@@ -335,7 +336,8 @@ Runtime priority:
 3. **Category default** - model inherited from the assigned category config
 4. **User `fallback_models`** - user-configured fallback list is tried before built-in fallback chains
 5. **Provider fallback chain** - built-in provider/model chain from OmO source
-6. **System default** - OpenCode's configured default model
+6. **Global `default_model`** - optional OmO-wide fallback for agents and categories with no specific model
+7. **System default** - OpenCode's configured default model
 
 #### Model Settings Compatibility
 

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -48,6 +48,8 @@ export const OhMyOpenCodeConfigSchema = z.object({
   hashline_edit: z.boolean().optional(),
   /** Enable model fallback on API errors (default: false). Set to true to enable automatic model switching when model errors occur. */
   model_fallback: z.boolean().optional(),
+  /** Default model for all agents and categories when no specific model is configured */
+  default_model: z.string().optional(),
   agents: AgentOverridesSchema.optional(),
   categories: CategoriesConfigSchema.optional(),
   claude_code: ClaudeCodeConfigSchema.optional(),

--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -159,6 +159,7 @@ export type TeamCreateExecutorConfig = {
   userCategories?: CategoriesConfig
   sisyphusJuniorModel?: string
   agentOverrides?: AgentOverrides
+  defaultModel?: string
 }
 
 type TeamCreateToolDeps = {
@@ -215,6 +216,7 @@ export function createTeamCreateTool(
           userCategories: executorConfig?.userCategories,
           sisyphusJuniorModel: executorConfig?.sisyphusJuniorModel,
           agentOverrides: executorConfig?.agentOverrides,
+          defaultModel: executorConfig?.defaultModel,
         },
         config,
         bgMgr,

--- a/src/plugin/tool-registry.team-mode.test.ts
+++ b/src/plugin/tool-registry.team-mode.test.ts
@@ -16,7 +16,7 @@ const fakeTool = tool({
   },
 })
 
-function createPluginConfig() {
+function createPluginConfig(overrides: Record<string, unknown> = {}) {
   return OhMyOpenCodeConfigSchema.parse({
     git_master: {
       commit_footer: false,
@@ -26,6 +26,7 @@ function createPluginConfig() {
     team_mode: {
       enabled: true,
     },
+    ...overrides,
   })
 }
 
@@ -49,7 +50,7 @@ describe("team-mode tool registry wiring", () => {
     // when
     createToolRegistry({
       ctx: { directory: "/tmp/team-mode", client } as Parameters<typeof createToolRegistry>[0]["ctx"],
-      pluginConfig: createPluginConfig(),
+      pluginConfig: createPluginConfig({ default_model: "openai/gpt-5.4" }),
       managers: {
         backgroundManager: {},
         tmuxSessionManager: {},
@@ -98,6 +99,7 @@ describe("team-mode tool registry wiring", () => {
 
     // then
     expect(createTeamCreateTool).toHaveBeenCalledWith(expect.anything(), client, expect.anything(), expect.anything(), expect.anything())
+    expect(createTeamCreateTool.mock.calls[0]?.[4]).toMatchObject({ defaultModel: "openai/gpt-5.4" })
     expect(createTeamDeleteTool).toHaveBeenCalledWith(expect.anything(), client, expect.anything(), expect.anything())
     expect(createTeamShutdownRequestTool).toHaveBeenCalledWith(expect.anything(), client)
     expect(createTeamApproveShutdownTool).toHaveBeenCalledWith(expect.anything(), client)

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -318,6 +318,7 @@ export function createToolRegistry(args: {
             userCategories: pluginConfig.categories,
             sisyphusJuniorModel: getSisyphusJuniorModelOverride(pluginConfig.agents?.["sisyphus-junior"]),
             agentOverrides: pluginConfig.agents,
+            defaultModel: pluginConfig.default_model,
           },
         ),
         team_delete: factories.createTeamDeleteTool(

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -235,6 +235,7 @@ export function createToolRegistry(args: {
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
+    defaultModel: pluginConfig.default_model,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/shared/prompt-async-route-audit.test.ts
+++ b/src/shared/prompt-async-route-audit.test.ts
@@ -8,7 +8,11 @@ const PROMPT_GATE_FILE = path.join(SOURCE_ROOT, "shared", "prompt-async-gate.ts"
 const RAW_PROMPT_ALLOWLIST = new Map<string, string>([
   [
     path.join(SOURCE_ROOT, "plugin", "event.ts"),
-    "team idle wake hint wires a client facade for downstream gate-routed dispatch",
+    "model fallback checks promptAsync availability before gate-routed dispatch",
+  ],
+  [
+    path.join(SOURCE_ROOT, "plugin", "build-team-idle-wake-hint-client.ts"),
+    "team idle wake hint binds SDK session methods for downstream gate-routed dispatch",
   ],
   [
     path.join(SOURCE_ROOT, "hooks", "session-recovery", "recover-unavailable-tool.ts"),

--- a/src/tools/delegate-task/categories.ts
+++ b/src/tools/delegate-task/categories.ts
@@ -11,6 +11,7 @@ export interface ResolveCategoryConfigOptions {
   inheritedModel?: string
   systemDefaultModel?: string
   availableModels?: Set<string>
+  defaultModel?: string
 }
 
 export interface ResolveCategoryConfigResult {
@@ -28,7 +29,7 @@ export function resolveCategoryConfig(
   categoryName: string,
   options: ResolveCategoryConfigOptions
 ): ResolveCategoryConfigResult | null {
-  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels } = options
+  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels, defaultModel } = options
 
   const defaultConfig = DEFAULT_CATEGORIES[categoryName]
   const userConfig = userCategories?.[categoryName]
@@ -51,12 +52,11 @@ export function resolveCategoryConfig(
     return null
   }
 
-  // Model priority for categories: user override > category default > system default
-  // Categories have explicit models - no inheritance from parent session
+  // Model priority for categories: user override > category default > default_model > system default
   const model = resolveModel({
     userModel: userConfig?.model,
-    inheritedModel: defaultConfig?.model, // Category's built-in model takes precedence over system default
-    systemDefault: systemDefaultModel,
+    inheritedModel: defaultConfig?.model, // Category's built-in model takes precedence over default_model
+    systemDefault: defaultModel ?? systemDefaultModel, // default_model takes precedence over system default
   })
   const isUserConfiguredModel = normalizeModel(userConfig?.model) !== undefined
   const config: CategoryConfig = {

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -86,6 +86,30 @@ describe("resolveCategoryExecution", () => {
 		expect(result.error).toContain("definitely-not-a-real-category-xyz123")
 	})
 
+	test("#given custom category has no model #when defaultModel is configured #then defaultModel wins over system default", async () => {
+		const args = {
+			category: "custom-review",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			"custom-review": {},
+		}
+		executorCtx.defaultModel = "openai/gpt-5.4"
+
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4",
+		})
+	})
+
 	test("uses category fallback_models for background/runtime fallback chain", async () => {
 		//#given
 		const args = {

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -64,6 +64,7 @@ export async function resolveCategoryExecution(
   defaultModel?: string
 ): Promise<CategoryResolutionResult> {
   const { client, userCategories, sisyphusJuniorModel } = executorCtx
+  const effectiveDefaultModel = defaultModel ?? executorCtx.defaultModel
 
   const categoryName = args.category!
   const enabledCategories = mergeCategories(userCategories)
@@ -90,7 +91,7 @@ export async function resolveCategoryExecution(
     inheritedModel,
     systemDefaultModel,
     availableModels,
-    defaultModel,
+    defaultModel: effectiveDefaultModel,
   })
 
   if (!resolved) {

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -60,7 +60,8 @@ export async function resolveCategoryExecution(
   args: DelegateTaskArgs,
   executorCtx: ExecutorContext,
   inheritedModel: string | undefined,
-  systemDefaultModel: string | undefined
+  systemDefaultModel: string | undefined,
+  defaultModel?: string
 ): Promise<CategoryResolutionResult> {
   const { client, userCategories, sisyphusJuniorModel } = executorCtx
 
@@ -89,6 +90,7 @@ export async function resolveCategoryExecution(
     inheritedModel,
     systemDefaultModel,
     availableModels,
+    defaultModel,
   })
 
   if (!resolved) {

--- a/src/tools/delegate-task/executor-types.ts
+++ b/src/tools/delegate-task/executor-types.ts
@@ -14,6 +14,7 @@ export interface ExecutorContext {
   agentOverrides?: AgentOverrides
   sisyphusAgentConfig?: SisyphusAgentConfig
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
+  defaultModel?: string
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   syncPollTimeoutMs?: number
 }

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -125,7 +125,7 @@ Create the work plan directly - that's your job as the planning agent.`,
 
     const availableModels = await getAvailableModelsForDelegateTask(client)
 
-    if (agentOverride?.model || agentCategoryModel || agentRequirement || matchedAgent.model) {
+    if (agentOverride?.model || agentCategoryModel || agentRequirement || matchedAgent.model || executorCtx.defaultModel) {
 
       const normalizedMatchedModel = matchedAgent.model
         ? normalizeModelFormat(matchedAgent.model)

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -140,7 +140,7 @@ Create the work plan directly - that's your job as the planning agent.`,
         categoryDefaultModel: matchedAgentModelStr,
         fallbackChain: agentRequirement?.fallbackChain,
         availableModels,
-        systemDefaultModel: undefined,
+        systemDefaultModel: executorCtx.defaultModel,
       })
 
       const resolutionSkipped = resolution && 'skipped' in resolution

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -101,7 +101,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       let maxPromptTokens: number | undefined
 
       if (delegateTaskArgs.category) {
-        const resolution = await resolveCategoryExecution(delegateTaskArgs, options, inheritedModel, systemDefaultModel)
+        const resolution = await resolveCategoryExecution(delegateTaskArgs, options, inheritedModel, systemDefaultModel, options.defaultModel)
         if (resolution.error) {
           return resolution.error
         }

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -70,6 +70,8 @@ export interface DelegateTaskToolOptions {
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
+  /** Default model for all agents and categories when no specific model is configured */
+  defaultModel?: string
 }
 
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -947,6 +947,31 @@ describe("resolveSubagentExecution", () => {
     expect(result.categoryModel?.modelID).toBe("claude-sonnet-4")
   })
 
+  test("#given subagent has no model #when defaultModel is configured #then uses defaultModel", async () => {
+    readProviderModelsCacheMock.mockReturnValue({
+      models: { openai: ["gpt-5.4"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    readConnectedProvidersCacheMock.mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "plain-agent" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "plain-agent", mode: "subagent" },
+      ]),
+      { defaultModel: "openai/gpt-5.4" },
+    )
+
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("plain-agent")
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+    })
+  })
+
   test("server agent takes precedence over user agent with same name", async () => {
     //#given
     readProviderModelsCacheMock.mockReturnValue({


### PR DESCRIPTION
Add global default_model configuration for all agents and categories

- Add default_model field to config schema
- Categories inherit default_model when no specific model is configured
- Agent-specific model settings override default_model

Fixes #2205