### PR TITLE
feat: add anthropic-server-compaction hook for Claude 4.6 server-side context compaction

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3326,6 +3326,29 @@
         "preemptive_compaction": {
           "type": "boolean"
         },
+        "server_compaction": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "trigger_tokens": {
+                  "type": "number",
+                  "minimum": 10000
+                },
+                "instructions": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "truncate_all_tool_outputs": {
           "type": "boolean"
         },

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -5,6 +5,17 @@ export const ExperimentalConfigSchema = z.object({
   aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
   preemptive_compaction: z.boolean().optional(),
+  /** Enable Anthropic server-side compaction for Claude 4.6 models (default: false). Set to true for defaults, or use object for advanced config. */
+  server_compaction: z
+    .union([
+      z.boolean(),
+      z.object({
+        enabled: z.boolean().optional(),
+        trigger_tokens: z.number().min(10000).optional(),
+        instructions: z.string().optional(),
+      }),
+    ])
+    .optional(),
   /** Truncate all tool outputs, not just whitelisted tools (default: false). Tool output truncator is enabled by default - disable via disabled_hooks. */
   truncate_all_tool_outputs: z.boolean().optional(),
   /** Dynamic context pruning configuration */

--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -48,6 +48,7 @@ export const HookNameSchema = z.enum([
   "runtime-fallback",
   "write-existing-file-guard",
   "anthropic-effort",
+  "anthropic-server-compaction",
   "hashline-read-enhancer",
   "read-image-resizer",
 ])

--- a/src/hooks/anthropic-server-compaction/hook.ts
+++ b/src/hooks/anthropic-server-compaction/hook.ts
@@ -1,0 +1,74 @@
+import { log, normalizeModelID } from "../../shared"
+
+const CLAUDE_4_6_PATTERN = /claude-(opus|sonnet)-4[-.]6/i
+
+const DEFAULT_TRIGGER_TOKENS = 128_000
+
+function isClaudeProvider(providerID: string, modelID: string): boolean {
+  if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
+  if (providerID === "github-copilot" && modelID.toLowerCase().includes("claude")) return true
+  return false
+}
+
+function isClaude46(modelID: string): boolean {
+  const normalized = normalizeModelID(modelID)
+  return CLAUDE_4_6_PATTERN.test(normalized)
+}
+
+interface ChatParamsInput {
+  sessionID: string
+  agent: { name?: string }
+  model: { providerID: string; modelID: string }
+  provider: { id: string }
+  message: { variant?: string }
+}
+
+interface ChatParamsOutput {
+  temperature?: number
+  topP?: number
+  topK?: number
+  options: Record<string, unknown>
+}
+
+export interface ServerCompactionConfig {
+  triggerTokens?: number
+  instructions?: string
+}
+
+export function createAnthropicServerCompactionHook(config: ServerCompactionConfig = {}) {
+  const triggerTokens = config.triggerTokens ?? DEFAULT_TRIGGER_TOKENS
+
+  return {
+    "chat.params": async (
+      input: ChatParamsInput,
+      output: ChatParamsOutput
+    ): Promise<void> => {
+      const { model } = input
+      if (!model?.modelID || !model?.providerID) return
+      if (!isClaudeProvider(model.providerID, model.modelID)) return
+      if (!isClaude46(model.modelID)) return
+      if (output.options.contextManagement !== undefined) return
+
+      const edit: Record<string, unknown> = {
+        type: "compact_20260112",
+        trigger: { type: "input_tokens", value: triggerTokens },
+        pauseAfterCompaction: false,
+      }
+
+      if (config.instructions) {
+        edit.instructions = config.instructions
+      }
+
+      output.options.contextManagement = {
+        edits: [edit],
+      }
+
+      log("anthropic-server-compaction: injected context_management", {
+        sessionID: input.sessionID,
+        provider: model.providerID,
+        model: model.modelID,
+        triggerTokens,
+      })
+    },
+  }
+}

--- a/src/hooks/anthropic-server-compaction/index.test.ts
+++ b/src/hooks/anthropic-server-compaction/index.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test"
+import { createAnthropicServerCompactionHook } from "./hook"
+
+function createMockInput(overrides: Partial<{
+  sessionID: string
+  agentName: string
+  providerID: string
+  modelID: string
+  providerId: string
+  variant: string
+}> = {}) {
+  return {
+    sessionID: overrides.sessionID ?? "test-session",
+    agent: { name: overrides.agentName ?? "sisyphus" },
+    model: {
+      providerID: overrides.providerID ?? "anthropic",
+      modelID: overrides.modelID ?? "claude-opus-4-6",
+    },
+    provider: { id: overrides.providerId ?? "anthropic" },
+    message: { variant: overrides.variant },
+  }
+}
+
+function createMockOutput(options: Record<string, unknown> = {}) {
+  return {
+    temperature: 0.7,
+    topP: undefined,
+    topK: undefined,
+    options: { ...options },
+  }
+}
+
+describe("anthropic-server-compaction", () => {
+  describe("#given default config", () => {
+    const hook = createAnthropicServerCompactionHook()
+
+    describe("#when model is claude-opus-4-6 on anthropic provider", () => {
+      it("#then injects contextManagement with default trigger", async () => {
+        const input = createMockInput({ providerID: "anthropic", modelID: "claude-opus-4-6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toEqual({
+          edits: [{
+            type: "compact_20260112",
+            trigger: { type: "input_tokens", value: 128_000 },
+            pauseAfterCompaction: false,
+          }],
+        })
+      })
+    })
+
+    describe("#when model is claude-sonnet-4-6 on anthropic provider", () => {
+      it("#then injects contextManagement", async () => {
+        const input = createMockInput({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+
+    describe("#when model is claude-opus-4.6 (dot variant)", () => {
+      it("#then injects contextManagement", async () => {
+        const input = createMockInput({ providerID: "anthropic", modelID: "claude-opus-4.6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+
+    describe("#when provider is google-vertex-anthropic", () => {
+      it("#then injects contextManagement", async () => {
+        const input = createMockInput({ providerID: "google-vertex-anthropic", modelID: "claude-opus-4-6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+
+    describe("#when provider is opencode", () => {
+      it("#then injects contextManagement for claude-sonnet-4.6", async () => {
+        const input = createMockInput({ providerID: "opencode", modelID: "claude-sonnet-4.6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+
+    describe("#when provider is github-copilot with claude model", () => {
+      it("#then injects contextManagement", async () => {
+        const input = createMockInput({ providerID: "github-copilot", modelID: "claude-sonnet-4-6" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+
+    describe("#when model is not Claude 4.6", () => {
+      it("#then does not inject for claude-sonnet-4-5", async () => {
+        const input = createMockInput({ modelID: "claude-sonnet-4-5" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeUndefined()
+      })
+ 
+      it("#then does not inject for gpt-5.2", async () => {
+        const input = createMockInput({ providerID: "openai", modelID: "gpt-5.2" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeUndefined()
+      })
+    })
+
+    describe("#when provider is non-anthropic with non-claude model", () => {
+      it("#then does not inject", async () => {
+        const input = createMockInput({ providerID: "openai", modelID: "gpt-5.2" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeUndefined()
+      })
+    })
+
+    describe("#when contextManagement is already set", () => {
+      it("#then does not overwrite", async () => {
+        const input = createMockInput()
+        const existing = { edits: [{ type: "custom" }] }
+        const output = createMockOutput({ contextManagement: existing })
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toEqual(existing)
+      })
+    })
+
+    describe("#when modelID is undefined", () => {
+      it("#then does not inject", async () => {
+        const input = createMockInput({ modelID: "" })
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        expect(output.options.contextManagement).toBeUndefined()
+      })
+    })
+
+    describe("#when preserving existing options", () => {
+      it("#then keeps effort and other options intact", async () => {
+        const input = createMockInput()
+        const output = createMockOutput({ effort: "max", thinking: { type: "enabled" } })
+        await hook["chat.params"](input, output)
+
+        expect(output.options.effort).toBe("max")
+        expect(output.options.thinking).toEqual({ type: "enabled" })
+        expect(output.options.contextManagement).toBeDefined()
+      })
+    })
+  })
+
+  describe("#given custom config", () => {
+    describe("#when triggerTokens is configured", () => {
+      it("#then uses configured value", async () => {
+        const hook = createAnthropicServerCompactionHook({ triggerTokens: 50_000 })
+        const input = createMockInput()
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        const cm = output.options.contextManagement as { edits: Array<{ trigger: { value: number } }> }
+        expect(cm.edits[0].trigger.value).toBe(50_000)
+      })
+    })
+
+    describe("#when instructions are configured", () => {
+      it("#then includes instructions in edit", async () => {
+        const hook = createAnthropicServerCompactionHook({
+          instructions: "Preserve code snippets and variable names.",
+        })
+        const input = createMockInput()
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        const cm = output.options.contextManagement as { edits: Array<{ instructions?: string }> }
+        expect(cm.edits[0].instructions).toBe("Preserve code snippets and variable names.")
+      })
+    })
+
+    describe("#when instructions are not configured", () => {
+      it("#then does not include instructions key", async () => {
+        const hook = createAnthropicServerCompactionHook()
+        const input = createMockInput()
+        const output = createMockOutput()
+        await hook["chat.params"](input, output)
+
+        const cm = output.options.contextManagement as { edits: Array<Record<string, unknown>> }
+        expect("instructions" in cm.edits[0]).toBe(false)
+      })
+    })
+  })
+})

--- a/src/hooks/anthropic-server-compaction/index.ts
+++ b/src/hooks/anthropic-server-compaction/index.ts
@@ -1,0 +1,2 @@
+export type { ServerCompactionConfig } from "./hook";
+export { createAnthropicServerCompactionHook } from "./hook";

--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -1,17 +1,16 @@
-import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 import type { OhMyOpenCodeConfig } from "./config"
-
-import { createChatParamsHandler } from "./plugin/chat-params"
-import { createChatHeadersHandler } from "./plugin/chat-headers"
-import { createChatMessageHandler } from "./plugin/chat-message"
-import { createMessagesTransformHandler } from "./plugin/messages-transform"
-import { createSystemTransformHandler } from "./plugin/system-transform"
-import { createEventHandler } from "./plugin/event"
-import { createToolExecuteAfterHandler } from "./plugin/tool-execute-after"
-import { createToolExecuteBeforeHandler } from "./plugin/tool-execute-before"
-
 import type { CreatedHooks } from "./create-hooks"
 import type { Managers } from "./create-managers"
+
+import { createChatHeadersHandler } from "./plugin/chat-headers"
+import { createChatMessageHandler } from "./plugin/chat-message"
+import { createChatParamsHandler } from "./plugin/chat-params"
+import { createEventHandler } from "./plugin/event"
+import { createMessagesTransformHandler } from "./plugin/messages-transform"
+import { createSystemTransformHandler } from "./plugin/system-transform"
+import { createToolExecuteAfterHandler } from "./plugin/tool-execute-after"
+import { createToolExecuteBeforeHandler } from "./plugin/tool-execute-before"
+import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 
 export function createPluginInterface(args: {
   ctx: PluginContext
@@ -33,7 +32,10 @@ export function createPluginInterface(args: {
     tool: tools,
 
     "chat.params": async (input: unknown, output: unknown) => {
-      const handler = createChatParamsHandler({ anthropicEffort: hooks.anthropicEffort })
+      const handler = createChatParamsHandler({
+        anthropicEffort: hooks.anthropicEffort,
+        anthropicServerCompaction: hooks.anthropicServerCompaction,
+      })
       await handler(input, output)
     },
 

--- a/src/plugin/chat-params.test.ts
+++ b/src/plugin/chat-params.test.ts
@@ -12,6 +12,7 @@ describe("createChatParamsHandler", () => {
           called = input.agent.name === "sisyphus"
         },
       },
+      anthropicServerCompaction: null,
     })
 
     const input = {

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -70,6 +70,7 @@ function isChatParamsOutput(raw: unknown): raw is ChatParamsOutput {
 
 export function createChatParamsHandler(args: {
   anthropicEffort: { "chat.params"?: (input: ChatParamsInput, output: ChatParamsOutput) => Promise<void> } | null
+  anthropicServerCompaction: { "chat.params"?: (input: ChatParamsInput, output: ChatParamsOutput) => Promise<void> } | null
 }): (input: unknown, output: unknown) => Promise<void> {
   return async (input, output): Promise<void> => {
     const normalizedInput = buildChatParamsInput(input)
@@ -77,5 +78,6 @@ export function createChatParamsHandler(args: {
     if (!isChatParamsOutput(output)) return
 
     await args.anthropicEffort?.["chat.params"]?.(normalizedInput, output)
+    await args.anthropicServerCompaction?.["chat.params"]?.(normalizedInput, output)
   }
 }

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -27,6 +27,7 @@ import {
   createRuntimeFallbackHook,
 } from "../../hooks"
 import { createAnthropicEffortHook } from "../../hooks/anthropic-effort"
+import { createAnthropicServerCompactionHook } from "../../hooks/anthropic-server-compaction"
 import {
   detectExternalNotificationPlugin,
   getNotificationConflictWarning,
@@ -59,6 +60,7 @@ export type SessionHooks = {
   questionLabelTruncator: ReturnType<typeof createQuestionLabelTruncatorHook> | null
   taskResumeInfo: ReturnType<typeof createTaskResumeInfoHook> | null
   anthropicEffort: ReturnType<typeof createAnthropicEffortHook> | null
+  anthropicServerCompaction: ReturnType<typeof createAnthropicServerCompactionHook> | null
   runtimeFallback: ReturnType<typeof createRuntimeFallbackHook> | null
 }
 
@@ -95,7 +97,8 @@ export function createSessionHooks(args: {
     const forceEnable = pluginConfig.notification?.force_enable ?? false
     const externalNotifier = detectExternalNotificationPlugin(ctx.directory)
     if (externalNotifier.detected && !forceEnable) {
-      log(getNotificationConflictWarning(externalNotifier.pluginName!))
+      const pluginName = externalNotifier.pluginName ?? "unknown"
+      log(getNotificationConflictWarning(pluginName))
     } else {
       sessionNotification = safeHook("session-notification", () => createSessionNotification(ctx))
     }
@@ -249,6 +252,19 @@ export function createSessionHooks(args: {
     ? safeHook("anthropic-effort", () => createAnthropicEffortHook())
     : null
 
+  const serverCompactionConfig = pluginConfig.experimental?.server_compaction
+  const serverCompactionEnabled = typeof serverCompactionConfig === "boolean"
+    ? serverCompactionConfig
+    : serverCompactionConfig?.enabled ?? false
+
+  const anthropicServerCompaction = serverCompactionEnabled && isHookEnabled("anthropic-server-compaction")
+    ? safeHook("anthropic-server-compaction", () => {
+      const triggerTokens = typeof serverCompactionConfig === "object" ? serverCompactionConfig.trigger_tokens : undefined
+      const instructions = typeof serverCompactionConfig === "object" ? serverCompactionConfig.instructions : undefined
+      return createAnthropicServerCompactionHook({ triggerTokens, instructions })
+    })
+    : null
+
   const runtimeFallbackConfig =
     typeof pluginConfig.runtime_fallback === "boolean"
       ? { enabled: pluginConfig.runtime_fallback }
@@ -284,6 +300,7 @@ export function createSessionHooks(args: {
     questionLabelTruncator,
     taskResumeInfo,
     anthropicEffort,
+    anthropicServerCompaction,
     runtimeFallback,
   }
 }


### PR DESCRIPTION
## Summary

Add server-side compaction support for Claude 4.6 models (Opus and Sonnet) via Anthropic's `compact_20260112` API. This hook injects `context_management` into the API request through the `chat.params` hook, enabling the Anthropic API to handle context compression automatically — no client-side compaction logic needed.

## Problem

Long-running sessions with Claude 4.6 currently rely on client-side compaction (`preemptive-compaction` hook), which:
- Requires a separate LLM call to generate the summary (extra cost + latency)
- Can lose critical context during summarization (known issue: #1346, #2225)
- Doesn't leverage Anthropic's optimized server-side implementation

Anthropic released server-side compaction as a beta feature with Claude 4.6 (`compact-2026-01-12`), which handles context management automatically with minimal integration work. This is the same approach used by Claude Code internally.

## Solution

New `anthropic-server-compaction` hook that:
1. Detects Claude 4.6 models (Opus + Sonnet) on Anthropic-compatible providers (`anthropic`, `google-vertex-anthropic`, `opencode`, `github-copilot`)
2. Injects `contextManagement` into `output.options` via `chat.params` hook
3. AI SDK automatically adds required beta headers (`compact-2026-01-12`, `context-management-2025-06-27`)
4. Anthropic API handles compaction server-side — returns `compaction` content blocks with conversation summary

### How it works

```
chat.params hook → output.options.contextManagement = { edits: [{ type: "compact_20260112", ... }] }
         ↓
opencode ProviderTransform.providerOptions() → { anthropic: { contextManagement: { ... } } }
         ↓
AI SDK @ai-sdk/anthropic → API request with context_management + beta headers
         ↓
Anthropic API → auto-compacts when input tokens exceed trigger threshold
```

### Configuration

Opt-in via `experimental.server_compaction`:

```jsonc
// oh-my-opencode.jsonc
{
  "experimental": {
    // Simple: enable with defaults (128K token trigger)
    "server_compaction": true,

    // Advanced: custom trigger threshold and instructions
    "server_compaction": {
      "enabled": true,
      "trigger_tokens": 100000,
      "instructions": "Preserve code snippets, file paths, and technical decisions."
    }
  }
}
```

### Coexistence with existing hooks

- **`preemptive-compaction`**: Both can be enabled. Server-side compaction triggers at the API level, while preemptive-compaction triggers client-side. In practice, server-side fires first, making preemptive-compaction redundant. Users may want to disable preemptive-compaction when using server-side.
- **`compaction-context-injector`**: Still works — it handles opencode's client-side compaction events
- **`compaction-todo-preserver`**: Still works — watches for compaction events

### Provider compatibility

| Provider | Supported | Notes |
|----------|-----------|-------|
| `anthropic` | ✅ | Direct API |
| `google-vertex-anthropic` | ✅ | Uses same `AnthropicMessagesLanguageModel` from `@ai-sdk/anthropic/internal` |
| `opencode` | ✅ | Anthropic via OpenCode proxy |
| `github-copilot` (Claude models) | ✅ | Claude models on Copilot |
| Non-Claude models | ⏭️ Skipped | Hook is a no-op for non-4.6 models |

## What's included

| Path | Description |
|------|-------------|
| `src/hooks/anthropic-server-compaction/hook.ts` | Hook implementation (74 LOC) |
| `src/hooks/anthropic-server-compaction/index.ts` | Barrel export |
| `src/hooks/anthropic-server-compaction/index.test.ts` | 15 tests covering positive/negative/edge cases |
| `src/config/schema/experimental.ts` | `server_compaction` config schema |
| `src/config/schema/hooks.ts` | Hook name registration |
| `src/plugin/chat-params.ts` | Handler wiring |
| `src/plugin/hooks/create-session-hooks.ts` | Hook instantiation |
| `src/plugin-interface.ts` | Hook passing to handler |

## Testing

```bash
bun test src/hooks/anthropic-server-compaction/index.test.ts
# 15 pass, 0 fail

bun run typecheck  # ✅
bun run build      # ✅
```

## Current limitations

- **Beta API**: Requires `compact-2026-01-12` beta header (handled automatically by AI SDK)
- **Same model for summarization**: Anthropic uses the same model for the compaction summary — no option to use a cheaper model
- **Claude 4.6 only**: `claude-opus-4-6` and `claude-sonnet-4-6` — older models are not supported

## References

- [Anthropic Compaction API docs](https://platform.claude.com/docs/en/build-with-claude/compaction)
- [Vercel AI SDK compact_20260112 support](https://github.com/vercel/ai/blob/main/packages/anthropic/src/anthropic-messages-language-model.ts#L552)
- Related opencode issues: [#2871](https://github.com/anomalyco/opencode/issues/2871), [#14233](https://github.com/anomalyco/opencode/issues/14233)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side context compaction for Claude 4.6 (Opus, Sonnet) using Anthropic’s compact_20260112 to reduce extra calls and keep more context. The new hook injects contextManagement via chat.params and activates only for supported Claude models.

- **New Features**
  - New anthropic-server-compaction hook injects contextManagement for Claude 4.6 on Anthropic, Google Vertex Anthropic, OpenCode, and GitHub Copilot (Claude).
  - Opt-in config: experimental.server_compaction true or object with trigger_tokens (default 128k) and optional instructions.
  - No-op for non-4.6 or non-Claude models; preserves existing options and won’t overwrite existing contextManagement.
  - SDK sends required beta headers automatically; tests added to cover positive/negative cases.

- **Migration**
  - Enable with experimental.server_compaction; optionally set trigger_tokens and instructions.
  - Consider disabling preemptive-compaction; server-side compaction typically triggers first.

<sup>Written for commit 78cec1aca47e887e6b0aa2d9f515212c8071872a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

