### PR TITLE
fix(tmux): use correct health check endpoint /global/health

### DIFF
--- a/src/shared/tmux/tmux-utils/server-health.ts
+++ b/src/shared/tmux/tmux-utils/server-health.ts
@@ -10,7 +10,7 @@ export async function isServerRunning(serverUrl: string): Promise<boolean> {
 		return true
 	}
 
-	const healthUrl = new URL("/health", serverUrl).toString()
+	const healthUrl = new URL("/global/health", serverUrl).toString()
 	const timeoutMs = 3000
 	const maxAttempts = 2
 


### PR DESCRIPTION
## Summary

- Fix tmux server health check using wrong URL path (`/health` → `/global/health`)
- The `/health` endpoint doesn't exist in OpenCode, returning HTTP 403 and causing tmux integration to silently skip pane splitting
- The correct endpoint is `/global/health` as defined in OpenCode's server routes

Fixes #2260

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed tmux server health check to call /global/health instead of /health. This prevents 403 responses in OpenCode and ensures pane splitting works as expected.

<sup>Written for commit d6fe9aa12396587b309b121ed0c45b5046ea025a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

