### PR TITLE
fix: strip null bytes from tool arguments to prevent bash crashes

### DIFF
--- a/src/hooks/null-byte-sanitizer/hook.test.ts
+++ b/src/hooks/null-byte-sanitizer/hook.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "bun:test"
+import { sanitizeToolArgsNullBytes } from "./hook"
+
+describe("sanitizeToolArgsNullBytes", () => {
+	describe("#given tool args with null bytes", () => {
+		it("#then strips null bytes from string args", () => {
+			const input = { tool: "bash" }
+			const output = { args: { command: "echo\x00 hello\x00" } }
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.command).toBe("echo hello")
+		})
+	})
+
+	describe("#given tool args without null bytes", () => {
+		it("#then leaves args unchanged", () => {
+			const input = { tool: "bash" }
+			const output = { args: { command: "echo hello" } }
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.command).toBe("echo hello")
+		})
+	})
+
+	describe("#given non-string args", () => {
+		it("#then skips non-string values", () => {
+			const input = { tool: "bash" }
+			const output = { args: { timeout: 5000, command: "ls\x00" } as Record<string, unknown> }
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.timeout).toBe(5000)
+			expect(output.args.command).toBe("ls")
+		})
+	})
+
+	describe("#given multiple string args with null bytes", () => {
+		it("#then strips null bytes from all string args", () => {
+			const input = { tool: "write" }
+			const output = {
+				args: {
+					filePath: "/tmp/\x00test.ts",
+					content: "const x\x00 = 1",
+				},
+			}
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.filePath).toBe("/tmp/test.ts")
+			expect(output.args.content).toBe("const x = 1")
+		})
+	})
+})

--- a/src/hooks/null-byte-sanitizer/hook.test.ts
+++ b/src/hooks/null-byte-sanitizer/hook.test.ts
@@ -52,4 +52,30 @@ describe("sanitizeToolArgsNullBytes", () => {
 			expect(output.args.content).toBe("const x = 1")
 		})
 	})
+
+	describe("#given string array args with null bytes", () => {
+		it("#then strips null bytes from array elements", () => {
+			const input = { tool: "ast_grep_search" }
+			const output = { args: { paths: ["/src/\x00foo", "/lib/\x00bar"] } as Record<string, unknown> }
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.paths).toEqual(["/src/foo", "/lib/bar"])
+		})
+	})
+
+	describe("#given nested object args with null bytes", () => {
+		it("#then strips null bytes from nested string values", () => {
+			const input = { tool: "write" }
+			const output = {
+				args: {
+					options: { path: "/tmp/\x00test", encoding: "utf-8" },
+				} as Record<string, unknown>,
+			}
+
+			sanitizeToolArgsNullBytes(input, output)
+
+			expect(output.args.options).toEqual({ path: "/tmp/test", encoding: "utf-8" })
+		})
+	})
 })

--- a/src/hooks/null-byte-sanitizer/hook.ts
+++ b/src/hooks/null-byte-sanitizer/hook.ts
@@ -2,8 +2,21 @@ import { log } from "../../shared"
 
 const NULL_BYTE_REGEX = /\x00/g
 
-function stripNullBytes(value: string): string {
-	return value.replace(NULL_BYTE_REGEX, "")
+function sanitizeValue(value: unknown): unknown {
+	if (typeof value === "string") {
+		return value.includes("\x00") ? value.replace(NULL_BYTE_REGEX, "") : value
+	}
+	if (Array.isArray(value)) {
+		return value.map(sanitizeValue)
+	}
+	if (value !== null && typeof value === "object") {
+		const result: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+			result[k] = sanitizeValue(v)
+		}
+		return result
+	}
+	return value
 }
 
 export function sanitizeToolArgsNullBytes(
@@ -14,8 +27,9 @@ export function sanitizeToolArgsNullBytes(
 	let sanitized = false
 
 	for (const [key, value] of Object.entries(argsObject)) {
-		if (typeof value === "string" && value.includes("\x00")) {
-			argsObject[key] = stripNullBytes(value)
+		const cleaned = sanitizeValue(value)
+		if (cleaned !== value) {
+			argsObject[key] = cleaned
 			sanitized = true
 		}
 	}

--- a/src/hooks/null-byte-sanitizer/hook.ts
+++ b/src/hooks/null-byte-sanitizer/hook.ts
@@ -1,0 +1,28 @@
+import { log } from "../../shared"
+
+const NULL_BYTE_REGEX = /\x00/g
+
+function stripNullBytes(value: string): string {
+	return value.replace(NULL_BYTE_REGEX, "")
+}
+
+export function sanitizeToolArgsNullBytes(
+	input: { tool: string },
+	output: { args: Record<string, unknown> },
+): void {
+	const argsObject = output.args
+	let sanitized = false
+
+	for (const [key, value] of Object.entries(argsObject)) {
+		if (typeof value === "string" && value.includes("\x00")) {
+			argsObject[key] = stripNullBytes(value)
+			sanitized = true
+		}
+	}
+
+	if (sanitized) {
+		log("[null-byte-sanitizer] Stripped null bytes from tool args", {
+			tool: input.tool,
+		})
+	}
+}

--- a/src/hooks/null-byte-sanitizer/index.ts
+++ b/src/hooks/null-byte-sanitizer/index.ts
@@ -1,0 +1,1 @@
+export { sanitizeToolArgsNullBytes } from "./hook"

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -8,6 +8,7 @@ import { resolveSessionAgent } from "./session-agent-resolver"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 import { ULTRAWORK_VERIFICATION_PROMISE } from "../hooks/ralph-loop/constants"
 import { readState, writeState } from "../hooks/ralph-loop/storage"
+import { sanitizeToolArgsNullBytes } from "../hooks/null-byte-sanitizer"
 
 import type { CreatedHooks } from "../create-hooks"
 
@@ -21,6 +22,7 @@ export function createToolExecuteBeforeHandler(args: {
   const { ctx, hooks } = args
 
   return async (input, output): Promise<void> => {
+    sanitizeToolArgsNullBytes(input, output)
     await hooks.writeExistingFileGuard?.["tool.execute.before"]?.(input, output)
     await hooks.questionLabelTruncator?.["tool.execute.before"]?.(input, output)
     await hooks.claudeCodeHooks?.["tool.execute.before"]?.(input, output)


### PR DESCRIPTION
## Summary

- Add `null-byte-sanitizer` pre-tool hook that strips `\x00` from all string tool arguments
- After context compaction or model fallback, the LLM sometimes generates tool call arguments containing null bytes, causing `child_process` to crash with "must be a string without null bytes"
- Sanitization runs as the first step in `tool-execute-before` handler, before any other hooks

## Test Results

4 tests pass covering: null byte removal, clean args passthrough, non-string arg preservation, multi-arg sanitization.

Fixes #2220

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips null bytes from string tool arguments before execution to prevent bash/Node.js `child_process` crashes. Fixes #2220 by adding a first-run sanitizer in `tool.execute.before`; now cleans arrays and nested objects.

- **Bug Fixes**
  - Adds `null-byte-sanitizer` pre-tool hook that recursively removes `\x00` from strings in arguments, arrays, and nested objects; non-strings unchanged.
  - Tests cover removal, passthrough, multi-arg, array, and nested object cases.

<sup>Written for commit 875896fa05ad86b843bd4f2d7ef970b4fe12b026. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

