### PR TITLE
fix(doctor): check config directory for plugin version detection

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { getLatestVersion } from "../../../hooks/auto-update-checker/checker"
 import { extractChannel } from "../../../hooks/auto-update-checker"
 import { PACKAGE_NAME } from "../constants"
-import { getOpenCodeCacheDir, parseJsonc } from "../../../shared"
+import { getOpenCodeConfigDir, parseJsonc } from "../../../shared"
 
 interface PackageJsonShape {
   version?: string
@@ -26,16 +26,6 @@ function getPlatformDefaultCacheDir(platform: NodeJS.Platform = process.platform
   return join(homedir(), ".cache")
 }
 
-function resolveOpenCodeCacheDir(): string {
-  const xdgCacheHome = process.env.XDG_CACHE_HOME
-  if (xdgCacheHome) return join(xdgCacheHome, "opencode")
-
-  const fromShared = getOpenCodeCacheDir()
-  const platformDefault = join(getPlatformDefaultCacheDir(), "opencode")
-  if (existsSync(fromShared) || !existsSync(platformDefault)) return fromShared
-  return platformDefault
-}
-
 function readPackageJson(filePath: string): PackageJsonShape | null {
   if (!existsSync(filePath)) return null
 
@@ -53,8 +43,26 @@ function normalizeVersion(value: string | undefined): string | null {
   return match?.[0] ?? null
 }
 
+function resolvePluginInstallDir(): string {
+  const configDir = getOpenCodeConfigDir({ binary: "opencode", version: null })
+  const configInstalled = join(configDir, "node_modules", PACKAGE_NAME, "package.json")
+  if (existsSync(configInstalled)) return configDir
+
+  const cacheDir = join(getPlatformDefaultCacheDir(), "opencode")
+  const cacheInstalled = join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
+  if (existsSync(cacheInstalled)) return cacheDir
+
+  const xdgCacheHome = process.env.XDG_CACHE_HOME
+  if (xdgCacheHome) {
+    const xdgDir = join(xdgCacheHome, "opencode")
+    if (existsSync(join(xdgDir, "node_modules", PACKAGE_NAME, "package.json"))) return xdgDir
+  }
+
+  return configDir
+}
+
 export function getLoadedPluginVersion(): LoadedVersionInfo {
-  const cacheDir = resolveOpenCodeCacheDir()
+  const cacheDir = resolvePluginInstallDir()
   const cachePackagePath = join(cacheDir, "package.json")
   const installedPackagePath = join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
 

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -44,19 +44,26 @@ function normalizeVersion(value: string | undefined): string | null {
 }
 
 function resolvePluginInstallDir(): string {
+  // 1. Config directory (primary install location)
   const configDir = getOpenCodeConfigDir({ binary: "opencode", version: null })
   const configInstalled = join(configDir, "node_modules", PACKAGE_NAME, "package.json")
   if (existsSync(configInstalled)) return configDir
 
-  const cacheDir = join(getPlatformDefaultCacheDir(), "opencode")
-  const cacheInstalled = join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
-  if (existsSync(cacheInstalled)) return cacheDir
-
+  // 2. XDG_CACHE_HOME override (per XDG spec, takes precedence over defaults)
   const xdgCacheHome = process.env.XDG_CACHE_HOME
   if (xdgCacheHome) {
     const xdgDir = join(xdgCacheHome, "opencode")
     if (existsSync(join(xdgDir, "node_modules", PACKAGE_NAME, "package.json"))) return xdgDir
   }
+
+  // 3. Default XDG cache path (covers macOS users without XDG_CACHE_HOME)
+  const defaultXdgCache = join(homedir(), ".cache", "opencode")
+  if (existsSync(join(defaultXdgCache, "node_modules", PACKAGE_NAME, "package.json"))) return defaultXdgCache
+
+  // 4. Platform-specific cache directory (~/Library/Caches on macOS, etc.)
+  const cacheDir = join(getPlatformDefaultCacheDir(), "opencode")
+  const cacheInstalled = join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
+  if (existsSync(cacheInstalled)) return cacheDir
 
   return configDir
 }


### PR DESCRIPTION
## Summary

- Fix `doctor` showing `oh-my-opencode unknown` when plugin is installed in config directory
- The version detection was only checking `~/.cache/opencode/` but the plugin is typically installed in `~/.config/opencode/`
- Now checks config directory first (`getOpenCodeConfigDir`), then falls back to platform cache directory and XDG cache
- Also fixes broken import of removed `getOpenCodeCacheDir` function

Fixes #2240

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doctor plugin version detection by checking the config directory first and correcting cache precedence, so the loaded version no longer shows `oh-my-opencode` as unknown when installed in `~/.config/opencode`. Fixes #2240.

- **Bug Fixes**
  - Detect plugin from config dir via getOpenCodeConfigDir, then fall back in order: XDG_CACHE_HOME, `~/.cache/opencode` (macOS XDG default), platform cache.
  - Replace removed getOpenCodeCacheDir import and add resolvePluginInstallDir to centralize lookup and fix XDG_CACHE_HOME priority.

<sup>Written for commit be76b0eb7d9f28cfaf8d04f9390357da76938791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

