### PR TITLE
feat(doctor): show oh-my-opencode.jsonc path in verbose output

### DIFF
--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
 
 import { MIN_OPENCODE_VERSION, CHECK_IDS, CHECK_NAMES } from "../constants"
 import type { CheckResult, DoctorIssue, SystemInfo } from "../types"
@@ -31,12 +32,26 @@ function buildMessage(status: CheckResult["status"], issues: DoctorIssue[]): str
   return `${issues.length} system warning(s) detected`
 }
 
+function findOmoConfigPath(configPath: string | null): string | null {
+  if (!configPath) return null
+  const configDir = dirname(configPath)
+
+  const jsoncPath = join(configDir, "oh-my-opencode.jsonc")
+  if (existsSync(jsoncPath)) return jsoncPath
+
+  const jsonPath = join(configDir, "oh-my-opencode.json")
+  if (existsSync(jsonPath)) return jsonPath
+
+  return null
+}
+
 export async function gatherSystemInfo(): Promise<SystemInfo> {
   const [binaryInfo, pluginInfo] = await Promise.all([findOpenCodeBinary(), Promise.resolve(getPluginInfo())])
   const loadedInfo = getLoadedPluginVersion()
 
   const opencodeVersion = binaryInfo ? await getOpenCodeVersion(binaryInfo.path) : null
   const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion
+  const omoConfigPath = findOmoConfigPath(pluginInfo.configPath)
 
   return {
     opencodeVersion,
@@ -45,7 +60,9 @@ export async function gatherSystemInfo(): Promise<SystemInfo> {
     loadedVersion: loadedInfo.loadedVersion,
     bunVersion: Bun.version,
     configPath: pluginInfo.configPath,
+    omoConfigPath,
     configValid: isConfigValid(pluginInfo.configPath),
+    omoConfigValid: isConfigValid(omoConfigPath),
     isLocalDev: pluginInfo.isLocalDev,
   }
 }

--- a/src/cli/doctor/format-verbose.ts
+++ b/src/cli/doctor/format-verbose.ts
@@ -29,6 +29,10 @@ export function formatVerbose(result: DoctorResult): string {
   lines.push(`${color.dim("\u2500".repeat(40))}`)
   const configStatus = systemInfo.configValid ? color.green("valid") : color.red("invalid")
   lines.push(`  ${formatStatusSymbol(systemInfo.configValid ? "pass" : "fail")} ${systemInfo.configPath ?? "unknown"} (${configStatus})`)
+  if (systemInfo.omoConfigPath) {
+    const omoStatus = systemInfo.omoConfigValid ? color.green("valid") : color.red("invalid")
+    lines.push(`  ${formatStatusSymbol(systemInfo.omoConfigValid ? "pass" : "fail")} ${systemInfo.omoConfigPath} (${omoStatus})`)
+  }
   lines.push("")
 
   lines.push(`${color.bold("Tools")}`)

--- a/src/cli/doctor/types.ts
+++ b/src/cli/doctor/types.ts
@@ -42,7 +42,9 @@ export interface SystemInfo {
   loadedVersion: string | null
   bunVersion: string | null
   configPath: string | null
+  omoConfigPath: string | null
   configValid: boolean
+  omoConfigValid: boolean
   isLocalDev: boolean
 }
 


### PR DESCRIPTION
## Summary

- Add `oh-my-opencode.jsonc` config path to `doctor --verbose` Configuration section
- Previously only showed `opencode.json` path, now shows both configs with validity status
- Adds `omoConfigPath` and `omoConfigValid` fields to `SystemInfo` type
- Auto-discovers `oh-my-opencode.jsonc` / `oh-my-opencode.json` in the same directory as `opencode.json`

**Before:**
```
Configuration
────────────────────────────────────────
  ✓ /Users/leo/.config/opencode/opencode.json (valid)
```

**After:**
```
Configuration
────────────────────────────────────────
  ✓ /Users/leo/.config/opencode/opencode.json (valid)
  ✓ /Users/leo/.config/opencode/oh-my-opencode.jsonc (valid)
```

Fixes #2239

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doctor --verbose now shows the oh-my-opencode config path and validity alongside opencode.json, making config issues easier to spot.

- **New Features**
  - Auto-discovers oh-my-opencode.jsonc or oh-my-opencode.json in the same directory as opencode.json.
  - Adds omoConfigPath and omoConfigValid to SystemInfo and renders them in the Configuration section.

<sup>Written for commit 310ea530f76de2765d03cf19fa1de03235844dbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

