### PR TITLE
fix(tmux): handle \r line endings and missing pane_title in list-panes

### DIFF
--- a/src/features/tmux-subagent/pane-state-querier.ts
+++ b/src/features/tmux-subagent/pane-state-querier.ts
@@ -27,7 +27,7 @@ export async function queryWindowState(sourcePaneId: string): Promise<WindowStat
     return null
   }
 
-  const lines = stdout.trim().split("\n").filter(Boolean)
+  const lines = stdout.trim().replace(/\r/g, "").split("\n").filter(Boolean)
   if (lines.length === 0) return null
 
   let windowWidth = 0
@@ -36,10 +36,10 @@ export async function queryWindowState(sourcePaneId: string): Promise<WindowStat
 
   for (const line of lines) {
 		const fields = line.split("\t")
-		if (fields.length < 9) continue
+		if (fields.length < 8) continue
 
 		const [paneId, widthStr, heightStr, leftStr, topStr, activeStr, windowWidthStr, windowHeightStr] = fields
-		const title = fields.slice(8).join("\t")
+		const title = fields.length > 8 ? fields.slice(8).join("\t") : ""
     const width = parseInt(widthStr, 10)
     const height = parseInt(heightStr, 10)
     const left = parseInt(leftStr, 10)


### PR DESCRIPTION
## Summary

- Strip `\r` characters from `list-panes` output to handle Windows-style line endings that caused pane rows to be dropped
- Relax field count check from 9 to 8 fields so panes with empty/missing `pane_title` are still parsed correctly
- This fixes the "first subagent split fails in single-pane session" bug where `mainPane` resolution failed because all pane rows were dropped by the parser

**Root cause:** In some environments, `tmux list-panes` output contains `\r\n` line endings or empty `pane_title` values. The parser's `split("\n")` left trailing `\r` in field values (corrupting parseInt), and the `fields.length < 9` check dropped rows where `pane_title` was absent.

Fixes #2241

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tmux list-panes parsing by removing \r characters and handling missing pane_title. This restores main pane detection and prevents the first subagent split from failing in single-pane sessions.

- **Bug Fixes**
  - Strip \r from list-panes output to support CRLF line endings.
  - Allow 8 fields and default pane_title to "" so panes aren’t dropped.

<sup>Written for commit e1952d35e694904abb08dafc516c4be838dc9ca5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

