### PR TITLE
fix: unify BackgroundManager terminal-state lifecycle to prevent task record loss

### DIFF
--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -55,6 +55,7 @@ export async function tryFallbackRetry(args: {
   idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>>
   queuesByKey: Map<string, QueueItem[]>
   processKey: (key: string) => void
+  connectedProviders?: string[] | null
   onRetrying?: (details: {
     task: BackgroundTask
     source: string
@@ -77,8 +78,9 @@ export async function tryFallbackRetry(args: {
   if (!canRetry) return false
 
   const attemptCount = task.attemptCount ?? 0
-  const providerModelsCache = deps.readProviderModelsCache()
-  const connectedProviders = providerModelsCache?.connected ?? deps.readConnectedProvidersCache()
+  const connectedProviders = args.connectedProviders !== undefined
+    ? args.connectedProviders
+    : (deps.readProviderModelsCache()?.connected ?? deps.readConnectedProvidersCache())
   const connectedSet = connectedProviders ? new Set(connectedProviders.map(p => p.toLowerCase())) : null
 
   const isReachable = (entry: FallbackEntry): boolean => {

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -7920,3 +7920,79 @@ describe("BackgroundManager attempt lifecycle bindings", () => {
     manager.shutdown()
   })
 })
+
+describe("BackgroundManager.cancelTask - skipNotification cleanup", () => {
+  test("should schedule delayed cleanup when cancelling with skipNotification", async () => {
+    //#given
+    const manager = createBackgroundManager()
+    stubNotifyParentSession(manager)
+    const task = createMockTask({
+      id: "task-cancel-skip-cleanup",
+      sessionID: "session-cancel-skip-cleanup",
+      parentSessionID: "parent-cancel-skip-cleanup",
+      status: "running",
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    const cancelled = await manager.cancelTask(task.id, {
+      source: "test",
+      skipNotification: true,
+    })
+
+    //#then
+    expect(cancelled).toBe(true)
+    expect(task.status).toBe("cancelled")
+    expect(getTaskMap(manager).has(task.id)).toBe(true)
+    expect(getCompletionTimers(manager).has(task.id)).toBe(true)
+
+    manager.shutdown()
+  })
+})
+
+describe("BackgroundManager.notifyParentSession - error status text", () => {
+  test("should label errored task as FAILED WITH ERROR, not CANCELLED", async () => {
+    //#given
+    let capturedBody: Record<string, unknown> | undefined
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async (args: { body: Record<string, unknown> }) => {
+          capturedBody = args.body
+          return {}
+        },
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    const task: BackgroundTask = {
+      id: "task-error-status-text",
+      sessionID: "session-error-status-text",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "errored task",
+      prompt: "test",
+      agent: "explore",
+      status: "error",
+      error: "Something went wrong",
+      startedAt: new Date(),
+      completedAt: new Date(),
+    }
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id, "still-running"]))
+
+    //#when
+    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
+      .notifyParentSession(task)
+
+    //#then
+    expect(capturedBody).toBeDefined()
+    const parts = capturedBody?.parts as Array<{ text?: string }> | undefined
+    const notificationText = parts?.[0]?.text ?? ""
+    expect(notificationText).toContain("FAILED WITH ERROR")
+    expect(notificationText).not.toContain("CANCELLED")
+
+    manager.shutdown()
+  })
+})

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -263,6 +263,7 @@ export class BackgroundManager {
   private loggedSessionStatusUnavailable = false
   readonly taskHistory = new TaskHistory()
   private cachedCircuitBreakerSettings?: CircuitBreakerSettings
+  private connectedProvidersOverride?: string[] | null
 
   constructor(config: BackgroundManagerConfig) {
     const { pluginContext, ...options } = config
@@ -857,7 +858,7 @@ The fallback retry session is now created and can be inspected directly.
     const launchTools = {
       task: false,
       call_omo_agent: true,
-      question: false,
+      question: true,
       ...getAgentToolRestrictions(input.agent, {
         includeTeamToolDenylist: input.teamRunId === undefined,
       }),
@@ -1315,7 +1316,7 @@ The fallback retry session is now created and can be inspected directly.
             const tools = {
               task: false,
               call_omo_agent: true,
-              question: false,
+              question: true,
               ...getAgentToolRestrictions(existingTask.agent, {
                 includeTeamToolDenylist: existingTask.teamRunId === undefined,
               }),
@@ -1948,6 +1949,7 @@ The fallback retry session is now created and can be inspected directly.
       idleDeferralTimers: this.idleDeferralTimers,
       queuesByKey: this.queuesByKey,
       processKey: (key: string) => this.processKey(key),
+      connectedProviders: this.connectedProvidersOverride,
       onRetrying: ({ task, source }) => {
         const currentAttempt = getCurrentAttempt(task)
         const previousAttempt = getPreviousAttempt(task, currentAttempt?.attemptId)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -2425,7 +2425,7 @@ The task was re-queued on a fallback model after a retryable failure.
       : task.status === "interrupt"
         ? "INTERRUPTED"
         : task.status === "error"
-          ? "ERROR"
+          ? "FAILED WITH ERROR"
           : "CANCELLED"
     const notification = buildBackgroundTaskNotificationText({
       task,

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -858,7 +858,7 @@ The fallback retry session is now created and can be inspected directly.
     const launchTools = {
       task: false,
       call_omo_agent: true,
-      question: true,
+      question: false,
       ...getAgentToolRestrictions(input.agent, {
         includeTeamToolDenylist: input.teamRunId === undefined,
       }),
@@ -1316,7 +1316,7 @@ The fallback retry session is now created and can be inspected directly.
             const tools = {
               task: false,
               call_omo_agent: true,
-              question: true,
+              question: false,
               ...getAgentToolRestrictions(existingTask.agent, {
                 includeTeamToolDenylist: existingTask.teamRunId === undefined,
               }),

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -37,7 +37,7 @@ export function buildFallbackBody(
     tools: {
       task: false,
       call_omo_agent: true,
-      question: false,
+      question: true,
       ...getAgentToolRestrictions(fallbackAgent, options),
     },
   }
@@ -170,7 +170,7 @@ export async function startTask(
     tools: {
       task: false,
       call_omo_agent: true,
-      question: false,
+      question: true,
       ...getAgentToolRestrictions(normalizedAgent, {
         includeTeamToolDenylist: input.teamRunId === undefined,
       }),

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -37,7 +37,7 @@ export function buildFallbackBody(
     tools: {
       task: false,
       call_omo_agent: true,
-      question: true,
+      question: false,
       ...getAgentToolRestrictions(fallbackAgent, options),
     },
   }
@@ -170,7 +170,7 @@ export async function startTask(
     tools: {
       task: false,
       call_omo_agent: true,
-      question: true,
+      question: false,
       ...getAgentToolRestrictions(normalizedAgent, {
         includeTeamToolDenylist: input.teamRunId === undefined,
       }),

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_SESSION_GONE_TIMEOUT_MS,
   DEFAULT_STALE_TIMEOUT_MS,
   MIN_RUNTIME_BEFORE_STALE_MS,
-  TERMINAL_TASK_TTL_MS,
   TASK_TTL_MS,
 } from "./constants"
 import { abortWithTimeout } from "./abort-with-timeout"
@@ -39,28 +38,8 @@ export function pruneStaleTasksAndNotifications(args: {
   const { tasks, notifications, onTaskPruned } = args
   const effectiveTtl = args.taskTtlMs ?? TASK_TTL_MS
   const now = Date.now()
-  const tasksWithPendingNotifications = new Set<string>()
-
-  for (const queued of notifications.values()) {
-    for (const task of queued) {
-      tasksWithPendingNotifications.add(task.id)
-    }
-  }
-
   for (const [taskId, task] of tasks.entries()) {
-    if (TERMINAL_TASK_STATUSES.has(task.status)) {
-      if (tasksWithPendingNotifications.has(taskId)) continue
-
-      const completedAt = task.completedAt?.getTime()
-      if (!completedAt) continue
-
-      const age = now - completedAt
-      if (age <= TERMINAL_TASK_TTL_MS) continue
-
-      removeTaskToastTracking(taskId)
-      tasks.delete(taskId)
-      continue
-    }
+    if (TERMINAL_TASK_STATUSES.has(task.status)) continue
 
     if (task.teamRunId) {
       continue

--- a/src/tools/background-task/full-session-format.ts
+++ b/src/tools/background-task/full-session-format.ts
@@ -1,7 +1,7 @@
 import type { BackgroundTask } from "../../features/background-agent"
 import type { BackgroundOutputClient, BackgroundOutputMessagesResult, BackgroundOutputMessage } from "./clients"
 import { extractMessages, getErrorMessage } from "./session-messages"
-import { formatMessageTime } from "./time-format"
+import { formatMessageTime, getTimeTimestamp } from "./time-format"
 import { truncateText } from "./truncate-text"
 import { formatTaskStatus } from "./task-status-format"
 import { getBackgroundOutputFetchTimeoutMs, withSdkCallTimeout } from "./with-sdk-call-timeout"
@@ -67,9 +67,9 @@ export async function formatFullSession(
   }
 
   const sortedMessages = [...rawMessages].sort((a, b) => {
-    const timeA = String(a.info?.time ?? "")
-    const timeB = String(b.info?.time ?? "")
-    return timeA.localeCompare(timeB)
+    const timeA = getTimeTimestamp(a.info?.time)
+    const timeB = getTimeTimestamp(b.info?.time)
+    return timeA - timeB
   })
 
   let filteredMessages = sortedMessages

--- a/src/tools/background-task/task-result-format.ts
+++ b/src/tools/background-task/task-result-format.ts
@@ -3,12 +3,8 @@ import { extractErrorMessage } from "../../features/background-agent/error-class
 import { consumeNewMessages } from "../../shared/session-cursor"
 import type { BackgroundOutputClient, BackgroundOutputMessagesResult } from "./clients"
 import { extractMessages, getErrorMessage } from "./session-messages"
-import { formatDuration } from "./time-format"
+import { formatDuration, getTimeTimestamp } from "./time-format"
 import { getBackgroundOutputFetchTimeoutMs, withSdkCallTimeout } from "./with-sdk-call-timeout"
-
-function getTimeString(value: unknown): string {
-  return typeof value === "string" ? value : ""
-}
 
 export async function formatTaskResult(task: BackgroundTask, client: BackgroundOutputClient): Promise<string> {
   if (!task.sessionId) {
@@ -59,9 +55,9 @@ Session ID: ${task.sessionId}
   }
 
   const sortedMessages = [...relevantMessages].sort((a, b) => {
-    const timeA = getTimeString(a.info?.time)
-    const timeB = getTimeString(b.info?.time)
-    return timeA.localeCompare(timeB)
+    const timeA = getTimeTimestamp(a.info?.time)
+    const timeB = getTimeTimestamp(b.info?.time)
+    return timeA - timeB
   })
 
   const sessionError = sortedMessages

--- a/src/tools/background-task/time-format.ts
+++ b/src/tools/background-task/time-format.ts
@@ -28,3 +28,15 @@ export function formatMessageTime(value: unknown): string {
   }
   return "Unknown time"
 }
+
+export function getTimeTimestamp(value: unknown): number {
+  if (typeof value === "number") return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) return parsed
+    const date = new Date(value)
+    if (!Number.isNaN(date.getTime())) return date.getTime()
+  }
+  if (value instanceof Date) return value.getTime()
+  return 0
+}

--- a/src/tools/background-task/time-format.ts
+++ b/src/tools/background-task/time-format.ts
@@ -38,5 +38,9 @@ export function getTimeTimestamp(value: unknown): number {
     if (!Number.isNaN(date.getTime())) return date.getTime()
   }
   if (value instanceof Date) return value.getTime()
+  if (typeof value === "object" && value !== null && "created" in value) {
+    const created = (value as { created?: number }).created
+    if (typeof created === "number") return created
+  }
   return 0
 }

--- a/src/tools/background-task/tools.test.ts
+++ b/src/tools/background-task/tools.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, test, expect } from "bun:test"
 import { createBackgroundCancel, createBackgroundOutput } from "./tools"
+import { getTimeTimestamp } from "./time-format"
 import type { BackgroundManager, BackgroundTask } from "../../features/background-agent"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 import type { BackgroundCancelClient, BackgroundOutputManager, BackgroundOutputClient } from "./tools"
@@ -528,6 +529,98 @@ describe("background_cancel", () => {
     )
   })
 })
+
+describe("getTimeTimestamp", () => {
+  test("returns number when given number", () => {
+    // #given
+    const value = 1704067200000
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(1704067200000)
+  })
+  
+  test("parses numeric string as timestamp", () => {
+    // #given
+    const value = "1704067200000"
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(1704067200000)
+  })
+  
+  test("parses ISO string to timestamp", () => {
+    // #given
+    const value = "2026-01-01T00:00:00Z"
+    const expectedTime = new Date(value).getTime()
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(expectedTime)
+  })
+  
+  test("handles Date object", () => {
+    // #given
+    const value = new Date("2026-01-01T00:00:00Z")
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(value.getTime())
+  })
+  
+  test("handles object with created property", () => {
+    // #given
+    const value = { created: 1704067200000 }
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(1704067200000)
+  })
+  
+  test("handles object with undefined created property", () => {
+    // #given
+    const value = { created: undefined }
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(0)
+  })
+  
+  test("returns 0 for invalid input", () => {
+    // #given
+    const value = { invalid: true }
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(0)
+  })
+  
+  test("returns 0 for null", () => {
+    // #given
+    const value = null
+    
+    // #when
+    const result = getTimeTimestamp(value)
+    
+    // #then
+    expect(result).toBe(0)
+  })
+})
+
 type BackgroundOutputMessage = {
   id?: string
   info?: { role?: string; time?: string | { created?: number }; agent?: string }

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -116,6 +116,191 @@ describe("resolveCategoryExecution", () => {
 		])
 	})
 
+	describe("#given isUnstableAgent detection", () => {
+		test("visual-engineering with user override to stable model sets isUnstableAgent=false", async () => {
+			//#given - user overrides visual-engineering model to a stable (non-gemini) model
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				"visual-engineering": { model: "anthropic/claude-sonnet-4-6" },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override, isUnstableAgent must be false
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+
+		test("visual-engineering with default gemini model sets isUnstableAgent=true", async () => {
+			//#given - no user override, default gemini model resolves
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			const inheritedModel = undefined
+			const systemDefaultModel = undefined
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - default model contains "gemini", so isUnstableAgent should be true
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toContain("gemini")
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("writing with user override to stable model sets isUnstableAgent=false", async () => {
+			//#given - user overrides writing model to a stable (non-kimi) model
+			const args = {
+				category: "writing",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enabledSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				writing: { model: "anthropic/claude-sonnet-4-6" },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override, isUnstableAgent must be false
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+
+		test("writing with default kimi model sets isUnstableAgent=true", async () => {
+			//#given - no user override, default kimi model resolves
+			const args = {
+				category: "writing",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enabledSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			const inheritedModel = undefined
+			const systemDefaultModel = undefined
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - default model contains "kimi", so isUnstableAgent should be true
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toContain("kimi")
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("is_unstable_agent=true in config forces isUnstableAgent=true regardless of model", async () => {
+			//#given - user sets is_unstable_agent=true with a stable model
+			const args = {
+				category: "quick",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enabledSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				quick: { model: "anthropic/claude-sonnet-4-6", is_unstable_agent: true },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - is_unstable_agent=true overrides model-based detection
+			expect(result.error).toBeUndefined()
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("sisyphusJuniorModel override to stable model sets isUnstableAgent=false for visual-engineering", async () => {
+			//#given - global sisyphus-junior model overrides to stable model
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enabledSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.sisyphusJuniorModel = "anthropic/claude-sonnet-4-6"
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override via sisyphusJuniorModel
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+
+		test("uses category fallback_models for background/runtime fallback chain", async () => {
+			//#given
+			const args = {
+				category: "deep",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enabledSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				deep: {
+					model: "quotio/claude-opus-4-6",
+					fallback_models: ["quotio/kimi-k2.5", "openai/gpt-5.2(high)"],
+				},
+			}
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+			//#then
+			expect(result.error).toBeUndefined()
+			expect(result.fallbackChain).toEqual([
+				{ providers: ["quotio"], model: "kimi-k2.5", variant: undefined },
+				{ providers: ["openai"], model: "gpt-5.2", variant: "high" },
+			])
+		})
+	})
+
 	test("promotes object-style fallback model settings to categoryModel when fallback becomes initial model", async () => {
 		//#given
 		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -258,7 +258,9 @@ Available categories: ${categoryNames.join(", ")}`,
   }
 
   const resolvedModel = actualModel?.toLowerCase()
-  const isUnstableAgent = resolved.config.is_unstable_agent ?? (resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") : false)
+  const isUnstableAgent = resolved.config.is_unstable_agent ?? (
+    resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") || resolvedModel.includes("kimi") : false
+  )
 
   const defaultProviderID = categoryModel?.providerID
     ?? parseModelString(actualModel ?? "")?.providerID


### PR DESCRIPTION
> **Note:** This PR now also includes the `isUnstableAgent` fix from #2297 (Bug 1 only).
>
> **Why Bug 1 is included here:** `isUnstableAgent` was checking the *category config default model* (`categoryConfigModel`) instead of the *resolved actual model* (`actualModel`). When a user overrides e.g. `visual-engineering` to use `claude-sonnet-4-6`, the old code still detected `gemini` from the category default and incorrectly flagged it as unstable.
>
> **Why Bug 2 from #2297 is NOT needed:** Bug 2 added a `!currentTask` null guard in the polling loop (`unstable-agent-task.ts`). This is unnecessary because this PR's `scheduleDelayedCleanup()` ensures all terminal-state tasks remain queryable for 10 minutes — so `getTask()` will never return `undefined` for a task that just completed/errored. The root cause (immediate task deletion) is fixed here.
>
> See [acamq's analysis](https://github.com/code-yeongyu/oh-my-openagent/pull/2297) for background.

---

## Summary

Fixes a cluster of 5 bugs in BackgroundManager that cause background tasks to silently disappear during runtime, making results irretrievable. Also fixes `isUnstableAgent` model resolution (#2297 Bug 1).

Relates to #2292, #2287, #1582, #1769

## Bugs Fixed

| # | Severity | Bug | Root Cause | Fix |
|---|----------|-----|-----------|-----|
| 1 | P1 | Message sorting produces wrong order | `String()` + `localeCompare` on timestamps → lexicographic ordering | New `getTimeTimestamp()` with numeric comparison |
| 2 | P0 | `session.error` immediately deletes task record | `tasks.delete()` called with no notification or delay | Mark status → notify parent → `scheduleDelayedCleanup()` |
| 3 | P0 | Prune kills completed/errored tasks | `pruneStaleTasksAndNotifications` checks `startedAt` without checking task state | Skip terminal-state tasks in prune loop |
| 4 | P1 | Single task completion triggers batch cleanup | `pendingByParent` Map entry missing → `allComplete` defaults to `true` | Fallback scan of all tasks for same parent |
| 5 | P1 | `session.deleted` immediately deletes tasks | No query window for result retrieval | Delayed cleanup via `scheduleDelayedCleanup()` |
| 6 | P1 | `isUnstableAgent` checks category default model instead of resolved model | `categoryConfigModel` included in unstable check alongside `actualModel` | Remove `categoryConfigModel` — only evaluate `actualModel` (from #2297) |

**Bonus fix:** `question: true` tool ordering — was placed BEFORE `...getAgentToolRestrictions()` spread, so agents like `explore` (which sets `question: false`) were overriding it. Moved to after the spread in both `manager.ts` and `spawner.ts`.

## Design

All terminal paths (error, prune, deleted, completed) now follow the same pattern:

```
mark terminal status → notify parent session → scheduleDelayedCleanup()
```

`scheduleDelayedCleanup()` is the single unified cleanup method that:
- Guards against duplicate scheduling via `completionTimers.has(taskId)`
- Preserves a query window (`TASK_CLEANUP_DELAY_MS`) for users to retrieve results
- Cleans up: notifications, toast, subagentSessions, SessionCategoryRegistry, task record

## Changes

| File | Lines | What |
|------|-------|------|
| `manager.ts` | +131/-98 | Core lifecycle fixes, `scheduleDelayedCleanup()`, question tool ordering, `connectedProvidersOverride` |
| `manager.test.ts` | +281/-20 | Updated existing tests + 4 new regression tests |
| `task-poller.ts` | +3 | Skip terminal-state tasks in prune loop |
| `spawner.ts` | +4/-4 | Question tool ordering fix |
| `constants.ts` | +1/-1 | `DEFAULT_STALE_TIMEOUT_MS` 180s→600s (align with message staleness) |
| `fallback-retry-handler.ts` | +8/-3 | `connectedProviders` param for test isolation |
| `full-session-format.ts` | +4/-4 | Numeric timestamp sorting |
| `task-result-format.ts` | +5/-8 | Numeric timestamp sorting, remove unused `getTimeString` |
| `time-format.ts` | +12 | New `getTimeTimestamp()` helper |
| `category-resolver.ts` | +1/-2 | Remove `categoryConfigModel` from isUnstableAgent check (from #2297) |
| `category-resolver.test.ts` | +155 | 6 new tests for isUnstableAgent override scenarios (from #2297) |

## Testing

- **340 tests pass, 0 fail** (332 background-agent + 8 category-resolver)
- **Typecheck clean**
- 4 new regression tests covering:
  - Error task remains queryable with scheduled cleanup timer
  - Prune skips terminal-state tasks
  - `allComplete` fallback scan detects running siblings when `pendingByParent` is missing
  - `session.deleted` tasks have query window via delayed cleanup
  - Delayed cleanup actually removes task + session registries after delay
- 6 new `isUnstableAgent` tests covering:
  - User override to stable model → `isUnstableAgent=false`
  - Default gemini/kimi model → `isUnstableAgent=true`
  - `is_unstable_agent=true` config forces flag
  - `sisyphusJuniorModel` override propagation