### PR TITLE
fix: deny bash tool for prometheus agent (#2273)

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -80,4 +80,59 @@ describe("applyToolConfig", () => {
       })
     })
   })
+
+  describe("#given prometheus agent", () => {
+    describe("#when applying tool config", () => {
+      it("#then should deny bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.bash).toBe("deny")
+      })
+
+      it("#then should deny interactive_bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.interactive_bash).toBe("deny")
+      })
+
+      it("#then should preserve other prometheus permissions", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.call_omo_agent).toBe("deny")
+        expect(agent.permission.task).toBe("allow")
+        expect(agent.permission["task_*"]).toBe("allow")
+        expect(agent.permission.teammate).toBe("allow")
+      })
+
+      it("#then should NOT deny bash for other agents", () => {
+        const otherAgents = ["atlas", "sisyphus", "hephaestus", "sisyphus-junior"]
+        const params = createParams({ agents: otherAgents })
+
+        applyToolConfig(params)
+
+        for (const agentName of otherAgents) {
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.bash).toBeUndefined()
+          expect(agent.permission.interactive_bash).toBeUndefined()
+        }
+      })
+    })
+  })
 })

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -85,6 +85,8 @@ export function applyToolConfig(params: {
       "task_*": "allow",
       teammate: "allow",
       ...denyTodoTools,
+      bash: "deny",
+      interactive_bash: "deny",
     };
   }
   const junior = agentByKey(params.agentResult, "sisyphus-junior");


### PR DESCRIPTION
## Summary

Closes #2273

**Problem:** Prometheus's `prometheus-md-only` hook only blocks `Write` and `Edit` tools, but bash commands (`cp`, `rm`, `python3 -c`, etc.) can bypass file restrictions entirely.

**Fix:** Added `bash: "deny"` and `interactive_bash: "deny"` to Prometheus's tool permissions in `tool-config-handler.ts`.

## Changes

- `src/plugin-handlers/tool-config-handler.ts` — Added bash and interactive_bash deny rules to Prometheus agent permissions
- `src/plugin-handlers/tool-config-handler.test.ts` — Added 4 new tests verifying the deny behavior for both tools

## Testing

- 4 new unit tests covering:
  - `bash` tool denied for Prometheus
  - `interactive_bash` tool denied for Prometheus
  - Verification that other agents (Sisyphus) are NOT affected by the deny rules
  - Verification that non-denied tools still work for Prometheus
- All existing tests pass
- TypeScript typecheck passes
- Build passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deny bash and interactive_bash tools for the Prometheus agent to enforce prometheus-md-only and stop shell command bypasses (cp, rm, python3 -c). Other agents are unaffected; non-denied tools still work for Prometheus.

<sup>Written for commit 403efd7796e0829ddf31c4f06c4ef4eca2c36c1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

