### PR TITLE
fix(call-omo-agent): respect syncPollTimeoutMs config for sync polling

### DIFF
--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -54,6 +54,7 @@ export function createToolRegistry(args: {
     pluginConfig.disabled_agents ?? [],
     pluginConfig.agents,
     pluginConfig.categories,
+    pluginConfig.background_task?.syncPollTimeoutMs,
   )
 
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(

--- a/src/tools/call-omo-agent/completion-poller.ts
+++ b/src/tools/call-omo-agent/completion-poller.ts
@@ -11,13 +11,15 @@ export async function waitForCompletion(
     abort: AbortSignal
     metadata?: (input: { title?: string; metadata?: Record<string, unknown> }) => void
   },
-  ctx: PluginInput
+  ctx: PluginInput,
+  timeoutMs?: number
 ): Promise<void> {
   log(`[call_omo_agent] Polling for completion...`)
 
   // Poll for session completion
   const POLL_INTERVAL_MS = 500
-  const MAX_POLL_TIME_MS = 5 * 60 * 1000 // 5 minutes max
+  const DEFAULT_MAX_POLL_TIME_MS = 5 * 60 * 1000 // 5 minutes default
+  const MAX_POLL_TIME_MS = timeoutMs ?? DEFAULT_MAX_POLL_TIME_MS
   const pollStart = Date.now()
   let lastMsgCount = 0
   let stablePolls = 0

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -19,6 +19,10 @@ type ExecuteSyncDeps = {
   setSessionFallbackChain: typeof setSessionFallbackChain
 }
 
+export type ExecuteSyncOptions = {
+  syncPollTimeoutMs?: number
+}
+
 const defaultDeps: ExecuteSyncDeps = {
   createOrGetSession,
   waitForCompletion,
@@ -38,6 +42,7 @@ export async function executeSync(
   ctx: PluginInput,
   deps: ExecuteSyncDeps = defaultDeps,
   fallbackChain?: FallbackEntry[],
+  options?: ExecuteSyncOptions,
 ): Promise<string> {
   const { sessionID } = await deps.createOrGetSession(args, toolContext, ctx)
 
@@ -75,7 +80,7 @@ export async function executeSync(
     return `Error: Failed to send prompt: ${errorMessage}\n\n<task_metadata>\nsession_id: ${sessionID}\n</task_metadata>`
   }
 
-  await deps.waitForCompletion(sessionID, toolContext, ctx)
+  await deps.waitForCompletion(sessionID, toolContext, ctx, options?.syncPollTimeoutMs)
 
   const responseText = await deps.processMessages(sessionID, ctx)
 

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -42,6 +42,7 @@ export function createCallOmoAgent(
   disabledAgents: string[] = [],
   agentOverrides?: AgentOverrides,
   userCategories?: CategoriesConfig,
+  syncPollTimeoutMs?: number,
 ): ToolDefinition {
   const agentDescriptions = ALLOWED_AGENTS.map(
     (name) => `- ${name}: Specialized agent for ${name} tasks`
@@ -95,7 +96,7 @@ export function createCallOmoAgent(
         return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain)
       }
 
-      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain)
+      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, { syncPollTimeoutMs })
     },
   })
 }


### PR DESCRIPTION
## Summary

- Fix `call_omo_agent` sync polling timeout being hardcoded at 300000ms (5 minutes), causing timeouts with slower models like gpt-5.4 high/medium
- Propagate existing `background_task.syncPollTimeoutMs` config to the `call_omo_agent` path, matching the `delegate-task` behavior

## Changes

| File | Change |
|------|--------|
| `src/tools/call-omo-agent/completion-poller.ts` | Add optional `timeoutMs` parameter to `waitForCompletion`, defaulting to 300000ms when unset |
| `src/tools/call-omo-agent/sync-executor.ts` | Add `ExecuteSyncOptions` type, thread `syncPollTimeoutMs` through to `waitForCompletion` |
| `src/tools/call-omo-agent/tools.ts` | Accept `syncPollTimeoutMs` in `createCallOmoAgent` factory, pass to `executeSync` |
| `src/plugin/tool-registry.ts` | Pass `pluginConfig.background_task?.syncPollTimeoutMs` to `createCallOmoAgent` |

## Testing

```bash
bun run typecheck
bun test
```

To override:
```jsonc
// .opencode/oh-my-opencode.jsonc
{
  "background_task": {
    "syncPollTimeoutMs": 600000  // 10 min (minimum: 60000)
  }
}
```

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `call_omo_agent` sync polling to respect `background_task.syncPollTimeoutMs` instead of a hardcoded 5 minutes, preventing timeouts with slower models. Matches the existing `delegate-task` behavior.

- **Bug Fixes**
  - Threads `syncPollTimeoutMs` from plugin config into `createCallOmoAgent` → `executeSync` → `waitForCompletion`.
  - Uses the configured value; falls back to 300000 ms when unset.

<sup>Written for commit 471eec8722bc2022f717e82771eb1708d6dbd803. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

