### PR TITLE
fix: deny bash/interactive_bash for Prometheus agent (#2273)

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -80,4 +80,59 @@ describe("applyToolConfig", () => {
       })
     })
   })
+
+  describe("#given prometheus agent", () => {
+    describe("#when applying tool config", () => {
+      it("#then should deny bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.bash).toBe("deny")
+      })
+
+      it("#then should deny interactive_bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.interactive_bash).toBe("deny")
+      })
+
+      it("#then should preserve other prometheus permissions", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.call_omo_agent).toBe("deny")
+        expect(agent.permission.task).toBe("allow")
+        expect(agent.permission["task_*"]).toBe("allow")
+        expect(agent.permission.teammate).toBe("allow")
+      })
+
+      it("#then should NOT deny bash for other agents", () => {
+        const otherAgents = ["atlas", "sisyphus", "hephaestus", "sisyphus-junior"]
+        const params = createParams({ agents: otherAgents })
+
+        applyToolConfig(params)
+
+        for (const agentName of otherAgents) {
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.bash).toBeUndefined()
+          expect(agent.permission.interactive_bash).toBeUndefined()
+        }
+      })
+    })
+  })
 })

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -85,6 +85,8 @@ export function applyToolConfig(params: {
       "task_*": "allow",
       teammate: "allow",
       ...denyTodoTools,
+      bash: "deny",
+      interactive_bash: "deny",
     };
   }
   const junior = agentByKey(params.agentResult, "sisyphus-junior");


### PR DESCRIPTION
> **Reopened from #2298** — see [discussion there](https://github.com/code-yeongyu/oh-my-openagent/pull/2298#issuecomment-4028400672) for why the alternative approach (Option A, bash command analyzer in #2403) is not viable.

## Summary

Closes #2273 — Prometheus agent can bypass file write restrictions via bash/interactive_bash tools.

## Context

The `prometheus-md-only` hook blocks `Write` and `Edit` tools, but Prometheus can still modify files via bash commands (`cp`, `rm`, `python3 -c`, etc.).

Three approaches were considered:

| Option | Approach | Status |
|--------|----------|--------|
| **A** | Enhance hook to parse/intercept bash commands | Implemented in #2403 — 424-line tokenizer still has 8 security bypasses after 2 review rounds. Bash syntax is too complex for static analysis. |
| **B** | Strengthen agent prompt to not work around restrictions | Unreliable — the original issue shows the model explicitly reasoning around the hook |
| **C (this PR)** | Deny bash tools, rely on existing read-only tools | Minimal, zero attack surface |

## Why Option C works

Prometheus needs bash for one thing: inspecting the codebase. But we already have purpose-built read-only tools:

| Bash command | Existing tool | Advantage |
|---|---|---|
| `cat`, `head`, `tail` | `Read` (with offset/limit) | Line numbers, pagination |
| `grep`, `rg` | `Grep` | Regex, output modes, file filtering |
| `find`, `ls` | `Glob` | Pattern matching, sorted by mtime |
| — | `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols` | Semantic code understanding |

Oracle, Librarian, and Explore are all read-only agents that operate without bash — and they work well. Prometheus would follow the same proven pattern.

## Changes

- `src/plugin-handlers/tool-config-handler.ts` — Added bash and interactive_bash deny rules to Prometheus agent permissions
- `src/plugin-handlers/tool-config-handler.test.ts` — Added 4 new tests verifying the deny behavior for both tools

## Testing

- 4 new tests, all passing
- Existing tests unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deny `bash` and `interactive_bash` for the Prometheus agent to stop command-based write/edit bypasses and keep the agent read-only. Closes #2273.

- **Bug Fixes**
  - Set `bash` and `interactive_bash` to "deny" for Prometheus in `src/plugin-handlers/tool-config-handler.ts`.
  - Kept other Prometheus permissions unchanged; other agents remain unaffected.
  - Added 4 tests to verify deny behavior and ensure no regression for other agents.

<sup>Written for commit 403efd7796e0829ddf31c4f06c4ef4eca2c36c1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

