### PR TITLE
fix(delegate-task): default run_in_background to false when orchestrator intent is detected

### DIFF
--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -123,7 +123,11 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       })
 
       if (args.run_in_background === undefined) {
-        throw new Error(`Invalid arguments: 'run_in_background' parameter is REQUIRED. Use run_in_background=false for task delegation, run_in_background=true only for parallel exploration.`)
+        if (args.category || args.subagent_type || args.session_id) {
+          args.run_in_background = false
+        } else {
+          throw new Error(`Invalid arguments: 'run_in_background' parameter is REQUIRED. Use run_in_background=false for task delegation, run_in_background=true only for parallel exploration.`)
+        }
       }
       if (typeof args.load_skills === "string") {
         try {


### PR DESCRIPTION
## Summary

Fixes #2375

When orchestrator agents (Sisyphus, Atlas) dynamically generate `task()` calls during planning, they sometimes omit the `run_in_background` parameter. Currently this throws a hard validation error, blocking the entire planning workflow.

## Changes

- **`src/tools/delegate-task/tools.ts`**: When `run_in_background` is undefined but orchestrator intent is detected (`category`, `subagent_type`, or `session_id` is present), auto-default to `false` instead of throwing an error. Non-orchestrator calls without the parameter still receive the validation error.

## Why This Fix

- Follows the existing `load_skills` auto-default pattern (lines 128-134 in the same file)
- `run_in_background=false` is the safe default for delegation (sync mode, wait for result)
- Preserves strict validation for ambiguous calls with no category/subagent_type/session_id
- Minimal 4-line change with zero risk of breaking existing behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent validation errors in delegate task planning by defaulting `run_in_background` to false when orchestrator intent is detected. Keeps strict validation for non-orchestrator calls. Addresses #2375.

- **Bug Fixes**
  - In `src/tools/delegate-task/tools.ts`, when `run_in_background` is undefined and any of `category`, `subagent_type`, or `session_id` is present, set `run_in_background = false`.
  - Non-orchestrator calls without the parameter still throw the existing error.

<sup>Written for commit 49b7e695cef6c122c0da938a7fca4a7444725792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

