### PR TITLE
fix(non-interactive-env): use detectShellType() instead of hardcoded unix prefix on Windows

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix, detectShellType } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,9 +52,8 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so always use unix export syntax.
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
+      const shellType = detectShellType()
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.


### PR DESCRIPTION
## Summary

Fixes #2344

The `non-interactive-env` hook hardcodes `"unix"` shell type when building the env prefix for git commands. On Windows with cmd.exe or PowerShell, this produces invalid `export VAR=value;` syntax that fails with "'export' is not recognized."

## Changes

- **`src/hooks/non-interactive-env/non-interactive-env-hook.ts`**: Replace hardcoded `"unix"` with `detectShellType()` which already exists in the codebase (`src/shared/shell-env.ts`) and correctly detects PowerShell, cmd, or Unix shells.

## How detectShellType() Works

The function uses this detection priority:
1. `PSModulePath` env var present → PowerShell (uses `$env:VAR='val';` syntax)
2. `SHELL` env var present → Unix (uses `export VAR=val;` syntax)
3. `process.platform === "win32"` → cmd (uses `set VAR="val" &&` syntax)
4. Fallback → Unix

All three shell types are already tested in `src/shared/shell-env.test.ts` (lines 196-277).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows shell syntax in the non-interactive env hook by detecting the shell instead of assuming Unix. Prevents "'export' is not recognized" errors in cmd and PowerShell during git commands.

- **Bug Fixes**
  - Use `detectShellType()` to build env prefixes instead of hardcoded "unix".
  - Correctly supports PowerShell (`$env:VAR='val';`), cmd (`set VAR="val" &&`), and Unix (`export VAR=val;`).
  - Change scoped to `src/hooks/non-interactive-env/non-interactive-env-hook.ts`.

<sup>Written for commit d3b49aaafebdf7cc94ca3afb0b530b171140a23c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

