### PR TITLE
fix(model-fallback): enable by default and add missing error patterns for usage limits

### DIFF
--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -153,7 +153,7 @@ export function createSessionHooks(args: {
 
   // Model fallback hook (configurable via model_fallback config + disabled_hooks)
   // This handles automatic model switching when model errors occur
-  const isModelFallbackConfigEnabled = pluginConfig.model_fallback ?? false
+  const isModelFallbackConfigEnabled = pluginConfig.model_fallback ?? true
   const modelFallback = isModelFallbackConfigEnabled && isHookEnabled("model-fallback")
     ? safeHook("model-fallback", () =>
       createModelFallbackHook({

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -55,9 +55,17 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "timeout",
   "service unavailable",
   "internal_server_error",
+  "free usage",
+  "usage exceeded",
+  "credit",
+  "balance",
+  "temporarily unavailable",
+  "try again",
   "503",
   "502",
   "504",
+  "429",
+  "529",
 ]
 
 const AUTO_RETRY_GATE_PATTERNS = [


### PR DESCRIPTION
## Summary

Fixes #2393

Two independent issues prevent model fallback from triggering on usage limits:

1. **`model_fallback` defaults to `false`** - The only fallback path capable of intercepting OpenCode's internal retry loop (`session.status`) is gated behind an undocumented config flag that defaults to `false`. Users who configure `fallback_models` expect fallback to work.

2. **Missing error patterns** - Several of OpenCode's transformed retry messages (notably `FreeUsageLimitError`) don't match any pattern in `RETRYABLE_MESSAGE_PATTERNS`.

## Changes

### Fix 1: Enable model_fallback by default
- **`src/plugin/hooks/create-session-hooks.ts`**: Change `pluginConfig.model_fallback ?? false` to `?? true`

### Fix 2: Add missing error patterns
- **`src/shared/model-error-classifier.ts`**: Add 8 missing patterns to `RETRYABLE_MESSAGE_PATTERNS`:
  - `"free usage"` - OpenCode's FreeUsageLimitError
  - `"usage exceeded"` - usage exhaustion variants
  - `"credit"` / `"balance"` - credit/balance related errors
  - `"temporarily unavailable"` / `"try again"` - transient failures
  - `"429"` / `"529"` - HTTP status codes for rate limit and capacity

These patterns align with `runtime-fallback/constants.ts` which already handles them via regex.

## Backward Compatibility

Users who explicitly set `"model_fallback": false` in their config are unaffected. The `?? true` only applies when the field is omitted (undefined).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable model fallback by default and expand retryable error patterns so fallback triggers on usage-limit and transient errors. Fixes #2393.

- **Bug Fixes**
  - Default `model_fallback` to true (only when undefined) to allow fallback during `session.status` retries.
  - Add to `RETRYABLE_MESSAGE_PATTERNS`: "free usage", "usage exceeded", "credit", "balance", "temporarily unavailable", "try again", "429", "529".

- **Migration**
  - No action needed. Explicit `model_fallback: false` is still respected.

<sup>Written for commit 059853554dd8da07c58766b2bcdb21c6209332eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

