### PR TITLE
fix: suppress stdout/stderr leak into TUI by using pipe instead of inherit

### DIFF
--- a/src/cli/config-manager/bun-install.ts
+++ b/src/cli/config-manager/bun-install.ts
@@ -31,8 +31,8 @@ export async function runBunInstallWithDetails(): Promise<BunInstallResult> {
   try {
     const proc = spawnWithWindowsHide(["bun", "install"], {
       cwd: cacheDir,
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "pipe",
+      stderr: "pipe",
     })
 
     let timeoutId: ReturnType<typeof setTimeout>

--- a/src/cli/run/on-complete-hook.ts
+++ b/src/cli/run/on-complete-hook.ts
@@ -26,8 +26,8 @@ export async function executeOnCompleteHook(options: {
         DURATION_MS: String(durationMs),
         MESSAGE_COUNT: String(messageCount),
       },
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "pipe",
+      stderr: "pipe",
     })
 
     const hookExitCode = await proc.exited


### PR DESCRIPTION
## Problem

When oh-my-opencode runs as an OpenCode plugin, the plugin is loaded via `import()` in the same process as the TUI. This means all spawned subprocesses share the same `process.stdout` and `process.stderr` file descriptors, which are being used by the TUI's alternate screen mode (`@opentui/solid`).

Using `stdout: "inherit"` and `stderr: "inherit"` in `spawnWithWindowsHide()` calls causes subprocess output to write directly to the terminal fd, rendering garbage text over the TUI interface.

### Symptoms

- `bun install` output (triggered by auto-update-checker) appears as random text in the TUI
- On-complete hook output leaks into the TUI display
- Users see garbled characters below the status bar

## Fix

Changed `stdout` and `stderr` from `"inherit"` to `"pipe"` in two files:

### `src/cli/config-manager/bun-install.ts`
```diff
  const proc = spawnWithWindowsHide(["bun", "install"], {
    cwd: cacheDir,
-   stdout: "inherit",
-   stderr: "inherit",
+   stdout: "pipe",
+   stderr: "pipe",
  })
```

### `src/cli/run/on-complete-hook.ts`
```diff
  const proc = spawnWithWindowsHide(["sh", "-c", trimmedCommand], {
    env: { ... },
-   stdout: "inherit",
-   stderr: "inherit",
+   stdout: "pipe",
+   stderr: "pipe",
  })
```

## Impact

- Subprocess output is silently captured via pipes instead of leaking to the terminal
- The `bun install` result is already checked via `proc.exitCode`, so the output is not needed
- The on-complete hook exit code is already checked and logged via `console.error`
- No functional behavior change — only visual output suppression when running inside a TUI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pipe subprocess stdout/stderr to stop output leaking into the TUI’s alternate screen when running as an OpenCode plugin. Prevents `bun install` and on-complete hook output from rendering over the UI.

- **Bug Fixes**
  - Changed spawn options from `"inherit"` to `"pipe"` in `src/cli/config-manager/bun-install.ts` and `src/cli/run/on-complete-hook.ts` to isolate subprocess output.

<sup>Written for commit 759c900a46309e8b66e9d67e58abdc69fc71de4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

