### PR TITLE
fix(agents): pass custom agent summaries instead of client object to createBuiltinAgents

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -78,6 +78,22 @@ export async function applyAgentConfig(params: {
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
 
+  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
+  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
+  const rawPluginAgents = params.pluginComponents.agents;
+
+  const customAgentSummaries = [
+    ...Object.entries(userAgents),
+    ...Object.entries(projectAgents),
+    ...Object.entries(rawPluginAgents).filter(([, config]) => config !== undefined),
+  ].map(([name, config]) => ({
+    name,
+    description: typeof (config as Record<string, unknown>)?.description === "string"
+      ? (config as Record<string, unknown>).description as string
+      : "",
+  }));
+
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
     params.pluginConfig.agents,
@@ -86,7 +102,7 @@ export async function applyAgentConfig(params: {
     params.pluginConfig.categories,
     params.pluginConfig.git_master,
     allDiscoveredSkills,
-    params.ctx.client,
+    customAgentSummaries,
     browserProvider,
     currentModel,
     disabledSkills,
@@ -94,11 +110,6 @@ export async function applyAgentConfig(params: {
     disableOmoEnv,
   );
 
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
-  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
-
-  const rawPluginAgents = params.pluginComponents.agents;
   const pluginAgents = Object.fromEntries(
     Object.entries(rawPluginAgents).map(([key, value]) => [
       key,


### PR DESCRIPTION
## Summary

Fixes #2386

Plugin agents (from OpenCode plugins) and user-installed agents (`~/.claude/agents/*.md`) are not injected into the Sisyphus system prompt. This is because `createBuiltinAgents()` receives `params.ctx.client` (an OpenCode SDK client object) as its 8th parameter (`customAgentSummaries`) instead of the expected array of agent summaries.

`parseRegisteredAgentSummaries()` checks `Array.isArray(input)`, gets `false` for the client object, and silently returns `[]`. Result: Sisyphus has zero awareness of any non-builtin agents.

## Root Cause

In `agent-config-handler.ts`, user/project/plugin agents were loaded **after** `createBuiltinAgents()` was called, so the summaries weren't available. The client object was passed as a placeholder that never worked.

## Changes

- **`src/plugin-handlers/agent-config-handler.ts`**:
  1. Move user agent, project agent, and plugin agent loading **before** `createBuiltinAgents()`
  2. Build a proper `customAgentSummaries` array with `{ name, description }` from all non-builtin agents
  3. Pass the summaries array as the 8th parameter instead of `params.ctx.client`
  4. Keep plugin agent migration (`migrateAgentConfig`) in its original position since it's only needed for the final agent merge

## Impact

- Sisyphus now discovers and can intelligently route to all registered agents (user, project, plugin)
- `task(subagent_type="some-plugin-agent")` works without the agent needing to guess the exact name
- No behavioral change for users who don't have custom agents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent discovery by loading user, project, and plugin agents before `createBuiltinAgents` and passing real `customAgentSummaries`, so Sisyphus includes all non-builtin agents in its system prompt. Enables correct routing to custom agents without changing behavior for users without them.

- **Bug Fixes**
  - Load user/project/plugin agents before calling `createBuiltinAgents`.
  - Build and pass `customAgentSummaries: { name, description }[]` instead of `params.ctx.client`.
  - Keep `migrateAgentConfig` position unchanged for the final merge.

<sup>Written for commit 46c3bfcf1f404bebc89bb30c875ebb39a3297a82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

