### PR TITLE
fix(hashline-edit): remove array type from lines union to fix Gemini Vertex schema validation

### DIFF
--- a/src/tools/hashline-edit/tools.ts
+++ b/src/tools/hashline-edit/tools.ts
@@ -30,8 +30,8 @@ export function createHashlineEditTool(): ToolDefinition {
             pos: tool.schema.string().optional().describe("Primary anchor in LINE#ID format"),
             end: tool.schema.string().optional().describe("Range end anchor in LINE#ID format"),
             lines: tool.schema
-              .union([tool.schema.string(), tool.schema.array(tool.schema.string()), tool.schema.null()])
-              .describe("Replacement or inserted lines. null/[] deletes with replace"),
+              .union([tool.schema.string(), tool.schema.null()])
+              .describe("Replacement or inserted lines as newline-delimited string. null deletes with replace"),
           })
         )
         .describe("Array of edit operations to apply (empty when delete=true)"),


### PR DESCRIPTION
## Summary

Fixes #2408

When using Gemini models from Google Vertex AI, the hashline edit tool fails with:
> "edit functionDeclaration parameters.edits.lines schema didn't specify the schema type field"

This does NOT happen with the original OpenCode edit tool, only with oMo's hashline-edit tool.

## Root Cause

The `lines` parameter schema uses a union containing an array type:
```typescript
union([string(), array(string()), null()])
```

When the OpenCode plugin SDK serializes this to Vertex AI's `functionDeclaration` format, the `array(string())` member inside the union doesn't get a proper `type: "array"` field in the generated JSON Schema. Vertex AI requires all schema elements to have explicit `type` fields, causing the validation error.

This is the **only tool** in the codebase that nests an array inside a union. All other array usages are at the top level (e.g., `delegate-task`'s `load_skills`, `ast-grep`'s `paths`).

## Changes

- **`src/tools/hashline-edit/tools.ts`**: Remove `tool.schema.array(tool.schema.string())` from the `lines` union, keeping only `string | null`. Models will send newline-delimited strings instead of arrays.

## Backward Compatibility

- The execution code (`normalize-edits.ts`) still accepts `string | string[] | null` via `RawHashlineEdit.lines` - if any model sends an array, it will still be handled correctly
- Claude/GPT models already commonly send strings for this parameter
- The description is updated to clarify "newline-delimited string" format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini Vertex AI schema validation in the hashline edit tool by removing the array type from the `lines` union. Addresses #2408 and allows edits to work reliably with Vertex.

- **Bug Fixes**
  - `lines` schema now accepts `string | null` only; use newline-delimited strings.
  - Updated description text for clarity.
  - Runtime still accepts `string[]` for backward compatibility.

<sup>Written for commit 204322b12004c7a73feb8bd3bf343893cb1ce154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

