### PR TITLE
feat(start-work): add config option to disable worktree enforcement

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3912,10 +3912,15 @@
         "auto_commit": {
           "default": true,
           "type": "boolean"
+        },
+        "worktree": {
+          "default": true,
+          "type": "boolean"
         }
       },
       "required": [
-        "auto_commit"
+        "auto_commit",
+        "worktree"
       ],
       "additionalProperties": false
     },

--- a/src/config/schema/start-work.test.ts
+++ b/src/config/schema/start-work.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { ZodError } from "zod"
+import { StartWorkConfigSchema } from "./start-work"
+
+describe("StartWorkConfigSchema", () => {
+  describe("worktree", () => {
+    describe("#given worktree set to false", () => {
+      test("#when parsed #then returns worktree: false", () => {
+        const result = StartWorkConfigSchema.parse({ worktree: false })
+
+        expect(result.worktree).toBe(false)
+      })
+    })
+
+    describe("#given worktree not provided", () => {
+      test("#when parsed #then defaults to true", () => {
+        const result = StartWorkConfigSchema.parse({})
+
+        expect(result.worktree).toBe(true)
+      })
+    })
+
+    describe("#given auto_commit and worktree together", () => {
+      test("#when parsed #then accepts both fields", () => {
+        const result = StartWorkConfigSchema.parse({
+          auto_commit: true,
+          worktree: false,
+        })
+
+        expect(result.auto_commit).toBe(true)
+        expect(result.worktree).toBe(false)
+      })
+    })
+
+    describe("#given worktree is non-boolean", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+
+        try {
+          StartWorkConfigSchema.parse({ worktree: "true" })
+        } catch (error) {
+          thrownError = error
+        }
+
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+  })
+
+  describe("auto_commit", () => {
+    describe("#given auto_commit set to false", () => {
+      test("#when parsed #then returns auto_commit: false", () => {
+        const result = StartWorkConfigSchema.parse({ auto_commit: false })
+
+        expect(result.auto_commit).toBe(false)
+      })
+    })
+
+    describe("#given auto_commit not provided", () => {
+      test("#when parsed #then defaults to true", () => {
+        const result = StartWorkConfigSchema.parse({})
+
+        expect(result.auto_commit).toBe(true)
+      })
+    })
+  })
+})

--- a/src/config/schema/start-work.ts
+++ b/src/config/schema/start-work.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 export const StartWorkConfigSchema = z.object({
   /** Enable auto-commit after each atomic task completion (default: true) */
   auto_commit: z.boolean().default(true),
+  /** Enable worktree enforcement for /start-work command (default: true) */
+  worktree: z.boolean().default(true),
 })
 
 export type StartWorkConfig = z.infer<typeof StartWorkConfigSchema>

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -4,33 +4,40 @@ import { INIT_DEEP_TEMPLATE } from "./templates/init-deep"
 import { RALPH_LOOP_TEMPLATE, ULW_LOOP_TEMPLATE, CANCEL_RALPH_TEMPLATE } from "./templates/ralph-loop"
 import { STOP_CONTINUATION_TEMPLATE } from "./templates/stop-continuation"
 import { REFACTOR_TEMPLATE } from "./templates/refactor"
-import { START_WORK_TEMPLATE } from "./templates/start-work"
+import { createStartWorkTemplate } from "./templates/start-work"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
 
-const BUILTIN_COMMAND_DEFINITIONS: Record<BuiltinCommandName, Omit<CommandDefinition, "name">> = {
-  "init-deep": {
-    description: "(builtin) Initialize hierarchical AGENTS.md knowledge base",
-    template: `<command-instruction>
+export function loadBuiltinCommands(
+  disabledCommands?: BuiltinCommandName[],
+  startWorkConfig?: { worktree?: boolean }
+): BuiltinCommands {
+  const disabled = new Set(disabledCommands ?? [])
+  const startWorkTemplate = createStartWorkTemplate({ worktreeEnabled: startWorkConfig?.worktree ?? true })
+
+  const definitions: Record<BuiltinCommandName, Omit<CommandDefinition, "name">> = {
+    "init-deep": {
+      description: "(builtin) Initialize hierarchical AGENTS.md knowledge base",
+      template: `<command-instruction>
 ${INIT_DEEP_TEMPLATE}
 </command-instruction>
 
 <user-request>
 $ARGUMENTS
 </user-request>`,
-    argumentHint: "[--create-new] [--max-depth=N]",
-  },
-   "ralph-loop": {
-     description: "(builtin) Start self-referential development loop until completion",
-     template: `<command-instruction>
+      argumentHint: "[--create-new] [--max-depth=N]",
+    },
+    "ralph-loop": {
+      description: "(builtin) Start self-referential development loop until completion",
+      template: `<command-instruction>
 ${RALPH_LOOP_TEMPLATE}
 </command-instruction>
 
 <user-task>
 $ARGUMENTS
 </user-task>`,
-     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--strategy=reset|continue]',
-   },
-   "ulw-loop": {
+      argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--strategy=reset|continue]',
+    },
+    "ulw-loop": {
       description: "(builtin) Start ultrawork loop - continues until completion with ultrawork mode",
       template: `<command-instruction>
 ${ULW_LOOP_TEMPLATE}
@@ -41,25 +48,25 @@ $ARGUMENTS
 </user-task>`,
       argumentHint: '"task description" [--completion-promise=TEXT] [--strategy=reset|continue]',
     },
-  "cancel-ralph": {
-    description: "(builtin) Cancel active Ralph Loop",
-    template: `<command-instruction>
+    "cancel-ralph": {
+      description: "(builtin) Cancel active Ralph Loop",
+      template: `<command-instruction>
 ${CANCEL_RALPH_TEMPLATE}
 </command-instruction>`,
-  },
-  refactor: {
-    description:
-      "(builtin) Intelligent refactoring command with LSP, AST-grep, architecture analysis, codemap, and TDD verification.",
-    template: `<command-instruction>
+    },
+    refactor: {
+      description:
+        "(builtin) Intelligent refactoring command with LSP, AST-grep, architecture analysis, codemap, and TDD verification.",
+      template: `<command-instruction>
 ${REFACTOR_TEMPLATE}
 </command-instruction>`,
-    argumentHint: "<refactoring-target> [--scope=<file|module|project>] [--strategy=<safe|aggressive>]",
-  },
-  "start-work": {
-    description: "(builtin) Start Sisyphus work session from Prometheus plan",
-    agent: "atlas",
-    template: `<command-instruction>
-${START_WORK_TEMPLATE}
+      argumentHint: "<refactoring-target> [--scope=<file|module|project>] [--strategy=<safe|aggressive>]",
+    },
+    "start-work": {
+      description: "(builtin) Start Sisyphus work session from Prometheus plan",
+      agent: "atlas",
+      template: `<command-instruction>
+${startWorkTemplate}
 </command-instruction>
 
 <session-context>
@@ -70,17 +77,17 @@ Timestamp: $TIMESTAMP
 <user-request>
 $ARGUMENTS
 </user-request>`,
-    argumentHint: "[plan-name]",
-  },
-  "stop-continuation": {
-    description: "(builtin) Stop all continuation mechanisms (ralph loop, todo continuation, boulder) for this session",
-    template: `<command-instruction>
+      argumentHint: "[plan-name]",
+    },
+    "stop-continuation": {
+      description: "(builtin) Stop all continuation mechanisms (ralph loop, todo continuation, boulder) for this session",
+      template: `<command-instruction>
 ${STOP_CONTINUATION_TEMPLATE}
 </command-instruction>`,
-  },
-  handoff: {
-    description: "(builtin) Create a detailed context summary for continuing work in a new session",
-    template: `<command-instruction>
+    },
+    handoff: {
+      description: "(builtin) Create a detailed context summary for continuing work in a new session",
+      template: `<command-instruction>
 ${HANDOFF_TEMPLATE}
 </command-instruction>
 
@@ -92,17 +99,13 @@ Timestamp: $TIMESTAMP
 <user-request>
 $ARGUMENTS
 </user-request>`,
-    argumentHint: "[goal]",
-  },
-}
+      argumentHint: "[goal]",
+    },
+  }
 
-export function loadBuiltinCommands(
-  disabledCommands?: BuiltinCommandName[]
-): BuiltinCommands {
-  const disabled = new Set(disabledCommands ?? [])
   const commands: BuiltinCommands = {}
 
-  for (const [name, definition] of Object.entries(BUILTIN_COMMAND_DEFINITIONS)) {
+  for (const [name, definition] of Object.entries(definitions)) {
     if (!disabled.has(name as BuiltinCommandName)) {
       const { argumentHint: _argumentHint, ...openCodeCompatible } = definition
       commands[name] = { ...openCodeCompatible, name } as CommandDefinition

--- a/src/features/builtin-commands/templates/start-work.ts
+++ b/src/features/builtin-commands/templates/start-work.ts
@@ -1,13 +1,47 @@
-export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
+export function createStartWorkTemplate(options?: { worktreeEnabled?: boolean }): string {
+  const worktreeEnabled = options?.worktreeEnabled ?? true
 
-## ARGUMENTS
-
-- \`/start-work [plan-name] [--worktree <path>]\`
+  const argumentsSection = worktreeEnabled
+    ? `- \`/start-work [plan-name] [--worktree <path>]\`
   - \`plan-name\` (optional): name or partial match of the plan to start
   - \`--worktree <path>\` (optional): absolute path to an existing git worktree to work in
     - If specified and valid: hook pre-sets worktree_path in boulder.json
     - If specified but invalid: you must run \`git worktree add <path> <branch>\` first
-    - If omitted: you MUST choose or create a worktree (see Worktree Setup below)
+    - If omitted: you MUST choose or create a worktree (see Worktree Setup below)`
+    : `- \`/start-work [plan-name]\`
+  - \`plan-name\` (optional): name or partial match of the plan to start`
+
+  const worktreeSetupSection = worktreeEnabled
+    ? `
+4. **Worktree Setup** (when \`worktree_path\` not already set in boulder.json):
+   1. \`git worktree list --porcelain\` — see available worktrees
+   2. Create: \`git worktree add <absolute-path> <branch-or-HEAD>\`
+   3. Update boulder.json to add \`"worktree_path": "<absolute-path>"\`
+   4. All work happens inside that worktree directory
+`
+    : ``
+
+  const boulderJsonWorktreeLine = worktreeEnabled
+    ? `      "worktree_path": "/absolute/path/to/git/worktree"\n`
+    : ``
+
+  const resumingWorktreeLine = worktreeEnabled
+    ? `Worktree: {worktree_path}\n`
+    : ``
+
+  const startingWorktreeLine = worktreeEnabled
+    ? `Worktree: {worktree_path}\n`
+    : ``
+
+  const worktreeCritical = worktreeEnabled
+    ? `- Always set worktree_path in boulder.json before executing any tasks\n`
+    : ``
+
+  return `You are starting a Sisyphus work session.
+
+## ARGUMENTS
+
+${argumentsSection}
 
 ## WHAT TO DO
 
@@ -23,25 +57,18 @@ export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
      - List available plan files
      - If ONE plan: auto-select it
      - If MULTIPLE plans: show list with timestamps, ask user to select
-
-4. **Worktree Setup** (when \`worktree_path\` not already set in boulder.json):
-   1. \`git worktree list --porcelain\` — see available worktrees
-   2. Create: \`git worktree add <absolute-path> <branch-or-HEAD>\`
-   3. Update boulder.json to add \`"worktree_path": "<absolute-path>"\`
-   4. All work happens inside that worktree directory
-
-5. **Create/Update boulder.json**:
+${worktreeSetupSection}
+${worktreeEnabled ? "5" : "4"}. **Create/Update boulder.json**:
    \`\`\`json
    {
      "active_plan": "/absolute/path/to/plan.md",
      "started_at": "ISO_TIMESTAMP",
      "session_ids": ["session_id_1", "session_id_2"],
-     "plan_name": "plan-name",
-     "worktree_path": "/absolute/path/to/git/worktree"
+     "plan_name": "plan-name"${worktreeEnabled ? `,\n     "worktree_path": "/absolute/path/to/git/worktree"` : ""}
    }
    \`\`\`
 
-6. **Read the plan file** and start executing tasks according to atlas workflow
+${worktreeEnabled ? "6" : "5"}. **Read the plan file** and start executing tasks according to atlas workflow
 
 ## OUTPUT FORMAT
 
@@ -65,8 +92,7 @@ Resuming Work Session
 Active Plan: {plan-name}
 Progress: {completed}/{total} tasks
 Sessions: {count} (appending current session)
-Worktree: {worktree_path}
-
+${resumingWorktreeLine}
 Reading plan and continuing from last incomplete task...
 \`\`\`
 
@@ -77,8 +103,7 @@ Starting Work Session
 Plan: {plan-name}
 Session ID: {session_id}
 Started: {timestamp}
-Worktree: {worktree_path}
-
+${startingWorktreeLine}
 Reading plan and beginning execution...
 \`\`\`
 
@@ -86,6 +111,8 @@ Reading plan and beginning execution...
 
 - The session_id is injected by the hook - use it directly
 - Always update boulder.json BEFORE starting work
-- Always set worktree_path in boulder.json before executing any tasks
-- Read the FULL plan file before delegating any tasks
+${worktreeCritical}- Read the FULL plan file before delegating any tasks
 - Follow atlas delegation protocols (7-section format)`
+}
+
+export const START_WORK_TEMPLATE = createStartWorkTemplate()

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -102,6 +102,7 @@ export interface ExecutorOptions {
   skills?: LoadedSkill[]
   pluginsEnabled?: boolean
   enabledPluginsOverride?: Record<string, boolean>
+  startWorkConfig?: { worktree?: boolean }
 }
 
 function discoverPluginCommands(options?: ExecutorOptions): CommandInfo[] {
@@ -132,7 +133,7 @@ async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandIn
   const opencodeGlobalCommands = discoverCommandsFromDir(opencodeGlobalDir, "opencode")
   const projectCommands = discoverCommandsFromDir(projectCommandsDir, "project")
   const opencodeProjectCommands = discoverCommandsFromDir(opencodeProjectDir, "opencode-project")
-  const builtinCommandsMap = loadBuiltinCommands()
+  const builtinCommandsMap = loadBuiltinCommands(undefined, options?.startWorkConfig)
   const builtinCommands: CommandInfo[] = Object.values(builtinCommandsMap).map(cmd => ({
     name: cmd.name,
     metadata: {

--- a/src/hooks/auto-slash-command/hook.ts
+++ b/src/hooks/auto-slash-command/hook.ts
@@ -24,6 +24,7 @@ export interface AutoSlashCommandHookOptions {
   skills?: LoadedSkill[]
   pluginsEnabled?: boolean
   enabledPluginsOverride?: Record<string, boolean>
+  startWorkConfig?: { worktree?: boolean }
 }
 
 export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions) {
@@ -31,6 +32,7 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
     skills: options?.skills,
     pluginsEnabled: options?.pluginsEnabled,
     enabledPluginsOverride: options?.enabledPluginsOverride,
+    startWorkConfig: options?.startWorkConfig,
   }
 
   return {

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -555,6 +555,29 @@ describe("start-work hook", () => {
        expect(output.parts[0].text).toContain("subagent")
        expect(output.parts[0].text).not.toContain("Worktree Setup Required")
      })
+
+     test("should enable worktree by default when worktreeEnabled option is undefined (regression)", async () => {
+       // given - single plan, no worktreeEnabled option (undefined = default enabled), valid worktree flag
+       const plansDir = join(testDir, ".sisyphus", "plans")
+       mkdirSync(plansDir, { recursive: true })
+       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+       detectSpy.mockReturnValue("/valid/wt")
+
+       const hook = createStartWorkHook(createMockPluginInput())
+       const output = {
+         parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /valid/wt</user-request>\n</session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+       // then - worktree is enabled by default, so Worktree Active block is injected
+       expect(output.parts[0].text).toContain("Auto-Selected Plan")
+       expect(output.parts[0].text).toContain("Worktree Active")
+       expect(output.parts[0].text).toContain("/valid/wt")
+       const state = readBoulderState(testDir)
+       expect(state?.worktree_path).toBe("/valid/wt")
+     })
    })
 
    describe("worktree disabled by config", () => {
@@ -625,42 +648,23 @@ describe("start-work hook", () => {
        expect(output.parts[0].text).toContain("RESUMING")
      })
 
-     test("should NOT store worktree_path in boulder.json when worktreeEnabled is false", async () => {
-       // given - single plan, worktreeEnabled: false
-       const plansDir = join(testDir, ".sisyphus", "plans")
-       mkdirSync(plansDir, { recursive: true })
-       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+      test("should NOT store worktree_path in boulder.json when worktreeEnabled is false", async () => {
+        // given - single plan, worktreeEnabled: false
+        const plansDir = join(testDir, ".sisyphus", "plans")
+        mkdirSync(plansDir, { recursive: true })
+        writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
 
-       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
-       const output = {
-         parts: [{ type: "text", text: "<session-context></session-context>" }],
-       }
+        const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+        const output = {
+          parts: [{ type: "text", text: "<session-context></session-context>" }],
+        }
 
-       // when
-       await hook["chat.message"]({ sessionID: "session-123" }, output)
+        // when
+        await hook["chat.message"]({ sessionID: "session-123" }, output)
 
-       // then - boulder.json should not have worktree_path
-       const state = readBoulderState(testDir)
-       expect(state?.worktree_path).toBeUndefined()
-     })
-
-     test("should enable worktree by default when worktreeEnabled option is undefined (regression)", async () => {
-       // given - single plan, no worktreeEnabled option (undefined = default enabled)
-       const plansDir = join(testDir, ".sisyphus", "plans")
-       mkdirSync(plansDir, { recursive: true })
-       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
-
-       const hook = createStartWorkHook(createMockPluginInput())
-       const output = {
-         parts: [{ type: "text", text: "<session-context></session-context>" }],
-       }
-
-       // when
-       await hook["chat.message"]({ sessionID: "session-123" }, output)
-
-       // then - should behave like worktree is enabled (no worktree content because no flag, but system ready for it)
-       expect(output.parts[0].text).toContain("Auto-Selected Plan")
-       expect(output.parts[0].text).not.toContain("Worktree Active")
-     })
+        // then - boulder.json should not have worktree_path
+        const state = readBoulderState(testDir)
+        expect(state?.worktree_path).toBeUndefined()
+      })
    })
 })

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test"
+import { describe, expect, test, beforeEach, afterEach, spyOn, mock } from "bun:test"
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir, homedir } from "node:os"
@@ -20,8 +20,12 @@ describe("start-work hook", () => {
   function createMockPluginInput() {
     return {
       directory: testDir,
-      client: {},
-    } as Parameters<typeof createStartWorkHook>[0]
+      client: {
+        tui: {
+          showToast: mock(() => Promise.resolve()),
+        },
+      },
+    } as unknown as Parameters<typeof createStartWorkHook>[0]
   }
 
   beforeEach(() => {
@@ -611,25 +615,27 @@ describe("start-work hook", () => {
        expect(output.parts[0].text).toContain("Auto-Selected Plan")
      })
 
-     test("should NOT inject worktree when --worktree flag is passed but worktreeEnabled is false", async () => {
-       // given - single plan + --worktree flag, but worktreeEnabled: false
-       const plansDir = join(testDir, ".sisyphus", "plans")
-       mkdirSync(plansDir, { recursive: true })
-       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+      test("should INJECT worktree when --worktree flag overrides worktreeEnabled:false", async () => {
+        // given - single plan + --worktree flag with path, worktreeEnabled: false (flag should override)
+        const plansDir = join(testDir, ".sisyphus", "plans")
+        mkdirSync(plansDir, { recursive: true })
+        writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+        detectSpy.mockReturnValue("/some/path")
 
-       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
-       const output = {
-         parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/path</user-request>\n</session-context>" }],
-       }
+        const mockShowToast = (createMockPluginInput().client.tui.showToast as any) as ReturnType<typeof mock>
+        const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+        const output = {
+          parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/path</user-request>\n</session-context>" }],
+        }
 
-       // when
-       await hook["chat.message"]({ sessionID: "session-123" }, output)
+        // when
+        await hook["chat.message"]({ sessionID: "session-123" }, output)
 
-       // then - config overrides flag, no worktree content in injected context
-       expect(output.parts[0].text).not.toContain("Worktree Active")
-       expect(output.parts[0].text).not.toContain("CRITICAL — DO NOT FORGET")
-       expect(output.parts[0].text).not.toContain("git worktree add")
-     })
+        // then - flag overrides config, worktree content IS injected
+        expect(output.parts[0].text).toContain("Worktree Active")
+        expect(output.parts[0].text).toContain("CRITICAL — DO NOT FORGET")
+        expect(output.parts[0].text).toContain("/some/path")
+      })
 
      test("should NOT inject worktree content when resuming with existing worktree_path but worktreeEnabled is false", async () => {
        // given - existing boulder with worktree_path, but worktreeEnabled: false
@@ -658,24 +664,96 @@ describe("start-work hook", () => {
        expect(output.parts[0].text).toContain("RESUMING")
      })
 
-      test("should NOT store worktree_path in boulder.json when worktreeEnabled is false", async () => {
-        // given - single plan, worktreeEnabled: false, valid --worktree flag that would normally be stored
-        const plansDir = join(testDir, ".sisyphus", "plans")
-        mkdirSync(plansDir, { recursive: true })
-        writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
-        detectSpy.mockReturnValue("/some/valid/wt")
+       test("should STORE worktree_path in boulder.json when --worktree flag overrides worktreeEnabled:false", async () => {
+         // given - single plan, worktreeEnabled: false, valid --worktree flag (flag should override)
+         const plansDir = join(testDir, ".sisyphus", "plans")
+         mkdirSync(plansDir, { recursive: true })
+         writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+         detectSpy.mockReturnValue("/some/valid/wt")
 
-        const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
-        const output = {
-          parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/valid/wt</user-request>\n</session-context>" }],
-        }
+         const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+         const output = {
+           parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/valid/wt</user-request>\n</session-context>" }],
+         }
 
-        // when
-        await hook["chat.message"]({ sessionID: "session-123" }, output)
+         // when
+         await hook["chat.message"]({ sessionID: "session-123" }, output)
 
-        // then - boulder.json should not have worktree_path despite the flag being present and valid
-        const state = readBoulderState(testDir)
-        expect(state?.worktree_path).toBeUndefined()
-      })
-   })
+         // then - boulder.json SHOULD have worktree_path because flag overrides config
+         const state = readBoulderState(testDir)
+         expect(state?.worktree_path).toBe("/some/valid/wt")
+       })
+
+       test("should NOT override when --worktree flag has no path value and worktreeEnabled is false", async () => {
+         // given - single plan, --worktree flag without path value, worktreeEnabled: false
+         const plansDir = join(testDir, ".sisyphus", "plans")
+         mkdirSync(plansDir, { recursive: true })
+         writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+
+         const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+         const output = {
+           parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree</user-request>\n</session-context>" }],
+         }
+
+         // when
+         await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+         // then - no override (flag needs a path value), no worktree content
+         expect(output.parts[0].text).not.toContain("Worktree Active")
+         expect(output.parts[0].text).not.toContain("git worktree")
+         const state = readBoulderState(testDir)
+         expect(state?.worktree_path).toBeUndefined()
+       })
+
+       test("should show needs setup block when override active but path is invalid", async () => {
+         // given - single plan, --worktree flag with invalid path, worktreeEnabled: false
+         const plansDir = join(testDir, ".sisyphus", "plans")
+         mkdirSync(plansDir, { recursive: true })
+         writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+         detectSpy.mockReturnValue(null)
+
+         const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+         const output = {
+           parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /invalid/path</user-request>\n</session-context>" }],
+         }
+
+         // when
+         await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+         // then - needs setup block shown, worktree_path undefined
+         expect(output.parts[0].text).toContain("needs setup")
+         expect(output.parts[0].text).toContain("git worktree add /invalid/path")
+         const state = readBoulderState(testDir)
+         expect(state?.worktree_path).toBeUndefined()
+       })
+
+       test("should override and show worktree active when resuming with --worktree flag and worktreeEnabled is false", async () => {
+         // given - existing boulder state, --worktree flag with valid path, worktreeEnabled: false
+         const planPath = join(testDir, "plan.md")
+         writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+         const existingState: BoulderState = {
+           active_plan: planPath,
+           started_at: "2026-01-01T00:00:00Z",
+           session_ids: ["old-session"],
+           plan_name: "plan",
+         }
+         writeBoulderState(testDir, existingState)
+         detectSpy.mockReturnValue("/override/wt")
+
+         const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+         const output = {
+           parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /override/wt</user-request>\n</session-context>" }],
+         }
+
+         // when
+         await hook["chat.message"]({ sessionID: "session-456" }, output)
+
+         // then - override is active, worktree content shown, worktree_path stored
+         expect(output.parts[0].text).toContain("Worktree Active")
+         expect(output.parts[0].text).toContain("/override/wt")
+         expect(output.parts[0].text).toContain("RESUMING")
+         const state = readBoulderState(testDir)
+         expect(state?.worktree_path).toBe("/override/wt")
+       })
+    })
 })

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -12,7 +12,6 @@ import {
 import type { BoulderState } from "../../features/boulder-state"
 import * as sessionState from "../../features/claude-code-session-state"
 import * as worktreeDetector from "./worktree-detector"
-import * as worktreeDetector from "./worktree-detector"
 
 describe("start-work hook", () => {
   let testDir: string
@@ -529,32 +528,139 @@ describe("start-work hook", () => {
       expect(state?.session_ids).toContain("session-456")
     })
 
-    test("should show existing worktree on resume when no --worktree flag", async () => {
-      // given - existing boulder already has worktree_path, no flag given
-      const planPath = join(testDir, "plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-      const existingState: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-01T00:00:00Z",
-        session_ids: ["old-session"],
-        plan_name: "plan",
-        worktree_path: "/existing/wt",
-      }
-      writeBoulderState(testDir, existingState)
+     test("should show existing worktree on resume when no --worktree flag", async () => {
+       // given - existing boulder already has worktree_path, no flag given
+       const planPath = join(testDir, "plan.md")
+       writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+       const existingState: BoulderState = {
+         active_plan: planPath,
+         started_at: "2026-01-01T00:00:00Z",
+         session_ids: ["old-session"],
+         plan_name: "plan",
+         worktree_path: "/existing/wt",
+       }
+       writeBoulderState(testDir, existingState)
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+       const hook = createStartWorkHook(createMockPluginInput())
+       const output = {
+         parts: [{ type: "text", text: "<session-context></session-context>" }],
+       }
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-789" }, output)
+       // when
+       await hook["chat.message"]({ sessionID: "session-789" }, output)
 
-      // then - shows strong worktree active instructions
-      expect(output.parts[0].text).toContain("Worktree Active")
-      expect(output.parts[0].text).toContain("/existing/wt")
-      expect(output.parts[0].text).toContain("subagent")
-      expect(output.parts[0].text).not.toContain("Worktree Setup Required")
-    })
-  })
+       // then - shows strong worktree active instructions
+       expect(output.parts[0].text).toContain("Worktree Active")
+       expect(output.parts[0].text).toContain("/existing/wt")
+       expect(output.parts[0].text).toContain("subagent")
+       expect(output.parts[0].text).not.toContain("Worktree Setup Required")
+     })
+   })
+
+   describe("worktree disabled by config", () => {
+     test("should NOT inject worktree content when worktreeEnabled is false and single plan auto-selected", async () => {
+       // given - single incomplete plan, worktreeEnabled: false
+       const plansDir = join(testDir, ".sisyphus", "plans")
+       mkdirSync(plansDir, { recursive: true })
+       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+
+       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+       const output = {
+         parts: [{ type: "text", text: "<session-context></session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+       // then - no worktree content should appear
+       expect(output.parts[0].text).not.toContain("Worktree Active")
+       expect(output.parts[0].text).not.toContain("git worktree")
+       expect(output.parts[0].text).toContain("Auto-Selected Plan")
+     })
+
+     test("should NOT inject worktree when --worktree flag is passed but worktreeEnabled is false", async () => {
+       // given - single plan + --worktree flag, but worktreeEnabled: false
+       const plansDir = join(testDir, ".sisyphus", "plans")
+       mkdirSync(plansDir, { recursive: true })
+       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+
+       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+       const output = {
+         parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/path</user-request>\n</session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+       // then - config overrides flag, no worktree content in injected context
+       expect(output.parts[0].text).not.toContain("Worktree Active")
+       expect(output.parts[0].text).not.toContain("CRITICAL — DO NOT FORGET")
+       expect(output.parts[0].text).not.toContain("git worktree add")
+     })
+
+     test("should NOT inject worktree content when resuming with existing worktree_path but worktreeEnabled is false", async () => {
+       // given - existing boulder with worktree_path, but worktreeEnabled: false
+       const planPath = join(testDir, "plan.md")
+       writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+       const existingState: BoulderState = {
+         active_plan: planPath,
+         started_at: "2026-01-01T00:00:00Z",
+         session_ids: ["old-session"],
+         plan_name: "plan",
+         worktree_path: "/existing/wt",
+       }
+       writeBoulderState(testDir, existingState)
+
+       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+       const output = {
+         parts: [{ type: "text", text: "<session-context></session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-456" }, output)
+
+       // then - no worktree content despite existing worktree_path
+       expect(output.parts[0].text).not.toContain("Worktree Active")
+       expect(output.parts[0].text).not.toContain("/existing/wt")
+       expect(output.parts[0].text).toContain("RESUMING")
+     })
+
+     test("should NOT store worktree_path in boulder.json when worktreeEnabled is false", async () => {
+       // given - single plan, worktreeEnabled: false
+       const plansDir = join(testDir, ".sisyphus", "plans")
+       mkdirSync(plansDir, { recursive: true })
+       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+
+       const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
+       const output = {
+         parts: [{ type: "text", text: "<session-context></session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+       // then - boulder.json should not have worktree_path
+       const state = readBoulderState(testDir)
+       expect(state?.worktree_path).toBeUndefined()
+     })
+
+     test("should enable worktree by default when worktreeEnabled option is undefined (regression)", async () => {
+       // given - single plan, no worktreeEnabled option (undefined = default enabled)
+       const plansDir = join(testDir, ".sisyphus", "plans")
+       mkdirSync(plansDir, { recursive: true })
+       writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+
+       const hook = createStartWorkHook(createMockPluginInput())
+       const output = {
+         parts: [{ type: "text", text: "<session-context></session-context>" }],
+       }
+
+       // when
+       await hook["chat.message"]({ sessionID: "session-123" }, output)
+
+       // then - should behave like worktree is enabled (no worktree content because no flag, but system ready for it)
+       expect(output.parts[0].text).toContain("Auto-Selected Plan")
+       expect(output.parts[0].text).not.toContain("Worktree Active")
+     })
+   })
 })

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -581,6 +581,16 @@ describe("start-work hook", () => {
    })
 
    describe("worktree disabled by config", () => {
+     let detectSpy: ReturnType<typeof spyOn>
+
+     beforeEach(() => {
+       detectSpy = spyOn(worktreeDetector, "detectWorktreePath").mockReturnValue(null)
+     })
+
+     afterEach(() => {
+       detectSpy.mockRestore()
+     })
+
      test("should NOT inject worktree content when worktreeEnabled is false and single plan auto-selected", async () => {
        // given - single incomplete plan, worktreeEnabled: false
        const plansDir = join(testDir, ".sisyphus", "plans")
@@ -649,20 +659,21 @@ describe("start-work hook", () => {
      })
 
       test("should NOT store worktree_path in boulder.json when worktreeEnabled is false", async () => {
-        // given - single plan, worktreeEnabled: false
+        // given - single plan, worktreeEnabled: false, valid --worktree flag that would normally be stored
         const plansDir = join(testDir, ".sisyphus", "plans")
         mkdirSync(plansDir, { recursive: true })
         writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+        detectSpy.mockReturnValue("/some/valid/wt")
 
         const hook = createStartWorkHook(createMockPluginInput(), { worktreeEnabled: false })
         const output = {
-          parts: [{ type: "text", text: "<session-context></session-context>" }],
+          parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /some/valid/wt</user-request>\n</session-context>" }],
         }
 
         // when
         await hook["chat.message"]({ sessionID: "session-123" }, output)
 
-        // then - boulder.json should not have worktree_path
+        // then - boulder.json should not have worktree_path despite the flag being present and valid
         const state = readBoulderState(testDir)
         expect(state?.worktree_path).toBeUndefined()
       })

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -64,7 +64,7 @@ function resolveWorktreeContext(
   }
 }
 
-export function createStartWorkHook(ctx: PluginInput) {
+export function createStartWorkHook(ctx: PluginInput, options?: { worktreeEnabled?: boolean }) {
   return {
     "chat.message": async (input: StartWorkHookInput, output: StartWorkHookOutput): Promise<void> => {
       const parts = output.parts
@@ -85,7 +85,10 @@ export function createStartWorkHook(ctx: PluginInput) {
       const timestamp = new Date().toISOString()
 
       const { planName: explicitPlanName, explicitWorktreePath } = parseUserRequest(promptText)
-      const { worktreePath, block: worktreeBlock } = resolveWorktreeContext(explicitWorktreePath)
+      const worktreeDisabled = options?.worktreeEnabled === false
+      const { worktreePath, block: worktreeBlock } = worktreeDisabled
+        ? { worktreePath: undefined, block: "" }
+        : resolveWorktreeContext(explicitWorktreePath)
 
       let contextInfo = ""
 
@@ -106,7 +109,7 @@ The requested plan "${getPlanName(matchedPlan)}" has been completed.
 All ${progress.total} tasks are done. Create a new plan with: /plan "your task"`
           } else {
             if (existingState) clearBoulderState(ctx.directory)
-            const newState = createBoulderState(matchedPlan, sessionId, "atlas", worktreePath)
+            const newState = createBoulderState(matchedPlan, sessionId, "atlas", worktreeDisabled ? undefined : worktreePath)
             writeBoulderState(ctx.directory, newState)
 
             contextInfo = `
@@ -152,9 +155,9 @@ No incomplete plans available. Create a new plan with: /plan "your task"`
         const progress = getPlanProgress(existingState.active_plan)
 
         if (!progress.isComplete) {
-          const effectiveWorktree = worktreePath ?? existingState.worktree_path
+          const effectiveWorktree = worktreeDisabled ? undefined : (worktreePath ?? existingState.worktree_path)
 
-          if (worktreePath !== undefined) {
+          if (!worktreeDisabled && worktreePath !== undefined) {
             const updatedSessions = existingState.session_ids.includes(sessionId)
               ? existingState.session_ids
               : [...existingState.session_ids, sessionId]
@@ -213,7 +216,7 @@ All ${plans.length} plan(s) are complete. Create a new plan with: /plan "your ta
         } else if (incompletePlans.length === 1) {
           const planPath = incompletePlans[0]
           const progress = getPlanProgress(planPath)
-          const newState = createBoulderState(planPath, sessionId, "atlas", worktreePath)
+          const newState = createBoulderState(planPath, sessionId, "atlas", worktreeDisabled ? undefined : worktreePath)
           writeBoulderState(ctx.directory, newState)
 
           contextInfo += `

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -34,7 +34,10 @@ function findPlanByName(plans: string[], requestedName: string): string | null {
   return partialMatch || null
 }
 
-function createWorktreeActiveBlock(worktreePath: string): string {
+function createWorktreeActiveBlock(worktreePath: string, overrideActive?: boolean): string {
+  const overrideNote = overrideActive
+    ? "\n\n> ⚠️ Worktree was enabled via --worktree flag override (config has start_work.worktree=false)"
+    : ""
   return `
 ## Worktree Active
 
@@ -43,11 +46,12 @@ function createWorktreeActiveBlock(worktreePath: string): string {
 **CRITICAL — DO NOT FORGET**: You are working inside a git worktree. ALL operations MUST be performed exclusively within this worktree directory.
 - Every file read, write, edit, and git operation MUST target paths under: \`${worktreePath}\`
 - When delegating tasks to subagents, you MUST include the worktree path in your delegation prompt so they also operate exclusively within the worktree
-- NEVER operate on the main repository directory — always use the worktree path above`
+- NEVER operate on the main repository directory — always use the worktree path above${overrideNote}`
 }
 
 function resolveWorktreeContext(
   explicitWorktreePath: string | null,
+  overrideActive?: boolean,
 ): { worktreePath: string | undefined; block: string } {
   if (explicitWorktreePath === null) {
     return { worktreePath: undefined, block: "" }
@@ -55,7 +59,7 @@ function resolveWorktreeContext(
 
   const validatedPath = detectWorktreePath(explicitWorktreePath)
   if (validatedPath) {
-    return { worktreePath: validatedPath, block: createWorktreeActiveBlock(validatedPath) }
+    return { worktreePath: validatedPath, block: createWorktreeActiveBlock(validatedPath, overrideActive) }
   }
 
   return {
@@ -86,9 +90,24 @@ export function createStartWorkHook(ctx: PluginInput, options?: { worktreeEnable
 
       const { planName: explicitPlanName, explicitWorktreePath } = parseUserRequest(promptText)
       const worktreeDisabled = options?.worktreeEnabled === false
-      const { worktreePath, block: worktreeBlock } = worktreeDisabled
+      const worktreeOverrideActive = worktreeDisabled && explicitWorktreePath !== null
+      const effectiveWorktreeDisabled = worktreeDisabled && !worktreeOverrideActive
+
+      if (worktreeOverrideActive) {
+        ctx.client.tui.showToast({
+          body: {
+            title: "Worktree Override Active",
+            message: "--worktree flag is overriding start_work.worktree=false config. Worktree enabled for this session.",
+            variant: "warning",
+            duration: 8000,
+          },
+        }).catch(() => {}) // Non-fatal
+        log(`[${HOOK_NAME}] Worktree override active - flag overriding config`, { sessionID: input.sessionID })
+      }
+
+      const { worktreePath, block: worktreeBlock } = effectiveWorktreeDisabled
         ? { worktreePath: undefined, block: "" }
-        : resolveWorktreeContext(explicitWorktreePath)
+        : resolveWorktreeContext(explicitWorktreePath, worktreeOverrideActive)
 
       let contextInfo = ""
 
@@ -107,9 +126,9 @@ export function createStartWorkHook(ctx: PluginInput, options?: { worktreeEnable
 
 The requested plan "${getPlanName(matchedPlan)}" has been completed.
 All ${progress.total} tasks are done. Create a new plan with: /plan "your task"`
-          } else {
-            if (existingState) clearBoulderState(ctx.directory)
-            const newState = createBoulderState(matchedPlan, sessionId, "atlas", worktreeDisabled ? undefined : worktreePath)
+           } else {
+             if (existingState) clearBoulderState(ctx.directory)
+             const newState = createBoulderState(matchedPlan, sessionId, "atlas", effectiveWorktreeDisabled ? undefined : worktreePath)
             writeBoulderState(ctx.directory, newState)
 
             contextInfo = `
@@ -154,10 +173,10 @@ No incomplete plans available. Create a new plan with: /plan "your task"`
       } else if (existingState) {
         const progress = getPlanProgress(existingState.active_plan)
 
-        if (!progress.isComplete) {
-          const effectiveWorktree = worktreeDisabled ? undefined : (worktreePath ?? existingState.worktree_path)
+         if (!progress.isComplete) {
+           const effectiveWorktree = effectiveWorktreeDisabled ? undefined : (worktreePath ?? existingState.worktree_path)
 
-          if (!worktreeDisabled && worktreePath !== undefined) {
+           if (!effectiveWorktreeDisabled && worktreePath !== undefined) {
             const updatedSessions = existingState.session_ids.includes(sessionId)
               ? existingState.session_ids
               : [...existingState.session_ids, sessionId]
@@ -170,7 +189,7 @@ No incomplete plans available. Create a new plan with: /plan "your task"`
             appendSessionId(ctx.directory, sessionId)
           }
 
-          const worktreeDisplay = effectiveWorktree ? createWorktreeActiveBlock(effectiveWorktree) : worktreeBlock
+          const worktreeDisplay = effectiveWorktree ? createWorktreeActiveBlock(effectiveWorktree, worktreeOverrideActive) : worktreeBlock
 
           contextInfo = `
 ## Active Work Session Found
@@ -213,10 +232,10 @@ Use Prometheus to create a work plan first: /plan "your task"`
 ## All Plans Complete
 
 All ${plans.length} plan(s) are complete. Create a new plan with: /plan "your task"`
-        } else if (incompletePlans.length === 1) {
-          const planPath = incompletePlans[0]
-          const progress = getPlanProgress(planPath)
-          const newState = createBoulderState(planPath, sessionId, "atlas", worktreeDisabled ? undefined : worktreePath)
+         } else if (incompletePlans.length === 1) {
+           const planPath = incompletePlans[0]
+           const progress = getPlanProgress(planPath)
+           const newState = createBoulderState(planPath, sessionId, "atlas", effectiveWorktreeDisabled ? undefined : worktreePath)
           writeBoulderState(ctx.directory, newState)
 
           contextInfo += `

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -23,7 +23,10 @@ export async function applyCommandConfig(params: {
   ctx: { directory: string };
   pluginComponents: PluginComponents;
 }): Promise<void> {
-  const builtinCommands = loadBuiltinCommands(params.pluginConfig.disabled_commands);
+  const builtinCommands = loadBuiltinCommands(
+    params.pluginConfig.disabled_commands,
+    params.pluginConfig.start_work
+  );
   const systemCommands = (params.config.command as Record<string, unknown>) ?? {};
 
   const includeClaudeCommands = params.pluginConfig.claude_code?.commands ?? true;

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -216,7 +216,7 @@ export function createSessionHooks(args: {
     : null
 
   const startWork = isHookEnabled("start-work")
-    ? safeHook("start-work", () => createStartWorkHook(ctx))
+    ? safeHook("start-work", () => createStartWorkHook(ctx, { worktreeEnabled: pluginConfig.start_work?.worktree }))
     : null
 
   const prometheusMdOnly = isHookEnabled("prometheus-md-only")

--- a/src/plugin/hooks/create-skill-hooks.ts
+++ b/src/plugin/hooks/create-skill-hooks.ts
@@ -42,6 +42,7 @@ export function createSkillHooks(args: {
           skills: mergedSkills,
           pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
           enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
+          startWorkConfig: pluginConfig.start_work,
         }))
     : null
 

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -105,6 +105,7 @@ export function createToolRegistry(args: {
   const commands = discoverCommandsSync(ctx.directory, {
     pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
+    startWorkConfig: pluginConfig.start_work,
   })
   const skillTool = createSkillTool({
     commands,
@@ -112,6 +113,7 @@ export function createToolRegistry(args: {
     mcpManager: managers.skillMcpManager,
     getSessionID: getSessionIDForMcp,
     gitMasterConfig: pluginConfig.git_master,
+    startWorkConfig: pluginConfig.start_work,
   })
 
   const taskSystemEnabled = pluginConfig.experimental?.task_system ?? false

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -199,6 +199,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     cachedCommands = discoverCommandsSync(undefined, {
       pluginsEnabled: options.pluginsEnabled,
       enabledPluginsOverride: options.enabledPluginsOverride,
+      startWorkConfig: options.startWorkConfig,
     })
     return cachedCommands
   }

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -37,4 +37,6 @@ export interface SkillLoadOptions {
   pluginsEnabled?: boolean
   /** Override plugin enablement from Claude settings by plugin key */
   enabledPluginsOverride?: Record<string, boolean>
+  /** start-work command configuration, controls worktree instructions in /start-work template */
+  startWorkConfig?: { worktree?: boolean }
 }

--- a/src/tools/slashcommand/command-discovery.ts
+++ b/src/tools/slashcommand/command-discovery.ts
@@ -15,6 +15,7 @@ import type { CommandInfo, CommandMetadata, CommandScope } from "./types"
 export interface CommandDiscoveryOptions {
   pluginsEnabled?: boolean
   enabledPluginsOverride?: Record<string, boolean>
+  startWorkConfig?: { worktree?: boolean }
 }
 
 function discoverCommandsFromDir(commandsDir: string, scope: CommandScope): CommandInfo[] {
@@ -91,7 +92,7 @@ export function discoverCommandsSync(
   const opencodeProjectCommands = discoverCommandsFromDir(opencodeProjectDir, "opencode-project")
   const pluginCommands = discoverPluginCommands(options)
 
-  const builtinCommandsMap = loadBuiltinCommands()
+  const builtinCommandsMap = loadBuiltinCommands(undefined, options?.startWorkConfig)
   const builtinCommands: CommandInfo[] = Object.values(builtinCommandsMap).map((command) => ({
     name: command.name,
     metadata: {


### PR DESCRIPTION
## Summary

Adds `start_work.worktree` config option to disable worktree enforcement in the `/start-work` command, allowing users to opt-out of worktrees entirely.

Closes #2494

## Changes

- **Schema**: Add `worktree: z.boolean().default(true)` to `StartWorkConfigSchema`
- **Template**: Convert `START_WORK_TEMPLATE` to `createStartWorkTemplate(options?)` function with conditional worktree sections
- **Hook**: Modify `createStartWorkHook()` to accept `options?: { worktreeEnabled?: boolean }` and skip worktree logic when disabled
- **Commands**: Wire config through `loadBuiltinCommands()` and `applyCommandConfig()`
- **Tests**: Add 5 test cases for worktree-disabled scenarios

## Usage

Set in your `.opencode/oh-my-opencode.jsonc`:

```jsonc
{
  "start_work": {
    "worktree": false
  }
}
```

When disabled:
- No "Worktree Setup" section in `/start-work` template
- No `worktree_path` stored in boulder.json
- `--worktree` flag is silently ignored (config takes precedence)

## Test Plan

- [x] `bun test src/config/schema/start-work.test.ts` - 6 tests pass
- [x] `bun test src/hooks/start-work/` - 39 tests pass
- [x] `bun test src/features/builtin-commands/` - 1 test passes
- [x] `bun run typecheck` - No errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `start_work.worktree` config to disable worktree enforcement in `/start-work`; when off, worktree UI/state are omitted. The `--worktree` flag can now override the config to enable worktree for a session with a toast and an override note, and the setting is honored across slash commands, the skill tool, and command discovery.

- **New Features**
  - Add `worktree: boolean` (default `true`) to `StartWorkConfigSchema` and `assets/oh-my-opencode.schema.json`.
  - Replace static template with `createStartWorkTemplate({ worktreeEnabled })` and use it in `loadBuiltinCommands()` so `/start-work` conditionally shows worktree steps.
  - Update `createStartWorkHook(ctx, { worktreeEnabled })` to skip worktree logic and storage when disabled, and let `--worktree <path>` explicitly re-enable it (shows a toast and adds an override note in the context).
  - Add tests for worktree-disabled flows, default-enabled regression, and override behavior (valid, missing value, and invalid path cases).

- **Bug Fixes**
  - Thread `startWorkConfig` through `createSkillHooks` → `createAutoSlashCommandHook`/executor, `discoverCommandsSync()` (`CommandDiscoveryOptions`), `tool-registry`, and the skill tool so the `/start-work` template and behavior honor `start_work.worktree` in all invocation paths.

<sup>Written for commit d8315a765905cac43874c3ffd3ff22c94f31f5b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

