### PR TITLE
fix(non-interactive-env): use platform-aware shell detection on Windows

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix, detectShellType } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,9 +52,9 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so always use unix export syntax.
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
+      // Use platform-aware shell detection: Git Bash/WSL on Windows uses unix syntax,
+      // PowerShell uses $env: syntax, and cmd.exe uses SET syntax.
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, detectShellType())
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.


### PR DESCRIPTION
## Summary

Closes #2344

Replaces the hardcoded `"unix"` shell type in the non-interactive-env hook with `detectShellType()` from the shared shell-env module.

Previously, the hook always prepended `export VAR=val;` syntax, which fails in cmd.exe and PowerShell on Windows. Now it uses the existing platform detection logic:

| Environment | Shell Type | Syntax |
|---|---|---|
| Linux/macOS | `unix` | `export CI=true ...;` |
| Windows + Git Bash/WSL | `unix` | `export CI=true ...;` |
| Windows + PowerShell | `powershell` | `$env:CI='true'; ...` |
| Windows + cmd.exe | `cmd` | `set CI="true" && ...` |

## Changes

- **`src/hooks/non-interactive-env/non-interactive-env-hook.ts`** — Import `detectShellType` and use it instead of hardcoded `"unix"`

## Backward Compatibility

No behavior change on Unix/macOS/Linux or Windows with Git Bash/WSL (all resolve to `"unix"` shell type). Only Windows users running OpenCode in native cmd.exe or PowerShell see the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix non-interactive env variable injection on Windows by using platform-aware shell detection. Replaces the hardcoded `unix` shell with `detectShellType()` so PowerShell and cmd use `$env:` and `set` syntax; Unix/macOS and Git Bash/WSL remain unchanged.

<sup>Written for commit f879fa1a900aec9902a74b7797a1047b8bfddac4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

