### PR TITLE
fix(delegate-task): only check resolved model for isUnstableAgent, not category default

### DIFF
--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -178,9 +178,8 @@ Available categories: ${categoryNames.join(", ")}`,
     }
   }
 
-  const unstableModel = actualModel?.toLowerCase()
-  const categoryConfigModel = resolved.config.model?.toLowerCase()
-  const isUnstableAgent = resolved.config.is_unstable_agent === true || [unstableModel, categoryConfigModel].some(m => m ? m.includes("gemini") || m.includes("minimax") || m.includes("kimi") : false)
+  const resolvedModel = actualModel?.toLowerCase()
+  const isUnstableAgent = resolved.config.is_unstable_agent === true || (resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") || resolvedModel.includes("kimi") : false)
 
   const defaultProviderID = categoryModel?.providerID
     ?? parseModelString(actualModel ?? "")?.providerID


### PR DESCRIPTION
## Summary

Closes #2287

The `isUnstableAgent` check in `category-resolver.ts` was checking **both** the resolved model (`actualModel`) and the category's default model (`resolved.config.model`). This meant that even when a user overrides `visual-engineering` or `writing` to use a stable model like `anthropic/claude-sonnet-4-6`, the default model name (`google/gemini-3.1-pro` or `kimi-for-coding/k2p5`) still triggered `isUnstableAgent = true`.

This routed tasks through `executeUnstableAgentTask()` instead of the stable execution path, causing a race condition where `manager.getTask(task.id)` returns `undefined` after the task completes before the polling loop catches it, resulting in "Task not found" errors.

## Changes

- **`src/tools/delegate-task/category-resolver.ts`** — Only check the resolved/actual model for unstable agent detection, not the category's hardcoded default model

## Before

```typescript
const unstableModel = actualModel?.toLowerCase()
const categoryConfigModel = resolved.config.model?.toLowerCase()
const isUnstableAgent = resolved.config.is_unstable_agent === true 
  || [unstableModel, categoryConfigModel].some(m => ...)
```

## After

```typescript
const resolvedModel = actualModel?.toLowerCase()
const isUnstableAgent = resolved.config.is_unstable_agent === true 
  || (resolvedModel ? resolvedModel.includes("gemini") || ... : false)
```

## Impact

| Category | Default Model | User Override | Before | After |
|---|---|---|---|---|
| visual-engineering | gemini-3.1-pro | claude-sonnet-4-6 | isUnstable=true (CRASH) | isUnstable=false (OK) |
| writing | kimi-k2p5 | claude-sonnet-4-6 | isUnstable=true (CRASH) | isUnstable=false (OK) |
| visual-engineering | gemini-3.1-pro | (none) | isUnstable=true | isUnstable=true (unchanged) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unstable-agent detection to consider only the resolved model, so stable overrides use the stable execution path. Resolves #2287 by removing misroutes that caused intermittent "Task not found" errors.

- **Bug Fixes**
  - Updated `src/tools/delegate-task/category-resolver.ts` to check only the resolved model in `isUnstableAgent`, not the category default.
  - Behavior is unchanged when no override is provided and the category’s default model is unstable.

<sup>Written for commit eb79d29696fb34a99bc800fda2ab5a5003b28b60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

