### PR TITLE
feat(fallback): add github-copilot as provider for GPT-5.3-Codex fallback chains

### DIFF
--- a/src/cli/model-fallback-requirements.ts
+++ b/src/cli/model-fallback-requirements.ts
@@ -21,12 +21,12 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   hephaestus: {
     fallbackChain: [
       {
-        providers: ["openai", "opencode"],
+        providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.3-codex",
         variant: "medium",
       },
     ],
-    requiresProvider: ["openai", "opencode"],
+    requiresProvider: ["openai", "github-copilot", "opencode"],
   },
   oracle: {
     fallbackChain: [
@@ -175,7 +175,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
     ultrabrain: {
       fallbackChain: [
         {
-          providers: ["openai", "opencode"],
+          providers: ["openai", "github-copilot", "opencode"],
           model: "gpt-5.3-codex",
           variant: "xhigh",
         },
@@ -194,7 +194,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
     deep: {
       fallbackChain: [
         {
-          providers: ["openai", "opencode"],
+          providers: ["openai", "github-copilot", "opencode"],
           model: "gpt-5.3-codex",
           variant: "medium",
         },
@@ -250,7 +250,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
           model: "claude-sonnet-4-5",
         },
         {
-          providers: ["openai", "opencode"],
+          providers: ["openai", "github-copilot", "opencode"],
           model: "gpt-5.3-codex",
           variant: "medium",
         },

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -41,7 +41,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   hephaestus: {
     fallbackChain: [
       {
-        providers: ["openai", "venice", "opencode"],
+        providers: ["openai", "github-copilot", "venice", "opencode"],
         model: "gpt-5.3-codex",
         variant: "medium",
       },
@@ -204,7 +204,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   ultrabrain: {
     fallbackChain: [
       {
-        providers: ["openai", "opencode"],
+        providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
         variant: "xhigh",
       },
@@ -223,7 +223,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   deep: {
     fallbackChain: [
       {
-        providers: ["openai", "opencode"],
+        providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.3-codex",
         variant: "medium",
       },
@@ -276,7 +276,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "claude-sonnet-4-6",
       },
       {
-        providers: ["openai", "opencode"],
+        providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.3-codex",
         variant: "medium",
       },


### PR DESCRIPTION
## Summary

Closes #2435

Adds `github-copilot` as a provider option for `gpt-5.3-codex` in fallback chains across both CLI and runtime model requirements. Previously, GPT-5.3-Codex was only available through `openai` and `opencode` providers, even though it's now available on GitHub Copilot.

## Changes

- **`src/cli/model-fallback-requirements.ts`** — Added `github-copilot` to gpt-5.3-codex provider lists for: hephaestus, ultrabrain, deep, unspecified-low categories
- **`src/shared/model-requirements.ts`** — Added `github-copilot` to gpt-5.3-codex provider lists for: hephaestus, ultrabrain, deep, unspecified-low categories (runtime)

## Impact

Users with only a GitHub Copilot subscription can now use GPT-5.3-Codex for:
- Hephaestus agent (primary model)
- Ultrabrain category tasks
- Deep category tasks
- Unspecified-low category tasks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `github-copilot` as a provider in GPT-5.3-Codex fallback chains across the CLI and runtime. This lets Copilot-only users run Hephaestus, Ultrabrain, Deep, and Unspecified-low tasks.

- **New Features**
  - CLI (`src/cli/model-fallback-requirements.ts`): Added `github-copilot` to `gpt-5.3-codex` provider lists for `hephaestus`, `ultrabrain`, `deep`, and `unspecified-low`; updated `requiresProvider` for `hephaestus`.
  - Runtime (`src/shared/model-requirements.ts`): Added `github-copilot` to fallback provider lists for `hephaestus`, `ultrabrain`, `deep`, and `unspecified-low`.

<sup>Written for commit ba469a0d066e4eb2ed0b80e1d717a3f9afe2d689. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

