### PR TITLE
fix(agents): always resolve fallback model for subagents to prevent run --agent crash

### DIFF
--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -75,7 +75,7 @@ export function collectPendingBuiltinAgents(input: {
       availableModels,
       systemDefaultModel,
     })
-    if (!resolution && isFirstRunNoCache && !override?.model) {
+    if (!resolution && !override?.model) {
       resolution = getFirstFallbackModel(requirement)
     }
     if (!resolution) continue


### PR DESCRIPTION
## Summary

Fixes `oh-my-opencode run --agent Librarian` crashing with `undefined is not an object (evaluating 'agent.model')`.

## Root Cause

In `collectPendingBuiltinAgents()`, when model resolution fails for an agent, the code only tries `getFirstFallbackModel()` on first run when model cache is empty (`isFirstRunNoCache` guard). On subsequent runs with cache present, if the preferred model isn't in the cache, subagent-only agents like Librarian are silently skipped from registration. When a user then runs `--agent Librarian`, the agent config is `undefined`, causing the crash.

## Fix

Remove the `isFirstRunNoCache` guard so `getFirstFallbackModel()` is always tried when model resolution fails. This ensures subagent agents are always registered with at least their first fallback chain entry, regardless of cache state.

## Files Changed

- `src/agents/builtin-agents/general-agents.ts` — Remove `isFirstRunNoCache` condition from fallback model resolution

Closes #2427

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always resolve a fallback model when model selection fails to prevent `oh-my-opencode run --agent Librarian` from crashing. Removes the `isFirstRunNoCache` guard in `collectPendingBuiltinAgents()` so `getFirstFallbackModel()` is always attempted when no model is resolved.

<sup>Written for commit e98154a5fb10e8e738ed03db9ef1142a934243c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

