### PR TITLE
feat(compaction): make preemptive compaction threshold configurable

### DIFF
--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -4,7 +4,13 @@ import { DynamicContextPruningConfigSchema } from "./dynamic-context-pruning"
 export const ExperimentalConfigSchema = z.object({
   aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
-  preemptive_compaction: z.boolean().optional(),
+  preemptive_compaction: z.union([
+    z.boolean(),
+    z.object({
+      /** Context usage ratio (0-1) at which preemptive compaction triggers (default: 0.78) */
+      threshold: z.number().min(0).max(1).optional(),
+    }),
+  ]).optional(),
   /** Truncate all tool outputs, not just whitelisted tools (default: false). Tool output truncator is enabled by default - disable via disabled_hooks. */
   truncate_all_tool_outputs: z.boolean().optional(),
   /** Dynamic context pruning configuration */

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -8,7 +8,7 @@ import {
 import { resolveCompactionModel } from "./shared/compaction-model-resolver"
 const PREEMPTIVE_COMPACTION_TIMEOUT_MS = 120_000
 
-const PREEMPTIVE_COMPACTION_THRESHOLD = 0.78
+const DEFAULT_COMPACTION_THRESHOLD = 0.78
 
 interface TokenInfo {
   input: number
@@ -59,11 +59,20 @@ type PluginInput = {
   directory: string
 }
 
+function resolveCompactionThreshold(pluginConfig: OhMyOpenCodeConfig): number {
+  const setting = pluginConfig.experimental?.preemptive_compaction
+  if (typeof setting === "object" && setting !== null && setting.threshold !== undefined) {
+    return setting.threshold
+  }
+  return DEFAULT_COMPACTION_THRESHOLD
+}
+
 export function createPreemptiveCompactionHook(
   ctx: PluginInput,
   pluginConfig: OhMyOpenCodeConfig,
   modelCacheState?: ContextLimitModelCacheState,
 ) {
+  const threshold = resolveCompactionThreshold(pluginConfig)
   const compactionInProgress = new Set<string>()
   const compactedSessions = new Set<string>()
   const tokenCache = new Map<string, CachedCompactionState>()
@@ -96,7 +105,7 @@ export function createPreemptiveCompactionHook(
     const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
     const usageRatio = totalInputTokens / actualLimit
 
-    if (usageRatio < PREEMPTIVE_COMPACTION_THRESHOLD) return
+    if (usageRatio < threshold) return
 
     const modelID = cached.modelID
     if (!modelID) return


### PR DESCRIPTION
## Summary

Makes the preemptive compaction threshold configurable instead of hardcoded at 0.78, allowing users to trigger compaction at custom context usage percentages.

## Changes

- **`src/config/schema/experimental.ts`** — Expand `preemptive_compaction` from `boolean` to `boolean | { threshold: number }` union type. The threshold accepts a 0-1 range value.
- **`src/hooks/preemptive-compaction.ts`** — Add `resolveCompactionThreshold()` helper that reads the config and falls back to default (0.78). Rename constant to `DEFAULT_COMPACTION_THRESHOLD` and use the resolved value.

## Usage

```jsonc
// Before: only boolean toggle
{ "experimental": { "preemptive_compaction": true } }

// After: also supports custom threshold
{ "experimental": { "preemptive_compaction": { "threshold": 0.55 } } }
```

Both forms are fully backward-compatible. `true` continues to use the 0.78 default.

Closes #2326

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the preemptive compaction threshold configurable so teams can trigger compaction at custom context usage ratios. Default remains 0.78 for backward compatibility.

- **New Features**
  - `experimental.preemptive_compaction` now accepts `boolean` or `{ threshold: number }` (0–1).

<sup>Written for commit d745a43b0cb9f3f1dd8dfcf9bd7837c7f29ba2f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

