### PR TITLE
fix(session-manager): match todo filenames exactly

### DIFF
--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -168,6 +168,26 @@ describe("session-manager storage", () => {
     expect(todos).toEqual([])
   })
 
+  test("readSessionTodos only reads the exact session todo file", async () => {
+    // given
+    writeFileSync(
+      join(TEST_TODO_DIR, "ses_1.json"),
+      JSON.stringify([{ id: "todo_exact", content: "Exact match", status: "pending" }]),
+    )
+    writeFileSync(
+      join(TEST_TODO_DIR, "ses_10.json"),
+      JSON.stringify([{ id: "todo_collision", content: "Wrong session", status: "completed" }]),
+    )
+
+    // when
+    const todos = await readSessionTodos("ses_1")
+
+    // then
+    expect(todos).toHaveLength(1)
+    expect(todos[0].id).toBe("todo_exact")
+    expect(todos[0].content).toBe("Exact match")
+  })
+
   test("getSessionInfo returns null for non-existent session", async () => {
     // when
     const info = await getSessionInfo("ses_nonexistent")

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -277,7 +277,7 @@ export async function readSessionTodos(sessionID: string): Promise<TodoItem[]> {
 
   try {
     const allFiles = await readdir(TODO_DIR)
-    const todoFiles = allFiles.filter((f) => f.includes(sessionID) && f.endsWith(".json"))
+    const todoFiles = allFiles.filter((f) => f === `${sessionID}.json`)
 
     for (const file of todoFiles) {
       try {


### PR DESCRIPTION
## Summary

- require an exact `sessionID.json` match when loading stable-mode todo files so `ses_1` no longer accidentally reads `ses_10.json`
- add a focused storage regression proving only the exact session todo file is loaded
- keep the patch isolated to the session-manager storage path without touching the SQLite/beta codepath

## Validation

- `npx -y bun@1.3.10 install --ignore-scripts`
- `npx -y bun@1.3.10 test src/tools/session-manager/storage.test.ts`
- `npx -y bun@1.3.10 run typecheck`

## Notes

- this PR is independent of the stale publish-workflow guard candidate in `.github/workflows/publish.yml`; that can be a separate follow-up if still needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an exact `sessionID.json` match when reading session todos in the stable JSON storage path to prevent collisions (e.g., `ses_1` no longer reads `ses_10.json`). Add a focused regression test to ensure only the exact session file is loaded; SQLite/beta codepath unchanged.

<sup>Written for commit edfa411684ef9e73f74e3c3025f6989c6271fb76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

