### PR TITLE
fix(delegate-task): report the real background task id

### DIFF
--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -102,7 +102,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     //#then - output and metadata should include canonical session linkage
     expectFn(result).toContain("<task_metadata>")
     expectFn(result).toContain("session_id: ses_sub_123")
-    expectFn(result).toContain("task_id: ses_sub_123")
+    expectFn(result).toContain("task_id: bg_resolved")
     expectFn(result).toContain("background_task_id: bg_resolved")
     expectFn(result).toContain("Background Task ID: bg_resolved")
     expectFn(metadataCalls).toHaveLength(1)
@@ -150,7 +150,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
     //#then - late session id still propagates to task metadata contract
     expectFn(result).toContain("session_id: ses_late_123")
-    expectFn(result).toContain("task_id: ses_late_123")
+    expectFn(result).toContain("task_id: bg_late")
     expectFn(result).toContain("background_task_id: bg_late")
     expectFn(metadataCalls).toHaveLength(1)
     expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_late_123")

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -82,7 +82,7 @@ export async function executeBackgroundTask(
     }
 
     const taskMetadataBlock = sessionId
-      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\ntask_id: ${sessionId}\nbackground_task_id: ${task.id}\n</task_metadata>`
+      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\ntask_id: ${task.id}\nbackground_task_id: ${task.id}\n</task_metadata>`
       : ""
 
     return `Background task launched.


### PR DESCRIPTION
## Summary

- emit the actual background task id in `<task_metadata>` instead of repeating the subagent session id under `task_id`
- keep `background_output(task_id=...)` aligned with the metadata block that background task producers return
- update the direct delegate-task compatibility tests to assert the corrected contract for resolved and late-resolved sessions

## Validation

- `npx -y bun@1.3.10 test src/tools/delegate-task/background-task.test.ts src/tools/delegate-task/tools.test.ts`
- `npx -y bun@1.3.10 run typecheck`

## Notes

- this PR stays fully outside the open session-manager storage fix (`#2524`); it only touches delegate-task background metadata formatting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delegate-task metadata to emit the actual background task ID instead of the session ID. Keeps `<task_metadata>` aligned with the `background_output(task_id=...)` contract so callers pass the correct ID.

- **Bug Fixes**
  - Set `task_id` in `<task_metadata>` to the background task ID; `session_id` remains unchanged.
  - Ensure `task_id` and `background_task_id` both reflect the launched task.
  - Updated tests for resolved and late-resolved sessions to assert the corrected contract.

<sup>Written for commit 1e0823a0fc577abc383d82434da5efcd7104076d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

