### PR TITLE
fix(tool-config): parse question permission from JSONC

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -129,6 +129,27 @@ describe("applyToolConfig", () => {
           expect(agent.permission.question).toBe("deny")
         },
       )
+
+      it.each(["sisyphus", "hephaestus", "prometheus"])(
+        "#then should parse JSONC config content for %s",
+        (agentName) => {
+          process.env.OPENCODE_CONFIG_CONTENT = `{
+            // allow comments in config content
+            "permission": {
+              "question": "deny"
+            }
+          }`
+          delete process.env.OPENCODE_CLI_RUN_MODE
+          const params = createParams({ agents: [agentName] })
+
+          applyToolConfig(params)
+
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.question).toBe("deny")
+        },
+      )
     })
 
     describe("#when config does not deny question permission", () => {

--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -7,6 +7,7 @@ function createParams(overrides: {
   taskSystem?: boolean
   agents?: string[]
   disabledTools?: string[]
+  questionPermission?: string
 }) {
   const agentResult: Record<string, { permission?: Record<string, unknown> }> = {}
   for (const agent of overrides.agents ?? []) {
@@ -14,7 +15,12 @@ function createParams(overrides: {
   }
 
   return {
-    config: { tools: {}, permission: {} } as Record<string, unknown>,
+    config: {
+      tools: {},
+      permission: overrides.questionPermission
+        ? { question: overrides.questionPermission }
+        : {},
+    } as Record<string, unknown>,
     pluginConfig: {
       experimental: overrides.taskSystem === undefined ? undefined : { task_system: overrides.taskSystem },
       disabled_tools: overrides.disabledTools,
@@ -89,21 +95,14 @@ describe("applyToolConfig", () => {
     })
   })
 
-  describe("#given OPENCODE_CONFIG_CONTENT has question set to deny", () => {
-    let originalConfigContent: string | undefined
+  describe("#given config.permission.question is available", () => {
     let originalCliRunMode: string | undefined
 
     beforeEach(() => {
-      originalConfigContent = process.env.OPENCODE_CONFIG_CONTENT
       originalCliRunMode = process.env.OPENCODE_CLI_RUN_MODE
     })
 
     afterEach(() => {
-      if (originalConfigContent === undefined) {
-        delete process.env.OPENCODE_CONFIG_CONTENT
-      } else {
-        process.env.OPENCODE_CONFIG_CONTENT = originalConfigContent
-      }
       if (originalCliRunMode === undefined) {
         delete process.env.OPENCODE_CLI_RUN_MODE
       } else {
@@ -115,11 +114,11 @@ describe("applyToolConfig", () => {
       it.each(["sisyphus", "hephaestus", "prometheus"])(
         "#then should deny question for %s even without CLI_RUN_MODE",
         (agentName) => {
-          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
-            permission: { question: "deny" },
+          delete process.env.OPENCODE_CLI_RUN_MODE
+          const params = createParams({
+            agents: [agentName],
+            questionPermission: "deny",
           })
-          delete process.env.OPENCODE_CLI_RUN_MODE
-          const params = createParams({ agents: [agentName] })
 
           applyToolConfig(params)
 
@@ -130,37 +129,17 @@ describe("applyToolConfig", () => {
         },
       )
 
-      it.each(["sisyphus", "hephaestus", "prometheus"])(
-        "#then should parse JSONC config content for %s",
-        (agentName) => {
-          process.env.OPENCODE_CONFIG_CONTENT = `{
-            // allow comments in config content
-            "permission": {
-              "question": "deny"
-            }
-          }`
-          delete process.env.OPENCODE_CLI_RUN_MODE
-          const params = createParams({ agents: [agentName] })
-
-          applyToolConfig(params)
-
-          const agent = params.agentResult[agentName] as {
-            permission: Record<string, unknown>
-          }
-          expect(agent.permission.question).toBe("deny")
-        },
-      )
     })
 
     describe("#when config does not deny question permission", () => {
       it.each(["sisyphus", "hephaestus", "prometheus"])(
         "#then should allow question for %s in interactive mode",
         (agentName) => {
-          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
-            permission: { question: "allow" },
+          const params = createParams({
+            agents: [agentName],
+            questionPermission: "allow",
           })
           delete process.env.OPENCODE_CLI_RUN_MODE
-          const params = createParams({ agents: [agentName] })
 
           applyToolConfig(params)
 
@@ -176,9 +155,6 @@ describe("applyToolConfig", () => {
       it.each(["sisyphus", "hephaestus", "prometheus"])(
         "#then should deny question for %s via CLI_RUN_MODE",
         (agentName) => {
-          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
-            permission: {},
-          })
           process.env.OPENCODE_CLI_RUN_MODE = "true"
           const params = createParams({ agents: [agentName] })
 
@@ -196,11 +172,11 @@ describe("applyToolConfig", () => {
       it.each(["sisyphus", "hephaestus", "prometheus"])(
         "#then should deny question for %s when config says deny regardless of CLI_RUN_MODE",
         (agentName) => {
-          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
-            permission: { question: "deny" },
-          })
           process.env.OPENCODE_CLI_RUN_MODE = "false"
-          const params = createParams({ agents: [agentName] })
+          const params = createParams({
+            agents: [agentName],
+            questionPermission: "deny",
+          })
 
           applyToolConfig(params)
 

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
+import { parse } from "jsonc-parser";
 import { getAgentDisplayName } from "../shared/agent-display-names";
 import { isTaskSystemEnabled } from "../shared";
 
@@ -8,7 +9,7 @@ function getConfigQuestionPermission(): string | null {
   const configContent = process.env.OPENCODE_CONFIG_CONTENT;
   if (!configContent) return null;
   try {
-    const parsed = JSON.parse(configContent);
+    const parsed = parse(configContent);
     return parsed?.permission?.question ?? null;
   } catch {
     return null;

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,19 +1,14 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { parse } from "jsonc-parser";
 import { getAgentDisplayName } from "../shared/agent-display-names";
 import { isTaskSystemEnabled } from "../shared";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
-function getConfigQuestionPermission(): string | null {
-  const configContent = process.env.OPENCODE_CONFIG_CONTENT;
-  if (!configContent) return null;
-  try {
-    const parsed = parse(configContent);
-    return parsed?.permission?.question ?? null;
-  } catch {
-    return null;
-  }
+function getConfigQuestionPermission(config: Record<string, unknown>): string | null {
+  const permission = config.permission;
+  if (!permission || typeof permission !== "object") return null;
+  const question = (permission as Record<string, unknown>).question;
+  return typeof question === "string" ? question : null;
 }
 
 function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
@@ -52,8 +47,8 @@ export function applyToolConfig(params: {
   };
 
   const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
-  const configQuestionPermission = getConfigQuestionPermission();
   const isQuestionDisabledByPlugin = params.pluginConfig.disabled_tools?.includes("question") ?? false;
+  const configQuestionPermission = getConfigQuestionPermission(params.config);
   const questionPermission =
     isQuestionDisabledByPlugin ? "deny" :
     configQuestionPermission === "deny" ? "deny" :


### PR DESCRIPTION
## Summary

- parse `OPENCODE_CONFIG_CONTENT` with `jsonc-parser` instead of `JSON.parse`
- keep `permission.question` overrides working when the config content includes JSONC comments
- add a focused regression in `tool-config-handler.test.ts` that proves JSONC comments no longer break the deny path

## Validation

- `npx -y bun@1.3.10 test src/plugin-handlers/tool-config-handler.test.ts`
- `npx -y bun@1.3.10 run typecheck`

## Notes

- this PR is independent from the open `session-manager` and background-task metadata PRs in the same repo; it only touches the plugin handler that maps question permissions into agent tool policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the resolved `params.config` to determine `question` tool permission and plugin-level disables. This removes reliance on `OPENCODE_CONFIG_CONTENT` and keeps overrides working even when the config has JSONC comments.

- **Bug Fixes**
  - Read `permission.question` from `params.config` (stop parsing `OPENCODE_CONFIG_CONTENT`) and honor `pluginConfig.disabled_tools` (deny `question` when listed).
  - Default `experimental.task_system` to true; deny `todowrite`/`todoread` by default.
  - When `permission.skill` is `deny`, disable `skill` and `skill_mcp` tools.
  - Prefer display names when mapping agents, improving permission application.

<sup>Written for commit 882cabd19324f1c94fe242bdf894e3a85ae10c5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

