### PR TITLE
fix(ralph-loop): add semantic completion detection fallback for ulw-loop

### DIFF
--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -50,7 +50,9 @@ export function detectCompletionInTranscript(
 				const entry = JSON.parse(line) as { type?: string; timestamp?: string }
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
-				lastAssistantLine = line
+				if (entry.type === "assistant") {
+					lastAssistantLine = line
+				}
 				if (pattern.test(line)) return true
 			} catch {
 				continue

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -2,11 +2,24 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import { existsSync, readFileSync } from "node:fs"
 import { log } from "../../shared/logger"
 import { HOOK_NAME } from "./constants"
+import { detectSemanticCompletion } from "./semantic-completion-detector"
 import { withTimeout } from "./with-timeout"
 
 interface OpenCodeSessionMessage {
 	info?: { role?: string }
 	parts?: Array<{ type: string; text?: string }>
+}
+
+function getAssistantMessageText(message: OpenCodeSessionMessage): string {
+	if (!message.parts) return ""
+
+	let responseText = ""
+	for (const part of message.parts) {
+		if (part.type !== "text") continue
+		responseText += `${responseText ? "\n" : ""}${part.text ?? ""}`
+	}
+
+	return responseText
 }
 
 function escapeRegex(str: string): string {
@@ -29,18 +42,30 @@ export function detectCompletionInTranscript(
 
 		const content = readFileSync(transcriptPath, "utf-8")
 		const pattern = buildPromisePattern(promise)
-		const lines = content.split("\n").filter((line) => line.trim())
+		const lines = content.split("\n").filter((line: string) => line.trim())
+		let lastAssistantLine: string | undefined
 
 		for (const line of lines) {
 			try {
 				const entry = JSON.parse(line) as { type?: string; timestamp?: string }
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
+				lastAssistantLine = line
 				if (pattern.test(line)) return true
 			} catch {
 				continue
 			}
 		}
+
+		const semanticSignal = detectSemanticCompletion(lastAssistantLine ?? "")
+		if (semanticSignal) {
+			log(`[${HOOK_NAME}] Semantic completion detected in transcript`, {
+				signal: semanticSignal,
+				transcriptPath,
+			})
+			return true
+		}
+
 		return false
 	} catch {
 		return false
@@ -89,17 +114,21 @@ export async function detectCompletionInSessionMessages(
 		const pattern = buildPromisePattern(options.promise)
 		for (let index = assistantMessages.length - 1; index >= 0; index -= 1) {
 			const assistant = assistantMessages[index]
-			if (!assistant.parts) continue
-
-			let responseText = ""
-			for (const part of assistant.parts) {
-				if (part.type !== "text") continue
-				responseText += `${responseText ? "\n" : ""}${part.text ?? ""}`
-			}
+			const responseText = getAssistantMessageText(assistant)
 
 			if (pattern.test(responseText)) {
 				return true
 			}
+		}
+
+		const latestAssistantMessage = assistantMessages[assistantMessages.length - 1]
+		const semanticSignal = detectSemanticCompletion(getAssistantMessageText(latestAssistantMessage))
+		if (semanticSignal) {
+			log(`[${HOOK_NAME}] Semantic completion detected in session messages`, {
+				sessionID: options.sessionID,
+				signal: semanticSignal,
+			})
+			return true
 		}
 
 		return false

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -51,7 +51,8 @@ export function detectCompletionInTranscript(
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
 				if (entry.type === "assistant") {
-					lastAssistantLine = line
+					const parsed = entry as { type?: string; text?: string; content?: string }
+					lastAssistantLine = parsed.text ?? parsed.content ?? ""
 				}
 				if (pattern.test(line)) return true
 			} catch {

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -16,10 +16,21 @@ const COMPLETION_PHRASES = [
 	"no remaining tasks",
 ] as const
 
+const NEGATION_PREFIXES = ["not ", "n't ", "no ", "never ", "hardly ", "barely "]
+
+const PHRASE_PATTERNS = COMPLETION_PHRASES.map(
+	(phrase) => ({ phrase, pattern: new RegExp(`\\b${phrase.replace(/\s+/g, "\\s+")}\\b`, "i") })
+)
+
+function isNegated(text: string, matchIndex: number): boolean {
+	const prefix = text.slice(Math.max(0, matchIndex - 12), matchIndex).toLowerCase()
+	return NEGATION_PREFIXES.some((neg) => prefix.endsWith(neg))
+}
+
 export function detectSemanticCompletion(text: string): string | undefined {
-	const normalizedText = text.toLowerCase()
-	for (const phrase of COMPLETION_PHRASES) {
-		if (normalizedText.includes(phrase)) {
+	for (const { phrase, pattern } of PHRASE_PATTERNS) {
+		const match = pattern.exec(text)
+		if (match && !isNegated(text, match.index)) {
 			return phrase
 		}
 	}

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -1,0 +1,27 @@
+const COMPLETION_PHRASES = [
+	"task is complete",
+	"task completed",
+	"all done",
+	"i have finished",
+	"work is done",
+	"nothing left to do",
+	"all requirements met",
+	"all tasks completed",
+	"all items completed",
+	"implementation complete",
+	"successfully completed",
+	"everything is done",
+	"have completed all",
+	"finished all tasks",
+	"no remaining tasks",
+] as const
+
+export function detectSemanticCompletion(text: string): string | undefined {
+	const normalizedText = text.toLowerCase()
+	for (const phrase of COMPLETION_PHRASES) {
+		if (normalizedText.includes(phrase)) {
+			return phrase
+		}
+	}
+	return undefined
+}

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -23,8 +23,8 @@ const PHRASE_PATTERNS = COMPLETION_PHRASES.map(
 )
 
 function isNegated(text: string, matchIndex: number): boolean {
-	const prefix = text.slice(Math.max(0, matchIndex - 12), matchIndex).toLowerCase()
-	return NEGATION_PREFIXES.some((neg) => prefix.endsWith(neg))
+	const prefix = text.slice(Math.max(0, matchIndex - 40), matchIndex).toLowerCase()
+	return NEGATION_PREFIXES.some((neg) => prefix.includes(neg))
 }
 
 export function detectSemanticCompletion(text: string): string | undefined {


### PR DESCRIPTION
## Summary

Fixes #2489 — ulw-loop sometimes doesn't stop even when the agent's task is already completed, because the agent uses natural language (e.g., "task completed", "all done", "implementation complete") instead of the required `<promise>DONE</promise>` format.

## Changes

### New: `semantic-completion-detector.ts`
- Phrase-based semantic fallback that detects 15 common completion expressions in assistant messages
- Returns the matched phrase for logging, or `undefined` if no match

### Modified: `completion-promise-detector.ts`
- After the strict regex `<promise>DONE</promise>` check fails, both detection paths (`detectCompletionInTranscript` and `detectCompletionInSessionMessages`) now call `detectSemanticCompletion()` on the last assistant message as a fallback
- Extracted `getAssistantMessageText()` helper to reduce duplication
- All semantic detections are logged with the matched signal for debugging

## How it works

```
1. Try strict regex: /<promise>\s*DONE\s*<\/promise>/is
2. If no match → try semantic fallback on last assistant message
3. If semantic match found → log signal + return true (stop loop)
4. If neither matches → continue loop as before
```

## Why this matters

Without this fix, when an agent completes work but uses natural language instead of the formal promise tag, the loop continues indefinitely — wasting tokens, especially dangerous for overnight/unattended tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2489 by adding a semantic completion fallback so `ulw-loop` stops when the agent says “all done” instead of emitting <promise>DONE</promise>, with stricter negation and content filtering to avoid false positives.

- **Bug Fixes**
  - Added `semantic-completion-detector.ts` with word-boundary regexes, a widened negation window (40 chars), and guards to detect 15 common “done” phrases and return the matched signal for logs.
  - Updated `completion-promise-detector.ts` to apply the fallback only to the latest assistant text: extract text content from messages/transcript (ignoring tool outputs and input fields), then log the signal and stop the loop.

<sup>Written for commit 822de50e27df26e25e3ac9b3744ed29f5613f4d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

