### PR TITLE
Refactor Hephaestus todo-discipline prompt sections

### DIFF
--- a/src/agents/hephaestus/gpt-5-3-codex.ts
+++ b/src/agents/hephaestus/gpt-5-3-codex.ts
@@ -21,75 +21,8 @@ import {
   buildAntiDuplicationSection,
   categorizeTools,
 } from "../dynamic-agent-prompt-builder";
+import { buildHephaestusTodoDisciplineSection } from "./todo-discipline";
 const MODE: AgentMode = "all";
-
-function buildTodoDisciplineSection(useTaskSystem: boolean): string {
-  if (useTaskSystem) {
-    return `## Task Discipline (NON-NEGOTIABLE)
-
-**Track ALL multi-step work with tasks. This is your execution backbone.**
-
-### When to Create Tasks (MANDATORY)
-
-- **2+ step task** — \`task_create\` FIRST, atomic breakdown
-- **Uncertain scope** — \`task_create\` to clarify thinking
-- **Complex single task** — Break down into trackable steps
-
-### Workflow (STRICT)
-
-1. **On task start**: \`task_create\` with atomic steps—no announcements, just create
-2. **Before each step**: \`task_update(status=\"in_progress\")\` (ONE at a time)
-3. **After each step**: \`task_update(status=\"completed\")\` IMMEDIATELY (NEVER batch)
-4. **Scope changes**: Update tasks BEFORE proceeding
-
-### Why This Matters
-
-- **Execution anchor**: Tasks prevent drift from original request
-- **Recovery**: If interrupted, tasks enable seamless continuation
-- **Accountability**: Each task = explicit commitment to deliver
-
-### Anti-Patterns (BLOCKING)
-
-- **Skipping tasks on multi-step work** — Steps get forgotten, user has no visibility
-- **Batch-completing multiple tasks** — Defeats real-time tracking purpose
-- **Proceeding without \`in_progress\`** — No indication of current work
-- **Finishing without completing tasks** — Task appears incomplete
-
-**NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-  }
-
-  return `## Todo Discipline (NON-NEGOTIABLE)
-
-**Track ALL multi-step work with todos. This is your execution backbone.**
-
-### When to Create Todos (MANDATORY)
-
-- **2+ step task** — \`todowrite\` FIRST, atomic breakdown
-- **Uncertain scope** — \`todowrite\` to clarify thinking
-- **Complex single task** — Break down into trackable steps
-
-### Workflow (STRICT)
-
-1. **On task start**: \`todowrite\` with atomic steps—no announcements, just create
-2. **Before each step**: Mark \`in_progress\` (ONE at a time)
-3. **After each step**: Mark \`completed\` IMMEDIATELY (NEVER batch)
-4. **Scope changes**: Update todos BEFORE proceeding
-
-### Why This Matters
-
-- **Execution anchor**: Todos prevent drift from original request
-- **Recovery**: If interrupted, todos enable seamless continuation
-- **Accountability**: Each todo = explicit commitment to deliver
-
-### Anti-Patterns (BLOCKING)
-
-- **Skipping todos on multi-step work** — Steps get forgotten, user has no visibility
-- **Batch-completing multiple todos** — Defeats real-time tracking purpose
-- **Proceeding without \`in_progress\`** — No indication of current work
-- **Finishing without completing todos** — Task appears incomplete
-
-**NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-}
 
 /**
  * Hephaestus - The Autonomous Deep Worker
@@ -128,7 +61,10 @@ export function buildHephaestusPrompt(
   const oracleSection = buildOracleSection(availableAgents);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
-  const todoDiscipline = buildTodoDisciplineSection(useTaskSystem);
+  const todoDiscipline = buildHephaestusTodoDisciplineSection(
+    "gpt-5-3-codex",
+    useTaskSystem,
+  );
   const toolCallFormat = buildToolCallFormatSection();
   return `You are Hephaestus, an autonomous deep worker for software engineering.
 

--- a/src/agents/hephaestus/gpt-5-4.ts
+++ b/src/agents/hephaestus/gpt-5-4.ts
@@ -18,52 +18,7 @@ import {
   buildAntiPatternsSection,
   buildAntiDuplicationSection,
 } from "../dynamic-agent-prompt-builder";
-
-function buildTodoDisciplineSection(useTaskSystem: boolean): string {
-  if (useTaskSystem) {
-    return `## Task Discipline (NON-NEGOTIABLE)
-
-Track ALL multi-step work with tasks. This is your execution backbone.
-
-### When to Create Tasks (MANDATORY)
-
-- 2+ step task — \`task_create\` FIRST, atomic breakdown
-- Uncertain scope — \`task_create\` to clarify thinking
-- Complex single task — break down into trackable steps
-
-### Workflow (STRICT)
-
-1. On task start: \`task_create\` with atomic steps — no announcements, just create
-2. Before each step: \`task_update(status="in_progress")\` (ONE at a time)
-3. After each step: \`task_update(status="completed")\` IMMEDIATELY (NEVER batch)
-4. Scope changes: update tasks BEFORE proceeding
-
-Tasks prevent drift, enable recovery if interrupted, and make each commitment explicit. Skipping tasks on multi-step work, batch-completing, or proceeding without \`in_progress\` are blocking violations.
-
-**NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-  }
-
-  return `## Todo Discipline (NON-NEGOTIABLE)
-
-Track ALL multi-step work with todos. This is your execution backbone.
-
-### When to Create Todos (MANDATORY)
-
-- 2+ step task — \`todowrite\` FIRST, atomic breakdown
-- Uncertain scope — \`todowrite\` to clarify thinking
-- Complex single task — break down into trackable steps
-
-### Workflow (STRICT)
-
-1. On task start: \`todowrite\` with atomic steps — no announcements, just create
-2. Before each step: mark \`in_progress\` (ONE at a time)
-3. After each step: mark \`completed\` IMMEDIATELY (NEVER batch)
-4. Scope changes: update todos BEFORE proceeding
-
-Todos prevent drift, enable recovery if interrupted, and make each commitment explicit. Skipping todos on multi-step work, batch-completing, or proceeding without \`in_progress\` are blocking violations.
-
-**NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-}
+import { buildHephaestusTodoDisciplineSection } from "./todo-discipline";
 
 export function buildHephaestusPrompt(
   availableAgents: AvailableAgent[] = [],
@@ -88,7 +43,10 @@ export function buildHephaestusPrompt(
   const oracleSection = buildOracleSection(availableAgents);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
-  const todoDiscipline = buildTodoDisciplineSection(useTaskSystem);
+  const todoDiscipline = buildHephaestusTodoDisciplineSection(
+    "gpt-5-4",
+    useTaskSystem,
+  );
 
   return `You are Hephaestus, an autonomous deep worker for software engineering.
 

--- a/src/agents/hephaestus/gpt.ts
+++ b/src/agents/hephaestus/gpt.ts
@@ -18,48 +18,7 @@ import {
   buildAntiPatternsSection,
   buildAntiDuplicationSection,
 } from "../dynamic-agent-prompt-builder";
-
-function buildTodoDisciplineSection(useTaskSystem: boolean): string {
-  if (useTaskSystem) {
-    return `## Task Discipline (NON-NEGOTIABLE)
-
-**Track ALL multi-step work with tasks. This is your execution backbone.**
-
-### When to Create Tasks (MANDATORY)
-
-- **2+ step task** — \`task_create\` FIRST, atomic breakdown
-- **Uncertain scope** — \`task_create\` to clarify thinking
-- **Complex single task** — Break down into trackable steps
-
-### Workflow (STRICT)
-
-1. **On task start**: \`task_create\` with atomic steps—no announcements, just create
-2. **Before each step**: \`task_update(status="in_progress")\` (ONE at a time)
-3. **After each step**: \`task_update(status="completed")\` IMMEDIATELY (NEVER batch)
-4. **Scope changes**: Update tasks BEFORE proceeding
-
-**NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-  }
-
-  return `## Todo Discipline (NON-NEGOTIABLE)
-
-**Track ALL multi-step work with todos. This is your execution backbone.**
-
-### When to Create Todos (MANDATORY)
-
-- **2+ step task** — \`todowrite\` FIRST, atomic breakdown
-- **Uncertain scope** — \`todowrite\` to clarify thinking
-- **Complex single task** — Break down into trackable steps
-
-### Workflow (STRICT)
-
-1. **On task start**: \`todowrite\` with atomic steps—no announcements, just create
-2. **Before each step**: Mark \`in_progress\` (ONE at a time)
-3. **After each step**: Mark \`completed\` IMMEDIATELY (NEVER batch)
-4. **Scope changes**: Update todos BEFORE proceeding
-
-**NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
-}
+import { buildHephaestusTodoDisciplineSection } from "./todo-discipline";
 
 export function buildHephaestusPrompt(
   availableAgents: AvailableAgent[] = [],
@@ -84,7 +43,10 @@ export function buildHephaestusPrompt(
   const oracleSection = buildOracleSection(availableAgents);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
-  const todoDiscipline = buildTodoDisciplineSection(useTaskSystem);
+  const todoDiscipline = buildHephaestusTodoDisciplineSection(
+    "gpt",
+    useTaskSystem,
+  );
 
   return `You are Hephaestus, an autonomous deep worker for software engineering.
 

--- a/src/agents/hephaestus/todo-discipline.test.ts
+++ b/src/agents/hephaestus/todo-discipline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { buildHephaestusTodoDisciplineSection } from "./todo-discipline"
+
+describe("buildHephaestusTodoDisciplineSection", () => {
+  test("#given gpt variant in todo mode #when building section #then preserves the legacy todo copy", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt", false)
+
+    expect(section).toContain("## Todo Discipline (NON-NEGOTIABLE)")
+    expect(section).toContain("**Track ALL multi-step work with todos. This is your execution backbone.**")
+    expect(section).toContain("1. **On task start**: `todowrite` with atomic steps—no announcements, just create")
+    expect(section).toContain("**NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**")
+  })
+
+  test("#given gpt variant in task mode #when building section #then preserves the legacy task copy", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt", true)
+
+    expect(section).toContain("## Task Discipline (NON-NEGOTIABLE)")
+    expect(section).toContain("**Track ALL multi-step work with tasks. This is your execution backbone.**")
+    expect(section).toContain("2. **Before each step**: `task_update(status=\"in_progress\")` (ONE at a time)")
+    expect(section).toContain("**NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**")
+  })
+
+  test("#given gpt-5-4 variant in todo mode #when building section #then keeps the variant-specific enforcement text", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt-5-4", false)
+
+    expect(section).toContain("Track ALL multi-step work with todos. This is your execution backbone.")
+    expect(section).toContain("2. Before each step: mark `in_progress` (ONE at a time)")
+    expect(section).toContain("Todos prevent drift, enable recovery if interrupted, and make each commitment explicit.")
+  })
+
+  test("#given gpt-5-4 variant in task mode #when building section #then keeps the variant-specific task wording", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt-5-4", true)
+
+    expect(section).toContain("Track ALL multi-step work with tasks. This is your execution backbone.")
+    expect(section).toContain("1. On task start: `task_create` with atomic steps — no announcements, just create")
+    expect(section).toContain("Skipping tasks on multi-step work, batch-completing, or proceeding without `in_progress` are blocking violations.")
+  })
+
+  test("#given gpt-5-3-codex variant in todo mode #when building section #then preserves the why-this-matters block", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt-5-3-codex", false)
+
+    expect(section).toContain("### Why This Matters")
+    expect(section).toContain("- **Execution anchor**: Todos prevent drift from original request")
+    expect(section).toContain("- **Finishing without completing todos** — Task appears incomplete")
+  })
+
+  test("#given gpt-5-3-codex variant in task mode #when building section #then preserves the escaped task-update examples", () => {
+    const section = buildHephaestusTodoDisciplineSection("gpt-5-3-codex", true)
+
+    expect(section).toContain("2. **Before each step**: `task_update(status=\\\"in_progress\\\")` (ONE at a time)")
+    expect(section).toContain("3. **After each step**: `task_update(status=\\\"completed\\\")` IMMEDIATELY (NEVER batch)")
+    expect(section).toContain("- **Batch-completing multiple tasks** — Defeats real-time tracking purpose")
+  })
+})

--- a/src/agents/hephaestus/todo-discipline.ts
+++ b/src/agents/hephaestus/todo-discipline.ts
@@ -1,0 +1,223 @@
+type HephaestusTodoDisciplineVariant = "gpt" | "gpt-5-4" | "gpt-5-3-codex"
+
+interface TodoDisciplineCopy {
+  trackLine: string
+  createBullets: [string, string, string]
+  workflowLines: [string, string, string, string]
+  detailBlock?: string[]
+}
+
+function buildSection(
+  heading: string,
+  nounPlural: "tasks" | "todos",
+  createHeading: string,
+  copy: TodoDisciplineCopy,
+): string {
+  const lines = [
+    `## ${heading}`,
+    "",
+    copy.trackLine,
+    "",
+    `### ${createHeading}`,
+    "",
+    ...copy.createBullets,
+    "",
+    "### Workflow (STRICT)",
+    "",
+    ...copy.workflowLines,
+  ]
+
+  if (copy.detailBlock && copy.detailBlock.length > 0) {
+    lines.push("", ...copy.detailBlock)
+  }
+
+  lines.push("", `**NO ${nounPlural.toUpperCase()} ON MULTI-STEP WORK = INCOMPLETE WORK.**`)
+
+  return lines.join("\n")
+}
+
+function getTodoDisciplineCopy(
+  variant: HephaestusTodoDisciplineVariant,
+  useTaskSystem: boolean,
+): {
+  heading: string
+  nounPlural: "tasks" | "todos"
+  createHeading: string
+  copy: TodoDisciplineCopy
+} {
+  if (variant === "gpt-5-4") {
+    if (useTaskSystem) {
+      return {
+        heading: "Task Discipline (NON-NEGOTIABLE)",
+        nounPlural: "tasks",
+        createHeading: "When to Create Tasks (MANDATORY)",
+        copy: {
+          trackLine: "Track ALL multi-step work with tasks. This is your execution backbone.",
+          createBullets: [
+            "- 2+ step task — `task_create` FIRST, atomic breakdown",
+            "- Uncertain scope — `task_create` to clarify thinking",
+            "- Complex single task — break down into trackable steps",
+          ],
+          workflowLines: [
+            "1. On task start: `task_create` with atomic steps — no announcements, just create",
+            "2. Before each step: `task_update(status=\"in_progress\")` (ONE at a time)",
+            "3. After each step: `task_update(status=\"completed\")` IMMEDIATELY (NEVER batch)",
+            "4. Scope changes: update tasks BEFORE proceeding",
+          ],
+          detailBlock: [
+            "Tasks prevent drift, enable recovery if interrupted, and make each commitment explicit. Skipping tasks on multi-step work, batch-completing, or proceeding without `in_progress` are blocking violations.",
+          ],
+        },
+      }
+    }
+
+    return {
+      heading: "Todo Discipline (NON-NEGOTIABLE)",
+      nounPlural: "todos",
+      createHeading: "When to Create Todos (MANDATORY)",
+      copy: {
+        trackLine: "Track ALL multi-step work with todos. This is your execution backbone.",
+        createBullets: [
+          "- 2+ step task — `todowrite` FIRST, atomic breakdown",
+          "- Uncertain scope — `todowrite` to clarify thinking",
+          "- Complex single task — break down into trackable steps",
+        ],
+        workflowLines: [
+          "1. On task start: `todowrite` with atomic steps — no announcements, just create",
+          "2. Before each step: mark `in_progress` (ONE at a time)",
+          "3. After each step: mark `completed` IMMEDIATELY (NEVER batch)",
+          "4. Scope changes: update todos BEFORE proceeding",
+        ],
+        detailBlock: [
+          "Todos prevent drift, enable recovery if interrupted, and make each commitment explicit. Skipping todos on multi-step work, batch-completing, or proceeding without `in_progress` are blocking violations.",
+        ],
+      },
+    }
+  }
+
+  if (variant === "gpt-5-3-codex") {
+    if (useTaskSystem) {
+      return {
+        heading: "Task Discipline (NON-NEGOTIABLE)",
+        nounPlural: "tasks",
+        createHeading: "When to Create Tasks (MANDATORY)",
+        copy: {
+          trackLine: "**Track ALL multi-step work with tasks. This is your execution backbone.**",
+          createBullets: [
+            "- **2+ step task** — `task_create` FIRST, atomic breakdown",
+            "- **Uncertain scope** — `task_create` to clarify thinking",
+            "- **Complex single task** — Break down into trackable steps",
+          ],
+          workflowLines: [
+            "1. **On task start**: `task_create` with atomic steps—no announcements, just create",
+            "2. **Before each step**: `task_update(status=\\\"in_progress\\\")` (ONE at a time)",
+            "3. **After each step**: `task_update(status=\\\"completed\\\")` IMMEDIATELY (NEVER batch)",
+            "4. **Scope changes**: Update tasks BEFORE proceeding",
+          ],
+          detailBlock: [
+            "### Why This Matters",
+            "",
+            "- **Execution anchor**: Tasks prevent drift from original request",
+            "- **Recovery**: If interrupted, tasks enable seamless continuation",
+            "- **Accountability**: Each task = explicit commitment to deliver",
+            "",
+            "### Anti-Patterns (BLOCKING)",
+            "",
+            "- **Skipping tasks on multi-step work** — Steps get forgotten, user has no visibility",
+            "- **Batch-completing multiple tasks** — Defeats real-time tracking purpose",
+            "- **Proceeding without `in_progress`** — No indication of current work",
+            "- **Finishing without completing tasks** — Task appears incomplete",
+          ],
+        },
+      }
+    }
+
+    return {
+      heading: "Todo Discipline (NON-NEGOTIABLE)",
+      nounPlural: "todos",
+      createHeading: "When to Create Todos (MANDATORY)",
+      copy: {
+        trackLine: "**Track ALL multi-step work with todos. This is your execution backbone.**",
+        createBullets: [
+          "- **2+ step task** — `todowrite` FIRST, atomic breakdown",
+          "- **Uncertain scope** — `todowrite` to clarify thinking",
+          "- **Complex single task** — Break down into trackable steps",
+        ],
+        workflowLines: [
+          "1. **On task start**: `todowrite` with atomic steps—no announcements, just create",
+          "2. **Before each step**: Mark `in_progress` (ONE at a time)",
+          "3. **After each step**: Mark `completed` IMMEDIATELY (NEVER batch)",
+          "4. **Scope changes**: Update todos BEFORE proceeding",
+        ],
+        detailBlock: [
+          "### Why This Matters",
+          "",
+          "- **Execution anchor**: Todos prevent drift from original request",
+          "- **Recovery**: If interrupted, todos enable seamless continuation",
+          "- **Accountability**: Each todo = explicit commitment to deliver",
+          "",
+          "### Anti-Patterns (BLOCKING)",
+          "",
+          "- **Skipping todos on multi-step work** — Steps get forgotten, user has no visibility",
+          "- **Batch-completing multiple todos** — Defeats real-time tracking purpose",
+          "- **Proceeding without `in_progress`** — No indication of current work",
+          "- **Finishing without completing todos** — Task appears incomplete",
+        ],
+      },
+    }
+  }
+
+  if (useTaskSystem) {
+    return {
+      heading: "Task Discipline (NON-NEGOTIABLE)",
+      nounPlural: "tasks",
+      createHeading: "When to Create Tasks (MANDATORY)",
+      copy: {
+        trackLine: "**Track ALL multi-step work with tasks. This is your execution backbone.**",
+        createBullets: [
+          "- **2+ step task** — `task_create` FIRST, atomic breakdown",
+          "- **Uncertain scope** — `task_create` to clarify thinking",
+          "- **Complex single task** — Break down into trackable steps",
+        ],
+        workflowLines: [
+          "1. **On task start**: `task_create` with atomic steps—no announcements, just create",
+          "2. **Before each step**: `task_update(status=\"in_progress\")` (ONE at a time)",
+          "3. **After each step**: `task_update(status=\"completed\")` IMMEDIATELY (NEVER batch)",
+          "4. **Scope changes**: Update tasks BEFORE proceeding",
+        ],
+      },
+    }
+  }
+
+  return {
+    heading: "Todo Discipline (NON-NEGOTIABLE)",
+    nounPlural: "todos",
+    createHeading: "When to Create Todos (MANDATORY)",
+    copy: {
+      trackLine: "**Track ALL multi-step work with todos. This is your execution backbone.**",
+      createBullets: [
+        "- **2+ step task** — `todowrite` FIRST, atomic breakdown",
+        "- **Uncertain scope** — `todowrite` to clarify thinking",
+        "- **Complex single task** — Break down into trackable steps",
+      ],
+      workflowLines: [
+        "1. **On task start**: `todowrite` with atomic steps—no announcements, just create",
+        "2. **Before each step**: Mark `in_progress` (ONE at a time)",
+        "3. **After each step**: Mark `completed` IMMEDIATELY (NEVER batch)",
+        "4. **Scope changes**: Update todos BEFORE proceeding",
+      ],
+    },
+  }
+}
+
+export function buildHephaestusTodoDisciplineSection(
+  variant: HephaestusTodoDisciplineVariant,
+  useTaskSystem: boolean,
+): string {
+  const { heading, nounPlural, createHeading, copy } = getTodoDisciplineCopy(
+    variant,
+    useTaskSystem,
+  )
+
+  return buildSection(heading, nounPlural, createHeading, copy)
+}


### PR DESCRIPTION
## Summary
- extract the Hephaestus todo/task-discipline copy into a shared helper
- keep the GPT, GPT-5.4, and GPT-5.3 Codex variant wording intact
- add regression tests for both todo mode and task-system mode across all three variants

## Testing
- `bun test src/agents/hephaestus/todo-discipline.test.ts src/agents/delegation-trust-prompt.test.ts`
- `bun run typecheck`

## Issue
- Closes #2553

## Notes
I also ran `bun test src/agents/utils.test.ts`, but it currently has unrelated failing Oracle fallback expectations on this branch baseline:
- expected `openai/gpt-5.4`
- received `opencode/glm-5-free`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the Hephaestus todo/task-discipline prompt by moving copy into a shared helper, preserving wording for `gpt`, `gpt-5-4`, and `gpt-5-3-codex`. Adds regression tests for todo and task modes across all variants. Closes #2553.

- **Refactors**
  - Introduces `buildHephaestusTodoDisciplineSection` in `src/agents/hephaestus/todo-discipline.ts`.
  - Updates `gpt`, `gpt-5-4`, and `gpt-5-3-codex` prompts to use the helper.
  - Preserves legacy text and escaping to prevent prompt drift (per Linear #2553).

- **Tests**
  - Adds `src/agents/hephaestus/todo-discipline.test.ts`.
  - Verifies key lines and escaping for each variant in both todo and task modes.

<sup>Written for commit 8895cf57fe1fea790b333577e8a1459d6b7f32dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

