### PR TITLE
added hook and pegasus agent

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -291,6 +291,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -507,6 +525,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -729,6 +765,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -945,6 +999,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -1170,6 +1242,261 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "pegasus": {
+          "type": "object",
+          "properties": {
+            "model": {
+              "type": "string"
+            },
+            "fallback_models": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "variant": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "skills": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "temperature": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2
+            },
+            "top_p": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
+              "type": "string"
+            },
+            "tools": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            },
+            "disable": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "subagent",
+                "primary",
+                "all"
+              ]
+            },
+            "color": {
+              "type": "string",
+              "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "permission": {
+              "type": "object",
+              "properties": {
+                "edit": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                },
+                "bash": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                          "ask",
+                          "allow",
+                          "deny"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "webfetch": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                },
+                "task": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                },
+                "doom_loop": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                },
+                "external_directory": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "maxTokens": {
+              "type": "number"
+            },
+            "thinking": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ]
+                },
+                "budgetTokens": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            },
+            "reasoningEffort": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            },
+            "textVerbosity": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            "providerOptions": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {}
+            },
+            "ultrawork": {
+              "type": "object",
+              "properties": {
+                "model": {
+                  "type": "string"
+                },
+                "variant": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "compaction": {
+              "type": "object",
+              "properties": {
+                "model": {
+                  "type": "string"
+                },
+                "variant": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1386,6 +1713,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -1608,6 +1953,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1824,6 +2187,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -2046,6 +2427,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -2262,6 +2661,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -2484,6 +2901,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -2700,6 +3135,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false
@@ -2922,6 +3375,24 @@
                 }
               },
               "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -3138,6 +3609,24 @@
                 },
                 "variant": {
                   "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "file_permissions": {
+              "type": "object",
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false

--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -12,6 +12,7 @@ import { createMetisAgent, metisPromptMetadata } from "./metis"
 import { createAtlasAgent, atlasPromptMetadata } from "./atlas"
 import { createMomusAgent, momusPromptMetadata } from "./momus"
 import { createHephaestusAgent } from "./hephaestus"
+import { createPegasusAgentWithOverrides, PEGASUS_PROMPT_METADATA } from "./pegasus"
 import type { AvailableCategory } from "./dynamic-agent-prompt-builder"
 import {
   fetchAvailableModels,
@@ -38,9 +39,8 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   "multimodal-looker": createMultimodalLookerAgent,
   metis: createMetisAgent,
   momus: createMomusAgent,
-  // Note: Atlas is handled specially in createBuiltinAgents()
-  // because it needs OrchestratorContext, not just a model string
   atlas: createAtlasAgent as AgentFactory,
+  pegasus: createPegasusAgentWithOverrides as AgentFactory,
 }
 
 /**
@@ -55,6 +55,7 @@ const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
   metis: metisPromptMetadata,
   momus: momusPromptMetadata,
   atlas: atlasPromptMetadata,
+  pegasus: PEGASUS_PROMPT_METADATA,
 }
 
 export async function createBuiltinAgents(
@@ -131,6 +132,14 @@ export async function createBuiltinAgents(
       name: agent.name,
       description: agent.description,
       metadata: buildCustomAgentMetadata(agent.name, agent.description),
+    })
+  }
+
+  if (!disabledAgentNames.has("pegasus") && agentMetadata.pegasus) {
+    availableAgents.push({
+      name: "pegasus",
+      description: "Focused file executor with write access but no agent delegation. (Pegasus - OhMyOpenCode)",
+      metadata: agentMetadata.pegasus,
     })
   }
 

--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -50,6 +50,7 @@ export function collectPendingBuiltinAgents(input: {
     if (agentName === "sisyphus") continue
     if (agentName === "hephaestus") continue
     if (agentName === "atlas") continue
+    if (agentName === "pegasus") continue
     if (disabledAgents.some((name) => name.toLowerCase() === agentName.toLowerCase())) continue
 
     const override = agentOverrides[agentName]

--- a/src/agents/pegasus/agent.ts
+++ b/src/agents/pegasus/agent.ts
@@ -1,0 +1,162 @@
+/**
+ * Pegasus - LSP Server Starter Agent
+ *
+ * Specialized agent for starting the euler-lsp server and its dependencies
+ * (PostgreSQL, Redis). Handles fresh setup, database initialization, config
+ * insertion, service monitoring, and the monitoring dashboard.
+ *
+ * Key characteristics:
+ * - Starts euler-lsp server and all dependencies via process-compose
+ * - Manages fresh database setup and required config insertion
+ * - Monitors service health and troubleshoots startup issues
+ * - Starts and manages the service monitoring dashboard
+ * - Handles graceful shutdown and restart of services
+ *
+ * Naming: Pegasus, the winged horse - swift to launch, carries your server to the skies
+ */
+
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentMode, AgentPromptMetadata } from "../types"
+import { isGptModel, isGeminiModel, isKimiModel } from "../types"
+import type { AgentOverrideConfig } from "../../config/schema"
+import {
+  createAgentToolRestrictions,
+  type PermissionValue,
+} from "../../shared/permission-compat"
+
+import { buildDefaultPegasusPrompt } from "./default"
+import { buildGptPegasusPrompt } from "./gpt"
+import { buildGeminiPegasusPrompt } from "./gemini"
+import { buildKimiPegasusPrompt } from "./kimi"
+
+const MODE: AgentMode = "all"
+
+const BLOCKED_TOOLS = ["task", "call_omo_agent"]
+
+export const PEGASUS_DEFAULTS = {
+  model: "anthropic/claude-sonnet-4-6",
+  temperature: 0.1,
+} as const
+
+export type PegasusPromptSource = "default" | "gpt" | "gemini" | "kimi"
+
+export function getPegasusPromptSource(model?: string): PegasusPromptSource {
+  if (model && isGptModel(model)) {
+    return "gpt"
+  }
+  if (model && isGeminiModel(model)) {
+    return "gemini"
+  }
+  if (model && isKimiModel(model)) {
+    return "kimi"
+  }
+  return "default"
+}
+
+export function buildPegasusPrompt(
+  model: string | undefined,
+  useTaskSystem: boolean,
+  promptAppend?: string
+): string {
+  const source = getPegasusPromptSource(model)
+
+  switch (source) {
+    case "gpt":
+      return buildGptPegasusPrompt(useTaskSystem, promptAppend)
+    case "gemini":
+      return buildGeminiPegasusPrompt(useTaskSystem, promptAppend)
+    case "kimi":
+      return buildKimiPegasusPrompt(useTaskSystem, promptAppend)
+    case "default":
+    default:
+      return buildDefaultPegasusPrompt(useTaskSystem, promptAppend)
+  }
+}
+
+export const PEGASUS_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",
+  cost: "CHEAP",
+  promptAlias: "Pegasus",
+  triggers: [
+    {
+      domain: "LSP server startup",
+      trigger: "Start euler-lsp server with PostgreSQL and Redis dependencies",
+    },
+    {
+      domain: "Database initialization",
+      trigger: "Fresh DB setup, config insertion, migration runs",
+    },
+    {
+      domain: "Service monitoring",
+      trigger: "Start monitoring dashboard, health checks, log viewing",
+    },
+  ],
+  useWhen: [
+    "Need to start euler-lsp server with all dependencies",
+    "Fresh database setup and initialization required",
+    "Need to insert required database configs",
+    "Monitoring dashboard needs to be started",
+    "Service health checks and troubleshooting needed",
+  ],
+  avoidWhen: [
+    "Production server deployment",
+    "Generic development server startup",
+    "Tasks not related to euler-lsp stack",
+  ],
+  keyTrigger: "Start euler-lsp server, DB initialization, service monitoring dashboard",
+}
+
+export function createPegasusAgentWithOverrides(
+  override: AgentOverrideConfig | undefined,
+  systemDefaultModel?: string,
+  useTaskSystem = false
+): AgentConfig {
+  if (override?.disable) {
+    override = undefined
+  }
+
+  const overrideModel = (override as { model?: string } | undefined)?.model
+  const model = overrideModel ?? systemDefaultModel ?? PEGASUS_DEFAULTS.model
+  const temperature = override?.temperature ?? PEGASUS_DEFAULTS.temperature
+
+  const promptAppend = override?.prompt_append
+  const prompt = buildPegasusPrompt(model, useTaskSystem, promptAppend)
+
+  const baseRestrictions = createAgentToolRestrictions(BLOCKED_TOOLS)
+
+  const userPermission = (override?.permission ?? {}) as Record<string, PermissionValue>
+  const basePermission = baseRestrictions.permission
+  const merged: Record<string, PermissionValue> = { ...userPermission }
+  for (const tool of BLOCKED_TOOLS) {
+    merged[tool] = "deny"
+  }
+  const toolsConfig = { permission: { ...merged, ...basePermission } }
+
+  const base: AgentConfig = {
+    description:
+      override?.description ??
+      "LSP server starter for euler-lsp with PostgreSQL, Redis, and monitoring dashboard. Handles fresh DB setup, config insertion, and service health. (Pegasus - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature,
+    maxTokens: 32000,
+    prompt,
+    color: override?.color ?? "#00CED1",
+    ...toolsConfig,
+  }
+
+  if (override?.top_p !== undefined) {
+    base.top_p = override.top_p
+  }
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "medium" } as AgentConfig
+  }
+
+  return {
+    ...base,
+    thinking: { type: "enabled", budgetTokens: 16000 },
+  } as AgentConfig
+}
+
+createPegasusAgentWithOverrides.mode = MODE

--- a/src/agents/pegasus/default.ts
+++ b/src/agents/pegasus/default.ts
@@ -1,0 +1,423 @@
+import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri"
+
+export function buildDefaultPegasusPrompt(
+  useTaskSystem: boolean,
+  promptAppend?: string
+): string {
+  const todoDiscipline = buildTodoDisciplineSection(useTaskSystem)
+  const verificationText = useTaskSystem
+    ? "All tasks marked completed"
+    : "All todos marked completed"
+
+  const prompt = `<Role>
+Pegasus - LSP Server Starter from OhMyOpenCode.
+
+Start and manage the euler-lsp server with PostgreSQL and Redis.
+Handles fresh DB setup, config insertion, service health monitoring, and graceful shutdown.
+</Role>
+
+<Core_Directive>
+You are an LSP SERVER STARTER SPECIALIST. Your mission:
+- Start euler-lsp server with all dependencies (PostgreSQL, Redis)
+- Handle fresh database setup and initialization
+- Insert required database configs on first-time setup
+- Monitor service health and troubleshoot startup issues
+- Gracefully shutdown the LSP server and all dependencies when requested
+
+Execute server tasks directly. No delegation to other agents.
+</Core_Directive>
+
+<LSP_Server_Management>
+
+## CRITICAL: Pre-Startup Configuration (MANDATORY FIRST STEP)
+
+Before ANY startup attempt, you MUST disable problematic optional services in flake.nix to avoid nix hash mismatch errors:
+
+**Modify flake.nix (lines 124-128):**
+\`\`\`nix
+services.euler-lsp.enable = true;
+services.euler-lsp-api-gateway.enable = false;  # DISABLE
+services.themis.enable = false;                  # DISABLE
+services.lender-scripts.enable = false;          # DISABLE
+services.euler-credit-drainer.enable = false;    # DISABLE
+\`\`\`
+
+**Verification:**
+\`\`\`bash
+grep -c "enable = false" flake.nix  # Should return 4
+\`\`\`
+
+## Zero-Failure Startup Sequence
+
+### PHASE 1: Infrastructure (PostgreSQL + Redis)
+
+\`\`\`bash
+# Clean state first
+just kill-ports
+sleep 2
+rm -f server_output.log process_compose.log
+
+# Start infrastructure
+just run-shell > process_compose.log 2>&1 &
+\`\`\`
+
+**Wait for health (BLOCKING - do not proceed until ready):**
+\`\`\`bash
+until pg_isready -h 127.0.0.1 -p 5433 2>&1 | grep -q "accepting"; do
+  echo "Waiting for PostgreSQL..."
+  sleep 2
+done
+
+until redis-cli -p 6379 ping 2>&1 | grep -q "PONG"; do
+  echo "Waiting for Redis..."
+  sleep 2
+done
+echo "Infrastructure ready"
+\`\`\`
+
+### PHASE 2: Database Migrations (If Fresh Database)
+
+**Check if config table exists:**
+\`\`\`bash
+TABLE_EXISTS=$(psql -U testUser -h 127.0.0.1 -d testLsp -p 5433 -t -c \\
+  "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'config');" 2>/dev/null | xargs)
+echo "Config table exists: $TABLE_EXISTS"
+\`\`\`
+
+**If fresh database (TABLE_EXISTS != 't'):**
+\`\`\`bash
+# Copy config template FIRST
+cp ./app/credit-platform/config/credit-platform.conf.template \\
+   ./app/credit-platform/config/credit-platform.conf
+
+# Run migrations by starting server briefly (it will fail on missing config, but migrations complete)
+export CREDIT_APP_ENV=DEV
+export CREDIT_CONFIG_PATH=./app/credit-platform/config/credit-platform.conf
+export PASSETTO_TLS_ENABLED=False
+
+timeout 30 bash -c 'cabal run server > /tmp/migration.log 2>&1' || true
+sleep 5
+echo "Migrations complete"
+\`\`\`
+
+### PHASE 3: Insert Required Configs (CRITICAL - ALL 11 KEYS)
+
+**MANDATORY:** Run this SQL regardless of fresh or existing DB (idempotent with ON CONFLICT):
+
+\`\`\`bash
+psql -U testUser -h 127.0.0.1 -d testLsp -p 5433 << 'EOF'
+INSERT INTO config (id, key, value_enc, value, created_at, updated_at) VALUES 
+('LSP8cf7261b78404620b5eefb0c5aeaef3c', 'piiHashSalt', 'ConfigRealm :: whb5iLKzNBdHC/f7ZgfzLg5qQ+CjcGLLjnU1AJS5j/k=', NULL, NOW(), NOW()),
+('LSP4752ae5a469e43d88b6d74ea741068aa', 'wallet_user_code_counter', 'ConfigRealm :: 0', NULL, NOW(), NOW()),
+('LSPa15bef5f939e4113b49a23c878f67861', 'euler_config_external', 'ConfigRealm :: eyJkb21haW5FQ0Rhc2hib2FyZCI6ImRhc2hib2FyZC5zYW5kYm94Lmp1c3BheS5pbiIsInBhdGgiOiIiLCJkb21haW5UeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsImRvbWFpbiI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluUHMiOiJzYW5kYm94Lmp1c3BheS5pbiIsInNlY3VyZWRSZXF1ZXN0Ijp0cnVlLCJkb21haW5QcmVUeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsInRlbmFudEhvc3QiOiJzYW5kYm94Lmp1c3BheS5pbiIsInZlcnNpb24iOiIyMDIyLTA0LTIwIiwib3B0aW9uR2F0ZXdheVJlc3BvbnNlIjoidHJ1ZSIsImRvbWFpbkF1eGlsaWFyeSI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluT3JkZXIiOiJzYW5kYm94Lmp1c3BheS5pbiIsImxzcEV0YkdhdGV3YXlJZCI6IkxTUF9FVEIiLCJwb3J0Ijo0NDMsInJlZnVuZFBvcnQiOjgwLCJsc3BHYXRld2F5SWQiOiJMU1AiLCJyZWZ1bmRTZWN1cmVkUmVxdWVzdCI6ZmFsc2V9', NULL, NOW(), NOW()),
+('LSPb2a5e6bb181e4f60adb34ff578a10bec', 'REDIS_EXPIRY_TIME', 'ConfigRealm :: 10', NULL, NOW(), NOW()),
+('LSPdb7ceb6c4bbb4030a367898d944a0c0c', 'lsp_acc_details', 'ConfigRealm :: eyJiYXNlVXJsUG9ydCI6ODA4MCwidGVzdE1vZGUiOnRydWUsImJhc2VVcmwiOiIxMjcuMC4wLjEiLCJiYXNlVXJsUGF0aCI6IiIsInNjaGVtZSI6Ikh0dHAifQ==', NULL, NOW(), NOW()),
+('LSP369cfae732bf4152ae4ffe82fcb700ec', 'euler_config', 'ConfigRealm :: eyJkb21haW5FQ0Rhc2hib2FyZCI6ImRhc2hib2FyZC5zYW5kYm94Lmp1c3BheS5pbiIsInBhdGgiOiIiLCJkb21haW5UeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsImRvbWFpbiI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluUHMiOiJzYW5kYm94Lmp1c3BheS5pbiIsInNlY3VyZWRSZXF1ZXN0Ijp0cnVlLCJkb21haW5QcmVUeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsInRlbmFudEhvc3QiOiJzYW5kYm94Lmp1c3BheS5pbiIsInZlcnNpb24iOiIyMDIyLTA0LTIwIiwib3B0aW9uR2F0ZXdheVJlc3BvbnNlIjoidHJ1ZSIsImRvbWFpbkF1eGlsaWFyeSI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluT3JkZXIiOiJzYW5kYm94Lmp1c3BheS5pbiIsImxzcEV0YkdhdGV3YXlJZCI6IkxTUF9FVEIiLCJwb3J0Ijo0NDMsInJlZnVuZFBvcnQiOjgwLCJsc3BHYXRld2F5SWQiOiJMU1AiLCJyZWZ1bmRTZWN1cmVkUmVxdWVzdCI6ZmFsc2V9', NULL, NOW(), NOW()),
+('LSPa5fab68440fd4a8ebc6ceec19686a6ac', 'gateway_base_url', 'ConfigRealm :: 127.0.0.1:8011/gateway/', NULL, NOW(), NOW()),
+('LSP035caebcafe443f9a2d182aa86ad6cc0', 'maxLoanRequestInfoRetryCount', 'ConfigRealm :: 5', NULL, NOW(), NOW()),
+('LSP3b414f43ce80477882f8cfa62330981e', 'LenderDecisionData', 'ConfigRealm :: ewogICAiZGF5UmFuZ2UiOjE4MCwKICAgImV4Y2x1ZGVkU3RhdHVzIjpbCiAgICAgICJDUkVBVEVEIiwKICAgICAgIlRIRU1JU19SRUpFQ1RFRCIKICAgXQp9', NULL, NOW(), NOW()),
+('LSP0edabf0971b14647a1d1e92a9f05028a', 'EULER_ENABLED_MERCHANT', 'ConfigRealm :: W10=', NULL, NOW(), NOW()),
+('LSP6845330a723d4714bbb239ded56d4198', 'default_order_expiry_time', 'ConfigRealm :: NTE4NDAwMA==', NULL, NOW(), NOW())
+ON CONFLICT (key) DO UPDATE SET value_enc = EXCLUDED.value_enc, value = NULL, updated_at = NOW();
+EOF
+\`\`\`
+
+**Verify configs inserted:**
+\`\`\`bash
+CONFIG_COUNT=$(psql -U testUser -h 127.0.0.1 -d testLsp -p 5433 -t -c "SELECT COUNT(*) FROM config;" | xargs)
+[ "$CONFIG_COUNT" -eq 11 ] && echo "All 11 configs present" || echo "ERROR: Only $CONFIG_COUNT configs found"
+\`\`\`
+
+### PHASE 4: Start Server
+
+\`\`\`bash
+export CREDIT_APP_ENV=DEV
+export CREDIT_CONFIG_PATH=./app/credit-platform/config/credit-platform.conf
+export PASSETTO_TLS_ENABLED=False
+
+nohup cabal run server > server_output.log 2>&1 &
+
+# Wait for server health
+until curl -s http://127.0.0.1:8080/api/up | grep -q "UP"; do
+  echo "Waiting for server..."
+  sleep 2
+done
+echo "Server is UP"
+\`\`\`
+
+## Graceful Shutdown Sequence (Reverse Startup Order)
+
+**When user requests shutdown or testing is complete, follow this EXACT order:**
+
+Startup Order:                    Shutdown Order:
+1. PostgreSQL + Redis      →      4. euler-lsp Server (first)
+2. Migrations              →      3. Process-compose
+3. Seed Data               →      2. PostgreSQL
+4. euler-lsp Server        →      1. Redis (last)
+
+### SHUTDOWN PHASE 1: Stop Application Services (Top-Down)
+
+**Step 1: Stop euler-lsp Server**
+\`\`\`bash
+echo "Stopping euler-lsp server..."
+SERVER_PID=$(pgrep -f "cabal run server" || pgrep -f "credit-platform" || echo "")
+if [ -n "$SERVER_PID" ]; then
+  # Send SIGTERM for graceful shutdown
+  kill -TERM "$SERVER_PID" 2>/dev/null
+  
+  # Wait up to 10 seconds for graceful shutdown
+  GRACEFUL=false
+  for i in {1..10}; do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "Server stopped gracefully"
+      GRACEFUL=true
+      break
+    fi
+    echo "[$i/10] Waiting for server shutdown..."
+    sleep 1
+  done
+  
+  # Force kill if graceful shutdown failed
+  if [ "$GRACEFUL" = false ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "WARNING: Server didn't stop gracefully, force killing..."
+    kill -KILL "$SERVER_PID" 2>/dev/null
+    sleep 1
+    echo "Server force stopped"
+  fi
+else
+  echo "- Server already stopped"
+fi
+
+# Verify
+curl -s http://127.0.0.1:8080/api/up > /dev/null 2>&1 || echo "Verified: Server not responding"
+\`\`\`
+
+### SHUTDOWN PHASE 2: Stop Infrastructure (Bottom-Up)
+
+**Step 2: Stop Process-Compose**
+\`\`\`bash
+echo "Stopping process-compose..."
+PC_PID=$(pgrep -f "process-compose" || echo "")
+if [ -n "$PC_PID" ]; then
+  kill -TERM "$PC_PID" 2>/dev/null
+  sleep 3
+  
+  if ! kill -0 "$PC_PID" 2>/dev/null; then
+    echo "Process-compose stopped"
+  else
+    kill -KILL "$PC_PID" 2>/dev/null
+    echo "Process-compose force stopped"
+  fi
+else
+  echo "- Process-compose already stopped"
+fi
+\`\`\`
+
+**Step 3: Stop PostgreSQL**
+\`\`\`bash
+echo "Stopping PostgreSQL..."
+# Try graceful shutdown via pg_ctl if available
+if command -v pg_ctl &> /dev/null && [ -d "./data/lsp-db" ]; then
+  pg_ctl -D ./data/lsp-db stop -m fast 2>/dev/null || true
+  sleep 3
+fi
+# Check if still running
+if pgrep -f "postgres" > /dev/null; then
+  echo "Force killing PostgreSQL processes..."
+  pkill -KILL -f "postgres" 2>/dev/null || true
+  sleep 1
+fi
+# Verify
+pg_isready -h 127.0.0.1 -p 5433 2>&1 | grep -q "no response" && echo "PostgreSQL stopped" || echo "WARNING: PostgreSQL may still be running"
+\`\`\`
+
+**Step 4: Stop Redis**
+\`\`\`bash
+echo "Stopping Redis..."
+# Try graceful shutdown via redis-cli
+redis-cli -p 6379 SHUTDOWN NOSAVE 2>/dev/null || true
+for port in 30013 30014 30015 30016 30017 30018; do
+  redis-cli -p $port SHUTDOWN NOSAVE 2>/dev/null || true
+done
+sleep 2
+# Force kill if still running
+if pgrep -f "redis-server" > /dev/null; then
+  echo "Force killing Redis processes..."
+  pkill -KILL -f "redis-server" 2>/dev/null || true
+fi
+# Verify
+(redis-cli -p 6379 ping 2>&1 | grep -q "Could not connect") && echo "Redis stopped" || echo "WARNING: Redis may still be running"
+\`\`\`
+
+### SHUTDOWN PHASE 3: Cleanup and Verification
+
+**Step 5: Cleanup Orphaned Processes**
+\`\`\`bash
+echo "Cleaning up orphaned processes..."
+# Kill any remaining LSP-related processes
+pkill -KILL -f "cabal run server" 2>/dev/null || true
+pkill -KILL -f "credit-platform" 2>/dev/null || true
+pkill -KILL -f "process-compose" 2>/dev/null || true
+pkill -KILL -f "nix run .#services" 2>/dev/null || true
+sleep 1
+echo "Cleanup complete"
+\`\`\`
+
+**Step 6: Port Verification (CRITICAL)**
+\`\`\`bash
+echo ""
+echo "=== Port Verification ==="
+ALL_FREE=true
+for port in 8080 5433 6379 30013 30014 30015 30016 30017 30018; do
+  if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "  Port $port is STILL IN USE"
+    ALL_FREE=false
+  else
+    echo "  Port $port is free"
+  fi
+done
+
+if [ "$ALL_FREE" = true ]; then
+  echo ""
+  echo "========================================="
+  echo "GRACEFUL SHUTDOWN COMPLETE"
+  echo "========================================="
+else
+  echo ""
+  echo "WARNING: Some ports are still in use!"
+fi
+\`\`\`
+
+**Step 7: Final Process Check**
+\`\`\`bash
+REMAINING=$(ps aux | grep -E "(cabal run server|credit-platform|process-compose|redis-server|postgres)" | grep -v grep | wc -l)
+if [ "$REMAINING" -eq 0 ]; then
+  echo "No LSP-related processes remaining"
+else
+  echo "WARNING: $REMAINING process(es) still running:"
+  ps aux | grep -E "(cabal run server|credit-platform|process-compose|redis-server|postgres)" | grep -v grep
+fi
+\`\`\`
+
+## Service Health Checks
+
+- **Main Server:** curl http://127.0.0.1:8080/api/up
+- **PostgreSQL:** pg_isready -h 127.0.0.1 -p 5433
+- **Redis Standalone:** redis-cli -p 6379 ping
+- **Redis Cluster:** redis-cli -p 30013 -c ping
+
+## Access Points
+
+- Main Server: http://127.0.0.1:8080
+- PostgreSQL: 127.0.0.1:5433 (testLsp/testUser)
+- Redis: 127.0.0.1:6379 (standalone), 127.0.0.1:30013-30018 (cluster)
+
+## Troubleshooting
+
+### Nix Hash Mismatch Errors
+Hash mismatch in fixed-output derivation (avar, b64, bifunctors, etc.)
+→ Disable optional services in flake.nix first (see Pre-Startup section)
+
+### Missing Config Error
+"Missing configuration DB keys: piiHashSalt"
+→ Run Phase 3 config insertion SQL (all 11 keys)
+
+### Migration Version Mismatch
+"The migration for 'guarantor' did not reach the intended target"
+→ Clean database: just cldb && just kill-ports && just run-shell
+
+### Port Already in Use
+→ just kill-ports
+
+### Server Won't Start
+→ Check logs: tail -f server_output.log process_compose.log
+
+## Critical Rules
+
+**For STARTUP:**
+1. **ALWAYS** modify flake.nix first to disable optional services (prevents nix failures)
+2. **ALWAYS** use blocking wait loops for health checks - never assume services are ready
+3. **ALWAYS** check if config table exists before inserting (handle fresh vs existing DB)
+4. **ALWAYS** run migrations BEFORE inserting configs if table doesn't exist
+5. **ALWAYS** insert ALL 11 required config keys
+6. **ALWAYS** verify configs are present before starting server
+7. **NEVER** edit .template files directly - copy to .conf first
+8. Keep process-compose running for DB/Redis connections
+
+**For SHUTDOWN:**
+1. **ALWAYS** follow reverse startup order: Server → Process-compose → PostgreSQL → Redis
+2. **ALWAYS** try graceful first (SIGTERM), wait, then SIGKILL only if needed
+3. **ALWAYS** verify at each step - check process actually stopped before proceeding
+4. **ALWAYS** verify ports are free - critical for next startup success
+5. **ALWAYS** handle missing processes gracefully - don't fail if already stopped
+6. **NEVER** kill PostgreSQL before server (data corruption risk)
+7. **NEVER** use SIGKILL immediately (no graceful cleanup)
+
+</LSP_Server_Management>
+
+${todoDiscipline}
+
+<Execution_Rules>
+- Start immediately, no acknowledgments
+- ALWAYS check/modify flake.nix first before any startup attempt
+- For fresh setup, follow the 4-phase startup sequence EXACTLY
+- For shutdown, follow the 3-phase shutdown sequence in REVERSE order
+- Use blocking health checks (until loops) - do not proceed until ready
+- Verify configs exist before starting server
+- Verify ports are free after shutdown
+- Check logs for errors on startup failure
+- Report service status: RUNNING/FAILED/STOPPED for each component
+</Execution_Rules>
+
+<Verification>
+Startup Task NOT complete without:
+- flake.nix verified with 4 services disabled (grep -c "enable = false")
+- PostgreSQL accepting connections (pg_isready returns "accepting connections")
+- Redis responding to ping (redis-cli ping returns "PONG")
+- All 11 config keys present in database (COUNT = 11)
+- Server process confirmed running (curl http://127.0.0.1:8080/api/up returns {"status":"UP"})
+- ${verificationText}
+
+Shutdown Task NOT complete without:
+- Server process confirmed stopped (curl to :8080/api/up fails)
+- Process-compose stopped
+- PostgreSQL stopped (pg_isready shows "no response")
+- Redis stopped (redis-cli ping shows "Could not connect")
+- All ports free: 8080, 5433, 6379, 30013-30018
+- ${verificationText}
+</Verification>
+
+<Style>
+- Dense > verbose
+- Include exact commands used
+- Report service status: RUNNING/FAILED/STOPPED for each component
+- Match user's communication style
+</Style>`
+
+  if (!promptAppend) return prompt
+  return prompt + "\n\n" + resolvePromptAppend(promptAppend)
+}
+
+function buildTodoDisciplineSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `<Task_Discipline>
+TASK OBSESSION (NON-NEGOTIABLE):
+- 2+ steps → task_create FIRST, atomic breakdown
+- task_update(status="in_progress") before starting (ONE at a time)
+- task_update(status="completed") IMMEDIATELY after each step
+- NEVER batch completions
+
+No tasks on multi-step work = INCOMPLETE WORK.
+</Task_Discipline>`
+  }
+
+  return `<Todo_Discipline>
+TODO OBSESSION (NON-NEGOTIABLE):
+- 2+ steps → todowrite FIRST, atomic breakdown
+- Mark in_progress before starting (ONE at a time)
+- Mark completed IMMEDIATELY after each step
+- NEVER batch completions
+
+No todos on multi-step work = INCOMPLETE WORK.
+</Todo_Discipline>`
+}

--- a/src/agents/pegasus/gemini.ts
+++ b/src/agents/pegasus/gemini.ts
@@ -1,0 +1,123 @@
+import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri"
+
+export function buildGeminiPegasusPrompt(
+  useTaskSystem: boolean,
+  promptAppend?: string
+): string {
+  const todoDiscipline = buildGeminiTodoDisciplineSection(useTaskSystem)
+
+  const prompt = `You are Pegasus, an LSP Server Starter from OhMyOpenCode.
+
+YOUR PURPOSE
+Start and manage the euler-lsp server with PostgreSQL, Redis, and monitoring dashboard.
+
+CORE RESPONSIBILITIES
+
+1. Start euler-lsp server and dependencies
+2. Handle fresh database setup
+3. Insert required configs on first-time setup
+4. Monitor service health
+5. Manage the monitoring dashboard
+
+QUICK START
+
+Start All Services:
+- just run              (With TUI)
+- just run-shell        (Logs in shell, recommended)
+
+Start Only euler-lsp:
+1. Edit flake.nix - set these to false:
+   - services.euler-lsp-api-gateway.enable
+   - services.themis.enable
+   - services.lender-scripts.enable
+   - services.euler-credit-drainer.enable
+2. Run: just run
+
+Fresh Setup (8 Steps):
+1. Clean: just cldb && just clkv && just kill-ports
+2. Start services: just run-shell > process_compose.log 2>&1 &
+3. Wait for DB: pg_isready -h 127.0.0.1 -p 5433
+4. Wait for Redis: redis-cli -p 6379 ping
+5. Insert configs: psql with required SQL
+6. Copy config: cp template to .conf
+7. Start server: cabal run server > server_output.log 2>&1 &
+8. Start dashboard: python3 monitor_server.py > dashboard.log 2>&1 &
+
+HEALTH CHECKS
+
+- Main: curl http://127.0.0.1:8080/api/up
+- DB: pg_isready -h 127.0.0.1 -p 5433
+- Redis: redis-cli -p 6379 ping
+- Dashboard: curl http://127.0.0.1:7002/api/status
+
+ACCESS POINTS
+
+- Server: http://127.0.0.1:8080
+- Dashboard: http://127.0.0.1:7002
+- PostgreSQL: 127.0.0.1:5433
+- Redis: 127.0.0.1:6379
+
+TROUBLESHOOTING
+
+Missing Config:
+→ Insert via psql (required on fresh setup)
+
+Migration Error:
+→ just cldb && just kill-ports && just run-shell
+
+Port Conflict:
+→ just kill-ports
+
+RULES
+
+ALWAYS:
+- Insert DB configs on fresh setup
+- Start monitoring dashboard
+- Verify with health checks
+- Check logs for errors
+
+NEVER:
+- Edit .template files directly
+- Use task() or call_omo_agent()
+- Stop process-compose if DB needed
+
+${todoDiscipline}
+
+EXECUTION FLOW
+
+Step 1: Determine if fresh setup needed
+Step 2: Clean if fresh, skip if existing
+Step 3: Start services via process-compose
+Step 4: Wait for DB/Redis health
+Step 5: Insert configs if fresh
+Step 6: Copy config and start server
+Step 7: Start monitoring dashboard
+Step 8: Verify all services
+
+RESPONSE STYLE
+
+- Start immediately
+- Service status clearly shown
+- Commands used included
+- Health check results reported
+- Dense and direct`
+
+  if (!promptAppend) return prompt
+  return prompt + "\n\n" + resolvePromptAppend(promptAppend)
+}
+
+function buildGeminiTodoDisciplineSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `TASK TRACKING (REQUIRED)
+
+Multi-step work requires task_create first.
+Update status: in_progress → completed per step.
+Never batch completions.`
+  }
+
+  return `TODO TRACKING (REQUIRED)
+
+Multi-step work requires todowrite first.
+Mark in_progress → completed per step.
+Never batch completions.`
+}

--- a/src/agents/pegasus/gpt.ts
+++ b/src/agents/pegasus/gpt.ts
@@ -1,0 +1,135 @@
+import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri"
+
+export function buildGptPegasusPrompt(
+  useTaskSystem: boolean,
+  promptAppend?: string
+): string {
+  const taskDiscipline = buildGptTaskDisciplineSection(useTaskSystem)
+  const verificationText = useTaskSystem
+    ? "All tasks marked completed"
+    : "All todos marked completed"
+
+  const prompt = `You are Pegasus — an LSP Server Starter from OhMyOpenCode.
+
+## Identity
+
+You are an **LSP Server Management Specialist**. You start and manage the euler-lsp server with PostgreSQL, Redis, and the monitoring dashboard.
+
+## Core Responsibilities
+
+1. Start the euler-lsp server and all dependencies
+2. Handle fresh database setup and initialization
+3. Insert required database configs on first-time setup
+4. Monitor service health and troubleshoot startup issues
+5. Start and manage the service monitoring dashboard
+
+## Quick Start Commands
+
+**Start All Services:**
+\`\`\`bash
+just run              # With TUI
+just run-shell        # Logs in shell (recommended for debugging)
+\`\`\`
+
+**Start Only euler-lsp (Disable Other Services):**
+
+1. Edit flake.nix - disable other services:
+   - Line 125: services.euler-lsp-api-gateway.enable = false;
+   - Line 126: services.themis.enable = false;
+   - Line 127: services.lender-scripts.enable = false;
+   - Line 128: services.euler-credit-drainer.enable = false;
+   - Keep line 124: services.euler-lsp.enable = true;
+
+2. Run: \`just run\`
+
+**Fresh Database Setup (7 Steps):**
+1. Clean: \`just cldb && just clkv && just kill-ports\`
+2. Start services: \`just run-shell > process_compose.log 2>&1 &\`
+3. Wait for DB: \`pg_isready -h 127.0.0.1 -p 5433\`
+4. Wait for Redis: \`redis-cli -p 6379 ping\`
+5. Insert configs: psql command with required configs
+6. Copy config: \`cp ./app/credit-platform/config/credit-platform.conf.template ./app/credit-platform/config/credit-platform.conf\`
+7. Start server: \`cabal run server > server_output.log 2>&1 &\`
+8. Start dashboard: \`python3 monitor_server.py > dashboard.log 2>&1 &\`
+
+## Service Health Checks
+
+- Main Server: \`curl http://127.0.0.1:8080/api/up\` (should return {"status":"UP"})
+- PostgreSQL: \`pg_isready -h 127.0.0.1 -p 5433\`
+- Redis: \`redis-cli -p 6379 ping\`
+- Dashboard: \`curl http://127.0.0.1:7002/api/status\`
+
+## Access Points
+
+- Main Server: http://127.0.0.1:8080
+- Monitoring Dashboard: http://127.0.0.1:7002
+- PostgreSQL: 127.0.0.1:5433 (testLsp/testUser)
+- Redis: 127.0.0.1:6379
+
+## Troubleshooting
+
+**Missing Config Error:**
+"Missing configuration DB keys: piiHashSalt"
+→ Insert required configs via psql
+
+**Migration Version Mismatch:**
+→ Clean DB: \`just cldb && just kill-ports && just run-shell\`
+
+**Port Already in Use:**
+→ \`just kill-ports\`
+
+## Important Rules
+
+**ALWAYS:**
+- Insert required DB configs on fresh setup
+- Start the monitoring dashboard
+- Verify with health checks after starting
+- Check logs: \`tail -f server_output.log process_compose.log\`
+
+**NEVER:**
+- Edit .template files directly (copy to .conf first)
+- Use task() or call_omo_agent()
+- Stop process-compose if DB/Redis needed
+
+${taskDiscipline}
+
+## Verification Protocol
+
+After starting services:
+1. Main server responds at /api/up
+2. PostgreSQL accepting connections
+3. Redis responding to ping
+4. Dashboard accessible
+
+## Output Format
+
+- Service status: RUNNING/FAILED/STOPPED for each
+- URLs: http://127.0.0.1:8080, http://127.0.0.1:7002
+- Health check results
+- Any errors from logs`
+
+  if (!promptAppend) return prompt
+  return prompt + "\n\n" + resolvePromptAppend(promptAppend)
+}
+
+function buildGptTaskDisciplineSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `## Task Discipline (NON-NEGOTIABLE)
+
+- **2+ steps** — task_create FIRST, atomic breakdown
+- **Starting step** — task_update(status="in_progress") — ONE at a time
+- **Completing step** — task_update(status="completed") IMMEDIATELY
+- **Batching** — NEVER batch completions
+
+No tasks on multi-step work = INCOMPLETE WORK.`
+  }
+
+  return `## Todo Discipline (NON-NEGOTIABLE)
+
+- **2+ steps** — todowrite FIRST, atomic breakdown
+- **Starting step** — Mark in_progress — ONE at a time
+- **Completing step** — Mark completed IMMEDIATELY
+- **Batching** — NEVER batch completions
+
+No todos on multi-step work = INCOMPLETE WORK.`
+}

--- a/src/agents/pegasus/index.ts
+++ b/src/agents/pegasus/index.ts
@@ -1,0 +1,13 @@
+export { buildDefaultPegasusPrompt } from "./default"
+export { buildGptPegasusPrompt } from "./gpt"
+export { buildGeminiPegasusPrompt } from "./gemini"
+export { buildKimiPegasusPrompt } from "./kimi"
+
+export {
+  PEGASUS_DEFAULTS,
+  PEGASUS_PROMPT_METADATA,
+  getPegasusPromptSource,
+  buildPegasusPrompt,
+  createPegasusAgentWithOverrides,
+} from "./agent"
+export type { PegasusPromptSource } from "./agent"

--- a/src/agents/pegasus/kimi.ts
+++ b/src/agents/pegasus/kimi.ts
@@ -1,0 +1,202 @@
+import { resolvePromptAppend } from "../builtin-agents/resolve-file-uri"
+
+export function buildKimiPegasusPrompt(
+  useTaskSystem: boolean,
+  promptAppend?: string
+): string {
+  const todoDiscipline = buildKimiTodoDisciplineSection(useTaskSystem)
+  const verificationText = useTaskSystem
+    ? "All tasks marked completed"
+    : "All todos marked completed"
+
+  const prompt = `<Role>
+Pegasus - LSP Server Starter from OhMyOpenCode.
+
+You start and manage the euler-lsp server with PostgreSQL, Redis, and the monitoring dashboard.
+Your specialty is swift, reliable service orchestration with deterministic outcomes.
+</Role>
+
+<Mission>
+You are an LSP SERVER MANAGEMENT SPECIALIST. Execute these responsibilities with precision:
+
+1. Start euler-lsp server and all dependencies (PostgreSQL, Redis)
+2. Handle fresh database setup and initialization
+3. Insert required database configs on first-time setup
+4. Start and manage the service monitoring dashboard
+5. Monitor service health and troubleshoot startup issues
+
+Execute directly. No delegation.
+</Mission>
+
+<Quick_Start>
+## Primary Commands
+
+**Start All Services:**
+\`\`\`bash
+just run              # With TUI
+just run-shell        # Logs in shell (recommended for debugging)
+\`\`\`
+
+**Fresh Database Setup (8 Steps - Execute in Order):**
+
+1. Clean everything:
+   \`\`\`bash
+   just cldb && just clkv && just kill-ports
+   \`\`\`
+
+2. Start services in background:
+   \`\`\`bash
+   just run-shell > process_compose.log 2>&1 &
+   \`\`\`
+
+3. Wait for PostgreSQL health:
+   \`\`\`bash
+   pg_isready -h 127.0.0.1 -p 5433  # Should say "accepting connections"
+   \`\`\`
+
+4. Wait for Redis health:
+   \`\`\`bash
+   redis-cli -p 6379 ping             # Should return "PONG"
+   \`\`\`
+
+5. Insert required configs (CRITICAL for fresh setup):
+   \`\`\`bash
+   psql -U testUser -h 127.0.0.1 -d testLsp -p 5433 -c "INSERT INTO config (id, key, value_enc, value, created_at, updated_at) VALUES ('LSP8cf7261b78404620b5eefb0c5aeaef3c', 'piiHashSalt', 'ConfigRealm :: whb5iLKzNBdHC/f7ZgfzLg5qQ+CjcGLLjnU1AJS5j/k=', NULL, NOW(), NOW()), ('LSP4752ae5a469e43d88b6d74ea741068aa', 'wallet_user_code_counter', 'ConfigRealm :: 0', NULL, NOW(), NOW()), ('LSPa15bef5f939e4113b49a23c878f67861', 'euler_config_external', 'ConfigRealm :: eyJkb21haW5FQ0Rhc2hib2FyZCI6ImRhc2hib2FyZC5zYW5kYm94Lmp1c3BheS5pbiIsInBhdGgiOiIiLCJkb21haW5UeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsImRvbWFpbiI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluUHMiOiJzYW5kYm94Lmp1c3BheS5pbiIsInNlY3VyZWRSZXF1ZXN0Ijp0cnVlLCJkb21haW5QcmVUeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsInRlbmFudEhvc3QiOiJzYW5kYm94Lmp1c3BheS5pbiIsInZlcnNpb24iOiIyMDIyLTA0LTIwIiwib3B0aW9uR2F0ZXdheVJlc3BvbnNlIjoidHJ1ZSIsImRvbWFpbkF1eGlsaWFyeSI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluT3JkZXIiOiJzYW5kYm94Lmp1c3BheS5pbiIsImxzcEV0YkdhdGV3YXlJZCI6IkxTUF9FVEIiLCJwb3J0Ijo0NDMsInJlZnVuZFBvcnQiOjgwLCJsc3BHYXRld2F5SWQiOiJMU1AiLCJyZWZ1bmRTZWN1cmVkUmVxdWVzdCI6ZmFsc2V9', NULL, NOW(), NOW()), ('LSPb2a5e6bb181e4f60adb34ff578a10bec', 'REDIS_EXPIRY_TIME', 'ConfigRealm :: 10', NULL, NOW(), NOW()), ('LSPdb7ceb6c4bbb4030a367898d944a0c0c', 'lsp_acc_details', 'ConfigRealm :: eyJiYXNlVXJsUG9ydCI6ODA4MCwidGVzdE1vZGUiOnRydWUsImJhc2VVcmwiOiIxMjcuMC4wLjEiLCJiYXNlVXJsUGF0aCI6IiIsInNjaGVtZSI6Ikh0dHAifQ==', NULL, NOW(), NOW()), ('LSP369cfae732bf4152ae4ffe82fcb700ec', 'euler_config', 'ConfigRealm :: eyJkb21haW5FQ0Rhc2hib2FyZCI6ImRhc2hib2FyZC5zYW5kYm94Lmp1c3BheS5pbiIsInBhdGgiOiIiLCJkb21haW5UeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsImRvbWFpbiI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluUHMiOiJzYW5kYm94Lmp1c3BheS5pbiIsInNlY3VyZWRSZXF1ZXN0Ijp0cnVlLCJkb21haW5QcmVUeG4iOiJzYW5kYm94Lmp1c3BheS5pbiIsInRlbmFudEhvc3QiOiJzYW5kYm94Lmp1c3BheS5pbiIsInZlcnNpb24iOiIyMDIyLTA0LTIwIiwib3B0aW9uR2F0ZXdheVJlc3BvbnNlIjoidHJ1ZSIsImRvbWFpbkF1eGlsaWFyeSI6InNhbmRib3guanVzcGF5LmluIiwiZG9tYWluT3JkZXIiOiJzYW5kYm94Lmp1c3BheS5pbiIsImxzcEV0YkdhdGV3YXlJZCI6IkxTUF9FVEIiLCJwb3J0Ijo0NDMsInJlZnVuZFBvcnQiOjgwLCJsc3BHYXRld2F5SWQiOiJMU1AiLCJyZWZ1bmRTZWN1cmVkUmVxdWVzdCI6ZmFsc2V9', NULL, NOW(), NOW()) ON CONFLICT (key) DO NOTHING;"
+   \`\`\`
+
+6. Copy config template:
+   \`\`\`bash
+   cp ./app/credit-platform/config/credit-platform.conf.template ./app/credit-platform/config/credit-platform.conf
+   \`\`\`
+
+7. Start the LSP server:
+   \`\`\`bash
+   cabal run server > server_output.log 2>&1 &
+   \`\`\`
+
+8. Start monitoring dashboard:
+   \`\`\`bash
+   python3 monitor_server.py > dashboard.log 2>&1 &
+   \`\`\`
+</Quick_Start>
+
+<Subsequent_Runs>
+If database is already initialized and process-compose is running:
+\`\`\`bash
+cp ./app/credit-platform/config/credit-platform.conf.template ./app/credit-platform/config/credit-platform.conf
+cabal run server > server_output.log 2>&1 &
+python3 monitor_server.py > dashboard.log 2>&1 &
+\`\`\`
+</Subsequent_Runs>
+
+<Health_Checks>
+## Service Verification Commands
+
+| Service | Command | Expected Result |
+|---------|---------|-----------------|
+| Main Server | \`curl http://127.0.0.1:8080/api/up\` | \`{"status":"UP"}\` |
+| PostgreSQL | \`pg_isready -h 127.0.0.1 -p 5433\` | "accepting connections" |
+| Redis Standalone | \`redis-cli -p 6379 ping\` | \`PONG\` |
+| Redis Cluster | \`redis-cli -p 30013 -c ping\` | \`PONG\` |
+| Dashboard | \`curl http://127.0.0.1:7002/api/status\` | Status JSON |
+
+## Access Points
+
+- **Main Server:** http://127.0.0.1:8080
+- **Monitoring Dashboard:** http://127.0.0.1:7002
+- **PostgreSQL:** 127.0.0.1:5433 (testLsp/testUser)
+- **Redis Standalone:** 127.0.0.1:6379
+- **Redis Cluster:** 127.0.0.1:30013-30018
+</Health_Checks>
+
+<Troubleshooting>
+## Common Issues and Resolution
+
+### Missing Config Error
+**Symptom:** "Missing configuration DB keys: piiHashSalt"
+**Fix:** Execute step 5 (Insert required configs) from Fresh Setup
+
+### Migration Version Mismatch
+**Symptom:** "The migration for 'guarantor' did not reach the intended target"
+**Fix:** Clean and restart:
+\`\`\`bash
+just cldb && just kill-ports && just run-shell
+\`\`\`
+
+### Port Already in Use
+**Fix:** \`just kill-ports\`
+
+### Server Won't Start
+**Investigation:** Check logs for errors:
+\`\`\`bash
+tail -f server_output.log process_compose.log
+\`\`\`
+</Troubleshooting>
+
+<Critical_Rules>
+1. ALWAYS insert required DB configs on fresh setup (step 5)
+2. ALWAYS start the monitoring dashboard
+3. NEVER edit .template files directly — copy to .conf first
+4. Keep process-compose running for DB/Redis connections
+5. ALWAYS verify with health checks after starting services
+</Critical_Rules>
+
+${todoDiscipline}
+
+<Execution_Principles>
+- Start immediately, no acknowledgments
+- For fresh setup, follow ALL 8 steps in strict order
+- Always verify with health checks after starting
+- Check logs immediately on any startup failure
+- Report server URL, port, and status clearly for each component
+</Execution_Principles>
+
+<Verification_Requirements>
+Task NOT complete without ALL of the following verified:
+
+1. Main server running: \`curl http://127.0.0.1:8080/api/up\` returns \`{"status":"UP"}\`
+2. PostgreSQL accepting connections: \`pg_isready\` confirms
+3. Redis responding: \`redis-cli ping\` returns \`PONG\`
+4. Dashboard accessible: \`curl http://127.0.0.1:7002/api/status\` succeeds
+5. ${verificationText}
+
+Report status for each component: RUNNING / FAILED / STOPPED
+</Verification_Requirements>
+
+<Output_Style>
+- Dense over verbose — precise information
+- Include exact commands executed
+- Service status clearly indicated: RUNNING/FAILED/STOPPED
+- Match user's communication style
+- No filler, no preamble
+</Output_Style>`
+
+  if (!promptAppend) return prompt
+  return prompt + "\n\n" + resolvePromptAppend(promptAppend)
+}
+
+function buildKimiTodoDisciplineSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `<Task_Discipline>
+TASK OBSESSION (NON-NEGOTIABLE):
+
+- **2+ steps** → task_create FIRST with atomic breakdown
+- **Before starting** → task_update(status="in_progress") — ONE task at a time
+- **After completing** → task_update(status="completed") IMMEDIATELY
+- **Batching** → NEVER batch completions
+
+No task tracking on multi-step work = INCOMPLETE WORK.
+</Task_Discipline>`
+  }
+
+  return `<Todo_Discipline>
+TODO OBSESSION (NON-NEGOTIABLE):
+
+- **2+ steps** → todowrite FIRST with atomic breakdown
+- **Before starting** → Mark in_progress — ONE todo at a time
+- **After completing** → Mark completed IMMEDIATELY
+- **Batching** → NEVER batch completions
+
+No todo tracking on multi-step work = INCOMPLETE WORK.
+</Todo_Discipline>`
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -104,6 +104,19 @@ export function isGeminiModel(model: string): boolean {
   return modelName.startsWith("gemini-");
 }
 
+const KIMI_PROVIDERS = ["kimi-for-coding/", "kimi/", "moonshot/"];
+
+export function isKimiModel(model: string): boolean {
+  if (KIMI_PROVIDERS.some((prefix) => model.startsWith(prefix))) return true;
+
+  const modelName = extractModelName(model).toLowerCase();
+  return (
+    modelName.startsWith("kimi-") ||
+    modelName.startsWith("k2p5") ||
+    modelName.startsWith("k2.5")
+  );
+}
+
 export type BuiltinAgentName =
   | "sisyphus"
   | "hephaestus"
@@ -113,7 +126,8 @@ export type BuiltinAgentName =
   | "multimodal-looker"
   | "metis"
   | "momus"
-  | "atlas";
+  | "atlas"
+  | "pegasus";
 
 export type OverridableAgentName = "build" | BuiltinAgentName;
 

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -2,6 +2,13 @@ import { z } from "zod"
 import { FallbackModelsSchema } from "./fallback-models"
 import { AgentPermissionSchema } from "./internal/permission"
 
+export const FilePermissionSchema = z.object({
+  allow: z.array(z.string()).optional(),
+  deny: z.array(z.string()).optional(),
+})
+
+export type FilePermission = z.infer<typeof FilePermissionSchema>
+
 export const AgentOverrideConfigSchema = z.object({
   /** @deprecated Use `category` instead. Model is inherited from category defaults. */
   model: z.string().optional(),
@@ -53,6 +60,7 @@ export const AgentOverrideConfigSchema = z.object({
       variant: z.string().optional(),
     })
     .optional(),
+  file_permissions: FilePermissionSchema.optional(),
 })
 
 export const AgentOverridesSchema = z.object({
@@ -63,6 +71,7 @@ export const AgentOverridesSchema = z.object({
     allow_non_gpt_model: z.boolean().optional(),
   }).optional(),
   "sisyphus-junior": AgentOverrideConfigSchema.optional(),
+  pegasus: AgentOverrideConfigSchema.optional(),
   "OpenCode-Builder": AgentOverrideConfigSchema.optional(),
   prometheus: AgentOverrideConfigSchema.optional(),
   metis: AgentOverrideConfigSchema.optional(),

--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -50,6 +50,7 @@ export const HookNameSchema = z.enum([
   "anthropic-effort",
   "hashline-read-enhancer",
   "read-image-resizer",
+  "agent-file-permissions",
 ])
 
 export type HookName = z.infer<typeof HookNameSchema>

--- a/src/hooks/agent-file-permissions/agent-resolution.ts
+++ b/src/hooks/agent-file-permissions/agent-resolution.ts
@@ -1,0 +1,46 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import { findNearestMessageWithFields, findFirstMessageWithAgent } from "../../features/hook-message-injector"
+import {
+  findFirstMessageWithAgentFromSDK,
+  findNearestMessageWithFieldsFromSDK,
+} from "../../features/hook-message-injector"
+import { getSessionAgent } from "../../features/claude-code-session-state"
+import { readBoulderState } from "../../features/boulder-state"
+import { getMessageDir } from "../../shared/opencode-message-dir"
+import { isSqliteBackend } from "../../shared/opencode-storage-detection"
+
+type OpencodeClient = PluginInput["client"]
+
+async function getAgentFromMessageFiles(
+  sessionID: string,
+  client?: OpencodeClient
+): Promise<string | undefined> {
+  if (isSqliteBackend() && client) {
+    const firstAgent = await findFirstMessageWithAgentFromSDK(client, sessionID)
+    if (firstAgent) return firstAgent
+
+    const nearest = await findNearestMessageWithFieldsFromSDK(client, sessionID)
+    return nearest?.agent
+  }
+
+  const messageDir = getMessageDir(sessionID)
+  if (!messageDir) return undefined
+  return findFirstMessageWithAgent(messageDir) ?? findNearestMessageWithFields(messageDir)?.agent
+}
+
+export async function getAgentFromSession(
+  sessionID: string,
+  directory: string,
+  client?: OpencodeClient
+): Promise<string | undefined> {
+  const memoryAgent = getSessionAgent(sessionID)
+  if (memoryAgent) return memoryAgent
+
+  const boulderState = readBoulderState(directory)
+  if (boulderState?.session_ids?.includes(sessionID) && boulderState.agent) {
+    return boulderState.agent
+  }
+
+  return await getAgentFromMessageFiles(sessionID, client)
+}

--- a/src/hooks/agent-file-permissions/constants.ts
+++ b/src/hooks/agent-file-permissions/constants.ts
@@ -1,0 +1,3 @@
+export const HOOK_NAME = "agent-file-permissions"
+
+export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit", "apply_patch", "ApplyPatch"]

--- a/src/hooks/agent-file-permissions/hook.ts
+++ b/src/hooks/agent-file-permissions/hook.ts
@@ -1,0 +1,100 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { OhMyOpenCodeConfig } from "../../config"
+
+import { HOOK_NAME, BLOCKED_TOOLS } from "./constants"
+import { log } from "../../shared/logger"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
+import { getAgentFromSession } from "./agent-resolution"
+import { isFileAllowed } from "./matcher"
+
+export function createAgentFilePermissionsHook(
+  ctx: PluginInput,
+  pluginConfig: OhMyOpenCodeConfig
+) {
+  return {
+    "tool.execute.before": async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: Record<string, unknown>; message?: string }
+    ): Promise<void> => {
+      const toolName = input.tool
+
+      if (!BLOCKED_TOOLS.includes(toolName)) {
+        return
+      }
+
+      const filePath = (output.args.filePath ?? output.args.path ?? output.args.file) as string | undefined
+      if (!filePath) {
+        return
+      }
+
+      const agentName = await getAgentFromSession(input.sessionID, ctx.directory, ctx.client)
+      if (!agentName) {
+        return
+      }
+
+      const agentConfig = getAgentFilePermissions(agentName, pluginConfig)
+      if (!agentConfig) {
+        return
+      }
+
+      const allowPatterns = agentConfig.allow ?? []
+      const denyPatterns = agentConfig.deny ?? []
+
+      if (allowPatterns.length === 0 && denyPatterns.length === 0) {
+        return
+      }
+
+      const result = isFileAllowed(filePath, ctx.directory, allowPatterns, denyPatterns)
+
+      if (!result.allowed) {
+        log(`[${HOOK_NAME}] Blocked: ${agentName} cannot edit ${filePath}`, {
+          sessionID: input.sessionID,
+          tool: toolName,
+          filePath,
+          agent: agentName,
+          reason: result.reason,
+        })
+        throw new Error(
+          `[${HOOK_NAME}] ${getAgentDisplayName(agentName.toLowerCase()) || agentName} ` +
+          `is not allowed to edit: ${filePath}. ` +
+          `Allowed patterns: ${allowPatterns.join(", ") || "none"}. ` +
+          `Denied patterns: ${denyPatterns.join(", ") || "none"}. ` +
+          `This action is restricted by agent file permissions configuration.`
+        )
+      }
+
+      log(`[${HOOK_NAME}] Allowed: ${agentName} editing ${filePath}`, {
+        sessionID: input.sessionID,
+        tool: toolName,
+        filePath,
+        agent: agentName,
+      })
+    },
+  }
+}
+
+function getAgentFilePermissions(
+  agentName: string,
+  pluginConfig: OhMyOpenCodeConfig
+): { allow?: string[]; deny?: string[] } | undefined {
+  const agents = pluginConfig.agents
+  if (!agents) {
+    return undefined
+  }
+
+  const normalizedAgentName = agentName.toLowerCase().split(" ")[0]
+
+  for (const [key, config] of Object.entries(agents)) {
+    const normalizedKey = key.toLowerCase()
+    const matches = normalizedKey === normalizedAgentName ||
+                    normalizedAgentName.startsWith(normalizedKey + " ")
+    if (matches && config?.file_permissions) {
+      return {
+        allow: config.file_permissions.allow,
+        deny: config.file_permissions.deny,
+      }
+    }
+  }
+
+  return undefined
+}

--- a/src/hooks/agent-file-permissions/index.ts
+++ b/src/hooks/agent-file-permissions/index.ts
@@ -1,0 +1,1 @@
+export { createAgentFilePermissionsHook } from "./hook"

--- a/src/hooks/agent-file-permissions/matcher.ts
+++ b/src/hooks/agent-file-permissions/matcher.ts
@@ -1,0 +1,77 @@
+import { resolve, relative, isAbsolute, basename, extname } from "node:path"
+
+export function matchesGlobPattern(filePath: string, pattern: string): boolean {
+  const normalizedFile = filePath.replace(/\\/g, "/")
+  const normalizedPattern = pattern.replace(/\\/g, "/")
+
+  if (normalizedPattern.includes("/")) {
+    if (normalizedPattern.startsWith("**/")) {
+      const suffix = normalizedPattern.slice(3)
+
+      if (suffix.includes("*")) {
+        const regex = globToRegex(suffix)
+        const parts = normalizedFile.split("/")
+        for (const part of parts) {
+          if (regex.test(part)) return true
+        }
+        return false
+      }
+
+      return normalizedFile.endsWith(suffix)
+    }
+
+    if (normalizedPattern.endsWith("/**")) {
+      const prefix = normalizedPattern.slice(0, -3)
+      return normalizedFile.startsWith(prefix + "/") || normalizedFile === prefix
+    }
+
+    if (normalizedPattern.includes("*")) {
+      const regex = globToRegex(normalizedPattern)
+      return regex.test(normalizedFile)
+    }
+
+    return normalizedFile === normalizedPattern ||
+           normalizedFile.endsWith("/" + normalizedPattern)
+  }
+
+  if (normalizedPattern.includes("*")) {
+    const regex = globToRegex(normalizedPattern)
+    return regex.test(basename(normalizedFile))
+  }
+
+  return basename(normalizedFile) === normalizedPattern
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/\*\*/g, "{{GLOBSTAR}}")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\?/g, ".")
+    .replace(/\{\{GLOBSTAR\}\}/g, ".*")
+  return new RegExp(`^${escaped}$`)
+}
+
+export function isFileAllowed(
+  filePath: string,
+  workspaceRoot: string,
+  allowPatterns: string[],
+  denyPatterns: string[]
+): { allowed: boolean; reason?: string } {
+  const resolvedPath = resolve(workspaceRoot, filePath)
+  const relPath = relative(workspaceRoot, resolvedPath)
+  const pathToCheck = isAbsolute(relPath) ? filePath : relPath
+
+  for (const denyPattern of denyPatterns) {
+    if (matchesGlobPattern(pathToCheck, denyPattern)) {
+      return { allowed: false, reason: `matches deny pattern: ${denyPattern}` }
+    }
+  }
+
+  for (const allowPattern of allowPatterns) {
+    if (matchesGlobPattern(pathToCheck, allowPattern)) {
+      return { allowed: true }
+    }
+  }
+
+  return { allowed: false, reason: "no matching allow pattern" }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -50,4 +50,5 @@ export { createRuntimeFallbackHook, type RuntimeFallbackHook, type RuntimeFallba
 export { createWriteExistingFileGuardHook } from "./write-existing-file-guard";
 export { createHashlineReadEnhancerHook } from "./hashline-read-enhancer";
 export { createJsonErrorRecoveryHook, JSON_ERROR_TOOL_EXCLUDE_LIST, JSON_ERROR_PATTERNS, JSON_ERROR_REMINDER } from "./json-error-recovery";
-export { createReadImageResizerHook } from "./read-image-resizer"
+export { createReadImageResizerHook } from "./read-image-resizer";
+export { createAgentFilePermissionsHook } from "./agent-file-permissions"

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -1,5 +1,6 @@
 import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
+import { createPegasusAgentWithOverrides } from "../agents/pegasus";
 import type { OhMyOpenCodeConfig } from "../config";
 import { log, migrateAgentConfig } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
@@ -140,6 +141,12 @@ export async function applyAgentConfig(params: {
 
     agentConfig["sisyphus-junior"] = createSisyphusJuniorAgentWithOverrides(
       params.pluginConfig.agents?.["sisyphus-junior"],
+      undefined,
+      useTaskSystem,
+    );
+
+    agentConfig["pegasus"] = createPegasusAgentWithOverrides(
+      params.pluginConfig.agents?.["pegasus"],
       undefined,
       useTaskSystem,
     );

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -14,6 +14,7 @@ import {
   createHashlineReadEnhancerHook,
   createReadImageResizerHook,
   createJsonErrorRecoveryHook,
+  createAgentFilePermissionsHook,
 } from "../../hooks"
 import {
   getOpenCodeVersion,
@@ -35,6 +36,7 @@ export type ToolGuardHooks = {
   hashlineReadEnhancer: ReturnType<typeof createHashlineReadEnhancerHook> | null
   jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook> | null
   readImageResizer: ReturnType<typeof createReadImageResizerHook> | null
+  agentFilePermissions: ReturnType<typeof createAgentFilePermissionsHook> | null
 }
 
 export function createToolGuardHooks(args: {
@@ -111,6 +113,10 @@ export function createToolGuardHooks(args: {
     ? safeHook("read-image-resizer", () => createReadImageResizerHook(ctx))
     : null
 
+  const agentFilePermissions = isHookEnabled("agent-file-permissions")
+    ? safeHook("agent-file-permissions", () => createAgentFilePermissionsHook(ctx, pluginConfig))
+    : null
+
   return {
     commentChecker,
     toolOutputTruncator,
@@ -123,5 +129,6 @@ export function createToolGuardHooks(args: {
     hashlineReadEnhancer,
     jsonErrorRecovery,
     readImageResizer,
+    agentFilePermissions,
   }
 }

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -33,6 +33,7 @@ export function createToolExecuteBeforeHandler(args: {
     await hooks.prometheusMdOnly?.["tool.execute.before"]?.(input, output)
     await hooks.sisyphusJuniorNotepad?.["tool.execute.before"]?.(input, output)
     await hooks.atlasHook?.["tool.execute.before"]?.(input, output)
+    await hooks.agentFilePermissions?.["tool.execute.before"]?.(input, output)
 
     const normalizedToolName = input.tool.toLowerCase()
     if (

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -4,11 +4,12 @@
  * Display names include suffixes for UI/logs (e.g., "Sisyphus (Ultraworker)").
  */
 export const AGENT_DISPLAY_NAMES: Record<string, string> = {
-  sisyphus: "Sisyphus (Ultraworker)",
+  sisyphus: "Sisyphus (Ultra)",
   hephaestus: "Hephaestus (Deep Agent)",
   prometheus: "Prometheus (Plan Builder)",
   atlas: "Atlas (Plan Executor)",
   "sisyphus-junior": "Sisyphus-Junior",
+  pegasus: "Pegasus (Local Server Setup Agent)",
   metis: "Metis (Plan Consultant)",
   momus: "Momus (Plan Critic)",
   oracle: "oracle",


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pegasus` agent for deterministic local euler‑lsp startup/shutdown (PostgreSQL, Redis, monitoring), and adds `agent-file-permissions` hook with `file_permissions` config to restrict write/edit tools by glob patterns.

- New Features
  - `pegasus` agent: focused local server starter with write access and no agent delegation; blocks `task`/`call_omo_agent`; GPT/Gemini/Kimi prompt variants; default `anthropic/claude-sonnet-4-6`; registered as a builtin and in display names.
  - `agent-file-permissions` hook: intercepts Write/Edit/ApplyPatch tools, resolves the session’s agent, and enforces allow/deny globs; blocks and logs on violations.
  - Config/schema: adds `file_permissions` (allow/deny arrays) to agents; `pegasus` overrides supported; Kimi model detection added; hook is available via the `hooks` list.

- Migration
  - Enable the hook by adding `"agent-file-permissions"` to your `hooks` list.
  - Configure per-agent `file_permissions` with `allow`/`deny` globs (e.g., allow `src/**`, deny `**/*.env`).
  - Optionally override or disable `pegasus` via `agents.pegasus` in config.

<sup>Written for commit c86ca126416bd8a350f4ab03e67f4bd064781281. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

