### PR TITLE
fix: union disabled_tools in mergeConfigs() like other disabled_* arrays

### DIFF
--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -115,6 +115,23 @@ describe("mergeConfigs", () => {
       expect(result.disabled_hooks).toContain("session-recovery");
       expect(result.disabled_hooks?.length).toBe(3);
     });
+
+    it("should union disabled_tools from base and override without duplicates", () => {
+      const base: OhMyOpenCodeConfig = {
+        disabled_tools: ["todowrite", "interactive_bash"],
+      };
+
+      const override: OhMyOpenCodeConfig = {
+        disabled_tools: ["interactive_bash", "look_at"],
+      };
+
+      const result = mergeConfigs(base, override);
+
+      expect(result.disabled_tools).toContain("todowrite");
+      expect(result.disabled_tools).toContain("interactive_bash");
+      expect(result.disabled_tools).toContain("look_at");
+      expect(result.disabled_tools?.length).toBe(3);
+    });
   });
 });
 

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -146,6 +146,12 @@ export function mergeConfigs(
         ...(override.disabled_skills ?? []),
       ]),
     ],
+    disabled_tools: [
+      ...new Set([
+        ...(base.disabled_tools ?? []),
+        ...(override.disabled_tools ?? []),
+      ]),
+    ],
     claude_code: deepMerge(base.claude_code, override.claude_code),
   };
 }


### PR DESCRIPTION
## Summary

- `disabled_tools` was defined in `OhMyOpenCodeConfigSchema` (Zod) but omitted from `mergeConfigs()`, causing project-level config to **shadow** user-level `disabled_tools` instead of preserving both
- Added Set union for `disabled_tools` following the exact same pattern as the other 5 `disabled_*` arrays
- Added regression test verifying union and deduplication

## Changes

- `src/plugin-config.ts`: Add `disabled_tools` Set union in `mergeConfigs()` (5 lines, between `disabled_skills` and `claude_code`)
- `src/plugin-config.test.ts`: Add test case for `disabled_tools` merge with overlap

## Testing

- `bun test src/plugin-config.test.ts` — 12/12 pass (was 11 before this change)
- New test verifies base `["todowrite", "interactive_bash"]` + override `["interactive_bash", "look_at"]` → merged result `["todowrite", "interactive_bash", "look_at"]` (3 items, no duplicates)

Closes #2555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the merge of `disabled_tools` in `mergeConfigs()` so user and project configs are unioned and deduplicated, matching other `disabled_*` arrays; closes #2555. Adds a regression test for overlapping lists.

<sup>Written for commit 9a774f1db28d814425ae980b8b3b387b67e5673d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

