### PR TITLE
fix(todo-continuation-enforcer): add plan agent to DEFAULT_SKIP_AGENTS (fixes #2526)

### DIFF
--- a/src/hooks/todo-continuation-enforcer/AGENTS.md
+++ b/src/hooks/todo-continuation-enforcer/AGENTS.md
@@ -38,7 +38,7 @@ session.idle
 ## CONSTANTS
 
 ```typescript
-DEFAULT_SKIP_AGENTS = ["prometheus", "compaction"]
+DEFAULT_SKIP_AGENTS = ["prometheus", "compaction", "plan"]
 CONTINUATION_COOLDOWN_MS = 30_000     // 30s between injections
 MAX_CONSECUTIVE_FAILURES = 5          // Then 5min pause (exponential backoff)
 FAILURE_RESET_WINDOW_MS = 5 * 60_000  // 5min window for failure reset

--- a/src/hooks/todo-continuation-enforcer/constants.ts
+++ b/src/hooks/todo-continuation-enforcer/constants.ts
@@ -2,7 +2,7 @@ import { createSystemDirective, SystemDirectiveTypes } from "../../shared/system
 
 export const HOOK_NAME = "todo-continuation-enforcer"
 
-export const DEFAULT_SKIP_AGENTS = ["prometheus", "compaction"]
+export const DEFAULT_SKIP_AGENTS = ["prometheus", "compaction", "plan"]
 
 export const CONTINUATION_PROMPT = `${createSystemDirective(SystemDirectiveTypes.TODO_CONTINUATION)}
 

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
@@ -47,4 +47,38 @@ describe("injectContinuation", () => {
     expect(capturedTools).toEqual({ question: false, bash: true })
     expect(capturedText).toContain(OMO_INTERNAL_INITIATOR_MARKER)
   })
+
+  test("skips injection when agent is plan (prevents Plan Mode infinite loop)", async () => {
+    // given
+    let injected = false
+    const ctx = {
+      directory: "/tmp/test",
+      client: {
+        session: {
+          todo: async () => ({ data: [{ id: "1", content: "todo", status: "pending", priority: "high" }] }),
+          promptAsync: async () => {
+            injected = true
+            return {}
+          },
+        },
+      },
+    }
+    const sessionStateStore = {
+      getExistingState: () => ({ inFlight: false, lastInjectedAt: 0, consecutiveFailures: 0 }),
+    }
+
+    // when
+    await injectContinuation({
+      ctx: ctx as never,
+      sessionID: "ses_plan_skip",
+      resolvedInfo: {
+        agent: "plan",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" },
+      },
+      sessionStateStore: sessionStateStore as never,
+    })
+
+    // then
+    expect(injected).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- Adds `"plan"` to `DEFAULT_SKIP_AGENTS` in `todo-continuation-enforcer/constants.ts` to prevent the infinite loop reported in #2526
- Adds regression test confirming plan agent sessions are skipped

## Problem
When a Plan Mode agent creates todo items, the `todo-continuation-enforcer` hook fires on `session.idle` and injects a continuation prompt telling the agent to "proceed without asking permission." But Plan Mode explicitly forbids all file edits ("STRICTLY FORBIDDEN: ANY file edits... This supersedes all other instructions"). The agent receives both contradictory directives, acknowledges the conflict, explains why it cannot proceed, then goes idle again — triggering another injection in an infinite loop.

Root cause analysis by @R-omk in #2526: the `injectContinuation()` function checks `DEFAULT_SKIP_AGENTS` but only skips `prometheus` and `compaction`, not `plan`.

## Fix
```diff
- export const DEFAULT_SKIP_AGENTS = ["prometheus", "compaction"]
+ export const DEFAULT_SKIP_AGENTS = ["prometheus", "compaction", "plan"]
```

This is the minimal, targeted fix: plan agents are read-only by design and should never receive continuation nudges.

## Changes
| File | Change |
|------|--------|
| `constants.ts` | Add `"plan"` to `DEFAULT_SKIP_AGENTS` |
| `continuation-injection.test.ts` | Add test verifying plan agent is skipped |
| `AGENTS.md` | Update docs to reflect new skip list |

## Testing
- New test: `skips injection when agent is plan (prevents Plan Mode infinite loop)` — verifies `injectContinuation` does not call `promptAsync` when agent is `"plan"`

Fixes #2526

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip continuation injection for `plan` sessions to stop the Plan Mode infinite loop. Adds `plan` to `DEFAULT_SKIP_AGENTS`, plus a regression test and docs update. Fixes #2526.

<sup>Written for commit 2b6b08345aa1188937decba63cb86cb5cf472e40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

