### PR TITLE
fix(background-agent): add circuit breaker to prevent subagent infinite loops (fixes #2571)

### DIFF
--- a/src/config/schema/background-task.ts
+++ b/src/config/schema/background-task.ts
@@ -11,6 +11,8 @@ export const BackgroundTaskConfigSchema = z.object({
   /** Timeout for tasks that never received any progress update, falling back to startedAt (default: 1800000 = 30 minutes, minimum: 60000 = 1 minute) */
   messageStalenessTimeoutMs: z.number().min(60000).optional(),
   syncPollTimeoutMs: z.number().min(60000).optional(),
+  /** Maximum tool calls per subagent task before circuit breaker triggers (default: 200, minimum: 10). Prevents runaway loops from burning unlimited tokens. */
+  maxToolCalls: z.number().int().min(10).optional(),
 })
 
 export type BackgroundTaskConfig = z.infer<typeof BackgroundTaskConfigSchema>

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -878,6 +878,21 @@ export class BackgroundManager {
       if (partInfo?.type === "tool" || partInfo?.tool) {
         task.progress.toolCalls += 1
         task.progress.lastTool = partInfo.tool
+
+        const maxToolCalls = this.config?.maxToolCalls ?? 200
+        if (task.progress.toolCalls >= maxToolCalls) {
+          log("[background-agent] Circuit breaker: tool call limit reached", {
+            taskId: task.id,
+            toolCalls: task.progress.toolCalls,
+            maxToolCalls,
+            agent: task.agent,
+            sessionID,
+          })
+          void this.cancelTask(task.id, {
+            source: "circuit-breaker",
+            reason: `Subagent exceeded maximum tool call limit (${maxToolCalls}). This usually indicates an infinite loop. The task was automatically cancelled to prevent excessive token usage.`,
+          })
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds a configurable `maxToolCalls` circuit breaker (default: 200) to automatically cancel background tasks that enter infinite tool-call loops
- Adds `maxToolCalls` to `BackgroundTaskConfigSchema` for user configurability

## Problem
In #2571, a Gemini 3.1 Pro subagent entered an infinite tool-call loop that ran for **3.5 hours** (809 consecutive tool calls), burning **~$350** in API costs. There was no safeguard to detect or stop the runaway loop.

The tool call count was already being tracked (`task.progress.toolCalls`) but nothing acted on it.

## Fix
Added a circuit breaker check after each tool call increment in the `handleEvent` method:

```typescript
const maxToolCalls = this.config?.maxToolCalls ?? 200
if (task.progress.toolCalls >= maxToolCalls) {
  void this.cancelTask(task.id, {
    source: "circuit-breaker",
    reason: `Subagent exceeded maximum tool call limit (${maxToolCalls})...`,
  })
}
```

**Default: 200 tool calls** — generous enough for legitimate complex tasks, but catches runaway loops well before they cause significant damage. For context, the #2571 incident hit 809 calls.

## Configuration
Users can adjust the limit in `oh-my-opencode.jsonc`:
```jsonc
{
  "background_task": {
    "maxToolCalls": 300  // default: 200, minimum: 10
  }
}
```

## Changes
| File | Change |
|------|--------|
| `src/config/schema/background-task.ts` | Add `maxToolCalls` field to schema |
| `src/features/background-agent/manager.ts` | Add circuit breaker check in tool call tracking |

## Design Decisions
- **Default 200**: The original incident was 809 calls. 200 is well below catastrophic but above any reasonable legitimate task
- **Cancels with clear error message**: User sees exactly what happened and why
- **Uses existing `cancelTask` flow**: Proper cleanup, notification to parent, concurrency release
- **Configurable**: Power users can raise/lower as needed

Fixes #2571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a circuit breaker to the background agent that cancels subagent tasks once they exceed a tool‑call limit (default 200) to stop infinite loops. Fixes #2571 and prevents runaway API costs.

- **Bug Fixes**
  - Check the limit in the tool‑call tracking path and cancel with source "circuit-breaker".
  - Add `maxToolCalls` to `BackgroundTaskConfigSchema` (min 10), configurable via `background_task.maxToolCalls` in `oh-my-opencode.jsonc`.
  - Log taskId, toolCalls, maxToolCalls, agent, and sessionID when the breaker trips.

<sup>Written for commit 3055454ecce76638baced396096d9746875fb776. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

