### PR TITLE
fix(todo-continuation-enforcer): detect context-length errors to prevent infinite loop (fixes #2462)

### DIFF
--- a/src/hooks/todo-continuation-enforcer/context-length-detection.ts
+++ b/src/hooks/todo-continuation-enforcer/context-length-detection.ts
@@ -1,0 +1,38 @@
+const CONTEXT_LENGTH_PATTERNS = [
+  "prompt is too long",
+  "context_length_exceeded",
+  "ContextLengthError",
+  "ContextOverflowError",
+  "maximum context length",
+  "token limit",
+  "exceeds the model's maximum",
+  "input is too long",
+  "max_tokens",
+]
+
+function extractErrorString(error: unknown): string {
+  if (typeof error === "string") return error
+  if (error === null || error === undefined) return ""
+
+  const obj = error as Record<string, unknown>
+  const parts: string[] = []
+
+  if (typeof obj.name === "string") parts.push(obj.name)
+  if (typeof obj.message === "string") parts.push(obj.message)
+  if (typeof obj.error === "string") parts.push(obj.error)
+
+  if (typeof obj.error === "object" && obj.error !== null) {
+    const nested = obj.error as Record<string, unknown>
+    if (typeof nested.message === "string") parts.push(nested.message)
+    if (typeof nested.type === "string") parts.push(nested.type)
+  }
+
+  return parts.join(" ")
+}
+
+export function isContextLengthError(error: unknown): boolean {
+  const errorStr = extractErrorString(error).toLowerCase()
+  if (!errorStr) return false
+
+  return CONTEXT_LENGTH_PATTERNS.some((pattern) => errorStr.includes(pattern.toLowerCase()))
+}

--- a/src/hooks/todo-continuation-enforcer/context-length-detection.ts
+++ b/src/hooks/todo-continuation-enforcer/context-length-detection.ts
@@ -25,7 +25,14 @@ function extractErrorString(error: unknown): string {
   if (typeof obj.data === "object" && obj.data !== null) {
     const data = obj.data as Record<string, unknown>
     if (typeof data.message === "string") parts.push(data.message)
-    if (typeof data.error === "string") parts.push(data.error)
+    if (typeof data.error === "string") {
+      parts.push(data.error)
+    } else if (typeof data.error === "object" && data.error !== null) {
+      const nestedError = data.error as Record<string, unknown>
+      if (typeof nestedError.message === "string") parts.push(nestedError.message)
+      if (typeof nestedError.code === "string") parts.push(nestedError.code)
+      if (typeof nestedError.type === "string") parts.push(nestedError.type)
+    }
     if (typeof data.type === "string") parts.push(data.type)
   }
 

--- a/src/hooks/todo-continuation-enforcer/context-length-detection.ts
+++ b/src/hooks/todo-continuation-enforcer/context-length-detection.ts
@@ -21,6 +21,14 @@ function extractErrorString(error: unknown): string {
   if (typeof obj.message === "string") parts.push(obj.message)
   if (typeof obj.error === "string") parts.push(obj.error)
 
+  // OpenCode SDK wraps errors in error.data or error.error
+  if (typeof obj.data === "object" && obj.data !== null) {
+    const data = obj.data as Record<string, unknown>
+    if (typeof data.message === "string") parts.push(data.message)
+    if (typeof data.error === "string") parts.push(data.error)
+    if (typeof data.type === "string") parts.push(data.type)
+  }
+
   if (typeof obj.error === "object" && obj.error !== null) {
     const nested = obj.error as Record<string, unknown>
     if (typeof nested.message === "string") parts.push(nested.message)

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -48,6 +48,7 @@ export function createTodoContinuationHandler(args: {
         state.isRecovering = true
         state.consecutiveFailures = MAX_CONSECUTIVE_FAILURES
         state.inFlight = false
+        state.contextLengthErrorAt = Date.now()
         log(`[${HOOK_NAME}] Context length error detected, blocking continuation`, {
           sessionID,
           errorName: error?.name,

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -6,10 +6,11 @@ import {
 } from "../../features/run-continuation-state"
 import { log } from "../../shared/logger"
 
-import { DEFAULT_SKIP_AGENTS, HOOK_NAME } from "./constants"
+import { DEFAULT_SKIP_AGENTS, HOOK_NAME, MAX_CONSECUTIVE_FAILURES } from "./constants"
 import type { SessionStateStore } from "./session-state"
 import { handleSessionIdle } from "./idle-event"
 import { handleNonIdleEvent } from "./non-idle-events"
+import { isContextLengthError } from "./context-length-detection"
 
 export function createTodoContinuationHandler(args: {
   ctx: PluginInput
@@ -35,11 +36,22 @@ export function createTodoContinuationHandler(args: {
       const sessionID = props?.sessionID as string | undefined
       if (!sessionID) return
 
-      const error = props?.error as { name?: string } | undefined
+      const error = props?.error as { name?: string; message?: string } | undefined
       if (error?.name === "MessageAbortedError" || error?.name === "AbortError") {
         const state = sessionStateStore.getState(sessionID)
         state.abortDetectedAt = Date.now()
         log(`[${HOOK_NAME}] Abort detected via session.error`, { sessionID, errorName: error.name })
+      }
+
+      if (isContextLengthError(error)) {
+        const state = sessionStateStore.getState(sessionID)
+        state.isRecovering = true
+        state.consecutiveFailures = MAX_CONSECUTIVE_FAILURES
+        state.inFlight = false
+        log(`[${HOOK_NAME}] Context length error detected, blocking continuation`, {
+          sessionID,
+          errorName: error?.name,
+        })
       }
 
       sessionStateStore.cancelCountdown(sessionID)

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -46,8 +46,18 @@ export async function handleSessionIdle(args: {
 
   const state = sessionStateStore.getState(sessionID)
   if (state.isRecovering) {
-    log(`[${HOOK_NAME}] Skipped: in recovery`, { sessionID })
-    return
+    // Auto-clear recovery lock after 5 minutes to prevent permanent lockout
+    // when the recovery hook doesn't fire (non-Anthropic providers, recovery failure)
+    const RECOVERY_TIMEOUT_MS = 5 * 60 * 1000
+    if (state.contextLengthErrorAt && Date.now() - state.contextLengthErrorAt > RECOVERY_TIMEOUT_MS) {
+      state.isRecovering = false
+      state.consecutiveFailures = 0
+      state.contextLengthErrorAt = undefined
+      log(`[${HOOK_NAME}] Auto-cleared stale recovery lock after timeout`, { sessionID })
+    } else {
+      log(`[${HOOK_NAME}] Skipped: in recovery`, { sessionID })
+      return
+    }
   }
 
   if (state.abortDetectedAt) {

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -27,6 +27,7 @@ export interface SessionState {
   countdownTimer?: ReturnType<typeof setTimeout>
   countdownInterval?: ReturnType<typeof setInterval>
   isRecovering?: boolean
+  contextLengthErrorAt?: number
   countdownStartedAt?: number
   abortDetectedAt?: number
   lastIncompleteCount?: number


### PR DESCRIPTION
## Summary
- Adds context-length error detection to the `session.error` handler in `todo-continuation-enforcer`
- Sets `isRecovering=true` and maxes out `consecutiveFailures` when a token-limit error is detected, blocking further continuation injections

## Problem
When a session hits the context window token limit, the `todo-continuation-enforcer` enters an infinite loop:

1. Session has incomplete todos -> `session.idle` fires -> continuation injected
2. Provider rejects (token limit) -> `session.error` fires
3. Error handler only checks for `MessageAbortedError`/`AbortError` -> does NOT block continuation
4. `session.idle` fires again -> loop repeats

In #2462: **590 duplicate messages** (295 user + 294 assistant) injected within ~5 minutes, destroying the session.

## Fix
Two changes:

### 1. `context-length-detection.ts` (new file)
Provider-agnostic detection of context-length errors, matching patterns from Anthropic, OpenAI, Gemini, and generic providers:
- `"prompt is too long"`, `"context_length_exceeded"`, `"ContextLengthError"`, `"ContextOverflowError"`, `"maximum context length"`, `"token limit"`, etc.

### 2. `handler.ts` (modified)
Added context-length error detection in the `session.error` handler:
```typescript
if (isContextLengthError(error)) {
  const state = sessionStateStore.getState(sessionID)
  state.isRecovering = true
  state.consecutiveFailures = MAX_CONSECUTIVE_FAILURES
  state.inFlight = false
}
```

This blocks all further continuation injections until recovery completes (handled by `anthropic-context-window-limit-recovery` hook or manual intervention).

## Design Decisions
- **Provider-agnostic**: Detects errors from all providers, not just Anthropic
- **Separate detection module**: Follows the codebase's modular architecture (no catch-all utils)
- **Conservative blocking**: Sets both `isRecovering` and max failures to ensure the loop is fully stopped
- **Works with existing recovery hook**: The `anthropic-context-window-limit-recovery` hook handles the actual recovery; this fix just ensures the continuation enforcer respects it

Fixes #2462

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects context-length/token-limit errors in `todo-continuation-enforcer` and blocks further continuations to stop the infinite loop when the context window is exceeded. Adds a 5-minute auto-clear to avoid permanent lockout on providers without a recovery hook. Fixes #2462.

- **Bug Fixes**
  - Added provider-agnostic context-length detection with deeper nested parsing, including `error.data.message` and nested `error.data.error` objects from OpenCode SDK.
  - On detection, `session.error` sets `isRecovering=true`, `consecutiveFailures=MAX_CONSECUTIVE_FAILURES`, `inFlight=false`, and logs the block; tracks `contextLengthErrorAt`.
  - Added 5-minute auto-clear in the idle handler to release the recovery lock and reset failures using `contextLengthErrorAt` for timeout.

<sup>Written for commit 5ce1836bc261a979258fbd9df62333b923977e2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

