### PR TITLE
fix(runtime-fallback): detect Gemini quota errors in session.status retry events (fixes #2454)

### DIFF
--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -1,6 +1,6 @@
 import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
-import { HOOK_NAME } from "./constants"
+import { HOOK_NAME, RETRYABLE_ERROR_PATTERNS } from "./constants"
 import { log } from "../../shared/logger"
 import { extractAutoRetrySignal } from "./error-classifier"
 import { createFallbackState } from "./fallback-state"
@@ -32,7 +32,14 @@ export function createSessionStatusHandler(
 
     const retryMessage = typeof status.message === "string" ? status.message : ""
     const retrySignal = extractAutoRetrySignal({ status: retryMessage, message: retryMessage })
-    if (!retrySignal) return
+    if (!retrySignal) {
+      // Fallback: status.type is already "retry", so check the message against
+      // retryable error patterns directly. This handles providers like Gemini whose
+      // retry status message may not contain "retrying in" text alongside the error.
+      const messageLower = retryMessage.toLowerCase()
+      const matchesRetryablePattern = RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(messageLower))
+      if (!matchesRetryablePattern) return
+    }
 
     const retryKey = `${extractRetryAttempt(status.attempt, retryMessage)}:${normalizeRetryStatusMessage(retryMessage)}`
     if (sessionStatusRetryKeys.get(sessionID) === retryKey) {


### PR DESCRIPTION
## Summary
- Adds fallback pattern matching in the `session.status` handler when `extractAutoRetrySignal` fails but `status.type` is already `"retry"`

## Problem
When Gemini returns a quota exhausted error ("You have exhausted your capacity on this model"), OpenCode auto-retries and fires `session.status` with `type="retry"`. The runtime-fallback hook's `session.status` handler uses `extractAutoRetrySignal()` which requires BOTH conditions to match:

1. `retrying\s+in` - the retry countdown text
2. One of the quota patterns (e.g., `exhausted\s+your\s+capacity`)

Some providers include only the error message in the retry status without the "retrying in" phrase, causing condition 1 to fail. The handler exits early and never triggers the fallback chain.

## Fix
Added a fallback check after `extractAutoRetrySignal` fails:

```typescript
if (!retrySignal) {
  // status.type is already "retry", so check message against
  // RETRYABLE_ERROR_PATTERNS directly
  const messageLower = retryMessage.toLowerCase()
  const matchesRetryablePattern = RETRYABLE_ERROR_PATTERNS.some(
    (pattern) => pattern.test(messageLower)
  )
  if (!matchesRetryablePattern) return
}
```

Since `status.type === "retry"` already confirms this is a retry event, the "retrying in" text check is redundant. The fallback path checks the message directly against the existing `RETRYABLE_ERROR_PATTERNS` (which already includes `exhausted\s+your\s+capacity`, `quota\s+will\s+reset\s+after`, etc.).

## Changes
| File | Change |
|------|--------|
| `session-status-handler.ts` | Add fallback pattern matching when `extractAutoRetrySignal` fails |

Fixes #2454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Gemini quota-exhausted retry events in runtime-fallback by matching `session.status` retry messages against `RETRYABLE_ERROR_PATTERNS` when `extractAutoRetrySignal` fails and `status.type === "retry"`. This triggers the fallback chain even when the message lacks "retrying in", fixing #2454.

<sup>Written for commit 7e3c36ee03518c7661166c5e330e9ab5133254c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

