### PR TITLE
fix(ralph-loop): add semantic completion detection for ulw-loop termination (fixes #2489)

### DIFF
--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -7,6 +7,7 @@ import {
 	detectCompletionInSessionMessages,
 	detectCompletionInTranscript,
 } from "./completion-promise-detector"
+import { detectSemanticCompletion } from "./semantic-completion-detector"
 import { continueIteration } from "./iteration-continuation"
 import { handlePendingVerification } from "./pending-verification-handler"
 import { handleDeletedLoopSession, handleErroredLoopSession } from "./session-event-handler"
@@ -116,24 +117,35 @@ export function createRalphLoopEventHandler(
 						sinceMessageIndex: state.message_count_at_start,
 					})
 
-				if (completionViaTranscript || completionViaApi) {
-					log(`[${HOOK_NAME}] Completion detected!`, {
-						sessionID,
-						iteration: state.iteration,
-						promise: state.completion_promise,
-						detectedVia: completionViaTranscript
-							? "transcript_file"
-							: "session_messages_api",
-					})
-					await handleDetectedCompletion(ctx, {
-						sessionID,
-						state,
-						loopState: options.loopState,
-						directory: options.directory,
-						apiTimeoutMs: options.apiTimeoutMs,
-					})
-					return
-				}
+			const completionViaSemantic = (completionViaTranscript || completionViaApi || state.verification_pending)
+				? false
+				: await detectSemanticCompletion(ctx, {
+					sessionID,
+					apiTimeoutMs: options.apiTimeoutMs,
+					directory: options.directory,
+					sinceMessageIndex: state.message_count_at_start,
+				})
+
+			if (completionViaTranscript || completionViaApi || completionViaSemantic) {
+				log(`[${HOOK_NAME}] Completion detected!`, {
+					sessionID,
+					iteration: state.iteration,
+					promise: state.completion_promise,
+					detectedVia: completionViaTranscript
+						? "transcript_file"
+						: completionViaApi
+							? "session_messages_api"
+							: "semantic_fallback",
+				})
+				await handleDetectedCompletion(ctx, {
+					sessionID,
+					state,
+					loopState: options.loopState,
+					directory: options.directory,
+					apiTimeoutMs: options.apiTimeoutMs,
+				})
+				return
+			}
 
 				if (state.verification_pending) {
 					await handlePendingVerification(ctx, {

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -1,0 +1,138 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { log } from "../../shared/logger"
+import { HOOK_NAME } from "./constants"
+import { withTimeout } from "./with-timeout"
+
+interface OpenCodeSessionMessage {
+  info?: { role?: string }
+  parts?: Array<{ type: string; text?: string }>
+}
+
+const COMPLETION_PATTERNS = [
+  /\ball\s+(?:tasks?|todos?|items?)\s+(?:are\s+)?(?:completed?|done|finished)\b/i,
+  /\btask\s+(?:is\s+)?(?:completed?|done|finished)\b/i,
+  /\bwork\s+(?:is\s+)?(?:completed?|done|finished)\b/i,
+  /\bimplementation\s+(?:is\s+)?(?:completed?|done|finished)\b/i,
+  /\beverything\s+(?:is\s+)?(?:completed?|done|finished)\b/i,
+  /\bsuccessfully\s+completed\b/i,
+  /\bnothing\s+(?:left|remaining|more)\s+to\s+do\b/i,
+  /\bcompleted?\s+all\s+(?:tasks?|todos?|items?|steps?)\b/i,
+  /任务[已都全]完成/,
+  /[已都全]完成[了啦]?[。！!]?\s*$/,
+  /规划[已都]完成/,
+  /工作[已都]完成/,
+  /所有.*(?:完成|结束)/,
+]
+
+function extractLastAssistantText(messages: OpenCodeSessionMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i]
+    if (msg.info?.role !== "assistant") continue
+    if (!msg.parts) continue
+
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool")
+    if (hasToolCalls) return null
+
+    let text = ""
+    for (const part of msg.parts) {
+      if (part.type === "text" && part.text) {
+        text += part.text
+      }
+    }
+
+    return text.trim() || null
+  }
+
+  return null
+}
+
+function countRecentCompletionMessages(messages: OpenCodeSessionMessage[], limit: number): number {
+  let count = 0
+  let checked = 0
+
+  for (let i = messages.length - 1; i >= 0 && checked < limit; i -= 1) {
+    const msg = messages[i]
+    if (msg.info?.role !== "assistant") continue
+    checked += 1
+
+    if (!msg.parts) continue
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool")
+    if (hasToolCalls) break
+
+    let text = ""
+    for (const part of msg.parts) {
+      if (part.type === "text" && part.text) {
+        text += part.text
+      }
+    }
+
+    if (COMPLETION_PATTERNS.some((pattern) => pattern.test(text))) {
+      count += 1
+    } else {
+      break
+    }
+  }
+
+  return count
+}
+
+export async function detectSemanticCompletion(
+  ctx: PluginInput,
+  options: {
+    sessionID: string
+    apiTimeoutMs: number
+    directory: string
+    sinceMessageIndex?: number
+  },
+): Promise<boolean> {
+  try {
+    const response = await withTimeout(
+      ctx.client.session.messages({
+        path: { id: options.sessionID },
+        query: { directory: options.directory },
+      }),
+      options.apiTimeoutMs,
+    )
+
+    const messagesResponse: unknown = response
+    const responseData =
+      typeof messagesResponse === "object" && messagesResponse !== null && "data" in messagesResponse
+        ? (messagesResponse as { data?: unknown }).data
+        : undefined
+
+    const messageArray: unknown[] = Array.isArray(messagesResponse)
+      ? messagesResponse
+      : Array.isArray(responseData)
+        ? responseData
+        : []
+
+    const scopedMessages =
+      typeof options.sinceMessageIndex === "number" && options.sinceMessageIndex >= 0 && options.sinceMessageIndex < messageArray.length
+        ? messageArray.slice(options.sinceMessageIndex)
+        : messageArray
+
+    const messages = scopedMessages as OpenCodeSessionMessage[]
+    const lastText = extractLastAssistantText(messages)
+    if (!lastText) return false
+
+    const matchesCompletionPattern = COMPLETION_PATTERNS.some((pattern) => pattern.test(lastText))
+    if (!matchesCompletionPattern) return false
+
+    const repeatedCompletionCount = countRecentCompletionMessages(messages, 3)
+    if (repeatedCompletionCount >= 2) {
+      log(`[${HOOK_NAME}] Semantic completion detected (repeated ${repeatedCompletionCount}x)`, {
+        sessionID: options.sessionID,
+        lastText: lastText.slice(0, 200),
+      })
+      return true
+    }
+
+    return false
+  } catch (err) {
+    log(`[${HOOK_NAME}] Semantic completion check failed`, {
+      sessionID: options.sessionID,
+      error: String(err),
+    })
+    return false
+  }
+}

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -21,7 +21,12 @@ const COMPLETION_PATTERNS = [
   /[已都全]完成[了啦]?[。！!]?\s*$/,
   /规划[已都]完成/,
   /工作[已都]完成/,
-  /所有.*(?:完成|结束)/,
+  /所有(?:任务|工作)[已都全](?:完成|结束)/,
+]
+
+const NEGATION_PATTERNS = [
+  /\b(?:not|isn't|aren't|hasn't|haven't|won't|can't|cannot|still|yet|pending|remaining)\b/i,
+  /(?:尚未|还没|并非|未能|没有|不是|还未|仍未)/,
 ]
 
 function extractLastAssistantText(messages: OpenCodeSessionMessage[]): string | null {
@@ -30,7 +35,7 @@ function extractLastAssistantText(messages: OpenCodeSessionMessage[]): string | 
     if (msg.info?.role !== "assistant") continue
     if (!msg.parts) continue
 
-    const hasToolCalls = msg.parts.some((p) => p.type === "tool")
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool_use")
     if (hasToolCalls) return null
 
     let text = ""
@@ -46,6 +51,10 @@ function extractLastAssistantText(messages: OpenCodeSessionMessage[]): string | 
   return null
 }
 
+function isNegated(text: string): boolean {
+  return NEGATION_PATTERNS.some((pattern) => pattern.test(text))
+}
+
 function countRecentCompletionMessages(messages: OpenCodeSessionMessage[], limit: number): number {
   let count = 0
   let checked = 0
@@ -56,7 +65,7 @@ function countRecentCompletionMessages(messages: OpenCodeSessionMessage[], limit
     checked += 1
 
     if (!msg.parts) continue
-    const hasToolCalls = msg.parts.some((p) => p.type === "tool")
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool_use")
     if (hasToolCalls) break
 
     let text = ""
@@ -107,7 +116,7 @@ export async function detectSemanticCompletion(
         : []
 
     const scopedMessages =
-      typeof options.sinceMessageIndex === "number" && options.sinceMessageIndex >= 0 && options.sinceMessageIndex < messageArray.length
+      typeof options.sinceMessageIndex === "number" && options.sinceMessageIndex >= 0 && options.sinceMessageIndex <= messageArray.length
         ? messageArray.slice(options.sinceMessageIndex)
         : messageArray
 
@@ -117,6 +126,8 @@ export async function detectSemanticCompletion(
 
     const matchesCompletionPattern = COMPLETION_PATTERNS.some((pattern) => pattern.test(lastText))
     if (!matchesCompletionPattern) return false
+
+    if (isNegated(lastText)) return false
 
     const repeatedCompletionCount = countRecentCompletionMessages(messages, 3)
     if (repeatedCompletionCount >= 2) {

--- a/src/hooks/ralph-loop/semantic-completion-detector.ts
+++ b/src/hooks/ralph-loop/semantic-completion-detector.ts
@@ -25,7 +25,7 @@ const COMPLETION_PATTERNS = [
 ]
 
 const NEGATION_PATTERNS = [
-  /\b(?:not|isn't|aren't|hasn't|haven't|won't|can't|cannot|still|yet|pending|remaining)\b/i,
+  /\b(?:not|isn't|aren't|hasn't|haven't|won't|can't|cannot|still|yet|pending)\b/i,
   /(?:尚未|还没|并非|未能|没有|不是|还未|仍未)/,
 ]
 
@@ -35,7 +35,7 @@ function extractLastAssistantText(messages: OpenCodeSessionMessage[]): string | 
     if (msg.info?.role !== "assistant") continue
     if (!msg.parts) continue
 
-    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool_use")
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool-invocation")
     if (hasToolCalls) return null
 
     let text = ""
@@ -65,7 +65,7 @@ function countRecentCompletionMessages(messages: OpenCodeSessionMessage[], limit
     checked += 1
 
     if (!msg.parts) continue
-    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool_use")
+    const hasToolCalls = msg.parts.some((p) => p.type === "tool" || p.type === "tool-invocation")
     if (hasToolCalls) break
 
     let text = ""
@@ -75,11 +75,13 @@ function countRecentCompletionMessages(messages: OpenCodeSessionMessage[], limit
       }
     }
 
-    if (COMPLETION_PATTERNS.some((pattern) => pattern.test(text))) {
-      count += 1
-    } else {
+    if (!COMPLETION_PATTERNS.some((pattern) => pattern.test(text))) {
       break
     }
+    if (isNegated(text)) {
+      break
+    }
+    count += 1
   }
 
   return count


### PR DESCRIPTION
## Summary
- Adds semantic completion detection as a fallback when literal `<promise>DONE</promise>` detection fails
- Prevents ulw-loop from running indefinitely when agents express completion in natural language

## Problem
Agents sometimes express task completion in natural language instead of the required `<promise>DONE</promise>` format:
- English: "Task complete", "All tasks done", "Implementation finished"
- Chinese: "任务已完成", "规划已完成", "所有任务完成"

The loop only checks for the literal `<promise>` tag, so it continues indefinitely, wasting tokens (especially dangerous during off-hours).

## Fix
Two changes:

### 1. `semantic-completion-detector.ts` (new file)
Detects common completion phrases in the last assistant messages. Safety mechanism: requires **2+ consecutive** completion-only messages (no tool calls) to trigger, preventing false positives from mid-work mentions of completion.

Patterns cover:
- English: "all tasks completed", "work is done", "successfully completed", etc.
- Chinese: "任务已完成", "规划已完成", "所有任务完成", etc.

### 2. `ralph-loop-event-handler.ts` (modified)
Integrates semantic detection as a third fallback path:
1. `detectCompletionInTranscript` (literal, transcript file)
2. `detectCompletionInSessionMessages` (literal, API)
3. **`detectSemanticCompletion` (semantic, API)** -- NEW

Only fires when literal detection fails AND not in verification mode.

## Design Decisions
- **2+ repeated messages required**: A single "task complete" could be mid-conversation. Two consecutive completion-only messages (no tool calls between them) strongly indicates genuine completion
- **No tool calls check**: Messages with tool calls are mid-work, not completion signals
- **Multilingual**: Supports English and Chinese patterns (the two most common languages in issue reports)
- **Skipped during verification**: Semantic detection only runs on the main session, not during Oracle verification

Fixes #2489

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a semantic completion fallback so the ulw-loop stops when agents say they’re done in natural language (English and Chinese), preventing infinite loops and wasted tokens. Fixes #2489 by ending the loop when `<promise>DONE</promise>` is missing but completion is clearly repeated.

- **Bug Fixes**
  - Added `semantic-completion-detector.ts` with EN/ZH patterns and a negation filter; removed “remaining” from negation and apply negation during repeat-counting; tightened Chinese rules to avoid false positives like “所有任务尚未完成”.
  - Requires 2+ consecutive assistant-only completion messages (no SDK `tool`/`tool-invocation` parts), scoped to the current iteration.
  - Integrated into `ralph-loop-event-handler.ts` as a third fallback after transcript/API checks; skipped during verification; logs detection as "semantic_fallback" and fixes the `sinceMessageIndex === length` boundary.

<sup>Written for commit c4a1cbccaee62279f5332deef1c713d0c54432d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

