### PR TITLE
fix(agent-registration): always attempt fallback when model resolution fails (fixes #2427, supersedes #2517)

### DIFF
--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -8,6 +8,7 @@ import { buildAgent, isFactory } from "../agent-builder"
 import { applyOverrides } from "./agent-overrides"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
+import { log } from "../../shared/logger"
 
 export function collectPendingBuiltinAgents(input: {
   agentSources: Record<BuiltinAgentName, import("../agent-builder").AgentSource>
@@ -75,7 +76,13 @@ export function collectPendingBuiltinAgents(input: {
       availableModels,
       systemDefaultModel,
     })
-    if (!resolution && isFirstRunNoCache && !override?.model) {
+    if (!resolution) {
+      if (override?.model) {
+        log("[agent-registration] User-configured model could not be resolved, falling back", {
+          agent: agentName,
+          configuredModel: override.model,
+        })
+      }
       resolution = getFirstFallbackModel(requirement)
     }
     if (!resolution) continue


### PR DESCRIPTION
## Summary
- Removes both `isFirstRunNoCache` AND `!override?.model` guards from fallback logic
- Adds log warning when user-configured model fails to resolve
- Supersedes #2517 with a more complete fix per @acamq's root cause analysis on #2427

## Problem
In `collectPendingBuiltinAgents()`, when `applyModelResolution()` returns `undefined`, the fallback to `getFirstFallbackModel()` was guarded by:

```typescript
if (!resolution && isFirstRunNoCache && !override?.model) {
  resolution = getFirstFallbackModel(requirement)
}
```

This caused two failure modes:
1. **General case** (no override): On non-first runs with cache, `isFirstRunNoCache` is false → fallback skipped → agent silently excluded
2. **Override case** (#2427): When user configures `librarian.model = "minimax/MiniMax-M2.5"` but that model isn't in `availableModels`, `!override?.model` is false → fallback skipped → `--agent Librarian` crashes with `undefined is not an object`

PR #2517 only fixed case 1 (removed `isFirstRunNoCache`). This PR fixes both cases.

## Fix
```typescript
if (!resolution) {
  if (override?.model) {
    log("[agent-registration] User-configured model could not be resolved, falling back", {
      agent: agentName,
      configuredModel: override.model,
    })
  }
  resolution = getFirstFallbackModel(requirement)
}
```

- Always attempts fallback when resolution fails, regardless of cache state or override presence
- Logs a warning when a user-configured model couldn't be resolved (previously silent)
- Agent registers with fallback model instead of being silently excluded

## Changes
| File | Change |
|------|--------|
| `general-agents.ts` | Remove both guards, add log warning for failed override resolution |

Fixes #2427
Supersedes #2517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always fall back to a supported model when model resolution fails during built-in agent registration. Adds a warning when a user-configured model can't be resolved, preventing silent exclusion and the Librarian crash (fixes #2427; supersedes #2517).

- **Bug Fixes**
  - Remove `isFirstRunNoCache` and `!override?.model` guards so fallback runs on any unresolved model.
  - When `applyModelResolution()` returns undefined, log the unresolved override and use `getFirstFallbackModel()`.

<sup>Written for commit abdd39da0065d3501209fabb46bdc758f5a8a66d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

