### PR TITLE
feat: add {file:path} template support for skill MCP env values

### DIFF
--- a/src/features/claude-code-mcp-loader/env-expander.test.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { expandEnvVars, expandEnvVarsInObject } from "./env-expander"
+
+describe("env-expander", () => {
+  const TEST_DIR = "/tmp/env-expander-test"
+  
+  beforeEach(() => {
+    // Create test directory and files
+    mkdirSync(TEST_DIR, { recursive: true })
+    writeFileSync(join(TEST_DIR, "secret-token.txt"), "secret-api-key-123")
+    writeFileSync(join(TEST_DIR, "config.json"), '{"host": "localhost", "port": 8080}')
+    writeFileSync(join(TEST_DIR, "multi-line.txt"), "line1\nline2\nline3")
+    writeFileSync(join(TEST_DIR, "whitespace.txt"), "  secret-with-whitespace  \n")
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  describe("expandEnvVars", () => {
+    it("resolves {file:path} templates to file content", () => {
+      const result = expandEnvVars(`Bearer {file:${TEST_DIR}/secret-token.txt}`)
+      expect(result).toBe("Bearer secret-api-key-123")
+    })
+
+    it("trims whitespace from file content", () => {
+      const result = expandEnvVars(`Token: {file:${TEST_DIR}/whitespace.txt}`)
+      expect(result).toBe("Token: secret-with-whitespace")
+    })
+
+    it("resolves multiple {file:} templates in same string", () => {
+      const result = expandEnvVars(`API_KEY={file:${TEST_DIR}/secret-token.txt} CONFIG={file:${TEST_DIR}/config.json}`)
+      expect(result).toBe(`API_KEY=secret-api-key-123 CONFIG={"host": "localhost", "port": 8080}`)
+    })
+
+    it("returns original string if file does not exist", () => {
+      const original = "{file:/nonexistent/file.txt}"
+      const result = expandEnvVars(original)
+      expect(result).toBe(original)
+    })
+
+    it("resolves relative paths from process.cwd()", () => {
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+      try {
+        const result = expandEnvVars("Token: {file:secret-token.txt}")
+        expect(result).toBe("Token: secret-api-key-123")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("resolves ${VAR} templates after {file:} templates", () => {
+      process.env.TEST_VAR = "env-value"
+      const result = expandEnvVars(`Config: {file:${TEST_DIR}/secret-token.txt} Env: \${TEST_VAR}`)
+      expect(result).toBe("Config: secret-api-key-123 Env: env-value")
+      delete process.env.TEST_VAR
+    })
+
+    it("handles {file:} template with default values for ${VAR}", () => {
+      const result = expandEnvVars(`{file:${TEST_DIR}/secret-token.txt} \${NONEXISTENT:-default}`)
+      expect(result).toBe("secret-api-key-123 default")
+    })
+
+    it("preserves ${VAR} functionality as before", () => {
+      process.env.TEST_VAR = "test-value"
+      const result = expandEnvVars("\${TEST_VAR}")
+      expect(result).toBe("test-value")
+      delete process.env.TEST_VAR
+    })
+
+    it("handles ${VAR} with default values", () => {
+      const result = expandEnvVars("\${NONEXISTENT:-default-value}")
+      expect(result).toBe("default-value")
+    })
+  })
+
+  describe("expandEnvVarsInObject", () => {
+    it("recursively resolves file templates in nested objects", () => {
+      const config = {
+        auth: {
+          token: `{file:${TEST_DIR}/secret-token.txt}`,
+          config: `{file:${TEST_DIR}/config.json}`
+        },
+        server: {
+          host: "localhost"
+        }
+      }
+      
+      const result = expandEnvVarsInObject(config)
+      expect(result).toEqual({
+        auth: {
+          token: "secret-api-key-123",
+          config: '{"host": "localhost", "port": 8080}'
+        },
+        server: {
+          host: "localhost"
+        }
+      })
+    })
+
+    it("resolves file templates in arrays", () => {
+      const config = {
+        tokens: [
+          `{file:${TEST_DIR}/secret-token.txt}`,
+          "static-token"
+        ]
+      }
+      
+      const result = expandEnvVarsInObject(config)
+      expect(result).toEqual({
+        tokens: [
+          "secret-api-key-123",
+          "static-token"
+        ]
+      })
+    })
+
+    it("handles combination of {file:} and ${VAR} templates", () => {
+      process.env.TEST_ENV = "env-value"
+      const config = {
+        secret: `{file:${TEST_DIR}/secret-token.txt}`,
+        env: "\${TEST_ENV}",
+        combined: `Token: {file:${TEST_DIR}/secret-token.txt} Env: \${TEST_ENV}`
+      }
+      
+      const result = expandEnvVarsInObject(config)
+      expect(result).toEqual({
+        secret: "secret-api-key-123",
+        env: "env-value",
+        combined: "Token: secret-api-key-123 Env: env-value"
+      })
+      delete process.env.TEST_ENV
+    })
+  })
+})

--- a/src/features/claude-code-mcp-loader/env-expander.test.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.test.ts
@@ -82,10 +82,11 @@ describe("env-expander", () => {
     })
 
     it("supports ~/homedir expansion", () => {
-      const homeFile = join(homedir(), "test-file.txt")
+      const testFileName = `.env-expander-test-${Date.now()}.txt`
+      const homeFile = join(homedir(), testFileName)
       writeFileSync(homeFile, "home-secret")
       try {
-        const result = expandEnvVars("{file:~/test-file.txt}")
+        const result = expandEnvVars(`{file:~/${testFileName}}`)
         expect(result).toBe("home-secret")
       } finally {
         rmSync(homeFile, { force: true })
@@ -97,6 +98,12 @@ describe("env-expander", () => {
       const relativePath = `{file:${TEST_DIR.split('/').pop()}/secret-token.txt}`
       const result = expandEnvVars(relativePath, baseDir)
       expect(result).toBe("secret-api-key-123")
+    })
+
+    it("preserves $ patterns in file content (no replacement corruption)", () => {
+      writeFileSync(join(TEST_DIR, "dollar-patterns.txt"), "secret-$$-and-$&-and-$1")
+      const result = expandEnvVars(`{file:${TEST_DIR}/dollar-patterns.txt}`)
+      expect(result).toBe("secret-$$-and-$&-and-$1") // All $ patterns preserved
     })
   })
 

--- a/src/features/claude-code-mcp-loader/env-expander.test.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync } from "fs"
-import { join } from "path"
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "fs"
+import { join, dirname } from "path"
+import { tmpdir, homedir } from "os"
 import { expandEnvVars, expandEnvVarsInObject } from "./env-expander"
 
 describe("env-expander", () => {
-  const TEST_DIR = "/tmp/env-expander-test"
+  let TEST_DIR: string
   
   beforeEach(() => {
     // Create test directory and files
-    mkdirSync(TEST_DIR, { recursive: true })
+    TEST_DIR = mkdtempSync(join(tmpdir(), "env-expander-test-"))
     writeFileSync(join(TEST_DIR, "secret-token.txt"), "secret-api-key-123")
     writeFileSync(join(TEST_DIR, "config.json"), '{"host": "localhost", "port": 8080}')
     writeFileSync(join(TEST_DIR, "multi-line.txt"), "line1\nline2\nline3")
     writeFileSync(join(TEST_DIR, "whitespace.txt"), "  secret-with-whitespace  \n")
+    writeFileSync(join(TEST_DIR, "with-env-var.txt"), "secret-${HOME}-key")
   })
 
   afterEach(() => {
@@ -35,10 +37,8 @@ describe("env-expander", () => {
       expect(result).toBe(`API_KEY=secret-api-key-123 CONFIG={"host": "localhost", "port": 8080}`)
     })
 
-    it("returns original string if file does not exist", () => {
-      const original = "{file:/nonexistent/file.txt}"
-      const result = expandEnvVars(original)
-      expect(result).toBe(original)
+    it("throws error when file does not exist", () => {
+      expect(() => expandEnvVars("{file:/nonexistent/file.txt}")).toThrow()
     })
 
     it("resolves relative paths from process.cwd()", () => {
@@ -74,6 +74,29 @@ describe("env-expander", () => {
     it("handles ${VAR} with default values", () => {
       const result = expandEnvVars("\${NONEXISTENT:-default-value}")
       expect(result).toBe("default-value")
+    })
+
+    it("does not expand env vars within file content (security fix)", () => {
+      const result = expandEnvVars(`{file:${TEST_DIR}/with-env-var.txt}`)
+      expect(result).toBe("secret-${HOME}-key") // ${HOME} should NOT be expanded
+    })
+
+    it("supports ~/homedir expansion", () => {
+      const homeFile = join(homedir(), "test-file.txt")
+      writeFileSync(homeFile, "home-secret")
+      try {
+        const result = expandEnvVars("{file:~/test-file.txt}")
+        expect(result).toBe("home-secret")
+      } finally {
+        rmSync(homeFile, { force: true })
+      }
+    })
+
+    it("supports baseDir parameter for relative paths", () => {
+      const baseDir = dirname(TEST_DIR)
+      const relativePath = `{file:${TEST_DIR.split('/').pop()}/secret-token.txt}`
+      const result = expandEnvVars(relativePath, baseDir)
+      expect(result).toBe("secret-api-key-123")
     })
   })
 
@@ -133,6 +156,30 @@ describe("env-expander", () => {
         combined: "Token: secret-api-key-123 Env: env-value"
       })
       delete process.env.TEST_ENV
+    })
+
+    it("supports baseDir parameter in expandEnvVarsInObject", () => {
+      const baseDir = dirname(TEST_DIR)
+      const relativePath = `{file:${TEST_DIR.split('/').pop()}/secret-token.txt}`
+      const config = {
+        token: relativePath
+      }
+      
+      const result = expandEnvVarsInObject(config, baseDir)
+      expect(result).toEqual({
+        token: "secret-api-key-123"
+      })
+    })
+
+    it("file content with env vars is not re-expanded in objects", () => {
+      const config = {
+        secret: `{file:${TEST_DIR}/with-env-var.txt}`
+      }
+      
+      const result = expandEnvVarsInObject(config)
+      expect(result).toEqual({
+        secret: "secret-${HOME}-key" // ${HOME} should NOT be expanded
+      })
     })
   })
 })

--- a/src/features/claude-code-mcp-loader/env-expander.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.ts
@@ -1,23 +1,36 @@
 import { readFileSync } from "fs"
 import { resolve } from "path"
+import { homedir } from "os"
 
-export function expandFileTemplates(value: string): string {
-  return value.replace(
-    /\{file:([^}]+)\}/g,
-    (match, filePath: string) => {
-      try {
-        const resolvedPath = resolve(process.cwd(), filePath.trim())
-        return readFileSync(resolvedPath, "utf-8").trim()
-      } catch {
-        return match // Return original if file not found
-      }
-    }
-  )
+function resolveFilePath(filePath: string, baseDir?: string): string {
+  const trimmed = filePath.trim()
+  if (trimmed.startsWith("~/")) {
+    return resolve(homedir(), trimmed.slice(2))
+  }
+  return resolve(baseDir ?? process.cwd(), trimmed)
 }
 
-export function expandEnvVars(value: string): string {
-  const fileExpanded = expandFileTemplates(value)
-  return fileExpanded.replace(
+function readFileTemplate(filePath: string, baseDir?: string): string {
+  const resolvedPath = resolveFilePath(filePath, baseDir)
+  return readFileSync(resolvedPath, "utf-8").trim()
+}
+
+export function expandEnvVars(value: string, baseDir?: string): string {
+  const fileMatches: Array<{ placeholder: string; filePath: string }> = []
+  let counter = 0
+
+  // Phase 1: Replace {file:...} with unique sentinels
+  const withSentinels = value.replace(
+    /\{file:([^}]+)\}/g,
+    (_, filePath: string) => {
+      const sentinel = `\x00FILE_TEMPLATE_${counter++}\x00`
+      fileMatches.push({ placeholder: sentinel, filePath })
+      return sentinel
+    }
+  )
+
+  // Phase 2: Expand ${VAR} env vars (sentinels are untouched)
+  const envExpanded = withSentinels.replace(
     /\$\{([^}:]+)(?::-([^}]*))?\}/g,
     (_, varName: string, defaultValue?: string) => {
       const envValue = process.env[varName]
@@ -26,18 +39,27 @@ export function expandEnvVars(value: string): string {
       return ""
     }
   )
+
+  // Phase 3: Replace sentinels with actual file content (never re-expanded)
+  let result = envExpanded
+  for (const { placeholder, filePath } of fileMatches) {
+    const content = readFileTemplate(filePath, baseDir)
+    result = result.replace(placeholder, content)
+  }
+
+  return result
 }
 
-export function expandEnvVarsInObject<T>(obj: T): T {
+export function expandEnvVarsInObject<T>(obj: T, baseDir?: string): T {
   if (obj === null || obj === undefined) return obj
-  if (typeof obj === "string") return expandEnvVars(obj) as T
+  if (typeof obj === "string") return expandEnvVars(obj, baseDir) as T
   if (Array.isArray(obj)) {
-    return obj.map((item) => expandEnvVarsInObject(item)) as T
+    return obj.map((item) => expandEnvVarsInObject(item, baseDir)) as T
   }
   if (typeof obj === "object") {
     const result: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(obj)) {
-      result[key] = expandEnvVarsInObject(value)
+      result[key] = expandEnvVarsInObject(value, baseDir)
     }
     return result as T
   }

--- a/src/features/claude-code-mcp-loader/env-expander.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.ts
@@ -44,7 +44,7 @@ export function expandEnvVars(value: string, baseDir?: string): string {
   let result = envExpanded
   for (const { placeholder, filePath } of fileMatches) {
     const content = readFileTemplate(filePath, baseDir)
-    result = result.replace(placeholder, content)
+    result = result.replace(placeholder, () => content)
   }
 
   return result

--- a/src/features/claude-code-mcp-loader/env-expander.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.ts
@@ -1,5 +1,23 @@
-export function expandEnvVars(value: string): string {
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+export function expandFileTemplates(value: string): string {
   return value.replace(
+    /\{file:([^}]+)\}/g,
+    (match, filePath: string) => {
+      try {
+        const resolvedPath = resolve(process.cwd(), filePath.trim())
+        return readFileSync(resolvedPath, "utf-8").trim()
+      } catch {
+        return match // Return original if file not found
+      }
+    }
+  )
+}
+
+export function expandEnvVars(value: string): string {
+  const fileExpanded = expandFileTemplates(value)
+  return fileExpanded.replace(
     /\$\{([^}:]+)(?::-([^}]*))?\}/g,
     (_, varName: string, defaultValue?: string) => {
       const envValue = process.env[varName]


### PR DESCRIPTION
## Summary

- Add `{file:path}` template support for skill MCP env values, enabling secrets to be read from files at MCP startup
- Matches OpenCode's native `{file:...}` config capability for skill-embedded MCPs

## Changes

- Modified `src/features/claude-code-mcp-loader/env-expander.ts` to resolve `{file:path}` templates before `${VAR}` expansion
- Added `expandFileTemplates` function that reads file content with proper error handling
- Updated `expandEnvVars` to call `expandFileTemplates` first, maintaining backward compatibility
- Added comprehensive tests in `env-expander.test.ts` covering file template resolution, error cases, and integration with existing env var expansion

## Testing

```bash
bun run typecheck
bun test src/features/claude-code-mcp-loader/
```

## Related Issues

Enables skill-embedded MCPs to authenticate using file-based secrets (e.g., \`{file:.secrets/api-token}\`), bringing parity with OpenCode's native MCP config \`environment\` field.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `{file:path}` support for skill MCP env values so secrets load from files at startup, matching OpenCode’s native config. Uses sentinel-based expansion with a safe replacer so `${VAR}` and file templates can mix without corrupting `$` patterns; file contents are trimmed and never re-expanded.

- **New Features**
  - Resolves `{file:...}` relative to optional `baseDir` (defaults to `process.cwd()`), with `~/` homedir support.
  - Works in nested objects and arrays via `expandEnvVarsInObject(baseDir?)`.
  - Missing files now throw a clear error.

<sup>Written for commit c1b02e6665457e98158a7da5a80e2d4745d03a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

