### PR TITLE
fix(config): keep default OpenCode Build agent enabled by default (fixes #2545)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -137,7 +137,7 @@ export async function applyAgentConfig(params: {
 
   const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
   const builderEnabled =
-    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
+    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? true;
   const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;


### PR DESCRIPTION
## Summary
- Changes `default_builder_enabled` default from `false` to `true`

## Problem
When OMO is installed, the default OpenCode Build and Plan agents are removed. This forces all users into the full OMO orchestration (Sisyphus) for every task, even simple ones where the lightweight Build agent would be more appropriate. Multiple users reported this as a significant usability regression (#2545, 7 comments).

## Fix
One-line change in `agent-config-handler.ts`:
```diff
- params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
+ params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? true;
```

Users who prefer the previous behavior (Build agent hidden) can set `default_builder_enabled: false` in their config.

Fixes #2545

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the OpenCode Build agent enabled by default so simple tasks don't require full Sisyphus orchestration (fixes #2545). This flips the fallback for `default_builder_enabled` to `true` in `src/plugin-handlers/agent-config-handler.ts`; you can still set it to `false` to hide the agent.

<sup>Written for commit 6455b851b8b9a3ed73434d7a05192f1026a1cb2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

