### PR TITLE
fix(cli): replace dead glm-4.7-free with gpt-5-nano as ultimate fallback (fixes #2101)

### DIFF
--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -19,7 +19,7 @@ export type { GeneratedOmoConfig } from "./model-fallback-types"
 
 const ZAI_MODEL = "zai-coding-plan/glm-4.7"
 
-const ULTIMATE_FALLBACK = "opencode/glm-4.7-free"
+const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 
 


### PR DESCRIPTION
## Summary
- Replaces dead `opencode/glm-4.7-free` with `opencode/gpt-5-nano` as ULTIMATE_FALLBACK

## Problem
`opencode/glm-4.7-free` was removed from the OpenCode platform. The CLI installer uses it as the last-resort fallback model when no major provider is configured, resulting in a non-functional model assignment for new installs.

## Fix
```diff
- const ULTIMATE_FALLBACK = "opencode/glm-4.7-free"
+ const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
```

`opencode/gpt-5-nano` is confirmed available per user reports (#2101 comment by @weitude) and is already used in multiple fallback chains throughout `model-requirements.ts`.

Fixes #2101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced dead `opencode/glm-4.7-free` with `opencode/gpt-5-nano` as the CLI’s ultimate fallback model. Restores a working default for new installs without a configured provider (fixes #2101).

<sup>Written for commit fc48df1d538edc5572cfe373642104b640eadf54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

