### PR TITLE
fix(prometheus-md-only): block file-modifying Bash commands in Prometheus (fixes #2273)

### DIFF
--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -14,11 +14,18 @@ export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
 export const BASH_TOOLS = ["Bash", "bash"]
 
 const WRITE_COMMAND_PATTERNS = [
-  /\b(cp|mv|rm|mkdir|rmdir|touch|chmod|chown)\b/,
-  /\b(sed\s+-i|perl\s+-[pi])/,
-  /\b(tee|install)\b/,
-  />[^>]/,
-  /\bgit\s+(add|commit|push|merge|rebase|reset|checkout\s+-b|branch\s+-[dD]|stash|cherry-pick|revert|tag)\b/,
+  // File-modifying commands at start of command or after pipe/chain operators
+  /(?:^|[;&|]\s*)(cp|mv|rm|mkdir|rmdir|touch|chmod|chown)\b/,
+  /(?:^|[;&|]\s*)(sed\s+-i|perl\s+-[pi])/,
+  /(?:^|[;&|]\s*)(tee)\b/,
+  // Redirect operators (both > and >>)
+  />+\s*[^&]/,
+  // Git mutating subcommands (excludes read-only: merge-base, tag -l, branch -a)
+  /\bgit\s+(add|commit|push|rebase|reset|stash|cherry-pick|revert)\b/,
+  /\bgit\s+merge\b(?!\s*-)/,
+  /\bgit\s+tag\b(?!\s+-(l|list)\b)/,
+  /\bgit\s+checkout\s+-b\b/,
+  /\bgit\s+branch\s+-[dD]\b/,
 ]
 
 export function isWriteCommand(command: string): boolean {

--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -11,6 +11,20 @@ export const ALLOWED_PATH_PREFIX = ".sisyphus"
 
 export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
 
+export const BASH_TOOLS = ["Bash", "bash"]
+
+const WRITE_COMMAND_PATTERNS = [
+  /\b(cp|mv|rm|mkdir|rmdir|touch|chmod|chown)\b/,
+  /\b(sed\s+-i|perl\s+-[pi])/,
+  /\b(tee|install)\b/,
+  />[^>]/,
+  /\bgit\s+(add|commit|push|merge|rebase|reset|checkout\s+-b|branch\s+-[dD]|stash|cherry-pick|revert|tag)\b/,
+]
+
+export function isWriteCommand(command: string): boolean {
+  return WRITE_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
+}
+
 export const PLANNING_CONSULT_WARNING = `
 
 ---

--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -14,15 +14,16 @@ export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
 export const BASH_TOOLS = ["Bash", "bash"]
 
 const WRITE_COMMAND_PATTERNS = [
-  // File-modifying commands at start of command or after pipe/chain operators
-  /(?:^|[;&|]\s*)(cp|mv|rm|mkdir|rmdir|touch|chmod|chown)\b/,
-  /(?:^|[;&|]\s*)(sed\s+-i|perl\s+-[pi])/,
-  /(?:^|[;&|]\s*)(tee)\b/,
+  // File-modifying commands at start of command, after newlines, or after chain operators.
+  // (?:(?:^|\n)\s*|[;&|]\s*) handles: leading whitespace, newline-separated, and chained cmds
+  /(?:(?:^|\n)\s*|[;&|]\s*)(cp|mv|rm|mkdir|rmdir|touch|chmod|chown)\b/,
+  /(?:(?:^|\n)\s*|[;&|]\s*)(sed\s+-i|perl\s+-[pi])/,
+  /(?:(?:^|\n)\s*|[;&|]\s*)(tee)\b/,
   // Redirect operators (both > and >>)
   />+\s*[^&]/,
   // Git mutating subcommands (excludes read-only: merge-base, tag -l, branch -a)
-  /\bgit\s+(add|commit|push|rebase|reset|stash|cherry-pick|revert)\b/,
-  /\bgit\s+merge\b(?!\s*-)/,
+  /\bgit\s+(add|commit|push|rebase|reset|stash|cherry-pick|revert|rm|clean|restore|pull)\b/,
+  /\bgit\s+merge(?!-)/,
   /\bgit\s+tag\b(?!\s+-(l|list)\b)/,
   /\bgit\s+checkout\s+-b\b/,
   /\bgit\s+branch\s+-[dD]\b/,

--- a/src/hooks/prometheus-md-only/hook.ts
+++ b/src/hooks/prometheus-md-only/hook.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { HOOK_NAME, BLOCKED_TOOLS, PLANNING_CONSULT_WARNING, PROMETHEUS_WORKFLOW_REMINDER } from "./constants"
+import { HOOK_NAME, BLOCKED_TOOLS, BASH_TOOLS, PLANNING_CONSULT_WARNING, PROMETHEUS_WORKFLOW_REMINDER, isWriteCommand } from "./constants"
 import { log } from "../../shared/logger"
 import { SYSTEM_DIRECTIVE_PREFIX } from "../../shared/system-directive"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
@@ -33,6 +33,24 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
             tool: toolName,
             agent: agentName,
           })
+        }
+        return
+      }
+
+      if (BASH_TOOLS.includes(toolName)) {
+        const command = output.args.command as string | undefined
+        if (command && isWriteCommand(command)) {
+          log(`[${HOOK_NAME}] Blocked: Prometheus cannot run file-modifying shell commands`, {
+            sessionID: input.sessionID,
+            tool: toolName,
+            command: command.slice(0, 200),
+            agent: agentName,
+          })
+          throw new Error(
+            `[${HOOK_NAME}] ${getAgentDisplayName("prometheus")} is a READ-ONLY planner and cannot run file-modifying shell commands. ` +
+            `Blocked command: ${command.slice(0, 100)}. ` +
+            `Use /start-work to execute your plan. Only read-only commands (git log, ls, grep, cat) are allowed.`
+          )
         }
         return
       }


### PR DESCRIPTION
## Summary
- Adds write-command detection for Bash tool calls in Prometheus
- Blocks file-modifying shell commands while allowing read-only ones

## Problem
Prometheus (Plan Builder) is supposed to be read-only, but the `BLOCKED_TOOLS` list only covers `Write` and `Edit`. Prometheus can bypass this by using Bash to run `cp`, `mv`, `rm`, `sed -i`, `git commit`, `echo >`, etc. — sisyphus-bot confirmed this as P1 in #2273.

## Fix
Two changes:

### 1. `constants.ts`
Added `BASH_TOOLS` list and `isWriteCommand()` that pattern-matches common file-modifying commands:
- File ops: `cp`, `mv`, `rm`, `mkdir`, `touch`, `chmod`, `tee`
- In-place edits: `sed -i`, `perl -pi`
- Redirects: `>` (but not `>>` for appending — conservative)
- Git mutations: `add`, `commit`, `push`, `merge`, `rebase`, `reset`, etc.

### 2. `hook.ts`
Added Bash-specific guard before the existing BLOCKED_TOOLS check:
- If command matches write patterns → throw error with clear message
- If command is read-only (`git log`, `ls`, `grep`, `cat`) → allow through

## Design Decisions
- **Pattern-based, not blocklist**: Write commands are detected via regex, not an exhaustive command list. This catches `sed -i` but allows `sed` (print-only), catches `git commit` but allows `git log`
- **Read-only commands preserved**: Prometheus legitimately needs `git log`, `ls`, `find` for planning. Completely blocking Bash would break planning workflows
- **Consistent with existing pattern**: Matches how task tools get PLANNING_CONSULT_WARNING injection

Fixes #2273

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks file-modifying Bash commands in Prometheus to keep the planner read-only and close the Bash bypass; detection now handles leading whitespace/chains and blocks > and >>. Fixes #2273.

- **Bug Fixes**
  - Added Bash write detection (`isWriteCommand`) for cp/mv/rm/mkdir/rmdir/touch/chmod/chown, sed -i/perl -pi, tee, redirects (> and >>), and expanded git mutations; matches only at start/after chain ops (handles leading whitespace) and not inside args; refined git patterns to exclude read-only variants (e.g., merge-base, tag -l, branch -a); removed `install`.
  - Added a Bash-specific guard that logs and throws a clear error when a write command is attempted.
  - Keeps read-only commands (git log, ls, grep, cat) for planning and directs users to use `/start-work` for execution.

<sup>Written for commit 134dcc6ca995105b4e1e12efba15d5fdb85b0b99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

