### PR TITLE
fix(prometheus-md-only): clarify error message to remove READ-ONLY contradiction (fixes #2150)

### DIFF
--- a/src/hooks/prometheus-md-only/hook.ts
+++ b/src/hooks/prometheus-md-only/hook.ts
@@ -54,11 +54,11 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
            agent: agentName,
          })
          throw new Error(
-           `[${HOOK_NAME}] ${getAgentDisplayName("prometheus")} can only write/edit .md files inside .sisyphus/ directory. ` +
-           `Attempted to modify: ${filePath}. ` +
-           `${getAgentDisplayName("prometheus")} is a READ-ONLY planner. Use /start-work to execute the plan. ` +
-           `APOLOGIZE TO THE USER, REMIND OF YOUR PLAN WRITING PROCESSES, TELL USER WHAT YOU WILL GOING TO DO AS THE PROCESS, WRITE THE PLAN`
-         )
+            `[${HOOK_NAME}] ${getAgentDisplayName("prometheus")} attempted to modify: ${filePath}. ` +
+            `Only .md files inside .sisyphus/plans/ and .sisyphus/drafts/ are writable. ` +
+            `All other files are off-limits during planning. Use /start-work to execute the plan. ` +
+            `APOLOGIZE TO THE USER, REMIND OF YOUR PLAN WRITING PROCESSES, TELL USER WHAT YOU WILL GOING TO DO AS THE PROCESS, WRITE THE PLAN`
+          )
        }
 
       const normalizedPath = filePath.toLowerCase().replace(/\\/g, "/")


### PR DESCRIPTION
## Summary
- Rewords the prometheus-md-only error message to remove the contradictory "READ-ONLY planner" label

## Problem
The error message contained a contradiction:
> "can only write/edit .md files inside .sisyphus/ directory" + "is a READ-ONLY planner"

Models interpreted this as a full write prohibition and refused to create plan files even in the allowed `.sisyphus/plans/` directory, breaking the planning workflow entirely.

## Fix
```diff
- can only write/edit .md files inside .sisyphus/ directory.
- Attempted to modify: ${filePath}.
- is a READ-ONLY planner.
+ attempted to modify: ${filePath}.
+ Only .md files inside .sisyphus/plans/ and .sisyphus/drafts/ are writable.
+ All other files are off-limits during planning.
```

The new message explicitly states which paths ARE writable, removing the ambiguity that caused models to refuse all writes.

Fixes #2150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the prometheus-md-only hook error to remove the “READ-ONLY” contradiction and explicitly list writable paths. Prevents models from refusing all writes during planning and allows .md files in .sisyphus/plans/ and .sisyphus/drafts/ (fixes #2150).

<sup>Written for commit 7d6ea5f3d0dfbcab9bcbe04c0536b0aec8c9a500. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

