### PR TITLE
fix(non-interactive-env): reduce git env prefix to prevent output noise (fixes #2599)

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -45,11 +45,11 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
         return
       }
 
-      // Minimal env prefix: only the 3 vars that prevent git from hanging.
+      // Minimal env prefix: only the 4 vars that prevent git from hanging.
       // Uses `export` so vars apply across chained commands (&&, ;).
       // Previous approach exported ALL 15 NON_INTERACTIVE_ENV vars, creating
       // a ~300 char prefix that polluted output and confused models (#2599).
-      const GIT_ENV_PREFIX = "export GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0;"
+      const GIT_ENV_PREFIX = "export GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never;"
 
       if (command.includes("GIT_EDITOR=:")) {
         return

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -45,11 +45,11 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
         return
       }
 
-      // Minimal env prefix: only the vars that prevent git from hanging.
-      // Previous approach used ALL NON_INTERACTIVE_ENV vars via `export`,
-      // creating a long prefix that polluted tool output and confused models
-      // into echoing it back as text (#2599).
-      const GIT_ENV_PREFIX = "GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0"
+      // Minimal env prefix: only the 3 vars that prevent git from hanging.
+      // Uses `export` so vars apply across chained commands (&&, ;).
+      // Previous approach exported ALL 15 NON_INTERACTIVE_ENV vars, creating
+      // a ~300 char prefix that polluted output and confused models (#2599).
+      const GIT_ENV_PREFIX = "export GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0;"
 
       if (command.includes("GIT_EDITOR=:")) {
         return

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { HOOK_NAME, SHELL_COMMAND_PATTERNS } from "./constants"
+import { log } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -45,28 +45,20 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
         return
       }
 
-      // NOTE: We intentionally removed the isNonInteractive() check here.
-      // Even when OpenCode runs in a TTY, the agent cannot interact with
-      // spawned bash processes. Git commands like `git rebase --continue`
-      // would open editors (vim/nvim) that hang forever.
-      // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
-      // for git commands to prevent interactive prompts.
+      // Minimal env prefix: only the vars that prevent git from hanging.
+      // Previous approach used ALL NON_INTERACTIVE_ENV vars via `export`,
+      // creating a long prefix that polluted tool output and confused models
+      // into echoing it back as text (#2599).
+      const GIT_ENV_PREFIX = "GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0"
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so always use unix export syntax.
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
-      
-      // Check if the command already starts with the prefix to avoid stacking.
-      // This maintains the non-interactive behavior and makes the operation idempotent.
-      if (command.trim().startsWith(envPrefix.trim())) {
+      if (command.includes("GIT_EDITOR=:")) {
         return
       }
 
-      output.args.command = `${envPrefix} ${command}`
+      output.args.command = `${GIT_ENV_PREFIX} ${command}`
 
-      log(`[${HOOK_NAME}] Prepended non-interactive env vars to git command`, {
+      log(`[${HOOK_NAME}] Prepended git env vars`, {
         sessionID: input.sessionID,
-        envPrefix,
       })
     },
   }


### PR DESCRIPTION
## Summary
- Reduces the git env prefix from 15 vars (~300 chars) to 3 essential vars (~50 chars)
- Uses inline env syntax instead of `export` for cleaner output

## Problem
The `non-interactive-env` hook prepended ALL 15 `NON_INTERACTIVE_ENV` vars with `export` syntax to every git command:
```
export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 GIT_EDITOR=: EDITOR=: VISUAL='' GIT_SEQUENCE_EDITOR=: GIT_MERGE_AUTOEDIT=no GIT_PAGER=cat PAGER=cat npm_config_yes=true PIP_NO_INPUT=1 YARN_ENABLE_IMMUTABLE_INSTALLS=false; git status
```

This caused two problems:
1. Tool output was polluted with a ~300 char prefix on every git command
2. Models (especially non-Claude) echoed this prefix back as text in their responses, confusing users (#2599)

## Fix
Reduced to only the 3 vars that actually prevent git from hanging:
```
GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0 git status
```

- `GIT_EDITOR=:` — prevents git from opening vim/nano (the #1 hang cause)
- `GIT_PAGER=cat` — prevents less/more from waiting for input
- `GIT_TERMINAL_PROMPT=0` — prevents git credential prompts

The other 12 vars (`CI`, `DEBIAN_FRONTEND`, `EDITOR`, `VISUAL`, etc.) are either redundant with the 3 above for git operations, or not relevant to git commands at all.

Fixes #2599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce the git env prefix in `non-interactive-env` from 15 vars to 4 essentials and use an `export`-based prefix so it works across chained commands, removing noisy output and echoing. Git commands are now prepended with `export GIT_EDITOR=: GIT_PAGER=cat GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never;`, fixing #2599.

<sup>Written for commit f657c749893390e7b20e7f7c1852317ed88f6501. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

