### PR TITLE
fix(tmux): defer subagent attach until pane focus

### DIFF
--- a/src/features/tmux-subagent/focus-activation.test.ts
+++ b/src/features/tmux-subagent/focus-activation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { getSessionsToActivate } from "./focus-activation"
+import type { TrackedSession, WindowState } from "./types"
+
+function createTrackedSession(overrides?: Partial<TrackedSession>): TrackedSession {
+	return {
+		sessionId: "ses_1",
+		paneId: "%1",
+		description: "Task",
+		attachActivated: false,
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		lastSeenAt: new Date("2026-01-01T00:00:00.000Z"),
+		closePending: false,
+		closeRetryCount: 0,
+		...overrides,
+	}
+}
+
+function createWindowState(overrides?: Partial<WindowState>): WindowState {
+	return {
+		windowWidth: 220,
+		windowHeight: 44,
+		mainPane: {
+			paneId: "%0",
+			width: 110,
+			height: 44,
+			left: 0,
+			top: 0,
+			title: "main",
+			isActive: true,
+		},
+		agentPanes: [
+			{
+				paneId: "%1",
+				width: 40,
+				height: 44,
+				left: 110,
+				top: 0,
+				title: "omo-subagent-Task",
+				isActive: true,
+			},
+		],
+		...overrides,
+	}
+}
+
+describe("getSessionsToActivate", () => {
+	test("returns focused tracked sessions that are not yet activated", () => {
+		const sessions = new Map<string, TrackedSession>([["ses_1", createTrackedSession()]])
+
+		const result = getSessionsToActivate(createWindowState(), sessions)
+
+		expect(result).toHaveLength(1)
+		expect(result[0]?.sessionId).toBe("ses_1")
+	})
+
+	test("skips unfocused panes and already activated sessions", () => {
+		const sessions = new Map<string, TrackedSession>([
+			["ses_1", createTrackedSession({ attachActivated: true })],
+			["ses_2", createTrackedSession({ sessionId: "ses_2", paneId: "%2" })],
+		])
+
+		const result = getSessionsToActivate(
+			createWindowState({
+				agentPanes: [
+					{
+						paneId: "%1",
+						width: 40,
+						height: 44,
+						left: 110,
+						top: 0,
+						title: "omo-subagent-Task 1",
+						isActive: true,
+					},
+					{
+						paneId: "%2",
+						width: 40,
+						height: 44,
+						left: 150,
+						top: 0,
+						title: "omo-subagent-Task 2",
+						isActive: false,
+					},
+				],
+			}),
+			sessions,
+		)
+
+		expect(result).toHaveLength(0)
+	})
+})

--- a/src/features/tmux-subagent/focus-activation.ts
+++ b/src/features/tmux-subagent/focus-activation.ts
@@ -1,0 +1,17 @@
+import type { TrackedSession, WindowState } from "./types"
+
+export function getSessionsToActivate(
+  state: WindowState,
+  sessions: Map<string, TrackedSession>,
+): TrackedSession[] {
+  if (sessions.size === 0) return []
+
+  const sessionsByPaneId = new Map(
+    Array.from(sessions.values()).map((tracked) => [tracked.paneId, tracked]),
+  )
+
+  return state.agentPanes
+    .filter((pane) => pane.isActive)
+    .map((pane) => sessionsByPaneId.get(pane.paneId))
+    .filter((tracked): tracked is TrackedSession => Boolean(tracked && !tracked.attachActivated))
+}

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, beforeEach, spyOn } from 'bun:test'
+import type { PluginInput } from '@opencode-ai/plugin'
 import type { TmuxConfig } from '../../config/schema'
 import type { WindowState, PaneAction } from './types'
 import type { ActionResult, ExecuteContext } from './action-executor'
@@ -34,6 +35,7 @@ const mockExecuteAction = mock<(
 ) => Promise<ActionResult>>(async () => ({ success: true }))
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
+const mockActivateTmuxPane = mock(async () => ({ success: true, paneId: '%mock' }))
 
 const mockTmuxDeps: TmuxUtilDeps = {
   isInsideTmux: mockIsInsideTmux,
@@ -65,6 +67,7 @@ mock.module('../../shared/tmux', () => {
   return {
     isInsideTmux,
     getCurrentPaneId,
+    activateTmuxPane: mockActivateTmuxPane,
     POLL_INTERVAL_BACKGROUND_MS,
     SESSION_TIMEOUT_MS,
     SESSION_MISSING_GRACE_MS,
@@ -78,7 +81,7 @@ const trackedSessions = new Set<string>()
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
   sessionMessagesResult?: { data?: unknown[] }
-}) {
+}): PluginInput {
   return {
     serverUrl: new URL('http://localhost:4096'),
     client: {
@@ -101,7 +104,7 @@ function createMockContext(overrides?: {
         }),
       },
     },
-  } as any
+  } as unknown as PluginInput
 }
 
 function createSessionCreatedEvent(
@@ -127,6 +130,33 @@ function createWindowState(overrides?: Partial<WindowState>): WindowState {
   }
 }
 
+function getDeferredQueue(target: object): string[] {
+	const deferredQueue = Reflect.get(target, 'deferredQueue')
+	if (!Array.isArray(deferredQueue)) {
+		throw new Error('Expected deferredQueue array')
+	}
+
+	return deferredQueue
+}
+
+function getActivateFocusedSessionPanes(target: object): () => Promise<void> {
+	const activateFocusedSessionPanes = Reflect.get(target, 'activateFocusedSessionPanes')
+	if (typeof activateFocusedSessionPanes !== 'function') {
+		throw new Error('Expected activateFocusedSessionPanes method')
+	}
+
+	return activateFocusedSessionPanes.bind(target)
+}
+
+function getTryAttachDeferredSession(target: object): () => Promise<void> {
+	const tryAttachDeferredSession = Reflect.get(target, 'tryAttachDeferredSession')
+	if (typeof tryAttachDeferredSession !== 'function') {
+		throw new Error('Expected tryAttachDeferredSession method')
+	}
+
+	return tryAttachDeferredSession.bind(target)
+}
+
 describe('TmuxSessionManager', () => {
   beforeEach(() => {
     mockQueryWindowState.mockClear()
@@ -135,6 +165,7 @@ describe('TmuxSessionManager', () => {
     mockExecuteAction.mockClear()
     mockIsInsideTmux.mockClear()
     mockGetCurrentPaneId.mockClear()
+    mockActivateTmuxPane.mockClear()
     trackedSessions.clear()
 
     mockQueryWindowState.mockImplementation(async () => createWindowState())
@@ -326,6 +357,117 @@ describe('TmuxSessionManager', () => {
       expect(actionsArg[0].type).toBe('spawn')
     })
 
+    test('activates attach only when pane is focused', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_focus', 'ses_parent', 'Focus Task')
+      )
+
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          agentPanes: [
+            {
+              paneId: '%mock',
+              width: 40,
+              height: 44,
+              left: 100,
+              top: 0,
+              title: 'omo-subagent-Focus Task',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+	      await getActivateFocusedSessionPanes(manager)()
+
+      expect(mockActivateTmuxPane).toHaveBeenCalledTimes(0)
+
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          agentPanes: [
+            {
+              paneId: '%mock',
+              width: 40,
+              height: 44,
+              left: 100,
+              top: 0,
+              title: 'omo-subagent-Focus Task',
+              isActive: true,
+            },
+          ],
+        })
+      )
+	      await getActivateFocusedSessionPanes(manager)()
+
+      // then
+      expect(mockActivateTmuxPane).toHaveBeenCalledTimes(1)
+      expect(mockActivateTmuxPane).toHaveBeenCalledWith(
+        '%mock',
+        'ses_focus',
+        'Focus Task',
+	        expect.objectContaining({
+	          enabled: true,
+	          layout: 'main-vertical',
+	        }),
+	        'http://localhost:4096/',
+      )
+    })
+
+    test('focus-based activation is idempotent across repeated checks', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_once_focus', 'ses_parent', 'Focus Once')
+      )
+
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          agentPanes: [
+            {
+              paneId: '%mock',
+              width: 40,
+              height: 44,
+              left: 100,
+              top: 0,
+              title: 'omo-subagent-Focus Once',
+              isActive: true,
+            },
+          ],
+        })
+      )
+
+      // when
+	      await getActivateFocusedSessionPanes(manager)()
+	      await getActivateFocusedSessionPanes(manager)()
+
+      // then
+      expect(mockActivateTmuxPane).toHaveBeenCalledTimes(1)
+    })
+
     test('does NOT spawn pane when session has no parentID', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
@@ -440,7 +582,7 @@ describe('TmuxSessionManager', () => {
 
       // then - with small window, manager defers instead of replacing
       expect(mockExecuteActions).toHaveBeenCalledTimes(0)
-      expect((manager as any).deferredQueue).toEqual(['ses_new'])
+	      expect(getDeferredQueue(manager)).toEqual(['ses_new'])
     })
 
     test('keeps deferred queue idempotent for duplicate session.created events', async () => {
@@ -484,7 +626,7 @@ describe('TmuxSessionManager', () => {
       )
 
       // then
-      expect((manager as any).deferredQueue).toEqual(['ses_dup'])
+	      expect(getDeferredQueue(manager)).toEqual(['ses_dup'])
     })
 
     test('auto-attaches deferred sessions in FIFO order', async () => {
@@ -538,17 +680,17 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionCreated(createSessionCreatedEvent('ses_1', 'ses_parent', 'Task 1'))
       await manager.onSessionCreated(createSessionCreatedEvent('ses_2', 'ses_parent', 'Task 2'))
       await manager.onSessionCreated(createSessionCreatedEvent('ses_3', 'ses_parent', 'Task 3'))
-      expect((manager as any).deferredQueue).toEqual(['ses_1', 'ses_2', 'ses_3'])
+	      expect(getDeferredQueue(manager)).toEqual(['ses_1', 'ses_2', 'ses_3'])
 
       // when
       mockQueryWindowState.mockImplementation(async () => createWindowState())
-      await (manager as any).tryAttachDeferredSession()
-      await (manager as any).tryAttachDeferredSession()
-      await (manager as any).tryAttachDeferredSession()
+	      await getTryAttachDeferredSession(manager)()
+	      await getTryAttachDeferredSession(manager)()
+	      await getTryAttachDeferredSession(manager)()
 
       // then
       expect(attachOrder).toEqual(['ses_1', 'ses_2', 'ses_3'])
-      expect((manager as any).deferredQueue).toEqual([])
+	      expect(getDeferredQueue(manager)).toEqual([])
     })
 
     test('does not attach deferred session more than once across repeated retries', async () => {
@@ -605,12 +747,12 @@ describe('TmuxSessionManager', () => {
 
       // when
       mockQueryWindowState.mockImplementation(async () => createWindowState())
-      await (manager as any).tryAttachDeferredSession()
-      await (manager as any).tryAttachDeferredSession()
+	      await getTryAttachDeferredSession(manager)()
+	      await getTryAttachDeferredSession(manager)()
 
       // then
       expect(attachCount).toBe(1)
-      expect((manager as any).deferredQueue).toEqual([])
+	      expect(getDeferredQueue(manager)).toEqual([])
     })
 
     test('removes deferred session when session is deleted before attach', async () => {
@@ -648,13 +790,13 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionCreated(
         createSessionCreatedEvent('ses_pending', 'ses_parent', 'Pending Task')
       )
-      expect((manager as any).deferredQueue).toEqual(['ses_pending'])
+	      expect(getDeferredQueue(manager)).toEqual(['ses_pending'])
 
       // when
       await manager.onSessionDeleted({ sessionID: 'ses_pending' })
 
       // then
-      expect((manager as any).deferredQueue).toEqual([])
+	      expect(getDeferredQueue(manager)).toEqual([])
       expect(mockExecuteAction).toHaveBeenCalledTimes(0)
     })
 
@@ -687,7 +829,7 @@ describe('TmuxSessionManager', () => {
             String(message).includes('failed to query window state, deferring session')
           )
         ).toBe(true)
-        expect((manager as any).deferredQueue).toEqual(['ses_null_state'])
+	        expect(getDeferredQueue(manager)).toEqual(['ses_null_state'])
 
         logSpy.mockRestore()
       })
@@ -728,7 +870,7 @@ describe('TmuxSessionManager', () => {
             String(message).includes('re-queueing deferred session after spawn failure')
           )
         ).toBe(true)
-        expect((manager as any).deferredQueue).toEqual(['ses_fail_no_close'])
+	        expect(getDeferredQueue(manager)).toEqual(['ses_fail_no_close'])
 
         logSpy.mockRestore()
       })
@@ -781,7 +923,7 @@ describe('TmuxSessionManager', () => {
             String(message).includes('re-queueing deferred session after spawn failure')
           )
         ).toBe(true)
-        expect((manager as any).deferredQueue).toEqual(['ses_fail_with_close'])
+	        expect(getDeferredQueue(manager)).toEqual(['ses_fail_with_close'])
 
         logSpy.mockRestore()
       })

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -3,6 +3,7 @@ import type { TmuxConfig } from "../../config/schema"
 import type { TrackedSession, CapacityConfig, WindowState } from "./types"
 import { log, normalizeSDKResponse } from "../../shared"
 import {
+  activateTmuxPane,
   isInsideTmux as defaultIsInsideTmux,
   getCurrentPaneId as defaultGetCurrentPaneId,
   POLL_INTERVAL_BACKGROUND_MS,
@@ -13,7 +14,12 @@ import { queryWindowState } from "./pane-state-querier"
 import { decideSpawnActions, decideCloseAction, type SessionMapping } from "./decision-engine"
 import { executeActions, executeAction } from "./action-executor"
 import { TmuxPollingManager } from "./polling-manager"
-import { createTrackedSession, markTrackedSessionClosePending } from "./tracked-session-state"
+import {
+  createTrackedSession,
+  markTrackedSessionActivated,
+  markTrackedSessionClosePending,
+} from "./tracked-session-state"
+import { getSessionsToActivate } from "./focus-activation"
 type OpencodeClient = PluginInput["client"]
 
 interface SessionCreatedEvent {
@@ -82,7 +88,8 @@ export class TmuxSessionManager {
     this.pollingManager = new TmuxPollingManager(
       this.client,
       this.sessions,
-      this.closeSessionById.bind(this)
+      this.closeSessionById.bind(this),
+      this.activateFocusedSessionPanes.bind(this),
     )
     log("[tmux-session-manager] initialized", {
       configEnabled: this.tmuxConfig.enabled,
@@ -425,6 +432,41 @@ export class TmuxSessionManager {
       timeoutMs: SESSION_READY_TIMEOUT_MS,
     })
     return false
+  }
+
+  private async activateFocusedSessionPanes(): Promise<void> {
+    if (!this.sourcePaneId || this.sessions.size === 0) return
+
+    const state = await queryWindowState(this.sourcePaneId)
+    if (!state) return
+
+    const sessionsToActivate = getSessionsToActivate(state, this.sessions)
+    for (const tracked of sessionsToActivate) {
+      const result = await activateTmuxPane(
+        tracked.paneId,
+        tracked.sessionId,
+        tracked.description,
+        this.tmuxConfig,
+        this.serverUrl,
+      )
+
+      if (!result.success) {
+        log("[tmux-session-manager] failed to activate focused session pane", {
+          sessionId: tracked.sessionId,
+          paneId: tracked.paneId,
+        })
+        continue
+      }
+
+      const latestTracked = this.sessions.get(tracked.sessionId)
+      if (!latestTracked) continue
+
+      this.sessions.set(tracked.sessionId, markTrackedSessionActivated(latestTracked))
+      log("[tmux-session-manager] activated focused session pane", {
+        sessionId: tracked.sessionId,
+        paneId: tracked.paneId,
+      })
+    }
   }
 
   async onSessionCreated(event: SessionCreatedEvent): Promise<void> {

--- a/src/features/tmux-subagent/polling-manager.test.ts
+++ b/src/features/tmux-subagent/polling-manager.test.ts
@@ -10,6 +10,7 @@ describe("TmuxPollingManager overlap", () => {
       sessionId: "ses-1",
       paneId: "%1",
       description: "test",
+      attachActivated: false,
       createdAt: new Date(),
       lastSeenAt: new Date(),
       closePending: false,

--- a/src/features/tmux-subagent/polling-manager.ts
+++ b/src/features/tmux-subagent/polling-manager.ts
@@ -16,7 +16,8 @@ export class TmuxPollingManager {
   constructor(
     private client: OpencodeClient,
     private sessions: Map<string, TrackedSession>,
-    private closeSessionById: (sessionId: string) => Promise<void>
+    private closeSessionById: (sessionId: string) => Promise<void>,
+    private activateFocusedSessions?: () => Promise<void>,
   ) {}
 
   startPolling(): void {
@@ -41,6 +42,10 @@ export class TmuxPollingManager {
     if (this.pollingInFlight) return
     this.pollingInFlight = true
     try {
+      if (this.activateFocusedSessions) {
+        await this.activateFocusedSessions()
+      }
+
       if (this.sessions.size === 0) {
         this.stopPolling()
         return

--- a/src/features/tmux-subagent/tracked-session-state.test.ts
+++ b/src/features/tmux-subagent/tracked-session-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import {
+	createTrackedSession,
+	markTrackedSessionActivated,
+	markTrackedSessionClosePending,
+} from "./tracked-session-state"
+
+describe("tracked-session-state", () => {
+	test("creates tracked sessions with activation disabled", () => {
+		const tracked = createTrackedSession({
+			sessionId: "ses_1",
+			paneId: "%1",
+			description: "Task",
+		})
+
+		expect(tracked.attachActivated).toBe(false)
+	})
+
+	test("activation marker is idempotent", () => {
+		const tracked = createTrackedSession({
+			sessionId: "ses_1",
+			paneId: "%1",
+			description: "Task",
+		})
+
+		const activatedOnce = markTrackedSessionActivated(tracked)
+		const activatedTwice = markTrackedSessionActivated(activatedOnce)
+
+		expect(activatedOnce.attachActivated).toBe(true)
+		expect(activatedTwice).toEqual(activatedOnce)
+	})
+
+	test("close pending retry increments only after first pending state", () => {
+		const tracked = createTrackedSession({
+			sessionId: "ses_1",
+			paneId: "%1",
+			description: "Task",
+		})
+
+		const first = markTrackedSessionClosePending(tracked)
+		const second = markTrackedSessionClosePending(first)
+
+		expect(first.closePending).toBe(true)
+		expect(first.closeRetryCount).toBe(0)
+		expect(second.closeRetryCount).toBe(1)
+	})
+})

--- a/src/features/tmux-subagent/tracked-session-state.ts
+++ b/src/features/tmux-subagent/tracked-session-state.ts
@@ -12,10 +12,20 @@ export function createTrackedSession(params: {
     sessionId: params.sessionId,
     paneId: params.paneId,
     description: params.description,
+    attachActivated: false,
     createdAt: now,
     lastSeenAt: now,
     closePending: false,
     closeRetryCount: 0,
+  }
+}
+
+export function markTrackedSessionActivated(tracked: TrackedSession): TrackedSession {
+  if (tracked.attachActivated) return tracked
+
+  return {
+    ...tracked,
+    attachActivated: true,
   }
 }
 

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -2,6 +2,7 @@ export interface TrackedSession {
   sessionId: string
   paneId: string
   description: string
+  attachActivated: boolean
   createdAt: Date
   lastSeenAt: Date
   closePending: boolean

--- a/src/features/tmux-subagent/zombie-pane.test.ts
+++ b/src/features/tmux-subagent/zombie-pane.test.ts
@@ -27,6 +27,7 @@ const mockExecuteActions = mock<(
 
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => "%0")
+const mockActivateTmuxPane = mock(async () => ({ success: true, paneId: "%1" }))
 
 mock.module("./pane-state-querier", () => ({
   queryWindowState: mockQueryWindowState,
@@ -40,6 +41,7 @@ mock.module("./action-executor", () => ({
 mock.module("../../shared/tmux", () => ({
   isInsideTmux: mockIsInsideTmux,
   getCurrentPaneId: mockGetCurrentPaneId,
+  activateTmuxPane: mockActivateTmuxPane,
   POLL_INTERVAL_BACKGROUND_MS: 10,
   SESSION_READY_POLL_INTERVAL_MS: 10,
   SESSION_READY_TIMEOUT_MS: 50,
@@ -108,6 +110,7 @@ function createTrackedSession(overrides?: Partial<TrackedSession>): TrackedSessi
     sessionId: "ses_pending",
     paneId: "%1",
     description: "Pending pane",
+    attachActivated: false,
     createdAt: new Date(),
     lastSeenAt: new Date(),
     closePending: false,

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -9,5 +9,6 @@ export type { PaneDimensions } from "./tmux-utils/pane-dimensions"
 export { spawnTmuxPane } from "./tmux-utils/pane-spawn"
 export { closeTmuxPane } from "./tmux-utils/pane-close"
 export { replaceTmuxPane } from "./tmux-utils/pane-replace"
+export { activateTmuxPane } from "./tmux-utils/pane-activate"
 
 export { applyLayout, enforceMainPaneWidth } from "./tmux-utils/layout"

--- a/src/shared/tmux/tmux-utils/pane-activate.ts
+++ b/src/shared/tmux/tmux-utils/pane-activate.ts
@@ -3,9 +3,9 @@ import type { TmuxConfig } from "../../../config/schema"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { SpawnPaneResult } from "../types"
 import { isInsideTmux } from "./environment"
-import { buildDetachedPanePlaceholderCommand } from "./pane-command"
+import { buildOpencodeAttachCommand } from "./pane-command"
 
-export async function replaceTmuxPane(
+export async function activateTmuxPane(
 	paneId: string,
 	sessionId: string,
 	description: string,
@@ -14,12 +14,7 @@ export async function replaceTmuxPane(
 ): Promise<SpawnPaneResult> {
 	const { log } = await import("../../logger")
 
-	log("[replaceTmuxPane] called", { paneId, sessionId, description })
-
-	if (!config.enabled) {
-		return { success: false }
-	}
-	if (!isInsideTmux()) {
+	if (!config.enabled || !isInsideTmux()) {
 		return { success: false }
 	}
 
@@ -28,16 +23,8 @@ export async function replaceTmuxPane(
 		return { success: false }
 	}
 
-	log("[replaceTmuxPane] sending Ctrl+C for graceful shutdown", { paneId })
-	const ctrlCProc = spawn([tmux, "send-keys", "-t", paneId, "C-c"], {
-		stdout: "pipe",
-		stderr: "pipe",
-	})
-	await ctrlCProc.exited
-
-	const placeholderCommand = buildDetachedPanePlaceholderCommand()
-
-	const proc = spawn([tmux, "respawn-pane", "-k", "-t", paneId, placeholderCommand], {
+	const opencodeCmd = buildOpencodeAttachCommand(serverUrl, sessionId)
+	const proc = spawn([tmux, "respawn-pane", "-k", "-t", paneId, opencodeCmd], {
 		stdout: "pipe",
 		stderr: "pipe",
 	})
@@ -45,7 +32,7 @@ export async function replaceTmuxPane(
 
 	if (exitCode !== 0) {
 		const stderr = await new Response(proc.stderr).text()
-		log("[replaceTmuxPane] FAILED", { paneId, exitCode, stderr: stderr.trim() })
+		log("[activateTmuxPane] FAILED", { paneId, sessionId, exitCode, stderr: stderr.trim() })
 		return { success: false }
 	}
 
@@ -58,13 +45,14 @@ export async function replaceTmuxPane(
 	const titleExitCode = await titleProc.exited
 	if (titleExitCode !== 0) {
 		const titleStderr = await stderrPromise
-		log("[replaceTmuxPane] WARNING: failed to set pane title", {
+		log("[activateTmuxPane] WARNING: failed to set pane title", {
 			paneId,
+			title,
 			exitCode: titleExitCode,
 			stderr: titleStderr.trim(),
 		})
 	}
 
-	log("[replaceTmuxPane] SUCCESS", { paneId, sessionId })
+	log("[activateTmuxPane] SUCCESS", { paneId, sessionId })
 	return { success: true, paneId }
 }

--- a/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import {
+	buildDetachedPanePlaceholderCommand,
+	buildOpencodeAttachCommand,
+} from "./pane-command"
+
+	describe("pane-command", () => {
+	test("buildDetachedPanePlaceholderCommand returns non-attach placeholder", () => {
+		const command = buildDetachedPanePlaceholderCommand()
+
+		expect(command).toContain("Subagent pane ready")
+		expect(command).toContain("sleep 3600")
+		expect(command).not.toContain("opencode attach")
+	})
+
+	test("buildOpencodeAttachCommand returns attach command", () => {
+		const command = buildOpencodeAttachCommand("http://localhost:4096", "ses_child")
+
+		expect(command).toBe(
+			"zsh -c 'opencode attach http://localhost:4096 --session ses_child'",
+		)
+	})
+})

--- a/src/shared/tmux/tmux-utils/pane-command.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.ts
@@ -1,0 +1,11 @@
+function escapeSingleQuotedShellText(value: string): string {
+	return value.replace(/'/g, "'\\''")
+}
+
+export function buildOpencodeAttachCommand(serverUrl: string, sessionId: string): string {
+	return `zsh -c 'opencode attach ${escapeSingleQuotedShellText(serverUrl)} --session ${escapeSingleQuotedShellText(sessionId)}'`
+}
+
+export function buildDetachedPanePlaceholderCommand(): string {
+	return "zsh -c 'printf \"[oh-my-opencode] Subagent pane ready. Focus pane to activate attach.\\n\"; while true; do sleep 3600; done'"
+}

--- a/src/shared/tmux/tmux-utils/pane-spawn.ts
+++ b/src/shared/tmux/tmux-utils/pane-spawn.ts
@@ -4,6 +4,7 @@ import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { SpawnPaneResult } from "../types"
 import type { SplitDirection } from "./environment"
 import { isInsideTmux } from "./environment"
+import { buildDetachedPanePlaceholderCommand } from "./pane-command"
 import { isServerRunning } from "./server-health"
 
 export async function spawnTmuxPane(
@@ -48,7 +49,7 @@ export async function spawnTmuxPane(
 
 	log("[spawnTmuxPane] all checks passed, spawning...")
 
-	const opencodeCmd = `zsh -c 'opencode attach ${serverUrl} --session ${sessionId}'`
+	const placeholderCommand = buildDetachedPanePlaceholderCommand()
 
 	const args = [
 		"split-window",
@@ -58,7 +59,7 @@ export async function spawnTmuxPane(
 		"-F",
 		"#{pane_id}",
 		...(targetPaneId ? ["-t", targetPaneId] : []),
-		opencodeCmd,
+		placeholderCommand,
 	]
 
 	const proc = spawn([tmux, ...args], { stdout: "pipe", stderr: "pipe" })


### PR DESCRIPTION
## Summary
This changes the tmux subagent flow so detached panes no longer start an interactive `opencode attach` process immediately when they are created or reused.
Instead, new/reused subagent panes start with an inert placeholder process, and the real attach only happens when that pane is actually focused. This keeps the existing tmux workflow intact while avoiding terminal input/output leakage into the parent OpenCode session.
## Problem
When tmux subagent panes were spawned, they immediately launched interactive `opencode attach` sessions in detached panes. In practice, that could leak terminal responses back into the parent chat UI and show up as random numbers or stray terminal junk in the main OpenCode input box.
## What Changed
- changed tmux pane spawn to use a detached placeholder command instead of immediate interactive attach
- changed pane reuse/replace flow to use the same placeholder behavior
- added a dedicated activation path that respawns the pane into the real `opencode attach` command only when activation is intended
- tracked per-session activation state so focused-pane activation is idempotent
- wired focus-based activation into tmux session polling using existing `pane_active` state
- added regression coverage for:
  - placeholder command construction
  - focused-pane activation selection
  - tracked-session activation state
  - tmux session manager activation behavior
  - related polling/zombie-pane behavior
## Why This Approach
This keeps detached pane creation safe and non-interactive, which is the important part for preventing terminal-response leakage, while preserving the normal subagent experience once a user intentionally focuses the pane.
It also keeps the behavior localized to the tmux integration layer rather than trying to patch around the symptom in the main chat UI.
## Testing
Passed:
- `bun test src/shared/tmux/tmux-utils/pane-command.test.ts src/features/tmux-subagent/focus-activation.test.ts src/features/tmux-subagent/tracked-session-state.test.ts src/features/tmux-subagent/action-executor.test.ts src/features/tmux-subagent/polling-manager.test.ts src/features/tmux-subagent/zombie-pane.test.ts src/features/tmux-subagent/manager.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers tmux subagent attach until the pane is focused to prevent interactive I/O from leaking into the main OpenCode session. Detached panes now start with a placeholder process; activation respawns into `opencode attach` only on focus.

- **Bug Fixes**
  - Spawn/replace use a non-interactive placeholder; activation is triggered by focused panes via tmux polling (`pane_active`).
  - Tracks per-session activation with `attachActivated` and a `focus-activation` selector to make focus-based attach idempotent.
  - Adds `activateTmuxPane` to respawn into `opencode attach` and set titles; tests cover placeholder command, activation selection, tracked state, polling, and manager behavior.

<sup>Written for commit 3223bdd8684b70b018c723ca9411f04809377772. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

