### PR TITLE
fix(schema): strip contentEncoding from MCP tool schemas for Gemini compatibility (fixes #2200)

### DIFF
--- a/src/plugin/normalize-tool-arg-schemas.test.ts
+++ b/src/plugin/normalize-tool-arg-schemas.test.ts
@@ -19,6 +19,11 @@ function getNestedRecord(record: Record<string, unknown>, key: string): Record<s
   return isRecord(value) ? value : undefined
 }
 
+function getNestedArray(record: Record<string, unknown>, key: string): unknown[] | undefined {
+  const value = record[key]
+  return Array.isArray(value) ? value : undefined
+}
+
 async function loadSeparateHostZodModule(): Promise<typeof import("zod")> {
   const pluginPackageDirectory = dirname(Bun.resolveSync("@opencode-ai/plugin/package.json", import.meta.dir))
   const sourceZodDirectory = join(pluginPackageDirectory, "node_modules", "zod")
@@ -93,5 +98,70 @@ describe("normalizeToolArgSchemas", () => {
     expect(afterQuery?.description).toBe("Free-text search query")
     expect(afterQuery?.title).toBe("Query")
     expect(afterQuery?.examples).toEqual(["issue 2314"])
+  })
+
+  it("strips nested contentEncoding fields from serialized tool schemas", async () => {
+    // given
+    const hostZod = await loadSeparateHostZodModule()
+    const toolDefinition = tool({
+      description: "Upload tool",
+      args: {
+        payload: tool.schema.object({
+          inline: tool.schema.string().base64(),
+          nested: tool.schema.object({
+            encoded: tool.schema.string().base64(),
+          }),
+          entries: tool.schema.array(
+            tool.schema.object({
+              content: tool.schema.string().base64(),
+            }),
+          ),
+        }),
+      },
+      async execute(): Promise<string> {
+        return "ok"
+      },
+    })
+
+    // when
+    const beforeSchema = serializeWithHostZod(hostZod, toolDefinition.args)
+    const beforeProperties = getNestedRecord(beforeSchema, "properties")
+    const beforePayload = beforeProperties ? getNestedRecord(beforeProperties, "payload") : undefined
+    const beforePayloadProperties = beforePayload ? getNestedRecord(beforePayload, "properties") : undefined
+    const beforeInline = beforePayloadProperties ? getNestedRecord(beforePayloadProperties, "inline") : undefined
+    const beforeNested = beforePayloadProperties ? getNestedRecord(beforePayloadProperties, "nested") : undefined
+    const beforeNestedProperties = beforeNested ? getNestedRecord(beforeNested, "properties") : undefined
+    const beforeEncoded = beforeNestedProperties ? getNestedRecord(beforeNestedProperties, "encoded") : undefined
+    const beforeEntries = beforePayloadProperties ? getNestedRecord(beforePayloadProperties, "entries") : undefined
+    const beforeItems = beforeEntries ? getNestedRecord(beforeEntries, "items") : undefined
+    const beforeItemsProperties = beforeItems ? getNestedRecord(beforeItems, "properties") : undefined
+    const beforeContent = beforeItemsProperties ? getNestedRecord(beforeItemsProperties, "content") : undefined
+    const beforeRequired = beforePayload ? getNestedArray(beforePayload, "required") : undefined
+
+    normalizeToolArgSchemas(toolDefinition)
+
+    const afterSchema = serializeWithHostZod(hostZod, toolDefinition.args)
+    const afterProperties = getNestedRecord(afterSchema, "properties")
+    const afterPayload = afterProperties ? getNestedRecord(afterProperties, "payload") : undefined
+    const afterPayloadProperties = afterPayload ? getNestedRecord(afterPayload, "properties") : undefined
+    const afterInline = afterPayloadProperties ? getNestedRecord(afterPayloadProperties, "inline") : undefined
+    const afterNested = afterPayloadProperties ? getNestedRecord(afterPayloadProperties, "nested") : undefined
+    const afterNestedProperties = afterNested ? getNestedRecord(afterNested, "properties") : undefined
+    const afterEncoded = afterNestedProperties ? getNestedRecord(afterNestedProperties, "encoded") : undefined
+    const afterEntries = afterPayloadProperties ? getNestedRecord(afterPayloadProperties, "entries") : undefined
+    const afterItems = afterEntries ? getNestedRecord(afterEntries, "items") : undefined
+    const afterItemsProperties = afterItems ? getNestedRecord(afterItems, "properties") : undefined
+    const afterContent = afterItemsProperties ? getNestedRecord(afterItemsProperties, "content") : undefined
+    const afterRequired = afterPayload ? getNestedArray(afterPayload, "required") : undefined
+
+    // then
+    expect(beforeInline?.contentEncoding).toBe("base64")
+    expect(beforeEncoded?.contentEncoding).toBe("base64")
+    expect(beforeContent?.contentEncoding).toBe("base64")
+
+    expect(afterInline?.contentEncoding).toBeUndefined()
+    expect(afterEncoded?.contentEncoding).toBeUndefined()
+    expect(afterContent?.contentEncoding).toBeUndefined()
+    expect(afterRequired).toEqual(beforeRequired)
   })
 })

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -9,9 +9,34 @@ type SchemaWithJsonSchemaOverride = ToolArgSchema & {
   }
 }
 
-function stripRootJsonSchemaFields(jsonSchema: Record<string, unknown>): Record<string, unknown> {
-  const { $schema: _schema, ...rest } = jsonSchema
-  return rest
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function sanitizeJsonSchema(value: unknown, depth = 0): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeJsonSchema(item, depth + 1))
+  }
+
+  if (!isRecord(value)) {
+    return value
+  }
+
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === "contentEncoding") {
+      continue
+    }
+
+    if (depth === 0 && key === "$schema") {
+      continue
+    }
+
+    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1)
+  }
+
+  return sanitized
 }
 
 function attachJsonSchemaOverride(schema: SchemaWithJsonSchemaOverride): void {
@@ -24,7 +49,9 @@ function attachJsonSchemaOverride(schema: SchemaWithJsonSchemaOverride): void {
     delete schema._zod.toJSONSchema
 
     try {
-      return stripRootJsonSchemaFields(tool.schema.toJSONSchema(schema))
+      const jsonSchema = tool.schema.toJSONSchema(schema)
+      const sanitizedJsonSchema = sanitizeJsonSchema(jsonSchema)
+      return isRecord(sanitizedJsonSchema) ? sanitizedJsonSchema : {}
     } finally {
       schema._zod.toJSONSchema = originalOverride
     }

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -13,9 +13,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function sanitizeJsonSchema(value: unknown, depth = 0): unknown {
+const UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["contentEncoding", "contentMediaType"])
+
+function sanitizeJsonSchema(value: unknown, depth = 0, parentKey?: string): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeJsonSchema(item, depth + 1))
+    return value.map((item) => sanitizeJsonSchema(item, depth + 1, parentKey))
   }
 
   if (!isRecord(value)) {
@@ -23,9 +25,10 @@ function sanitizeJsonSchema(value: unknown, depth = 0): unknown {
   }
 
   const sanitized: Record<string, unknown> = {}
+  const isInsideProperties = parentKey === "properties"
 
   for (const [key, nestedValue] of Object.entries(value)) {
-    if (key === "contentEncoding" || key === "contentMediaType") {
+    if (!isInsideProperties && UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
       continue
     }
 
@@ -33,7 +36,7 @@ function sanitizeJsonSchema(value: unknown, depth = 0): unknown {
       continue
     }
 
-    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1)
+    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1, key)
   }
 
   return sanitized

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -15,9 +15,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 const UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["contentEncoding", "contentMediaType"])
 
-function sanitizeJsonSchema(value: unknown, depth = 0, parentKey?: string): unknown {
+function sanitizeJsonSchema(value: unknown, depth = 0, isPropertyName = false): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeJsonSchema(item, depth + 1, parentKey))
+    return value.map((item) => sanitizeJsonSchema(item, depth + 1, false))
   }
 
   if (!isRecord(value)) {
@@ -25,10 +25,9 @@ function sanitizeJsonSchema(value: unknown, depth = 0, parentKey?: string): unkn
   }
 
   const sanitized: Record<string, unknown> = {}
-  const isInsideProperties = parentKey === "properties"
 
   for (const [key, nestedValue] of Object.entries(value)) {
-    if (!isInsideProperties && UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+    if (!isPropertyName && UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
       continue
     }
 
@@ -36,7 +35,8 @@ function sanitizeJsonSchema(value: unknown, depth = 0, parentKey?: string): unkn
       continue
     }
 
-    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1, key)
+    const childIsPropertyName = key === "properties" && !isPropertyName
+    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1, childIsPropertyName)
   }
 
   return sanitized

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -25,7 +25,7 @@ function sanitizeJsonSchema(value: unknown, depth = 0): unknown {
   const sanitized: Record<string, unknown> = {}
 
   for (const [key, nestedValue] of Object.entries(value)) {
-    if (key === "contentEncoding") {
+    if (key === "contentEncoding" || key === "contentMediaType") {
       continue
     }
 


### PR DESCRIPTION
## Summary
- Strip `contentEncoding` from MCP tool schemas to prevent Gemini 400 errors

## Problem
MCP tools (e.g. chrome-devtools-mcp) include `contentEncoding: "base64"` in their JSON schemas. This is valid JSON Schema but unsupported by Gemini's function calling API, causing 400 Bad Request errors when Junior Sisyphus agents use Gemini models.

## Fix
Added recursive `contentEncoding` stripping in the schema sanitization pipeline. The keyword is not used by any LLM provider's function calling API, so it's safe to strip universally.

## Changes
| File | Change |
|------|--------|
| `src/plugin/normalize-tool-arg-schemas.ts` | Added recursive schema sanitizer that removes root `$schema` and nested `contentEncoding` keys before tool schema serialization. |
| `src/plugin/normalize-tool-arg-schemas.test.ts` | Added regression test verifying nested `contentEncoding` fields are stripped while preserving other schema fields. |

Fixes #2200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Gemini 400 errors by stripping `contentEncoding` and `contentMediaType` from MCP tool JSON Schemas during serialization. Handles parameters named `properties` correctly, skips stripping for property names, and removes the root `$schema`.

- **Bug Fixes**
  - Treat JSON Schema `properties` as a container and avoid collisions when a parameter is named `properties`.
  - Add tests for nested objects/arrays and confirm `required` arrays stay unchanged.

<sup>Written for commit dd08225cad924fddfcd6c477e143969afd7d223b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

