### PR TITLE
Fix discovery for plugin-bundled OpenCode skills

### DIFF
--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "os"
 
 const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
 const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
+const ORIGINAL_OPENCODE_CONFIG_DIR = process.env.OPENCODE_CONFIG_DIR
+const ORIGINAL_XDG_CACHE_HOME = process.env.XDG_CACHE_HOME
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)
@@ -24,6 +26,16 @@ describe("skill loader MCP parsing", () => {
 
   afterEach(() => {
     rmSync(TEST_DIR, { recursive: true, force: true })
+    if (ORIGINAL_OPENCODE_CONFIG_DIR !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = ORIGINAL_OPENCODE_CONFIG_DIR
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
+    if (ORIGINAL_XDG_CACHE_HOME !== undefined) {
+      process.env.XDG_CACHE_HOME = ORIGINAL_XDG_CACHE_HOME
+    } else {
+      delete process.env.XDG_CACHE_HOME
+    }
   })
 
   describe("parseSkillMcpConfig", () => {
@@ -615,5 +627,83 @@ Skill body.
       expect(skill).toBeDefined()
       expect(skill?.scope).toBe("project")
     })
+  })
+})
+
+describe("plugin-bundled skill discovery", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+    if (ORIGINAL_OPENCODE_CONFIG_DIR !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = ORIGINAL_OPENCODE_CONFIG_DIR
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
+    if (ORIGINAL_XDG_CACHE_HOME !== undefined) {
+      process.env.XDG_CACHE_HOME = ORIGINAL_XDG_CACHE_HOME
+    } else {
+      delete process.env.XDG_CACHE_HOME
+    }
+  })
+
+  it("discovers plugin-packaged OpenCode skills from the OpenCode cache node_modules", async () => {
+    const configDir = join(TEST_DIR, ".config", "opencode")
+    const cacheDir = join(TEST_DIR, ".cache")
+    const pluginRoot = join(cacheDir, "opencode", "node_modules", "superpowers")
+    const pluginEntryDir = join(pluginRoot, ".opencode", "plugins")
+    const pluginSkillsDir = join(pluginRoot, "skills", "systematic-debugging")
+
+    mkdirSync(pluginEntryDir, { recursive: true })
+    mkdirSync(pluginSkillsDir, { recursive: true })
+    writeFileSync(join(pluginEntryDir, "superpowers.js"), "export const plugin = {};\n")
+    writeFileSync(
+      join(pluginSkillsDir, "SKILL.md"),
+      `---
+name: systematic-debugging
+description: Root-cause debugging workflow
+---
+Debug things systematically.
+`
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = configDir
+    process.env.XDG_CACHE_HOME = cacheDir
+
+    const { discoverSkills } = await import("./loader")
+    const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
+
+    expect(skills.some(s => s.name === "superpowers/systematic-debugging")).toBe(true)
+  })
+
+  it("preserves npm scope for plugin-packaged OpenCode skills", async () => {
+    const configDir = join(TEST_DIR, ".config", "opencode")
+    const cacheDir = join(TEST_DIR, ".cache")
+    const pluginRoot = join(cacheDir, "opencode", "node_modules", "@obra", "superpowers")
+    const pluginEntryDir = join(pluginRoot, ".opencode", "plugins")
+    const pluginSkillsDir = join(pluginRoot, "skills", "systematic-debugging")
+
+    mkdirSync(pluginEntryDir, { recursive: true })
+    mkdirSync(pluginSkillsDir, { recursive: true })
+    writeFileSync(join(pluginEntryDir, "superpowers.js"), "export const plugin = {};\n")
+    writeFileSync(
+      join(pluginSkillsDir, "SKILL.md"),
+      `---
+name: systematic-debugging
+description: Root-cause debugging workflow
+---
+Debug things systematically.
+`
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = configDir
+    process.env.XDG_CACHE_HOME = cacheDir
+
+    const { discoverSkills } = await import("./loader")
+    const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
+
+    expect(skills.some(s => s.name === "@obra/superpowers/systematic-debugging")).toBe(true)
   })
 })

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -1,8 +1,10 @@
 import { join } from "path"
 import { homedir } from "os"
+import { readdir } from "node:fs/promises"
 import { getClaudeConfigDir } from "../../shared/claude-config-dir"
 import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import { getOpenCodeSkillDirs } from "../../shared/opencode-command-dirs"
+import { getOpenCodeCacheDir } from "../../shared/data-path"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { LoadedSkill } from "./types"
 import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
@@ -26,7 +28,10 @@ export async function loadOpencodeGlobalSkills(): Promise<Record<string, Command
   const allSkills = await Promise.all(
     skillDirs.map(skillsDir => loadSkillsFromDir({ skillsDir, scope: "opencode" }))
   )
-  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
+  const bundledPluginSkills = await discoverOpencodePluginBundledSkills()
+  return skillsToCommandDefinitionRecord(
+    deduplicateSkillsByName([...allSkills.flat(), ...bundledPluginSkills])
+  )
 }
 
 export async function loadOpencodeProjectSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
@@ -41,10 +46,11 @@ export interface DiscoverSkillsOptions {
 }
 
 export async function discoverAllSkills(directory?: string): Promise<LoadedSkill[]> {
-  const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] =
+  const [opencodeProjectSkills, opencodeGlobalSkills, bundledPluginSkills, projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
       discoverOpencodeProjectSkills(directory),
       discoverOpencodeGlobalSkills(),
+      discoverOpencodePluginBundledSkills(),
       discoverProjectClaudeSkills(directory),
       discoverUserClaudeSkills(),
       discoverProjectAgentsSkills(directory),
@@ -55,6 +61,7 @@ export async function discoverAllSkills(directory?: string): Promise<LoadedSkill
   return deduplicateSkillsByName([
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
+    ...bundledPluginSkills,
     ...projectSkills,
     ...agentsProjectSkills,
     ...userSkills,
@@ -65,14 +72,19 @@ export async function discoverAllSkills(directory?: string): Promise<LoadedSkill
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
   const { includeClaudeCodePaths = true, directory } = options
 
-  const [opencodeProjectSkills, opencodeGlobalSkills] = await Promise.all([
+  const [opencodeProjectSkills, opencodeGlobalSkills, bundledPluginSkills] = await Promise.all([
     discoverOpencodeProjectSkills(directory),
     discoverOpencodeGlobalSkills(),
+    discoverOpencodePluginBundledSkills(),
   ])
 
   if (!includeClaudeCodePaths) {
     // Priority: opencode-project > opencode
-    return deduplicateSkillsByName([...opencodeProjectSkills, ...opencodeGlobalSkills])
+    return deduplicateSkillsByName([
+      ...opencodeProjectSkills,
+      ...opencodeGlobalSkills,
+      ...bundledPluginSkills,
+    ])
   }
 
   const [projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] = await Promise.all([
@@ -86,6 +98,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   return deduplicateSkillsByName([
     ...opencodeProjectSkills,
     ...opencodeGlobalSkills,
+    ...bundledPluginSkills,
     ...projectSkills,
     ...agentsProjectSkills,
     ...userSkills,
@@ -114,6 +127,92 @@ export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
     skillDirs.map(skillsDir => loadSkillsFromDir({ skillsDir, scope: "opencode" }))
   )
   return deduplicateSkillsByName(allSkills.flat())
+}
+
+async function discoverOpencodePluginBundledSkills(): Promise<LoadedSkill[]> {
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const nodeModulesDirs = deduplicatePaths([
+    join(configDir, "node_modules"),
+    join(getOpenCodeCacheDir(), "node_modules"),
+  ])
+
+  const packageRoots = (
+    await Promise.all(nodeModulesDirs.map(dir => discoverNodeModulesPackageRoots(dir)))
+  ).flat()
+
+  const skillGroups = await Promise.all(
+    packageRoots.map(async ({ packageName, packageRoot }) => {
+      const pluginDir = join(packageRoot, ".opencode", "plugins")
+      const skillsDir = join(packageRoot, "skills")
+      const pluginEntries = await readdir(pluginDir, { withFileTypes: true }).catch(() => [])
+      const hasPluginEntry = pluginEntries.some(
+        entry =>
+          !entry.name.startsWith(".") &&
+          !entry.isDirectory() &&
+          /\.(?:[cm]?js|ts)$/.test(entry.name)
+      )
+
+      if (!hasPluginEntry) {
+        return []
+      }
+
+      return loadSkillsFromDir({
+        skillsDir,
+        scope: "opencode",
+        namePrefix: packageName,
+      })
+    })
+  )
+
+  return deduplicateSkillsByName(skillGroups.flat())
+}
+
+interface NodeModulesPackageRoot {
+  packageName: string
+  packageRoot: string
+}
+
+async function discoverNodeModulesPackageRoots(nodeModulesDir: string): Promise<NodeModulesPackageRoot[]> {
+  const entries = await readdir(nodeModulesDir, { withFileTypes: true }).catch(() => [])
+  const packageRoots: NodeModulesPackageRoot[] = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue
+    }
+
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue
+    }
+
+    const entryPath = join(nodeModulesDir, entry.name)
+    if (entry.name.startsWith("@")) {
+      const scopedEntries = await readdir(entryPath, { withFileTypes: true }).catch(() => [])
+      for (const scopedEntry of scopedEntries) {
+        if (scopedEntry.name.startsWith(".")) {
+          continue
+        }
+        if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+          packageRoots.push({
+            packageName: `${entry.name}/${scopedEntry.name}`,
+            packageRoot: join(entryPath, scopedEntry.name),
+          })
+        }
+      }
+      continue
+    }
+
+    packageRoots.push({
+      packageName: entry.name,
+      packageRoot: entryPath,
+    })
+  }
+
+  return packageRoots
+}
+
+function deduplicatePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths))
 }
 
 export async function discoverOpencodeProjectSkills(directory?: string): Promise<LoadedSkill[]> {


### PR DESCRIPTION
Title: Fix discovery for plugin-bundled OpenCode skills

Summary:
OMO's custom skill loader currently discovers filesystem-backed OpenCode skills under config skill dirs, but misses skills bundled inside OpenCode plugins that are injected at runtime, such as `superpowers/systematic-debugging`.

Problem:
- `superpowers` follows the official OpenCode installation flow by registering an OpenCode plugin and exposing its skills from the package `skills/` directory.
- OpenCode can use those skills, but OMO's `skill` tool only scans physical OpenCode skill directories and does not discover plugin-bundled skills from package roots.
- Result: users see false negatives like `Skill or command "systematic-debugging" not found` even though `superpowers/systematic-debugging` is installed and available.

What this changes:
- Extend OMO skill discovery to inspect OpenCode package roots under:
  - the OpenCode config `node_modules`
  - the OpenCode cache `node_modules`
- Treat a package as a plugin-bundled skill provider when it has:
  - `.opencode/plugins/*`
  - `skills/`
- Load those bundled skills with a package-based name prefix such as `superpowers/...`
- Keep the existing deduplication and priority behavior intact

Regression coverage:
- Adds a test that creates a fake plugin package in the OpenCode cache and verifies that `discoverSkills({ includeClaudeCodePaths: false })` finds `superpowers/systematic-debugging`

Why this is safe:
- Discovery remains read-only
- Packages are only considered when they look like actual OpenCode plugins
- Namespacing uses the package basename, matching how users expect to reference plugin-bundled skills

Validation:
- `bun test src/features/opencode-skill-loader/loader.test.ts`
- Verified locally against `superpowers` that all namespaced skills load through OMO after discovery is fixed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode plugin skill discovery so OMO finds skills bundled in plugins (e.g., `superpowers/systematic-debugging`, `@obra/superpowers/systematic-debugging`) and stops “skill not found” errors. OMO now scans plugin package roots in config/cache `node_modules` and loads their `skills/` with a namespaced prefix that preserves npm scopes.

- **Bug Fixes**
  - Scan OpenCode config and cache `node_modules` for plugin packages.
  - Detect plugins via `.opencode/plugins/*` JS/TS entries; load from `skills/`.
  - Prefix skill names with the package (including npm scope) to avoid collisions.
  - Integrate bundled skills into `discoverSkills`, `discoverAllSkills`, and `loadOpencodeGlobalSkills` with existing priority unchanged.
  - Add tests for cache discovery and scoped packages.

<sup>Written for commit 8e87ea63bc8ea26f7b626bcae92554e2cf704498. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

