### PR TITLE
fix(runtime-fallback): detect prettified quota errors without HTTP status codes (fixes #2747)

### DIFF
--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -11,7 +11,7 @@ import type { RuntimeFallbackConfig } from "../../config"
  */
 export const DEFAULT_CONFIG: Required<RuntimeFallbackConfig> = {
   enabled: false,
-  retry_on_errors: [429, 500, 502, 503, 504],
+  retry_on_errors: [402, 429, 500, 502, 503, 504],
   max_fallback_attempts: 3,
   cooldown_seconds: 60,
   timeout_seconds: 30,
@@ -37,6 +37,11 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /try.?again/i,
   /credit.*balance.*too.*low/i,
   /insufficient.?(?:credits?|funds?|balance)/i,
+  /subscription.*quota/i,
+  /billing.?(?:hard.?)?limit/i,
+  /payment.?required/i,
+  /out\s+of\s+credits?/i,
+  /(?:^|\s)402(?:\s|$)/,
   /(?:^|\s)429(?:\s|$)/,
   /(?:^|\s)503(?:\s|$)/,
   /(?:^|\s)529(?:\s|$)/,

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -238,4 +238,28 @@ describe("quota error detection (fixes #2747)", () => {
     //#then
     expect(retryable).toBe(true)
   })
+
+  test("classifies QuotaExceededError by errorName even without quota keywords in message", () => {
+    //#given
+    const error = { name: "QuotaExceededError", message: "Request failed." }
+
+    //#when
+    const errorType = classifyErrorType(error)
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+  })
+
+  test("matches payment required pattern directly via RETRYABLE_ERROR_PATTERNS", () => {
+    //#given — message has no quota keyword, only "payment required"
+    const error = { message: "Error 402: payment required for this request" }
+
+    //#when — classifyErrorType will NOT match (no quota keyword), so isRetryableError must use RETRYABLE_ERROR_PATTERNS
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 503])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
 })

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -250,11 +250,11 @@ describe("quota error detection (fixes #2747)", () => {
     expect(errorType).toBe("quota_exceeded")
   })
 
-  test("matches payment required pattern directly via RETRYABLE_ERROR_PATTERNS", () => {
-    //#given — message has no quota keyword, only "payment required"
+  test("detects payment required errors as retryable", () => {
+    //#given
     const error = { message: "Error 402: payment required for this request" }
 
-    //#when — classifyErrorType will NOT match (no quota keyword), so isRetryableError must use RETRYABLE_ERROR_PATTERNS
+    //#when
     const errorType = classifyErrorType(error)
     const retryable = isRetryableError(error, [429, 503])
 

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -166,3 +166,76 @@ describe("extractStatusCode", () => {
     expect(extractStatusCode(error)).toBe(400)
   })
 })
+
+describe("quota error detection (fixes #2747)", () => {
+  test("classifies prettified subscription quota error as quota_exceeded", () => {
+    //#given
+    const error = {
+      name: "AI_APICallError",
+      message: "Subscription quota exceeded. You can continue using free models.",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [402, 429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies billing hard limit error as quota_exceeded", () => {
+    //#given
+    const error = { message: "You have reached your billing hard limit." }
+
+    //#when
+    const errorType = classifyErrorType(error)
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+  })
+
+  test("classifies exhausted capacity error as quota_exceeded", () => {
+    //#given
+    const error = { message: "You have exhausted your capacity on this model." }
+
+    //#when
+    const errorType = classifyErrorType(error)
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+  })
+
+  test("classifies out of credits error as quota_exceeded", () => {
+    //#given
+    const error = { message: "Out of credits. Please add more credits to continue." }
+
+    //#when
+    const errorType = classifyErrorType(error)
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+  })
+
+  test("treats HTTP 402 Payment Required as retryable", () => {
+    //#given
+    const error = { statusCode: 402, message: "Payment Required" }
+
+    //#when
+    const retryable = isRetryableError(error, [402, 429, 500, 502, 503, 504])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("matches subscription quota pattern in RETRYABLE_ERROR_PATTERNS", () => {
+    //#given
+    const error = { message: "Subscription quota exceeded. You can continue using free models." }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+})

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -120,6 +120,9 @@ export function classifyErrorType(error: unknown): string | undefined {
   }
 
   if (
+    errorName?.includes("quotaexceeded") ||
+    errorName?.includes("insufficientquota") ||
+    errorName?.includes("billingerror") ||
     /quota.?exceeded/i.test(message) ||
     /subscription.*quota/i.test(message) ||
     /insufficient.?quota/i.test(message) ||

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -21,6 +21,13 @@ export function getErrorMessage(error: unknown): string {
     }
   }
 
+  const errorObj2 = error as Record<string, unknown>
+  const name = errorObj2.name
+  if (typeof name === "string" && name.length > 0) {
+    const nameColonMatch = name.match(/:\s*(.+)/)
+    if (nameColonMatch) return nameColonMatch[1].trim().toLowerCase()
+  }
+
   try {
     return JSON.stringify(error).toLowerCase()
   } catch {
@@ -112,6 +119,18 @@ export function classifyErrorType(error: unknown): string | undefined {
     return "model_not_found"
   }
 
+  if (
+    /quota.?exceeded/i.test(message) ||
+    /subscription.*quota/i.test(message) ||
+    /insufficient.?quota/i.test(message) ||
+    /billing.?(?:hard.?)?limit/i.test(message) ||
+    /exhausted\s+your\s+capacity/i.test(message) ||
+    /out\s+of\s+credits?/i.test(message) ||
+    /payment.?required/i.test(message)
+  ) {
+    return "quota_exceeded"
+  }
+
   return undefined
 }
 
@@ -178,6 +197,10 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
   }
 
   if (errorType === "model_not_found") {
+    return true
+  }
+
+  if (errorType === "quota_exceeded") {
     return true
   }
 


### PR DESCRIPTION
## Summary
- Detect provider quota errors even when OpenCode prettifies them (strips HTTP status codes)
- Add HTTP 402 (Payment Required) to default retryable status codes
- Add `quota_exceeded` error type classification for pattern-based detection

## Problem
When providers return quota-exhaustion errors (e.g., `"Subscription quota exceeded. You can continue using free models."`), OpenCode prettifies the raw HTTP error into a friendly message. This strips the HTTP status code (402 Payment Required), so the runtime-fallback hook's status-code-based detection fails. The hook never triggers the fallback chain, and the session errors out instead of switching to a fallback model.

## Fix
Three-layer detection approach that works regardless of error prettification:

1. **Status code**: Added HTTP 402 to `retry_on_errors` default list alongside 429/500/502/503/504
2. **Error type classification**: Added `"quota_exceeded"` to `classifyErrorType()` that matches quota/billing/subscription patterns by message content. This type is always treated as retryable (like `missing_api_key` and `model_not_found`)
3. **Pattern expansion**: Added `subscription.*quota`, `billing.*limit`, `payment.*required`, `out of credits` patterns to `RETRYABLE_ERROR_PATTERNS`

## Changes
| File | Change |
|------|--------|
| `src/hooks/runtime-fallback/constants.ts` | Added HTTP 402 to `retry_on_errors`; added 4 new patterns to `RETRYABLE_ERROR_PATTERNS` |
| `src/hooks/runtime-fallback/error-classifier.ts` | Added `"quota_exceeded"` classification in `classifyErrorType()`; made it always retryable in `isRetryableError()`; enhanced `getErrorMessage()` fallback extraction |
| `src/hooks/runtime-fallback/error-classifier.test.ts` | Added 6 regression tests covering prettified quota errors, billing limits, capacity exhaustion, and HTTP 402 |

Fixes #2747

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects provider quota/billing errors even when status codes are missing or prettified, so runtime fallback switches to a fallback model instead of failing. Fixes #2747.

- Bug Fixes
  - Treat HTTP 402 as retryable by default.
  - Add `quota_exceeded` error type based on message patterns and `error.name`; always retry on it.
  - Expand `RETRYABLE_ERROR_PATTERNS` (subscription quota, billing limit, payment required, out of credits, textual "402").
  - Improve error-name message extraction; add tests for prettified and name-only errors; rename a test to reflect the `quota_exceeded` path.

<sup>Written for commit 44fb1143707f29b608a0e902db25257fb6310d36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

