### PR TITLE
feat: support multi-slash model IDs and provider hint extraction

### DIFF
--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test"
+declare const require: (name: string) => any
+const { describe, expect, it } = require("bun:test")
 import {
   getHighVariant,
   isAlreadyHighVariant,
@@ -146,6 +147,11 @@ describe("think-mode switcher", () => {
         expect(getHighVariant("custom-llm/gemini-3.1-pro")).toBe("custom-llm/gemini-3-1-pro-high")
       })
 
+			it("should preserve multi-slash prefixes when getting high variant", () => {
+				expect(getHighVariant("nvidia/aws/claude-opus-4-6")).toBe("nvidia/aws/claude-opus-4-6-high")
+				expect(getHighVariant("nvidia/aws/gpt-5.4")).toBe("nvidia/aws/gpt-5-4-high")
+			})
+
       it("should return null for prefixed models without high variant mapping", () => {
         // given prefixed model IDs without high variant mapping
         expect(getHighVariant("vertex_ai/unknown-model")).toBeNull()
@@ -166,6 +172,11 @@ describe("think-mode switcher", () => {
         expect(isAlreadyHighVariant("openai/gpt-5-4-high")).toBe(true)
         expect(isAlreadyHighVariant("custom/gemini-3.1-pro-high")).toBe(true)
       })
+
+			it("should detect -high suffix in multi-slash prefixed models", () => {
+				expect(isAlreadyHighVariant("nvidia/aws/claude-opus-4-6-high")).toBe(true)
+				expect(isAlreadyHighVariant("nvidia/aws/gpt-5.4-high")).toBe(true)
+			})
 
       it("should return false for prefixed base models", () => {
         // given prefixed base model IDs without -high suffix

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -28,10 +28,10 @@ import { normalizeModelID } from "../../shared"
  * extractModelPrefix("openai/gpt-5.4") // { prefix: "openai/", base: "gpt-5.4" }
  */
 function extractModelPrefix(modelID: string): { prefix: string; base: string } {
-  const slashIndex = modelID.indexOf("/")
-  if (slashIndex === -1) {
-    return { prefix: "", base: modelID }
-  }
+	const slashIndex = modelID.lastIndexOf("/")
+	if (slashIndex === -1) {
+		return { prefix: "", base: modelID }
+	}
   return {
     prefix: modelID.slice(0, slashIndex + 1),
     base: modelID.slice(slashIndex + 1),

--- a/src/shared/extract-provider-hint.test.ts
+++ b/src/shared/extract-provider-hint.test.ts
@@ -1,0 +1,31 @@
+declare const require: (name: string) => any
+const { describe, expect, test } = require("bun:test")
+import { extractProviderHint } from "./extract-provider-hint"
+
+describe("extractProviderHint", () => {
+  test("returns undefined when first segment is not a connected provider", () => {
+    expect(
+      extractProviderHint("aws/anthropic/bedrock-claude-opus-4-6", ["nvidia", "anthropic"]),
+    ).toBeUndefined()
+  })
+
+  test("returns provider hint when model string is fully qualified", () => {
+    expect(
+      extractProviderHint("nvidia/aws/anthropic/bedrock-claude-opus-4-6", ["nvidia", "anthropic"]),
+    ).toEqual(["nvidia"])
+  })
+
+  test("returns provider hint for standard provider-prefixed model", () => {
+    expect(
+      extractProviderHint("anthropic/claude-opus-4-6", ["nvidia", "anthropic"]),
+    ).toEqual(["anthropic"])
+  })
+
+  test("returns undefined when model string has no slash", () => {
+    expect(extractProviderHint("claude-opus-4-6", ["nvidia", "anthropic"])).toBeUndefined()
+  })
+
+  test("returns undefined when connected providers cache is unavailable", () => {
+    expect(extractProviderHint("aws/anthropic/bedrock-claude-opus-4-6", null)).toBeUndefined()
+  })
+})

--- a/src/shared/extract-provider-hint.ts
+++ b/src/shared/extract-provider-hint.ts
@@ -1,0 +1,25 @@
+export function extractProviderHint(
+  modelString: string,
+  connectedProviders: readonly string[] | null | undefined,
+): string[] | undefined {
+  if (!connectedProviders || connectedProviders.length === 0) {
+    return undefined
+  }
+
+  const trimmed = modelString.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  const parts = trimmed.split("/")
+  if (parts.length < 2) {
+    return undefined
+  }
+
+  const provider = parts[0]?.trim()
+  if (!provider) {
+    return undefined
+  }
+
+  return connectedProviders.includes(provider) ? [provider] : undefined
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -43,6 +43,7 @@ export type {
   ModelResolutionResult,
 } from "./model-resolution-types"
 export * from "./model-availability"
+export * from "./extract-provider-hint"
 export * from "./fallback-model-availability"
 export * from "./connected-providers-cache"
 export * from "./context-limit-resolver"

--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -391,6 +391,18 @@ describe("fuzzyMatchModel", () => {
 		expect(result).toBe("openai/gpt-5.4")
 	})
 
+	it("should retry without provider filter when filtered candidates are empty for multi-slash model IDs", () => {
+		const available = new Set([
+			"nvidia/aws/anthropic/bedrock-claude-opus-4-6",
+		])
+		const result = fuzzyMatchModel(
+			"aws/anthropic/bedrock-claude-opus-4-6",
+			available,
+			["aws"],
+		)
+		expect(result).toBe("nvidia/aws/anthropic/bedrock-claude-opus-4-6")
+	})
+
 	// given empty available set
 	// when searching
 	// then return null

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -46,7 +46,8 @@ export function fuzzyMatchModel(
 	const targetNormalized = normalizeModelName(target)
 
 	// Filter by providers if specified
-	let candidates = Array.from(available)
+	const allCandidates = Array.from(available)
+	let candidates = allCandidates
 	if (providers && providers.length > 0) {
 		const providerSet = new Set(providers)
 		candidates = candidates.filter((model) => {
@@ -57,8 +58,17 @@ export function fuzzyMatchModel(
 	}
 
 	if (candidates.length === 0) {
+		if (providers && providers.length > 0) {
+			log("[fuzzyMatchModel] no candidates after provider filter, retrying without provider filter", {
+				target,
+				providers,
+				availableCount: available.size,
+			})
+			candidates = allCandidates
+		} else {
 		log("[fuzzyMatchModel] no candidates after filter")
 		return null
+		}
 	}
 
 	// Find all matches (case-insensitive substring match with normalization)

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -58,17 +58,12 @@ export function fuzzyMatchModel(
 	}
 
 	if (candidates.length === 0) {
-		if (providers && providers.length > 0) {
-			log("[fuzzyMatchModel] no candidates after provider filter, retrying without provider filter", {
-				target,
-				providers,
-				availableCount: available.size,
-			})
-			candidates = allCandidates
-		} else {
-		log("[fuzzyMatchModel] no candidates after filter")
-		return null
-		}
+		log("[fuzzyMatchModel] no candidates after provider filter, retrying without provider filter", {
+			target,
+			providers,
+			availableCount: available.size,
+		})
+		candidates = allCandidates
 	}
 
 	// Find all matches (case-insensitive substring match with normalization)

--- a/src/shared/model-resolution-pipeline.test.ts
+++ b/src/shared/model-resolution-pipeline.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, test } from "bun:test"
+declare const require: (name: string) => any
+const { afterEach, describe, expect, spyOn, test } = require("bun:test")
 import { resolveModelPipeline } from "./model-resolution-pipeline"
+import * as connectedProvidersCache from "./connected-providers-cache"
 
 describe("resolveModelPipeline", () => {
+  let readConnectedProvidersSpy: ReturnType<typeof spyOn> | undefined
+
+  afterEach(() => {
+    readConnectedProvidersSpy?.mockRestore()
+  })
+
   test("does not return unused explicit user config metadata in override result", () => {
     // given
     const result = resolveModelPipeline({
@@ -21,5 +29,43 @@ describe("resolveModelPipeline", () => {
     // then
     expect(result).toEqual({ model: "openai/gpt-5.3-codex", provenance: "override" })
     expect(hasExplicitUserConfigField).toBe(false)
+  })
+
+  test("resolves category default with multi-slash model ID when first segment is not a connected provider", () => {
+    readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["nvidia"])
+
+    const result = resolveModelPipeline({
+      intent: {
+        categoryDefaultModel: "aws/anthropic/bedrock-claude-opus-4-6",
+      },
+      constraints: {
+        availableModels: new Set(["nvidia/aws/anthropic/bedrock-claude-opus-4-6"]),
+      },
+    })
+
+    expect(result).toEqual({
+      model: "nvidia/aws/anthropic/bedrock-claude-opus-4-6",
+      provenance: "category-default",
+      attempted: ["aws/anthropic/bedrock-claude-opus-4-6"],
+    })
+  })
+
+  test("resolves user fallback model with multi-slash model ID when first segment is not a connected provider", () => {
+    readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["nvidia"])
+
+    const result = resolveModelPipeline({
+      intent: {
+        userFallbackModels: ["aws/anthropic/bedrock-claude-opus-4-6"],
+      },
+      constraints: {
+        availableModels: new Set(["nvidia/aws/anthropic/bedrock-claude-opus-4-6"]),
+      },
+    })
+
+    expect(result).toEqual({
+      model: "nvidia/aws/anthropic/bedrock-claude-opus-4-6",
+      provenance: "provider-fallback",
+      attempted: ["aws/anthropic/bedrock-claude-opus-4-6"],
+    })
   })
 })

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -1,6 +1,7 @@
 import { log } from "./logger"
 import * as connectedProvidersCache from "./connected-providers-cache"
 import { fuzzyMatchModel } from "./model-availability"
+import { extractProviderHint } from "./extract-provider-hint"
 import type { FallbackEntry } from "./model-requirements"
 import { transformModelForProvider } from "./provider-model-id-transform"
 import { normalizeModel } from "./model-normalization"
@@ -45,6 +46,7 @@ export function resolveModelPipeline(
   const availableModels = constraints.availableModels
   const fallbackChain = policy?.fallbackChain
   const systemDefaultModel = policy?.systemDefaultModel
+  const connectedProviders = constraints.connectedProviders ?? connectedProvidersCache.readConnectedProvidersCache()
 
   const normalizedUiModel = normalizeModel(intent?.uiSelectedModel)
   if (normalizedUiModel) {
@@ -62,8 +64,7 @@ export function resolveModelPipeline(
   if (normalizedCategoryDefault) {
     attempted.push(normalizedCategoryDefault)
     if (availableModels.size > 0) {
-      const parts = normalizedCategoryDefault.split("/")
-      const providerHint = parts.length >= 2 ? [parts[0]] : undefined
+      const providerHint = extractProviderHint(normalizedCategoryDefault, connectedProviders)
       const match = fuzzyMatchModel(normalizedCategoryDefault, availableModels, providerHint)
       if (match) {
         log("Model resolved via category default (fuzzy matched)", {
@@ -73,18 +74,17 @@ export function resolveModelPipeline(
         return { model: match, provenance: "category-default", attempted }
       }
     } else {
-      const connectedProviders = constraints.connectedProviders ?? connectedProvidersCache.readConnectedProvidersCache()
       if (connectedProviders === null) {
         log("Model resolved via category default (no cache, first run)", {
           model: normalizedCategoryDefault,
         })
         return { model: normalizedCategoryDefault, provenance: "category-default", attempted }
       }
-      const parts = normalizedCategoryDefault.split("/")
-      if (parts.length >= 2) {
-        const provider = parts[0]
+      const providerHint = extractProviderHint(normalizedCategoryDefault, connectedProviders)
+      const provider = providerHint?.[0]
+      if (provider) {
         if (connectedProviders.includes(provider)) {
-          const modelName = parts.slice(1).join("/")
+          const modelName = normalizedCategoryDefault.split("/").slice(1).join("/")
           const transformedModel = `${provider}/${transformModelForProvider(provider, modelName)}`
           log("Model resolved via category default (connected provider)", {
             model: transformedModel,
@@ -103,17 +103,16 @@ export function resolveModelPipeline(
   const userFallbackModels = intent?.userFallbackModels
   if (userFallbackModels && userFallbackModels.length > 0) {
     if (availableModels.size === 0) {
-      const connectedProviders = constraints.connectedProviders ?? connectedProvidersCache.readConnectedProvidersCache()
       const connectedSet = connectedProviders ? new Set(connectedProviders) : null
 
       if (connectedSet !== null) {
         for (const model of userFallbackModels) {
           attempted.push(model)
-          const parts = model.split("/")
-          if (parts.length >= 2) {
-            const provider = parts[0]
+          const providerHint = extractProviderHint(model, connectedProviders)
+          const provider = providerHint?.[0]
+          if (provider) {
             if (connectedSet.has(provider)) {
-              const modelName = parts.slice(1).join("/")
+              const modelName = model.split("/").slice(1).join("/")
               const transformedModel = `${provider}/${transformModelForProvider(provider, modelName)}`
               log("Model resolved via user fallback_models (connected provider)", { model: transformedModel, original: model })
               return { model: transformedModel, provenance: "provider-fallback", attempted }
@@ -125,8 +124,7 @@ export function resolveModelPipeline(
     } else {
       for (const model of userFallbackModels) {
         attempted.push(model)
-        const parts = model.split("/")
-        const providerHint = parts.length >= 2 ? [parts[0]] : undefined
+        const providerHint = extractProviderHint(model, connectedProviders)
         const match = fuzzyMatchModel(model, availableModels, providerHint)
         if (match) {
           log("Model resolved via user fallback_models (availability confirmed)", { model: model, match })

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -137,7 +137,6 @@ export function resolveModelPipeline(
 
   if (fallbackChain && fallbackChain.length > 0) {
     if (availableModels.size === 0) {
-      const connectedProviders = constraints.connectedProviders ?? connectedProvidersCache.readConnectedProvidersCache()
       const connectedSet = connectedProviders ? new Set(connectedProviders) : null
 
       if (connectedSet === null) {

--- a/src/tools/call-omo-agent/background-executor.ts
+++ b/src/tools/call-omo-agent/background-executor.ts
@@ -20,6 +20,7 @@ export async function executeBackground(
   manager: BackgroundManager,
   client: PluginInput["client"],
   fallbackChain?: FallbackEntry[],
+  agentModel?: { providerID: string; modelID: string; variant?: string },
 ): Promise<string> {
   try {
     const messageDir = getMessageDir(toolContext.sessionID)
@@ -50,6 +51,7 @@ export async function executeBackground(
       parentMessageID: toolContext.messageID,
       parentAgent,
       parentTools: getSessionTools(toolContext.sessionID),
+      model: agentModel,
       fallbackChain,
     })
 

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -46,6 +46,7 @@ export async function executeSync(
   deps: ExecuteSyncDeps = defaultDeps,
   fallbackChain?: FallbackEntry[],
   spawnReservation?: SpawnReservation,
+  agentModel?: { providerID: string; modelID: string; variant?: string },
 ): Promise<string> {
   let sessionID: string | undefined
   let createdSessionForExecution = false
@@ -82,6 +83,8 @@ export async function executeSync(
         path: { id: sessionID },
         body: {
           agent: args.subagent_type,
+          ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
+          ...(agentModel?.variant ? { variant: agentModel.variant } : {}),
           tools: {
             ...getAgentToolRestrictions(args.subagent_type),
             task: false,

--- a/src/tools/call-omo-agent/tools.test.ts
+++ b/src/tools/call-omo-agent/tools.test.ts
@@ -165,6 +165,62 @@ describe("createCallOmoAgent", () => {
     ])
   })
 
+  test("inherits category model and variant when launching background subagent", async () => {
+    //#given
+    const launch = mock((_input: { model?: { providerID: string; modelID: string; variant?: string } }) => Promise.resolve({
+      id: "task-model",
+      sessionID: "sub-session",
+      description: "Test task",
+      agent: "explore",
+      status: "pending",
+    }))
+    const managerWithLaunch = {
+      launch,
+      getTask: mock(() => undefined),
+    }
+    const toolDef = createCallOmoAgent(
+      mockCtx,
+      managerWithLaunch,
+      [],
+      {
+        explore: {
+          category: "deep",
+        },
+      },
+      {
+        deep: {
+          model: "nvidia/aws/anthropic/bedrock-claude-opus-4-6",
+          variant: "max",
+        },
+      },
+    )
+    const executeFunc = toolDef.execute as Function
+
+    //#when
+    await executeFunc(
+      {
+        description: "Test category model",
+        prompt: "Test prompt",
+        subagent_type: "explore",
+        run_in_background: true,
+      },
+      { sessionID: "test", messageID: "msg", agent: "test", abort: new AbortController().signal },
+    )
+
+    //#then
+    const firstLaunchCall = launch.mock.calls[0]
+    if (firstLaunchCall === undefined) {
+      throw new Error("Expected launch to be called")
+    }
+
+    const [launchArgs] = firstLaunchCall
+    expect(launchArgs.model).toEqual({
+      providerID: "nvidia",
+      modelID: "aws/anthropic/bedrock-claude-opus-4-6",
+      variant: "max",
+    })
+  })
+
   test("should return a tool error when sync spawn depth validation fails", async () => {
     //#given
     reserveSubagentSpawnMock.mockRejectedValueOnce(new Error("Subagent spawn blocked: child depth 4 exceeds background_task.maxDepth=3."))

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -8,6 +8,7 @@ import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { normalizeFallbackModels } from "../../shared/model-resolver"
 import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
+import { normalizeModelFormat } from "../../shared/model-format-normalizer"
 import { log } from "../../shared"
 import { executeBackground } from "./background-executor"
 import { executeSync } from "./sync-executor"
@@ -34,6 +35,27 @@ function resolveFallbackChainForCallOmoAgent(args: {
   const configuredFallbackChain = buildFallbackChainFromModels(normalizedFallbackModels, defaultProviderID)
 
   return configuredFallbackChain ?? agentRequirement?.fallbackChain
+}
+
+function resolveModelForCallOmoAgent(args: {
+  subagentType: string
+  agentOverrides?: AgentOverrides
+}): { providerID: string; modelID: string; variant?: string } | undefined {
+  const { subagentType, agentOverrides } = args
+  const agentConfigKey = getAgentConfigKey(subagentType)
+  const agentOverride = agentOverrides?.[agentConfigKey as keyof AgentOverrides]
+    ?? (agentOverrides
+      ? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1]
+      : undefined)
+
+  if (!agentOverride?.model) return undefined
+
+  const normalized = normalizeModelFormat(agentOverride.model)
+  if (!normalized) return undefined
+
+  return agentOverride.variant
+    ? { ...normalized, variant: agentOverride.variant }
+    : normalized
 }
 
 export function createCallOmoAgent(
@@ -88,25 +110,30 @@ export function createCallOmoAgent(
         userCategories,
       })
 
+      const agentModel = resolveModelForCallOmoAgent({
+        subagentType: args.subagent_type,
+        agentOverrides,
+      })
+
       if (args.run_in_background) {
         if (args.session_id) {
           return `Error: session_id is not supported in background mode. Use run_in_background=false to continue an existing session.`
         }
-        return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain)
+        return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain, agentModel)
       }
 
       if (!args.session_id) {
         let spawnReservation: Awaited<ReturnType<BackgroundManager["reserveSubagentSpawn"]>> | undefined
         try {
           spawnReservation = await backgroundManager.reserveSubagentSpawn(toolCtx.sessionID)
-          return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, spawnReservation)
+          return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, spawnReservation, agentModel)
         } catch (error) {
           spawnReservation?.rollback()
           return `Error: ${error instanceof Error ? error.message : String(error)}`
         }
       }
 
-      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain)
+      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, undefined, agentModel)
     },
   })
 }

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -40,22 +40,26 @@ function resolveFallbackChainForCallOmoAgent(args: {
 function resolveModelForCallOmoAgent(args: {
   subagentType: string
   agentOverrides?: AgentOverrides
+  userCategories?: CategoriesConfig
 }): { providerID: string; modelID: string; variant?: string } | undefined {
-  const { subagentType, agentOverrides } = args
+  const { subagentType, agentOverrides, userCategories } = args
   const agentConfigKey = getAgentConfigKey(subagentType)
   const agentOverride = agentOverrides?.[agentConfigKey as keyof AgentOverrides]
     ?? (agentOverrides
       ? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1]
       : undefined)
 
-  if (!agentOverride?.model) return undefined
+  const modelString = agentOverride?.model
+    ?? (agentOverride?.category ? userCategories?.[agentOverride.category]?.model : undefined)
+  if (!modelString) return undefined
 
-  const normalized = normalizeModelFormat(agentOverride.model)
+  const normalized = normalizeModelFormat(modelString)
   if (!normalized) return undefined
 
-  return agentOverride.variant
-    ? { ...normalized, variant: agentOverride.variant }
-    : normalized
+  const variant = agentOverride?.variant
+    ?? (agentOverride?.category ? userCategories?.[agentOverride.category]?.variant : undefined)
+
+  return variant ? { ...normalized, variant } : normalized
 }
 
 export function createCallOmoAgent(
@@ -113,6 +117,7 @@ export function createCallOmoAgent(
       const agentModel = resolveModelForCallOmoAgent({
         subagentType: args.subagent_type,
         agentOverrides,
+        userCategories,
       })
 
       if (args.run_in_background) {

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -73,6 +73,7 @@ describe("resolveModelForDelegateTask", () => {
 		beforeEach(() => {
 			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
 			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["nvidia", "anthropic", "openai"])
 		})
 
 		describe("#when availableModels is empty (cache exists but empty)", () => {
@@ -121,6 +122,26 @@ describe("resolveModelForDelegateTask", () => {
 				})
 
 				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "medium" })
+			})
+
+			test("#then resolves a provider-less multi-slash fallback model against the correct available provider", () => {
+				const result = resolveModelForDelegateTask({
+					userFallbackModels: ["aws/anthropic/bedrock-claude-opus-4-6"],
+					availableModels: new Set(["nvidia/aws/anthropic/bedrock-claude-opus-4-6"]),
+				})
+
+				expect(result).toEqual({ model: "nvidia/aws/anthropic/bedrock-claude-opus-4-6" })
+			})
+		})
+
+		describe("#when category default omits provider for multi-slash model ID", () => {
+			test("#then resolves against available models without forcing the first segment as provider", () => {
+				const result = resolveModelForDelegateTask({
+					categoryDefaultModel: "aws/anthropic/bedrock-claude-opus-4-6",
+					availableModels: new Set(["nvidia/aws/anthropic/bedrock-claude-opus-4-6"]),
+				})
+
+				expect(result).toEqual({ model: "nvidia/aws/anthropic/bedrock-claude-opus-4-6" })
 			})
 		})
 	})

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -2,7 +2,8 @@ import type { FallbackEntry } from "../../shared/model-requirements"
 import { normalizeModel } from "../../shared/model-normalization"
 import { fuzzyMatchModel } from "../../shared/model-availability"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
-import { hasConnectedProvidersCache, hasProviderModelsCache } from "../../shared/connected-providers-cache"
+import { extractProviderHint } from "../../shared/extract-provider-hint"
+import { hasConnectedProvidersCache, hasProviderModelsCache, readConnectedProvidersCache } from "../../shared/connected-providers-cache"
 import { parseModelString, parseVariantFromModelID } from "./model-string-parser"
 
 function isExplicitHighModel(model: string): boolean {
@@ -23,11 +24,13 @@ function parseUserFallbackModel(fallbackModel: string): {
     return undefined
   }
 
-  const parsedFullModel = parseModelString(normalizedFallback)
+  const connectedProviders = readConnectedProvidersCache()
+  const providerHint = extractProviderHint(normalizedFallback, connectedProviders)
+  const parsedFullModel = providerHint ? parseModelString(normalizedFallback) : undefined
   if (parsedFullModel) {
     return {
       baseModel: `${parsedFullModel.providerID}/${parsedFullModel.modelID}`,
-      providerHint: [parsedFullModel.providerID],
+      providerHint,
       variant: parsedFullModel.variant,
     }
   }
@@ -52,6 +55,7 @@ export function resolveModelForDelegateTask(input: {
   availableModels: Set<string>
   systemDefaultModel?: string
 }): { model: string; variant?: string } | { skipped: true } | undefined {
+  const connectedProviders = readConnectedProvidersCache()
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     return { model: userModel }
@@ -71,8 +75,7 @@ export function resolveModelForDelegateTask(input: {
       return { model: categoryDefault }
     }
 
-    const parts = categoryDefault.split("/")
-    const providerHint = parts.length >= 2 ? [parts[0]] : undefined
+    const providerHint = extractProviderHint(categoryDefault, connectedProviders)
     const match = fuzzyMatchModel(categoryDefault, input.availableModels, providerHint)
     if (match) {
       if (isExplicitHighModel(categoryDefault) && match !== categoryDefault) {


### PR DESCRIPTION
 ## Summary                                                                                                                                                                
                                                                                                                                                                            
  - Fix model resolution for multi-slash model IDs (e.g., `aws/anthropic/bedrock-claude-opus-4-6`) where the first `/`-segment is not a real provider, causing agents to    
  fall through to free/default models
  - Forward user-configured model overrides to sub-agents dispatched via `call-omo-agent`, which previously sent prompts without any `model` field                          
                                                                                                                                                                            
  ## Changes
                                                                                                                                                                            
  - **New `extractProviderHint` utility** (`src/shared/extract-provider-hint.ts`): Validates the first segment of a model string against the connected-providers cache      
  before using it as a provider filter. Returns `undefined` for unrecognized providers, enabling cross-provider matching.
  - **`fuzzyMatchModel` cross-provider fallback** (`src/shared/model-availability.ts`): When provider-filtered candidates = 0, retries without the provider filter instead  
  of returning `null` immediately. Acts as a universal safety net for multi-slash IDs.                                                                                      
  - **`extractModelPrefix` fix** (`src/hooks/think-mode/switcher.ts`): Changed `indexOf("/")` to `lastIndexOf("/")` so think-mode correctly extracts the base model name
  from multi-slash IDs.                                                                                                                                                     
  - **Model resolution pipeline** (`src/shared/model-resolution-pipeline.ts`): Replaced naive `[parts[0]]` provider hint extraction at 4 sites with `extractProviderHint` 
  validated against connected providers.                                                                                                                                    
  - **Delegate-task model selection** (`src/tools/delegate-task/model-selection.ts`): Same `extractProviderHint` fix for the category-default and user fallback model paths.
  - **`call-omo-agent` model forwarding** (`src/tools/call-omo-agent/tools.ts`, `sync-executor.ts`, `background-executor.ts`): Added `resolveModelForCallOmoAgent` to read  
  agent override model from config, and pass `model`/`variant` in the `promptAsync` body and `manager.launch()` call -- matching how `delegate-task` already handles this.  
                                                                                                                                                                            
  ## Testing                                                                                                                                                                
                                                                                                                                                                          
  ```bash
  bun run typecheck        # Clean
  bun test                 # 2514 pass, 3 pre-existing failures (jest.clearAllTimers in unrelated files)
                                                                                                                                                                            
  New test coverage for multi-slash model ID handling in:                                                                                                                   
  - src/shared/extract-provider-hint.test.ts                                                                                                                                
  - src/shared/model-availability.test.ts                                                                                                                                   
  - src/shared/model-resolution-pipeline.test.ts                                                                                                                          
  - src/tools/delegate-task/model-selection.test.ts                                                                                                                         
  - src/hooks/think-mode/switcher.test.ts 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust support for multi-slash model IDs and forwards user-selected models to sub-agents, including inheriting model/variant from user categories. This prevents unintended fallbacks and keeps sub-agent runs aligned with user-selected models.

- **New Features**
  - Extracts a validated provider hint from model strings using connected providers; supports IDs like `aws/anthropic/bedrock-claude-opus-4-6` when the first segment isn’t a real provider.
  - `fuzzyMatchModel` retries without the provider filter if no candidates remain after filtering, enabling cross-provider resolution.
  - For `call-omo-agent`, forwards the configured `model` and optional `variant` to both sync and background executors, and inherits them from user categories when the override references a category.

- **Bug Fixes**
  - Think-mode now uses the last slash to extract the base model, so high-variant logic works with multi-slash IDs.
  - Model resolution and delegate-task selection use validated provider hints instead of naive splitting, fixing multi-slash category defaults and user fallbacks.

<sup>Written for commit b6bc1a24a5945e551b93ae5f238aa673bb947826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

