### PR TITLE
feat: filter agent-restricted skills from prompts and tool description

### DIFF
--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -100,8 +100,6 @@ export async function createBuiltinAgents(
     description: categories?.[name]?.description ?? CATEGORY_DESCRIPTIONS[name] ?? "General tasks",
   }))
 
-  const availableSkills = buildAvailableSkills(discoveredSkills, browserProvider, disabledSkills, teamModeEnabled)
-
   // Collect general agents first (for availableAgents), but don't add to result yet
   const { pendingAgentConfigs, availableAgents } = collectPendingBuiltinAgents({
     agentSources,
@@ -129,7 +127,7 @@ export async function createBuiltinAgents(
     systemDefaultModel,
     isFirstRunNoCache,
     availableAgents,
-    availableSkills,
+    availableSkills: buildAvailableSkills(discoveredSkills, browserProvider, disabledSkills, teamModeEnabled, "sisyphus"),
     availableCategories,
     mergedCategories,
     directory,
@@ -148,7 +146,7 @@ export async function createBuiltinAgents(
     systemDefaultModel,
     isFirstRunNoCache,
     availableAgents,
-    availableSkills,
+    availableSkills: buildAvailableSkills(discoveredSkills, browserProvider, disabledSkills, teamModeEnabled, "hephaestus"),
     availableCategories,
     mergedCategories,
     directory,
@@ -171,7 +169,7 @@ export async function createBuiltinAgents(
     availableModels,
     systemDefaultModel,
     availableAgents,
-    availableSkills,
+    availableSkills: buildAvailableSkills(discoveredSkills, browserProvider, disabledSkills, teamModeEnabled, "atlas"),
     mergedCategories,
     directory,
     userCategories: categories,

--- a/src/agents/builtin-agents/available-skills.test.ts
+++ b/src/agents/builtin-agents/available-skills.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, test } from "bun:test"
-
+/// <reference types="bun-types" />
+import { describe, expect, it, test } from "bun:test"
+import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
 import { buildAvailableSkills } from "./available-skills"
 
 type DiscoveredSkills = Parameters<typeof buildAvailableSkills>[0]
+
+function makeSkill(name: string, agent?: string): LoadedSkill {
+  return {
+    name,
+    resolvedPath: `/test/skills/${name}`,
+    definition: {
+      name,
+      description: `Skill ${name}`,
+      template: "",
+      agent,
+    },
+    scope: "user",
+  }
+}
 
 describe("buildAvailableSkills", () => {
   test("includes team-mode when team mode is enabled", () => {
@@ -25,5 +40,69 @@ describe("buildAvailableSkills", () => {
 
     // then
     expect(availableSkills.some((skill) => skill.name === "team-mode")).toBe(false)
+  })
+})
+
+describe("buildAvailableSkills - agentName filtering", () => {
+  it("includes agent-restricted skill when agentName is not provided (backward compat)", () => {
+    // given
+    const skills = [makeSkill("oracle-only", "oracle")]
+
+    // when
+    const result = buildAvailableSkills(skills, undefined, undefined, undefined, undefined)
+
+    // then: no agentName → no filtering, skill is included
+    expect(result.map((s) => s.name)).toContain("oracle-only")
+  })
+
+  it("includes skill when agentName matches the skill's agent field", () => {
+    // given
+    const skills = [makeSkill("sisyphus-only", "sisyphus")]
+
+    // when
+    const result = buildAvailableSkills(skills, undefined, undefined, undefined, "sisyphus")
+
+    // then: matching agent → included
+    expect(result.map((s) => s.name)).toContain("sisyphus-only")
+  })
+
+  it("excludes skill when agentName does not match the skill's agent field", () => {
+    // given
+    const skills = [makeSkill("sisyphus-only", "sisyphus")]
+
+    // when
+    const result = buildAvailableSkills(skills, undefined, undefined, undefined, "oracle")
+
+    // then: wrong agent → excluded
+    expect(result.map((s) => s.name)).not.toContain("sisyphus-only")
+  })
+
+  it("includes skill with no agent field regardless of agentName", () => {
+    // given
+    const skills = [makeSkill("public-skill")]
+
+    // when
+    const result = buildAvailableSkills(skills, undefined, undefined, undefined, "sisyphus")
+
+    // then: no agent restriction → always included
+    expect(result.map((s) => s.name)).toContain("public-skill")
+  })
+
+  it("filters per-agent while keeping public skills", () => {
+    // given
+    const skills = [
+      makeSkill("public-skill"),
+      makeSkill("sisyphus-only", "sisyphus"),
+      makeSkill("oracle-only", "oracle"),
+    ]
+
+    // when
+    const result = buildAvailableSkills(skills, undefined, undefined, undefined, "sisyphus")
+
+    // then
+    const names = result.map((s) => s.name)
+    expect(names).toContain("public-skill")
+    expect(names).toContain("sisyphus-only")
+    expect(names).not.toContain("oracle-only")
   })
 })

--- a/src/agents/builtin-agents/available-skills.ts
+++ b/src/agents/builtin-agents/available-skills.ts
@@ -14,6 +14,7 @@ export function buildAvailableSkills(
   browserProvider?: BrowserAutomationProvider,
   disabledSkills?: Set<string>,
   teamModeEnabled?: boolean,
+  agentName?: string,
 ): AvailableSkill[] {
   const builtinSkills = createBuiltinSkills({ browserProvider, disabledSkills, teamModeEnabled })
   const builtinSkillNames = new Set(builtinSkills.map(s => s.name))
@@ -25,7 +26,13 @@ export function buildAvailableSkills(
   }))
 
   const discoveredAvailable: AvailableSkill[] = discoveredSkills
-    .filter(s => !builtinSkillNames.has(s.name) && !disabledSkills?.has(s.name))
+    .filter(s => {
+      if (builtinSkillNames.has(s.name) || disabledSkills?.has(s.name)) return false
+      // If the skill declares an agent restriction and we know the current agent,
+      // exclude skills that don't belong to this agent.
+      if (agentName && s.definition.agent && s.definition.agent !== agentName) return false
+      return true
+    })
     .map((skill) => ({
       name: skill.name,
       description: skill.definition.description ?? "",

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -64,13 +64,18 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     if (!force && cachedDescription) return cachedDescription
     const skills = await getSkills()
     const commands = getCommands()
-    const skillInfos = skills.map(loadedSkillToInfo)
+    // Exclude agent-restricted skills from the description: they must not be
+    // visible to agents that are not their designated owner.  The execute-time
+    // check already enforces the restriction at call time.
+    const publicSkills = skills.filter((s) => !s.definition.agent)
+    const skillInfos = publicSkills.map(loadedSkillToInfo)
     cachedDescription = formatCombinedDescription(skillInfos, commands)
     return cachedDescription
   }
 
   if (options.skills !== undefined) {
-    const skillInfos = options.skills.map(loadedSkillToInfo)
+    const publicSkills = options.skills.filter((s) => !s.definition.agent)
+    const skillInfos = publicSkills.map(loadedSkillToInfo)
     const commandsForDescription = options.commands ?? []
     let needsAsyncRefresh = false
 

--- a/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
+++ b/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
@@ -636,6 +636,50 @@ describe("skill tool - dynamic discovery", () => {
     expect(result).not.toContain("SHOULD_BE_OVERRIDDEN")
   })
 })
+describe("skill tool - agent-restricted skill visibility in description", () => {
+  it("excludes agent-restricted skill from description <available_items>", () => {
+    // given: a skill restricted to oracle, and a public skill
+    const loadedSkills = [
+      createMockSkill("public-skill"),
+      createMockSkill("oracle-only-skill", { agent: "oracle" }),
+    ]
+
+    // when: tool is created with these skills (as tool-registry would inject them)
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // then: oracle-only skill must NOT appear in the description
+    expect(tool.description).toContain("public-skill")
+    expect(tool.description).not.toContain("oracle-only-skill")
+  })
+
+  it("includes public skill (no agent field) in description regardless of context", () => {
+    // given
+    const loadedSkills = [createMockSkill("public-skill")]
+
+    // when
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // then
+    expect(tool.description).toContain("public-skill")
+  })
+
+  it("execute still works for agent-restricted skill when called with correct agent context", async () => {
+    // given: tool created WITHOUT the restricted skill in description list,
+    // but the full skill list is available for execute via getSkills()
+    // (simulating what tool-registry does: description uses filtered list,
+    //  but execute discovers from disk / full list)
+    const restrictedSkill = createMockSkill("oracle-only-skill", { agent: "oracle" })
+    const tool = createSkillTool({ skills: [restrictedSkill] })
+    const oracleContext = { ...mockContext, agent: "oracle" }
+
+    // when: oracle agent explicitly calls the skill
+    const result = await tool.execute({ name: "oracle-only-skill" }, oracleContext)
+
+    // then: execution succeeds
+    expect(result).toContain("oracle-only-skill")
+  })
+})
+
 describe("skill tool - dynamic description cache invalidation", () => {
   it("keeps description available after execute misses a skill", async () => {
     // given


### PR DESCRIPTION
## Problem

Skills with an `agent` frontmatter field are intended to be restricted to a specific agent. However, they currently appear in:

1. **Every agent's system prompt** — `buildAvailableSkills` returned all skills regardless of the `definition.agent` field, so a skill marked `agent: oracle` would still show up in Sisyphus's and Hephaestus's skill delegation sections, wasting tokens and potentially misleading the LLM.
2. **The `skill` tool's `<available_items>` description** — shared across all agents, again leaking restricted skills to unintended agents.

The execution-time check (throwing an error when the wrong agent calls a restricted skill) already existed, but that only catches the problem *after* the LLM has already decided to make the call.

## Solution

Add a **description-level visibility gate** so restricted skills are never shown to agents that cannot use them.

### Changes

- **`buildAvailableSkills`** (`available-skills.ts`): new optional `agentName` parameter. When provided, skills whose `definition.agent` does not match the current agent are filtered out. Fully backward-compatible — omitting `agentName` preserves existing behaviour.

- **`createBuiltinAgents`** (`builtin-agents.ts`): call `buildAvailableSkills` with the agent name for `sisyphus`, `hephaestus`, and `atlas` individually, so each agent's prompt only lists its own skills.

- **`createSkillTool`** (`tools.ts`): filter agent-restricted skills out of both the eager and lazy description builds. The full skill list is still used at execute time, so the existing execution-time check remains intact.

## Tests (TDD)

- **New file** `src/agents/builtin-agents/available-skills.test.ts` — 5 cases:
  - backward compat: no `agentName` → restricted skills still included
  - matching agent → included
  - non-matching agent → excluded
  - public skill (no `agent` field) → always included
  - mixed list filters correctly per agent

- **`tools.test.ts`** — 3 new cases in a new `describe` block:
  - agent-restricted skill absent from `<available_items>` description
  - public skill present in description
  - execute still succeeds for a restricted skill when called with the correct agent context

## Behavior summary

| Scenario | Before | After |
|---|---|---|
| `agent: oracle` skill in Sisyphus's prompt | ✅ visible | ❌ hidden |
| `agent: oracle` skill in Oracle's prompt | ✅ visible | ✅ visible |
| `skill` tool `<available_items>` for any agent | shows all skills | shows only public skills |
| Oracle calls `skill(name="oracle-only")` at runtime | ✅ works | ✅ works |
| Sisyphus calls `skill(name="oracle-only")` at runtime | ❌ throws | ❌ throws (unchanged) |
| Skills without `agent` field | ✅ visible everywhere | ✅ visible everywhere |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide agent-restricted skills from non-owner agents in prompts and the shared `skill` tool description. This reduces prompt tokens and prevents misleading calls; runtime enforcement is unchanged.

- **New Features**
  - Added optional `agentName` to `buildAvailableSkills`; filters by `definition.agent` when provided (backward compatible when omitted).
  - Updated `createBuiltinAgents` to pass agent names for Sisyphus, Hephaestus, and Atlas so each prompt lists only its own skills.
  - Updated `createSkillTool` to exclude agent-restricted skills from both eager and lazy description builds (e.g., `<available_items>`); execution still uses the full list.

<sup>Written for commit 088693697aca6bc148819408fa03ad71ccdfb8ea. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/2827?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

