### PR TITLE
Add experimental.cross_project_agents_md_injection config option

### DIFF
--- a/packages/agents-md-core/src/finder.ts
+++ b/packages/agents-md-core/src/finder.ts
@@ -15,6 +15,7 @@ export async function findAgentsMdUp(input: AgentsMdDiscoveryInput): Promise<str
   return findAgentsMdUpCore({
     startDir: input.startDir,
     rootDir: input.rootDir,
+    unbounded: input.unbounded,
     cache: input.cache,
   });
 }

--- a/packages/agents-md-core/src/injector.ts
+++ b/packages/agents-md-core/src/injector.ts
@@ -1,6 +1,6 @@
 import type { AgentsMdCache } from "@oh-my-opencode/rules-engine";
 import { promises as fsPromises } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, relative } from "node:path";
 
 import { findAgentsMdUp, resolveFilePath } from "./finder";
 import { formatAgentsMdContextBlock } from "./formatter";
@@ -20,11 +20,17 @@ export async function processFilePathForAgentsInjection(input: {
   readonly filePath: string;
   readonly sessionID: string;
   readonly output: AgentsMdContextOutput;
+  readonly crossProject?: boolean;
+  readonly nativeSupport?: boolean;
 }): Promise<void> {
   if (typeof input.output.output !== "string") return;
 
   const resolved = resolveFilePath(input.rootDirectory, input.filePath);
   if (!resolved) return;
+
+  const outside = relative(input.rootDirectory, resolved).startsWith("..");
+
+  if (input.nativeSupport && !outside) return;
 
   const dir = dirname(resolved);
   const cache = getSessionCache({
@@ -36,6 +42,7 @@ export async function processFilePathForAgentsInjection(input: {
   const agentsPaths = await findAgentsMdUp({
     startDir: dir,
     rootDir: input.rootDirectory,
+    unbounded: input.crossProject && outside,
     cache: input.agentsMdCache,
   });
 

--- a/packages/agents-md-core/src/types.ts
+++ b/packages/agents-md-core/src/types.ts
@@ -23,5 +23,6 @@ export interface AgentsMdInjectedPathsStorage {
 export interface AgentsMdDiscoveryInput {
   readonly startDir: string;
   readonly rootDir: string;
+  readonly unbounded?: boolean;
   readonly cache?: AgentsMdCache;
 }

--- a/packages/rules-engine/src/agents-md.ts
+++ b/packages/rules-engine/src/agents-md.ts
@@ -7,6 +7,7 @@ export interface FindAgentsMdUpInput {
   readonly startDir: string;
   readonly rootDir: string;
   readonly skipRoot?: boolean;
+  readonly unbounded?: boolean;
   readonly cache?: AgentsMdCache;
 }
 
@@ -14,7 +15,8 @@ export async function findAgentsMdUp(input: FindAgentsMdUpInput): Promise<string
   const startDir = resolve(input.startDir);
   const rootDir = resolve(input.rootDir);
   const skipRoot = input.skipRoot ?? true;
-  const cacheKey = [startDir, rootDir, skipRoot ? "1" : "0"].join("\0");
+  const unbounded = input.unbounded ?? false;
+  const cacheKey = [startDir, rootDir, skipRoot ? "1" : "0", unbounded ? "1" : "0"].join("\0");
   const cached = input.cache?.get(cacheKey);
   if (cached) return [...cached];
   const found: string[] = [];
@@ -27,7 +29,8 @@ export async function findAgentsMdUp(input: FindAgentsMdUpInput): Promise<string
     }
     if (isRootDir) break;
     const parent = dirname(current);
-    if (parent === current || !isSameOrChildPath(parent, rootDir)) break;
+    if (parent === current) break;
+    if (!unbounded && !isSameOrChildPath(parent, rootDir)) break;
     current = parent;
   }
   const result = found.reverse();

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -23,7 +23,7 @@ export const ExperimentalConfigSchema = z.object({
   /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
   max_tools: z.number().int().min(1).optional(),
   /** Allow AGENTS.md discovery beyond the project root when reading files from other projects (default: false) */
-  cross_project_agents_injection: z.boolean().optional(),
+  cross_project_agents_md_injection: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -22,6 +22,8 @@ export const ExperimentalConfigSchema = z.object({
   model_fallback_title: z.boolean().optional(),
   /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
   max_tools: z.number().int().min(1).optional(),
+  /** Allow AGENTS.md discovery beyond the project root when reading files from other projects (default: false) */
+  cross_project_agents_injection: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/hooks/directory-agents-injector/hook.ts
+++ b/src/hooks/directory-agents-injector/hook.ts
@@ -38,6 +38,7 @@ interface EventInput {
 export function createDirectoryAgentsInjectorHook(
   ctx: PluginInput,
   modelCacheState?: { anthropicContext1MEnabled: boolean },
+  options?: { crossProject?: boolean; nativeSupport?: boolean },
 ): DirectoryAgentsInjectorHook {
   const sessionCaches = new Map<string, Set<string>>();
   const agentsMdCache = createAgentsMdCache();
@@ -56,6 +57,8 @@ export function createDirectoryAgentsInjectorHook(
         filePath: output.title,
         sessionID: input.sessionID,
         output,
+        crossProject: options?.crossProject,
+        nativeSupport: options?.nativeSupport,
       });
       return;
     }

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -79,7 +79,7 @@ export function createToolGuardHooks(args: {
     const currentVersion = getOpenCodeVersion()
     const hasNativeSupport =
       currentVersion !== null && isOpenCodeVersionAtLeast(OPENCODE_NATIVE_AGENTS_INJECTION_VERSION)
-    const crossProject = pluginConfig.experimental?.cross_project_agents_injection ?? false
+    const crossProject = pluginConfig.experimental?.cross_project_agents_md_injection ?? false
     if (hasNativeSupport && !crossProject) {
       log("directory-agents-injector auto-disabled due to native OpenCode support", {
         currentVersion,

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -79,14 +79,18 @@ export function createToolGuardHooks(args: {
     const currentVersion = getOpenCodeVersion()
     const hasNativeSupport =
       currentVersion !== null && isOpenCodeVersionAtLeast(OPENCODE_NATIVE_AGENTS_INJECTION_VERSION)
-    if (hasNativeSupport) {
+    const crossProject = pluginConfig.experimental?.cross_project_agents_injection ?? false
+    if (hasNativeSupport && !crossProject) {
       log("directory-agents-injector auto-disabled due to native OpenCode support", {
         currentVersion,
         nativeVersion: OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
       })
     } else {
       directoryAgentsInjector = safeHook("directory-agents-injector", () =>
-        createDirectoryAgentsInjectorHook(ctx, modelCacheState))
+        createDirectoryAgentsInjectorHook(ctx, modelCacheState, {
+          crossProject,
+          nativeSupport: hasNativeSupport,
+        }))
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `experimental.cross_project_agents_injection` config option to allow AGENTS.md discovery beyond the project root when reading files from other projects

## Changes

- `src/config/schema/experimental.ts`: Add `cross_project_agents_injection: z.boolean().optional()` field
- `src/hooks/directory-agents-injector/finder.ts`: Add `unbounded` parameter to `findAgentsMdUp` that skips the `parent.startsWith(rootDir)` boundary check
- `src/hooks/directory-agents-injector/injector.ts`: Detect cross-project files via `path.relative`, skip in-project files when native OpenCode support handles them, pass `unbounded: true` for cross-project files
- `src/hooks/directory-agents-injector/hook.ts`: Accept and forward `crossProject`/`nativeSupport` options
- `src/plugin/hooks/create-tool-guard-hooks.ts`: Read config, override native auto-disable when cross-project is enabled, pass options to hook

### Behavior

| Scenario | cross_project=false (default) | cross_project=true |
|---|---|---|
| Read file inside project | Normal AGENTS.md injection | Same (unchanged) |
| Read file outside project | No AGENTS.md found | Walks up full directory tree |
| Native OpenCode support detected | Hook auto-disabled | Hook stays active for cross-project files only |

### Usage

```jsonc
// .opencode/oh-my-opencode.jsonc
{
  "experimental": {
    "cross_project_agents_injection": true
  }
}
```

## Testing

```bash
bun run typecheck
```

Tested locally by reading files from a sibling project directory - AGENTS.md files from that project are now correctly discovered and injected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `experimental.cross_project_agents_md_injection` to discover and inject AGENTS.md for files read outside the project root. When native OpenCode support exists, the hook runs only for cross‑project files to avoid duplicates.

- **New Features**
  - `experimental.cross_project_agents_md_injection` (default: false).
  - Renamed from `experimental.cross_project_agents_injection`.

- **Behavior**
  - Inside project: unchanged.
  - Outside project: disabled → no AGENTS.md; enabled → walk up full directory tree.
  - With native OpenCode support: cross_project=false → hook disabled; cross_project=true → hook active only for cross‑project files.

<sup>Written for commit 7a7fb07d72b38ee843625b4e56cafa20592fa91c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/2839?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

