### PR TITLE
Add Configurable TDD To Sisyphus Agent Schema

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -4267,9 +4267,6 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "tdd"
-      ],
       "additionalProperties": false
     },
     "comment_checker": {

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -4261,8 +4261,15 @@
         },
         "replace_plan": {
           "type": "boolean"
+        },
+        "tdd": {
+          "default": true,
+          "type": "boolean"
         }
       },
+      "required": [
+        "tdd"
+      ],
       "additionalProperties": false
     },
     "comment_checker": {
@@ -4885,6 +4892,11 @@
       "additionalProperties": false
     },
     "git_master": {
+      "default": {
+        "commit_footer": true,
+        "include_co_authored_by": true,
+        "git_env_prefix": "GIT_MASTER=1"
+      },
       "type": "object",
       "properties": {
         "commit_footer": {
@@ -5035,5 +5047,8 @@
       }
     }
   },
+  "required": [
+    "git_master"
+  ],
   "additionalProperties": false
 }

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5044,8 +5044,5 @@
       }
     }
   },
-  "required": [
-    "git_master"
-  ],
   "additionalProperties": false
 }

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -64,7 +64,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
     commit_footer: true,
     include_co_authored_by: true,
     git_env_prefix: "GIT_MASTER=1",
-  }).optional(),
+  }),
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -64,7 +64,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
     commit_footer: true,
     include_co_authored_by: true,
     git_env_prefix: "GIT_MASTER=1",
-  }),
+  }).optional(),
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),

--- a/src/config/schema/sisyphus-agent.ts
+++ b/src/config/schema/sisyphus-agent.ts
@@ -5,7 +5,7 @@ export const SisyphusAgentConfigSchema = z.object({
   default_builder_enabled: z.boolean().optional(),
   planner_enabled: z.boolean().optional(),
   replace_plan: z.boolean().optional(),
-  tdd: z.boolean().default(true),
+  tdd: z.boolean().default(true).optional(),
 })
 
 export type SisyphusAgentConfig = z.infer<typeof SisyphusAgentConfigSchema>

--- a/src/config/schema/sisyphus-agent.ts
+++ b/src/config/schema/sisyphus-agent.ts
@@ -5,7 +5,6 @@ export const SisyphusAgentConfigSchema = z.object({
   default_builder_enabled: z.boolean().optional(),
   planner_enabled: z.boolean().optional(),
   replace_plan: z.boolean().optional(),
-  /** Enable TDD-oriented planning for plan agent prompts (default: true) */
   tdd: z.boolean().default(true),
 })
 

--- a/src/config/schema/sisyphus-agent.ts
+++ b/src/config/schema/sisyphus-agent.ts
@@ -5,6 +5,8 @@ export const SisyphusAgentConfigSchema = z.object({
   default_builder_enabled: z.boolean().optional(),
   planner_enabled: z.boolean().optional(),
   replace_plan: z.boolean().optional(),
+  /** Enable TDD-oriented planning for plan agent prompts (default: true) */
+  tdd: z.boolean().default(true),
 })
 
 export type SisyphusAgentConfig = z.infer<typeof SisyphusAgentConfigSchema>

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -75,6 +75,7 @@ export function createToolRegistry(args: {
     disabledSkills: skillContext.disabledSkills,
     availableCategories,
     availableSkills: skillContext.availableSkills,
+    sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -23,7 +23,8 @@ export async function executeBackgroundTask(
   const { manager } = executorCtx
 
   try {
-    const effectivePrompt = buildTaskPrompt(args.prompt, agentToUse)
+    const tddEnabled = executorCtx.sisyphusAgentConfig?.tdd
+    const effectivePrompt = buildTaskPrompt(args.prompt, agentToUse, tddEnabled)
     const task = await manager.launch({
       description: args.description,
       prompt: effectivePrompt,

--- a/src/tools/delegate-task/executor-types.ts
+++ b/src/tools/delegate-task/executor-types.ts
@@ -1,5 +1,5 @@
 import type { BackgroundManager } from "../../features/background-agent"
-import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides } from "../../config/schema"
+import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides, SisyphusAgentConfig } from "../../config/schema"
 import type { OpencodeClient } from "./types"
 
 export interface ExecutorContext {
@@ -11,6 +11,7 @@ export interface ExecutorContext {
   sisyphusJuniorModel?: string
   browserProvider?: BrowserAutomationProvider
   agentOverrides?: AgentOverrides
+  sisyphusAgentConfig?: SisyphusAgentConfig
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   syncPollTimeoutMs?: number
 }

--- a/src/tools/delegate-task/prompt-builder.ts
+++ b/src/tools/delegate-task/prompt-builder.ts
@@ -3,14 +3,23 @@ import { buildPlanAgentSystemPrepend, isPlanAgent } from "./constants"
 import { buildSystemContentWithTokenLimit } from "./token-limiter"
 
 const FREE_OR_LOCAL_PROMPT_TOKEN_LIMIT = 24000
-const PLAN_AGENT_PROMPT_APPEND = `
+const PLAN_AGENT_PROMPT_BASE = `
 
 Additional requirements for this planning request:
 - Answer in English.
 - Write the plan in English.
 - Plan well for ultrawork execution.
-- Use TDD-oriented planning.
 - Include a clear atomic commit strategy.`
+
+const TDD_LINE = "- Use TDD-oriented planning."
+
+function buildPlanAgentPromptAppend(tddEnabled: boolean): string {
+  if (tddEnabled) {
+    return `${PLAN_AGENT_PROMPT_BASE}
+${TDD_LINE}`
+  }
+  return PLAN_AGENT_PROMPT_BASE
+}
 
 function usesFreeOrLocalModel(model: { providerID: string; modelID: string; variant?: string } | undefined): boolean {
   if (!model) {
@@ -61,10 +70,11 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
   )
 }
 
-export function buildTaskPrompt(prompt: string, agentName: string | undefined): string {
+export function buildTaskPrompt(prompt: string, agentName: string | undefined, tddEnabled?: boolean): string {
   if (!isPlanAgent(agentName)) {
     return prompt
   }
 
-  return `${prompt}${PLAN_AGENT_PROMPT_APPEND}`
+  const effectiveTdd = tddEnabled ?? true
+  return `${prompt}${buildPlanAgentPromptAppend(effectiveTdd)}`
 }

--- a/src/tools/delegate-task/sync-continuation.ts
+++ b/src/tools/delegate-task/sync-continuation.ts
@@ -19,7 +19,7 @@ export async function executeSyncContinuation(
   executorCtx: ExecutorContext,
   deps: SyncContinuationDeps = syncContinuationDeps
 ): Promise<string> {
-  const { client, syncPollTimeoutMs } = executorCtx
+  const { client, syncPollTimeoutMs, sisyphusAgentConfig } = executorCtx
   const toastManager = getTaskToastManager()
   const taskId = `resume_sync_${args.session_id!.slice(0, 8)}`
   const startTime = new Date()
@@ -83,7 +83,8 @@ export async function executeSyncContinuation(
     }
 
     const allowTask = isPlanFamily(resumeAgent)
-    const effectivePrompt = buildTaskPrompt(args.prompt, resumeAgent)
+    const tddEnabled = sisyphusAgentConfig?.tdd
+    const effectivePrompt = buildTaskPrompt(args.prompt, resumeAgent, tddEnabled)
     const tools = {
       task: allowTask,
       call_omo_agent: true,

--- a/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,4 +1,5 @@
 import type { DelegateTaskArgs, OpencodeClient, DelegatedModelConfig } from "./types"
+import type { SisyphusAgentConfig } from "../../config/schema"
 import { isPlanFamily } from "./constants"
 import { buildTaskPrompt } from "./prompt-builder"
 import {
@@ -41,11 +42,13 @@ export async function sendSyncPrompt(
     categoryModel: DelegatedModelConfig | undefined
     toastManager: { removeTask: (id: string) => void } | null | undefined
     taskId: string | undefined
+    sisyphusAgentConfig?: SisyphusAgentConfig
   },
   deps: SendSyncPromptDeps = sendSyncPromptDeps
 ): Promise<string | null> {
   const allowTask = isPlanFamily(input.agentToUse)
-  const effectivePrompt = buildTaskPrompt(input.args.prompt, input.agentToUse)
+  const tddEnabled = input.sisyphusAgentConfig?.tdd
+  const effectivePrompt = buildTaskPrompt(input.args.prompt, input.agentToUse, tddEnabled)
   const tools = {
     task: allowTask,
     call_omo_agent: true,

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -126,6 +126,7 @@ export async function executeSyncTask(
       categoryModel,
       toastManager,
       taskId,
+      sisyphusAgentConfig: executorCtx.sisyphusAgentConfig,
     })
     if (promptError) {
       return promptError

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -3129,6 +3129,35 @@ describe("sisyphus-task", () => {
       // then
       expect(result).toBe(prompt)
     })
+
+    test("excludes TDD line when tddEnabled is false", () => {
+      // given
+      const { buildTaskPrompt } = require("./tools")
+      const prompt = "Create a work plan for this feature"
+
+      // when
+      const result = buildTaskPrompt(prompt, "plan", false)
+
+      // then
+      expect(result).toContain(prompt)
+      expect(result).toContain("Answer in English.")
+      expect(result).toContain("Write the plan in English.")
+      expect(result).toContain("Plan well for ultrawork execution.")
+      expect(result).toContain("Include a clear atomic commit strategy.")
+      expect(result).not.toContain("Use TDD-oriented planning.")
+    })
+
+    test("includes TDD line when tddEnabled is true", () => {
+      // given
+      const { buildTaskPrompt } = require("./tools")
+      const prompt = "Create a work plan for this feature"
+
+      // when
+      const result = buildTaskPrompt(prompt, "plan", true)
+
+      // then
+      expect(result).toContain("Use TDD-oriented planning.")
+    })
   })
 
   describe("modelInfo detection via resolveCategoryConfig", () => {

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
-import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides } from "../../config/schema"
+import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides, SisyphusAgentConfig } from "../../config/schema"
 import type {
   AvailableCategory,
   AvailableSkill,
@@ -67,6 +67,7 @@ export interface DelegateTaskToolOptions {
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]
   agentOverrides?: AgentOverrides
+  sisyphusAgentConfig?: SisyphusAgentConfig
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
 }

--- a/src/tools/delegate-task/unstable-agent-task.ts
+++ b/src/tools/delegate-task/unstable-agent-task.ts
@@ -20,12 +20,13 @@ export async function executeUnstableAgentTask(
   systemContent: string | undefined,
   actualModel: string | undefined
 ): Promise<string> {
-  const { manager, client, syncPollTimeoutMs } = executorCtx
+  const { manager, client, syncPollTimeoutMs, sisyphusAgentConfig } = executorCtx
   let cleanupReason: string | undefined
   let launchedTaskID: string | undefined
 
   try {
-    const effectivePrompt = buildTaskPrompt(args.prompt, agentToUse)
+    const tddEnabled = sisyphusAgentConfig?.tdd
+    const effectivePrompt = buildTaskPrompt(args.prompt, agentToUse, tddEnabled)
     const task = await manager.launch({
       description: args.description,
       prompt: effectivePrompt,


### PR DESCRIPTION

## Summary

1. Add tdd config option to the sisyphus agent schema
2. Propagates this config through the delegate task system
3. Makes the TDD line in the plan agent prompt conditional on this config

## Changes

1. src/config/schema/sisyphus-agent.ts - Added tdd: z.boolean().default(true) field to schema
2. src/tools/delegate-task/prompt-builder.ts - Refactored to make TDD line conditional:
   - Split PLAN_AGENT_PROMPT_APPEND into PLAN_AGENT_PROMPT_BASE and TDD_LINE
   - Added buildPlanAgentPromptAppend(tddEnabled: boolean) helper
   - Updated buildTaskPrompt to accept optional tddEnabled?: boolean (defaults to true)
3. src/tools/delegate-task/types.ts - Added SisyphusAgentConfig import and sisyphusAgentConfig?: SisyphusAgentConfig to DelegateTaskToolOptions
4. src/tools/delegate-task/executor-types.ts - Added SisyphusAgentConfig import and sisyphusAgentConfig?: SisyphusAgentConfig to ExecutorContext
5. src/plugin/tool-registry.ts - Now passes sisyphusAgentConfig: pluginConfig.sisyphus_agent to createDelegateTask
6. Updated 4 callers of buildTaskPrompt:
   - background-task.ts
   - unstable-agent-task.ts
   - sync-continuation.ts
   - sync-prompt-sender.ts


## Testing
src/tools/delegate-task/tools.test.ts - Added 2 new test cases for TDD disable/enable behavior

`bun run typecheck`
`bun test`

17 test failures, none of which are a result of this diff.


## Related Issues

#2730 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable `tdd` flag to `sisyphus_agent` to toggle TDD guidance in plan prompts; default is true to preserve current behavior. Also adds sensible defaults for `git_master` (addresses #2730).

- **New Features**
  - Added `tdd: boolean` (optional) to `sisyphus_agent`; prompt builder includes the TDD line only when enabled.
  - Plumbed `sisyphusAgentConfig` through `tool-registry`, `ExecutorContext`, `DelegateTaskToolOptions`, and all delegate-task paths (sync, background, unstable).
  - Set defaults for `git_master` in `assets/oh-my-opencode.schema.json`.
  - Added tests for TDD on/off prompt behavior.

<sup>Written for commit f9e487f55a49677128c241847d4e05e41bb4ac0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

@minpeter 