### PR TITLE
feat(runtime-fallback): add error_patterns_to_fallback config field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ notepad.md
 oauth-success.html
 *.bun-build
 .omx/
+openspec/

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -4610,6 +4610,12 @@
             },
             "notify_on_fallback": {
               "type": "boolean"
+            },
+            "error_patterns_to_fallback": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -658,19 +658,21 @@ Auto-switches to backup models on API errors.
     "max_fallback_attempts": 3,
     "cooldown_seconds": 60,
     "timeout_seconds": 30,
-    "notify_on_fallback": true
+    "notify_on_fallback": true,
+    "error_patterns_to_fallback": ["extra inputs are not permitted", "unsupported.?parameter"]
   }
 }
 ```
 
-| Option                  | Default             | Description                                                                                                                    |
-| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `enabled`               | `false`             | Enable runtime fallback                                                                                                        |
-| `retry_on_errors`       | `[400,429,503,529]` | HTTP codes that trigger fallback. Also handles classified provider key errors.                                                 |
-| `max_fallback_attempts` | `3`                 | Max fallback attempts per session (1–20)                                                                                       |
-| `cooldown_seconds`      | `60`                | Seconds before retrying a failed model                                                                                         |
-| `timeout_seconds`       | `30`                | Seconds before forcing next fallback. **Set to `0` to disable timeout-based escalation and provider retry message detection.** |
-| `notify_on_fallback`    | `true`              | Toast notification on model switch                                                                                             |
+| Option                        | Default             | Description                                                                                                                    |
+| ----------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                     | `false`             | Enable runtime fallback                                                                                                        |
+| `retry_on_errors`             | `[400,429,503,529]` | HTTP codes that trigger fallback. Also handles classified provider key errors.                                                 |
+| `max_fallback_attempts`       | `3`                 | Max fallback attempts per session (1–20)                                                                                       |
+| `cooldown_seconds`            | `60`                | Seconds before retrying a failed model                                                                                         |
+| `timeout_seconds`             | `30`                | Seconds before forcing next fallback. **Set to `0` to disable timeout-based escalation and provider retry message detection.** |
+| `notify_on_fallback`          | `true`              | Toast notification on model switch                                                                                             |
+| `error_patterns_to_fallback`  | `[]`                | Regex patterns (as strings) merged with built-in patterns — any match triggers fallback, evaluated case-insensitively.         |
 
 Define `fallback_models` per agent or category:
 

--- a/src/config/schema/runtime-fallback.ts
+++ b/src/config/schema/runtime-fallback.ts
@@ -13,6 +13,8 @@ export const RuntimeFallbackConfigSchema = z.object({
   timeout_seconds: z.number().min(0).optional(),
   /** Show toast notification when switching to fallback model (default: true) */
   notify_on_fallback: z.boolean().optional(),
+  /** Regex patterns (as strings) merged with built-in patterns — any match triggers fallback. */
+  error_patterns_to_fallback: z.array(z.string()).optional(),
 })
 
 export type RuntimeFallbackConfig = z.infer<typeof RuntimeFallbackConfigSchema>

--- a/src/config/schema/runtime-fallback.ts
+++ b/src/config/schema/runtime-fallback.ts
@@ -14,7 +14,14 @@ export const RuntimeFallbackConfigSchema = z.object({
   /** Show toast notification when switching to fallback model (default: true) */
   notify_on_fallback: z.boolean().optional(),
   /** Regex patterns (as strings) merged with built-in patterns — any match triggers fallback. */
-  error_patterns_to_fallback: z.array(z.string()).optional(),
+  error_patterns_to_fallback: z.array(z.string().refine(pattern => { 
+    try { 
+      new RegExp(pattern); 
+      return true 
+    } catch { 
+      return false 
+    } 
+  }, { message: "invalid regex pattern" })).optional(),
 })
 
 export type RuntimeFallbackConfig = z.infer<typeof RuntimeFallbackConfigSchema>

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -16,11 +16,13 @@ export const DEFAULT_CONFIG: Required<RuntimeFallbackConfig> = {
   cooldown_seconds: 60,
   timeout_seconds: 30,
   notify_on_fallback: true,
+  error_patterns_to_fallback: [],
 }
 
 /**
- * Error patterns that indicate rate limiting or temporary failures
+ * Built-in error patterns that indicate rate limiting or temporary failures
  * These are checked in addition to HTTP status codes
+ * Extend via `error_patterns_to_fallback` in config
  */
 export const RETRYABLE_ERROR_PATTERNS = [
   /rate.?limit/i,

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -293,4 +293,61 @@ describe("quota error detection (fixes #2747)", () => {
     expect(retryable2).toBe(true)
     expect(retryable3).toBe(true)
   })
+
+  describe("error_patterns_to_fallback", () => {
+    test("extra pattern matches message", () => {
+      //#given
+      const error = { message: "litellm.BadRequestError: invalid_request_error: effort: Extra inputs are not permitted" }
+
+      //#when
+      const retryable = isRetryableError(error, [], [/extra inputs are not permitted/i])
+
+      //#then
+      expect(retryable).toBe(true)
+    })
+
+    test("extra pattern does not match unrelated message", () => {
+      //#given
+      const error = { message: "prompt must be a string" }
+
+      //#when
+      const retryable = isRetryableError(error, [], [/extra inputs are not permitted/i])
+
+      //#then
+      expect(retryable).toBe(false)
+    })
+
+    test("built-in patterns still match when extra patterns are provided", () => {
+      //#given
+      const error = { message: "rate limit exceeded" }
+
+      //#when
+      const retryable = isRetryableError(error, [], [/extra inputs are not permitted/i])
+
+      //#then
+      expect(retryable).toBe(true)
+    })
+
+    test("built-in patterns still match when extra patterns array is empty", () => {
+      //#given
+      const error = { message: "rate limit exceeded" }
+
+      //#when
+      const retryable = isRetryableError(error, [], [])
+
+      //#then
+      expect(retryable).toBe(true)
+    })
+
+    test("no match when neither built-in nor extra patterns match", () => {
+      //#given
+      const error = { message: "prompt must be a string" }
+
+      //#when
+      const retryable = isRetryableError(error, [], [])
+
+      //#then
+      expect(retryable).toBe(false)
+    })
+  })
 })

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -190,7 +190,7 @@ export function containsErrorContent(
   return { hasError: false }
 }
 
-export function isRetryableError(error: unknown, retryOnErrors: number[]): boolean {
+export function isRetryableError(error: unknown, retryOnErrors: number[], extraPatterns: RegExp[] = []): boolean {
   const statusCode = extractStatusCode(error, retryOnErrors)
   const message = getErrorMessage(error)
   const errorType = classifyErrorType(error)
@@ -211,5 +211,5 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
     return true
   }
 
-  return RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+  return [...RETRYABLE_ERROR_PATTERNS, ...extraPatterns].some((p) => p.test(message))
 }

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -120,7 +120,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       errorType: classifyErrorType(error),
     })
 
-    if (!isRetryableError(error, config.retry_on_errors)) {
+    if (!isRetryableError(error, config.retry_on_errors, deps.patterns)) {
       log(`[${HOOK_NAME}] Error not retryable, skipping fallback`, {
         sessionID,
         retryable: false,

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -22,7 +22,10 @@ export function createRuntimeFallbackHook(
     cooldown_seconds: options?.config?.cooldown_seconds ?? DEFAULT_CONFIG.cooldown_seconds,
     timeout_seconds: options?.config?.timeout_seconds ?? DEFAULT_CONFIG.timeout_seconds,
     notify_on_fallback: options?.config?.notify_on_fallback ?? DEFAULT_CONFIG.notify_on_fallback,
+    error_patterns_to_fallback: options?.config?.error_patterns_to_fallback ?? DEFAULT_CONFIG.error_patterns_to_fallback,
   }
+
+  const patterns = config.error_patterns_to_fallback.map(s => new RegExp(s, "i"))
 
   let pluginConfig = options?.pluginConfig
   if (!pluginConfig) {
@@ -36,6 +39,7 @@ export function createRuntimeFallbackHook(
   const deps: HookDeps = {
     ctx,
     config,
+    patterns,
     options,
     pluginConfig,
     sessionStates: new Map(),

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -96,7 +96,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         errorType: classifyErrorType(error),
       })
 
-      if (!isRetryableError(error, config.retry_on_errors)) {
+      if (!isRetryableError(error, config.retry_on_errors, deps.patterns)) {
         log(`[${HOOK_NAME}] message.updated error not retryable, skipping fallback`, {
           sessionID,
           statusCode: extractStatusCode(error, config.retry_on_errors),

--- a/src/hooks/runtime-fallback/types.ts
+++ b/src/hooks/runtime-fallback/types.ts
@@ -66,6 +66,7 @@ export interface RuntimeFallbackHook {
 export interface HookDeps {
   ctx: RuntimeFallbackPluginInput
   config: Required<RuntimeFallbackConfig>
+  patterns: RegExp[]
   options: RuntimeFallbackOptions | undefined
   pluginConfig: OhMyOpenCodeConfig | undefined
   sessionStates: Map<string, FallbackState>


### PR DESCRIPTION
Allow users to declare regex patterns (as strings) in config that are merged with built-in RETRYABLE_ERROR_PATTERNS and evaluated case-insensitively. Any match triggers fallback, parallel to the existing retry_on_errors status-code list.

## Summary

- Add error_patterns_to_fallback to runtime_fallback config — regex patterns (as strings) merged
with built-in RETRYABLE_ERROR_PATTERNS and evaluated case-insensitively; any match triggers fallback
- Parallel to the existing retry_on_errors status-code list: "retry_on_errors": [429, 503] →
"error_patterns_to_fallback": ["extra inputs are not permitted"]
- All existing logic unchanged; built-in patterns always apply regardless of what is configured

- 

## Changes

- src/config/schema/runtime-fallback.ts — new error_patterns_to_fallback: string[] field
- src/hooks/runtime-fallback/constants.ts — field added to DEFAULT_CONFIG (empty default), comment
on RETRYABLE_ERROR_PATTERNS updated to reference config extension point
- src/hooks/runtime-fallback/types.ts — patterns: RegExp[] added to HookDeps (converted custom
patterns, resolved at init)
- src/hooks/runtime-fallback/hook.ts — converts config strings to RegExp at init, stores in
deps.patterns
- src/hooks/runtime-fallback/error-classifier.ts — isRetryableError third param is now
extraPatterns: RegExp[] = []; built-ins always merged internally so the function is correct
regardless of call context
- src/hooks/runtime-fallback/event-handler.ts / message-update-handler.ts — pass deps.patterns to
isRetryableError
- src/hooks/runtime-fallback/error-classifier.test.ts — 5 new tests covering match, no-match,
built-ins unconditional with and without extras
- assets/oh-my-opencode.schema.json — regenerated
- docs/reference/configuration.md — field added to option table and example config block

- 

## Testing

bun run typecheck
bun test src/hooks/runtime-fallback/error-classifier.test.ts
bun run build

## Related Issues

https://github.com/code-yeongyu/oh-my-openagent/issues/2924

<!-- Closes #2924  -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `error_patterns_to_fallback` to runtime fallback config so users can define case-insensitive regex strings that trigger fallback on error message match. These patterns merge with built-in retryable patterns and complement `retry_on_errors`; invalid regex strings are rejected at config parse time.

- **New Features**
  - New `error_patterns_to_fallback: string[]` config (default `[]`); any match triggers fallback, evaluated case-insensitively.
  - Config strings are compiled to `RegExp` at init and passed to `isRetryableError`; built-in patterns always apply.
  - Schema/docs updated; JSON schema regenerated; tests added for match/no-match and built-in behavior.

- **Bug Fixes**
  - Validate `error_patterns_to_fallback` entries as valid regex during config parsing; invalid entries error with "invalid regex pattern".

<sup>Written for commit 2aca737379a45949505b9a9198de53b3c8e5c2ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

