### PR TITLE
fix(delegate-task): replace mutual exclusion throw with category-wins override (#2847)

### DIFF
--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -465,7 +465,7 @@ describe("sisyphus-task", () => {
        expect(args.subagent_type).toBe("Sisyphus-Junior")
     }, { timeout: 10000 })
 
-    test("rejects when both category and subagent_type are provided", async () => {
+    test("prefers category over subagent_type when both are provided", async () => {
       //#given
       const { createDelegateTask } = require("./tools")
 
@@ -516,8 +516,11 @@ describe("sisyphus-task", () => {
         load_skills: [],
       }
 
-      //#when + #then
-      await expect(tool.execute(args, toolContext)).rejects.toThrow("mutually exclusive")
+      //#when
+      await tool.execute(args, toolContext)
+
+      //#then - category takes precedence, subagent_type is overridden to sisyphus-junior
+      expect(args.subagent_type).toBe("Sisyphus-Junior")
     }, { timeout: 10000 })
 
     test("proceeds without error when systemDefaultModel is undefined", async () => {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -109,14 +109,9 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
     async execute(args: DelegateTaskArgs, toolContext) {
       const ctx = toolContext as ToolContextWithMetadata
 
+      let categoryOverrideNote: string | undefined
       if (args.category && args.subagent_type) {
-        throw new Error(
-          `Invalid arguments: 'category' and 'subagent_type' are mutually exclusive. Provide EXACTLY ONE.\n` +
-          `  - You provided: category="${args.category}", subagent_type="${args.subagent_type}"\n` +
-          `  - Use category for task delegation (e.g., category="${categoryExamples.split(", ")[0]}")\n` +
-          `  - Use subagent_type for direct agent invocation (e.g., subagent_type="explore")\n` +
-          `  - subagent_type must be a callable non-primary agent name returned by app.agents()`
-        )
+        categoryOverrideNote = `[Note: You provided both category="${args.category}" and subagent_type="${args.subagent_type}". category takes precedence \u2014 subagent_type was ignored. Next time, provide ONLY category.]`
       }
       if (args.category) {
         args.subagent_type = SISYPHUS_JUNIOR_AGENT
@@ -226,7 +221,8 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
             availableCategories,
             availableSkills,
           })
-          return executeUnstableAgentTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
+          const result = await executeUnstableAgentTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
+          return categoryOverrideNote ? `${categoryOverrideNote}\n\n${result}` : result
         }
       } else {
         const resolution = await resolveSubagentExecution(args, options, parentContext.agent, categoryExamples)
@@ -249,11 +245,13 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         availableSkills,
       })
 
+      const prependNote = (result: string) => categoryOverrideNote ? `${categoryOverrideNote}\n\n${result}` : result
+
       if (runInBackground) {
-        return executeBackgroundTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, fallbackChain)
+        return prependNote(await executeBackgroundTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, fallbackChain))
       }
 
-      return executeSyncTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, modelInfo, fallbackChain)
+      return prependNote(await executeSyncTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, modelInfo, fallbackChain))
     },
   })
 }


### PR DESCRIPTION
## Summary

Fixes an infinite loop where agents get stuck unable to delegate when passing both `category` and `subagent_type` to `task()`.

## Root Cause

Two systems both map `category → sisyphus-junior` but the validation between them rejects the result:

1. **Pre-hook** (`tool-execute-before.ts:127`): When `category` is set, always sets `subagent_type = "sisyphus-junior"` (added Feb 13 for TUI display)
2. **Tool validation** (`tools.ts:113`): Sees both params → throws "mutually exclusive" (added Mar 27 for #2847)

This means every category-based `task()` call that goes through the pre-hook hits this error. The agent sees `You provided: category="deep", subagent_type="sisyphus-junior"` and retries infinitely because the pre-hook always re-adds `subagent_type`.

## Timeline

| Date | Change | Author | Effect |
|------|--------|--------|--------|
| Feb 8 | Pre-hook created with safe guard: `if (category && !subagentType)` | YeonGyu-Kim | Works correctly |
| Feb 13 | Guard relaxed to `if (category)` — always override | YeonGyu-Kim | For TUI display. Tool had silent override, so no conflict. |
| Mar 27 | Silent override replaced with hard throw | MoerAI (#2847) | **Bug introduced.** Pre-hook + throw = every category call fails. |

## Fix

- When both `category` and `subagent_type` are provided, `category` silently wins — `subagent_type` is overridden to `SISYPHUS_JUNIOR_AGENT`
- Agent receives a note prepended to the task result informing it that category took precedence and to provide only category next time
- No log call, no throw — just proceeds with correct behavior

## Verification

- 118 tests pass, 0 fail
- `tsc --noEmit` clean
- `bun run build` success

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite retries in delegate tasks by making `category` win over `subagent_type` when both are provided. The tool no longer throws and proceeds with a clear note in the result.

- **Bug Fixes**
  - If both are set, override `subagent_type` with `SISYPHUS_JUNIOR_AGENT` instead of throwing.
  - Prepend a note to the task result explaining the override and to use only `category` next time.
  - Applies across all execution paths.
  - Updated test to expect category preference.

<sup>Written for commit 3905d0727388ef9e19bb12fa759523f8e2d56902. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

