### PR TITLE
fix(context-injector): prefix synthetic part ids with prt_

### DIFF
--- a/src/features/context-injector/injector.test.ts
+++ b/src/features/context-injector/injector.test.ts
@@ -106,6 +106,8 @@ describe("createContextInjectorMessagesTransformHook", () => {
     expect(
       "synthetic" in secondSyntheticPart && secondSyntheticPart.synthetic === true
     ).toBe(true)
+    expect(typeof secondSyntheticPart.id).toBe("string")
+    expect(secondSyntheticPart.id.startsWith("prt_")).toBe(true)
     expect(secondSyntheticPart.id).toBe(firstSyntheticPart.id)
   })
 

--- a/src/features/context-injector/injector.ts
+++ b/src/features/context-injector/injector.ts
@@ -148,7 +148,7 @@ export function createContextInjectorMessagesTransformHook(
 
       // synthetic part pattern (minimal fields)
       const syntheticPart = {
-        id: `synthetic_hook_${sessionID}`,
+        id: `prt_synthetic_hook_${sessionID}`,
         messageID: lastUserMessage.info.id,
         sessionID: (lastUserMessage.info as { sessionID?: string }).sessionID ?? "",
         type: "text" as const,


### PR DESCRIPTION
## Summary
- fix context injector synthetic part ID to use `prt_` prefix so generated message parts satisfy OpenCode schema validation
- add assertion in `injector.test.ts` to ensure synthetic part IDs keep the required `prt_` prefix
- prevents new-session failures caused by `Invalid string: must start with "prt"` when transform-injected parts are validated

## Verification
- bun test src/features/context-injector/injector.test.ts
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefixes synthetic context-injected message part IDs with `prt_` to satisfy OpenCode’s part-id schema. Fixes new-session validation errors caused by IDs not starting with `prt_`.

- **Bug Fixes**
  - Emit synthetic IDs as `prt_synthetic_hook_${sessionID}` in the injector.
  - Add a test assertion to ensure synthetic IDs always start with `prt_`.

<sup>Written for commit 607fce17dc9432c3bc1009689400733660e6bf1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

