### PR TITLE
fix(chat-message): refresh stale session-agent cache from explicit input.agent

### DIFF
--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -1,7 +1,6 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { CreatedHooks } from "../create-hooks"
 
-import { getMainSessionID, setSessionAgent, subagentSessions } from "../features/claude-code-session-state"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 import {
   isModelCacheAvailable,
@@ -11,6 +10,7 @@ import {
 } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
 import { getSessionModel, setSessionModel } from "../shared/session-model-state"
+import { getMainSessionID, setSessionAgent, updateSessionAgent, subagentSessions } from "../features/claude-code-session-state"
 import { NATIVE_LOOP_TRIGGERED_FLAG } from "./command-execute-before"
 import type { PluginContext } from "./types"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
@@ -203,7 +203,7 @@ export function createChatMessageHandler(args: {
     }
 
     if (input.agent) {
-      setSessionAgent(input.sessionID, input.agent)
+      updateSessionAgent(input.sessionID, input.agent)
     }
 
     const isFirstMessage = firstMessageVariantGate.shouldOverride(input.sessionID)


### PR DESCRIPTION
## Summary

- When `chat.message` receives a turn with an explicit `input.agent`, update the session-agent map unconditionally instead of ignoring it if a value already exists
- Adds regression test covering the stale-agent scenario

## Problem

`setSessionAgent` uses first-write-wins semantics (only writes if key doesn't exist). This is correct for initial session setup (e.g. `delegate-task/sync-task.ts` initializing a subagent session), but wrong in `chat-message.ts` where OpenCode delivers an explicit agent on every turn.

Any programmatic caller that sends `session.promptAsync` with an explicit `agent` to an already-initialized session gets silently ignored — the session stays pinned to whatever agent was set first. This affects:

- External integrations calling the session API directly
- `opencode run` with `--agent` on a resumed session
- Any MCP client interacting with existing sessions

Normal TUI agent switching is unaffected (it goes through different code paths).

## Changes

**`src/plugin/chat-message.ts`** (2 lines)
- Import `updateSessionAgent` alongside existing `setSessionAgent`
- Replace `setSessionAgent(input.sessionID, input.agent)` with `updateSessionAgent(input.sessionID, input.agent)`

**`src/plugin/chat-message.test.ts`** (13 lines)
- New test: pre-sets agent to "hephaestus", sends turn with `input.agent = "build"`, verifies map updates to "build"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always refresh the per-session agent cache on turns with `input.agent` in the chat-message handler. Fixes stale agent binding for external callers, resumed sessions with `--agent`, and MCP clients.

- **Bug Fixes**
  - Replace `setSessionAgent` with `updateSessionAgent` in `src/plugin/chat-message.ts` to overwrite the session-agent mapping on each turn.

<sup>Written for commit 696682e953705c3148730f16b5e982f5b8fb92ee. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/2965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

