### PR TITLE
fix: detect canonical plugin installs for updates

### DIFF
--- a/src/hooks/auto-update-checker/checker/cached-version.test.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 // Hold mutable mock state so beforeEach can swap the cache root for each test.
-const mockState: { candidates: string[]; walkUpResult: string | null } = {
+const mockState: {
+  candidates: Iterable<string>
+  walkUpResult: string | null | (() => string | null)
+} = {
   candidates: [],
   walkUpResult: null,
 }
@@ -25,7 +28,11 @@ mock.module("../constants", () => ({
 }))
 
 mock.module("./package-json-locator", () => ({
-  findPackageJsonUp: () => mockState.walkUpResult,
+  findPackageJsonUp: () => (
+    typeof mockState.walkUpResult === "function"
+      ? mockState.walkUpResult()
+      : mockState.walkUpResult
+  ),
 }))
 
 import { getCachedVersion } from "./cached-version"
@@ -82,6 +89,29 @@ describe("getCachedVersion (GH-3257)", () => {
 
   it("returns null when neither candidate exists and fallbacks find nothing", () => {
     expect(getCachedVersion()).toBeNull()
+  })
+
+  it("continues to execPath fallback when installed package candidates cannot be iterated", () => {
+    const execFallbackDir = join(cacheRoot, "exec-path", "node_modules", "oh-my-openagent")
+    mkdirSync(execFallbackDir, { recursive: true })
+    const execFallbackPackageJson = join(execFallbackDir, "package.json")
+    writeFileSync(
+      execFallbackPackageJson,
+      JSON.stringify({ name: "oh-my-openagent", version: "3.18.0" })
+    )
+
+    let lookupCount = 0
+    mockState.walkUpResult = () => {
+      lookupCount += 1
+      return lookupCount === 1 ? null : execFallbackPackageJson
+    }
+    mockState.candidates = {
+      [Symbol.iterator]: () => {
+        throw new Error("candidate paths unavailable")
+      },
+    }
+
+    expect(getCachedVersion()).toBe("3.18.0")
   })
 
   it("prefers the loaded module's package.json over flat-install candidates", () => {

--- a/src/hooks/auto-update-checker/checker/cached-version.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.ts
@@ -29,14 +29,18 @@ export function getCachedVersion(): string | null {
     log("[auto-update-checker] Failed to resolve version from current directory:", err)
   }
 
-  for (const candidate of INSTALLED_PACKAGE_JSON_CANDIDATES) {
-    try {
-      if (fs.existsSync(candidate)) {
-        return readPackageVersion(candidate)
+  try {
+    for (const candidate of INSTALLED_PACKAGE_JSON_CANDIDATES) {
+      try {
+        if (fs.existsSync(candidate)) {
+          return readPackageVersion(candidate)
+        }
+      } catch {
+        // ignore; try next candidate
       }
-    } catch {
-      // ignore; try next candidate
     }
+  } catch (err) {
+    log("[auto-update-checker] Failed to resolve version from installed package metadata:", err)
   }
 
   try {


### PR DESCRIPTION
## Summary
- detect canonical plugin entries in version/update checks
- resolve installed versions from both config-dir and cache-dir installs
- sync the active workspace package.json before background auto-updates

## Testing
- bun test src/hooks/auto-update-checker/checker/plugin-entry.test.ts src/hooks/auto-update-checker/checker/cached-version.test.ts src/hooks/auto-update-checker/checker/sync-package-json.test.ts src/hooks/auto-update-checker/hook/background-update-check.test.ts src/hooks/auto-update-checker/hook/workspace-resolution.test.ts
- bun run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the auto-update flow to recognize the canonical plugin name `oh-my-openagent` (and legacy `oh-my-opencode`), resolve the installed version from the right place, and sync the active workspace before running updates. Also keeps version checks resilient so path-helper or candidate-iteration failures never skip current-dir or `execPath` fallbacks.

- **Bug Fixes**
  - Detect both `oh-my-openagent` and `oh-my-opencode` in plugin entry parsing, package.json lookup, and workspace resolution.
  - Read installed version from the config-dir first; fall back to the cache-dir. Wrap installed-package candidate enumeration in try/catch so errors don’t block the `execPath` fallback.
  - Sync the active workspace package.json to match opencode.json intent (handles pins vs tags and canonical key) before auto-updates.
  - Run `bun install` in the resolved workspace; abort on sync errors to avoid bad states.
  - Added tests for canonical entry detection, version resolution (including candidate-iterator throw path), sync behavior, and workspace selection.

<sup>Written for commit 1f827e6de7abf0a17aa54ff9ae77ce89f76ad695. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/2975?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

