### PR TITLE
Fix OpenCode plugin registration for managed installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Fetch the installation guide and follow it:
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/docs/guide/installation.md
 ```
 
-**Note**: Use the published package and binary name `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config files still commonly use `oh-my-opencode.json` or `oh-my-opencode.jsonc`, and both legacy and renamed basenames are recognized during the transition.
+**Note**: Use the published package and binary name `oh-my-opencode`. For reliable installs on current OpenCode releases, the installer registers a managed `file://.../node_modules/oh-my-opencode/dist/index.js` plugin entry in `opencode.json` and keeps the dependency in the OpenCode config directory's `package.json`. Direct package-name entries are now mainly for migration compatibility. Plugin config files still commonly use `oh-my-opencode.json` or `oh-my-opencode.jsonc`, and both legacy and renamed basenames are recognized during the transition.
 
 ---
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -26,7 +26,7 @@ Follow the prompts to configure your Claude, ChatGPT, and Gemini subscriptions. 
 
 After you install it, you can read this [overview guide](./overview.md) to understand more.
 
-The published package and local binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config loading recognizes both `oh-my-openagent.json[c]` and `oh-my-opencode.json[c]` during the transition. If you see a "Using legacy package name" warning from `bunx oh-my-opencode doctor`, update your `opencode.json` plugin entry from `"oh-my-opencode"` to `"oh-my-openagent"`.
+The published package and local binary are still `oh-my-opencode`. For reliable installs on current OpenCode releases, the installer now writes a managed `file://.../node_modules/oh-my-opencode/dist/index.js` entry into `opencode.json` and keeps the package dependency in the OpenCode config directory's `package.json`. Direct package-name entries in `opencode.json` are migration-only during the rename transition, and legacy `oh-my-opencode` entries still warn when detected by `bunx oh-my-opencode doctor`. Plugin config loading recognizes both `oh-my-openagent.json[c]` and `oh-my-opencode.json[c]`.
 
 ## For LLM Agents
 
@@ -114,7 +114,8 @@ bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> -
 
 The CLI will:
 
-- Register the plugin in `opencode.json`
+- Register the plugin in `opencode.json` using a managed `file://` entry
+- Create or update `package.json` in the active OpenCode config directory so OpenCode can install the plugin dependency
 - Configure agent models based on subscription flags
 - Show which auth steps are needed
 
@@ -122,7 +123,8 @@ The CLI will:
 
 ```bash
 opencode --version  # Should be 1.0.150 or higher
-cat ~/.config/opencode/opencode.json  # Should contain "oh-my-openagent" in plugin array, or the legacy "oh-my-opencode" entry while you are still migrating
+cat ~/.config/opencode/opencode.json   # Should contain a file://.../node_modules/oh-my-opencode/dist/index.js plugin entry
+cat ~/.config/opencode/package.json    # Should contain "oh-my-opencode" in dependencies
 ```
 #### Run Doctor Verification
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Complete reference for the published `oh-my-opencode` CLI. During the rename transition, OpenCode plugin registration now prefers `oh-my-openagent` inside `opencode.json`.
+Complete reference for the published `oh-my-opencode` CLI. On current OpenCode releases, the installer registers the plugin via a managed `file://.../node_modules/oh-my-opencode/dist/index.js` entry in `opencode.json`, while direct package-name entries remain part of the rename-compat path.
 
 ## Basic Usage
 
@@ -39,7 +39,7 @@ bunx oh-my-opencode install
 ### Installation Process
 
 1. **Subscription Selection**: Choose which providers and subscriptions you actually have
-2. **Plugin Registration**: Registers `oh-my-openagent` in OpenCode settings, or upgrades a legacy `oh-my-opencode` entry during the compatibility window
+2. **Plugin Registration**: Registers a managed `file://.../node_modules/oh-my-opencode/dist/index.js` entry in OpenCode settings and maintains the matching dependency in the active config directory's `package.json`
 3. **Configuration File Creation**: Writes the generated OmO config to `oh-my-opencode.json` in the active OpenCode config directory
 4. **Authentication Hints**: Shows the `opencode auth login` steps for the providers you selected, unless `--skip-auth` is set
 
@@ -65,7 +65,7 @@ bunx oh-my-opencode install
 Diagnoses your environment to ensure Oh My OpenCode is functioning correctly. The current checks are grouped into system, config, tools, and models.
 
 The doctor command detects common issues including:
-- Legacy plugin entry references in `opencode.json` (warns when `oh-my-opencode` is still used instead of `oh-my-openagent`)
+- Legacy direct package-name references in `opencode.json` (warns when `oh-my-opencode` is still used instead of `oh-my-openagent`)
 - Configuration file validity and JSONC parsing errors
 - Model resolution and fallback chain verification
 - Missing or misconfigured MCP servers
@@ -231,7 +231,7 @@ The runtime loads user config as the base config, then merges project config on 
 1. **Project Level**: `.opencode/oh-my-openagent.jsonc`, `.opencode/oh-my-openagent.json`, `.opencode/oh-my-opencode.jsonc`, or `.opencode/oh-my-opencode.json`
 2. **User Level**: `~/.config/opencode/oh-my-openagent.jsonc`, `~/.config/opencode/oh-my-openagent.json`, `~/.config/opencode/oh-my-opencode.jsonc`, or `~/.config/opencode/oh-my-opencode.json`
 
-**Naming Note**: The published package and binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`. Plugin config loading recognizes both `oh-my-openagent.*` and legacy `oh-my-opencode.*` basenames. If both basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
+**Naming Note**: The published package and binary are still `oh-my-opencode`. On current OpenCode releases, installer-managed setups use a `file://.../node_modules/oh-my-opencode/dist/index.js` plugin entry in `opencode.json`. Plugin config loading still recognizes both `oh-my-openagent.*` and legacy `oh-my-opencode.*` basenames. If both basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
 
 ### Filename Compatibility
 
@@ -297,13 +297,13 @@ bunx oh-my-opencode doctor --json
 
 ### "Using legacy package name" Warning
 
-The doctor warns if it finds the legacy plugin entry `oh-my-opencode` in `opencode.json`. Update the plugin array to the canonical `oh-my-openagent` entry:
+The doctor warns if it finds a direct legacy package-name entry like `oh-my-opencode` in `opencode.json`. The simplest fix is to rerun the installer so it rewrites the plugin registration to the managed `file://` form:
 
 ```bash
-# Replace the legacy plugin entry in user config
-jq '.plugin = (.plugin // [] | map(if . == "oh-my-opencode" then "oh-my-openagent" else . end))' \
-  ~/.config/opencode/opencode.json > /tmp/opencode.json && mv /tmp/opencode.json ~/.config/opencode/opencode.json
+bunx oh-my-opencode install
 ```
+
+If you are intentionally maintaining direct package-name entries during the rename transition, update them to `oh-my-openagent` manually.
 ---
 
 ## refresh-model-capabilities

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -194,7 +194,7 @@ When you use a Category, a special agent called **Sisyphus-Junior** performs the
 
 ### Rename Compatibility
 
-The published package and binary remain `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config files (`oh-my-openagent.json[c]` or legacy `oh-my-opencode.json[c]`) are recognized during the transition. Run `bunx oh-my-opencode doctor` to check for legacy package name warnings.
+The published package and binary remain `oh-my-opencode`. On current OpenCode releases, the installer writes a managed `file://.../node_modules/oh-my-opencode/dist/index.js` entry into `opencode.json` and tracks the dependency through the OpenCode config directory's `package.json`. Direct package-name entries remain part of the rename-compat transition, and legacy `oh-my-opencode` entries still warn when detected. Plugin config files (`oh-my-openagent.json[c]` or legacy `oh-my-opencode.json[c]`) are recognized during the transition. Run `bunx oh-my-opencode doctor` to check for legacy package name warnings.
 
 ### Fallback Models
 

--- a/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -1,12 +1,103 @@
-import { readFileSync, writeFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { applyEdits, modify } from "jsonc-parser"
 import type { ConfigMergeResult } from "../types"
-import { PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../shared"
-import { getConfigDir } from "./config-context"
+import { LEGACY_PLUGIN_NAME, PLUGIN_NAME, parseJsonc } from "../../shared"
+import { getConfigContext, getConfigDir } from "./config-context"
 import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists"
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
 import { detectConfigFormat } from "./opencode-config-format"
 import { parseOpenCodeConfigFileWithError, type OpenCodeConfig } from "./parse-opencode-config-file"
 import { getPluginNameWithVersion } from "./plugin-name-with-version"
+
+interface PackageJsonShape {
+  dependencies?: Record<string, string>
+  [key: string]: unknown
+}
+
+const INSTALL_PACKAGE_NAME = LEGACY_PLUGIN_NAME
+
+function isPackageEntry(entry: string, packageName: string): boolean {
+  return entry === packageName || entry.startsWith(`${packageName}@`)
+}
+
+function isOurPackageEntry(entry: string): boolean {
+  return isPackageEntry(entry, PLUGIN_NAME) || isPackageEntry(entry, LEGACY_PLUGIN_NAME)
+}
+
+function isOurFileEntry(entry: string): boolean {
+  return entry.startsWith("file://") && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))
+}
+
+function isManagedFileEntry(entry: string): boolean {
+  return entry.startsWith("file://") && entry.includes(`/node_modules/${INSTALL_PACKAGE_NAME}/dist/index.js`)
+}
+
+function getDependencySpecFromPackageEntry(entry: string): string | null {
+  if (!isOurPackageEntry(entry)) {
+    return null
+  }
+
+  const atIndex = entry.indexOf("@")
+  if (atIndex === -1) {
+    return "latest"
+  }
+
+  return entry.slice(atIndex + 1) || "latest"
+}
+
+function getDependencySpecFromExistingPackageJson(packageJsonPath: string): string | null {
+  if (!existsSync(packageJsonPath)) {
+    return null
+  }
+
+  const content = readFileSync(packageJsonPath, "utf-8")
+  const parsed = parseJsonc<PackageJsonShape>(content)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Invalid package.json at ${packageJsonPath}`)
+  }
+
+  return parsed.dependencies?.[INSTALL_PACKAGE_NAME] ?? parsed.dependencies?.[PLUGIN_NAME] ?? null
+}
+
+function buildManagedPluginEntry(configDir: string): string {
+  return pathToFileURL(join(configDir, "node_modules", INSTALL_PACKAGE_NAME, "dist", "index.js")).toString()
+}
+
+function writeJsoncPluginArray(path: string, pluginEntries: string[]): void {
+  const content = readFileSync(path, "utf-8")
+  const edits = modify(content, ["plugin"], pluginEntries, {
+    formattingOptions: {
+      insertSpaces: true,
+      tabSize: 2,
+      eol: "\n",
+    },
+    getInsertionIndex: () => 0,
+  })
+
+  writeFileSync(path, edits.length > 0 ? applyEdits(content, edits) : content)
+}
+
+function writePackageJsonDependency(packageJsonPath: string, dependencySpec: string): void {
+  let packageJson: PackageJsonShape = {}
+
+  if (existsSync(packageJsonPath)) {
+    const content = readFileSync(packageJsonPath, "utf-8")
+    const parsed = parseJsonc<PackageJsonShape>(content)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`Invalid package.json at ${packageJsonPath}`)
+    }
+    packageJson = parsed
+  }
+
+  const dependencies = { ...(packageJson.dependencies ?? {}) }
+  delete dependencies[PLUGIN_NAME]
+  dependencies[INSTALL_PACKAGE_NAME] = dependencySpec
+  packageJson.dependencies = dependencies
+
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n")
+}
 
 export async function addPluginToOpenCodeConfig(currentVersion: string): Promise<ConfigMergeResult> {
   try {
@@ -20,11 +111,18 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
   }
 
   const { format, path } = detectConfigFormat()
-  const pluginEntry = await getPluginNameWithVersion(currentVersion, PLUGIN_NAME)
+  const configDir = getConfigDir()
+  const packageJsonPath = getConfigContext().paths.packageJson
+  const managedPluginEntry = buildManagedPluginEntry(configDir)
 
   try {
+    const pluginEntry = await getPluginNameWithVersion(currentVersion, INSTALL_PACKAGE_NAME)
+    const defaultDependencySpec = getDependencySpecFromPackageEntry(pluginEntry) ?? "latest"
+
     if (format === "none") {
-      const config: OpenCodeConfig = { plugin: [pluginEntry] }
+      writePackageJsonDependency(packageJsonPath, defaultDependencySpec)
+
+      const config: OpenCodeConfig = { plugin: [managedPluginEntry] }
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
       return { success: true, configPath: path }
     }
@@ -40,45 +138,27 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
 
     const config = parseResult.config
     const plugins = config.plugin ?? []
+    const localDevEntries = plugins.filter((plugin) => isOurFileEntry(plugin) && !isManagedFileEntry(plugin))
+    const packageEntries = plugins.filter(isOurPackageEntry)
+    const normalizedPlugins = plugins.filter((plugin) => !isOurPackageEntry(plugin) && !isOurFileEntry(plugin))
 
-    const canonicalEntries = plugins.filter(
-      (plugin) => plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`)
-    )
-    const legacyEntries = plugins.filter(
-      (plugin) => plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
-    )
-    const otherPlugins = plugins.filter(
-      (plugin) => !(plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`))
-        && !(plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`))
-    )
-
-    const normalizedPlugins = [...otherPlugins]
-
-    if (canonicalEntries.length > 0) {
-      normalizedPlugins.push(canonicalEntries[0])
-    } else if (legacyEntries.length > 0) {
-      const versionMatch = legacyEntries[0].match(/@(.+)$/)
-      const preservedVersion = versionMatch ? versionMatch[1] : null
-      normalizedPlugins.push(preservedVersion ? `${PLUGIN_NAME}@${preservedVersion}` : pluginEntry)
+    if (localDevEntries.length > 0) {
+      normalizedPlugins.push(localDevEntries[0])
     } else {
-      normalizedPlugins.push(pluginEntry)
+      const preservedDependencySpec = packageEntries
+        .map(getDependencySpecFromPackageEntry)
+        .find((value): value is string => Boolean(value))
+        ?? getDependencySpecFromExistingPackageJson(packageJsonPath)
+        ?? defaultDependencySpec
+
+      writePackageJsonDependency(packageJsonPath, preservedDependencySpec)
+      normalizedPlugins.push(managedPluginEntry)
     }
 
     config.plugin = normalizedPlugins
 
     if (format === "jsonc") {
-      const content = readFileSync(path, "utf-8")
-      const pluginArrayRegex = /((?:"plugin"|plugin)\s*:\s*)\[([\s\S]*?)\]/
-      const match = content.match(pluginArrayRegex)
-
-      if (match) {
-        const formattedPlugins = normalizedPlugins.map((p) => `"${p}"`).join(",\n    ")
-        const newContent = content.replace(pluginArrayRegex, `$1[\n    ${formattedPlugins}\n  ]`)
-        writeFileSync(path, newContent)
-      } else {
-        const newContent = content.replace(/(\{)/, `$1\n  "plugin": ["${pluginEntry}"],`)
-        writeFileSync(path, newContent)
-      }
+      writeJsoncPluginArray(path, normalizedPlugins)
     } else {
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
     }

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -57,7 +57,8 @@ function detectProvidersFromOmoConfig(): {
 
 function isOurPlugin(plugin: string): boolean {
   return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-         plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+         plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`) ||
+         (plugin.startsWith("file://") && (plugin.includes(PLUGIN_NAME) || plugin.includes(LEGACY_PLUGIN_NAME)))
 }
 
 export function detectCurrentConfig(): DetectedConfig {

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 
 import { resetConfigContext } from "./config-context"
 import { detectCurrentConfig } from "./detect-current-config"
@@ -39,6 +40,18 @@ describe("detectCurrentConfig - single package detection", () => {
     expect(result.isInstalled).toBe(true)
   })
 
+  it("detects installer-managed file plugin entries", () => {
+    // given
+    const managedEntry = pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString()
+    writeFileSync(testConfigPath, JSON.stringify({ plugin: [managedEntry] }, null, 2) + "\n", "utf-8")
+
+    // when
+    const result = detectCurrentConfig()
+
+    // then
+    expect(result.isInstalled).toBe(true)
+  })
+
   it("returns false when plugin not present with similar name", () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent-extra"] }, null, 2) + "\n", "utf-8")
@@ -67,10 +80,12 @@ describe("detectCurrentConfig - single package detection", () => {
 describe("addPluginToOpenCodeConfig - single package writes", () => {
   let testConfigDir = ""
   let testConfigPath = ""
+  let testPackageJsonPath = ""
 
   beforeEach(() => {
     testConfigDir = join(tmpdir(), `omo-add-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`)
     testConfigPath = join(testConfigDir, "opencode.json")
+    testPackageJsonPath = join(testConfigDir, "package.json")
 
     mkdirSync(testConfigDir, { recursive: true })
     process.env.OPENCODE_CONFIG_DIR = testConfigDir
@@ -83,7 +98,7 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     delete process.env.OPENCODE_CONFIG_DIR
   })
 
-  it("writes canonical plugin entry for new installs", async () => {
+  it("writes a managed file plugin entry for new installs", async () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({}, null, 2) + "\n", "utf-8")
 
@@ -93,10 +108,15 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual([
+      pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString(),
+    ])
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "latest" })
   })
 
-  it("upgrades a bare legacy plugin entry to canonical", async () => {
+  it("upgrades a bare legacy plugin entry to a managed file entry", async () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n", "utf-8")
 
@@ -106,10 +126,15 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual([
+      pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString(),
+    ])
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "latest" })
   })
 
-  it("upgrades a version-pinned legacy entry to canonical", async () => {
+  it("upgrades a version-pinned legacy entry to a managed file entry", async () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode@3.10.0"] }, null, 2) + "\n", "utf-8")
 
@@ -119,7 +144,12 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"])
+    expect(savedConfig.plugin).toEqual([
+      pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString(),
+    ])
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "3.10.0" })
   })
 
   it("removes stale legacy entry when canonical and legacy entries both exist", async () => {
@@ -132,10 +162,15 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual([
+      pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString(),
+    ])
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "latest" })
   })
 
-  it("preserves a canonical entry when it already exists", async () => {
+  it("preserves a canonical version pin when converting to a managed file entry", async () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent@3.10.0"] }, null, 2) + "\n", "utf-8")
 
@@ -145,7 +180,26 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"])
+    expect(savedConfig.plugin).toEqual([
+      pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString(),
+    ])
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "3.10.0" })
+  })
+
+  it("preserves an existing local-dev file entry", async () => {
+    // given
+    const localDevEntry = pathToFileURL("/tmp/oh-my-openagent/dist/index.js").toString()
+    writeFileSync(testConfigPath, JSON.stringify({ plugin: [localDevEntry, "oh-my-openagent"] }, null, 2) + "\n", "utf-8")
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
+    expect(savedConfig.plugin).toEqual([localDevEntry])
   })
 
   it("rewrites quoted jsonc plugin field in place", async () => {
@@ -159,7 +213,10 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedContent = readFileSync(testConfigPath, "utf-8")
-    expect(savedContent.includes('"plugin": [\n    "oh-my-openagent"\n  ]')).toBe(true)
-    expect(savedContent.includes("oh-my-opencode")).toBe(false)
+    expect(savedContent.includes(`"plugin": [\n    "${pathToFileURL(join(testConfigDir, "node_modules", "oh-my-opencode", "dist", "index.js")).toString()}"\n  ]`)).toBe(true)
+    expect(savedContent.includes('"plugin": ["oh-my-opencode"]')).toBe(false)
+
+    const packageJson = JSON.parse(readFileSync(testPackageJsonPath, "utf-8"))
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "latest" })
   })
 })

--- a/src/cli/doctor/checks/system-plugin.test.ts
+++ b/src/cli/doctor/checks/system-plugin.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { findPluginEntry } from "./system-plugin"
+
+describe("findPluginEntry", () => {
+  it("treats installer-managed node_modules file entries as non-local installs", () => {
+    const result = findPluginEntry([
+      "file:///tmp/opencode/node_modules/oh-my-opencode/dist/index.js",
+    ])
+
+    expect(result).toEqual({
+      entry: "file:///tmp/opencode/node_modules/oh-my-opencode/dist/index.js",
+      isLocalDev: false,
+    })
+  })
+
+  it("treats repo file entries as local-dev installs", () => {
+    const result = findPluginEntry([
+      "file:///workspaces/oh-my-openagent/dist/index.js",
+    ])
+
+    expect(result).toEqual({
+      entry: "file:///workspaces/oh-my-openagent/dist/index.js",
+      isLocalDev: true,
+    })
+  })
+})

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -50,7 +50,9 @@ function findPluginEntry(entries: string[]): { entry: string; isLocalDev: boolea
     }
     // Check for file:// paths that include either name
     if (entry.startsWith("file://") && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))) {
-      return { entry, isLocalDev: true }
+      const isManagedInstall = entry.includes(`/node_modules/${PLUGIN_NAME}/dist/index.js`)
+        || entry.includes(`/node_modules/${LEGACY_PLUGIN_NAME}/dist/index.js`)
+      return { entry, isLocalDev: !isManagedInstall }
     }
   }
 

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -111,12 +111,16 @@ describe("install CLI - binary check behavior", () => {
 
     // then should create opencode.json
     const configPath = join(tempDir, "opencode.json")
+    const packageJsonPath = join(tempDir, "package.json")
     expect(existsSync(configPath)).toBe(true)
+    expect(existsSync(packageJsonPath)).toBe(true)
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"))
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"))
     expect(config.plugin).toBeDefined()
-    expect(config.plugin.some((p: string) => p.includes("oh-my-openagent"))).toBe(true)
-    expect(config.plugin.some((p: string) => p.includes("oh-my-opencode"))).toBe(false)
+    expect(config.plugin.some((p: string) => p.startsWith("file://"))).toBe(true)
+    expect(config.plugin.some((p: string) => p.includes("/node_modules/oh-my-opencode/dist/index.js"))).toBe(true)
+    expect(packageJson.dependencies).toEqual({ "oh-my-opencode": "latest" })
 
     // then exit code should be 0 (success)
     expect(exitCode).toBe(0)

--- a/src/hooks/auto-update-checker/checker/local-dev-path.test.ts
+++ b/src/hooks/auto-update-checker/checker/local-dev-path.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { pathToFileURL } from "node:url"
+import { getLocalDevPath } from "./local-dev-path"
+
+describe("getLocalDevPath", () => {
+  let temporaryDirectory: string
+  let configPath: string
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "omo-local-dev-path-test-"))
+    const opencodeDirectory = path.join(temporaryDirectory, ".opencode")
+    fs.mkdirSync(opencodeDirectory, { recursive: true })
+    configPath = path.join(opencodeDirectory, "opencode.json")
+  })
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true })
+  })
+
+  test("returns repo paths for local-dev file entries", () => {
+    const localDevEntry = pathToFileURL(path.join(temporaryDirectory, "oh-my-opencode", "dist", "index.js")).toString()
+    fs.writeFileSync(configPath, JSON.stringify({ plugin: [localDevEntry] }))
+
+    expect(getLocalDevPath(temporaryDirectory)).toBe(path.join(temporaryDirectory, "oh-my-opencode", "dist", "index.js"))
+  })
+
+  test("ignores installer-managed node_modules entries", () => {
+    const managedEntry = pathToFileURL(path.join(temporaryDirectory, ".opencode", "node_modules", "oh-my-opencode", "dist", "index.js")).toString()
+    fs.writeFileSync(configPath, JSON.stringify({ plugin: [managedEntry] }))
+
+    expect(getLocalDevPath(temporaryDirectory)).toBeNull()
+  })
+})

--- a/src/hooks/auto-update-checker/checker/local-dev-path.ts
+++ b/src/hooks/auto-update-checker/checker/local-dev-path.ts
@@ -2,8 +2,15 @@ import * as fs from "node:fs"
 import { fileURLToPath } from "node:url"
 import type { OpencodeConfig } from "../types"
 import { PACKAGE_NAME } from "../constants"
+import { LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../../shared"
 import { getConfigPaths } from "./config-paths"
 import { stripJsonComments } from "./jsonc-strip"
+
+function isManagedInstallEntry(entry: string): boolean {
+  return entry.includes(`/node_modules/${PLUGIN_NAME}/dist/index.js`)
+    || entry.includes(`/node_modules/${LEGACY_PLUGIN_NAME}/dist/index.js`)
+    || entry.includes(`/node_modules/${PACKAGE_NAME}/dist/index.js`)
+}
 
 export function isLocalDevMode(directory: string): boolean {
   return getLocalDevPath(directory) !== null
@@ -18,7 +25,14 @@ export function getLocalDevPath(directory: string): string | null {
       const plugins = config.plugin ?? []
 
       for (const entry of plugins) {
-        if (entry.startsWith("file://") && entry.includes(PACKAGE_NAME)) {
+        if (
+          entry.startsWith("file://") &&
+          (entry.includes(PACKAGE_NAME) || entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))
+        ) {
+          if (isManagedInstallEntry(entry)) {
+            continue
+          }
+
           try {
             return fileURLToPath(entry)
           } catch {

--- a/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
+import { pathToFileURL } from "node:url"
 import { findPluginEntry } from "./plugin-entry"
 
 describe("findPluginEntry", () => {
@@ -61,6 +62,48 @@ describe("findPluginEntry", () => {
   test("returns pinned for explicit semver", () => {
     // #given plugin is configured with explicit version
     fs.writeFileSync(configPath, JSON.stringify({ plugin: ["oh-my-opencode@3.5.2"] }))
+
+    // #when plugin entry is detected
+    const pluginInfo = findPluginEntry(temporaryDirectory)
+
+    // #then explicit semver is treated as pin
+    expect(pluginInfo).not.toBeNull()
+    expect(pluginInfo?.isPinned).toBe(true)
+    expect(pluginInfo?.pinnedVersion).toBe("3.5.2")
+  })
+
+  test("reads channel intent from installer-managed file entries", () => {
+    // #given plugin is configured as a managed file:// entry
+    const workspacePackageJson = path.join(temporaryDirectory, ".opencode", "package.json")
+    fs.writeFileSync(workspacePackageJson, JSON.stringify({
+      dependencies: {
+        "oh-my-opencode": "latest",
+      },
+    }))
+    fs.writeFileSync(configPath, JSON.stringify({
+      plugin: [pathToFileURL(path.join(temporaryDirectory, ".opencode", "node_modules", "oh-my-opencode", "dist", "index.js")).toString()],
+    }))
+
+    // #when plugin entry is detected
+    const pluginInfo = findPluginEntry(temporaryDirectory)
+
+    // #then latest is treated as channel, not pin
+    expect(pluginInfo).not.toBeNull()
+    expect(pluginInfo?.isPinned).toBe(false)
+    expect(pluginInfo?.pinnedVersion).toBe("latest")
+  })
+
+  test("reads pinned versions from installer-managed file entries", () => {
+    // #given plugin is configured as a managed file:// entry with a pinned dependency
+    const workspacePackageJson = path.join(temporaryDirectory, ".opencode", "package.json")
+    fs.writeFileSync(workspacePackageJson, JSON.stringify({
+      dependencies: {
+        "oh-my-opencode": "3.5.2",
+      },
+    }))
+    fs.writeFileSync(configPath, JSON.stringify({
+      plugin: [pathToFileURL(path.join(temporaryDirectory, ".opencode", "node_modules", "oh-my-opencode", "dist", "index.js")).toString()],
+    }))
 
     // #when plugin entry is detected
     const pluginInfo = findPluginEntry(temporaryDirectory)

--- a/src/hooks/auto-update-checker/checker/plugin-entry.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.ts
@@ -1,6 +1,9 @@
 import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
 import type { OpencodeConfig } from "../types"
 import { PACKAGE_NAME } from "../constants"
+import { LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../../shared"
 import { getConfigPaths } from "./config-paths"
 import { stripJsonComments } from "./jsonc-strip"
 
@@ -12,6 +15,54 @@ export interface PluginEntryInfo {
 }
 
 const EXACT_SEMVER_REGEX = /^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+const PACKAGE_NAMES = [PLUGIN_NAME, LEGACY_PLUGIN_NAME, PACKAGE_NAME]
+
+interface WorkspacePackageJson {
+  dependencies?: Record<string, string>
+}
+
+function readDependencyVersionForFileEntry(entry: string): string | null {
+  try {
+    const pluginPath = fileURLToPath(entry)
+    const packageRoot = path.dirname(path.dirname(pluginPath))
+    const workspaceDir = path.dirname(path.dirname(packageRoot))
+    const workspacePackageJsonPath = path.join(workspaceDir, "package.json")
+
+    if (!fs.existsSync(workspacePackageJsonPath)) {
+      return null
+    }
+
+    const content = fs.readFileSync(workspacePackageJsonPath, "utf-8")
+    const parsed = JSON.parse(content) as WorkspacePackageJson
+    const dependencies = parsed.dependencies ?? {}
+
+    for (const packageName of PACKAGE_NAMES) {
+      if (dependencies[packageName]) {
+        return dependencies[packageName]
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return null
+}
+
+function getEntryVersionInfo(entry: string, packageName: string): { isPinned: boolean; pinnedVersion: string | null } {
+  if (entry === packageName) {
+    return { isPinned: false, pinnedVersion: null }
+  }
+
+  if (entry.startsWith(`${packageName}@`)) {
+    const pinnedVersion = entry.slice(packageName.length + 1).trim() || null
+    return {
+      isPinned: pinnedVersion !== null && EXACT_SEMVER_REGEX.test(pinnedVersion),
+      pinnedVersion,
+    }
+  }
+
+  return { isPinned: false, pinnedVersion: null }
+}
 
 export function findPluginEntry(directory: string): PluginEntryInfo | null {
   for (const configPath of getConfigPaths(directory)) {
@@ -22,13 +73,25 @@ export function findPluginEntry(directory: string): PluginEntryInfo | null {
       const plugins = config.plugin ?? []
 
       for (const entry of plugins) {
-        if (entry === PACKAGE_NAME) {
-          return { entry, isPinned: false, pinnedVersion: null, configPath }
+        for (const packageName of PACKAGE_NAMES) {
+          if (entry === packageName || entry.startsWith(`${packageName}@`)) {
+            const versionInfo = getEntryVersionInfo(entry, packageName)
+            return { entry, ...versionInfo, configPath }
+          }
         }
-        if (entry.startsWith(`${PACKAGE_NAME}@`)) {
-          const pinnedVersion = entry.slice(PACKAGE_NAME.length + 1)
-          const isPinned = EXACT_SEMVER_REGEX.test(pinnedVersion.trim())
-          return { entry, isPinned, pinnedVersion, configPath }
+
+        if (
+          entry.startsWith("file://") &&
+          PACKAGE_NAMES.some((packageName) => entry.includes(`/node_modules/${packageName}/dist/index.js`))
+        ) {
+          const dependencyVersion = readDependencyVersionForFileEntry(entry)
+          const pinnedVersion = dependencyVersion?.trim() || null
+          return {
+            entry,
+            isPinned: pinnedVersion !== null && EXACT_SEMVER_REGEX.test(pinnedVersion),
+            pinnedVersion,
+            configPath,
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
- switch installer-managed OpenCode registrations from direct package-name entries to a managed `file://.../node_modules/oh-my-opencode/dist/index.js` entry
- keep the matching `oh-my-opencode` dependency in the active OpenCode config directory `package.json`
- teach install detection, doctor checks, and update-check helpers to treat installer-managed file entries as normal installs instead of local-dev overrides
- update installation docs to describe the managed plugin registration flow

## Reproduction
Environment I reproduced this on:
- Ubuntu 24.04.3 LTS
- OpenCode 1.3.8
- oh-my-openagent 3.14.0

Steps:
1. Install `oh-my-openagent` with the current CLI so `opencode.json` contains a direct package entry such as `"oh-my-openagent"` or `"oh-my-openagent@latest"`.
2. Start OpenCode.
3. Observe plugin load failure similar to `resolved server entry outside plugin directory` and missing OmO agents.

I also reproduced that a managed file entry works:
1. Put `"file:///.../node_modules/oh-my-opencode/dist/index.js"` in `opencode.json`.
2. Add `"oh-my-opencode"` to the matching config-dir `package.json` dependencies.
3. Start OpenCode and verify the plugin loads successfully.

## Root Cause
Recent OpenCode builds are stricter about resolving plugin server entries from npm package registrations. The current installer still writes package-name entries into `opencode.json`, which goes through the failing npm plugin resolution path instead of the working file-entry path.

## Fix
- write a managed `file://` plugin entry during install/update
- maintain the dependency in the config-dir `package.json` so OpenCode can install it before loading
- preserve explicit version pins by translating existing package entries into dependency specs
- preserve true local-dev `file://` overrides instead of overwriting them
- update detection logic so installer-managed `file://.../node_modules/...` entries are recognized as installed and not treated as local-dev mode

## Verification
- `bun run typecheck`
- `bun run build`
- `bun test src/cli/config-manager/plugin-detection.test.ts src/cli/install.test.ts src/cli/doctor/checks/system.test.ts`
- `bun test src/cli/doctor/checks/system-plugin.test.ts`
- `bun test src/hooks/auto-update-checker/checker/plugin-entry.test.ts src/hooks/auto-update-checker/checker/local-dev-path.test.ts`
- `bun test src/hooks/auto-update-checker/checker/sync-package-json.test.ts src/hooks/auto-update-checker/hook/workspace-resolution.test.ts src/hooks/auto-update-checker/hook/background-update-check.test.ts`
- manual verification with a temporary `OPENCODE_CONFIG_DIR`, confirming OpenCode logs `loading plugin path=file:///tmp/.../node_modules/oh-my-opencode/dist/index.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch installer-managed OpenCode plugin registration to a managed file entry (`file://.../node_modules/oh-my-opencode/dist/index.js`) and track the dependency in the config-dir `package.json`. This fixes plugin load failures on recent OpenCode and ensures doctor/update checks treat managed installs as normal, not local-dev.

- **Bug Fixes**
  - Write a managed `file://` plugin entry during install/update; preserve true local-dev `file://` overrides.
  - Keep `oh-my-opencode` in the active OpenCode config directory `package.json`, preserving version pins or channel from existing entries.
  - Update detection, doctor, and auto-update checker to recognize managed entries and read pins from `package.json`.
  - Refresh docs to explain the managed registration flow.

- **Migration**
  - Recommended: run `bunx oh-my-opencode install` to update `opencode.json` and `package.json`.
  - Manual: set `plugin` to `file://.../node_modules/oh-my-opencode/dist/index.js` and add `oh-my-opencode` to the same directory’s `package.json`.

<sup>Written for commit 0002eebba85e1558c5983742966d3b33f4ded99e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

