### PR TITLE
Update installation.md to fix broken link

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -460,7 +460,7 @@ Tell the user of following:
 
 3. **Need precision?** Press **Tab** to enter Prometheus (Planner) mode, create a work plan through an interview process, then run `/start-work` to execute it with full orchestration.
 
-4. You wanna have your own agent- catalog setup? I can read the [docs](docs/guide/agent-model-matching.md) and set up for you after interviewing!
+4. You wanna have your own agent- catalog setup? I can read the [docs](agent-model-matching.md) and set up for you after interviewing!
 
 That's it. The agent will figure out the rest and handle everything automatically.
 


### PR DESCRIPTION
This PR fixes a broken link (docs) in the install file. Links are relative to the file, not absolute.

To test, just click the link and make sure it works.

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
| <img width="1624" height="1060" alt="before" src="https://github.com/user-attachments/assets/098a0dc1-9a78-479c-881e-8ee4d98d9ccc" /> | <img width="1624" height="1060" alt="after" src="https://github.com/user-attachments/assets/1743a31b-c98f-46b4-af01-75ca3c286c52" /> |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken link in docs/guide/installation.md by correcting the relative path to agent-model-matching.md. The "docs" link now resolves properly from its location; no content changes.

<sup>Written for commit c1aaaef7bf28e779e480a476f0dd1ff51fa6a479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

