### PR TITLE
fix(package): add ./server export for OpenCode-Go plugin compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./server": "./dist/index.js",
     "./schema.json": "./dist/oh-my-opencode.schema.json"
   },
   "scripts": {


### PR DESCRIPTION
OpenCode-Go's resolveExportPath checks exports["./server"] before falling back to the main field. Without this entry, fs.realpathSync resolves the entry path relative to CWD instead of the package directory, triggering a containment security check failure:

  ERROR path=oh-my-opencode error=Plugin resolved server entry outside plugin directory

Fixes #2966

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `exports["./server"]` to package.json so `OpenCode-Go` resolves the server entry correctly and avoids the containment check error. Fixes #2966.

<sup>Written for commit 28b0a75705a8d139a0010000e3e4814366b467c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

