### PR TITLE
fix(doctor): improve opencode binary detection for WSL

### DIFF
--- a/src/cli/doctor/checks/system-binary.ts
+++ b/src/cli/doctor/checks/system-binary.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs"
+import { existsSync, accessSync, constants } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { spawnWithWindowsHide } from "../../../shared/spawn-with-windows-hide"
@@ -6,6 +6,15 @@ import { spawnWithWindowsHide } from "../../../shared/spawn-with-windows-hide"
 import { OPENCODE_BINARIES } from "../constants"
 
 const WINDOWS_EXECUTABLE_EXTS = [".exe", ".cmd", ".bat", ".ps1"]
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
 
 export interface OpenCodeBinaryInfo {
   binary: string
@@ -94,15 +103,43 @@ export function findDesktopBinary(
   return null
 }
 
-export async function findOpenCodeBinary(): Promise<OpenCodeBinaryInfo | null> {
+export async function findOpenCodeBinary(
+  platform: NodeJS.Platform = process.platform,
+  checkExists: (path: string) => boolean = existsSync,
+): Promise<OpenCodeBinaryInfo | null> {
+  // 1) Try Bun.which first
   for (const binary of OPENCODE_BINARIES) {
     const path = Bun.which(binary)
-    if (path) {
+    if (path && checkExists(path)) {
       return { binary, path }
     }
   }
 
-  return findDesktopBinary()
+  // 2) Manually search through PATH directories (robust for WSL/mixed environments)
+  const pathEnv = process.env.PATH ?? ""
+  const delimiter = platform === "win32" ? ";" : ":"
+  const candidates = getCommandCandidates(platform)
+
+  for (const entry of pathEnv.split(delimiter).filter(Boolean)) {
+    for (const command of candidates) {
+      const fullPath = join(entry, command)
+      if (checkExists(fullPath) && isExecutable(fullPath)) {
+        return { binary: command, path: fullPath }
+      }
+    }
+  }
+
+  // 3) Fall back to desktop app paths
+  return findDesktopBinary(platform, checkExists)
+}
+
+function getCommandCandidates(platform: NodeJS.Platform): string[] {
+  if (platform !== "win32") return [...OPENCODE_BINARIES]
+
+  const WINDOWS_SUFFIXES = ["", ...WINDOWS_EXECUTABLE_EXTS] as const
+  return OPENCODE_BINARIES.flatMap((command) =>
+    WINDOWS_SUFFIXES.map((suffix) => `${command}${suffix}`),
+  )
 }
 
 export async function getOpenCodeVersion(


### PR DESCRIPTION
## Summary

- doctor command's `findOpenCodeBinary()` only used `Bun.which()`, which fails on WSL due to mixed PATH environment (Windows + Linux paths)
- Added manual PATH directory search as fallback (robust for WSL/mixed environments)
- Mirrors `findWorkingOpencodeBinary()` approach from the `run` command

## Changes

- `src/cli/doctor/checks/system-binary.ts`: Enhanced `findOpenCodeBinary()` with 3-tier fallback:
  1. `Bun.which()` first (existing)
  2. Manual PATH directory traversal (new)
  3. Desktop app paths fallback (existing)

## Problem

On WSL, `Bun.which()` fails to detect opencode binary even when it's in PATH, because WSL has a mixed environment with both Windows (`/mnt/c/...`) and Linux paths.

## Testing

- Verified on WSL2 with opencode binary at `~/.opencode/bin/opencode`
- Doctor now correctly detects the binary

Fixes: WSL opencode binary detection in doctor command

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WSL binary detection in the `doctor` command by adding a PATH search with platform-aware candidates and executable checks, matching the `run` command.

- **Bug Fixes**
  - Try `Bun.which()` first and ensure it exists; fall back to PATH traversal, then desktop app paths.
  - Use OS-specific PATH delimiter and Windows suffixes (.exe, .cmd, .bat, .ps1) via a shared constant.
  - Check executability with `fs.accessSync(X_OK)` before returning a match.
  - Accept `platform` and `checkExists` for tests and pass them to desktop fallback; validated on WSL2 with `~/.opencode/bin/opencode`.

<sup>Written for commit c507ce7c56df3ef803b0a2ff3a8406d60af12911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

