### PR TITLE
fix(skills): resolve skills by frontmatter name and discover nested directories

### DIFF
--- a/src/features/opencode-skill-loader/skill-directory-loader.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.ts
@@ -13,7 +13,7 @@ export async function loadSkillsFromDir(options: {
 }): Promise<LoadedSkill[]> {
   const namePrefix = options.namePrefix ?? ""
   const depth = options.depth ?? 0
-  const maxDepth = options.maxDepth ?? 2
+  const maxDepth = options.maxDepth ?? 4
 
   const entries = await fs.readdir(options.skillsDir, { withFileTypes: true }).catch(() => [])
   const skillMap = new Map<string, LoadedSkill>()

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -241,8 +241,13 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
 
       const requestedName = args.name.replace(/^\//, "")
 
-      // Check skills first (exact match, case-insensitive)
-      const matchedSkill = skills.find(s => s.name.toLowerCase() === requestedName.toLowerCase())
+      // Check skills first (exact match on full name, then fallback to last segment for frontmatter-name lookups)
+      const lower = requestedName.toLowerCase()
+      const matchedSkill = skills.find(s => s.name.toLowerCase() === lower)
+        ?? skills.find(s => {
+          const segments = s.name.split("/")
+          return segments[segments.length - 1].toLowerCase() === lower
+        })
 
       if (matchedSkill) {
         if (matchedSkill.definition.agent && (!ctx?.agent || matchedSkill.definition.agent !== ctx.agent)) {


### PR DESCRIPTION
Fixes #2971

## Problem

The `skill()` tool fails to resolve skills installed via GitHub skill repositories. Two independent root causes:

### 1. Discovery: Skills nested 3+ levels deep are never loaded

`loadSkillsFromDir()` defaults to `maxDepth=2`, but real-world skill repos like `posit-dev/skills/quarto/quarto-authoring` are 4 levels deep. The recursion guard (`depth < maxDepth`) stops at depth 2, leaving these skills invisible.

### 2. Resolution: Name mismatch between storage and lookup

The plugin stores skills with directory-prefixed names (e.g., `posit-dev/skills/quarto/quarto-authoring`), but OpenCode core's `<available_skills>` presents only the frontmatter name (`quarto-authoring`). The LLM sends the frontmatter name to `skill()`, which does an exact match against the prefixed name and fails.

## Changes

- **`skill-directory-loader.ts`**: Increase default `maxDepth` from 2 to 4 to discover skills in deeply nested directory structures (covers all known skill repo layouts).
- **`tools.ts`**: Add fallback matching in the skill resolver: try exact match first, then try matching against the last `/`-separated segment (the frontmatter name). This aligns with what OpenCode core presents in `<available_skills>`.

Both changes are backward compatible: exact matches still work first, and `config-source-discovery` retains its own explicit depth control.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2971 by reliably resolving skills installed from GitHub repos. We now discover skills nested up to 4 levels and resolve by frontmatter name when a full path match isn’t provided.

- **Bug Fixes**
  - Discovery: increased `maxDepth` from 2→4 in `loadSkillsFromDir()` (`src/features/opencode-skill-loader/skill-directory-loader.ts`) to find 3–4 level nested skills.
  - Resolution: updated `skill()` resolver (`src/tools/skill/tools.ts`) to try exact name first, then match the last path segment (frontmatter name) to align with `<available_skills>`; remains backward compatible.

<sup>Written for commit 8ee6df3fc711db21cff03e543db30fab88c482e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

