### PR TITLE
fix: strip mcp_ prefix from tool names before dispatch

### DIFF
--- a/src/plugin/tool-execute-before-mcp-prefix.test.ts
+++ b/src/plugin/tool-execute-before-mcp-prefix.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test"
+import { createToolExecuteBeforeHandler } from "./tool-execute-before"
+import type { PluginContext } from "./types"
+import type { CreatedHooks } from "../create-hooks"
+
+function createMockContext(): PluginContext {
+  return {
+    directory: "/tmp/test-dir",
+    sessionId: "test-session",
+  } as unknown as PluginContext
+}
+
+function createMockHooks(): CreatedHooks {
+  return {
+    ralphLoop: null,
+    startWork: null,
+    autoSlashCommand: null,
+  } as unknown as CreatedHooks
+}
+
+describe("tool-execute-before mcp_ prefix stripping", () => {
+  test("should strip mcp_ prefix from mcp_background_output", async () => {
+    // given
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createMockContext(),
+      hooks: createMockHooks(),
+    })
+    const input = { tool: "mcp_background_output", sessionID: "ses_123", callID: "call_123" }
+    const output = { args: {} }
+
+    // when
+    await handler(input, output)
+
+    // then
+    expect(input.tool).toBe("background_output")
+  })
+
+  test("should strip mcp_ prefix from mcp_background_cancel", async () => {
+    // given
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createMockContext(),
+      hooks: createMockHooks(),
+    })
+    const input = { tool: "mcp_background_cancel", sessionID: "ses_123", callID: "call_123" }
+    const output = { args: {} }
+
+    // when
+    await handler(input, output)
+
+    // then
+    expect(input.tool).toBe("background_cancel")
+  })
+
+  test("should strip mcp_ prefix from mcp_nocturne-memory_read_memory", async () => {
+    // given
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createMockContext(),
+      hooks: createMockHooks(),
+    })
+    const input = { tool: "mcp_nocturne-memory_read_memory", sessionID: "ses_123", callID: "call_123" }
+    const output = { args: {} }
+
+    // when
+    await handler(input, output)
+
+    // then
+    expect(input.tool).toBe("nocturne-memory_read_memory")
+  })
+
+  test("should NOT strip mcp_ prefix from tools that already work (e.g., mcp_bash)", async () => {
+    // given — mcp_bash works fine because OpenCode handles it natively,
+    // but our prefix stripping should still normalize it
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createMockContext(),
+      hooks: createMockHooks(),
+    })
+    const input = { tool: "mcp_bash", sessionID: "ses_123", callID: "call_123" }
+    const output = { args: { command: "echo hello" } }
+
+    // when
+    await handler(input, output)
+
+    // then — prefix stripped, bash handler still processes it
+    expect(input.tool).toBe("bash")
+  })
+
+  test("should not modify tool names without mcp_ prefix", async () => {
+    // given
+    const handler = createToolExecuteBeforeHandler({
+      ctx: createMockContext(),
+      hooks: createMockHooks(),
+    })
+    const input = { tool: "background_output", sessionID: "ses_123", callID: "call_123" }
+    const output = { args: {} }
+
+    // when
+    await handler(input, output)
+
+    // then
+    expect(input.tool).toBe("background_output")
+  })
+})

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -51,6 +51,19 @@ export function createToolExecuteBeforeHandler(args: {
   }
 
   return async (input, output): Promise<void> => {
+    // Strip mcp_ prefix from tool names — the model may emit mcp_background_output
+    // but the runtime registry has it as background_output (fixes #2697)
+    if (/^mcp_/i.test(input.tool)) {
+      const stripped = input.tool.replace(/^mcp_/i, "")
+      log("[tool-execute-before] Stripped mcp_ prefix from tool name", {
+        original: input.tool,
+        resolved: stripped,
+        sessionID: input.sessionID,
+        callID: input.callID,
+      })
+      input.tool = stripped
+    }
+
     if (input.tool.toLowerCase() === "bash" && typeof output.args.command === "string") {
       if (output.args.command.includes("\x00")) {
         output.args.command = output.args.command.replace(/\x00/g, "")

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -52,6 +52,19 @@ export function createToolExecuteBeforeHandler(args: {
   }
 
   return async (input, output): Promise<void> => {
+    // Strip mcp_ prefix from tool names — the model may emit mcp_background_output
+    // but the runtime registry has it as background_output (fixes #2697)
+    if (/^mcp_/i.test(input.tool)) {
+      const stripped = input.tool.replace(/^mcp_/i, "")
+      log("[tool-execute-before] Stripped mcp_ prefix from tool name", {
+        original: input.tool,
+        resolved: stripped,
+        sessionID: input.sessionID,
+        callID: input.callID,
+      })
+      input.tool = stripped
+    }
+
     if (input.tool.toLowerCase() === "bash" && typeof output.args.command === "string") {
       if (output.args.command.includes("\x00")) {
         replaceToolArgs(output, { command: output.args.command.replace(/\x00/g, "") })


### PR DESCRIPTION
## Summary
Fixes #2697 — `mcp_background_output` and similar tool calls no longer fail with 'unavailable tool' errors.

## Root Cause
The model emits tool names with `mcp_` prefix (e.g., `mcp_background_output`), but the runtime tool registry stores them without the prefix (`background_output`). While `transformToolName()` in `shared/tool-name.ts` already handles prefix stripping for display, the actual tool dispatch path in `tool-execute-before.ts` was not stripping the prefix before looking up the tool.

## Fix
Added `mcp_` prefix stripping at the earliest point in the tool execution pipeline (`tool-execute-before` handler), before any tool name comparisons or dispatch happens.

## Affected Tools (all now fixed)
- `mcp_background_output` -> `background_output`
- `mcp_background_cancel` -> `background_cancel`
- `mcp_nocturne-memory_*` -> `nocturne-memory_*` (all 6 tools)

## Tests
5 new test cases covering:
- `mcp_background_output` prefix stripping
- `mcp_background_cancel` prefix stripping
- `mcp_nocturne-memory_read_memory` prefix stripping
- `mcp_bash` (already working tools still work)
- Tools without `mcp_` prefix are not modified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip the mcp_ prefix from tool names at dispatch time to prevent "unavailable tool" errors. Fixes #2697 and restores background_* and nocturne-memory_* tool calls.

- **Bug Fixes**
  - Normalize tool names by removing leading `mcp_` in `tool-execute-before`.
  - Ensures `mcp_background_output` -> `background_output`, `mcp_background_cancel` -> `background_cancel`, and all `mcp_nocturne-memory_*` resolve correctly.
  - Leaves non-prefixed tools unchanged; normalizes `mcp_bash` to `bash`.
  - Added 5 tests to cover prefix stripping and non-regression cases.

<sup>Written for commit a562d5367f194b8f6b2897c1588c270a7c2a1c20. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3035?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

