### PR TITLE
fix(prompt): prefer edit tool for GPT-5.4 juniors

### DIFF
--- a/src/agents/sisyphus-junior/gpt-5-4.ts
+++ b/src/agents/sisyphus-junior/gpt-5-4.ts
@@ -97,7 +97,7 @@ Style:
 1. SEARCH existing codebase for similar patterns/styles
 2. Match naming, indentation, import styles, error handling conventions
 3. Default to ASCII. Add comments only for non-obvious blocks
-4. ${GPT_APPLY_PATCH_GUIDANCE}
+4. For existing files, use the edit tool instead of write/apply_patch. Use write only when creating a new file. Do not use cat or echo for file creation/editing. ${GPT_APPLY_PATCH_GUIDANCE}
 5. Do not chain bash commands with separators - each command should be a separate tool call
 
 ### After Implementation (MANDATORY - DO NOT SKIP)

--- a/src/agents/sisyphus-junior/index.test.ts
+++ b/src/agents/sisyphus-junior/index.test.ts
@@ -181,6 +181,18 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
     })
   })
 
+  describe("GPT-5.4 edit protocol", () => {
+    test("GPT-5.4 prompt prefers edit tool over apply_patch for existing files", () => {
+      // given / when
+      const prompt = buildSisyphusJuniorPrompt("openai/gpt-5.4-mini", false)
+
+      // then
+      expect(prompt).toContain("For existing files, use the edit tool instead of write/apply_patch.")
+      expect(prompt).toContain("Use write only when creating a new file.")
+      expect(prompt).not.toContain("Always use apply_patch for manual code edits.")
+    })
+  })
+
   describe("tool safety (task blocked, call_omo_agent allowed)", () => {
     test("task remains blocked, call_omo_agent is allowed via tools format", () => {
       // given


### PR DESCRIPTION
## Summary
- update the GPT-5.4 Sisyphus-Junior prompt to prefer the edit tool for existing files
- keep write guidance only for new-file creation instead of steering GPT-5.4 juniors toward apply_patch
- add a prompt-level regression test for the new edit/write guidance

## Why
Issue #3041 reports GPT variants hanging on existing-file edits while following an apply_patch-first instruction that conflicts with this repo's edit-tool path. This change aligns the prompt with the existing write-existing-file guard and edit-tool workflow.

## Testing
- unable to run `bun test src/agents/sisyphus-junior/index.test.ts` locally because `bun` is not installed in this environment

Closes #3041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GPT-5.4 Sisyphus-Junior prompt to prefer the edit tool for existing files and use write only for new files. This removes `apply_patch`-first guidance that caused hangs and aligns with the agent’s edit workflow.

- **Bug Fixes**
  - Replaced `apply_patch` instruction with: use edit for existing files; write only for new files; do not use cat/echo.
  - Added a regression test that asserts the new guidance and ensures the prompt no longer says “Always use apply_patch for manual code edits.”

<sup>Written for commit 87ad159bbe611c6c7427607738a053026c3de07c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

