### PR TITLE
fix(look_at): wait for multimodal session to finish

### DIFF
--- a/src/tools/look-at/session-poller.ts
+++ b/src/tools/look-at/session-poller.ts
@@ -21,12 +21,19 @@ export async function pollSessionUntilIdle(
   const startTime = Date.now()
 
   while (Date.now() - startTime < timeout) {
-    const statusResult = await client.session.status().catch((error) => {
+    const status = client.session.status
+    if (typeof status !== "function") {
+      log("[look_at] session.status unavailable (treating as idle)")
+      return
+    }
+
+    const statusResult = await status.call(client.session).catch((error) => {
       log(`[look_at] session.status error (treating as idle):`, error)
       return { data: undefined, error }
     })
 
-    if (statusResult.error || !statusResult.data) {
+    const statusError = "error" in statusResult ? statusResult.error : undefined
+    if (statusError || !statusResult.data) {
       return
     }
 

--- a/src/tools/look-at/tools.test.ts
+++ b/src/tools/look-at/tools.test.ts
@@ -374,6 +374,68 @@ describe("look-at tool", () => {
       expect(statusFn).toHaveBeenCalledTimes(1)
     })
 
+    // given the multimodal session is still running after prompt returns
+    // when look_at fetches the result
+    // then it should wait for the child session to become idle before reading messages
+    test("waits for child session to become idle before reading messages", async () => {
+      const callOrder: string[] = []
+      const statusFn = mock(async () => {
+        callOrder.push("status")
+        if (callOrder.filter((entry) => entry === "status").length === 1) {
+          return { data: { ses_sync_wait: { type: "busy" } } }
+        }
+        return { data: { ses_sync_wait: { type: "idle" } } }
+      })
+      const messagesFn = mock(async () => {
+        callOrder.push("messages")
+        return {
+          data: [
+            { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "final result" }] },
+          ],
+        }
+      })
+
+      const mockClient = {
+        app: {
+          agents: async () => ({ data: [] }),
+        },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_sync_wait" } }),
+          prompt: async () => ({}),
+          promptAsync: async () => ({}),
+          status: statusFn,
+          messages: messagesFn,
+        },
+      }
+
+      const tool = createLookAt({
+        client: mockClient,
+        directory: "/project",
+      } as any)
+
+      const toolContext: ToolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        directory: "/project",
+        worktree: "/project",
+        abort: new AbortController().signal,
+        metadata: () => {},
+        ask: async () => {},
+      }
+
+      const result = await tool.execute(
+        { file_path: "/test/file.png", goal: "analyze" },
+        toolContext,
+      )
+
+      expect(result).toBe("final result")
+      expect(statusFn).toHaveBeenCalledTimes(2)
+      expect(messagesFn).toHaveBeenCalledTimes(1)
+      expect(callOrder).toEqual(["status", "status", "messages"])
+    })
+
     test("#given sync prompt returns ambiguous EOF #when look_at runs #then it waits for idle before reading messages", async () => {
       // given
       const callOrder: string[] = []


### PR DESCRIPTION
## Summary

Fixes #3033 by waiting for the child `multimodal-looker` session to become idle before `look_at` reads back assistant messages.

## Root Cause

`look_at` already uses `session.prompt` so the request is sent synchronously, but it still fetched session messages immediately afterwards. In practice the child session can still be busy for a short period, which means `look_at` may read the session too early and return stale or incomplete assistant output.

## Fix

1. Reuse the existing `pollSessionUntilIdle()` helper in `src/tools/look-at/tools.ts`
2. Poll the child session after prompting and before reading messages
3. Add a regression test that proves `look_at` waits for a busy child session to go idle before fetching messages

## Testing

- `git diff --check`
- Could not run `bun test src/tools/look-at/tools.test.ts src/tools/look-at/session-poller.test.ts` locally because `bun` is not installed in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `look_at` waits for the multimodal child session to be idle before reading messages, preventing stale or incomplete assistant output and removing flakiness.

- **Bug Fixes**
  - After prompting, call `pollSessionUntilIdle` before fetching messages.
  - Harden polling: guard and bind `session.status` correctly; treat errors, missing functions, or unknown responses as idle; added a test for a busy→idle transition that verifies the call order before reading messages.

<sup>Written for commit 6499a2f85d261c7736531dbe9a5f9b921fc3b7ca. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

