### PR TITLE
feat(look-at): add multi-file support for look_at tool

### DIFF
--- a/packages/omo-opencode/src/agents/multimodal-looker.ts
+++ b/packages/omo-opencode/src/agents/multimodal-looker.ts
@@ -25,7 +25,9 @@ export function createMultimodalLookerAgent(model: string): AgentConfig {
 
 During look_at invocations, the file or image is already attached to the message. Analyze the attachment directly. Never call tools, never spawn other agents, and never try to load the file by path.
 
-Your job: examine the attached file and extract ONLY what was requested.
+Your job: examine the attached file(s) and extract ONLY what was requested.
+
+When multiple files are provided, analyze each and address the goal across all files. If the goal involves comparison, explicitly compare and contrast.
 
 When to use you:
 - Media files that need visual or document interpretation

--- a/packages/omo-opencode/src/tools/look-at/look-at-arguments.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-arguments.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeArgs, validateArgs } from "./look-at-arguments"
+
+describe("look-at arguments", () => {
+  describe("normalizeArgs", () => {
+    describe("#given singular inputs", () => {
+      describe("#when file_path is provided", () => {
+        test("#then normalizes single file_path into file_paths", () => {
+          const normalized = normalizeArgs({
+            file_path: "/tmp/example.png",
+            goal: "analyze image",
+          })
+
+          expect(normalized.file_path).toBe("/tmp/example.png")
+          expect(normalized.file_paths).toEqual(["/tmp/example.png"])
+          expect(normalized.image_data_list).toBeUndefined()
+        })
+      })
+
+      describe("#when image_data is provided", () => {
+        test("#then normalizes single image_data into image_data_list", () => {
+          const normalized = normalizeArgs({
+            image_data: "data:image/png;base64,abc123",
+            goal: "analyze image",
+          })
+
+          expect(normalized.image_data).toBe("data:image/png;base64,abc123")
+          expect(normalized.image_data_list).toEqual(["data:image/png;base64,abc123"])
+          expect(normalized.file_paths).toBeUndefined()
+        })
+      })
+    })
+
+    describe("#given plural inputs", () => {
+      describe("#when arrays are provided", () => {
+        test("#then preserves provided file_paths and image_data_list arrays", () => {
+          const normalized = normalizeArgs({
+            file_paths: ["/tmp/a.png", "/tmp/b.png"],
+            image_data_list: ["data:image/png;base64,abc123"],
+            goal: "compare inputs",
+          })
+
+          expect(normalized.file_paths).toEqual(["/tmp/a.png", "/tmp/b.png"])
+          expect(normalized.image_data_list).toEqual(["data:image/png;base64,abc123"])
+        })
+      })
+    })
+  })
+
+  describe("validateArgs", () => {
+    describe("#given valid backward-compatible inputs", () => {
+      describe("#when a single file_path is provided", () => {
+        test("#then validation succeeds", () => {
+          const args = normalizeArgs({
+            file_path: "/tmp/example.png",
+            goal: "analyze image",
+          })
+
+          expect(validateArgs(args)).toBeNull()
+          expect(args.file_paths).toEqual(["/tmp/example.png"])
+        })
+      })
+
+      describe("#when a single image_data value is provided", () => {
+        test("#then validation succeeds", () => {
+          const args = normalizeArgs({
+            image_data: "data:image/png;base64,abc123",
+            goal: "analyze image",
+          })
+
+          expect(validateArgs(args)).toBeNull()
+          expect(args.image_data_list).toEqual(["data:image/png;base64,abc123"])
+        })
+      })
+    })
+
+    describe("#given valid multi-file inputs", () => {
+      describe("#when file_paths is provided", () => {
+        test("#then validation succeeds", () => {
+          const args = normalizeArgs({
+            file_paths: ["/tmp/a.png", "/tmp/b.png"],
+            goal: "compare images",
+          })
+
+          expect(validateArgs(args)).toBeNull()
+        })
+      })
+
+      describe("#when file_paths and image_data_list are both provided", () => {
+        test("#then validation succeeds for mixed sources", () => {
+          const args = normalizeArgs({
+            file_paths: ["/tmp/a.png", "/tmp/b.png"],
+            image_data_list: ["data:image/png;base64,abc123"],
+            goal: "compare inputs",
+          })
+
+          expect(validateArgs(args)).toBeNull()
+        })
+      })
+    })
+
+    describe("#given conflicting singular and plural forms", () => {
+      describe("#when file_path and file_paths are both provided", () => {
+        test("#then validation rejects the conflict", () => {
+          const args = normalizeArgs({
+            file_path: "/tmp/a.png",
+            file_paths: ["/tmp/b.png"],
+            goal: "compare images",
+          })
+
+          expect(validateArgs(args)).toContain("file_path")
+          expect(validateArgs(args)).toContain("file_paths")
+        })
+      })
+
+      describe("#when image_data and image_data_list are both provided", () => {
+        test("#then validation rejects the conflict", () => {
+          const args = normalizeArgs({
+            image_data: "data:image/png;base64,abc123",
+            image_data_list: ["data:image/png;base64,def456"],
+            goal: "compare images",
+          })
+
+          expect(validateArgs(args)).toContain("image_data")
+          expect(validateArgs(args)).toContain("image_data_list")
+        })
+      })
+    })
+
+    describe("#given invalid collections", () => {
+      describe("#when file_paths is empty", () => {
+        test("#then validation rejects the empty array", () => {
+          const args = normalizeArgs({
+            file_paths: [],
+            goal: "analyze images",
+          })
+
+          expect(validateArgs(args)).toContain("file_paths")
+        })
+      })
+
+      describe("#when no file or image inputs are provided", () => {
+        test("#then validation rejects the missing inputs", () => {
+          const args = normalizeArgs({
+            goal: "analyze images",
+          })
+
+          expect(validateArgs(args)).toContain("file_path")
+          expect(validateArgs(args)).toContain("file_paths")
+          expect(validateArgs(args)).toContain("image_data")
+          expect(validateArgs(args)).toContain("image_data_list")
+        })
+      })
+    })
+
+    describe("#given invalid file paths", () => {
+      describe("#when any file_paths entry is a remote URL", () => {
+        test("#then validation rejects the remote path", () => {
+          const args = normalizeArgs({
+            file_paths: ["/tmp/a.png", "https://example.com/remote.png"],
+            goal: "compare images",
+          })
+
+          expect(validateArgs(args)).toContain("Remote URLs are not supported")
+        })
+      })
+    })
+  })
+})

--- a/packages/omo-opencode/src/tools/look-at/look-at-arguments.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-arguments.ts
@@ -4,29 +4,95 @@ export interface LookAtArgsWithAlias extends LookAtArgs {
   path?: string
 }
 
+interface NormalizedLookAtArgs extends LookAtArgs {
+  _normalized_file_paths_from_singular?: boolean
+  _normalized_image_data_list_from_singular?: boolean
+}
+
+function hasNonEmptyString(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+function hasValues(values: string[] | undefined): values is string[] {
+  return Array.isArray(values) && values.length > 0
+}
+
+function isRemoteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
+}
+
 export function normalizeArgs(args: LookAtArgsWithAlias): LookAtArgs {
-  return {
-    file_path: args.file_path ?? args.path,
-    image_data: args.image_data,
+  const filePath = args.file_path ?? args.path
+  const imageData = args.image_data
+  const filePathsFromSingular = !args.file_paths && hasNonEmptyString(filePath)
+  const imageDataListFromSingular = !args.image_data_list && hasNonEmptyString(imageData)
+
+  const normalized: NormalizedLookAtArgs = {
+    file_path: filePath,
+    file_paths: args.file_paths ?? (filePathsFromSingular ? [filePath] : undefined),
+    image_data: imageData,
+    image_data_list: args.image_data_list ?? (imageDataListFromSingular ? [imageData] : undefined),
     goal: args.goal ?? "",
+    _normalized_file_paths_from_singular: filePathsFromSingular || undefined,
+    _normalized_image_data_list_from_singular: imageDataListFromSingular || undefined,
   }
+
+  return normalized
 }
 
 export function validateArgs(args: LookAtArgs): string | null {
+  const normalizedArgs = args as NormalizedLookAtArgs
   const filePath = args.file_path
-  const hasFilePath = Boolean(filePath && filePath.length > 0)
-  const hasImageData = Boolean(args.image_data && args.image_data.length > 0)
+  const hasFilePath = hasNonEmptyString(args.file_path)
+  const hasFilePaths = Array.isArray(args.file_paths)
+  const hasImageData = hasNonEmptyString(args.image_data)
+  const hasImageDataList = Array.isArray(args.image_data_list)
+  const filePathsFromSingular = normalizedArgs._normalized_file_paths_from_singular === true
+  const imageDataListFromSingular = normalizedArgs._normalized_image_data_list_from_singular === true
 
-  if (filePath && /^https?:\/\//i.test(filePath)) {
+  if (hasFilePath && hasFilePaths && !filePathsFromSingular) {
+    return "Error: Provide either 'file_path' or 'file_paths', not both."
+  }
+
+  if (hasImageData && hasImageDataList && !imageDataListFromSingular) {
+    return "Error: Provide either 'image_data' or 'image_data_list', not both."
+  }
+
+  if (hasFilePaths && !hasValues(args.file_paths)) {
+    return "Error: 'file_paths' must contain at least one local file path."
+  }
+
+  if (hasImageDataList && !hasValues(args.image_data_list)) {
+    return "Error: 'image_data_list' must contain at least one Base64 image string."
+  }
+
+  if (hasValues(args.file_paths)) {
+    for (const filePath of args.file_paths) {
+      if (!hasNonEmptyString(filePath)) {
+        return "Error: 'file_paths' must contain only non-empty local file paths."
+      }
+      if (isRemoteUrl(filePath)) {
+        return "Error: Remote URLs are not supported for file_paths. Download the file first or use a local path."
+      }
+    }
+  }
+
+  if (hasValues(args.image_data_list)) {
+    for (const imageData of args.image_data_list) {
+      if (!hasNonEmptyString(imageData)) {
+        return "Error: 'image_data_list' must contain only non-empty Base64 image strings."
+      }
+    }
+  }
+
+  if (hasNonEmptyString(filePath) && isRemoteUrl(filePath)) {
     return "Error: Remote URLs are not supported for file_path. Download the file first or use a local path."
   }
-  if (!hasFilePath && !hasImageData) {
-    return `Error: Must provide either 'file_path' or 'image_data'. Usage:
+  if (!hasFilePath && !hasValues(args.file_paths) && !hasImageData && !hasValues(args.image_data_list)) {
+    return `Error: Must provide at least one of 'file_path', 'file_paths', 'image_data', or 'image_data_list'. Usage:
 - look_at(file_path="/path/to/file", goal="what to extract")
+- look_at(file_paths=["/path/to/file-1", "/path/to/file-2"], goal="what to extract")
 - look_at(image_data="base64_encoded_data", goal="what to extract")`
-  }
-  if (hasFilePath && hasImageData) {
-    return "Error: Provide only one of 'file_path' or 'image_data', not both."
   }
   if (!args.goal) {
     return "Error: Missing required parameter 'goal'. Usage: look_at(file_path=\"/path/to/file\", goal=\"what to extract\")"

--- a/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
@@ -22,8 +22,7 @@ export interface LookAtFilePart {
 }
 
 export interface PreparedLookAtInput {
-  readonly filePart: LookAtFilePart
-  readonly isBase64Input: boolean
+  readonly fileParts: LookAtFilePart[]
   readonly sourceDescription: string
   cleanup(): void
 }
@@ -51,54 +50,21 @@ function getTemporaryConversionPath(error: unknown): string | null {
 }
 
 export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
-  const imageData = args.image_data
-  const filePath = args.file_path
+  const filePaths = args.file_paths ?? (args.file_path ? [args.file_path] : [])
+  const imageDataList = args.image_data_list ?? (args.image_data ? [args.image_data] : [])
+  const totalInputs = filePaths.length + imageDataList.length
 
-  if (imageData) {
-    const mimeType = inferMimeTypeFromBase64(imageData)
-
-    let finalBase64Data = extractBase64Data(imageData)
-    let finalMimeType = mimeType
-    let tempFilesToCleanup: string[] = []
-
-    if (needsConversion(mimeType)) {
-      log(`[look_at] Detected unsupported Base64 format: ${mimeType}, converting to JPEG...`)
-      try {
-        const { base64, tempFiles } = convertBase64ImageToJpeg(finalBase64Data, mimeType)
-        finalBase64Data = base64
-        finalMimeType = "image/jpeg"
-        tempFilesToCleanup = tempFiles
-        log("[look_at] Base64 conversion successful")
-      } catch (conversionError) {
-        log(`[look_at] Base64 conversion failed: ${conversionError}`)
-        return {
-          ok: false,
-          error: `Error: Failed to convert Base64 image format. ${conversionError}`,
-        }
-      }
-    }
-
+  if (totalInputs === 0) {
     return {
-      ok: true,
-      value: {
-        isBase64Input: true,
-        sourceDescription: "clipboard/pasted image",
-        filePart: {
-          type: "file",
-          mime: finalMimeType,
-          url: `data:${finalMimeType};base64,${finalBase64Data}`,
-          filename: `clipboard-image.${finalMimeType.split("/")[1] || "png"}`,
-        },
-        cleanup() {
-          for (const temporaryFile of tempFilesToCleanup) {
-            cleanupConvertedImage(temporaryFile)
-          }
-        },
-      },
+      ok: false,
+      error: "Error: Must provide either 'file_path', 'file_paths', 'image_data', or 'image_data_list'.",
     }
   }
 
-  if (filePath) {
+  const fileParts: LookAtFilePart[] = []
+  const tempFilesToCleanup: string[] = []
+
+  for (const filePath of filePaths) {
     let mimeType = inferMimeTypeFromFilePath(filePath)
     let actualFilePath = filePath
     let tempConversionPath: string | null = null
@@ -124,28 +90,65 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       }
     }
 
-    return {
-      ok: true,
-      value: {
-        isBase64Input: false,
-        sourceDescription: filePath,
-        filePart: {
-          type: "file",
-          mime: mimeType,
-          url: pathToFileURL(actualFilePath).href,
-          filename: basename(actualFilePath),
-        },
-        cleanup() {
-          if (tempConversionPath) {
-            cleanupConvertedImage(tempConversionPath)
-          }
-        },
-      },
+    if (tempConversionPath) {
+      tempFilesToCleanup.push(tempConversionPath)
     }
+
+    fileParts.push({
+      type: "file",
+      mime: mimeType,
+      url: pathToFileURL(actualFilePath).href,
+      filename: basename(actualFilePath),
+    })
   }
 
+  for (const imageData of imageDataList) {
+    const mimeType = inferMimeTypeFromBase64(imageData)
+
+    let finalBase64Data = extractBase64Data(imageData)
+    let finalMimeType = mimeType
+
+    if (needsConversion(mimeType)) {
+      log(`[look_at] Detected unsupported Base64 format: ${mimeType}, converting to JPEG...`)
+      try {
+        const { base64, tempFiles } = convertBase64ImageToJpeg(finalBase64Data, mimeType)
+        finalBase64Data = base64
+        finalMimeType = "image/jpeg"
+        tempFilesToCleanup.push(...tempFiles)
+        log("[look_at] Base64 conversion successful")
+      } catch (conversionError) {
+        log(`[look_at] Base64 conversion failed: ${conversionError}`)
+        return {
+          ok: false,
+          error: `Error: Failed to convert Base64 image format. ${conversionError}`,
+        }
+      }
+    }
+
+    fileParts.push({
+      type: "file",
+      mime: finalMimeType,
+      url: `data:${finalMimeType};base64,${finalBase64Data}`,
+      filename: `clipboard-image.${finalMimeType.split("/")[1] || "png"}`,
+    })
+  }
+
+  const sourceDescription = totalInputs > 1
+    ? `${totalInputs} files/images`
+    : imageDataList.length === 1
+      ? "clipboard/pasted image"
+      : filePaths[0]
+
   return {
-    ok: false,
-    error: "Error: Must provide either 'file_path' or 'image_data'.",
+    ok: true,
+    value: {
+      fileParts,
+      sourceDescription,
+      cleanup() {
+        for (const temporaryFile of tempFilesToCleanup) {
+          cleanupConvertedImage(temporaryFile)
+        }
+      },
+    },
   }
 }

--- a/packages/omo-opencode/src/tools/look-at/look-at-prompt.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-prompt.ts
@@ -1,12 +1,26 @@
+import type { LookAtFilePart } from "./look-at-input-preparer"
+
 export const READ_ENABLED = false
 
-export function buildLookAtPrompt(goal: string, isBase64Input: boolean): string {
-  const subjectNoun = isBase64Input ? "image" : "file"
+function sanitizeFilename(filename: string): string {
+  const basename = filename.split("/").pop() ?? filename
+  return basename.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100)
+}
+
+export function buildLookAtPrompt(goal: string, fileParts: LookAtFilePart[]): string {
+  const isPlural = fileParts.length > 1
+  const subjectNoun = isPlural ? "files/images" : "file/image"
+  const pronoun = isPlural ? "them" : "it"
+  const labels = isPlural
+    ? `\n\nAttached files/images:\n${fileParts
+      .map((filePart, index) => `File ${index + 1}: ${sanitizeFilename(filePart.filename)}`)
+      .join("\n")}`
+    : ""
   const sourceClause = READ_ENABLED
     ? "Use the Read tool on the provided file path to load its contents, then analyze it."
-    : `The ${subjectNoun} is already attached to this message. Analyze it directly from the attachment. Do NOT attempt to use the Read tool. The Read tool is disabled for this invocation and the ${subjectNoun} cannot be loaded by path.`
+    : `The attached ${subjectNoun} ${isPlural ? "are" : "is"} already included in this message. Analyze ${pronoun} directly from the attachment. Do NOT attempt to load by path — the ${subjectNoun} cannot be loaded by path.`
 
-  return `Analyze the attached ${subjectNoun} and extract the requested information.
+  return `Analyze ${isPlural ? "these files/images" : "this file/image"} and extract the requested information.${labels}
 
 ${sourceClause}
 

--- a/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
@@ -12,18 +12,16 @@ interface RunLookAtSessionInput {
   ctx: PluginInput
   toolContext: ToolContext
   goal: string
-  filePart: LookAtFilePart
-  isBase64Input: boolean
+  fileParts: LookAtFilePart[]
 }
 
 export async function runLookAtSession({
   ctx,
   toolContext,
   goal,
-  filePart,
-  isBase64Input,
+  fileParts,
 }: RunLookAtSessionInput): Promise<string> {
-  const prompt = buildLookAtPrompt(goal, isBase64Input)
+  const prompt = buildLookAtPrompt(goal, fileParts)
   const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
 
   log(`[look_at] Creating session with parent: ${toolContext.sessionID}`)
@@ -60,7 +58,7 @@ Original error: ${createResult.error}`
   const sessionID = createResult.data.id
   log(`[look_at] Created session: ${sessionID}`)
 
-  log(`[look_at] Sending prompt with ${isBase64Input ? "base64 image" : "file"} to session ${sessionID}`)
+  log(`[look_at] Sending prompt with ${fileParts.length} file(s) to session ${sessionID}`)
   let shouldWaitForStatus = true
   try {
     await promptSyncWithModelSuggestionRetry(ctx.client, {
@@ -75,7 +73,7 @@ Original error: ${createResult.error}`
         },
         parts: [
           { type: "text", text: prompt },
-          filePart,
+          ...fileParts,
         ],
         ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
         ...(agentVariant ? { variant: agentVariant } : {}),

--- a/packages/omo-opencode/src/tools/look-at/tools.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.test.ts
@@ -2,10 +2,55 @@ import { afterEach, describe, expect, test, mock } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 import { clearVisionCapableModelsCache, setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
+import type { LookAtArgs } from "./types"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
 type LookAtPart = { type: string; url: string; mime: string; filename: string; text: string }
 type LookAtPromptBody = { model?: unknown; tools: Record<string, boolean>; parts: LookAtPart[] }
+
+function createToolContext(): ToolContext {
+  return {
+    sessionID: "parent-session",
+    messageID: "parent-message",
+    agent: "sisyphus",
+    directory: "/project",
+    worktree: "/project",
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  }
+}
+
+function createPromptCaptureHarness() {
+  let promptBody: LookAtPromptBody | undefined
+
+  const lookAtTool = createLookAt({
+    client: {
+      app: {
+        agents: async () => ({ data: [] }),
+      },
+      session: {
+        get: async () => ({ data: { directory: "/project" } }),
+        create: async () => ({ data: { id: "ses_multi_file_test" } }),
+        prompt: async (input: { body: LookAtPromptBody }) => {
+          promptBody = input.body
+          return { data: {} }
+        },
+        messages: async () => ({
+          data: [
+            { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "analyzed" }] },
+          ],
+        }),
+      },
+    },
+    directory: "/project",
+  } as never)
+
+  return {
+    lookAtTool,
+    getPromptBody: () => promptBody,
+  }
+}
 
 describe("look-at tool", () => {
   afterEach(() => {
@@ -73,7 +118,7 @@ describe("look-at tool", () => {
     // when validated
     // then clear error message
     test("returns error when neither file_path nor image_data provided", () => {
-      const args = unsafeTestValue({ goal: "analyze" })
+      const args = unsafeTestValue<LookAtArgs>({ goal: "analyze" })
       const error = validateArgs(args)
       expect(error).toContain("file_path")
       expect(error).toContain("image_data")
@@ -81,18 +126,17 @@ describe("look-at tool", () => {
 
     // given both file_path and image_data
     // when validated
-    // then return error (mutually exclusive)
-    test("returns error when both file_path and image_data provided", () => {
+    // then allow mixed local-file and base64 inputs
+    test("returns null when both file_path and image_data provided", () => {
       const args = { file_path: "/path.png", image_data: "base64data", goal: "analyze" }
-      const error = validateArgs(args)
-      expect(error).toContain("only one")
+      expect(validateArgs(args)).toBeNull()
     })
 
     // given goal missing
     // when validated
     // then clear error message
     test("returns error when goal is missing", () => {
-      const args = unsafeTestValue({ file_path: "/some/path.png" })
+      const args = unsafeTestValue<LookAtArgs>({ file_path: "/some/path.png" })
       const error = validateArgs(args)
       expect(error).toContain("goal")
       expect(error).toContain("required")
@@ -764,10 +808,7 @@ describe("look-at tool", () => {
       expect(promptText).not.toMatch(/\buse\s+Read\b/i)
     })
 
-    // given prompt is generated for any invocation where Read is denied
-    // when LookAt tool sends prompt to multimodal-looker
-    // then prompt explicitly tells the agent NOT to attempt Read tool
-    test("explicitly warns the agent not to attempt Read when Read is disabled", async () => {
+    test("does not mention the Read tool when Read is disabled", async () => {
       const { mockClient, captured } = captureLastPromptBody()
 
       const tool = createLookAt(unsafeTestValue({
@@ -782,8 +823,159 @@ describe("look-at tool", () => {
 
       const promptPart = captured.body.parts.find((p: LookAtPart) => p.type === "text")!
       const promptText: string = promptPart.text
-      // The prompt must mention the agent cannot use Read so the agent does not hallucinate
-      expect(promptText.toLowerCase()).toContain("read tool")
+      expect(promptText).not.toMatch(/\bread tool\b/i)
+      expect(promptText).not.toMatch(/\buse\s+Read\b/i)
+    })
+  })
+
+  describe("createLookAt multi-file processing", () => {
+    test("schema exposes file_paths as an optional string array", () => {
+      const lookAtTool = createLookAt({ client: {}, directory: "/project" } as never)
+      const filePathsSchema = lookAtTool.args.file_paths
+      const filePathsDef = typeof filePathsSchema === "object" && filePathsSchema !== null
+        ? Reflect.get(filePathsSchema, "def")
+        : undefined
+      const filePathsInnerType = typeof filePathsDef === "object" && filePathsDef !== null
+        ? Reflect.get(filePathsDef, "innerType")
+        : undefined
+      const filePathsInnerDef = typeof filePathsInnerType === "object" && filePathsInnerType !== null
+        ? Reflect.get(filePathsInnerType, "def")
+        : undefined
+      const filePathsElement = typeof filePathsInnerDef === "object" && filePathsInnerDef !== null
+        ? Reflect.get(filePathsInnerDef, "element")
+        : undefined
+      const filePathsElementDef = typeof filePathsElement === "object" && filePathsElement !== null
+        ? Reflect.get(filePathsElement, "def")
+        : undefined
+
+      expect(filePathsSchema).toBeDefined()
+      expect(Reflect.get(filePathsDef as object, "type")).toBe("optional")
+      expect(Reflect.get(filePathsInnerDef as object, "type")).toBe("array")
+      expect(Reflect.get(filePathsElementDef as object, "type")).toBe("string")
+    })
+
+    test("schema exposes image_data_list as an optional string array", () => {
+      const lookAtTool = createLookAt({ client: {}, directory: "/project" } as never)
+      const imageDataListSchema = lookAtTool.args.image_data_list
+      const imageDataListDef = typeof imageDataListSchema === "object" && imageDataListSchema !== null
+        ? Reflect.get(imageDataListSchema, "def")
+        : undefined
+      const imageDataListInnerType = typeof imageDataListDef === "object" && imageDataListDef !== null
+        ? Reflect.get(imageDataListDef, "innerType")
+        : undefined
+      const imageDataListInnerDef = typeof imageDataListInnerType === "object" && imageDataListInnerType !== null
+        ? Reflect.get(imageDataListInnerType, "def")
+        : undefined
+      const imageDataListElement = typeof imageDataListInnerDef === "object" && imageDataListInnerDef !== null
+        ? Reflect.get(imageDataListInnerDef, "element")
+        : undefined
+      const imageDataListElementDef = typeof imageDataListElement === "object" && imageDataListElement !== null
+        ? Reflect.get(imageDataListElement, "def")
+        : undefined
+
+      expect(imageDataListSchema).toBeDefined()
+      expect(Reflect.get(imageDataListDef as object, "type")).toBe("optional")
+      expect(Reflect.get(imageDataListInnerDef as object, "type")).toBe("array")
+      expect(Reflect.get(imageDataListElementDef as object, "type")).toBe("string")
+    })
+
+    test("builds two file parts and plural prompt text for multi-file paths", async () => {
+      const { lookAtTool, getPromptBody } = createPromptCaptureHarness()
+
+      await lookAtTool.execute(
+        {
+          file_paths: ["/tmp/first.png", "/tmp/second.jpg"],
+          goal: "compare the screenshots",
+        },
+        createToolContext(),
+      )
+
+      const promptBody = getPromptBody()
+      expect(promptBody).toBeDefined()
+
+      const fileParts = promptBody!.parts.filter((part) => part.type === "file")
+      const promptText = promptBody!.parts[0]?.text ?? ""
+
+      expect(fileParts).toHaveLength(2)
+      expect(fileParts.map((part) => part.filename)).toEqual(["first.png", "second.jpg"])
+      expect(promptText).toContain("these files/images")
+      expect(promptText).toContain("File 1: first.png")
+      expect(promptText).toContain("File 2: second.jpg")
+    })
+
+    test("builds one file part and singular prompt text for backward-compatible file_path input", async () => {
+      const { lookAtTool, getPromptBody } = createPromptCaptureHarness()
+
+      await lookAtTool.execute(
+        {
+          file_path: "/tmp/single.png",
+          goal: "describe the screenshot",
+        },
+        createToolContext(),
+      )
+
+      const promptBody = getPromptBody()
+      expect(promptBody).toBeDefined()
+
+      const fileParts = promptBody!.parts.filter((part) => part.type === "file")
+      const promptText = promptBody!.parts[0]?.text ?? ""
+
+      expect(fileParts).toHaveLength(1)
+      expect(fileParts[0]?.filename).toBe("single.png")
+      expect(promptText).toContain("this file/image")
+      expect(promptText).not.toContain("File 1:")
+    })
+
+    test("builds one file part per image_data_list entry", async () => {
+      const { lookAtTool, getPromptBody } = createPromptCaptureHarness()
+
+      await lookAtTool.execute(
+        {
+          image_data_list: [
+            "data:image/png;base64,iVBORw0KGgo=",
+            "data:image/png;base64,iVBORw0KGgo=",
+            "data:image/png;base64,iVBORw0KGgo=",
+          ],
+          goal: "compare these pasted images",
+        },
+        createToolContext(),
+      )
+
+      const promptBody = getPromptBody()
+      expect(promptBody).toBeDefined()
+
+      const fileParts = promptBody!.parts.filter((part) => part.type === "file")
+      const promptText = promptBody!.parts[0]?.text ?? ""
+
+      expect(fileParts).toHaveLength(3)
+      expect(fileParts.every((part) => part.url.startsWith("data:image/png;base64,"))).toBe(true)
+      expect(promptText).toContain("these files/images")
+    })
+
+    test("combines file_paths and image_data_list into one parts array", async () => {
+      const { lookAtTool, getPromptBody } = createPromptCaptureHarness()
+
+      await lookAtTool.execute(
+        {
+          file_paths: ["/tmp/local.png"],
+          image_data_list: ["data:image/png;base64,iVBORw0KGgo="],
+          goal: "compare the local file and pasted image",
+        },
+        createToolContext(),
+      )
+
+      const promptBody = getPromptBody()
+      expect(promptBody).toBeDefined()
+
+      const fileParts = promptBody!.parts.filter((part) => part.type === "file")
+      const promptText = promptBody!.parts[0]?.text ?? ""
+
+      expect(fileParts).toHaveLength(2)
+      expect(fileParts[0]?.filename).toBe("local.png")
+      expect(fileParts[1]?.filename).toContain("clipboard-image")
+      expect(promptText).toContain("these files/images")
+      expect(promptText).toContain("File 1: local.png")
+      expect(promptText).toContain("File 2: clipboard-image")
     })
   })
 })

--- a/packages/omo-opencode/src/tools/look-at/tools.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.ts
@@ -15,7 +15,9 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
     description: LOOK_AT_DESCRIPTION,
     args: {
       file_path: tool.schema.string().optional().describe("Absolute path to the file to analyze"),
+      file_paths: tool.schema.array(tool.schema.string()).optional().describe("Absolute paths to the files to analyze"),
       image_data: tool.schema.string().optional().describe("Base64 encoded image data (for clipboard/pasted images)"),
+      image_data_list: tool.schema.array(tool.schema.string()).optional().describe("Base64 encoded image data entries (for multiple clipboard/pasted images)"),
       goal: tool.schema.string().describe("What specific information to extract from the file"),
     },
     async execute(rawArgs: LookAtArgs, toolContext) {
@@ -32,7 +34,7 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
       }
 
       const preparedInput = preparedInputResult.value
-      const { isBase64Input, sourceDescription } = preparedInput
+      const { sourceDescription } = preparedInput
       log(`[look_at] Analyzing ${sourceDescription}, goal: ${args.goal}`)
 
       try {
@@ -40,8 +42,7 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
           ctx,
           toolContext,
           goal: args.goal,
-          filePart: preparedInput.filePart,
-          isBase64Input,
+          fileParts: preparedInput.fileParts,
         })
       } catch (error) {
         const missingFilePath = getMissingLookAtFilePath(error, args)

--- a/packages/omo-opencode/src/tools/look-at/types.ts
+++ b/packages/omo-opencode/src/tools/look-at/types.ts
@@ -1,5 +1,7 @@
 export interface LookAtArgs {
   file_path?: string
+  file_paths?: string[]
   image_data?: string  // base64 encoded image data (for clipboard images)
+  image_data_list?: string[]
   goal: string
 }


### PR DESCRIPTION
## Summary

- Add `file_paths` and `image_data_list` array parameters to the `look_at` tool, enabling agents to compare multiple images/documents in a single call
- Backward-compatible: existing singular `file_path`/`image_data` parameters still work unchanged
- Mixed types supported: file paths and base64 image data can be provided simultaneously
- Updated multimodal-looker agent prompt for multi-file analysis with comparison guidance

## Changes

### Tool Schema (`src/tools/look-at/tools.ts`)
- Added `file_paths: string[]` (optional) and `image_data_list: string[]` (optional) to tool args
- Processing loop creates fileParts for each file, sends `[text, ...fileParts]` to agent
- Prompt switches between singular/plural text, includes "File N: filename" labels for multi-file calls
- Extracted `prepareFilePart()` helper for single-file-to-part conversion (file path or base64)

### Validation (`src/tools/look-at/look-at-arguments.ts`)
- `normalizeArgs()` converts singular params to arrays for downstream consumption
- `validateArgs()` accepts singular OR array per field (not both), allows mixed file_paths + image_data_list
- Rejects: empty arrays, remote URLs per element, missing all inputs, singular+array conflict on same field

### Agent Prompt (`src/agents/multimodal-looker.ts`)
- "examine the attached file" -> "examine the attached file(s)"
- Added: "When multiple files are provided, analyze each and address the goal across all files. If the goal involves comparison, explicitly compare and contrast."

### Tests
- `look-at-arguments.test.ts`: 12 tests covering backward compat, multi-file, mixed types, rejection cases
- `tools.test.ts`: Extended with multi-file processing, plural/singular prompt, file labels

## Motivation

Agents frequently need to compare screenshots, documents, or diagrams side-by-side. Previously this required multiple sequential `look_at` calls with no cross-file context. Multi-file support lets agents send all files at once, enabling the multimodal-looker to analyze them together.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-file support to `look_at` so agents can analyze and compare several files/images in one call, mixing local paths and Base64. Backward-compatible, with clearer prompts, per-file labels, and no “Read tool” wording.

- **New Features**
  - Added `file_paths` and `image_data_list`; singular `file_path`/`image_data` still work and can be mixed (e.g., `file_path` + `image_data`).
  - Prompt pluralizes and lists sanitized labels (“File N: <name>”); multimodal-looker copy guides compare/contrast across files.
  - Validation allows mixed sources, rejects empty arrays and remote URLs, blocks singular+array conflicts on the same field, and errors clearly when none of the four inputs are provided.

- **Refactors**
  - Input preparer builds `fileParts[]` from all inputs, converts unsupported formats, sets concise source descriptions, and cleans temp files.
  - Session runner sends `[text, ...fileParts]` and logs file count; tests cover schema exposure, backward compatibility, mixed inputs, plural/singular prompt text and labels, error handling, and absence of “Read tool” mentions.

<sup>Written for commit e9d16ddf43414a10c449d104233c973b753ff5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

