### PR TITLE
feat(skill-mcp): add CDP endpoint URL support for Playwright MCP

### DIFF
--- a/packages/omo-opencode/src/features/skill-mcp-manager/manager.test.ts
+++ b/packages/omo-opencode/src/features/skill-mcp-manager/manager.test.ts
@@ -1,12 +1,18 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock, spyOn } from "bun:test"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
+import * as connectionModule from "./connection"
 import type { SkillMcpClientInfo, SkillMcpServerContext } from "./types"
 import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types"
 import type { OAuthTokenData } from "../mcp-oauth/storage"
 import { setHttpClientDependenciesForTesting } from "./http-client"
 import { setStdioClientDependenciesForTesting } from "./stdio-client"
-import { SkillMcpManager } from "./manager"
+import { SkillMcpManager, buildSkillMcpClientKey } from "./manager"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+
+function createMockClient(name: string): Client {
+  return new Client({ name, version: "1.0.0" }, { capabilities: {} })
+}
 
 const mockHttpConnect = mock(() => Promise.reject(new Error("Mocked HTTP connection failure")))
 const mockHttpClose = mock(() => Promise.resolve())
@@ -99,6 +105,7 @@ describe("SkillMcpManager", () => {
     await manager.disconnectAll()
     setHttpClientDependenciesForTesting()
     setStdioClientDependenciesForTesting()
+    mock.restore()
   })
 
   describe("getOrCreateClient", () => {
@@ -969,6 +976,206 @@ describe("SkillMcpManager", () => {
       // when / #then
       await expect(manager.callTool(info, context, "test-tool", {})).rejects.toThrow(/403/)
       expect(mockLogin).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("CDP-aware cache keys and config injection", () => {
+    it("builds the default cache key without a cdpUrl suffix", () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+
+      // when
+      const clientKey = buildSkillMcpClientKey(info)
+
+      // then
+      expect(clientKey).toBe("session-1:browser-skill:playwright")
+    })
+
+    it("builds a cache key with a cdpUrl suffix when provided", () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+
+      // when
+      const clientKey = buildSkillMcpClientKey(info, { cdpUrl: "http://localhost:9222" })
+
+      // then
+      expect(clientKey).toBe("session-1:browser-skill:playwright::cdp=http://localhost:9222")
+    })
+
+    it("reuses the cached client for the same cdpUrl", async () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+      const config: ClaudeCodeMcpServer = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+      const clientsByKey = new Map<string, Client>()
+      const getOrCreateSpy = spyOn(connectionModule, "getOrCreateClient")
+      getOrCreateSpy.mockImplementation(async ({ clientKey }) => {
+        const existingClient = clientsByKey.get(clientKey)
+        if (existingClient) {
+          return existingClient
+        }
+
+        const newClient = createMockClient(`client-${clientsByKey.size + 1}`)
+        clientsByKey.set(clientKey, newClient)
+        return newClient
+      })
+
+      // when
+      const firstClient = await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9222" })
+      const secondClient = await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9222" })
+
+      // then
+      expect(firstClient).toBe(secondClient)
+      expect(getOrCreateSpy).toHaveBeenCalledTimes(2)
+      expect(getOrCreateSpy.mock.calls[0]?.[0].clientKey).toBe(
+        "session-1:browser-skill:playwright::cdp=http://localhost:9222"
+      )
+      expect(getOrCreateSpy.mock.calls[1]?.[0].clientKey).toBe(
+        "session-1:browser-skill:playwright::cdp=http://localhost:9222"
+      )
+    })
+
+    it("creates separate clients for different cdpUrl values", async () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+      const config: ClaudeCodeMcpServer = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+      const clientsByKey = new Map<string, Client>()
+      const getOrCreateSpy = spyOn(connectionModule, "getOrCreateClient")
+      getOrCreateSpy.mockImplementation(async ({ clientKey }) => {
+        const existingClient = clientsByKey.get(clientKey)
+        if (existingClient) {
+          return existingClient
+        }
+
+        const newClient = createMockClient(`client-${clientsByKey.size + 1}`)
+        clientsByKey.set(clientKey, newClient)
+        return newClient
+      })
+
+      // when
+      const firstClient = await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9222" })
+      const secondClient = await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9333" })
+
+      // then
+      expect(firstClient).not.toBe(secondClient)
+      expect(Array.from(clientsByKey.keys())).toEqual([
+        "session-1:browser-skill:playwright::cdp=http://localhost:9222",
+        "session-1:browser-skill:playwright::cdp=http://localhost:9333",
+      ])
+    })
+
+    it("keeps the default client and cdpUrl client separate", async () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+      const config: ClaudeCodeMcpServer = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+      const clientsByKey = new Map<string, Client>()
+      const getOrCreateSpy = spyOn(connectionModule, "getOrCreateClient")
+      getOrCreateSpy.mockImplementation(async ({ clientKey }) => {
+        const existingClient = clientsByKey.get(clientKey)
+        if (existingClient) {
+          return existingClient
+        }
+
+        const newClient = createMockClient(`client-${clientsByKey.size + 1}`)
+        clientsByKey.set(clientKey, newClient)
+        return newClient
+      })
+
+      // when
+      const defaultClient = await manager.getOrCreateClient(info, config)
+      const cdpClient = await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9222" })
+
+      // then
+      expect(defaultClient).not.toBe(cdpClient)
+      expect(getOrCreateSpy.mock.calls[0]?.[0].clientKey).toBe("session-1:browser-skill:playwright")
+      expect(getOrCreateSpy.mock.calls[1]?.[0].clientKey).toBe(
+        "session-1:browser-skill:playwright::cdp=http://localhost:9222"
+      )
+    })
+
+    it("appends the cdp-endpoint args when cdpUrl is provided", async () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+      const config: ClaudeCodeMcpServer = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+      const getOrCreateSpy = spyOn(connectionModule, "getOrCreateClient")
+      getOrCreateSpy.mockResolvedValue(createMockClient("client-1"))
+
+      // when
+      await manager.getOrCreateClient(info, config, { cdpUrl: "http://localhost:9222" })
+
+      // then
+      const passedConfig = getOrCreateSpy.mock.calls[0]?.[0].config
+      expect(passedConfig).toEqual({
+        command: "npx",
+        args: ["@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"],
+      })
+      expect(passedConfig).not.toBe(config)
+      expect(config.args).toEqual(["@playwright/mcp@latest"])
+    })
+
+    it("leaves args unchanged when no cdpUrl is provided", async () => {
+      // given
+      const info: SkillMcpClientInfo = {
+        serverName: "playwright",
+        skillName: "browser-skill",
+        sessionID: "session-1",
+        scope: "builtin",
+      }
+      const config: ClaudeCodeMcpServer = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+      const getOrCreateSpy = spyOn(connectionModule, "getOrCreateClient")
+      getOrCreateSpy.mockResolvedValue(createMockClient("client-1"))
+
+      // when
+      await manager.getOrCreateClient(info, config)
+
+      // then
+      const passedConfig = getOrCreateSpy.mock.calls[0]?.[0].config
+      expect(passedConfig).toBe(config)
+      expect(passedConfig.args).toEqual(["@playwright/mcp@latest"])
     })
   })
 })

--- a/packages/omo-opencode/src/features/skill-mcp-manager/manager.ts
+++ b/packages/omo-opencode/src/features/skill-mcp-manager/manager.ts
@@ -12,6 +12,32 @@ import type {
   SkillMcpServerContext,
 } from "./types"
 
+export interface SkillMcpClientOptions {
+  cdpUrl?: string
+}
+
+export function buildSkillMcpClientKey(info: SkillMcpClientInfo, options?: SkillMcpClientOptions): string {
+  const baseKey = `${info.sessionID}:${info.skillName}:${info.serverName}`
+  if (!options?.cdpUrl) {
+    return baseKey
+  }
+
+  return `${baseKey}::cdp=${options.cdpUrl}`
+}
+
+function withInjectedCdpEndpoint(
+  config: ClaudeCodeMcpServer,
+  options?: SkillMcpClientOptions
+): ClaudeCodeMcpServer {
+  if (!options?.cdpUrl) {
+    return config
+  }
+
+  const configWithCdpEndpoint = structuredClone(config)
+  configWithCdpEndpoint.args = [...(configWithCdpEndpoint.args ?? []), "--cdp-endpoint", options.cdpUrl]
+  return configWithCdpEndpoint
+}
+
 export class SkillMcpManager {
   private readonly state: SkillMcpManagerState
 
@@ -32,17 +58,22 @@ export class SkillMcpManager {
     }
   }
 
-  private getClientKey(info: SkillMcpClientInfo): string {
-    return `${info.sessionID}:${info.skillName}:${info.serverName}`
+  private getClientKey(info: SkillMcpClientInfo, options?: SkillMcpClientOptions): string {
+    return buildSkillMcpClientKey(info, options)
   }
 
-  async getOrCreateClient(info: SkillMcpClientInfo, config: ClaudeCodeMcpServer): Promise<McpClient> {
-    const clientKey = this.getClientKey(info)
+  async getOrCreateClient(
+    info: SkillMcpClientInfo,
+    config: ClaudeCodeMcpServer,
+    options?: SkillMcpClientOptions
+  ): Promise<McpClient> {
+    const clientKey = this.getClientKey(info, options)
+    const resolvedConfig = withInjectedCdpEndpoint(config, options)
     return await getOrCreateClient({
       state: this.state,
       clientKey,
       info,
-      config,
+      config: resolvedConfig,
     })
   }
 
@@ -54,20 +85,20 @@ export class SkillMcpManager {
     await disconnectAll(this.state)
   }
 
-  async listTools(info: SkillMcpClientInfo, context: SkillMcpServerContext): Promise<Tool[]> {
-    const client = await this.getOrCreateClientWithRetry(info, context.config)
+  async listTools(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Tool[]> {
+    const client = await this.getOrCreateClientWithRetry(info, context.config, options)
     const result = await client.listTools()
     return result.tools
   }
 
-  async listResources(info: SkillMcpClientInfo, context: SkillMcpServerContext): Promise<Resource[]> {
-    const client = await this.getOrCreateClientWithRetry(info, context.config)
+  async listResources(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Resource[]> {
+    const client = await this.getOrCreateClientWithRetry(info, context.config, options)
     const result = await client.listResources()
     return result.resources
   }
 
-  async listPrompts(info: SkillMcpClientInfo, context: SkillMcpServerContext): Promise<Prompt[]> {
-    const client = await this.getOrCreateClientWithRetry(info, context.config)
+  async listPrompts(info: SkillMcpClientInfo, context: SkillMcpServerContext, options?: SkillMcpClientOptions): Promise<Prompt[]> {
+    const client = await this.getOrCreateClientWithRetry(info, context.config, options)
     const result = await client.listPrompts()
     return result.prompts
   }
@@ -76,16 +107,17 @@ export class SkillMcpManager {
     info: SkillMcpClientInfo,
     context: SkillMcpServerContext,
     name: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options?: SkillMcpClientOptions
   ): Promise<unknown> {
-    return await this.withOperationRetry(info, context.config, async (client) => {
+    return await this.withOperationRetry(info, context.config, options, async (client) => {
       const result = await client.callTool({ name, arguments: args })
       return result.content
     })
   }
 
-  async readResource(info: SkillMcpClientInfo, context: SkillMcpServerContext, uri: string): Promise<unknown> {
-    return await this.withOperationRetry(info, context.config, async (client) => {
+  async readResource(info: SkillMcpClientInfo, context: SkillMcpServerContext, uri: string, options?: SkillMcpClientOptions): Promise<unknown> {
+    return await this.withOperationRetry(info, context.config, options, async (client) => {
       const result = await client.readResource({ uri })
       return result.contents
     })
@@ -95,9 +127,10 @@ export class SkillMcpManager {
     info: SkillMcpClientInfo,
     context: SkillMcpServerContext,
     name: string,
-    args: Record<string, string>
+    args: Record<string, string>,
+    options?: SkillMcpClientOptions
   ): Promise<unknown> {
-    return await this.withOperationRetry(info, context.config, async (client) => {
+    return await this.withOperationRetry(info, context.config, options, async (client) => {
       const result = await client.getPrompt({ name, arguments: args })
       return result.messages
     })
@@ -106,6 +139,7 @@ export class SkillMcpManager {
   private async withOperationRetry<T>(
     info: SkillMcpClientInfo,
     config: ClaudeCodeMcpServer,
+    options: SkillMcpClientOptions | undefined,
     operation: (client: McpClient) => Promise<T>
   ): Promise<T> {
     const maxRetries = 3
@@ -114,7 +148,7 @@ export class SkillMcpManager {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        const client = await this.getOrCreateClientWithRetry(info, config)
+        const client = await this.getOrCreateClientWithRetry(info, config, options)
         return await operation(client)
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error))
@@ -127,7 +161,7 @@ export class SkillMcpManager {
           createOAuthProvider: this.state.createOAuthProvider,
         })
         if (stepUpHandled) {
-          await forceReconnect(this.state, this.getClientKey(info))
+          await forceReconnect(this.state, this.getClientKey(info, options))
           continue
         }
 
@@ -150,7 +184,7 @@ export class SkillMcpManager {
           throw new Error(`Failed after ${maxRetries} reconnection attempts: ${lastError.message}`)
         }
 
-        await forceReconnect(this.state, this.getClientKey(info))
+        await forceReconnect(this.state, this.getClientKey(info, options))
       }
     }
 
@@ -158,13 +192,18 @@ export class SkillMcpManager {
   }
 
   // NOTE: tests spy on this exact method name via `spyOn(manager as any, 'getOrCreateClientWithRetry')`.
-  private async getOrCreateClientWithRetry(info: SkillMcpClientInfo, config: ClaudeCodeMcpServer): Promise<McpClient> {
-    const clientKey = this.getClientKey(info)
+  private async getOrCreateClientWithRetry(
+    info: SkillMcpClientInfo,
+    config: ClaudeCodeMcpServer,
+    options?: SkillMcpClientOptions
+  ): Promise<McpClient> {
+    const clientKey = this.getClientKey(info, options)
+    const resolvedConfig = withInjectedCdpEndpoint(config, options)
     return await getOrCreateClientWithRetryImpl({
       state: this.state,
       clientKey,
       info,
-      config,
+      config: resolvedConfig,
     })
   }
 

--- a/packages/omo-opencode/src/tools/skill-mcp/tools.test.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test"
+import { describe, it, expect, beforeEach, spyOn } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 import { createSkillMcpTool, applyGrepFilter } from "./tools"
 import { SkillMcpManager } from "../../features/skill-mcp-manager"
@@ -164,6 +164,107 @@ describe("skill_mcp tool", () => {
       // then
       expect(tool.description).toBeDefined()
     })
+
+    it("mentions cdp_url support", () => {
+      // given / #when
+      const tool = createSkillMcpTool({
+        manager,
+        getLoadedSkills: () => [],
+        getSessionID: () => "session",
+      })
+
+      // then
+      expect(tool.description).toContain("cdp_url")
+    })
+
+    it("includes cdp_url as an optional string in schema", () => {
+      // given / #when
+      const tool = createSkillMcpTool({
+        manager,
+        getLoadedSkills: () => [],
+        getSessionID: () => "session",
+      })
+      const cdpUrlSchema = tool.args.cdp_url
+      const cdpUrlDef = typeof cdpUrlSchema === "object" && cdpUrlSchema !== null
+        ? Reflect.get(cdpUrlSchema, "def")
+        : undefined
+      const cdpUrlInnerType = typeof cdpUrlDef === "object" && cdpUrlDef !== null
+        ? Reflect.get(cdpUrlDef, "innerType")
+        : undefined
+      const cdpUrlInnerDef = typeof cdpUrlInnerType === "object" && cdpUrlInnerType !== null
+        ? Reflect.get(cdpUrlInnerType, "def")
+        : undefined
+
+      // then
+      expect(cdpUrlSchema).toBeDefined()
+      expect(Reflect.get(cdpUrlDef as object, "type")).toBe("optional")
+      expect(Reflect.get(cdpUrlInnerDef as object, "type")).toBe("string")
+    })
+  })
+
+  describe("cdp_url execution", () => {
+    it("passes cdpUrl options through to manager.callTool when provided", async () => {
+      // given
+      loadedSkills = [
+        createMockSkillWithMcp("browser-skill", {
+          playwright: { command: "npx", args: ["@playwright/mcp@latest"] },
+        }),
+      ]
+      const callToolSpy = spyOn(manager, "callTool").mockResolvedValue([{ type: "text", text: "ok" }] as never)
+      const tool = createSkillMcpTool({
+        manager,
+        getLoadedSkills: () => loadedSkills,
+        getSessionID: () => sessionID,
+      })
+
+      // when
+      await tool.execute({
+        mcp_name: "playwright",
+        tool_name: "browser_navigate",
+        arguments: { url: "https://example.com" },
+        cdp_url: "http://localhost:9222",
+      }, mockContext)
+
+      // then
+      expect(callToolSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName: "playwright", sessionID: mockContext.sessionID }),
+        expect.any(Object),
+        "browser_navigate",
+        { url: "https://example.com" },
+        { cdpUrl: "http://localhost:9222" },
+      )
+    })
+
+    it("uses manager.callTool when cdp_url is omitted", async () => {
+      // given
+      loadedSkills = [
+        createMockSkillWithMcp("browser-skill", {
+          playwright: { command: "npx", args: ["@playwright/mcp@latest"] },
+        }),
+      ]
+      const callToolSpy = spyOn(manager, "callTool").mockResolvedValue([{ type: "text", text: "ok" }] as never)
+      const tool = createSkillMcpTool({
+        manager,
+        getLoadedSkills: () => loadedSkills,
+        getSessionID: () => sessionID,
+      })
+
+      // when
+      await tool.execute({
+        mcp_name: "playwright",
+        tool_name: "browser_navigate",
+        arguments: { url: "https://example.com" },
+      }, mockContext)
+
+      // then
+      expect(callToolSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName: "playwright", sessionID: mockContext.sessionID }),
+        expect.any(Object),
+        "browser_navigate",
+        { url: "https://example.com" },
+        undefined,
+      )
+    })
   })
 
   describe("session resolution", () => {
@@ -190,6 +291,7 @@ describe("skill_mcp tool", () => {
         expect.any(Object),
         "some-tool",
         {},
+        undefined,
       )
     })
 
@@ -216,6 +318,7 @@ describe("skill_mcp tool", () => {
         expect.any(Object),
         "some-tool",
         {},
+        undefined,
       )
     })
   })

--- a/packages/omo-opencode/src/tools/skill-mcp/tools.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/tools.ts
@@ -100,7 +100,7 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
   const { manager, getLoadedSkills, getSessionID } = options
 
   return tool({
-    description: SKILL_MCP_DESCRIPTION,
+    description: `${SKILL_MCP_DESCRIPTION} Optional cdp_url connects Playwright to a runtime CDP endpoint.`,
     args: {
       mcp_name: tool.schema.string().describe("Name of the MCP server from skill config"),
       tool_name: tool.schema.string().optional().describe("MCP tool to call"),
@@ -114,6 +114,12 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
         .string()
         .optional()
         .describe("Regex pattern to filter output lines (only matching lines returned)"),
+      cdp_url: tool.schema
+        .string()
+        .optional()
+        .describe(
+          "CDP endpoint URL to connect Playwright to an existing browser (e.g. http://localhost:9222). Creates a separate MCP instance per unique URL."
+        ),
     },
     async execute(args: SkillMcpArgs, toolContext: ToolContext) {
       const operation = validateOperationParams(args)
@@ -156,14 +162,16 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
       const parsedArgs = parseSkillMcpArguments(args.arguments)
 
       let output: string
+      const cdpOptions = args.cdp_url ? { cdpUrl: args.cdp_url } : undefined
+
       switch (operation.type) {
         case "tool": {
-          const result = await manager.callTool(info, context, operation.name, parsedArgs)
+          const result = await manager.callTool(info, context, operation.name, parsedArgs, cdpOptions)
           output = JSON.stringify(result, null, 2)
           break
         }
         case "resource": {
-          const result = await manager.readResource(info, context, operation.name)
+          const result = await manager.readResource(info, context, operation.name, cdpOptions)
           output = JSON.stringify(result, null, 2)
           break
         }
@@ -172,7 +180,7 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
           for (const [key, value] of Object.entries(parsedArgs)) {
             stringArgs[key] = String(value)
           }
-          const result = await manager.getPrompt(info, context, operation.name, stringArgs)
+          const result = await manager.getPrompt(info, context, operation.name, stringArgs, cdpOptions)
           output = JSON.stringify(result, null, 2)
           break
         }

--- a/packages/omo-opencode/src/tools/skill-mcp/types.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/types.ts
@@ -4,5 +4,6 @@ export interface SkillMcpArgs {
   resource_name?: string
   prompt_name?: string
   arguments?: string | Record<string, unknown>
+  cdp_url?: string
   grep?: string
 }


### PR DESCRIPTION
## Summary

- Add optional `cdp_url` parameter to the `skill_mcp` tool, allowing agents to connect Playwright to an existing browser session via Chrome DevTools Protocol
- Concurrent MCP instances: different CDP endpoints create separate Playwright MCP processes, keyed by URL
- Use case: connecting to a non-headless real Chrome browser via a forwarded CDP port (port changes between sessions, so this must be a runtime argument, not static config)

## Changes

### Tool Schema (`src/tools/skill-mcp/tools.ts`)
- Added `cdp_url: string` (optional) to tool args with description
- When `cdp_url` provided, passes `{ cdpUrl: args.cdp_url }` to `manager.getOrCreateClient()`
- Updated tool description to mention CDP URL capability

### SkillMcpManager (`src/features/skill-mcp-manager/manager.ts`)
- `getOrCreateClient()` accepts optional `options?: { cdpUrl?: string }`
- New pure function `buildSkillMcpClientKey()` extends cache key with `::cdp=<url>` suffix when cdpUrl provided
- `withInjectedCdpEndpoint()` clones config via `structuredClone()` and appends `--cdp-endpoint <url>` to MCP args
- Default (no cdpUrl) behavior completely unchanged

### Tests
- `manager.test.ts`: 202 new lines covering default key backward compat, parameterized keys, client reuse/separation, CDP arg injection
- `tools.test.ts`: 132 new lines covering schema, description, cdp_url passthrough, backward compat

## How It Works

```
Agent calls skill_mcp(mcp_name="playwright", tool_name="browser_navigate", cdp_url="http://localhost:9222", ...)
  -> SkillMcpManager sees cdp_url
  -> Cache key: "session:playwright:playwright::cdp=http://localhost:9222"
  -> If no cached client for this key: clone config, append --cdp-endpoint, start new MCP process
  -> If cached: reuse existing client
  -> Multiple CDP endpoints = multiple concurrent Playwright MCP instances
```

## Motivation

When agents need to interact with a real browser (not headless), the user forwards a Chrome DevTools Protocol port to the agent's environment. The CDP port changes between sessions, so it cannot be a static config field. Making it a runtime tool argument lets the agent specify which browser to connect to on each call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `cdp_url` to the `skill_mcp` tool so Playwright (`@playwright/mcp`) can connect to an existing Chrome session via CDP. Different URLs create separate cached clients; list APIs, tool/resource/prompt calls, retries, and reconnects are CDP-aware.

- **New Features**
  - Tool: added `cdp_url`; description and schema updated; forwards `{ cdpUrl }` to manager for tool/resource/prompt calls.
  - Manager: accepts `options?: { cdpUrl?: string }` across `list*`, `callTool`, `readResource`, `getPrompt`; exports `buildSkillMcpClientKey`; clones config to inject `--cdp-endpoint <url>` (no mutation); cache keys, retries, and reconnects include CDP; default behavior unchanged.

- **Bug Fixes**
  - Resolved a rebase conflict in `manager.test.ts` to stabilize test setup and mocks.

<sup>Written for commit e85895e1ef8edc173e6f540824a67814a431f2c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

