### PR TITLE
fix(tmux): target isolated window in applyLayout to prevent layout bleed

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -71,6 +71,7 @@ const mockSpawnTmuxSession = mock<(
 }))
 const mockKillTmuxSessionIfExists = mock<(sessionName: string) => Promise<boolean>>(async () => true)
 const mockSweepStaleOmoAgentSessions = mock<() => Promise<number>>(async () => 0)
+const mockCloseTmuxPane = mock<(paneId: string) => Promise<boolean>>(async () => true)
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
 
@@ -107,6 +108,7 @@ function registerModuleMocks(): void {
       killTmuxSessionIfExists: mockKillTmuxSessionIfExists,
       getIsolatedSessionName: (pid: number = 12345) => `omo-agents-${pid}`,
       sweepStaleOmoAgentSessions: mockSweepStaleOmoAgentSessions,
+      closeTmuxPane: mockCloseTmuxPane,
     }
   })
 }
@@ -227,6 +229,7 @@ describe('TmuxSessionManager', () => {
     mockSpawnTmuxSession.mockClear()
     mockIsInsideTmux.mockClear()
     mockGetCurrentPaneId.mockClear()
+    mockCloseTmuxPane.mockClear()
     trackedSessions.clear()
     readySessions.clear()
 
@@ -1751,12 +1754,10 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_first' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
-      expect(mockExecuteAction.mock.calls[0]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-session-ses_first',
-        sessionId: 'ses_first',
-      })
+      // The isolated container pane is closed via closeTmuxPane (not executeAction) so
+      // applyLayout is never run against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-session-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })
@@ -1817,12 +1818,10 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_first' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
-      expect(mockExecuteAction.mock.calls[0]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-window-ses_first',
-        sessionId: 'ses_first',
-      })
+      // The isolated container pane is closed via closeTmuxPane (not executeAction) so
+      // applyLayout is never run against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-window-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })
@@ -1913,17 +1912,16 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_second' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(2)
+      // Subagent pane closed via executeAction (so layout is enforced inside the isolated window).
+      // Container pane in the user's window closed via closeTmuxPane directly to avoid
+      // applyLayout being run against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
       expect(mockExecuteAction.mock.calls[0]?.[0]).toEqual({
         type: 'close',
         paneId: '%mock',
         sessionId: 'ses_second',
       })
-      expect(mockExecuteAction.mock.calls[1]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-session-ses_first',
-        sessionId: 'ses_second',
-      })
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-session-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })
@@ -2014,17 +2012,16 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_second' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(2)
+      // Subagent pane closed via executeAction (so layout is enforced inside the isolated window).
+      // Container pane in the user's window closed via closeTmuxPane directly to avoid
+      // applyLayout being run against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
       expect(mockExecuteAction.mock.calls[0]?.[0]).toEqual({
         type: 'close',
         paneId: '%mock',
         sessionId: 'ses_second',
       })
-      expect(mockExecuteAction.mock.calls[1]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-window-ses_first',
-        sessionId: 'ses_second',
-      })
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-window-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })
@@ -2135,17 +2132,16 @@ describe('TmuxSessionManager', () => {
       await closeSessionById.call(manager, 'ses_second')
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(3)
+      // After my fix: only 2 executeAction calls (one per subagent close).
+      // The container close goes through closeTmuxPane to avoid running applyLayout
+      // against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(2)
       expect(mockExecuteAction.mock.calls[1]?.[0]).toEqual({
         type: 'close',
         paneId: '%mock',
         sessionId: 'ses_second',
       })
-      expect(mockExecuteAction.mock.calls[2]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-session-ses_first',
-        sessionId: 'ses_second',
-      })
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-session-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })
@@ -2221,7 +2217,10 @@ describe('TmuxSessionManager', () => {
       await manager.cleanup()
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(3)
+      // After my fix: only 2 executeAction calls (one per subagent close).
+      // The container close goes through closeTmuxPane to avoid running applyLayout
+      // against the user's main pane.
+      expect(mockExecuteAction).toHaveBeenCalledTimes(2)
       expect(mockExecuteAction.mock.calls[0]?.[0]).toEqual({
         type: 'close',
         paneId: '%isolated-session-ses_first',
@@ -2232,11 +2231,7 @@ describe('TmuxSessionManager', () => {
         paneId: '%mock',
         sessionId: 'ses_second',
       })
-      expect(mockExecuteAction.mock.calls[2]?.[0]).toEqual({
-        type: 'close',
-        paneId: '%isolated-session-ses_first',
-        sessionId: 'ses_second',
-      })
+      expect(mockCloseTmuxPane).toHaveBeenCalledWith('%isolated-session-ses_first')
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBeUndefined()
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBeUndefined()
     })

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -1905,6 +1905,9 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      // Container close MUST NOT happen yet — it should be deferred until the last
+      // tracked session exits. An early close here would silently pass without this check.
+      expect(mockCloseTmuxPane).not.toHaveBeenCalled()
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBe('%isolated-session-ses_first')
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBe('%mock')
 
@@ -2005,6 +2008,9 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      // Container close MUST NOT happen yet — it should be deferred until the last
+      // tracked session exits. An early close here would silently pass without this check.
+      expect(mockCloseTmuxPane).not.toHaveBeenCalled()
       expect(Reflect.get(manager, 'isolatedContainerPaneId')).toBe('%isolated-window-ses_first')
       expect(Reflect.get(manager, 'isolatedWindowPaneId')).toBe('%mock')
 

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -11,6 +11,7 @@ import {
   killTmuxSessionIfExists,
   getIsolatedSessionName,
   sweepStaleOmoAgentSessions,
+  closeTmuxPane,
 } from "../../shared/tmux"
 import { queryWindowState as defaultQueryWindowState } from "./pane-state-querier"
 import { decideSpawnActions, decideCloseAction, type SessionMapping } from "./decision-engine"
@@ -276,18 +277,14 @@ export class TmuxSessionManager {
     }
 
     try {
-      const result = await executeAction(
-        { type: "close", paneId: isolatedContainerPaneId, sessionId: tracked.sessionId },
-        {
-          config: this.tmuxConfig,
-          directory: this.projectDirectory,
-          serverUrl: this.serverUrl,
-          windowState: state,
-          sourcePaneId: this.sourcePaneId ?? tracked.paneId,
-        },
-      )
+      // Skip enforceLayoutAndMainPane: in isolation mode, the isolated container
+      // lives in the user's main window. Going through executeAction would call
+      // applyLayout against this.sourcePaneId (the user's main pane), forcing the
+      // user's window into our configured layout (e.g. main-vertical) and
+      // scrambling their custom pane arrangement. Direct close is sufficient.
+      const success = await closeTmuxPane(isolatedContainerPaneId)
 
-      if (!result.success) {
+      if (!success) {
         log("[tmux-session-manager] failed to close isolated container pane after anchor session deletion", {
           sessionId: tracked.sessionId,
           paneId: isolatedContainerPaneId,


### PR DESCRIPTION
## Summary

`applyLayout` runs `select-layout` and `set-window-option` without `-t`, so they hit the calling process's current window instead of the isolated omo-agents window. When the tmux isolation feature routes pane creation to the omo-agents window, every subsequent layout enforcement blasts the caller's window layout.

## Changes

- **`layout.ts`**: Added `targetPaneId?` to `LayoutDeps`. When provided, both `select-layout` and `set-window-option` commands include `-t <paneId>` to target the correct window.
- **`action-executor.ts`**: `enforceLayoutAndMainPane` now passes `sourcePaneId` through to `applyLayout` so layout enforcement targets the isolated window.
- **`layout.test.ts`**: Added tests verifying `-t` is passed when `targetPaneId` is provided, and omitted when it isn't.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout bleed in tmux isolation. `applyLayout` now targets the isolated window with `-t`, and container cleanup skips layout enforcement so the caller’s window stays untouched.

- **Bug Fixes**
  - Added optional `targetPaneId` to `LayoutDeps`; `select-layout`/`set-window-option` pass `-t` when provided (forwarded from `enforceLayoutAndMainPane`); tests cover targeted layout.
  - `TmuxSessionManager`: close the isolated container pane via `closeTmuxPane` (not `executeAction`) and defer it until the last tracked session; subagent panes still close via `executeAction`; tests assert no layout runs on the user’s window and verify deferral and call paths.

<sup>Written for commit 32b949e0d8a9154efe38d99bfefefa6c9ee42200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

