### PR TITLE
fix(lsp): wait for published diagnostics before fallback

### DIFF
--- a/src/tools/lsp/client.test.ts
+++ b/src/tools/lsp/client.test.ts
@@ -71,6 +71,83 @@ describe("LSPClient", () => {
     })
   })
 
+  describe("diagnostics", () => {
+    it("waits for published diagnostics before falling back to the diagnostics store", async () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-client-diagnostics-test-"))
+      const filePath = join(dir, "test.ts")
+      writeFileSync(filePath, "const a = 1\n")
+
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+
+      const client = new LSPClient(dir, server)
+      const expected = [{
+        message: "published later",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 1 },
+        },
+        severity: 1,
+      }]
+
+      const openFileSpy = spyOn(client, "openFile")
+      openFileSpy.mockImplementation(async () => {})
+
+      const sendRequestSpy = spyOn(
+        client as unknown as { sendRequest: (m: string, p?: unknown) => Promise<unknown> },
+        "sendRequest"
+      )
+      sendRequestSpy.mockRejectedValue(new Error("not supported"))
+
+      const originalSetTimeout = globalThis.setTimeout
+      globalThis.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
+        if (ms === 100) {
+          queueMicrotask(fn)
+          return 0 as unknown as ReturnType<typeof setTimeout>
+        }
+
+        if (ms === 5000) {
+          return 0 as unknown as ReturnType<typeof setTimeout>
+        }
+
+        return originalSetTimeout(fn as TimerHandler, 0)
+      }) as typeof setTimeout
+
+      let pollCount = 0
+      const dateNowSpy = spyOn(Date, "now")
+      dateNowSpy.mockImplementation(() => {
+        pollCount += 1
+        if (pollCount === 3) {
+          ;(client as unknown as { diagnosticsStore: Map<string, unknown[]> }).diagnosticsStore.set(
+            new URL(`file://${filePath}`).href,
+            expected as unknown[]
+          )
+        }
+        return pollCount * 100
+      })
+
+      try {
+        // #when
+        const result = await client.diagnostics(filePath)
+
+        // #then
+        expect(result.items).toEqual(expected)
+        expect(openFileSpy).toHaveBeenCalledWith(filePath)
+      } finally {
+        openFileSpy.mockRestore()
+        sendRequestSpy.mockRestore()
+        dateNowSpy.mockRestore()
+        globalThis.setTimeout = originalSetTimeout
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
   describe("LSPServerManager", () => {
     it("recreates client after init failure instead of staying permanently blocked", async () => {
       //#given

--- a/src/tools/lsp/lsp-client.ts
+++ b/src/tools/lsp/lsp-client.ts
@@ -11,6 +11,21 @@ export class LSPClient extends LSPClientConnection {
   private documentVersions = new Map<string, number>()
   private lastSyncedText = new Map<string, string>()
 
+  private async waitForPublishedDiagnostics(uri: string, timeoutMs = 5000, intervalMs = 100): Promise<Diagnostic[]> {
+    const start = Date.now()
+
+    while (Date.now() - start < timeoutMs) {
+      const existing = this.diagnosticsStore.get(uri)
+      if (existing) {
+        return existing
+      }
+
+      await new Promise((r) => setTimeout(r, intervalMs))
+    }
+
+    return this.diagnosticsStore.get(uri) ?? []
+  }
+
   async openFile(filePath: string): Promise<void> {
     const absPath = resolve(filePath)
 
@@ -94,7 +109,7 @@ export class LSPClient extends LSPClientConnection {
     const absPath = resolve(filePath)
     const uri = pathToFileURL(absPath).href
     await this.openFile(absPath)
-    await new Promise((r) => setTimeout(r, 500))
+    await this.waitForPublishedDiagnostics(uri)
 
     try {
       const result = await this.sendRequest<{ items?: Diagnostic[] }>("textDocument/diagnostic", {


### PR DESCRIPTION
## Summary
- wait for asynchronously published LSP diagnostics before falling back to the local diagnostics store
- fix delayed-diagnostics servers such as vtsls returning empty results from `lsp_diagnostics`
- add a regression test covering delayed published diagnostics

## Verification
- `bun test src/tools/lsp/client.test.ts`
- `bun run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for LSP-published diagnostics before falling back to the local store using a 5s/100ms polling loop. Fixes empty or outdated diagnostics with delayed servers like `vtsls`, while still preferring pull diagnostics when supported.

- **Bug Fixes**
  - Replace fixed 500ms sleep with a polling wait; try `textDocument/diagnostic` first, then fall back to published diagnostics.
  - Add a test for delayed publish without pull support.

<sup>Written for commit e4da67b9a7c40206744269cf8ba1796bb2610d5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

