### PR TITLE
fix(sisyphus-junior-notepad): scope plan directive to delegated workers

### DIFF
--- a/src/hooks/sisyphus-junior-notepad/constants.ts
+++ b/src/hooks/sisyphus-junior-notepad/constants.ts
@@ -12,18 +12,13 @@ NOTEPAD PATH: .omo/notepads/{plan-name}/
 You SHOULD append findings to notepad files after completing work.
 IMPORTANT: Always APPEND to notepad files - never overwrite or use Edit tool.
 
-## Plan Location (READ ONLY)
+## Plan Location (subagent: READ ONLY)
 PLAN PATH: .omo/plans/{plan-name}.md
 
-CRITICAL RULE: NEVER MODIFY THE PLAN FILE
-
-The plan file (.omo/plans/*.md) is SACRED and READ-ONLY.
-- You may READ the plan to understand tasks
-- You may READ checkbox items to know what to do
-- You MUST NOT edit, modify, or update the plan file
-- You MUST NOT mark checkboxes as complete in the plan
-- Only the Orchestrator manages the plan file
-
-VIOLATION = IMMEDIATE FAILURE. The Orchestrator tracks plan state.
+SUBAGENT PLAN RESTRICTION (applies to YOU, the delegated worker — NOT to the Orchestrator):
+- You may READ the plan to understand your assigned tasks
+- You may READ checkbox items to know what to work on
+- You MUST NOT edit the plan file or mark checkboxes — that is the Orchestrator's job
+- The Orchestrator (Atlas) updates checkboxes after verifying your completed work
 </Work_Context>
 `


### PR DESCRIPTION
## Summary
- clarify that the plan file restriction applies to delegated workers, not the orchestrator
- remove absolute threat-style wording while preserving the same behavior constraints
- make the prompt match the actual Atlas → subagent responsibility split

## Why
The current NOTEPAD_DIRECTIVE still says the plan file is \"SACRED and READ-ONLY\" with \"VIOLATION = IMMEDIATE FAILURE\". That wording is unscoped and can be misread as a universal constraint, even though this hook is specifically prepended to delegated worker prompts.

This change is behavior-preserving: subagents still must not edit the plan, but the directive now states that explicitly as a subagent-only rule and names the orchestrator as the actor that updates plan state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the notepad directive so the plan file is read-only for delegated workers, and Atlas updates checkboxes after verifying work. Simplified wording to match the Atlas → subagent split.

- **Bug Fixes**
  - Scoped the plan rule to subagents (header now “Plan Location (subagent: READ ONLY)”) and stated that Atlas updates checkboxes; behavior unchanged.

<sup>Written for commit 342954ca1573e8165fc7cc2d3fde36cc2eeecfbb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

