### PR TITLE
fix(event): suppress openclaw stop until background work settles

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -281,6 +281,10 @@ function getDispatchedParentWakes(manager: BackgroundManager): Map<string, Pendi
   }>(manager)).parentWakeNotifier.getDispatchedParentWakes()
 }
 
+function getNotificationQueueByParent(manager: BackgroundManager): Map<string, Promise<void>> {
+  return (cast<{ notificationQueueByParent: Map<string, Promise<void>> }>(manager)).notificationQueueByParent
+}
+
 function getCompletionTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
   return (cast<{ completionTimers: Map<string, ReturnType<typeof setTimeout>> }>(manager)).completionTimers
 }
@@ -345,6 +349,30 @@ function waitForParentWakeRequeue(manager: BackgroundManager, sessionID: string)
 function waitForParentWakeErrorSettle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 260))
 }
+
+describe("BackgroundManager notification settlement", () => {
+  test("hasPendingParentNotificationWork should return true for buffered notifications", () => {
+    const manager = createBackgroundManager()
+
+    manager.queuePendingNotification("ses_parent", "done")
+
+    expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+  })
+
+  test("hasPendingParentNotificationWork should return true for queued notification promises", () => {
+    const manager = createBackgroundManager()
+
+    getNotificationQueueByParent(manager).set("ses_parent", Promise.resolve())
+
+    expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+  })
+
+  test("hasPendingParentNotificationWork should return false when no notification work remains", () => {
+    const manager = createBackgroundManager()
+
+    expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(false)
+  })
+})
 
 function createToastRemoveTaskTracker(): { removeTaskCalls: string[]; resetToastManager: () => void } {
   _resetTaskToastManagerForTesting()

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -351,26 +351,66 @@ function waitForParentWakeErrorSettle(): Promise<void> {
 }
 
 describe("BackgroundManager notification settlement", () => {
-  test("hasPendingParentNotificationWork should return true for buffered notifications", () => {
+  test("hasPendingParentNotificationWork should return true for buffered notifications", async () => {
     const manager = createBackgroundManager()
 
     manager.queuePendingNotification("ses_parent", "done")
 
     expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+
+    await manager.shutdown()
   })
 
-  test("hasPendingParentNotificationWork should return true for queued notification promises", () => {
+  test("hasPendingParentNotificationWork should return true for queued notification promises", async () => {
     const manager = createBackgroundManager()
 
     getNotificationQueueByParent(manager).set("ses_parent", Promise.resolve())
 
     expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+
+    await manager.shutdown()
   })
 
-  test("hasPendingParentNotificationWork should return false when no notification work remains", () => {
+  test("hasPendingParentNotificationWork should return false when no notification work remains", async () => {
     const manager = createBackgroundManager()
 
     expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(false)
+
+    await manager.shutdown()
+  })
+
+  test("settlement callback should fire after queued notification work drains", async () => {
+    const manager = createBackgroundManager()
+    try {
+      const settledSessionIDs: string[] = []
+      const setOnParentNotificationWorkSettled = (manager as unknown as {
+        setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => void
+      }).setOnParentNotificationWorkSettled.bind(manager)
+      const enqueueNotificationForParent = (manager as unknown as {
+        enqueueNotificationForParent: (
+          parentSessionID: string | undefined,
+          operation: () => Promise<void>,
+        ) => Promise<void>
+      }).enqueueNotificationForParent.bind(manager)
+
+      setOnParentNotificationWorkSettled((sessionID) => {
+        settledSessionIDs.push(sessionID)
+      })
+
+      const firstNotification = enqueueNotificationForParent("ses_parent", async () => {
+        await Promise.resolve()
+      })
+
+      expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+
+      await firstNotification
+      await flushBackgroundNotifications()
+
+      expect(settledSessionIDs).toEqual(["ses_parent"])
+      expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(false)
+    } finally {
+      await manager.shutdown()
+    }
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -371,6 +371,42 @@ describe("BackgroundManager notification settlement", () => {
     await manager.shutdown()
   })
 
+  test("hasPendingParentNotificationWork should return true for queued parent wakes", async () => {
+    const manager = createBackgroundManager()
+    try {
+      const queuePendingParentWake = (cast<{
+        queuePendingParentWake: (
+          sessionID: string,
+          notification: string,
+          promptContext: Record<string, never>,
+          shouldReply: boolean,
+          delayMs?: number,
+        ) => void
+      }>(manager)).queuePendingParentWake.bind(manager)
+
+      queuePendingParentWake("ses_parent", "done", {}, false, 10_000)
+
+      expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("hasPendingParentNotificationWork should return true for dispatched parent wakes", async () => {
+    const manager = createBackgroundManager()
+    try {
+      getDispatchedParentWakes(manager).set("ses_parent", {
+        promptContext: {},
+        notifications: ["done"],
+        shouldReply: false,
+      })
+
+      expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
   test("hasPendingParentNotificationWork should return false when no notification work remains", async () => {
     const manager = createBackgroundManager()
 
@@ -409,6 +445,38 @@ describe("BackgroundManager notification settlement", () => {
       expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(true)
 
       await firstNotification
+      await flushBackgroundNotifications()
+
+      expect(settledSessionIDs).toEqual(["ses_parent"])
+      expect(manager.hasPendingParentNotificationWork("ses_parent")).toBe(false)
+    } finally {
+      await manager.shutdown()
+    }
+  })
+
+  test("settlement callback should fire after dispatched parent wake clears", async () => {
+    const manager = createBackgroundManager()
+    try {
+      const settledSessionIDs: string[] = []
+      const setOnParentNotificationWorkSettled: (
+        callback: (sessionID: string) => void | Promise<void>
+      ) => void = (cast<{
+        setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => void
+      }>(manager)).setOnParentNotificationWorkSettled.bind(manager)
+      const clearDispatchedParentWake: (sessionID: string) => void = (cast<{
+        clearDispatchedParentWake: (sessionID: string) => void
+      }>(manager)).clearDispatchedParentWake.bind(manager)
+
+      setOnParentNotificationWorkSettled((sessionID: string) => {
+        settledSessionIDs.push(sessionID)
+      })
+      getDispatchedParentWakes(manager).set("ses_parent", {
+        promptContext: {},
+        notifications: ["done"],
+        shouldReply: false,
+      })
+
+      clearDispatchedParentWake("ses_parent")
       await flushBackgroundNotifications()
 
       expect(settledSessionIDs).toEqual(["ses_parent"])

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -383,17 +383,22 @@ describe("BackgroundManager notification settlement", () => {
     const manager = createBackgroundManager()
     try {
       const settledSessionIDs: string[] = []
-      const setOnParentNotificationWorkSettled = (manager as unknown as {
+      const setOnParentNotificationWorkSettled: (
+        callback: (sessionID: string) => void | Promise<void>
+      ) => void = (cast<{
         setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => void
-      }).setOnParentNotificationWorkSettled.bind(manager)
-      const enqueueNotificationForParent = (manager as unknown as {
+      }>(manager)).setOnParentNotificationWorkSettled.bind(manager)
+      const enqueueNotificationForParent: (
+        parentSessionID: string | undefined,
+        operation: () => Promise<void>,
+      ) => Promise<void> = (cast<{
         enqueueNotificationForParent: (
           parentSessionID: string | undefined,
           operation: () => Promise<void>,
         ) => Promise<void>
-      }).enqueueNotificationForParent.bind(manager)
+      }>(manager)).enqueueNotificationForParent.bind(manager)
 
-      setOnParentNotificationWorkSettled((sessionID) => {
+      setOnParentNotificationWorkSettled((sessionID: string) => {
         settledSessionIDs.push(sessionID)
       })
 

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -260,6 +260,7 @@ export class BackgroundManager {
   private onSubagentSessionCreated?: OnSubagentSessionCreated
   private onSubagentSessionDeleted?: OnSubagentSessionDeleted
   private onShutdown?: () => void | Promise<void>
+  private onParentNotificationWorkSettled?: (sessionID: string) => void | Promise<void>
 
   private queuesByKey: Map<string, QueueItem[]> = new Map()
   private processingKeys: Set<string> = new Set()
@@ -1151,6 +1152,12 @@ The fallback retry session is now created and can be inspected directly.
     const hasQueuedNotification = this.notificationQueueByParent.has(sessionID)
     const hasBufferedNotification = (this.pendingNotifications.get(sessionID)?.length ?? 0) > 0
     return hasQueuedNotification || hasBufferedNotification
+  }
+
+  setOnParentNotificationWorkSettled(
+    callback: ((sessionID: string) => void | Promise<void>) | undefined,
+  ): void {
+    this.onParentNotificationWorkSettled = callback
   }
 
   findBySession(sessionID: string): BackgroundTask | undefined {
@@ -2230,6 +2237,7 @@ The task was re-queued on a fallback model after a retryable failure.
 
     const notificationContent = pendingNotifications.join("\n\n")
     this.pendingNotifications.delete(sessionID)
+    this.emitParentNotificationWorkSettled(sessionID)
     this.queuePendingParentWake(sessionID, notificationContent, {}, false, PENDING_PARENT_WAKE_DEBOUNCE_MS)
   }
 
@@ -2501,6 +2509,19 @@ The task was re-queued on a fallback model after a retryable failure.
 
   private unregisterProcessCleanup(): void {
     unregisterManagerForCleanup(this)
+  }
+
+  private emitParentNotificationWorkSettled(sessionID: string): void {
+    if (this.hasPendingParentNotificationWork(sessionID)) {
+      return
+    }
+
+    void Promise.resolve(this.onParentNotificationWorkSettled?.(sessionID)).catch((error) => {
+      log("[background-agent] Error in parent notification settlement callback:", {
+        sessionID,
+        error,
+      })
+    })
   }
 
   /**
@@ -3182,6 +3203,8 @@ The task was re-queued on a fallback model after a retryable failure.
       if (this.notificationQueueByParent.get(parentSessionID) === current) {
         this.notificationQueueByParent.delete(parentSessionID)
       }
+
+      this.emitParentNotificationWorkSettled(parentSessionID)
     }
 
     const current = previous

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1151,7 +1151,8 @@ The fallback retry session is now created and can be inspected directly.
   hasPendingParentNotificationWork(sessionID: string): boolean {
     const hasQueuedNotification = this.notificationQueueByParent.has(sessionID)
     const hasBufferedNotification = (this.pendingNotifications.get(sessionID)?.length ?? 0) > 0
-    return hasQueuedNotification || hasBufferedNotification
+    const hasParentWakeWork = this.hasPendingParentWake(sessionID)
+    return hasQueuedNotification || hasBufferedNotification || hasParentWakeWork
   }
 
   setOnParentNotificationWorkSettled(
@@ -1545,6 +1546,7 @@ The fallback retry session is now created and can be inspected directly.
   private clearDispatchedParentWake(sessionID: string): void {
     this.clearParentWakeTextDeltaBuffers(sessionID)
     this.parentWakeNotifier.clearDispatchedParentWake(sessionID)
+    this.emitParentNotificationWorkSettled(sessionID)
   }
 
   private async requeueDispatchedParentWake(sessionID: string, reason: string): Promise<boolean> {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -1147,6 +1147,12 @@ The fallback retry session is now created and can be inspected directly.
     return result
   }
 
+  hasPendingParentNotificationWork(sessionID: string): boolean {
+    const hasQueuedNotification = this.notificationQueueByParent.has(sessionID)
+    const hasBufferedNotification = (this.pendingNotifications.get(sessionID)?.length ?? 0) > 0
+    return hasQueuedNotification || hasBufferedNotification
+  }
+
   findBySession(sessionID: string): BackgroundTask | undefined {
     for (const task of this.tasks.values()) {
       if (task.sessionId === sessionID) {

--- a/packages/omo-opencode/src/index.openclaw.test.ts
+++ b/packages/omo-opencode/src/index.openclaw.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { createPluginModule } from "./testing/create-plugin-module"
+
+const mockCreateTools = mock(async () => {
+  throw new Error("createTools failed")
+})
+const mockInitializeOpenClaw = mock(async () => true)
+const mockStopReplyListener = mock(async () => ({ success: true, message: "stopped" }))
+const mockLog = mock(() => {})
+
+function createTestPluginModule(): ReturnType<typeof createPluginModule> {
+  return createPluginModule({
+    initConfigContext: mock(() => {}),
+    installAgentSortShim: mock(() => {}),
+    setAgentSortOrder: mock(() => {}),
+    log: mockLog,
+    logLegacyPluginStartupWarning: mock(() => {}),
+    migrateLegacyWorkspaceDirectory: mock(() => ({ migrated: false, skipped: [] })),
+    detectDuplicateOmoPlugin: mock(() => ({
+      detected: false,
+      pluginName: null,
+      duplicatePlugins: [],
+      allPlugins: [],
+    })),
+    getDuplicateOmoPluginWarning: mock(() => ""),
+    detectExternalSkillPlugin: mock(() => ({ detected: false, pluginName: null, allPlugins: [] })),
+    getSkillPluginConflictWarning: mock(() => ""),
+    injectServerAuthIntoClient: mock(() => {}),
+    initLiveServerRoute: mock(() => {}),
+    setLiveParentWakeRoutingDisabled: mock(() => {}),
+    warmLiveServerProbe: mock(() => {}),
+    loadPluginConfig: mock(() => ({
+      tui: { sidebar: { enabled: false } },
+      openclaw: {
+        enabled: true,
+        gateways: {},
+        hooks: {},
+        replyListener: { telegramBotToken: "token" },
+      },
+      disabled_hooks: [],
+      experimental: {},
+    })) as never,
+    initI18n: mock(() => {}),
+    initializeOpenClaw: mockInitializeOpenClaw as never,
+    stopReplyListener: mockStopReplyListener as never,
+    isTmuxIntegrationEnabled: mock(() => false),
+    startTmuxCheck: mock(() => {}),
+    createFirstMessageVariantGate: mock(() => ({
+      shouldOverride: () => false,
+      markApplied: () => {},
+      markSessionCreated: () => {},
+      clear: () => {},
+    })),
+    createRuntimeTmuxConfig: mock(() => ({
+      enabled: false,
+      layout: "tiled",
+      main_pane_size: 60,
+      main_pane_min_width: 80,
+      agent_pane_min_width: 40,
+      isolation: "inline",
+    })) as never,
+    createModelCacheState: mock(() => ({})) as never,
+    createManagers: mock(() => ({
+      backgroundManager: { shutdown: async () => {} },
+      skillMcpManager: { disconnectAll: async () => {} },
+      configHandler: async () => {},
+    })) as never,
+    createTools: mockCreateTools as never,
+    createRuntimeSkillSourceServer: mock(() => ({
+      url: "http://127.0.0.1:49152/runtime-skills",
+      stop: mock(() => {}),
+    })) as never,
+    createHooks: mock(() => ({
+      disposeHooks: () => {},
+      compactionContextInjector: undefined,
+      compactionTodoPreserver: undefined,
+      claudeCodeHooks: undefined,
+    })) as never,
+    createPluginInterface: mock(() => ({})) as never,
+  })
+}
+
+describe("createPluginModule OpenClaw startup cleanup", () => {
+  beforeEach(() => {
+    mockCreateTools.mockClear()
+    mockInitializeOpenClaw.mockClear()
+    mockStopReplyListener.mockClear()
+    mockLog.mockClear()
+  })
+
+  it("stops the reply listener when startup fails after this instance started it", async () => {
+    mockInitializeOpenClaw.mockImplementation(async () => true)
+    const pluginModule = createTestPluginModule()
+
+    await expect(
+      pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0]),
+    ).rejects.toThrow("createTools failed")
+
+    expect(mockInitializeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(mockStopReplyListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not stop a reply listener that was not started by this instance", async () => {
+    mockInitializeOpenClaw.mockImplementation(async () => false)
+    const pluginModule = createTestPluginModule()
+
+    await expect(
+      pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0]),
+    ).rejects.toThrow("createTools failed")
+
+    expect(mockInitializeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(mockStopReplyListener).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/plugin-dispose.openclaw.test.ts
+++ b/packages/omo-opencode/src/plugin-dispose.openclaw.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, mock } from "bun:test"
+
+const { createPluginDispose } = await import("./plugin-dispose")
+
+describe("createPluginDispose OpenClaw wiring", () => {
+  it("stops the reply listener during disposal", async () => {
+    const shutdown = mock(async () => {})
+    const disconnectAll = mock(async () => {})
+    const disposeHooks = mock(() => {})
+    const disposeOpenClaw = mock(async () => {})
+
+    const dispose = createPluginDispose({
+      backgroundManager: { shutdown },
+      skillMcpManager: { disconnectAll },
+      disposeHooks,
+      disposeOpenClaw,
+    })
+
+    await dispose()
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(disconnectAll).toHaveBeenCalledTimes(1)
+    expect(disposeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(disposeHooks).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips OpenClaw disposal when no listener was started by this instance", async () => {
+    const shutdown = mock(async () => {})
+    const disconnectAll = mock(async () => {})
+    const disposeHooks = mock(() => {})
+
+    const dispose = createPluginDispose({
+      backgroundManager: { shutdown },
+      skillMcpManager: { disconnectAll },
+      disposeHooks,
+    })
+
+    await dispose()
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(disconnectAll).toHaveBeenCalledTimes(1)
+    expect(disposeHooks).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/omo-opencode/src/plugin-dispose.ts
+++ b/packages/omo-opencode/src/plugin-dispose.ts
@@ -10,8 +10,9 @@ export function createPluginDispose(args: {
     disconnectAll: () => Promise<void>
   }
   disposeHooks: () => void
+  disposeOpenClaw?: () => Promise<void>
 }): PluginDispose {
-  const { backgroundManager, skillMcpManager, disposeHooks } = args
+  const { backgroundManager, skillMcpManager, disposeHooks, disposeOpenClaw } = args
   let disposePromise: Promise<void> | null = null
 
   return async (): Promise<void> => {
@@ -30,6 +31,11 @@ export function createPluginDispose(args: {
         await skillMcpManager.disconnectAll()
       } catch (error) {
         log("[plugin-dispose] skillMcpManager.disconnectAll() error:", error)
+      }
+      try {
+        await disposeOpenClaw?.()
+      } catch (error) {
+        log("[plugin-dispose] disposeOpenClaw() error:", error)
       }
       try {
         disposeHooks()

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -1384,6 +1384,47 @@ describe("createEventHandler - event forwarding", () => {
 		expect(openClawSpy).not.toHaveBeenCalled()
 	})
 
+	it("retries deferred OpenClaw session.idle after descendant background tasks settle", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_task_settled")
+		let activeTasks = [{ id: "bg_1", status: "running" }]
+		let onParentNotificationWorkSettled: ((sessionID: string) => void | Promise<void>) | undefined
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => activeTasks,
+					hasPendingParentNotificationWork: () => false,
+					setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => {
+						onParentNotificationWorkSettled = callback
+					},
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_task_settled" },
+			},
+		}))
+		expect(openClawSpy).not.toHaveBeenCalled()
+
+		activeTasks = []
+		await onParentNotificationWorkSettled?.("ses_openclaw_task_settled")
+
+		expect(openClawSpy).toHaveBeenCalledTimes(1)
+		expect(openClawSpy.mock.calls[0]?.[0]?.rawEvent).toBe("session.idle")
+	})
+
 	it("does not dispatch OpenClaw for main session.idle while parent notification work is unsettled", async () => {
 		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
 		openClawSpy.mockResolvedValue(null)

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -1410,6 +1410,104 @@ describe("createEventHandler - event forwarding", () => {
 		expect(openClawSpy).not.toHaveBeenCalled()
 	})
 
+	it("retries deferred OpenClaw session.idle when parent notification work settles", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_retry")
+		let hasPendingNotificationWork = true
+		let onParentNotificationWorkSettled: ((sessionID: string) => void | Promise<void>) | undefined
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => [],
+					hasPendingParentNotificationWork: () => hasPendingNotificationWork,
+					setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => {
+						onParentNotificationWorkSettled = callback
+					},
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_retry" },
+			},
+		}))
+		expect(openClawSpy).not.toHaveBeenCalled()
+
+		hasPendingNotificationWork = false
+		await onParentNotificationWorkSettled?.("ses_openclaw_retry")
+
+		const call = openClawSpy.mock.calls[0]?.[0] as
+			| {
+				rawEvent?: string
+				context?: { sessionId?: string; projectPath?: string; tmuxPaneId?: string }
+			  }
+			| undefined
+		expect(openClawSpy).toHaveBeenCalledTimes(1)
+		expect(call?.rawEvent).toBe("session.idle")
+		expect(call?.context).toEqual({
+			sessionId: "ses_openclaw_retry",
+			projectPath: "/tmp/project-idle",
+			tmuxPaneId: undefined,
+		})
+	})
+
+	it("does not retry stale deferred OpenClaw session.idle after the session is deleted", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_deleted")
+		let hasPendingNotificationWork = true
+		let onParentNotificationWorkSettled: ((sessionID: string) => void | Promise<void>) | undefined
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => [],
+					hasPendingParentNotificationWork: () => hasPendingNotificationWork,
+					setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => {
+						onParentNotificationWorkSettled = callback
+					},
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_deleted" },
+			},
+		}))
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.deleted",
+				properties: { info: { id: "ses_openclaw_deleted" } },
+			},
+		}))
+
+		hasPendingNotificationWork = false
+		await onParentNotificationWorkSettled?.("ses_openclaw_deleted")
+
+		expect(openClawSpy).toHaveBeenCalledTimes(1)
+		expect(openClawSpy.mock.calls[0]?.[0]?.rawEvent).toBe("session.deleted")
+	})
+
 	it("clears stored prompt params on session.deleted", async () => {
 		const eventHandler = createEventHandler({
 			ctx: {} as never,

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -1508,6 +1508,51 @@ describe("createEventHandler - event forwarding", () => {
 		expect(openClawSpy.mock.calls[0]?.[0]?.rawEvent).toBe("session.deleted")
 	})
 
+	it("does not retry stale deferred OpenClaw session.idle after an active info session event", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_active_info")
+		let hasPendingNotificationWork = true
+		let onParentNotificationWorkSettled: ((sessionID: string) => void | Promise<void>) | undefined
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => [],
+					hasPendingParentNotificationWork: () => hasPendingNotificationWork,
+					setOnParentNotificationWorkSettled: (callback: (sessionID: string) => void | Promise<void>) => {
+						onParentNotificationWorkSettled = callback
+					},
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_active_info" },
+			},
+		}))
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "message.updated",
+				properties: { info: { sessionID: "ses_openclaw_active_info", role: "user" } },
+			},
+		}))
+
+		hasPendingNotificationWork = false
+		await onParentNotificationWorkSettled?.("ses_openclaw_active_info")
+
+		expect(openClawSpy).not.toHaveBeenCalled()
+	})
+
 	it("clears stored prompt params on session.deleted", async () => {
 		const eventHandler = createEventHandler({
 			ctx: {} as never,

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -1348,6 +1348,68 @@ describe("createEventHandler - event forwarding", () => {
 		})
 	})
 
+	it("does not dispatch OpenClaw for main session.idle while descendant background tasks are active", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_busy")
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => [{ id: "bg_1", status: "running" }],
+					hasPendingParentNotificationWork: () => false,
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_busy" },
+			},
+		}))
+
+		expect(openClawSpy).not.toHaveBeenCalled()
+	})
+
+	it("does not dispatch OpenClaw for main session.idle while parent notification work is unsettled", async () => {
+		const openClawSpy = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
+		openClawSpy.mockResolvedValue(null)
+		setMainSession("ses_openclaw_unsettled")
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp/project-idle" }),
+			pluginConfig: asPluginConfig({ openclaw: { enabled: true, gateways: {}, hooks: {} } }),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				backgroundManager: {
+					getAllDescendantTasks: () => [],
+					hasPendingParentNotificationWork: () => true,
+				},
+				skillMcpManager: { disconnectSession: async () => {} },
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.idle",
+				properties: { sessionID: "ses_openclaw_unsettled" },
+			},
+		}))
+
+		expect(openClawSpy).not.toHaveBeenCalled()
+	})
+
 	it("clears stored prompt params on session.deleted", async () => {
 		const eventHandler = createEventHandler({
 			ctx: {} as never,

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -46,6 +46,11 @@ function createEventHandlerManagers(
 	overrides: Record<string, unknown> = {},
 ): EventHandlerArgs["managers"] {
 	return cast<EventHandlerArgs["managers"]>({
+		backgroundManager: {
+			getAllDescendantTasks: () => [],
+			hasPendingParentNotificationWork: () => false,
+			setOnParentNotificationWorkSettled: () => {},
+		},
 		tmuxSessionManager: {
 			onEvent: () => {},
 			onSessionCreated: async () => {},

--- a/packages/omo-opencode/src/plugin/event.ts
+++ b/packages/omo-opencode/src/plugin/event.ts
@@ -48,6 +48,7 @@ export function createEventHandler(args: {
   const recentSyntheticIdles = new Map<string, number>();
   const recentRealIdles = new Map<string, number>();
   const recentAnyIdles = new Map<string, number>();
+  const deferredStopWakeSessions = new Set<string>();
   const dedupWindowMs = 500;
   const teamHandlers = createEventTeamHandlers({ pluginConfig, pluginContext, managers });
 
@@ -98,8 +99,33 @@ export function createEventHandler(args: {
     return false;
   };
 
-  const shouldDispatchOpenClawStopWake = (sessionID: string): boolean =>
-    shouldAutoRetrySession(sessionID) && !shouldSuppressOpenClawStopWake(sessionID);
+  const dispatchOpenClawStopWake = async (sessionID: string): Promise<boolean> => {
+    if (!pluginConfig.openclaw || !shouldAutoRetrySession(sessionID)) {
+      deferredStopWakeSessions.delete(sessionID);
+      return false;
+    }
+
+    if (managers.backgroundManager?.hasPendingParentNotificationWork(sessionID)) {
+      deferredStopWakeSessions.add(sessionID);
+    }
+
+    if (shouldSuppressOpenClawStopWake(sessionID)) return false;
+
+    await dispatchOpenClawSessionEvent({
+      pluginConfig,
+      pluginContext,
+      managers,
+      rawEvent: "session.idle",
+      sessionID,
+    });
+    deferredStopWakeSessions.delete(sessionID);
+    return true;
+  };
+
+  managers.backgroundManager?.setOnParentNotificationWorkSettled?.(async (sessionID) => {
+    if (!deferredStopWakeSessions.has(sessionID)) return;
+    await dispatchOpenClawStopWake(sessionID);
+  });
 
   const dispatchIdleOnlyHooks = async (input: EventInput): Promise<void> => {
     managers.tmuxSessionManager?.onEvent?.(input.event);
@@ -119,15 +145,7 @@ export function createEventHandler(args: {
     if (!shouldDispatchIdleEvent(sessionID, now)) return;
 
     await dispatchToHooks(syntheticIdle);
-    if (shouldDispatchOpenClawStopWake(sessionID)) {
-      await dispatchOpenClawSessionEvent({
-        pluginConfig,
-        pluginContext,
-        managers,
-        rawEvent: "session.idle",
-        sessionID,
-      });
-    }
+    await dispatchOpenClawStopWake(sessionID);
     await dispatchIdleOnlyHooks(syntheticIdle);
   };
 
@@ -162,6 +180,11 @@ export function createEventHandler(args: {
     const { event } = input;
     managers.tuiStateMirror?.onEvent(event);
     const props = event.properties as Record<string, unknown> | undefined;
+    const eventSessionID = resolveSessionEventID(props);
+
+    if (eventSessionID && event.type !== "session.idle" && !syntheticIdle) {
+      deferredStopWakeSessions.delete(eventSessionID);
+    }
 
     if (tmuxIntegrationEnabled && TMUX_ACTIVITY_EVENT_TYPES.has(event.type)) {
       managers.tmuxSessionManager.onEvent?.(event as { type: string; properties?: Record<string, unknown> });
@@ -196,10 +219,8 @@ export function createEventHandler(args: {
     if (event.type === "message.removed") handleMessageRemovedEvent(props);
 
     if (event.type === "session.idle") {
-      const sessionID = resolveSessionEventID(props);
-      if (sessionID && shouldDispatchOpenClawStopWake(sessionID)) {
-        await dispatchOpenClawSessionEvent({ pluginConfig, pluginContext, managers, rawEvent: event.type, sessionID });
-      }
+      const sessionID = eventSessionID;
+      if (sessionID) await dispatchOpenClawStopWake(sessionID);
       await dispatchIdleOnlyHooks(input);
       await Promise.resolve().then(() => managers.monitorManager?.handleEvent({
         type: "session.idle",

--- a/packages/omo-opencode/src/plugin/event.ts
+++ b/packages/omo-opencode/src/plugin/event.ts
@@ -105,11 +105,10 @@ export function createEventHandler(args: {
       return false;
     }
 
-    if (managers.backgroundManager?.hasPendingParentNotificationWork(sessionID)) {
+    if (shouldSuppressOpenClawStopWake(sessionID)) {
       deferredStopWakeSessions.add(sessionID);
+      return false;
     }
-
-    if (shouldSuppressOpenClawStopWake(sessionID)) return false;
 
     await dispatchOpenClawSessionEvent({
       pluginConfig,

--- a/packages/omo-opencode/src/plugin/event.ts
+++ b/packages/omo-opencode/src/plugin/event.ts
@@ -75,6 +75,32 @@ export function createEventHandler(args: {
     return true;
   };
 
+  const shouldSuppressOpenClawStopWake = (sessionID: string): boolean => {
+    const backgroundTasks = managers.backgroundManager
+      ?.getAllDescendantTasks(sessionID)
+      .filter((task) => task.status === "pending" || task.status === "running") ?? [];
+
+    if (backgroundTasks.length > 0) {
+      log("[event] suppressing openclaw stop wake while background tasks remain active", {
+        sessionID,
+        activeBackgroundTaskCount: backgroundTasks.length,
+      });
+      return true;
+    }
+
+    if (managers.backgroundManager?.hasPendingParentNotificationWork(sessionID)) {
+      log("[event] suppressing openclaw stop wake while background notifications remain unsettled", {
+        sessionID,
+      });
+      return true;
+    }
+
+    return false;
+  };
+
+  const shouldDispatchOpenClawStopWake = (sessionID: string): boolean =>
+    shouldAutoRetrySession(sessionID) && !shouldSuppressOpenClawStopWake(sessionID);
+
   const dispatchIdleOnlyHooks = async (input: EventInput): Promise<void> => {
     managers.tmuxSessionManager?.onEvent?.(input.event);
     await runEventHookSafely("teamIdleWakeHint", teamHandlers.teamIdleWakeHint, input);
@@ -93,13 +119,15 @@ export function createEventHandler(args: {
     if (!shouldDispatchIdleEvent(sessionID, now)) return;
 
     await dispatchToHooks(syntheticIdle);
-    await dispatchOpenClawSessionEvent({
-      pluginConfig,
-      pluginContext,
-      managers,
-      rawEvent: "session.idle",
-      sessionID,
-    });
+    if (shouldDispatchOpenClawStopWake(sessionID)) {
+      await dispatchOpenClawSessionEvent({
+        pluginConfig,
+        pluginContext,
+        managers,
+        rawEvent: "session.idle",
+        sessionID,
+      });
+    }
     await dispatchIdleOnlyHooks(syntheticIdle);
   };
 
@@ -169,7 +197,7 @@ export function createEventHandler(args: {
 
     if (event.type === "session.idle") {
       const sessionID = resolveSessionEventID(props);
-      if (sessionID) {
+      if (sessionID && shouldDispatchOpenClawStopWake(sessionID)) {
         await dispatchOpenClawSessionEvent({ pluginConfig, pluginContext, managers, rawEvent: event.type, sessionID });
       }
       await dispatchIdleOnlyHooks(input);

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -8,7 +8,7 @@ import { createManagers } from "../create-managers"
 import { createRuntimeTmuxConfig, isTmuxIntegrationEnabled } from "../create-runtime-tmux-config"
 import { createTools } from "../create-tools"
 import { createRuntimeSkillSourceServer, selectRuntimeSecuritySkills } from "../features/opencode-runtime-skills"
-import { initializeOpenClaw } from "../openclaw"
+import { initializeOpenClaw, stopReplyListener } from "../openclaw"
 import { createPluginDispose } from "../plugin-dispose"
 import { createPluginInterface } from "../plugin-interface"
 import { loadPluginConfig } from "../plugin-config"
@@ -61,6 +61,7 @@ export type PluginModuleDeps = {
   loadPluginConfig: typeof loadPluginConfig
   initI18n: typeof initI18n
   initializeOpenClaw: typeof initializeOpenClaw
+  stopReplyListener: typeof stopReplyListener
   isTmuxIntegrationEnabled: typeof isTmuxIntegrationEnabled
   startTmuxCheck: typeof startTmuxCheck
   createFirstMessageVariantGate: typeof createFirstMessageVariantGate
@@ -91,6 +92,7 @@ const defaultPluginModuleDeps: PluginModuleDeps = {
   loadPluginConfig,
   initI18n,
   initializeOpenClaw,
+  stopReplyListener,
   isTmuxIntegrationEnabled,
   startTmuxCheck,
   createFirstMessageVariantGate,
@@ -153,101 +155,126 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     deps.initI18n(pluginConfig.i18n?.locale ? { locale: pluginConfig.i18n.locale } : undefined)
     deps.setAgentSortOrder(pluginConfig.agent_order)
 
-    if (pluginConfig.openclaw) {
-      await deps.initializeOpenClaw(pluginConfig.openclaw)
-    }
-    if (pluginConfig.team_mode?.enabled) {
-      const teamModeConfig = pluginConfig.team_mode
-      try {
-        const { ensureBaseDirs, resolveBaseDir } = await import("../features/team-mode/team-registry/paths")
-        const { checkTeamModeDependencies } = await import("../features/team-mode/deps")
-        await checkTeamModeDependencies(teamModeConfig)
-        await ensureBaseDirs(resolveBaseDir(teamModeConfig))
-        if (pluginConfig.disabled_skills?.includes("team-mode")) {
-          console.warn(
-            "[team-mode] enabled=true but team-mode skill is disabled; skill docs hidden but tools still registered (D-29)",
-          )
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          console.warn("[team-mode] init failed:", error)
-        } else {
-          console.warn("[team-mode] init failed:", String(error))
+    let openClawStarted = false
+    try {
+      if (pluginConfig.openclaw) {
+        openClawStarted = await deps.initializeOpenClaw(pluginConfig.openclaw)
+      }
+
+      if (pluginConfig.team_mode?.enabled) {
+        const teamModeConfig = pluginConfig.team_mode
+        try {
+          const { ensureBaseDirs, resolveBaseDir } = await import("../features/team-mode/team-registry/paths")
+          const { checkTeamModeDependencies } = await import("../features/team-mode/deps")
+          await checkTeamModeDependencies(teamModeConfig)
+          await ensureBaseDirs(resolveBaseDir(teamModeConfig))
+          if (pluginConfig.disabled_skills?.includes("team-mode")) {
+            console.warn(
+              "[team-mode] enabled=true but team-mode skill is disabled; skill docs hidden but tools still registered (D-29)",
+            )
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            console.warn("[team-mode] init failed:", error)
+          } else {
+            console.warn("[team-mode] init failed:", String(error))
+          }
         }
       }
+
+      const tmuxIntegrationEnabled = deps.isTmuxIntegrationEnabled(pluginConfig)
+      if (tmuxIntegrationEnabled) {
+        deps.startTmuxCheck()
+      }
+      const disabledHooks = new Set(pluginConfig.disabled_hooks ?? [])
+
+      const isHookEnabled = (hookName: HookName): boolean => !disabledHooks.has(hookName)
+      const safeHookEnabled = pluginConfig.experimental?.safe_hook_creation ?? true
+
+      const firstMessageVariantGate = deps.createFirstMessageVariantGate()
+
+      const tmuxConfig = deps.createRuntimeTmuxConfig(pluginConfig)
+
+      const modelCacheState = deps.createModelCacheState()
+
+      const managers = deps.createManagers({
+        ctx: input,
+        pluginConfig,
+        tmuxConfig,
+        modelCacheState,
+        backgroundNotificationHookEnabled: isHookEnabled("background-notification"),
+        runtimeSkillSourceUrl: runtimeSkillSource?.url,
+      })
+
+      const toolsResult = await deps.createTools({
+        ctx: input,
+        pluginConfig,
+        managers,
+      })
+
+      const hooks = deps.createHooks({
+        ctx: input,
+        pluginConfig,
+        modelCacheState,
+        backgroundManager: managers.backgroundManager,
+        modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
+        monitorManager: managers.monitorManager,
+        isHookEnabled,
+        safeHookEnabled,
+        mergedSkills: toolsResult.mergedSkills,
+        availableSkills: toolsResult.availableSkills,
+      })
+
+      const pluginInterface = deps.createPluginInterface({
+        ctx: input,
+        pluginConfig,
+        firstMessageVariantGate,
+        managers,
+        hooks,
+        tools: toolsResult.filteredTools,
+      })
+
+      const dispose = createPluginDispose({
+        backgroundManager: managers.backgroundManager,
+        skillMcpManager: managers.skillMcpManager,
+        disposeHooks: hooks.disposeHooks,
+        disposeOpenClaw: openClawStarted
+          ? async () => {
+              const result = await deps.stopReplyListener()
+              if (!result.success) {
+                deps.log("[OhMyOpenCodePlugin] stopReplyListener() failed during dispose", result)
+              }
+            }
+          : undefined,
+      })
+
+      const pluginHooks: HooksWithRuntimeLifecycle = {
+        ...pluginInterface,
+
+        "experimental.session.compacting": createSessionCompactingHandler(hooks),
+
+        "experimental.compaction.autocontinue": createCompactionAutocontinueHandler(hooks),
+
+        dispose: async (): Promise<void> => {
+          runtimeSkillSource?.stop()
+          await dispose()
+        },
+      }
+
+      return pluginHooks
+    } catch (error) {
+      if (openClawStarted) {
+        try {
+          const result = await deps.stopReplyListener()
+          if (!result.success) {
+            deps.log("[OhMyOpenCodePlugin] stopReplyListener() failed after startup failure", result)
+          }
+        } catch (stopError) {
+          deps.log("[OhMyOpenCodePlugin] stopReplyListener() error after startup failure", stopError)
+        }
+      }
+      throw error
     }
-    const tmuxIntegrationEnabled = deps.isTmuxIntegrationEnabled(pluginConfig)
-    if (tmuxIntegrationEnabled) {
-      deps.startTmuxCheck()
-    }
-    const disabledHooks = new Set(pluginConfig.disabled_hooks ?? [])
-
-    const isHookEnabled = (hookName: HookName): boolean => !disabledHooks.has(hookName)
-    const safeHookEnabled = pluginConfig.experimental?.safe_hook_creation ?? true
-
-    const firstMessageVariantGate = deps.createFirstMessageVariantGate()
-
-    const tmuxConfig = deps.createRuntimeTmuxConfig(pluginConfig)
-
-    const modelCacheState = deps.createModelCacheState()
-
-    const managers = deps.createManagers({
-      ctx: input,
-      pluginConfig,
-      tmuxConfig,
-      modelCacheState,
-      backgroundNotificationHookEnabled: isHookEnabled("background-notification"),
-      runtimeSkillSourceUrl: runtimeSkillSource?.url,
-    })
-
-    const toolsResult = await deps.createTools({
-      ctx: input,
-      pluginConfig,
-      managers,
-    })
-
-    const hooks = deps.createHooks({
-      ctx: input,
-      pluginConfig,
-      modelCacheState,
-      backgroundManager: managers.backgroundManager,
-      modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
-      monitorManager: managers.monitorManager,
-      isHookEnabled,
-      safeHookEnabled,
-      mergedSkills: toolsResult.mergedSkills,
-      availableSkills: toolsResult.availableSkills,
-    })
-
-    const pluginInterface = deps.createPluginInterface({
-      ctx: input,
-      pluginConfig,
-      firstMessageVariantGate,
-      managers,
-      hooks,
-      tools: toolsResult.filteredTools,
-    })
-
-    const dispose = createPluginDispose({
-      backgroundManager: managers.backgroundManager,
-      skillMcpManager: managers.skillMcpManager,
-      disposeHooks: hooks.disposeHooks,
-    })
-
-    const pluginHooks: HooksWithRuntimeLifecycle = {
-      ...pluginInterface,
-
-      "experimental.session.compacting": createSessionCompactingHandler(hooks),
-
-      "experimental.compaction.autocontinue": createCompactionAutocontinueHandler(hooks),
-
-      dispose: async (): Promise<void> => {
-        runtimeSkillSource?.stop()
-        await dispose()
-      },
-    }
-
-    return pluginHooks
   }
 
   return {

--- a/packages/openclaw-core/src/__tests__/runtime-dispatch.test.ts
+++ b/packages/openclaw-core/src/__tests__/runtime-dispatch.test.ts
@@ -36,7 +36,11 @@ describe("dispatchOpenClawEvent", () => {
       context: { sessionId: "ses-1", projectPath: "/tmp/project", tmuxPaneId: "%1", tmuxSession: "main" },
     })
 
-    expect(wakeSpy.mock.calls.map((call) => call[1])).toEqual(["session.created", "session-start"])
+    const wakeCalls = wakeSpy.mock.calls as Array<[unknown, string, { sessionId?: string }]>
+    const eventsForSession = wakeCalls
+      .filter((call) => call[2]?.sessionId === "ses-1")
+      .map((call) => call[1])
+    expect(eventsForSession).toEqual(["session.created", "session-start"])
   })
 
   test("registers reply correlation when wake returns outbound metadata", async () => {

--- a/packages/openclaw-core/src/index.ts
+++ b/packages/openclaw-core/src/index.ts
@@ -129,17 +129,18 @@ export async function wakeOpenClaw(
   }
 }
 
-export async function initializeOpenClaw(config: OpenClawConfig): Promise<void> {
+export async function initializeOpenClaw(config: OpenClawConfig): Promise<boolean> {
   const hasReplyListenerCredentials = Boolean(
     config.replyListener?.discordBotToken || config.replyListener?.telegramBotToken,
   )
 
   if (config.enabled && hasReplyListenerCredentials) {
-    await startReplyListener(config)
-    return
+    const result = await startReplyListener(config)
+    return result.success && result.started
   }
 
   await stopReplyListener()
+  return false
 }
 
 export { startReplyListener, stopReplyListener }

--- a/packages/openclaw-core/src/reply-listener-start.ts
+++ b/packages/openclaw-core/src/reply-listener-start.ts
@@ -42,10 +42,11 @@ function getNormalizedReplyListenerConfig(config: OpenClawConfig): OpenClawConfi
 function createStartFailureResult(
   message: string,
   state: ReplyListenerDaemonState,
-): { success: false; message: string; state: ReplyListenerDaemonState } {
+): { success: false; message: string; started: false; state: ReplyListenerDaemonState } {
   return {
     success: false,
     message,
+    started: false,
     state,
   }
 }
@@ -59,13 +60,20 @@ export function resolveReplyListenerDaemonScript(currentFileUrl: string): string
 
 export async function startReplyListener(
   config: OpenClawConfig,
-): Promise<{ success: boolean; message: string; state?: ReplyListenerDaemonState; error?: string }> {
+): Promise<{
+  success: boolean
+  message: string
+  started: boolean
+  state?: ReplyListenerDaemonState
+  error?: string
+}> {
   const normalizedConfig = getNormalizedReplyListenerConfig(config)
   const replyListener = normalizedConfig.replyListener
   if (!replyListener?.discordBotToken && !replyListener?.telegramBotToken) {
     return {
       success: false,
       message: "No enabled reply listener platforms configured (missing bot tokens/channels)",
+      started: false,
     }
   }
 
@@ -77,6 +85,7 @@ export async function startReplyListener(
       return {
         success: true,
         message: "Reply listener daemon is already running",
+        started: false,
         state: state || undefined,
       }
     }
@@ -86,6 +95,7 @@ export async function startReplyListener(
       return {
         success: false,
         message: "Failed to restart reply listener daemon",
+        started: false,
         state: stopResult.state,
         error: stopResult.error ?? stopResult.message,
       }
@@ -98,6 +108,7 @@ export async function startReplyListener(
       return {
         success: false,
         message: "Timed out waiting for reply listener daemon to stop before restart",
+        started: false,
         state: readReplyListenerDaemonState() || undefined,
       }
     }
@@ -107,6 +118,7 @@ export async function startReplyListener(
     return {
       success: false,
       message: "tmux not available - reply injection requires tmux",
+      started: false,
     }
   }
 
@@ -160,6 +172,7 @@ export async function startReplyListener(
     return {
       success: true,
       message: `Reply listener daemon started with PID ${processInfo.pid}`,
+      started: true,
       state: readyState,
     }
   } catch (error) {
@@ -172,6 +185,7 @@ export async function startReplyListener(
     return {
       success: false,
       message: "Failed to start daemon",
+      started: false,
       state: stoppedState,
       error: error instanceof Error ? error.message : String(error),
     }

--- a/packages/team-core/src/team-state-store/locks.ts
+++ b/packages/team-core/src/team-state-store/locks.ts
@@ -50,6 +50,7 @@ async function pathExists(path: string): Promise<boolean> {
     return true
   } catch (error) {
     if (!(error instanceof Error)) throw error
+    if (errorCode(error) === "EPERM") return true
     return false
   }
 }


### PR DESCRIPTION
## Summary
- suppress OpenClaw `stop` notifications while descendant background tasks are still pending or running
- delay `stop` until parent-session background completion notifications have drained so the final reminder can land first
- add regression coverage for the event stop gate and background notification settlement helper

## Changes
- add `BackgroundManager.hasPendingParentNotificationWork()` to detect buffered or queued parent notification work
- update `createEventHandler()` stop gating to inspect descendant background tasks and unsettled parent notification work before calling `wakeOpenClaw(..., \"stop\")`
- add tests in `src/plugin/event.openclaw.test.ts` and `src/features/background-agent/manager.test.ts`

## Testing
- `bun run typecheck`
- `bun run build`
- `bun test src/plugin/event.openclaw.test.ts`
- `bun test src/features/background-agent/manager.test.ts -t "hasPendingParentNotificationWork"`
- Note: `bun test src/features/background-agent/manager.test.ts` still has a pre-existing unrelated failure in `BackgroundManager process cleanup > should remove listeners after last shutdown`

## Related Issues
- None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers OpenClaw stop (“session.idle”) until descendant background tasks and parent notifications settle, then auto-retries. Adds safe reply-listener ownership on startup/disposal to prevent orphaned daemons; also treats Windows EPERM as lock contention.

- **Bug Fixes**
  - Suppress “stop” in `createEventHandler()` while descendant tasks run or `BackgroundManager.hasPendingParentNotificationWork()` is true; auto-retry via `setOnParentNotificationWorkSettled()`.
  - Clear deferred stops on non-idle events (`info.sessionID`/`info.id`) and on session deletion; preserve idle dispatch contract; ignore subagent idles.
  - Safely stop reply listener on startup failure only if started by this instance; stop on dispose only when owned by this instance.
  - Treat Windows `EPERM` in `team-core` lock checks as contention to avoid false errors.

- **New Features**
  - Add `BackgroundManager.hasPendingParentNotificationWork()` and `setOnParentNotificationWorkSettled()`; track buffered/queued notifications and queued/dispatched parent wakes; emit settlement callbacks when clear.
  - Update `initializeOpenClaw()` and `startReplyListener()` to return a `started` flag; wire `stopReplyListener()` into plugin startup failure and disposal via `createPluginDispose()`.

<sup>Written for commit 81f0135671ec84397b1d0298a6e4d42e7878806b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

