### PR TITLE
fix: wire OpenClaw runtime lifecycle

### DIFF
--- a/packages/omo-opencode/src/index.openclaw.test.ts
+++ b/packages/omo-opencode/src/index.openclaw.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { createPluginModule } from "./testing/create-plugin-module"
+
+const mockCreateTools = mock(async () => {
+  throw new Error("createTools failed")
+})
+const mockInitializeOpenClaw = mock(async () => true)
+const mockStopReplyListener = mock(async () => ({ success: true, message: "stopped" }))
+const mockLog = mock(() => {})
+
+function createTestPluginModule(): ReturnType<typeof createPluginModule> {
+  return createPluginModule({
+    initConfigContext: mock(() => {}),
+    installAgentSortShim: mock(() => {}),
+    setAgentSortOrder: mock(() => {}),
+    log: mockLog,
+    logLegacyPluginStartupWarning: mock(() => {}),
+    migrateLegacyWorkspaceDirectory: mock(() => ({ migrated: false, skipped: [] })),
+    detectDuplicateOmoPlugin: mock(() => ({
+      detected: false,
+      pluginName: null,
+      duplicatePlugins: [],
+      allPlugins: [],
+    })),
+    getDuplicateOmoPluginWarning: mock(() => ""),
+    detectExternalSkillPlugin: mock(() => ({ detected: false, pluginName: null, allPlugins: [] })),
+    getSkillPluginConflictWarning: mock(() => ""),
+    injectServerAuthIntoClient: mock(() => {}),
+    initLiveServerRoute: mock(() => {}),
+    setLiveParentWakeRoutingDisabled: mock(() => {}),
+    warmLiveServerProbe: mock(() => {}),
+    loadPluginConfig: mock(() => ({
+      tui: { sidebar: { enabled: false } },
+      openclaw: {
+        enabled: true,
+        gateways: {},
+        hooks: {},
+        replyListener: { telegramBotToken: "token" },
+      },
+      disabled_hooks: [],
+      experimental: {},
+    })) as never,
+    initI18n: mock(() => {}),
+    initializeOpenClaw: mockInitializeOpenClaw as never,
+    stopReplyListener: mockStopReplyListener as never,
+    isTmuxIntegrationEnabled: mock(() => false),
+    startTmuxCheck: mock(() => {}),
+    createFirstMessageVariantGate: mock(() => ({
+      shouldOverride: () => false,
+      markApplied: () => {},
+      markSessionCreated: () => {},
+      clear: () => {},
+    })),
+    createRuntimeTmuxConfig: mock(() => ({
+      enabled: false,
+      layout: "tiled",
+      main_pane_size: 60,
+      main_pane_min_width: 80,
+      agent_pane_min_width: 40,
+      isolation: "inline",
+    })) as never,
+    createModelCacheState: mock(() => ({})) as never,
+    createManagers: mock(() => ({
+      backgroundManager: { shutdown: async () => {} },
+      skillMcpManager: { disconnectAll: async () => {} },
+      configHandler: async () => {},
+    })) as never,
+    createTools: mockCreateTools as never,
+    createRuntimeSkillSourceServer: mock(() => ({
+      url: "http://127.0.0.1:49152/runtime-skills",
+      stop: mock(() => {}),
+    })) as never,
+    createHooks: mock(() => ({
+      disposeHooks: () => {},
+      compactionContextInjector: undefined,
+      compactionTodoPreserver: undefined,
+      claudeCodeHooks: undefined,
+    })) as never,
+    createPluginInterface: mock(() => ({})) as never,
+  })
+}
+
+describe("createPluginModule OpenClaw startup cleanup", () => {
+  beforeEach(() => {
+    mockCreateTools.mockClear()
+    mockInitializeOpenClaw.mockClear()
+    mockStopReplyListener.mockClear()
+    mockLog.mockClear()
+  })
+
+  it("stops the reply listener when startup fails after this instance started it", async () => {
+    mockInitializeOpenClaw.mockImplementation(async () => true)
+    const pluginModule = createTestPluginModule()
+
+    await expect(
+      pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0]),
+    ).rejects.toThrow("createTools failed")
+
+    expect(mockInitializeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(mockStopReplyListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not stop a reply listener that was not started by this instance", async () => {
+    mockInitializeOpenClaw.mockImplementation(async () => false)
+    const pluginModule = createTestPluginModule()
+
+    await expect(
+      pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0]),
+    ).rejects.toThrow("createTools failed")
+
+    expect(mockInitializeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(mockStopReplyListener).not.toHaveBeenCalled()
+  })
+})

--- a/packages/omo-opencode/src/plugin-dispose.openclaw.test.ts
+++ b/packages/omo-opencode/src/plugin-dispose.openclaw.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, mock } from "bun:test"
+
+const { createPluginDispose } = await import("./plugin-dispose")
+
+describe("createPluginDispose OpenClaw wiring", () => {
+  it("stops the reply listener during disposal", async () => {
+    const shutdown = mock(async () => {})
+    const disconnectAll = mock(async () => {})
+    const disposeHooks = mock(() => {})
+    const disposeOpenClaw = mock(async () => {})
+
+    const dispose = createPluginDispose({
+      backgroundManager: { shutdown },
+      skillMcpManager: { disconnectAll },
+      disposeHooks,
+      disposeOpenClaw,
+    })
+
+    await dispose()
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(disconnectAll).toHaveBeenCalledTimes(1)
+    expect(disposeOpenClaw).toHaveBeenCalledTimes(1)
+    expect(disposeHooks).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips OpenClaw disposal when no listener was started by this instance", async () => {
+    const shutdown = mock(async () => {})
+    const disconnectAll = mock(async () => {})
+    const disposeHooks = mock(() => {})
+
+    const dispose = createPluginDispose({
+      backgroundManager: { shutdown },
+      skillMcpManager: { disconnectAll },
+      disposeHooks,
+    })
+
+    await dispose()
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+    expect(disconnectAll).toHaveBeenCalledTimes(1)
+    expect(disposeHooks).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/omo-opencode/src/plugin-dispose.ts
+++ b/packages/omo-opencode/src/plugin-dispose.ts
@@ -10,8 +10,9 @@ export function createPluginDispose(args: {
     disconnectAll: () => Promise<void>
   }
   disposeHooks: () => void
+  disposeOpenClaw?: () => Promise<void>
 }): PluginDispose {
-  const { backgroundManager, skillMcpManager, disposeHooks } = args
+  const { backgroundManager, skillMcpManager, disposeHooks, disposeOpenClaw } = args
   let disposePromise: Promise<void> | null = null
 
   return async (): Promise<void> => {
@@ -30,6 +31,11 @@ export function createPluginDispose(args: {
         await skillMcpManager.disconnectAll()
       } catch (error) {
         log("[plugin-dispose] skillMcpManager.disconnectAll() error:", error)
+      }
+      try {
+        await disposeOpenClaw?.()
+      } catch (error) {
+        log("[plugin-dispose] disposeOpenClaw() error:", error)
       }
       try {
         disposeHooks()

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -8,7 +8,7 @@ import { createManagers } from "../create-managers"
 import { createRuntimeTmuxConfig, isTmuxIntegrationEnabled } from "../create-runtime-tmux-config"
 import { createTools } from "../create-tools"
 import { createRuntimeSkillSourceServer, selectRuntimeSecuritySkills } from "../features/opencode-runtime-skills"
-import { initializeOpenClaw } from "../openclaw"
+import { initializeOpenClaw, stopReplyListener } from "../openclaw"
 import { createPluginDispose } from "../plugin-dispose"
 import { createPluginInterface } from "../plugin-interface"
 import { loadPluginConfig } from "../plugin-config"
@@ -61,6 +61,7 @@ export type PluginModuleDeps = {
   loadPluginConfig: typeof loadPluginConfig
   initI18n: typeof initI18n
   initializeOpenClaw: typeof initializeOpenClaw
+  stopReplyListener: typeof stopReplyListener
   isTmuxIntegrationEnabled: typeof isTmuxIntegrationEnabled
   startTmuxCheck: typeof startTmuxCheck
   createFirstMessageVariantGate: typeof createFirstMessageVariantGate
@@ -91,6 +92,7 @@ const defaultPluginModuleDeps: PluginModuleDeps = {
   loadPluginConfig,
   initI18n,
   initializeOpenClaw,
+  stopReplyListener,
   isTmuxIntegrationEnabled,
   startTmuxCheck,
   createFirstMessageVariantGate,
@@ -153,101 +155,126 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     deps.initI18n(pluginConfig.i18n?.locale ? { locale: pluginConfig.i18n.locale } : undefined)
     deps.setAgentSortOrder(pluginConfig.agent_order)
 
-    if (pluginConfig.openclaw) {
-      await deps.initializeOpenClaw(pluginConfig.openclaw)
-    }
-    if (pluginConfig.team_mode?.enabled) {
-      const teamModeConfig = pluginConfig.team_mode
-      try {
-        const { ensureBaseDirs, resolveBaseDir } = await import("../features/team-mode/team-registry/paths")
-        const { checkTeamModeDependencies } = await import("../features/team-mode/deps")
-        await checkTeamModeDependencies(teamModeConfig)
-        await ensureBaseDirs(resolveBaseDir(teamModeConfig))
-        if (pluginConfig.disabled_skills?.includes("team-mode")) {
-          console.warn(
-            "[team-mode] enabled=true but team-mode skill is disabled; skill docs hidden but tools still registered (D-29)",
-          )
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          console.warn("[team-mode] init failed:", error)
-        } else {
-          console.warn("[team-mode] init failed:", String(error))
+    let openClawStarted = false
+    try {
+      if (pluginConfig.openclaw) {
+        openClawStarted = await deps.initializeOpenClaw(pluginConfig.openclaw)
+      }
+
+      if (pluginConfig.team_mode?.enabled) {
+        const teamModeConfig = pluginConfig.team_mode
+        try {
+          const { ensureBaseDirs, resolveBaseDir } = await import("../features/team-mode/team-registry/paths")
+          const { checkTeamModeDependencies } = await import("../features/team-mode/deps")
+          await checkTeamModeDependencies(teamModeConfig)
+          await ensureBaseDirs(resolveBaseDir(teamModeConfig))
+          if (pluginConfig.disabled_skills?.includes("team-mode")) {
+            console.warn(
+              "[team-mode] enabled=true but team-mode skill is disabled; skill docs hidden but tools still registered (D-29)",
+            )
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            console.warn("[team-mode] init failed:", error)
+          } else {
+            console.warn("[team-mode] init failed:", String(error))
+          }
         }
       }
+
+      const tmuxIntegrationEnabled = deps.isTmuxIntegrationEnabled(pluginConfig)
+      if (tmuxIntegrationEnabled) {
+        deps.startTmuxCheck()
+      }
+      const disabledHooks = new Set(pluginConfig.disabled_hooks ?? [])
+
+      const isHookEnabled = (hookName: HookName): boolean => !disabledHooks.has(hookName)
+      const safeHookEnabled = pluginConfig.experimental?.safe_hook_creation ?? true
+
+      const firstMessageVariantGate = deps.createFirstMessageVariantGate()
+
+      const tmuxConfig = deps.createRuntimeTmuxConfig(pluginConfig)
+
+      const modelCacheState = deps.createModelCacheState()
+
+      const managers = deps.createManagers({
+        ctx: input,
+        pluginConfig,
+        tmuxConfig,
+        modelCacheState,
+        backgroundNotificationHookEnabled: isHookEnabled("background-notification"),
+        runtimeSkillSourceUrl: runtimeSkillSource?.url,
+      })
+
+      const toolsResult = await deps.createTools({
+        ctx: input,
+        pluginConfig,
+        managers,
+      })
+
+      const hooks = deps.createHooks({
+        ctx: input,
+        pluginConfig,
+        modelCacheState,
+        backgroundManager: managers.backgroundManager,
+        modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
+        monitorManager: managers.monitorManager,
+        isHookEnabled,
+        safeHookEnabled,
+        mergedSkills: toolsResult.mergedSkills,
+        availableSkills: toolsResult.availableSkills,
+      })
+
+      const pluginInterface = deps.createPluginInterface({
+        ctx: input,
+        pluginConfig,
+        firstMessageVariantGate,
+        managers,
+        hooks,
+        tools: toolsResult.filteredTools,
+      })
+
+      const dispose = createPluginDispose({
+        backgroundManager: managers.backgroundManager,
+        skillMcpManager: managers.skillMcpManager,
+        disposeHooks: hooks.disposeHooks,
+        disposeOpenClaw: openClawStarted
+          ? async () => {
+              const result = await deps.stopReplyListener()
+              if (!result.success) {
+                deps.log("[OhMyOpenCodePlugin] stopReplyListener() failed during dispose", result)
+              }
+            }
+          : undefined,
+      })
+
+      const pluginHooks: HooksWithRuntimeLifecycle = {
+        ...pluginInterface,
+
+        "experimental.session.compacting": createSessionCompactingHandler(hooks),
+
+        "experimental.compaction.autocontinue": createCompactionAutocontinueHandler(hooks),
+
+        dispose: async (): Promise<void> => {
+          runtimeSkillSource?.stop()
+          await dispose()
+        },
+      }
+
+      return pluginHooks
+    } catch (error) {
+      if (openClawStarted) {
+        try {
+          const result = await deps.stopReplyListener()
+          if (!result.success) {
+            deps.log("[OhMyOpenCodePlugin] stopReplyListener() failed after startup failure", result)
+          }
+        } catch (stopError) {
+          deps.log("[OhMyOpenCodePlugin] stopReplyListener() error after startup failure", stopError)
+        }
+      }
+      throw error
     }
-    const tmuxIntegrationEnabled = deps.isTmuxIntegrationEnabled(pluginConfig)
-    if (tmuxIntegrationEnabled) {
-      deps.startTmuxCheck()
-    }
-    const disabledHooks = new Set(pluginConfig.disabled_hooks ?? [])
-
-    const isHookEnabled = (hookName: HookName): boolean => !disabledHooks.has(hookName)
-    const safeHookEnabled = pluginConfig.experimental?.safe_hook_creation ?? true
-
-    const firstMessageVariantGate = deps.createFirstMessageVariantGate()
-
-    const tmuxConfig = deps.createRuntimeTmuxConfig(pluginConfig)
-
-    const modelCacheState = deps.createModelCacheState()
-
-    const managers = deps.createManagers({
-      ctx: input,
-      pluginConfig,
-      tmuxConfig,
-      modelCacheState,
-      backgroundNotificationHookEnabled: isHookEnabled("background-notification"),
-      runtimeSkillSourceUrl: runtimeSkillSource?.url,
-    })
-
-    const toolsResult = await deps.createTools({
-      ctx: input,
-      pluginConfig,
-      managers,
-    })
-
-    const hooks = deps.createHooks({
-      ctx: input,
-      pluginConfig,
-      modelCacheState,
-      backgroundManager: managers.backgroundManager,
-      modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
-      monitorManager: managers.monitorManager,
-      isHookEnabled,
-      safeHookEnabled,
-      mergedSkills: toolsResult.mergedSkills,
-      availableSkills: toolsResult.availableSkills,
-    })
-
-    const pluginInterface = deps.createPluginInterface({
-      ctx: input,
-      pluginConfig,
-      firstMessageVariantGate,
-      managers,
-      hooks,
-      tools: toolsResult.filteredTools,
-    })
-
-    const dispose = createPluginDispose({
-      backgroundManager: managers.backgroundManager,
-      skillMcpManager: managers.skillMcpManager,
-      disposeHooks: hooks.disposeHooks,
-    })
-
-    const pluginHooks: HooksWithRuntimeLifecycle = {
-      ...pluginInterface,
-
-      "experimental.session.compacting": createSessionCompactingHandler(hooks),
-
-      "experimental.compaction.autocontinue": createCompactionAutocontinueHandler(hooks),
-
-      dispose: async (): Promise<void> => {
-        runtimeSkillSource?.stop()
-        await dispose()
-      },
-    }
-
-    return pluginHooks
   }
 
   return {

--- a/packages/openclaw-core/src/index.ts
+++ b/packages/openclaw-core/src/index.ts
@@ -129,17 +129,18 @@ export async function wakeOpenClaw(
   }
 }
 
-export async function initializeOpenClaw(config: OpenClawConfig): Promise<void> {
+export async function initializeOpenClaw(config: OpenClawConfig): Promise<boolean> {
   const hasReplyListenerCredentials = Boolean(
     config.replyListener?.discordBotToken || config.replyListener?.telegramBotToken,
   )
 
   if (config.enabled && hasReplyListenerCredentials) {
-    await startReplyListener(config)
-    return
+    const result = await startReplyListener(config)
+    return result.success && result.started
   }
 
   await stopReplyListener()
+  return false
 }
 
 export { startReplyListener, stopReplyListener }

--- a/packages/openclaw-core/src/reply-listener-start.ts
+++ b/packages/openclaw-core/src/reply-listener-start.ts
@@ -42,10 +42,11 @@ function getNormalizedReplyListenerConfig(config: OpenClawConfig): OpenClawConfi
 function createStartFailureResult(
   message: string,
   state: ReplyListenerDaemonState,
-): { success: false; message: string; state: ReplyListenerDaemonState } {
+): { success: false; message: string; started: false; state: ReplyListenerDaemonState } {
   return {
     success: false,
     message,
+    started: false,
     state,
   }
 }
@@ -59,13 +60,20 @@ export function resolveReplyListenerDaemonScript(currentFileUrl: string): string
 
 export async function startReplyListener(
   config: OpenClawConfig,
-): Promise<{ success: boolean; message: string; state?: ReplyListenerDaemonState; error?: string }> {
+): Promise<{
+  success: boolean
+  message: string
+  started: boolean
+  state?: ReplyListenerDaemonState
+  error?: string
+}> {
   const normalizedConfig = getNormalizedReplyListenerConfig(config)
   const replyListener = normalizedConfig.replyListener
   if (!replyListener?.discordBotToken && !replyListener?.telegramBotToken) {
     return {
       success: false,
       message: "No enabled reply listener platforms configured (missing bot tokens/channels)",
+      started: false,
     }
   }
 
@@ -77,6 +85,7 @@ export async function startReplyListener(
       return {
         success: true,
         message: "Reply listener daemon is already running",
+        started: false,
         state: state || undefined,
       }
     }
@@ -86,6 +95,7 @@ export async function startReplyListener(
       return {
         success: false,
         message: "Failed to restart reply listener daemon",
+        started: false,
         state: stopResult.state,
         error: stopResult.error ?? stopResult.message,
       }
@@ -98,6 +108,7 @@ export async function startReplyListener(
       return {
         success: false,
         message: "Timed out waiting for reply listener daemon to stop before restart",
+        started: false,
         state: readReplyListenerDaemonState() || undefined,
       }
     }
@@ -107,6 +118,7 @@ export async function startReplyListener(
     return {
       success: false,
       message: "tmux not available - reply injection requires tmux",
+      started: false,
     }
   }
 
@@ -160,6 +172,7 @@ export async function startReplyListener(
     return {
       success: true,
       message: `Reply listener daemon started with PID ${processInfo.pid}`,
+      started: true,
       state: readyState,
     }
   } catch (error) {
@@ -172,6 +185,7 @@ export async function startReplyListener(
     return {
       success: false,
       message: "Failed to start daemon",
+      started: false,
       state: stoppedState,
       error: error instanceof Error ? error.message : String(error),
     }


### PR DESCRIPTION
## Summary
- wire OpenClaw startup into plugin bootstrap and route lifecycle events through the runtime event pipeline
- stop reply listeners only when this plugin instance actually started them, including startup-failure cleanup
- add regression coverage for startup cleanup, dispose ownership, and event-name/session-id mapping

## Testing
- `bun test src/index.openclaw.test.ts src/plugin-dispose.test.ts src/plugin-dispose.openclaw.test.ts src/plugin/event.openclaw.test.ts`
- `bun run typecheck`
- `bun run build`
- manual QA: `HOME=/tmp/omo-openclaw-home opencode run "say hi" --agent sisyphus --print-logs` recreated fresh `reply-listener-{config,state,log,pid}` files under `/tmp/omo-openclaw-home/.omx/state`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the OpenClaw runtime into plugin startup and disposal with ownership-aware reply listener management and failure-safe cleanup. Prevents orphaned listeners and ensures lifecycle events reach OpenClaw.

- **New Features**
  - Start the reply listener during bootstrap when OpenClaw is enabled and bot tokens are present; otherwise ensure it is stopped.
  - Dispatch plugin lifecycle events to OpenClaw via `wakeOpenClaw`, including a `session.deleted` → `session-end` alias.
  - Extract session IDs from event payloads (`sessionID`, `info.id`, or `info.sessionID`).

- **Bug Fixes**
  - Track listener ownership: `initializeOpenClaw` returns whether this instance started the listener; `startReplyListener` reports a `started` flag across all paths.
  - Stop the listener on dispose only if this instance started it, via an optional `disposeOpenClaw` hook that calls `stopReplyListener`.
  - On startup failures after initialization, stop the listener if we started it.

<sup>Written for commit 3c02e7f3a1be78f0e536dbf4ec10f99f7b8bff12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

