### PR TITLE
fix(notification): use concrete task IDs in all-complete notification

### DIFF
--- a/src/features/background-agent/background-task-notification-template.test.ts
+++ b/src/features/background-agent/background-task-notification-template.test.ts
@@ -118,7 +118,7 @@ Use \`background_output(task_id="task-2")\` to retrieve this result when ready.
 - \`task-2\`: Summarize logs [CANCELLED] - User aborted
 - \`task-3\`: Fallback task [ERROR] - Denied
 
-Use \`background_output(task_id="<id>")\` to retrieve each result.
+Use background_output(task_id="task-1"), background_output(task_id="task-2"), background_output(task_id="task-3") to retrieve each result.
 
 **ACTION REQUIRED:** 2 task(s) failed. Check errors above and decide whether to retry or proceed.
 </system-reminder>`

--- a/src/features/background-agent/background-task-notification-template.ts
+++ b/src/features/background-agent/background-task-notification-template.ts
@@ -49,12 +49,16 @@ export function buildBackgroundTaskNotificationText(input: {
       body = `- \`${task.id}\`: ${safeDescription(task)} [${task.status.toUpperCase()}]${task.error ? ` - ${task.error}` : ""}\n`
     }
 
+    const outputCalls = completedTasks
+      .map((t) => `background_output(task_id="${t.id}")`)
+      .join(", ")
+
     return `<system-reminder>
 ${header}
 
 ${body.trim()}
 
-Use \`background_output(task_id="<id>")\` to retrieve each result.${hasFailures ? `\n\n**ACTION REQUIRED:** ${failedTasks.length} task(s) failed. Check errors above and decide whether to retry or proceed.` : ""}
+Use ${outputCalls} to retrieve each result.${hasFailures ? `\n\n**ACTION REQUIRED:** ${failedTasks.length} task(s) failed. Check errors above and decide whether to retry or proceed.` : ""}
 </system-reminder>`
   }
 


### PR DESCRIPTION
## Problem

When all background tasks complete, the notification message contained a generic placeholder:

```
Use `background_output(task_id="<id>")` to retrieve each result.
```

Some models (e.g. kimi/k2p5) failed to infer which actual task ID to substitute for `<id>`, and generated malformed JSON tool calls — resulting in `JSON Parse error: Unterminated string`.

## Fix

Replace the placeholder with explicit `background_output()` calls for each completed task:

```
Use background_output(task_id="bg_005e706a"), background_output(task_id="bg_6088b1e4") to retrieve each result.
```

This makes the correct task IDs unambiguous for all models.

## Test

Updated snapshot in `background-task-notification-template.test.ts` to reflect the new format (5/5 passing).

---

> Co-authored-by: AI assistant (Claude)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `background_output(task_id="<id>")` placeholder in the background task completion notification with explicit calls for each completed task. This removes ambiguity and prevents malformed JSON tool calls from some models; updated the snapshot test.

<sup>Written for commit 451b2b42af072f125545e46c9e1b716c24850531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

