### PR TITLE
fix(git-master): add PowerShell compatibility for git_env_prefix (fix #3207)

### DIFF
--- a/src/features/opencode-skill-loader/git-master-template-injection.test.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.test.ts
@@ -219,16 +219,24 @@ describe("#given PowerShell env prefix conversion", () => {
 
 	describe("#when shell is Bash (SHELL env is unset)", () => {
 		it("#then keeps bash-format prefix unchanged", () => {
-			delete process.env.SHELL
-			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
-				commit_footer: false,
-				include_co_authored_by: false,
-				git_env_prefix: "GIT_MASTER=1",
-			})
+			const originalPlatform = process.platform
+			Object.defineProperty(process, "platform", { value: "linux" })
+			try {
+				delete process.env.SHELL
+				delete process.env.Shell
+				delete process.env.ComSpec
+				const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+					commit_footer: false,
+					include_co_authored_by: false,
+					git_env_prefix: "GIT_MASTER=1",
+				})
 
-			expect(result).toContain("GIT_MASTER=1 git status")
-			expect(result).toContain("GIT_MASTER=1 git commit")
-			expect(result).toContain("GIT_MASTER=1 git push")
+				expect(result).toContain("GIT_MASTER=1 git status")
+				expect(result).toContain("GIT_MASTER=1 git commit")
+				expect(result).toContain("GIT_MASTER=1 git push")
+			} finally {
+				Object.defineProperty(process, "platform", { value: originalPlatform })
+			}
 		})
 	})
 })

--- a/src/features/opencode-skill-loader/git-master-template-injection.test.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.test.ts
@@ -154,6 +154,85 @@ describe("#given git_env_prefix with commit footer", () => {
 	})
 })
 
+describe("#given PowerShell env prefix conversion", () => {
+	const originalShell: string | undefined = process.env.SHELL
+
+	afterEach(() => {
+		if (originalShell !== undefined) {
+			process.env.SHELL = originalShell
+		} else {
+			delete process.env.SHELL
+		}
+	})
+
+	describe("#when shell is PowerShell (SHELL env contains pwsh)", () => {
+		it("#then converts bash-format prefix to PowerShell $env: syntax", () => {
+			process.env.SHELL = "/usr/bin/pwsh"
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			expect(result).toContain("$env:GIT_MASTER='1' git status")
+			expect(result).toContain("$env:GIT_MASTER='1' git commit")
+			expect(result).toContain("$env:GIT_MASTER='1' git push")
+			expect(result).toContain("$env:GIT_MASTER='1' git add")
+		})
+
+		it("#then converts multi-var prefix to PowerShell format", () => {
+			process.env.SHELL = "/usr/bin/pwsh"
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "CI=true DEBIAN_FRONTEND=noninteractive",
+			})
+
+			expect(result).toContain("$env:CI='true'; $env:DEBIAN_FRONTEND='noninteractive' git status")
+			expect(result).not.toContain("CI=true DEBIAN_FRONTEND")
+		})
+
+		it("#then commit examples use PowerShell prefix", () => {
+			process.env.SHELL = "/usr/bin/pwsh"
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: true,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			expect(result).toContain("$env:GIT_MASTER='1' git commit")
+			expect(result).toContain("Ultraworked with [Sisyphus]")
+		})
+
+		it("#then does not double-convert already-converted prefix", () => {
+			process.env.SHELL = "/usr/bin/pwsh"
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			// Should not have double $env: prefixes
+			expect(result).not.toContain("$env:$env:")
+		})
+	})
+
+	describe("#when shell is Bash (SHELL env is unset)", () => {
+		it("#then keeps bash-format prefix unchanged", () => {
+			delete process.env.SHELL
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			expect(result).toContain("GIT_MASTER=1 git status")
+			expect(result).toContain("GIT_MASTER=1 git commit")
+			expect(result).toContain("GIT_MASTER=1 git push")
+		})
+	})
+})
+
 describe("#given idempotency of prefixGitCommandsInBashCodeBlocks", () => {
 	describe("#when git_env_prefix is provided and template already has prefixed commands in env prefix section", () => {
 		it("#then does NOT double-prefix the already-prefixed commands", () => {

--- a/src/features/opencode-skill-loader/git-master-template-injection.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.ts
@@ -23,16 +23,60 @@ export function detectShellType(): "bash" | "pwsh" {
 
 /** Convert a bash-format env prefix ("VAR=value VAR2=value2") to PowerShell format */
 function convertEnvPrefixForPwsh(bashPrefix: string): string {
-	return bashPrefix
-		.split(" ")
-		.map((assignment) => {
-			const eqIndex = assignment.indexOf("=")
-			if (eqIndex === -1) return assignment
-			const key = assignment.slice(0, eqIndex)
-			const value = assignment.slice(eqIndex + 1)
-			return `$env:${key}='${value}'`
-		})
-		.join("; ")
+	const result: string[] = []
+	let i = 0
+	while (i < bashPrefix.length) {
+		// Skip leading whitespace
+		while (i < bashPrefix.length && bashPrefix[i] === " ") i++
+		if (i >= bashPrefix.length) break
+
+		// Find the key name (up to '=')
+		const eqIndex = bashPrefix.indexOf("=", i)
+		if (eqIndex === -1) {
+			// No '=' found, append remaining as-is
+			result.push(bashPrefix.slice(i).replace(/\s+$/, ""))
+			break
+		}
+		const key = bashPrefix.slice(i, eqIndex)
+		i = eqIndex + 1
+
+		// Extract value (respecting quotes)
+		let value: string
+		if (bashPrefix[i] === '"') {
+			// Double-quoted: find closing "
+			const end = bashPrefix.indexOf('"', i + 1)
+			if (end === -1) {
+				value = bashPrefix.slice(i + 1)
+				i = bashPrefix.length
+			} else {
+				value = bashPrefix.slice(i + 1, end)
+				i = end + 1
+			}
+		} else if (bashPrefix[i] === "'") {
+			// Single-quoted: find closing '
+			const end = bashPrefix.indexOf("'", i + 1)
+			if (end === -1) {
+				value = bashPrefix.slice(i + 1)
+				i = bashPrefix.length
+			} else {
+				value = bashPrefix.slice(i + 1, end)
+				i = end + 1
+			}
+		} else {
+			// Unquoted: consume until next space
+			const end = bashPrefix.indexOf(" ", i)
+			if (end === -1) {
+				value = bashPrefix.slice(i)
+				i = bashPrefix.length
+			} else {
+				value = bashPrefix.slice(i, end)
+				i = end
+			}
+		}
+
+		result.push(`$env:${key}='${value}'`)
+	}
+	return result.join("; ")
 }
 
 export function getShellAwareEnvPrefix(bashPrefix: string): string {
@@ -42,13 +86,28 @@ export function getShellAwareEnvPrefix(bashPrefix: string): string {
 	return bashPrefix
 }
 
+/**
+ * Returns true if the given shell prefix is PowerShell format.
+ * Used to avoid injecting pwsh syntax into ```bash blocks.
+ */
+function isPwshPrefix(prefix: string): boolean {
+	return prefix.includes("$env:")
+}
+
 export function injectGitMasterConfig(template: string, config?: GitMasterConfig): string {
 	const commitFooter = config?.commit_footer ?? true
 	const includeCoAuthoredBy = config?.include_co_authored_by ?? true
 	const gitEnvPrefix = assertValidGitEnvPrefix(config?.git_env_prefix ?? "GIT_MASTER=1")
 	const shellPrefix = gitEnvPrefix ? getShellAwareEnvPrefix(gitEnvPrefix) : ""
+	// Bash code blocks should not get a PowerShell-prefix injection — it would
+	// mix syntaxes inside a ```bash block. Only prefix if the prefix format
+	// matches the code block language (or the block language is unspecified).
+	const codeBlockPrefix = isPwshPrefix(shellPrefix) ? "" : shellPrefix
 
-	let result = gitEnvPrefix ? injectGitEnvPrefix(template, shellPrefix) : template
+	// Determine the code block language for the injected env prefix section.
+	// PowerShell-prefixed commands belong in a ```pwsh block, not ```bash.
+	const codeBlockLang = isPwshPrefix(shellPrefix) ? "pwsh" : "bash"
+	let result = gitEnvPrefix ? injectGitEnvPrefix(template, shellPrefix, codeBlockLang) : template
 
 	if (commitFooter || includeCoAuthoredBy) {
 		const injection = buildCommitFooterInjection(commitFooter, includeCoAuthoredBy, shellPrefix)
@@ -64,10 +123,10 @@ export function injectGitMasterConfig(template: string, config?: GitMasterConfig
 				: result + "\n\n" + injection
 	}
 
-	return gitEnvPrefix ? prefixGitCommandsInBashCodeBlocks(result, shellPrefix) : result
+	return gitEnvPrefix ? prefixGitCommandsInBashCodeBlocks(result, codeBlockPrefix) : result
 }
 
-function injectGitEnvPrefix(template: string, prefix: string): string {
+function injectGitEnvPrefix(template: string, prefix: string, codeBlockLang: string): string {
 	const envPrefixSection = [
 		"## GIT COMMAND PREFIX (MANDATORY)",
 		"",
@@ -76,7 +135,7 @@ function injectGitEnvPrefix(template: string, prefix: string): string {
 		"",
 		"This allows custom git hooks to detect when git-master skill is active.",
 		"",
-		"```bash",
+		`\`\`\`${codeBlockLang}`,
 		`${prefix} git status`,
 		`${prefix} git add <files>`,
 		`${prefix} git commit -m "message"`,

--- a/src/features/opencode-skill-loader/git-master-template-injection.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.ts
@@ -4,15 +4,54 @@ const BASH_CODE_BLOCK_PATTERN = /```bash\r?\n([\s\S]*?)```/g
 const LEADING_GIT_COMMAND_PATTERN = /^([ \t]*(?:[A-Za-z_][A-Za-z0-9_]*=[^ \t]+\s+)*)git(?=[ \t]|$)/gm
 const INLINE_GIT_COMMAND_PATTERN = /([;&|()][ \t]*)git(?=[ \t]|$)/g
 
+// Shell detection (exposed for testing)
+export function detectShellType(): "bash" | "pwsh" {
+	if (process.platform === "win32") {
+		const shell = process.env.Shell ?? process.env.ComSpec ?? ""
+		if (/powershell|pwsh|psexec/i.test(shell)) {
+			return "pwsh"
+		}
+		// On Windows outside of known shells, assume PowerShell
+		return "pwsh"
+	}
+	const shell = process.env.SHELL ?? ""
+	if (/powershell|pwsh/i.test(shell)) {
+		return "pwsh"
+	}
+	return "bash"
+}
+
+/** Convert a bash-format env prefix ("VAR=value VAR2=value2") to PowerShell format */
+function convertEnvPrefixForPwsh(bashPrefix: string): string {
+	return bashPrefix
+		.split(" ")
+		.map((assignment) => {
+			const eqIndex = assignment.indexOf("=")
+			if (eqIndex === -1) return assignment
+			const key = assignment.slice(0, eqIndex)
+			const value = assignment.slice(eqIndex + 1)
+			return `$env:${key}='${value}'`
+		})
+		.join("; ")
+}
+
+export function getShellAwareEnvPrefix(bashPrefix: string): string {
+	if (detectShellType() === "pwsh") {
+		return convertEnvPrefixForPwsh(bashPrefix)
+	}
+	return bashPrefix
+}
+
 export function injectGitMasterConfig(template: string, config?: GitMasterConfig): string {
 	const commitFooter = config?.commit_footer ?? true
 	const includeCoAuthoredBy = config?.include_co_authored_by ?? true
 	const gitEnvPrefix = assertValidGitEnvPrefix(config?.git_env_prefix ?? "GIT_MASTER=1")
+	const shellPrefix = gitEnvPrefix ? getShellAwareEnvPrefix(gitEnvPrefix) : ""
 
-	let result = gitEnvPrefix ? injectGitEnvPrefix(template, gitEnvPrefix) : template
+	let result = gitEnvPrefix ? injectGitEnvPrefix(template, shellPrefix) : template
 
 	if (commitFooter || includeCoAuthoredBy) {
-		const injection = buildCommitFooterInjection(commitFooter, includeCoAuthoredBy, gitEnvPrefix)
+		const injection = buildCommitFooterInjection(commitFooter, includeCoAuthoredBy, shellPrefix)
 		const insertionPoint = result.indexOf("```\n</execution>")
 
 		result =
@@ -25,7 +64,7 @@ export function injectGitMasterConfig(template: string, config?: GitMasterConfig
 				: result + "\n\n" + injection
 	}
 
-	return gitEnvPrefix ? prefixGitCommandsInBashCodeBlocks(result, gitEnvPrefix) : result
+	return gitEnvPrefix ? prefixGitCommandsInBashCodeBlocks(result, shellPrefix) : result
 }
 
 function injectGitEnvPrefix(template: string, prefix: string): string {


### PR DESCRIPTION
## Summary

Fixes **#3207** — git-master skill environment variable prefix is bash-only and fails on PowerShell.

### Root Cause

`GIT_MASTER=1` is bash syntax. When the skill injects this as a prefix to git commands in a PowerShell environment (Windows pwsh), the shell interprets `GIT_MASTER=1` as a command name rather than an environment variable assignment, causing a "term not recognized" error.

### Fix

1. `detectShellType()` — Detects `bash` vs `pwsh` by checking `process.platform` and `SHELL`/`Shell` env vars at runtime.
2. `convertEnvPrefixForPwsh()` — Transforms bash-format prefix (`VAR=value VAR2=value2`) into PowerShell format (`$env:VAR='value'; $env:VAR2='value2'`).
3. `getShellAwareEnvPrefix()` — Returns the appropriate format based on detected shell.
4. All template injection points now use the shell-aware prefix, including the env prefix section, bash code block command prefixing, and commit footer examples.

### Testing

Added PowerShell-specific test cases covering:
- Basic VAR=value to PowerShell $env: conversion
- Multi-variable prefix conversion
- Commit example syntax in PowerShell
- Idempotency (no double-conversion)

Note: Tests require `bun test` (Bun runtime). Please verify with `bun test src/features/opencode-skill-loader/git-master-template-injection.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3207 by making `git_env_prefix` shell-aware and safe for PowerShell. Handles quoted values and avoids mixing PowerShell syntax in bash code blocks so git-master works in pwsh across platforms.

- **Bug Fixes**
  - Detect shell at runtime with `detectShellType()` using `process.platform` and `SHELL`/`Shell`/`ComSpec`.
  - Convert `VAR=value` to `$env:VAR='value'` via `convertEnvPrefixForPwsh()`; supports multiple vars and quoted values.
  - Use `getShellAwareEnvPrefix()` for all injections; use ```pwsh``` for the env-prefix section when needed; skip injecting pwsh prefixes into ```bash``` code blocks.
  - Add and stabilize tests for pwsh conversion, multi-var and quoted values, commit examples, and idempotency; mock `process.platform` to `linux` and clear Windows env vars to avoid flakiness.

<sup>Written for commit fdde3b57b0caf0479757675aa654a62d53166b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

