### PR TITLE
fix(copilot): mark internal marker prompts as agent-initiated

### DIFF
--- a/packages/omo-opencode/src/features/context-injector/injector.test.ts
+++ b/packages/omo-opencode/src/features/context-injector/injector.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test"
-import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { ContextCollector } from "./collector"
 import {
   createContextInjectorHook,
@@ -209,11 +209,10 @@ describe("createContextInjectorMessagesTransformHook", () => {
     })
     const messages = [
       createMockMessage("user", "Real user message", sessionID),
-      createMockMessage(
-        "user",
-        `Internal prompt\n${OMO_INTERNAL_INITIATOR_MARKER}`,
-        sessionID,
-      ),
+      {
+        ...createMockMessage("user", "Internal prompt", sessionID),
+        parts: [createInternalAgentTextPart("Internal prompt")],
+      },
     ]
     const originalMessages = structuredClone(messages)
     const output = unsafeTestValue({ messages })

--- a/packages/omo-opencode/src/features/context-injector/injector.test.ts
+++ b/packages/omo-opencode/src/features/context-injector/injector.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test"
-import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { ContextCollector } from "./collector"
 import {

--- a/packages/omo-opencode/src/features/monitor/output-injector.test.ts
+++ b/packages/omo-opencode/src/features/monitor/output-injector.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test"
 import { MonitorOutputInjector } from "./output-injector"
 import type { MonitorCounters, MonitorRecord, OutputBatch } from "./types"
 import type { InternalPromptDispatchResult, PromptAsyncInput, PromptDispatchClient } from "../../shared/prompt-async-gate/types"
+import { OMO_INTERNAL_INITIATOR_METADATA_KEY } from "../../shared/internal-initiator-marker"
 
 type DispatchCall = {
   source: string
@@ -19,7 +20,7 @@ type FakeMessage = {
   role?: string
   finish?: string
   time?: { created?: unknown }
-  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; content?: unknown; state?: { status?: unknown } }>
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; metadata?: Record<string, unknown>; content?: unknown; state?: { status?: unknown } }>
 }
 
 const baseCounters = {
@@ -239,7 +240,7 @@ describe("MonitorOutputInjector", () => {
       const acceptedText = "[OMO MONITOR OUTPUT]\nmonitor_id: mon_1\nbatch: 7\n<!-- OMO_INTERNAL_INITIATOR -->\n<!-- OMO_INTERNAL_NOREPLY -->"
       const { injector, calls } = createHarness({
         dispatchResults: [{ status: "failed", error: new Error("unexpected eof"), dispatchAttempted: true }],
-        messages: [{ role: "user", time: { created: 1_000 }, parts: [{ type: "text", text: acceptedText }] }],
+        messages: [{ role: "user", time: { created: 1_000 }, parts: [{ type: "text", text: acceptedText, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }] }],
         now: 1_000,
       })
       injector.queueBatch(record, batch)
@@ -277,7 +278,7 @@ describe("MonitorOutputInjector", () => {
       const priorNoReplyMonitorMessage = {
         role: "user",
         time: { created: 900 },
-        parts: [{ type: "text", text: "[OMO MONITOR OUTPUT]\nmonitor_id: mon_1\nbatch: 1\n<!-- OMO_INTERNAL_INITIATOR -->\n<!-- OMO_INTERNAL_NOREPLY -->" }],
+        parts: [{ type: "text", text: "[OMO MONITOR OUTPUT]\nmonitor_id: mon_1\nbatch: 1\n<!-- OMO_INTERNAL_INITIATOR -->\n<!-- OMO_INTERNAL_NOREPLY -->", synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       }
       const batch = createBatch(12)
       const { injector, calls } = createHarness({ messages: [priorNoReplyMonitorMessage], now: 1_000 })

--- a/packages/omo-opencode/src/hooks/auto-slash-command/detector.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import {
   detectSlashCommand,
   extractPromptText,
@@ -306,7 +306,7 @@ After`
       // given
       const parts = [
         { type: "text", text: "/commit from synthetic", synthetic: true },
-        { type: "text", text: `/commit from marker\n${OMO_INTERNAL_INITIATOR_MARKER}` },
+        createInternalAgentTextPart("/commit from marker"),
         { type: "text", text: "real request" },
       ]
 
@@ -323,7 +323,7 @@ After`
       // given
       const parts = [
         { type: "text", text: "/commit synthetic", synthetic: true },
-        { type: "text", text: `/plan internal\n${OMO_INTERNAL_INITIATOR_MARKER}` },
+        createInternalAgentTextPart("/plan internal"),
         { type: "text", text: "/real-command" },
       ]
 
@@ -338,7 +338,7 @@ After`
       // given
       const parts = [
         { type: "text", text: "/commit synthetic", synthetic: true },
-        { type: "text", text: `/plan internal\n${OMO_INTERNAL_INITIATOR_MARKER}` },
+        createInternalAgentTextPart("/plan internal"),
       ]
 
       // when

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/index.test.ts
@@ -20,6 +20,7 @@ afterAll(() => {
 
 import { createCompactionContextInjector } from "./index"
 import { setCompactionAgentConfigCheckpoint } from "../../shared/compaction-agent-config-checkpoint"
+import { OMO_INTERNAL_INITIATOR_METADATA_KEY } from "../../shared/internal-initiator-marker"
 
 type PromptAsyncInput = {
   path: { id: string }
@@ -32,7 +33,7 @@ type PromptAsyncInput = {
       type: "text"
       text: string
       synthetic?: true
-      metadata?: { compaction_continue?: true }
+      metadata?: Record<string, unknown>
     }>
   }
   query?: { directory: string }
@@ -125,7 +126,10 @@ describe("createCompactionContextInjector", () => {
       expect(recoveryCall?.body.parts[0]?.type).toBe("text")
       expect(recoveryCall?.body.parts[0]?.text).toContain("restore checkpointed session agent configuration")
       expect(recoveryCall?.body.parts[0]?.synthetic).toBe(true)
-      expect(recoveryCall?.body.parts[0]?.metadata).toEqual({ compaction_continue: true })
+      expect(recoveryCall?.body.parts[0]?.metadata).toEqual({
+        [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true,
+        compaction_continue: true,
+      })
       expect(recoveryCall?.query).toEqual({ directory: "/tmp/test" })
     })
 
@@ -192,7 +196,10 @@ describe("createCompactionContextInjector", () => {
       expect(recoveryCall?.body.parts[0]?.type).toBe("text")
       expect(recoveryCall?.body.parts[0]?.text).toContain("restore checkpointed session agent configuration")
       expect(recoveryCall?.body.parts[0]?.synthetic).toBe(true)
-      expect(recoveryCall?.body.parts[0]?.metadata).toEqual({ compaction_continue: true })
+      expect(recoveryCall?.body.parts[0]?.metadata).toEqual({
+        [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true,
+        compaction_continue: true,
+      })
       expect(recoveryCall?.query).toEqual({ directory: "/tmp/test" })
     })
 

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.test.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.test.ts
@@ -3,6 +3,11 @@
 import { afterEach, describe, expect, it } from "bun:test"
 import { setCompactionAgentConfigCheckpoint } from "../../shared/compaction-agent-config-checkpoint"
 import { OMO_INTERNAL_INITIATOR_METADATA_KEY } from "../../shared/internal-initiator-marker"
+import {
+  dispatchInternalPrompt,
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../shared/prompt-async-gate"
 import { createCompactionContextInjector } from "./index"
 
 type SessionMessageResponse = Array<{

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.test.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.test.ts
@@ -2,11 +2,7 @@
 
 import { afterEach, describe, expect, it } from "bun:test"
 import { setCompactionAgentConfigCheckpoint } from "../../shared/compaction-agent-config-checkpoint"
-import {
-  dispatchInternalPrompt,
-  releaseAllPromptAsyncReservationsForTesting,
-  releasePromptAsyncReservation,
-} from "../shared/prompt-async-gate"
+import { OMO_INTERNAL_INITIATOR_METADATA_KEY } from "../../shared/internal-initiator-marker"
 import { createCompactionContextInjector } from "./index"
 
 type SessionMessageResponse = Array<{
@@ -24,7 +20,7 @@ type PromptAsyncInput = {
       type: "text"
       text: string
       synthetic?: true
-      metadata?: { compaction_continue?: true }
+      metadata?: Record<string, unknown>
     }>
   }
   query?: { directory: string }
@@ -259,7 +255,10 @@ describe("createCompactionContextInjector recovery", () => {
     expect(promptAsyncRecorder.calls.length).toBe(1)
     const recoveryPart = promptAsyncRecorder.calls[0]?.body.parts[0]
     expect(recoveryPart?.synthetic).toBe(true)
-    expect(recoveryPart?.metadata).toEqual({ compaction_continue: true })
+    expect(recoveryPart?.metadata).toEqual({
+      [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true,
+      compaction_continue: true,
+    })
   })
 
   it("does not immediately retry recovery when the recovered prompt config still mismatches expected model or tools", async () => {

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -7,7 +7,7 @@ import * as sessionState from "../../features/claude-code-session-state"
 import { _resetForTesting, clearSessionAgent, setMainSession, updateSessionAgent } from "../../features/claude-code-session-state"
 import { ContextCollector } from "../../features/context-injector"
 import * as sharedModule from "../../shared"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { createKeywordDetectorHook } from "./index"
 
 type ToastOptions = { body: { title: string } }
@@ -208,10 +208,11 @@ describe("keyword-detector message transform", () => {
     const sessionID = "internal-peer-message-session"
     getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
     const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
-    const peerText = `<peer_message from="researcher">search the issue thread</peer_message>\n${OMO_INTERNAL_INITIATOR_MARKER}`
+    const internalPart = createInternalAgentTextPart('<peer_message from="researcher">search the issue thread</peer_message>')
+    const peerText = internalPart.text
     const output = {
       message: {} as Record<string, unknown>,
-      parts: [{ type: "text", text: peerText }],
+      parts: [internalPart],
     }
 
     // when

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { handleNonIdleEvent } from "./non-idle-events"
 import { createSessionStateStore, type SessionStateStore } from "./session-state"
 
@@ -55,9 +55,7 @@ describe("handleNonIdleEvent", () => {
       properties: {
         sessionID,
         info: { role: "user" },
-        parts: [
-          { type: "text", text: `internal wake\n${OMO_INTERNAL_INITIATOR_MARKER}` },
-        ],
+        parts: [createInternalAgentTextPart("internal wake")],
       },
       sessionStateStore,
     })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 
-import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart, OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
 import { handleNonIdleEvent } from "./non-idle-events"
 import { createSessionStateStore, type SessionStateStore } from "./session-state"
 
@@ -81,11 +81,7 @@ describe("handleNonIdleEvent", () => {
         sessionID,
         info: { role: "user" },
         parts: [
-          {
-            type: "text",
-            text: `ultrawork [SYSTEM DIRECTIVE: OH-MY-OPENCODE - RALPH LOOP 2/500]\ncontinue\n${OMO_INTERNAL_INITIATOR_MARKER}`,
-            synthetic: true,
-          },
+          createInternalAgentTextPart("ultrawork [SYSTEM DIRECTIVE: OH-MY-OPENCODE - RALPH LOOP 2/500]\ncontinue"),
         ],
       },
       sessionStateStore,

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 
-import { createInternalAgentTextPart, OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { handleNonIdleEvent } from "./non-idle-events"
 import { createSessionStateStore, type SessionStateStore } from "./session-state"
 
@@ -161,9 +161,7 @@ describe("handleNonIdleEvent", () => {
         sessionID,
         part: {
           messageID,
-          type: "text",
-          text: `internal wake\n${OMO_INTERNAL_INITIATOR_MARKER}`,
-          synthetic: true,
+          ...createInternalAgentTextPart("internal wake"),
         },
       },
       sessionStateStore,
@@ -228,7 +226,7 @@ describe("handleNonIdleEvent", () => {
         part: {
           type: "text",
           messageID: "msg_split_internal",
-          text: `${OMO_INTERNAL_INITIATOR_MARKER}\ncontinuation echo`,
+          ...createInternalAgentTextPart("continuation echo"),
         },
       },
       sessionStateStore,

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/pending-question-detection.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
 
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { hasUnansweredQuestion } from "./pending-question-detection"
 
 describe("hasUnansweredQuestion", () => {
@@ -118,9 +118,7 @@ describe("hasUnansweredQuestion", () => {
       },
       {
         info: { role: "user" },
-        parts: [
-          { type: "text", text: `internal continuation\n${OMO_INTERNAL_INITIATOR_MARKER}` },
-        ],
+        parts: [createInternalAgentTextPart("internal continuation")],
       },
     ]
     expect(hasUnansweredQuestion(messages)).toBe(true)

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
 
-import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { resolveLatestMessageInfo } from "./resolve-message-info"
 import type { MessageWithInfo } from "./types"

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
@@ -1,8 +1,8 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
 
-import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import { resolveLatestMessageInfo } from "./resolve-message-info"
 import type { MessageWithInfo } from "./types"
 
@@ -48,7 +48,7 @@ describe("resolveLatestMessageInfo", () => {
       },
       {
         info: { role: "user", agent: "hephaestus", model: internalModel },
-        parts: [{ type: "text", text: `internal wake\n${OMO_INTERNAL_INITIATOR_MARKER}` }],
+        parts: [createInternalAgentTextPart("internal wake")],
       },
     ]
 

--- a/packages/omo-opencode/src/plugin/chat-headers.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-headers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test"
 
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../shared"
+import {
+  OMO_INTERNAL_INITIATOR_MARKER,
+  OMO_INTERNAL_INITIATOR_METADATA_KEY,
+} from "../shared"
 import { createChatHeadersHandler } from "./chat-headers"
 
 describe("createChatHeadersHandler", () => {
@@ -11,10 +14,13 @@ describe("createChatHeadersHandler", () => {
           session: {
             message: async () => ({
               data: {
+                info: { role: "user" },
                 parts: [
                   {
                     type: "text",
                     text: `notification\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+                    synthetic: true,
+                    metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
                   },
                 ],
               },
@@ -47,10 +53,13 @@ describe("createChatHeadersHandler", () => {
           session: {
             message: async () => ({
               data: {
+                info: { role: "user" },
                 parts: [
                   {
                     type: "text",
                     text: `notification\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+                    synthetic: true,
+                    metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
                   },
                 ],
               },
@@ -107,17 +116,20 @@ describe("createChatHeadersHandler", () => {
     expect(output.headers["x-initiator"]).toBeUndefined()
   })
 
-  test("skips x-initiator override when model uses @ai-sdk/github-copilot", async () => {
+  test("sets x-initiator for trusted internal marker messages when model uses @ai-sdk/github-copilot", async () => {
     const handler = createChatHeadersHandler({
       ctx: {
         client: {
           session: {
             message: async () => ({
               data: {
+                info: { role: "user" },
                 parts: [
                   {
                     type: "text",
                     text: `notification\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+                    synthetic: true,
+                    metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
                   },
                 ],
               },
@@ -135,6 +147,44 @@ describe("createChatHeadersHandler", () => {
         model: { api: { npm: "@ai-sdk/github-copilot" } },
         message: {
           id: "msg_4",
+          role: "user",
+        },
+      },
+      output,
+    )
+
+    expect(output.headers["x-initiator"]).toBe("agent")
+  })
+
+  test("does not trust a user-spoofed marker without synthetic metadata", async () => {
+    const handler = createChatHeadersHandler({
+      ctx: {
+        client: {
+          session: {
+            message: async () => ({
+              data: {
+                info: { role: "user" },
+                parts: [
+                  {
+                    type: "text",
+                    text: `normal user text\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+                  },
+                ],
+              },
+            }),
+          },
+        },
+      } as never,
+    })
+    const output: { headers: Record<string, string> } = { headers: {} }
+
+    await handler(
+      {
+        sessionID: "ses_5",
+        provider: { id: "github-copilot" },
+        model: { api: { npm: "@ai-sdk/github-copilot" } },
+        message: {
+          id: "msg_5",
           role: "user",
         },
       },

--- a/packages/omo-opencode/src/plugin/chat-headers.ts
+++ b/packages/omo-opencode/src/plugin/chat-headers.ts
@@ -1,5 +1,4 @@
-import { isRecord } from "@oh-my-opencode/utils"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../shared"
+import { isSyntheticOrInternalUserMessage } from "../shared"
 import type { PluginContext } from "./types"
 
 type ChatHeadersInput = {
@@ -53,7 +52,7 @@ function isCopilotProvider(providerID: string): boolean {
   return providerID === "github-copilot" || providerID === "github-copilot-enterprise"
 }
 
-async function hasInternalMarker(
+async function hasTrustedInternalMarker(
   client: PluginContext["client"],
   sessionID: string,
   messageID: string,
@@ -78,13 +77,7 @@ async function hasInternalMarker(
       return false
     }
 
-    const hasMarker = data.parts.some((part) => {
-      if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
-        return false
-      }
-
-      return part.text.includes(OMO_INTERNAL_INITIATOR_MARKER)
-    })
+    const hasMarker = isSyntheticOrInternalUserMessage(data)
 
     internalMarkerCache.set(cacheKey, hasMarker)
     if (internalMarkerCache.size > INTERNAL_MARKER_CACHE_LIMIT) {
@@ -114,7 +107,7 @@ async function isOmoInternalMessage(input: ChatHeadersInput, client: PluginConte
     return false
   }
 
-  return hasInternalMarker(client, input.sessionID, input.message.id)
+  return hasTrustedInternalMarker(client, input.sessionID, input.message.id)
 }
 
 export function createChatHeadersHandler(args: { ctx: PluginContext }): (input: unknown, output: unknown) => Promise<void> {
@@ -126,16 +119,6 @@ export function createChatHeadersHandler(args: { ctx: PluginContext }): (input: 
     if (!isChatHeadersOutput(output)) return
 
     if (!isCopilotProvider(normalizedInput.provider.id)) return
-
-    // Do not override x-initiator when @ai-sdk/github-copilot is active.
-    // OpenCode's copilot fetch wrapper already sets x-initiator based on
-    // the actual request body content. Overriding it here causes a mismatch
-    // that the Copilot API rejects with "invalid initiator".
-    const model = isRecord(input) && isRecord((input as Record<string, unknown>).model)
-      ? (input as Record<string, unknown>).model as Record<string, unknown>
-      : undefined
-    const api = model && isRecord(model.api) ? model.api as Record<string, unknown> : undefined
-    if (api?.npm === "@ai-sdk/github-copilot") return
 
     if (!(await isOmoInternalMessage(normalizedInput, ctx.client))) return
 

--- a/packages/omo-opencode/src/plugin/chat-headers.ts
+++ b/packages/omo-opencode/src/plugin/chat-headers.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@oh-my-opencode/utils"
 import { isSyntheticOrInternalUserMessage } from "../shared"
 import type { PluginContext } from "./types"
 

--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -12,7 +12,7 @@ import { validateObjective } from "../hooks/goal/validation"
 import { createStartWorkHook } from "../hooks/start-work"
 import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
-import { OMO_INTERNAL_INITIATOR_MARKER } from "../shared/internal-initiator-marker"
+import { OMO_INTERNAL_INITIATOR_MARKER, OMO_INTERNAL_INITIATOR_METADATA_KEY } from "../shared/internal-initiator-marker"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
 import { createChatMessageHandler } from "./chat-message"
 import type { PluginContext } from "./types"
@@ -160,7 +160,14 @@ describe("createChatMessageHandler - synthetic/internal messages", () => {
     const handler = createChatMessageHandler(args)
     const output: ChatMessageHandlerOutput = {
       message: {},
-      parts: [{ type: "text", text: `/commit\n${OMO_INTERNAL_INITIATOR_MARKER}` }],
+      parts: [
+        {
+          type: "text",
+          text: `/commit\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+          synthetic: true,
+          metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
+        },
+      ],
     }
 
     // when

--- a/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
+++ b/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
@@ -13,6 +13,7 @@ import {
   isTerminalNoReplyUserMessage,
   OMO_INTERNAL_INITIATOR_MARKER,
   OMO_INTERNAL_INITIATOR_METADATA_KEY,
+  OMO_INTERNAL_NOREPLY_MARKER,
   stripInternalInitiatorMarkers,
   withInternalNoReplyMarker,
 } from "./internal-initiator-marker"
@@ -241,7 +242,10 @@ describe("internal-initiator-marker", () => {
 
       // then
       expect(part.synthetic).toBe(true)
-      expect(part.metadata).toEqual({ compaction_continue: true })
+      expect(part.metadata).toEqual({
+        [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true,
+        compaction_continue: true,
+      })
       expect(hasInternalNoReplyMarker(part.text)).toBe(true)
     })
 

--- a/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
+++ b/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
@@ -12,7 +12,7 @@ import {
   isSyntheticOrInternalUserMessage,
   isTerminalNoReplyUserMessage,
   OMO_INTERNAL_INITIATOR_MARKER,
-  OMO_INTERNAL_NOREPLY_MARKER,
+  OMO_INTERNAL_INITIATOR_METADATA_KEY,
   stripInternalInitiatorMarkers,
   withInternalNoReplyMarker,
 } from "./internal-initiator-marker"
@@ -31,7 +31,7 @@ describe("internal-initiator-marker", () => {
       expect(part.text).toBe(`Hello world\n${OMO_INTERNAL_INITIATOR_MARKER}`)
     })
 
-    test("#given regular internal text #when creating a text part #then leaves it visible as a normal message part", () => {
+    test("#given regular internal text #when creating a text part #then marks it as a trusted OMO internal part", () => {
       // given
       const text = "Visible notification"
 
@@ -39,8 +39,8 @@ describe("internal-initiator-marker", () => {
       const part = createInternalAgentTextPart(text)
 
       // then
-      expect("synthetic" in part).toBe(false)
-      expect("metadata" in part).toBe(false)
+      expect(part.synthetic).toBe(true)
+      expect(part.metadata[OMO_INTERNAL_INITIATOR_METADATA_KEY]).toBe(true)
     })
 
     test("#given text already ending with the marker #when creating a text part #then does not duplicate the marker", () => {
@@ -107,6 +107,7 @@ describe("internal-initiator-marker", () => {
       expect(part.type).toBe("text")
       expect(part.text).toBe(`Continue the loop\n${OMO_INTERNAL_INITIATOR_MARKER}`)
       expect(part.synthetic).toBe(true)
+      expect(part.metadata[OMO_INTERNAL_INITIATOR_METADATA_KEY]).toBe(true)
       expect(part.metadata.compaction_continue).toBe(true)
     })
   })
@@ -169,11 +170,16 @@ describe("internal-initiator-marker", () => {
       expect(result).toBe(true)
     })
 
-    test("#given synthetic and marker-only user parts #when classifying text parts #then treats them as internal-only", () => {
+    test("#given synthetic and trusted marker user parts #when classifying text parts #then treats them as internal-only", () => {
       // given
       const parts = [
         { type: "text", text: "hidden", synthetic: true },
-        { type: "text", text: `reminder\n${OMO_INTERNAL_INITIATOR_MARKER}` },
+        {
+          type: "text",
+          text: `reminder\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+          synthetic: true,
+          metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
+        },
       ]
 
       // when
@@ -202,7 +208,7 @@ describe("internal-initiator-marker", () => {
       expect(isRealUserMessage(message)).toBe(true)
     })
 
-    test("#given user message with only a marker-tagged text part #when classifying #then rejects it as real user input", () => {
+    test("#given user message with only a marker-tagged text part #when classifying #then keeps it as real user input", () => {
       // given
       const message = {
         role: "user",
@@ -213,8 +219,8 @@ describe("internal-initiator-marker", () => {
       const result = isRealUserMessage(message)
 
       // then
-      expect(result).toBe(false)
-      expect(isSyntheticOrInternalUserMessage(message)).toBe(true)
+      expect(result).toBe(true)
+      expect(isSyntheticOrInternalUserMessage(message)).toBe(false)
     })
   })
 

--- a/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   OMO_INTERNAL_INITIATOR_MARKER,
+  OMO_INTERNAL_INITIATOR_METADATA_KEY,
   OMO_INTERNAL_NOREPLY_MARKER,
 } from "../internal-initiator-marker"
 import { latestAssistantTurnBlocksInternalPrompt } from "./pending-tool-turn"
@@ -68,7 +69,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
           role: "user",
           time: { created: 4000 },
         },
-        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->", synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -101,7 +102,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
           role: "user",
           time: { created: 4000 },
         },
-        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->", synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -134,7 +135,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
           role: "user",
           time: { created: 4000 },
         },
-        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+        parts: [{ type: "text", text: "wake\n<!-- OMO_INTERNAL_INITIATOR -->", synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -223,7 +224,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
           role: "user",
           time: { created: 3000 },
         },
-        parts: [{ type: "text", text: "continue\n<!-- OMO_INTERNAL_INITIATOR -->", synthetic: true }],
+        parts: [{ type: "text", text: "continue\n<!-- OMO_INTERNAL_INITIATOR -->", synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -311,7 +312,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
           role: "user",
           time: { created: 3000 },
         },
-        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -335,11 +336,11 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
       },
       {
         info: { role: "user", time: { created: 3000 } },
-        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
       {
         info: { role: "user", time: { created: 4000 } },
-        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -363,11 +364,11 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
       },
       {
         info: { role: "user", time: { created: 3000 } },
-        parts: [{ type: "text", text: REPLY_EXPECTING_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: REPLY_EXPECTING_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
       {
         info: { role: "user", time: { created: 4000 } },
-        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 
@@ -391,7 +392,7 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
       },
       {
         info: { role: "user", time: { created: 3000 } },
-        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true, metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true } }],
       },
     ]
 

--- a/packages/utils/src/internal-initiator-marker.ts
+++ b/packages/utils/src/internal-initiator-marker.ts
@@ -1,4 +1,5 @@
 export const OMO_INTERNAL_INITIATOR_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
+export const OMO_INTERNAL_INITIATOR_METADATA_KEY = "omo_internal_initiator"
 
 export const OMO_INTERNAL_NOREPLY_MARKER = "<!-- OMO_INTERNAL_NOREPLY -->"
 
@@ -11,6 +12,7 @@ export type InternalInitiatorTextPartLike = {
   type?: string
   text?: string
   synthetic?: boolean
+  metadata?: Record<string, unknown>
 }
 
 export type InternalInitiatorMessageLike = {
@@ -36,9 +38,16 @@ export function isTextPartLike(
 export function isSyntheticOrInternalTextPart(
   part: InternalInitiatorTextPartLike
 ): boolean {
+  if (!isTextPartLike(part)) return false
+
+  if (part.synthetic === true && !hasInternalInitiatorMarker(part.text)) {
+    return true
+  }
+
   return (
-    isTextPartLike(part) &&
-    (part.synthetic === true || hasInternalInitiatorMarker(part.text))
+    part.synthetic === true &&
+    part.metadata?.[OMO_INTERNAL_INITIATOR_METADATA_KEY] === true &&
+    hasInternalInitiatorMarker(part.text)
   )
 }
 
@@ -94,11 +103,15 @@ export function stripInternalInitiatorMarkers(text: string): string {
 export function createInternalAgentTextPart(text: string): {
   type: "text"
   text: string
+  synthetic: true
+  metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true }
 } {
   const cleanText = stripInternalInitiatorMarkers(text)
   return {
     type: "text",
     text: `${cleanText}\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+    synthetic: true,
+    metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true },
   }
 }
 
@@ -106,12 +119,12 @@ export function createInternalAgentContinuationTextPart(text: string): {
   type: "text"
   text: string
   synthetic: true
-  metadata: { compaction_continue: true }
+  metadata: { [OMO_INTERNAL_INITIATOR_METADATA_KEY]: true; compaction_continue: true }
 } {
+  const part = createInternalAgentTextPart(text)
   return {
-    ...createInternalAgentTextPart(text),
-    synthetic: true,
-    metadata: { compaction_continue: true },
+    ...part,
+    metadata: { ...part.metadata, compaction_continue: true },
   }
 }
 

--- a/packages/utils/src/prompt-async-gate/prompt-message-state.ts
+++ b/packages/utils/src/prompt-async-gate/prompt-message-state.ts
@@ -76,6 +76,9 @@ function toInternalInitiatorTextPartLike(part: unknown): InternalInitiatorTextPa
   if (typeof part.synthetic === "boolean") {
     result.synthetic = part.synthetic
   }
+  if (isRecord(part.metadata)) {
+    result.metadata = part.metadata as Record<string, unknown>
+  }
   return result
 }
 


### PR DESCRIPTION
## Summary
- set `message.initiator = "agent"` in `chat.message` when any outgoing text part contains `<!-- OMO_INTERNAL_INITIATOR -->`
- keeps normal user prompts unchanged
- adds coverage to ensure internal-marker notifications are tagged, while plain user text is not

## Why
OpenCode Copilot auth now relies on message-level initiator classification to set `x-initiator`. In sessions using background notifications from oh-my-openagent, many synthetic `<system-reminder>` turns were persisted as `role=user` without `initiator`, causing premium-request overcounting.

## Validation
- `bun test src/plugin/chat-message.test.ts src/plugin/chat-headers.test.ts`
- `bun run typecheck`

## Related Context
- https://github.com/anomalyco/opencode/issues/8030
- https://github.com/anomalyco/opencode/issues/8030#issuecomment-4191005303

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trust only synthetic internal prompts with `metadata[OMO_INTERNAL_INITIATOR_METADATA_KEY]=true` and the marker as agent-initiated, and set Copilot `x-initiator=agent` for those. Blocks user-spoofed markers and fixes initiator overcounting across providers, including models from `@ai-sdk/github-copilot`.

- **Bug Fixes**
  - Tightened `isSyntheticOrInternalUserMessage` to require `synthetic: true` plus the trusted metadata key and marker; user text with only the marker is no longer trusted.
  - Applied the check in `chat.message` and `chat-headers`; set `x-initiator=agent` for trusted internal messages even with `@ai-sdk/github-copilot`.
  - Updated `createInternalAgentTextPart` and continuation to emit `synthetic: true` and the metadata key (continuation also adds `compaction_continue: true`); preserved `part.metadata` through the prompt async gate; tests updated.

<sup>Written for commit a73421aa0629a37bbf70239ea2a843bbae9de80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Linked Issue
Closes #2632