### PR TITLE
fix(variant): fall back to top-level info.variant for real SDK shape

### DIFF
--- a/src/features/hook-message-injector/injector.test.ts
+++ b/src/features/hook-message-injector/injector.test.ts
@@ -50,6 +50,7 @@ function createMockClient(messages: Array<{
     model?: { providerID?: string; modelID?: string; variant?: string }
     providerID?: string
     modelID?: string
+    variant?: string
     tools?: Record<string, boolean>
     time?: { created?: number }
   }
@@ -93,6 +94,27 @@ describe("findNearestMessageWithFieldsFromSDK", () => {
     expect(result).toEqual({
       agent: "sisyphus",
       model: { providerID: "openai", modelID: "gpt-5" },
+      tools: undefined,
+    })
+  })
+
+  it("preserves top-level variant on assistant shape (real SDK shape)", async () => {
+    const mockClient = createMockClient([
+      {
+        info: {
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-opus-4-6",
+          variant: "max",
+        },
+      },
+    ])
+
+    const result = await findNearestMessageWithFieldsFromSDK(mockClient as any, "ses_123")
+
+    expect(result).toEqual({
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-6", variant: "max" },
       tools: undefined,
     })
   })

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -28,6 +28,7 @@ interface SDKMessage {
     }
     providerID?: string
     modelID?: string
+    variant?: string
     tools?: Record<string, ToolPermission>
     time?: {
       created?: number
@@ -50,7 +51,7 @@ function convertSDKMessageToStoredMessage(msg: SDKMessage): StoredMessage | null
 
   const providerID = info.model?.providerID ?? info.providerID
   const modelID = info.model?.modelID ?? info.modelID
-  const variant = info.model?.variant
+  const variant = info.model?.variant ?? info.variant
 
   if (!info.agent && !providerID && !modelID) {
     return null

--- a/src/hooks/atlas/recent-model-resolver.test.ts
+++ b/src/hooks/atlas/recent-model-resolver.test.ts
@@ -42,4 +42,38 @@ describe("resolveRecentPromptContextForSession", () => {
     expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(result.tools).toEqual({ edit: true })
   })
+
+  test("#given assistant message with top-level variant (real SDK shape) #when resolving prompt context #then variant is propagated", async () => {
+    // given
+    const ctx = {
+      client: {
+        session: {
+          messages: mock(async () => ({
+            data: [
+              {
+                id: "msg_real_sdk",
+                info: {
+                  providerID: "anthropic",
+                  modelID: "claude-opus-4-6",
+                  variant: "max",
+                  tools: { read: true },
+                  time: { created: 100 },
+                },
+              },
+            ],
+          })),
+        },
+      },
+    } as unknown as PluginInput
+
+    // when
+    const result = await resolveRecentPromptContextForSession(ctx, "ses_123")
+
+    // then
+    expect(result.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+      variant: "max",
+    })
+  })
 })

--- a/src/hooks/atlas/recent-model-resolver.ts
+++ b/src/hooks/atlas/recent-model-resolver.ts
@@ -38,6 +38,7 @@ export async function resolveRecentPromptContextForSession(
         model?: ModelInfo
         modelID?: string
         providerID?: string
+        variant?: string
         tools?: Record<string, boolean | "allow" | "deny" | "ask">
         time?: { created?: number }
       }
@@ -66,7 +67,14 @@ export async function resolveRecentPromptContextForSession(
       }
 
       if (info?.providerID && info?.modelID) {
-        return { model: { providerID: info.providerID, modelID: info.modelID }, tools }
+        return {
+          model: {
+            providerID: info.providerID,
+            modelID: info.modelID,
+            ...(info.variant ? { variant: info.variant } : {}),
+          },
+          tools,
+        }
       }
     }
   } catch {

--- a/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -217,4 +217,56 @@ describe("ralph-loop continuation prompt injector", () => {
     })
     expect(promptBody?.variant).toBe("max")
   })
+
+  test("#given assistant message with top-level variant (real SDK shape) #when injecting continuation prompt #then promptAsync receives variant", async () => {
+    // given
+    let promptBody:
+      | {
+          model?: { providerID: string; modelID: string }
+          variant?: string
+        }
+      | undefined
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                info: {
+                  agent: "sisyphus",
+                  providerID: "openai",
+                  modelID: "gpt-5.3-codex",
+                  variant: "max",
+                },
+              },
+            ],
+          }),
+          promptAsync: async (input: {
+            body: {
+              model?: { providerID: string; modelID: string }
+              variant?: string
+            }
+          }) => {
+            promptBody = input.body
+            return {}
+          },
+        },
+      },
+    }
+
+    // when
+    await injectContinuationPrompt(ctx as never, {
+      sessionID: "ses_ralph_real_sdk",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(promptBody?.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.3-codex",
+    })
+    expect(promptBody?.variant).toBe("max")
+  })
 })

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -19,6 +19,7 @@ type MessageInfo = {
 	model?: { providerID: string; modelID: string; variant?: string }
 	modelID?: string
 	providerID?: string
+	variant?: string
 	tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
@@ -100,7 +101,11 @@ export async function injectContinuationPrompt(
 				model =
 					info.model ??
 					(info.providerID && info.modelID
-						? { providerID: info.providerID, modelID: info.modelID }
+						? {
+							providerID: info.providerID,
+							modelID: info.modelID,
+							...(info.variant ? { variant: info.variant } : {}),
+						}
 						: undefined)
 				tools = info.tools
 				break

--- a/src/hooks/unstable-agent-babysitter/index.test.ts
+++ b/src/hooks/unstable-agent-babysitter/index.test.ts
@@ -660,4 +660,47 @@ describe("unstable-agent-babysitter hook", () => {
     expect(text).toContain("Agent: Sisyphus - ultraworker")
     expect(text).not.toContain("Agent: Sisyphus (Ultraworker)")
   })
+
+  test("#given main session message has top-level variant (real SDK shape) #when injecting reminder #then promptAsync receives variant", async () => {
+    // given
+    setMainSession("main-1")
+    const promptCalls: Array<{ input: unknown }> = []
+    const ctx = createMockPluginInput({
+      messagesBySession: {
+        "main-1": [
+          {
+            info: {
+              agent: "sisyphus",
+              providerID: "openai",
+              modelID: "gpt-4",
+              variant: "max",
+            },
+          },
+        ],
+        "bg-1": [
+          { info: { role: "assistant" }, parts: [{ type: "thinking", thinking: "deep thought" }] },
+        ],
+      },
+      promptCalls,
+    })
+    const backgroundManager = createBackgroundManager([createTask()])
+    const hook = createUnstableAgentBabysitterHook(ctx, {
+      backgroundManager,
+      config: { timeout_ms: 120000 },
+    })
+
+    // when
+    await hook.event({ event: { type: "session.idle", properties: { sessionID: "main-1" } } })
+
+    // then
+    expect(promptCalls.length).toBe(1)
+    const payload = promptCalls[0].input as {
+      body?: {
+        model?: { providerID: string; modelID: string }
+        variant?: string
+      }
+    }
+    expect(payload.body?.model).toEqual({ providerID: "openai", modelID: "gpt-4" })
+    expect(payload.body?.variant).toBe("max")
+  })
 })

--- a/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
+++ b/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
@@ -9,6 +9,7 @@ type MessageInfo = {
   model?: { providerID: string; modelID: string; variant?: string }
   providerID?: string
   modelID?: string
+  variant?: string
   tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
@@ -40,12 +41,18 @@ export function getMessageInfo(value: unknown): MessageInfo | undefined {
         ...(typeof modelValue.variant === "string" ? { variant: modelValue.variant } : {}),
       }
     : undefined
+  const variant = typeof modelValue?.variant === "string"
+    ? modelValue.variant
+    : typeof info.variant === "string"
+      ? info.variant
+      : undefined
   return {
     role: typeof info.role === "string" ? info.role : undefined,
     agent: typeof info.agent === "string" ? info.agent : undefined,
     model,
     providerID: typeof info.providerID === "string" ? info.providerID : undefined,
     modelID: typeof info.modelID === "string" ? info.modelID : undefined,
+    variant,
     tools: isRecord(info.tools)
       ? Object.entries(info.tools).reduce<Record<string, boolean | "allow" | "deny" | "ask">>((acc, [key, value]) => {
           if (

--- a/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
+++ b/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
@@ -69,7 +69,15 @@ async function resolveMainSessionTarget(
       const info = getMessageInfo(messages[i])
       if (info?.agent || info?.model || (info?.providerID && info?.modelID)) {
         agent = agent ?? info?.agent
-        model = info?.model ?? (info?.providerID && info?.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+        model =
+          info?.model ??
+          (info?.providerID && info?.modelID
+            ? {
+                providerID: info.providerID,
+                modelID: info.modelID,
+                ...(info.variant ? { variant: info.variant } : {}),
+              }
+            : undefined)
         tools = resolveInheritedPromptTools(sessionID, info?.tools) ?? tools
         break
       }


### PR DESCRIPTION
## Summary

- #3081 routes `variant` through every promptAsync continuation, but only reads it from `info.model.variant`. Real `AssistantMessage` payloads from `@opencode-ai/sdk@1.4.0` place `providerID`/`modelID`/`variant` directly on the message — there is no nested `model` object — so all 5 continuation paths drop the user's reasoning intensity (`max`/`high`/...) on every automatic continuation.
- Add a top-level `info.variant` fallback in the root SDK helper plus the four hook callers, and add 4 regression tests that use the real SDK shape (the existing #3081 tests all use a synthetic `info.model.variant` shape that does not exist on the wire).

## Why #3081 Missed This

The SDK type itself lives at the top level:

```ts
// node_modules/@opencode-ai/sdk@1.4.0/dist/v2/gen/types.gen.d.ts
export type AssistantMessage = {
  modelID: string
  providerID: string
  // ...
  variant?: string  // top-level, no nested model object
  finish?: string
}
```

Verified against my live opencode 1.4.1 SQLite database (`~/.local/share/opencode/opencode.db`, ~31 GB):

| Metric (since 2026-04-01, opencode 1.4.x) | Count |
|---|---|
| `assistant` messages total | **37,026** |
| `assistant` messages carrying `variant` | **32,504** |
| `assistant` messages using `info.model.variant` (the shape #3081 reads) | **0** |

A representative row pulled from the live db (today, 2026-04-08 21:01):

```json
{
  "role": "assistant",
  "agent": "Sisyphus (Ultraworker)",
  "variant": "max",
  "modelID": "claude-opus-4-6",
  "providerID": "anthropic",
  "time": { "created": 1775653262367 }
}
```

There is no `model` object — `variant` lives at the top level, and the existing #3081 tests are the only place in the entire codebase where `info.model.variant` actually appears.

## Changes

- **`src/features/hook-message-injector/injector.ts`**: `convertSDKMessageToStoredMessage` now reads `info.model?.variant ?? info.variant` and the `SDKMessage` type gains a top-level `variant?: string`. This is the root helper used by the SQLite path of `recent-model-resolver`, `continuation-prompt-injector`, and friends.
- **`src/hooks/atlas/recent-model-resolver.ts`**: the existing `info?.providerID && info?.modelID` fallback branch now propagates `info.variant`. Without this, atlas/boulder continuation always loses variant on real SDK data.
- **`src/hooks/unstable-agent-babysitter/task-message-analyzer.ts`**: `MessageInfo` gets a top-level `variant?: string`, and `getMessageInfo()` falls back to `info.variant` when there is no nested `modelValue.variant`.
- **`src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts`**: `resolveMainSessionTarget` now propagates `info.variant` onto the synthesized model object (the path that fires for every real SDK message).
- **`src/hooks/ralph-loop/continuation-prompt-injector.ts`**: same fallback on the synthesized model object inside `injectContinuationPrompt`.

## Tests

4 new regression tests (one per surface) use the **real SDK shape** with top-level `providerID`/`modelID`/`variant` and no nested `model` object:

- `src/features/hook-message-injector/injector.test.ts` — `it("preserves top-level variant on assistant shape (real SDK shape)")`
- `src/hooks/atlas/recent-model-resolver.test.ts` — `test("#given assistant message with top-level variant (real SDK shape) ...")`
- `src/hooks/ralph-loop/continuation-prompt-injector.test.ts` — `test("#given assistant message with top-level variant (real SDK shape) ...")`
- `src/hooks/unstable-agent-babysitter/index.test.ts` — `test("#given main session message has top-level variant (real SDK shape) ...")`

All 4 tests fail against current `dev` (variant comes back as `undefined`) and pass after this PR.

```bash
bun run typecheck                               # clean
bun test src/features/hook-message-injector \
         src/hooks/atlas \
         src/hooks/ralph-loop \
         src/hooks/unstable-agent-babysitter \
         src/hooks/todo-continuation-enforcer \
         src/hooks/session-recovery \
         src/features/background-agent
# 830 pass, 0 fail, 1596 expect() calls — 66 files
```

## User Impact

Before this PR, every user on opencode 1.4.x who set a non-default reasoning intensity (`max`, `high`, `medium`) was silently downgraded to the model default the moment any auto-continuation fired (atlas, boulder, ralph-loop, todo-continuation-enforcer, unstable-agent babysitter, session recovery). After this PR the variant survives all 5 paths.

## Related Issues

Refs #3081 (the propagation work this completes for the real SDK shape).
