### PR TITLE
feat(background-task): make taskCleanupDelayMs configurable

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5687,6 +5687,10 @@
           "type": "number",
           "minimum": 10000
         },
+        "taskCleanupDelayMs": {
+          "type": "number",
+          "minimum": 60000
+        },
         "syncPollTimeoutMs": {
           "type": "number",
           "minimum": 60000

--- a/src/config/schema/background-task.ts
+++ b/src/config/schema/background-task.ts
@@ -20,6 +20,8 @@ export const BackgroundTaskConfigSchema = z.object({
   taskTtlMs: z.number().min(300000).optional(),
   /** Timeout for tasks whose session has completely disappeared from the status registry (default: 60000 = 1 minute, minimum: 10000 = 10 seconds). When a session is gone (likely crashed), this shorter timeout is used instead of the normal stale timeout. */
   sessionGoneTimeoutMs: z.number().min(10000).optional(),
+  /** Delay before removing completed/cancelled/errored tasks from memory in milliseconds (default: 600000 = 10 minutes, minimum: 60000 = 1 minute). */
+  taskCleanupDelayMs: z.number().min(60000).optional(),
   syncPollTimeoutMs: z.number().min(60000).optional(),
   /** Maximum tool calls per subagent task before circuit breaker triggers (default: 200, minimum: 10). Prevents runaway loops from burning unlimited tokens. */
   maxToolCalls: z.number().int().min(10).optional(),

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1510,7 +1510,7 @@ export class BackgroundManager {
         SessionCategoryRegistry.remove(task.sessionID)
       }
       log("[background-agent] Removed completed task from memory:", taskId)
-    }, TASK_CLEANUP_DELAY_MS)
+    }, this.config?.taskCleanupDelayMs ?? TASK_CLEANUP_DELAY_MS)
 
     this.completionTimers.set(taskId, timer)
   }


### PR DESCRIPTION
## Summary

- `TASK_CLEANUP_DELAY_MS` — the delay between a background task reaching a terminal state (`completed`/`cancelled`/`errored`) and its removal from the in-memory task store — is currently a hard-coded 10-minute constant in `src/features/background-agent/constants.ts`.
- For long-running background workflows, 10 minutes is often too short: users end up with `background_output` hitting "task not found" when they come back to inspect results more than ~10 minutes after completion.
- This PR exposes the cleanup delay as a user-configurable `taskCleanupDelayMs` field on `BackgroundTaskConfigSchema`, mirroring the existing `taskTtlMs` pattern from #2825. Default remains **10 minutes** (unchanged), so existing users see zero behavior change unless they opt in.

## Why mirror `taskTtlMs`?

`taskTtlMs` (landed in #2825) already lets users tune the non-terminal task TTL. `taskCleanupDelayMs` is its natural counterpart for the terminal-state side of the task lifecycle, and users running long background workflows need both to express their actual needs. Keeping the naming, JSDoc style, and `this.config?.* ?? CONSTANT` fallback pattern identical to `taskTtlMs` should make this a trivial review.

## Changes

- **`src/config/schema/background-task.ts`**: add `taskCleanupDelayMs: z.number().min(60000).optional()` with a JSDoc comment matching the `taskTtlMs` style (default shown, minimum documented).
- **`src/features/background-agent/manager.ts`**: `scheduleCompletionRemoval()` now reads `this.config?.taskCleanupDelayMs ?? TASK_CLEANUP_DELAY_MS`. The constant remains the fallback so unconfigured users retain the current 10-minute default.
- **`assets/oh-my-opencode.schema.json`**: regenerated via `bun run build:schema`.

3 files changed, 7 insertions(+), 1 deletion(-).

## Defaults & bounds

| | Value |
|---|---|
| Default (unchanged) | `600000` ms = 10 min (= `TASK_CLEANUP_DELAY_MS`) |
| Minimum | `60000` ms = 1 min |
| Schema location | `background_task.taskCleanupDelayMs` |

Example config (`oh-my-opencode.jsonc`):

```jsonc
{
  "background_task": {
    "taskTtlMs": 7200000,          // 2h - already configurable via #2825
    "taskCleanupDelayMs": 1800000  // 30min - this PR
  }
}
```

## Testing

```bash
bun run typecheck                            # clean
bun test src/features/background-agent       # 411 pass, 0 fail, 25 files
```

No new tests were added because the change is a pure configuration passthrough (`this.config?.taskCleanupDelayMs ?? TASK_CLEANUP_DELAY_MS`) and the existing `background-agent` test suite already exercises the completion-removal timer. Happy to add a dedicated test if reviewers would like one.

## Related Issues

Refs #2825 (established the `taskTtlMs` pattern this PR mirrors).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the delay before removing completed/cancelled/errored background tasks configurable via `taskCleanupDelayMs`. This helps long-running workflows keep results available longer and avoid "task not found" in `background_output`.

- **New Features**
  - Added `taskCleanupDelayMs` to `BackgroundTaskConfigSchema` (min 60,000 ms). Default remains 10 minutes.
  - `BackgroundManager.scheduleCompletionRemoval()` uses `this.config?.taskCleanupDelayMs ?? TASK_CLEANUP_DELAY_MS`.
  - Schema updated; configure via `background_task.taskCleanupDelayMs` if you need a longer retention window.

<sup>Written for commit 14c25cbbf56124f38235cb79a3424754c84f7dc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

