### PR TITLE
fix(publish): generate openagent alias packages from canonical manifests

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -65,7 +65,7 @@ jobs:
           VERSION="$INPUT_VERSION"
           DIST_TAG="$INPUT_DIST_TAG"
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Invalid version: $VERSION"
             exit 1
           fi
@@ -85,15 +85,11 @@ jobs:
         run: |
           PLATFORM_KEY="${{ matrix.platform }}"
           PLATFORM_KEY="${PLATFORM_KEY//-/_}"
-          
-          # Check oh-my-opencode
           OC_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-opencode-${{ matrix.platform }}/${VERSION}")
-          # Check oh-my-openagent
           OA_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-openagent-${{ matrix.platform }}/${VERSION}")
-          
+
           echo "oh-my-opencode-${{ matrix.platform }}@${VERSION}: ${OC_STATUS}"
           echo "oh-my-openagent-${{ matrix.platform }}@${VERSION}: ${OA_STATUS}"
-          
           if [ "$OC_STATUS" = "200" ]; then
             echo "skip_opencode=true" >> $GITHUB_OUTPUT
             echo "✓ oh-my-opencode-${{ matrix.platform }}@${VERSION} already published"
@@ -101,7 +97,6 @@ jobs:
             echo "skip_opencode=false" >> $GITHUB_OUTPUT
             echo "→ oh-my-opencode-${{ matrix.platform }}@${VERSION} needs publishing"
           fi
-          
           if [ "$OA_STATUS" = "200" ]; then
             echo "skip_openagent=true" >> $GITHUB_OUTPUT
             echo "✓ oh-my-openagent-${{ matrix.platform }}@${VERSION} already published"
@@ -109,12 +104,14 @@ jobs:
             echo "skip_openagent=false" >> $GITHUB_OUTPUT
             echo "→ oh-my-openagent-${{ matrix.platform }}@${VERSION} needs publishing"
           fi
-          
-          # Skip build only if BOTH are already published
+
+          # Need artifact if either package needs publishing.
           if [ "$OC_STATUS" = "200" ] && [ "$OA_STATUS" = "200" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip_${PLATFORM_KEY}=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
+            echo "skip_${PLATFORM_KEY}=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Update version in package.json
@@ -252,6 +249,11 @@ jobs:
       matrix:
         platform: [darwin-arm64, darwin-x64, darwin-x64-baseline, linux-x64, linux-x64-baseline, linux-arm64, linux-x64-musl, linux-x64-musl-baseline, linux-arm64-musl, windows-x64, windows-x64-baseline]
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - name: Validate release inputs
         id: validate
         env:
@@ -261,7 +263,7 @@ jobs:
           VERSION="$INPUT_VERSION"
           DIST_TAG="$INPUT_DIST_TAG"
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Invalid version: $VERSION"
             exit 1
           fi
@@ -281,22 +283,20 @@ jobs:
         run: |
           OC_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-opencode-${{ matrix.platform }}/${VERSION}")
           OA_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-openagent-${{ matrix.platform }}/${VERSION}")
-          
           if [ "$OC_STATUS" = "200" ]; then
             echo "skip_opencode=true" >> $GITHUB_OUTPUT
             echo "✓ oh-my-opencode-${{ matrix.platform }}@${VERSION} already published"
           else
             echo "skip_opencode=false" >> $GITHUB_OUTPUT
           fi
-          
           if [ "$OA_STATUS" = "200" ]; then
             echo "skip_openagent=true" >> $GITHUB_OUTPUT
             echo "✓ oh-my-openagent-${{ matrix.platform }}@${VERSION} already published"
           else
             echo "skip_openagent=false" >> $GITHUB_OUTPUT
           fi
-          
-          # Need artifact if either package needs publishing
+
+          # Need artifact if either package needs publishing.
           if [ "$OC_STATUS" = "200" ] && [ "$OA_STATUS" = "200" ]; then
             echo "skip_all=true" >> $GITHUB_OUTPUT
           else
@@ -311,6 +311,12 @@ jobs:
         with:
           name: binary-${{ matrix.platform }}
           path: .
+
+      - name: Fail if required artifact download failed
+        if: steps.check.outputs.skip_all != 'true' && steps.download.outcome != 'success'
+        run: |
+          echo "::error::Required artifact binary-${{ matrix.platform }} could not be downloaded"
+          exit 1
 
       - name: Extract artifact
         if: steps.check.outputs.skip_all != 'true' && steps.download.outcome == 'success'
@@ -357,14 +363,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
-          cd packages/${{ matrix.platform }}
+          ALIAS_OUT="$RUNNER_TEMP/oh-my-openagent-${{ matrix.platform }}"
+          bun run script/publish/build-alias-platform-package.ts \
+            --source "packages/${{ matrix.platform }}" \
+            --out "$ALIAS_OUT"
 
-          # Rename package for oh-my-openagent
-          jq --arg name "oh-my-openagent-${{ matrix.platform }}" \
-             --arg desc "Platform-specific binary for oh-my-openagent (${{ matrix.platform }})" \
-             '.name = $name | .description = $desc | .bin = {"oh-my-openagent": (.bin | to_entries | .[0].value)}' \
-             package.json > tmp.json && mv tmp.json package.json
-
+          cd "$ALIAS_OUT"
           if [ -n "$DIST_TAG" ]; then
             npm publish --access public --provenance --tag "$DIST_TAG"
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
             esac
           fi
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Invalid version: $VERSION"
             exit 1
           fi
@@ -200,17 +200,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
-          # Update package name, version, and optionalDependencies for oh-my-openagent
-          jq --arg v "$VERSION" '
-            .name = "oh-my-openagent" |
-            .version = $v |
-            .optionalDependencies = (
-              .optionalDependencies | to_entries |
-              map(.key = (.key | sub("^oh-my-opencode-"; "oh-my-openagent-")) | .value = $v) |
-              from_entries
-            )
-          ' package.json > tmp.json && mv tmp.json package.json
+          ALIAS_OUT="$RUNNER_TEMP/oh-my-openagent-main"
+          bun run script/publish/build-alias-package.ts --source . --out "$ALIAS_OUT" --version "$VERSION"
 
+          cd "$ALIAS_OUT"
           if [ -n "$DIST_TAG" ]; then
             npm publish --access public --provenance --tag "$DIST_TAG"
           else

--- a/script/publish-script.test.ts
+++ b/script/publish-script.test.ts
@@ -1,0 +1,168 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import * as fs from "node:fs"
+import { readFileSync } from "node:fs"
+import * as path from "node:path"
+import { publishPlatformBatch, publishPlatformPair } from "./publish"
+
+function createTempDir(prefix: string): string {
+  const tempRoot = path.join(process.env.HOME ?? process.cwd(), "tmp")
+  fs.mkdirSync(tempRoot, { recursive: true })
+  return fs.mkdtempSync(path.join(tempRoot, prefix))
+}
+
+describe("script/publish.ts", () => {
+  test("tracks the full canonical platform package matrix", () => {
+    const script = readFileSync(new URL("./publish.ts", import.meta.url), "utf8")
+
+    expect(script).toContain('"darwin-x64-baseline"')
+    expect(script).toContain('"linux-x64-baseline"')
+    expect(script).toContain('"linux-x64-musl-baseline"')
+    expect(script).toContain('"windows-x64-baseline"')
+    expect(script).toContain('const totalPackages = PLATFORM_PACKAGES.length * 2 + 2')
+  })
+
+  test("skips alias platform publish when canonical platform publish fails", () => {
+    const script = readFileSync(new URL("./publish.ts", import.meta.url), "utf8")
+
+    expect(script).toContain("if (!result.success) {")
+    expect(script).toContain("aliasResult: null")
+    expect(script).toContain("Skipping ${aliasPkgName} because ${pkgName} failed")
+    expect(script).toContain("if (!aliasResult) {")
+  })
+
+  test("converts alias generation throws into structured alias publish failures", () => {
+    const script = readFileSync(new URL("./publish.ts", import.meta.url), "utf8")
+
+    expect(script).toContain("try {")
+    expect(script).toContain("createAliasPlatformPackage(pkgDir, aliasDir)")
+    expect(script).toContain("} catch (error) {")
+    expect(script).toContain("aliasResult: {")
+    expect(script).toContain("error: error instanceof Error ? error.message : String(error)")
+  })
+
+  test("returns structured alias failure when alias generation throws", async () => {
+    const calls: string[] = []
+
+    const outcome = await publishPlatformPair("linux-x64", "1.2.3", "next", {
+      publishPackage: async (cwd, distTag, useProvenance, pkgName) => {
+        calls.push(`publish:${pkgName}:${cwd}:${distTag}:${useProvenance}`)
+        return { success: true }
+      },
+      createAliasPlatformPackage: () => {
+        throw new Error("alias explosion")
+      },
+      createTempDir: () => "/tmp/fake-alias-dir",
+    })
+
+    expect(outcome.pkgName).toBe("oh-my-opencode-linux-x64")
+    expect(outcome.aliasPkgName).toBe("oh-my-openagent-linux-x64")
+    expect(outcome.result).toEqual({ success: true })
+    expect(outcome.aliasResult).toEqual({ success: false, error: "alias explosion" })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain("publish:oh-my-opencode-linux-x64:")
+  })
+
+  test("continues batch processing when one platform returns an alias failure", async () => {
+    const calls: string[] = []
+
+    const results = await publishPlatformBatch(["linux-x64", "darwin-arm64"], "1.2.3", "next", {
+      publishPlatformPair: async (platform) => {
+        calls.push(platform)
+        if (platform === "linux-x64") {
+          return {
+            platform,
+            pkgName: "oh-my-opencode-linux-x64",
+            result: { success: true },
+            aliasPkgName: "oh-my-openagent-linux-x64",
+            aliasResult: { success: false, error: "alias explosion" },
+          }
+        }
+
+        return {
+          platform,
+          pkgName: "oh-my-opencode-darwin-arm64",
+          result: { success: true },
+          aliasPkgName: "oh-my-openagent-darwin-arm64",
+          aliasResult: { success: true },
+        }
+      },
+    })
+
+    expect(calls).toEqual(["linux-x64", "darwin-arm64"])
+    expect(results).toHaveLength(2)
+    expect(results[0]?.aliasResult).toEqual({ success: false, error: "alias explosion" })
+    expect(results[1]?.aliasResult).toEqual({ success: true })
+  })
+
+  test("integrates real alias generation failure handling across a batch", async () => {
+    const root = createTempDir("publish-batch-")
+    const packagesDir = path.join(root, "packages")
+    fs.mkdirSync(packagesDir, { recursive: true })
+
+    const writePackage = (platform: string, withBinary: boolean) => {
+      const pkgDir = path.join(packagesDir, platform)
+      fs.mkdirSync(path.join(pkgDir, "bin"), { recursive: true })
+      fs.writeFileSync(
+        path.join(pkgDir, "package.json"),
+        JSON.stringify(
+          {
+            name: `oh-my-opencode-${platform}`,
+            version: "1.2.3",
+            description: `Platform-specific binary for oh-my-opencode (${platform})`,
+            bin: { "oh-my-opencode": "./bin/oh-my-opencode" },
+          },
+          null,
+          2
+        )
+      )
+
+      if (withBinary) {
+        fs.writeFileSync(path.join(pkgDir, "bin", "oh-my-opencode"), "binary")
+      }
+    }
+
+    writePackage("linux-x64", false)
+    writePackage("darwin-arm64", true)
+
+    const calls: string[] = []
+    const previousCwd = process.cwd()
+    process.chdir(root)
+
+    try {
+      const results = await publishPlatformBatch(["linux-x64", "darwin-arm64"], "1.2.3", "next", {
+        platformPublishDependencies: {
+          publishPackage: async (cwd, distTag, useProvenance, pkgName) => {
+            calls.push(`publish:${pkgName}:${cwd}:${distTag}:${useProvenance}`)
+            return { success: true }
+          },
+          createAliasPlatformPackage: (sourceDir, outDir) => {
+            const pkgName = JSON.parse(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).name as string
+            if (pkgName === "oh-my-opencode-linux-x64") {
+              throw new Error("alias explosion")
+            }
+
+            fs.mkdirSync(outDir, { recursive: true })
+            fs.writeFileSync(
+              path.join(outDir, "package.json"),
+              JSON.stringify({ name: "oh-my-openagent-darwin-arm64", version: "1.2.3", bin: { "oh-my-openagent": "./bin/oh-my-openagent" } }, null, 2)
+            )
+          },
+          createTempDir: (platform) => path.join(root, `alias-${platform}`),
+        },
+      })
+
+      expect(results).toHaveLength(2)
+      expect(results[0]?.aliasResult).toEqual({ success: false, error: "alias explosion" })
+      expect(results[1]?.aliasResult).toEqual({ success: true })
+      expect(calls).toHaveLength(3)
+      expect(calls[0]).toContain("publish:oh-my-opencode-linux-x64:")
+      expect(calls[1]).toContain("publish:oh-my-opencode-darwin-arm64:")
+      expect(calls[2]).toContain("publish:oh-my-openagent-darwin-arm64:")
+    } finally {
+      process.chdir(previousCwd)
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -18,4 +18,37 @@ describe("test workflows", () => {
       expect(workflow).toMatch(/run: bun (test|run script\/run-ci-tests\.ts)/)
     }
   })
+
+  test("publish workflow generates alias main package from a temp directory", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/publish.yml", import.meta.url), "utf8")
+
+    expect(workflow).toMatch(/- name: Publish oh-my-opencode[\s\S]*?if: steps\.check\.outputs\.skip != 'true'/)
+    expect(workflow).toMatch(/- name: Publish oh-my-openagent[\s\S]*?if: steps\.check-openagent\.outputs\.skip != 'true'/)
+    expect(workflow).toMatch(/- name: Publish oh-my-openagent[\s\S]*?ALIAS_OUT="\$RUNNER_TEMP\/oh-my-openagent-main"/)
+    expect(workflow).toMatch(/- name: Publish oh-my-openagent[\s\S]*?bun run script\/publish\/build-alias-package\.ts --source \. --out "\$ALIAS_OUT" --version "\$VERSION"/)
+    expect(workflow).toMatch(/- name: Publish oh-my-openagent[\s\S]*?cd "\$ALIAS_OUT"/)
+    expect(workflow).toContain('uses: ./.github/workflows/publish-platform.yml')
+  })
+
+  test("publish-platform workflow fails when a required artifact download is missing", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/publish-platform.yml", import.meta.url), "utf8")
+
+    expect(workflow).toContain("continue-on-error: true")
+    expect(workflow).toContain("- name: Fail if required artifact download failed")
+    expect(workflow).toContain('steps.check.outputs.skip_all != \'true\' && steps.download.outcome != \'success\'')
+    expect(workflow).toContain('echo "::error::Required artifact binary-${{ matrix.platform }} could not be downloaded"')
+  })
+
+  test("publish-platform workflow checks and publishes both canonical and alias package families", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/publish-platform.yml", import.meta.url), "utf8")
+
+    expect(workflow).toContain('https://registry.npmjs.org/oh-my-opencode-${{ matrix.platform }}/${VERSION}')
+    expect(workflow).toContain('https://registry.npmjs.org/oh-my-openagent-${{ matrix.platform }}/${VERSION}')
+    expect(workflow).toContain("if: steps.check.outputs.skip_opencode != 'true' && steps.download.outcome == 'success'")
+    expect(workflow).toContain("if: steps.check.outputs.skip_openagent != 'true' && steps.download.outcome == 'success'")
+    expect(workflow).toContain('cd packages/${{ matrix.platform }}')
+    expect(workflow).toContain('ALIAS_OUT="$RUNNER_TEMP/oh-my-openagent-${{ matrix.platform }}"')
+    expect(workflow).toContain('bun run script/publish/build-alias-platform-package.ts')
+    expect(workflow).toContain('cd "$ALIAS_OUT"')
+  })
 })

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -3,8 +3,18 @@
 import { $ } from "bun"
 import { existsSync } from "node:fs"
 import { join } from "node:path"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { createAliasMainPackage } from "./publish/alias-main-package"
+import { createAliasPlatformPackage } from "./publish/alias-platform-package"
+import {
+  ALIAS_PACKAGE_NAME,
+  getAliasPlatformPackageName,
+  getCanonicalPlatformPackageName,
+  CANONICAL_PACKAGE_NAME,
+} from "./publish/identity"
 
-const PACKAGE_NAME = "oh-my-opencode"
+const PACKAGE_NAME = CANONICAL_PACKAGE_NAME
 const bump = process.env.BUMP as "major" | "minor" | "patch" | undefined
 const versionOverride = process.env.VERSION
 const republishMode = process.env.REPUBLISH === "true"
@@ -13,11 +23,15 @@ const prepareOnly = process.argv.includes("--prepare-only")
 const PLATFORM_PACKAGES = [
   "darwin-arm64",
   "darwin-x64",
+  "darwin-x64-baseline",
   "linux-x64",
+  "linux-x64-baseline",
   "linux-arm64",
   "linux-x64-musl",
+  "linux-x64-musl-baseline",
   "linux-arm64-musl",
   "windows-x64",
+  "windows-x64-baseline",
 ]
 
 console.log("=== Publishing oh-my-opencode (multi-package) ===\n")
@@ -66,7 +80,7 @@ async function updateAllPackageVersions(newVersion: string): Promise<void> {
   // Update optionalDependencies versions in main package.json
   let mainPkg = await Bun.file(mainPkgPath).text()
   for (const platform of PLATFORM_PACKAGES) {
-    const pkgName = `oh-my-opencode-${platform}`
+    const pkgName = getCanonicalPlatformPackageName(platform)
     mainPkg = mainPkg.replace(
       new RegExp(`"${pkgName}": "[^"]+"`),
       `"${pkgName}": "${newVersion}"`
@@ -188,6 +202,25 @@ interface PublishResult {
   error?: string
 }
 
+interface PlatformPublishOutcome {
+  platform: string
+  pkgName: string
+  result: PublishResult
+  aliasPkgName: string
+  aliasResult: PublishResult | null
+}
+
+interface PlatformPublishDependencies {
+  publishPackage: typeof publishPackage
+  createAliasPlatformPackage: typeof createAliasPlatformPackage
+  createTempDir: (platform: string) => string
+}
+
+interface BatchExecutionDependencies {
+  publishPlatformPair?: typeof publishPlatformPair
+  platformPublishDependencies?: PlatformPublishDependencies
+}
+
 async function checkPackageVersionExists(pkgName: string, version: string): Promise<boolean> {
   try {
     const res = await fetch(`https://registry.npmjs.org/${pkgName}/${version}`)
@@ -246,6 +279,74 @@ async function publishPackage(cwd: string, distTag: string | null, useProvenance
   }
 }
 
+export async function publishPlatformPair(
+  platform: string,
+  version: string,
+  distTag: string | null,
+  deps: PlatformPublishDependencies = {
+    publishPackage,
+    createAliasPlatformPackage,
+    createTempDir: (name) => mkdtempSync(join(tmpdir(), `oh-my-openagent-${name}-`)),
+  }
+): Promise<PlatformPublishOutcome> {
+  const pkgDir = join(process.cwd(), "packages", platform)
+  const pkgName = `oh-my-opencode-${platform}`
+
+  console.log(`    Starting ${pkgName}...`)
+  const result = await deps.publishPackage(pkgDir, distTag, false, pkgName, version)
+
+  if (!result.success) {
+    return {
+      platform,
+      pkgName,
+      result,
+      aliasPkgName: getAliasPlatformPackageName(platform),
+      aliasResult: null,
+    }
+  }
+
+  const aliasPkgName = getAliasPlatformPackageName(platform)
+
+  try {
+    const aliasDir = deps.createTempDir(platform)
+    deps.createAliasPlatformPackage(pkgDir, aliasDir)
+
+    console.log(`    Starting ${aliasPkgName}...`)
+    const aliasResult = await deps.publishPackage(aliasDir, distTag, false, aliasPkgName, version)
+
+    return {
+      platform,
+      pkgName,
+      result,
+      aliasPkgName,
+      aliasResult,
+    }
+  } catch (error) {
+    return {
+      platform,
+      pkgName,
+      result,
+      aliasPkgName,
+      aliasResult: {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+}
+
+export async function publishPlatformBatch(
+  batch: string[],
+  version: string,
+  distTag: string | null,
+  deps: BatchExecutionDependencies = {}
+): Promise<PlatformPublishOutcome[]> {
+  const publishPair = deps.publishPlatformPair ?? ((platform, resolvedVersion, resolvedDistTag) =>
+    publishPlatformPair(platform, resolvedVersion, resolvedDistTag, deps.platformPublishDependencies))
+
+  return Promise.all(batch.map((platform) => publishPair(platform, version, distTag)))
+}
+
 async function publishAllPackages(version: string): Promise<void> {
   const distTag = getDistTag(version)
   const skipPlatform = process.env.SKIP_PLATFORM_PACKAGES === "true"
@@ -268,28 +369,36 @@ async function publishAllPackages(version: string): Promise<void> {
       
       console.log(`\n  Batch ${batchNum}/${totalBatches}: ${batch.join(", ")}`)
       
-      const publishPromises = batch.map(async (platform) => {
-        const pkgDir = join(process.cwd(), "packages", platform)
-        const pkgName = `oh-my-opencode-${platform}`
-        
-        console.log(`    Starting ${pkgName}...`)
-        const result = await publishPackage(pkgDir, distTag, false, pkgName, version)
-        
-        return { platform, pkgName, result }
-      })
-      
-      const results = await Promise.all(publishPromises)
-      
-      for (const { pkgName, result } of results) {
+      const results = await publishPlatformBatch(batch, version, distTag)
+
+      for (const { pkgName, result, aliasPkgName, aliasResult } of results) {
         if (result.success) {
           if (result.alreadyPublished) {
-            console.log(`    ✓ ${pkgName}@${version} (already published)`)
+            console.log(`    ✓ ${pkgName}@${version} (already published)`) 
           } else {
             console.log(`    ✓ ${pkgName}@${version}`)
           }
         } else {
           console.error(`    ✗ ${pkgName} failed: ${result.error}`)
           failures.push(pkgName)
+          console.error(`    ↷ Skipping ${aliasPkgName} because ${pkgName} failed`)
+          continue
+        }
+
+        if (!aliasResult) {
+          console.error(`    ↷ Skipping ${aliasPkgName} because alias publish did not run`)
+          continue
+        }
+
+        if (aliasResult.success) {
+          if (aliasResult.alreadyPublished) {
+            console.log(`    ✓ ${aliasPkgName}@${version} (already published)`)
+          } else {
+            console.log(`    ✓ ${aliasPkgName}@${version}`)
+          }
+        } else {
+          console.error(`    ✗ ${aliasPkgName} failed: ${aliasResult.error}`)
+          failures.push(aliasPkgName)
         }
       }
     }
@@ -312,6 +421,22 @@ async function publishAllPackages(version: string): Promise<void> {
   } else {
     console.error(`  ✗ ${PACKAGE_NAME} failed: ${mainResult.error}`)
     throw new Error(`Failed to publish ${PACKAGE_NAME}`)
+  }
+
+  console.log(`\n📦 Publishing alias main package...`)
+  const aliasMainDir = mkdtempSync(join(tmpdir(), "oh-my-openagent-main-"))
+  createAliasMainPackage(process.cwd(), aliasMainDir, { version })
+  const aliasMainResult = await publishPackage(aliasMainDir, distTag, true, ALIAS_PACKAGE_NAME, version)
+
+  if (aliasMainResult.success) {
+    if (aliasMainResult.alreadyPublished) {
+      console.log(`  ✓ ${ALIAS_PACKAGE_NAME}@${version} (already published)`)
+    } else {
+      console.log(`  ✓ ${ALIAS_PACKAGE_NAME}@${version}`)
+    }
+  } else {
+    console.error(`  ✗ ${ALIAS_PACKAGE_NAME} failed: ${aliasMainResult.error}`)
+    throw new Error(`Failed to publish ${ALIAS_PACKAGE_NAME}`)
   }
 }
 
@@ -417,7 +542,10 @@ async function main() {
   await publishAllPackages(newVersion)
   await gitTagAndRelease(newVersion, notes)
 
-  console.log(`\n=== Successfully published ${PACKAGE_NAME}@${newVersion} (8 packages) ===`)
+  const totalPackages = PLATFORM_PACKAGES.length * 2 + 2
+  console.log(`\n=== Successfully published ${PACKAGE_NAME}@${newVersion} (${totalPackages} packages) ===`)
 }
 
-main()
+if (import.meta.main) {
+  main()
+}

--- a/script/publish/alias-main-package.test.ts
+++ b/script/publish/alias-main-package.test.ts
@@ -1,0 +1,262 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { execFileSync } from "node:child_process"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { createAliasMainPackage } from "./alias-main-package"
+
+function createTempDir(prefix: string): string {
+  const tempRoot = path.join(process.env.HOME ?? process.cwd(), "tmp")
+  fs.mkdirSync(tempRoot, { recursive: true })
+  return fs.mkdtempSync(path.join(tempRoot, prefix))
+}
+
+interface AliasMainFixtureOptions {
+  packageJson: Record<string, unknown>
+  indexJsContent?: string
+  cliIndexJsContent?: string
+  includeWrapper?: boolean
+}
+
+function writeAliasMainFixture(sourceRoot: string, options: AliasMainFixtureOptions): void {
+  fs.mkdirSync(path.join(sourceRoot, "dist", "cli"), { recursive: true })
+  fs.mkdirSync(path.join(sourceRoot, "dist", "hooks", "auto-update-checker"), { recursive: true })
+  fs.mkdirSync(path.join(sourceRoot, "bin"), { recursive: true })
+
+  fs.writeFileSync(
+    path.join(sourceRoot, "package.json"),
+    `${JSON.stringify(options.packageJson, null, 2)}\n`
+  )
+  fs.writeFileSync(path.join(sourceRoot, "bin", "platform.js"), 'return "oh-my-opencode-linux-x64/bin/oh-my-opencode";')
+  if (options.includeWrapper !== false) {
+    fs.writeFileSync(path.join(sourceRoot, "bin", "oh-my-opencode.js"), 'console.log("oh-my-opencode")')
+  }
+  fs.writeFileSync(path.join(sourceRoot, "postinstall.mjs"), 'console.log("oh-my-opencode")')
+  fs.writeFileSync(
+    path.join(sourceRoot, "dist", "index.js"),
+    options.indexJsContent ?? 'var PACKAGE_NAME = "oh-my-opencode";'
+  )
+  fs.writeFileSync(
+    path.join(sourceRoot, "dist", "cli", "index.js"),
+    options.cliIndexJsContent ?? 'var PACKAGE_NAME2 = "oh-my-opencode", NPM_REGISTRY_URL;'
+  )
+  fs.writeFileSync(
+    path.join(sourceRoot, "dist", "hooks", "auto-update-checker", "constants.d.ts"),
+    [
+      'export declare const PACKAGE_NAME = "oh-my-opencode";',
+      'export declare const NPM_REGISTRY_URL = "https://registry.npmjs.org/-/package/oh-my-opencode/dist-tags";',
+    ].join("\n")
+  )
+  fs.writeFileSync(path.join(sourceRoot, "dist", "oh-my-opencode.schema.json"), "{}")
+}
+
+const cleanupPaths: string[] = []
+
+afterEach(() => {
+  for (const target of cleanupPaths.splice(0)) {
+    fs.rmSync(target, { recursive: true, force: true })
+  }
+})
+
+describe("createAliasMainPackage", () => {
+  it("rewrites alias publish metadata without mutating the source package", () => {
+    const sourceRoot = createTempDir("omo-source-")
+    const outDir = createTempDir("omo-out-")
+    cleanupPaths.push(sourceRoot, outDir)
+
+    writeAliasMainFixture(sourceRoot, {
+      packageJson: {
+        name: "oh-my-opencode",
+        version: "3.16.0",
+        bin: { "oh-my-opencode": "bin/oh-my-opencode.js" },
+        exports: { "./schema.json": "./dist/oh-my-opencode.schema.json" },
+        optionalDependencies: {
+          "oh-my-opencode-linux-x64": "3.16.0",
+          "oh-my-opencode-windows-x64": "3.16.0",
+        },
+      },
+    })
+
+    createAliasMainPackage(sourceRoot, outDir)
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      name: string
+      bin: Record<string, string>
+      exports: Record<string, string>
+      optionalDependencies: Record<string, string>
+      scripts?: Record<string, string>
+    }
+
+    expect(generatedPackage.name).toBe("oh-my-openagent")
+    expect(generatedPackage.bin).toEqual({ "oh-my-openagent": "bin/oh-my-openagent.js" })
+    expect(generatedPackage.exports["./schema.json"]).toBe("./dist/oh-my-openagent.schema.json")
+    expect(Object.keys(generatedPackage.optionalDependencies)).toEqual([
+      "oh-my-openagent-linux-x64",
+      "oh-my-openagent-windows-x64",
+    ])
+    expect(generatedPackage.scripts).toBeUndefined()
+
+    expect(fs.existsSync(path.join(outDir, "bin", "oh-my-openagent.js"))).toBe(true)
+    expect(fs.existsSync(path.join(outDir, "bin", "oh-my-opencode.js"))).toBe(false)
+    expect(fs.existsSync(path.join(outDir, "dist", "oh-my-openagent.schema.json"))).toBe(true)
+    expect(fs.existsSync(path.join(outDir, "dist", "oh-my-opencode.schema.json"))).toBe(false)
+
+    expect(fs.readFileSync(path.join(outDir, "bin", "platform.js"), "utf-8")).toContain("oh-my-openagent")
+    expect(fs.readFileSync(path.join(outDir, "dist", "index.js"), "utf-8")).toContain('var PACKAGE_NAME = "oh-my-openagent";')
+    expect(fs.readFileSync(path.join(outDir, "dist", "cli", "index.js"), "utf-8")).toContain('var PACKAGE_NAME2 = "oh-my-openagent",')
+
+    const sourcePackage = JSON.parse(fs.readFileSync(path.join(sourceRoot, "package.json"), "utf-8")) as {
+      name: string
+    }
+    expect(sourcePackage.name).toBe("oh-my-opencode")
+  })
+
+  it("can override alias package version and dependency versions", () => {
+    const sourceRoot = createTempDir("omo-source-version-")
+    const outDir = createTempDir("omo-out-version-")
+    cleanupPaths.push(sourceRoot, outDir)
+
+    writeAliasMainFixture(sourceRoot, {
+      packageJson: {
+        name: "oh-my-opencode",
+        version: "3.15.0",
+        bin: { "oh-my-opencode": "bin/oh-my-opencode.js" },
+        exports: { "./schema.json": "./dist/oh-my-opencode.schema.json" },
+        optionalDependencies: {
+          "oh-my-opencode-linux-x64": "3.15.0",
+          "oh-my-opencode-windows-x64": "3.15.0",
+        },
+      },
+    })
+
+    createAliasMainPackage(sourceRoot, outDir, { version: "3.16.0-alpha-1" })
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      version: string
+      optionalDependencies: Record<string, string>
+    }
+
+    expect(generatedPackage.version).toBe("3.16.0-alpha-1")
+    expect(generatedPackage.optionalDependencies).toEqual({
+      "oh-my-openagent-linux-x64": "3.16.0-alpha-1",
+      "oh-my-openagent-windows-x64": "3.16.0-alpha-1",
+    })
+  })
+
+  it("removes prepare and prepublishOnly from the generated alias manifest", () => {
+    const sourceRoot = createTempDir("omo-source-scripts-")
+    const outDir = createTempDir("omo-out-scripts-")
+    cleanupPaths.push(sourceRoot, outDir)
+
+    writeAliasMainFixture(sourceRoot, {
+      packageJson: {
+        name: "oh-my-opencode",
+        version: "3.16.0",
+        bin: { "oh-my-opencode": "bin/oh-my-opencode.js" },
+        exports: { "./schema.json": "./dist/oh-my-opencode.schema.json" },
+        scripts: {
+          prepare: "bun run build",
+          prepublishOnly: "bun run clean && bun run build",
+          postinstall: "node postinstall.mjs",
+        },
+      },
+      cliIndexJsContent: 'var PACKAGE_NAME2 = "oh-my-opencode";',
+    })
+
+    createAliasMainPackage(sourceRoot, outDir)
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(generatedPackage.scripts).toEqual({
+      postinstall: "node postinstall.mjs",
+    })
+  })
+
+  it("fails loudly when a required runtime rewrite target is missing", () => {
+    const sourceRoot = createTempDir("omo-source-missing-")
+    const outDir = createTempDir("omo-out-missing-")
+    cleanupPaths.push(sourceRoot, outDir)
+
+    writeAliasMainFixture(sourceRoot, {
+      packageJson: {
+        name: "oh-my-opencode",
+        version: "3.16.0",
+        bin: { "oh-my-opencode": "bin/oh-my-opencode.js" },
+        exports: { "./schema.json": "./dist/oh-my-opencode.schema.json" },
+      },
+      indexJsContent: 'var PACKAGE_NAME = "different-name";',
+    })
+
+    expect(() => createAliasMainPackage(sourceRoot, outDir)).toThrow("Expected to find")
+  })
+
+  it("fails when the canonical CLI wrapper is missing", () => {
+    const sourceRoot = createTempDir("omo-source-no-wrapper-")
+    const outDir = createTempDir("omo-out-no-wrapper-")
+    cleanupPaths.push(sourceRoot, outDir)
+
+    writeAliasMainFixture(sourceRoot, {
+      packageJson: {
+        name: "oh-my-opencode",
+        version: "3.16.0",
+        bin: { "oh-my-opencode": "bin/oh-my-opencode.js" },
+        exports: { "./schema.json": "./dist/oh-my-opencode.schema.json" },
+      },
+      includeWrapper: false,
+    })
+
+    expect(() => createAliasMainPackage(sourceRoot, outDir)).toThrow("Expected canonical wrapper")
+  })
+
+  it("works against the real current built artifact shape", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..")
+    const outDir = createTempDir("omo-real-artifact-")
+    cleanupPaths.push(outDir)
+
+    createAliasMainPackage(repoRoot, outDir, { version: "9.9.9-alpha-1" })
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      name: string
+      version: string
+      scripts?: Record<string, string>
+      optionalDependencies: Record<string, string>
+    }
+
+    expect(generatedPackage.name).toBe("oh-my-openagent")
+    expect(generatedPackage.version).toBe("9.9.9-alpha-1")
+    expect(generatedPackage.scripts?.prepare).toBeUndefined()
+    expect(generatedPackage.scripts?.prepublishOnly).toBeUndefined()
+    expect(generatedPackage.scripts?.postinstall).toBe("node postinstall.mjs")
+    expect(generatedPackage.optionalDependencies["oh-my-openagent-linux-x64"]).toBe("9.9.9-alpha-1")
+
+    expect(fs.readFileSync(path.join(outDir, "dist", "index.js"), "utf-8")).toContain('var PACKAGE_NAME = "oh-my-openagent";')
+    expect(fs.readFileSync(path.join(outDir, "dist", "cli", "index.js"), "utf-8")).toContain('var PACKAGE_NAME2 = "oh-my-openagent"')
+  })
+
+  it("can be packed by npm from the generated temp artifact directory", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..")
+    const outDir = createTempDir("omo-real-pack-")
+    cleanupPaths.push(outDir)
+
+    createAliasMainPackage(repoRoot, outDir, { version: "9.9.9-alpha-1" })
+
+    const packedFile = execFileSync("npm", ["pack", outDir], {
+      cwd: outDir,
+      encoding: "utf8",
+    }).trim()
+
+    expect(packedFile).toBe("oh-my-openagent-9.9.9-alpha-1.tgz")
+    expect(fs.existsSync(path.join(outDir, packedFile))).toBe(true)
+  })
+})

--- a/script/publish/alias-main-package.ts
+++ b/script/publish/alias-main-package.ts
@@ -1,0 +1,163 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import {
+  ALIAS_BINARY_NAME,
+  ALIAS_PACKAGE_NAME,
+  ALIAS_SCHEMA_FILE,
+  CANONICAL_BINARY_NAME,
+  CANONICAL_PACKAGE_NAME,
+  CANONICAL_SCHEMA_FILE,
+  renameOptionalDependencyKeys,
+} from "./identity"
+
+interface PackageJson {
+  name: string
+  version: string
+  description?: string
+  bin?: Record<string, string>
+  exports?: Record<string, unknown>
+  optionalDependencies?: Record<string, string>
+  scripts?: Record<string, string>
+  [key: string]: unknown
+}
+
+interface AliasMainPackageOptions {
+  version?: string
+}
+
+function copyIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) return
+  fs.cpSync(sourcePath, targetPath, { recursive: true })
+}
+
+function removeIfExists(filePath: string): void {
+  if (!fs.existsSync(filePath)) return
+  fs.rmSync(filePath, { recursive: true, force: true })
+}
+
+function rewriteFile(filePath: string, replacements: Array<[string, string]>): void {
+  if (!fs.existsSync(filePath)) return
+
+  let content = fs.readFileSync(filePath, "utf-8")
+  for (const [from, to] of replacements) {
+    if (!content.includes(from)) {
+      throw new Error(`Expected to find '${from}' in ${filePath}`)
+    }
+    content = content.split(from).join(to)
+  }
+  fs.writeFileSync(filePath, content)
+}
+
+function createAliasManifest(pkg: PackageJson, options: AliasMainPackageOptions): PackageJson {
+  const exportsField = { ...(pkg.exports ?? {}) }
+  if (exportsField["./schema.json"] === `./dist/${CANONICAL_SCHEMA_FILE}`) {
+    exportsField["./schema.json"] = `./dist/${ALIAS_SCHEMA_FILE}`
+  }
+
+  const version = options.version ?? pkg.version
+  const scripts = { ...(pkg.scripts ?? {}) }
+  delete scripts.prepare
+  delete scripts.prepublishOnly
+
+  const nextScripts = Object.keys(scripts).length > 0 ? scripts : undefined
+
+  return {
+    ...pkg,
+    name: ALIAS_PACKAGE_NAME,
+    version,
+    bin: {
+      [ALIAS_BINARY_NAME]: `bin/${ALIAS_BINARY_NAME}.js`,
+    },
+    exports: exportsField,
+    scripts: nextScripts,
+    optionalDependencies: renameOptionalDependencyKeys(
+      pkg.optionalDependencies,
+      CANONICAL_PACKAGE_NAME,
+      ALIAS_PACKAGE_NAME
+    )
+      ? Object.fromEntries(
+          Object.entries(
+            renameOptionalDependencyKeys(
+              pkg.optionalDependencies,
+              CANONICAL_PACKAGE_NAME,
+              ALIAS_PACKAGE_NAME
+            ) ?? {}
+          ).map(([name]) => [name, version])
+        )
+      : undefined,
+  }
+}
+
+function copyPackageFiles(sourceRoot: string, outDir: string): void {
+  for (const entry of ["dist", "bin", "postinstall.mjs", "package.json"]) {
+    copyIfExists(path.join(sourceRoot, entry), path.join(outDir, entry))
+  }
+
+  for (const entry of fs.readdirSync(sourceRoot)) {
+    if (!/^(README|LICENSE)/i.test(entry)) continue
+    copyIfExists(path.join(sourceRoot, entry), path.join(outDir, entry))
+  }
+}
+
+function rewriteRuntimeIdentity(outDir: string): void {
+  rewriteFile(path.join(outDir, "bin", "platform.js"), [[CANONICAL_BINARY_NAME, ALIAS_BINARY_NAME]])
+  rewriteFile(path.join(outDir, "bin", `${ALIAS_BINARY_NAME}.js`), [[CANONICAL_BINARY_NAME, ALIAS_BINARY_NAME]])
+  rewriteFile(path.join(outDir, "postinstall.mjs"), [[CANONICAL_BINARY_NAME, ALIAS_BINARY_NAME]])
+
+  rewriteFile(path.join(outDir, "dist", "index.js"), [
+    [`var PACKAGE_NAME = "${CANONICAL_PACKAGE_NAME}";`, `var PACKAGE_NAME = "${ALIAS_PACKAGE_NAME}";`],
+  ])
+  const cliIndexPath = path.join(outDir, "dist", "cli", "index.js")
+  if (fs.existsSync(cliIndexPath)) {
+    const cliIndexContent = fs.readFileSync(cliIndexPath, "utf-8")
+    if (cliIndexContent.includes(`var PACKAGE_NAME2 = "${CANONICAL_PACKAGE_NAME}",`)) {
+      rewriteFile(cliIndexPath, [
+        [`var PACKAGE_NAME2 = "${CANONICAL_PACKAGE_NAME}",`, `var PACKAGE_NAME2 = "${ALIAS_PACKAGE_NAME}",`],
+      ])
+    } else {
+      rewriteFile(cliIndexPath, [
+        [`var PACKAGE_NAME2 = "${CANONICAL_PACKAGE_NAME}";`, `var PACKAGE_NAME2 = "${ALIAS_PACKAGE_NAME}";`],
+      ])
+    }
+  }
+  rewriteFile(path.join(outDir, "dist", "hooks", "auto-update-checker", "constants.d.ts"), [
+    [`export declare const PACKAGE_NAME = "${CANONICAL_PACKAGE_NAME}";`, `export declare const PACKAGE_NAME = "${ALIAS_PACKAGE_NAME}";`],
+    [
+      `export declare const NPM_REGISTRY_URL = "https://registry.npmjs.org/-/package/${CANONICAL_PACKAGE_NAME}/dist-tags";`,
+      `export declare const NPM_REGISTRY_URL = "https://registry.npmjs.org/-/package/${ALIAS_PACKAGE_NAME}/dist-tags";`,
+    ],
+  ])
+}
+
+export function createAliasMainPackage(
+  sourceRoot: string,
+  outDir: string,
+  options: AliasMainPackageOptions = {}
+): void {
+  removeIfExists(outDir)
+  fs.mkdirSync(outDir, { recursive: true })
+
+  copyPackageFiles(sourceRoot, outDir)
+
+  const packageJsonPath = path.join(outDir, "package.json")
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as PackageJson
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(createAliasManifest(packageJson, options), null, 2)}\n`)
+
+  const canonicalWrapperPath = path.join(outDir, "bin", `${CANONICAL_BINARY_NAME}.js`)
+  const aliasWrapperPath = path.join(outDir, "bin", `${ALIAS_BINARY_NAME}.js`)
+  if (!fs.existsSync(canonicalWrapperPath)) {
+    throw new Error(`Expected canonical wrapper at ${canonicalWrapperPath}`)
+  }
+
+  fs.copyFileSync(canonicalWrapperPath, aliasWrapperPath)
+  removeIfExists(canonicalWrapperPath)
+
+  const canonicalSchemaPath = path.join(outDir, "dist", CANONICAL_SCHEMA_FILE)
+  const aliasSchemaPath = path.join(outDir, "dist", ALIAS_SCHEMA_FILE)
+  if (fs.existsSync(canonicalSchemaPath)) {
+    fs.copyFileSync(canonicalSchemaPath, aliasSchemaPath)
+    removeIfExists(canonicalSchemaPath)
+  }
+
+  rewriteRuntimeIdentity(outDir)
+}

--- a/script/publish/alias-platform-package.test.ts
+++ b/script/publish/alias-platform-package.test.ts
@@ -1,0 +1,155 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { createAliasPlatformPackage } from "./alias-platform-package"
+
+function createTempDir(prefix: string): string {
+  const tempRoot = path.join(process.env.HOME ?? process.cwd(), "tmp")
+  fs.mkdirSync(tempRoot, { recursive: true })
+  return fs.mkdtempSync(path.join(tempRoot, prefix))
+}
+
+const cleanupPaths: string[] = []
+
+afterEach(() => {
+  for (const target of cleanupPaths.splice(0)) {
+    fs.rmSync(target, { recursive: true, force: true })
+  }
+})
+
+describe("createAliasPlatformPackage", () => {
+  it("rewrites platform package metadata and binary name for alias publish", () => {
+    const sourceDir = createTempDir("omo-platform-source-")
+    const outDir = createTempDir("omo-platform-out-")
+    cleanupPaths.push(sourceDir, outDir)
+
+    fs.mkdirSync(path.join(sourceDir, "bin"), { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "oh-my-opencode-linux-x64",
+          version: "3.16.0",
+          description: "Platform-specific binary for oh-my-opencode (linux-x64)",
+          bin: { "oh-my-opencode": "./bin/oh-my-opencode" },
+        },
+        null,
+        2
+      )}\n`
+    )
+    fs.writeFileSync(path.join(sourceDir, "bin", "oh-my-opencode"), "binary")
+
+    createAliasPlatformPackage(sourceDir, outDir)
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      name: string
+      description: string
+      bin: Record<string, string>
+    }
+
+    expect(generatedPackage.name).toBe("oh-my-openagent-linux-x64")
+    expect(generatedPackage.description).toBe("Platform-specific binary for oh-my-openagent (linux-x64)")
+    expect(generatedPackage.bin).toEqual({ "oh-my-openagent": "./bin/oh-my-openagent" })
+
+    expect(fs.existsSync(path.join(outDir, "bin", "oh-my-openagent"))).toBe(true)
+    expect(fs.existsSync(path.join(outDir, "bin", "oh-my-opencode"))).toBe(false)
+  })
+
+  it("fails when the declared platform binary is missing", () => {
+    const sourceDir = createTempDir("omo-platform-missing-")
+    const outDir = createTempDir("omo-platform-out-missing-")
+    cleanupPaths.push(sourceDir, outDir)
+
+    fs.mkdirSync(path.join(sourceDir, "bin"), { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "oh-my-opencode-linux-x64",
+          version: "3.16.0",
+          description: "Platform-specific binary for oh-my-opencode (linux-x64)",
+          bin: { "oh-my-opencode": "./bin/oh-my-opencode" },
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    expect(() => createAliasPlatformPackage(sourceDir, outDir)).toThrow("Expected platform binary")
+  })
+
+  it("rejects bin paths that escape the output directory", () => {
+    const sourceDir = createTempDir("omo-platform-escape-")
+    const outDir = createTempDir("omo-platform-out-escape-")
+    cleanupPaths.push(sourceDir, outDir)
+
+    fs.mkdirSync(path.join(sourceDir, "bin"), { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "oh-my-opencode-linux-x64",
+          version: "3.16.0",
+          description: "Platform-specific binary for oh-my-opencode (linux-x64)",
+          bin: { "oh-my-opencode": "../outside/oh-my-opencode" },
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    expect(() => createAliasPlatformPackage(sourceDir, outDir)).toThrow("Expected path within")
+  })
+
+  it("handles the real linux-x64 package manifest shape", () => {
+    const sourceDir = createTempDir("omo-platform-real-shape-")
+    const outDir = createTempDir("omo-platform-real-shape-out-")
+    cleanupPaths.push(sourceDir, outDir)
+
+    const repoRoot = path.resolve(import.meta.dir, "../..")
+    const realPackageJsonPath = path.join(repoRoot, "packages", "linux-x64", "package.json")
+    const realPackageJson = JSON.parse(fs.readFileSync(realPackageJsonPath, "utf-8")) as {
+      name: string
+      version: string
+      description?: string
+      bin: Record<string, string>
+    }
+
+    fs.mkdirSync(path.join(sourceDir, "bin"), { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      `${JSON.stringify(realPackageJson, null, 2)}\n`
+    )
+
+    const declaredBinary = Object.values(realPackageJson.bin)[0]
+    if (!declaredBinary) {
+      throw new Error("Expected real package manifest to declare a binary")
+    }
+
+    const binaryRelativePath = declaredBinary.replace(/^\.\//, "")
+    const binaryPath = path.join(sourceDir, binaryRelativePath)
+    fs.mkdirSync(path.dirname(binaryPath), { recursive: true })
+    fs.writeFileSync(binaryPath, "binary")
+
+    createAliasPlatformPackage(sourceDir, outDir)
+
+    const generatedPackage = JSON.parse(
+      fs.readFileSync(path.join(outDir, "package.json"), "utf-8")
+    ) as {
+      name: string
+      version: string
+      bin: Record<string, string>
+    }
+
+    expect(generatedPackage.name).toBe("oh-my-openagent-linux-x64")
+    expect(generatedPackage.version).toBe(realPackageJson.version)
+    expect(generatedPackage.bin).toEqual({
+      "oh-my-openagent": "./bin/oh-my-openagent",
+    })
+    expect(fs.existsSync(path.join(outDir, "bin", "oh-my-openagent"))).toBe(true)
+  })
+})

--- a/script/publish/alias-platform-package.ts
+++ b/script/publish/alias-platform-package.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import {
+  ALIAS_BINARY_NAME,
+  ALIAS_PACKAGE_NAME,
+  CANONICAL_BINARY_NAME,
+  CANONICAL_PACKAGE_NAME,
+} from "./identity"
+
+interface PlatformPackageJson {
+  name: string
+  version: string
+  description?: string
+  bin?: Record<string, string>
+  [key: string]: unknown
+}
+
+function removeIfExists(filePath: string): void {
+  if (!fs.existsSync(filePath)) return
+  fs.rmSync(filePath, { recursive: true, force: true })
+}
+
+function getCanonicalBinaryRelativePath(pkg: PlatformPackageJson): string {
+  const firstEntry = Object.entries(pkg.bin ?? {})[0]?.[1]
+  if (!firstEntry) {
+    throw new Error(`Package ${pkg.name} is missing a binary entry`)
+  }
+
+  return firstEntry.replace(/^\.\//, "")
+}
+
+function resolvePathWithinOutDir(outDir: string, relativePath: string): string {
+  const resolvedOutDir = path.resolve(outDir)
+  const resolvedPath = path.resolve(outDir, relativePath)
+  const relativeToOutDir = path.relative(resolvedOutDir, resolvedPath)
+
+  if (relativeToOutDir.startsWith("..") || path.isAbsolute(relativeToOutDir)) {
+    throw new Error(`Expected path within ${resolvedOutDir}, got ${relativePath}`)
+  }
+
+  return resolvedPath
+}
+
+export function createAliasPlatformPackage(sourceDir: string, outDir: string): void {
+  removeIfExists(outDir)
+  fs.cpSync(sourceDir, outDir, { recursive: true })
+
+  const packageJsonPath = path.join(outDir, "package.json")
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as PlatformPackageJson
+
+  const canonicalBinaryRelativePath = getCanonicalBinaryRelativePath(packageJson)
+  const aliasBinaryRelativePath = canonicalBinaryRelativePath.replace(CANONICAL_BINARY_NAME, ALIAS_BINARY_NAME)
+
+  const nextPackageJson: PlatformPackageJson = {
+    ...packageJson,
+    name: packageJson.name.replace(CANONICAL_PACKAGE_NAME, ALIAS_PACKAGE_NAME),
+    description: packageJson.description?.replace(CANONICAL_PACKAGE_NAME, ALIAS_PACKAGE_NAME),
+    bin: {
+      [ALIAS_BINARY_NAME]: `./${aliasBinaryRelativePath}`,
+    },
+  }
+
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(nextPackageJson, null, 2)}\n`)
+
+  const canonicalBinaryPath = resolvePathWithinOutDir(outDir, canonicalBinaryRelativePath)
+  const aliasBinaryPath = resolvePathWithinOutDir(outDir, aliasBinaryRelativePath)
+
+  if (!fs.existsSync(canonicalBinaryPath)) {
+    throw new Error(`Expected platform binary at ${canonicalBinaryRelativePath}`)
+  }
+
+  fs.copyFileSync(canonicalBinaryPath, aliasBinaryPath)
+  removeIfExists(canonicalBinaryPath)
+}

--- a/script/publish/build-alias-package.ts
+++ b/script/publish/build-alias-package.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+
+import { fileURLToPath } from "node:url"
+import * as path from "node:path"
+import { createAliasMainPackage } from "./alias-main-package"
+
+function getArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return null
+
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith("--")) {
+    return null
+  }
+
+  return value
+}
+
+const outDir = getArg("--out")
+if (!outDir) {
+  throw new Error("Missing required --out argument")
+}
+
+const version = getArg("--version")
+
+const sourceRoot =
+  getArg("--source") ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+createAliasMainPackage(sourceRoot, path.resolve(outDir), {
+  version: version ?? undefined,
+})

--- a/script/publish/build-alias-platform-package.ts
+++ b/script/publish/build-alias-platform-package.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+
+import * as path from "node:path"
+import { createAliasPlatformPackage } from "./alias-platform-package"
+
+function getArg(flag: string): string | null {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return null
+
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith("--")) {
+    return null
+  }
+
+  return value
+}
+
+const sourceDir = getArg("--source")
+const outDir = getArg("--out")
+
+if (!sourceDir || !outDir) {
+  throw new Error("Missing required --source or --out argument")
+}
+
+createAliasPlatformPackage(path.resolve(sourceDir), path.resolve(outDir))

--- a/script/publish/identity.ts
+++ b/script/publish/identity.ts
@@ -1,0 +1,31 @@
+export const CANONICAL_PACKAGE_NAME = "oh-my-opencode"
+export const ALIAS_PACKAGE_NAME = "oh-my-openagent"
+
+export const CANONICAL_BINARY_NAME = "oh-my-opencode"
+export const ALIAS_BINARY_NAME = "oh-my-openagent"
+
+export const CANONICAL_SCHEMA_FILE = `${CANONICAL_PACKAGE_NAME}.schema.json`
+export const ALIAS_SCHEMA_FILE = `${ALIAS_PACKAGE_NAME}.schema.json`
+
+export function getCanonicalPlatformPackageName(platform: string): string {
+  return `${CANONICAL_PACKAGE_NAME}-${platform}`
+}
+
+export function getAliasPlatformPackageName(platform: string): string {
+  return `${ALIAS_PACKAGE_NAME}-${platform}`
+}
+
+export function renameOptionalDependencyKeys(
+  optionalDependencies: Record<string, string> | undefined,
+  fromPrefix: string,
+  toPrefix: string
+): Record<string, string> | undefined {
+  if (!optionalDependencies) return undefined
+
+  return Object.fromEntries(
+    Object.entries(optionalDependencies).map(([name, version]) => {
+      if (!name.startsWith(`${fromPrefix}-`)) return [name, version]
+      return [name.replace(fromPrefix, toPrefix), version]
+    })
+  )
+}


### PR DESCRIPTION
## Summary

This PR fixes the `oh-my-opencode` / `oh-my-openagent` identity drift at the release boundary.

The main change is that `oh-my-openagent` is now published from generated alias package directories derived from the canonical `oh-my-opencode` manifests. The release workflows no longer rewrite tracked `package.json` files in place and then try to restore them afterward.

That keeps the architecture simpler:

- runtime identity stays canonical as `oh-my-opencode`
- `oh-my-openagent` remains a publish-time compatibility alias
- release metadata is generated deterministically from canonical manifests instead of being patched ad hoc in CI

## Root cause

The recent regressions were not just about one stale constant. The deeper problem was that the publish pipeline was synthesizing `oh-my-openagent` by mutating checked-out manifests in place while the runtime and package ecosystem still treat `oh-my-opencode` as the canonical identity.

That made it too easy for released artifacts to drift:

- some surfaces were still canonical
- some were alias-specific
- some were partially rewritten in CI
- some were restored afterward

This PR removes that fragile boundary.

## What changed

### 1. Added explicit alias-package generators

New files under `script/publish/`:

- `identity.ts`
- `alias-main-package.ts`
- `build-alias-package.ts`
- `alias-platform-package.ts`
- `build-alias-platform-package.ts`

These helpers centralize the canonical and alias names and generate `oh-my-openagent` publish artifacts from canonical package data.

### 2. Updated publish workflows to use generated temp directories

Updated:

- `.github/workflows/publish.yml`
- `.github/workflows/publish-platform.yml`

Instead of mutating the checked-out manifest with `jq`, the workflows now:

1. build the canonical package as before
2. generate an alias package into `$RUNNER_TEMP/...`
3. publish from that generated directory

This removes the rename/restore cycle from CI.

### 3. Kept runtime identity canonical

This PR does **not** try to make runtime logic bilingual across both names.

That is intentional.

The cleaner boundary here is:

- canonical runtime/package identity: `oh-my-opencode`
- generated publish alias: `oh-my-openagent`

Trying to spread alias handling deeper into startup/update/runtime code would make the internal identity model harder to reason about and would not actually address the publish-time failure mode that caused the shipped drift.

### 4. Added targeted regression coverage

Added:

- `script/publish/alias-main-package.test.ts`
- `script/publish/alias-platform-package.test.ts`

These tests verify that the generated alias artifacts have the expected:

- package names
- bin names
- schema export path
- optional dependency keys
- platform package metadata

without mutating the canonical source manifests.

## Verification

Ran:

- `bun run typecheck`
- `bun test script/publish/alias-main-package.test.ts script/publish/alias-platform-package.test.ts bin/platform.test.ts`

Also generated dry-run alias artifacts locally and inspected the resulting manifests.

Confirmed for the generated main alias package:

- `name: oh-my-openagent`
- `bin.oh-my-openagent = bin/oh-my-openagent.js`
- `exports["./schema.json"] = ./dist/oh-my-openagent.schema.json`
- `optionalDependencies` are rewritten to `oh-my-openagent-*`

Confirmed for the generated platform alias package:

- package name becomes `oh-my-openagent-<platform>`
- description is rewritten accordingly
- platform binary entry becomes `oh-my-openagent`

## Why this should be easier to maintain

The release aliasing logic now lives in source files with direct tests instead of in workflow-local manifest mutations.

That makes future publish behavior easier to review, easier to test, and much harder to ship partially.

## Scope

This PR intentionally fixes the release root cause only.

It does not attempt a broader cleanup of every remaining user-facing `OhMyOpenCode` string or every legacy canonical naming surface in the runtime. Those can be handled separately without reopening the publish-time identity problem.
