### PR TITLE
test(doctor): cover custom provider config regression

### DIFF
--- a/src/cli/doctor/checks/config.test.ts
+++ b/src/cli/doctor/checks/config.test.ts
@@ -55,5 +55,75 @@ describe("config check", () => {
         }
       }
     })
+
+    it("does not flag configured custom providers as unavailable when they exist in opencode.json", async () => {
+      const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+      const originalXdgConfig = process.env.XDG_CONFIG_HOME
+      const originalXdgCache = process.env.XDG_CACHE_HOME
+      const testRootDir = join(
+        tmpdir(),
+        `omo-doctor-custom-provider-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      )
+      const pluginConfigDir = join(testRootDir, "plugin")
+      const xdgConfigDir = join(testRootDir, "xdg-config")
+      const xdgCacheDir = join(testRootDir, "xdg-cache")
+
+      try {
+        mkdirSync(pluginConfigDir, { recursive: true })
+        mkdirSync(join(xdgConfigDir, "opencode"), { recursive: true })
+        mkdirSync(join(xdgCacheDir, "opencode"), { recursive: true })
+
+        process.env.OPENCODE_CONFIG_DIR = pluginConfigDir
+        process.env.XDG_CONFIG_HOME = xdgConfigDir
+        process.env.XDG_CACHE_HOME = xdgCacheDir
+
+        writeFileSync(
+          join(pluginConfigDir, "oh-my-openagent.json"),
+          JSON.stringify({ agents: { sisyphus: { model: "kiro/claude-opus-4-6" } } }, null, 2) + "\n",
+          "utf-8",
+        )
+        writeFileSync(
+          join(xdgConfigDir, "opencode", "opencode.json"),
+          JSON.stringify({
+            provider: {
+              kiro: {
+                npm: "@ai-sdk/openai-compatible",
+                models: { "claude-opus-4-6": {} },
+              },
+            },
+          }, null, 2) + "\n",
+          "utf-8",
+        )
+        writeFileSync(
+          join(xdgCacheDir, "opencode", "models.json"),
+          JSON.stringify({
+            openai: { models: { "gpt-5.4": {} } },
+          }, null, 2) + "\n",
+          "utf-8",
+        )
+
+        const result = await config.checkConfig()
+        const providerIssue = result.issues.find((issue) => issue.title === "Model override uses unavailable provider")
+
+        expect(providerIssue).toBeUndefined()
+      } finally {
+        rmSync(testRootDir, { recursive: true, force: true })
+        if (originalConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+        }
+        if (originalXdgConfig === undefined) {
+          delete process.env.XDG_CONFIG_HOME
+        } else {
+          process.env.XDG_CONFIG_HOME = originalXdgConfig
+        }
+        if (originalXdgCache === undefined) {
+          delete process.env.XDG_CACHE_HOME
+        } else {
+          process.env.XDG_CACHE_HOME = originalXdgCache
+        }
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add a config-level regression test for custom providers declared in `opencode.json`
- verify `checkConfig()` does not report `Model override uses unavailable provider` for a valid custom provider such as `kiro`
- link the regression coverage to the published false-positive reported in #3293

## Validation
- `bun test src/cli/doctor/checks/config.test.ts src/cli/doctor/checks/model-resolution-cache.test.ts src/cli/doctor/checks/model-resolution.test.ts --bail`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to ensure custom providers declared in `opencode.json` are recognized by the doctor config check and not flagged as unavailable. Verifies `checkConfig()` accepts a valid provider like `kiro`, guarding against the false positive reported in #3293.

<sup>Written for commit 02d64e448f361a79bbd36ca1a78de11059fef3df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

