### PR TITLE
fix: treat zero limit.output as unknown to enable fallback to bundled…

### DIFF
--- a/src/shared/model-capabilities/runtime-model-readers.ts
+++ b/src/shared/model-capabilities/runtime-model-readers.ts
@@ -186,5 +186,7 @@ export function readRuntimeModelLimitOutput(
 		return undefined
 	}
 
-	return readNumber(limit.output)
+	const output = readNumber(limit.output)
+	// Treat 0 or negative as unknown so ?? fallback to bundled snapshot works
+	return output && output > 0 ? output : undefined
 }


### PR DESCRIPTION
## Summary
- Fix `maxOutputTokens must be >= 1` error when using custom OpenAI-compatible providers (e.g., infini-ai) that don't return model limits
- Treat zero/negative `limit.output` values as unknown to enable fallback to bundled snapshot with correct limits
- Aligns `readRuntimeModelLimitOutput` behavior with the nullish coalescing fallback chain in `get-model-capabilities.ts`
## Changes
- Modified `readRuntimeModelLimitOutput()` in `src/shared/model-capabilities/runtime-model-readers.ts`:
  - Changed return from `readNumber(limit.output)` to check for positive values only
  - Returns `undefined` for 0 or negative values instead of passing them through
  - This allows the `??` operator in `getModelCapabilities()` to fall through to bundled snapshot entries
## Screenshots
<!-- Not applicable - this is a backend logic fix with no UI changes. -->
## Testing
```bash
bun run typecheck
bun test
To verify the fix manually:
1. Configure a custom OpenAI-compatible provider that doesn't return model limits
2. Use any agent (e.g., sisyphus) with a model from that provider
3. Confirm no maxOutputTokens must be >= 1 error occurs
4. Verify maxOutputTokens falls back to bundled snapshot values (e.g., 32768 for kimi-k2.5)
Related Issues
<!-- Add issue number if one exists, e.g., Closes #123 -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes maxOutputTokens errors with some OpenAI-compatible providers by treating zero or negative `limit.output` as unknown. `readRuntimeModelLimitOutput()` now returns `undefined` for non‑positive values so `getModelCapabilities()` falls back to bundled snapshot limits.

<sup>Written for commit 6c3308aab3904b1e91ea29fba3487e77865c689b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

