### PR TITLE
fix: resolve startup toast version detection for local and cached installs

### DIFF
--- a/src/hooks/auto-update-checker/checker/cached-version.test.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.test.ts
@@ -3,13 +3,32 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+const FIXED_CACHE_LAYOUT_ROOT = join(tmpdir(), "omo-cache-layout-fixed")
+
 // Hold mutable mock state so beforeEach can swap the cache root for each test.
-const mockState: { candidates: string[] } = { candidates: [] }
+const mockState: { cacheCandidates: string[]; configCandidates: string[] } = {
+  cacheCandidates: [],
+  configCandidates: [],
+}
 
 mock.module("../constants", () => ({
+  ACCEPTED_PACKAGE_NAMES: ["oh-my-opencode", "oh-my-openagent"],
+  CACHE_DIR: FIXED_CACHE_LAYOUT_ROOT,
   INSTALLED_PACKAGE_JSON_CANDIDATES: new Proxy([], {
     get(_, prop) {
-      const current = mockState.candidates
+      const current = mockState.cacheCandidates
+      // Forward array methods/properties to the mutable candidates list
+      // so getCachedVersion's `for (... of ...)` sees fresh data per test.
+      const value = (current as unknown as Record<PropertyKey, unknown>)[prop]
+      if (typeof value === "function") {
+        return (value as (...args: unknown[]) => unknown).bind(current)
+      }
+      return value
+    },
+  }),
+  CONFIG_DIR_PACKAGE_JSON_CANDIDATES: new Proxy([], {
+    get(_, prop) {
+      const current = mockState.configCandidates
       // Forward array methods/properties to the mutable candidates list
       // so getCachedVersion's `for (... of ...)` sees fresh data per test.
       const value = (current as unknown as Record<PropertyKey, unknown>)[prop]
@@ -29,18 +48,31 @@ import { getCachedVersion } from "./cached-version"
 
 describe("getCachedVersion (GH-3257)", () => {
   let cacheRoot: string
+  let configRoot: string
+  let cachePackagesRoot: string
 
   beforeEach(() => {
     cacheRoot = mkdtempSync(join(tmpdir(), "omo-cached-version-"))
-    mockState.candidates = [
+    configRoot = mkdtempSync(join(tmpdir(), "omo-config-version-"))
+    cachePackagesRoot = FIXED_CACHE_LAYOUT_ROOT
+    rmSync(cachePackagesRoot, { recursive: true, force: true })
+    mkdirSync(cachePackagesRoot, { recursive: true })
+    mockState.cacheCandidates = [
       join(cacheRoot, "node_modules", "oh-my-opencode", "package.json"),
       join(cacheRoot, "node_modules", "oh-my-openagent", "package.json"),
+    ]
+    mockState.configCandidates = [
+      join(configRoot, "node_modules", "oh-my-opencode", "package.json"),
+      join(configRoot, "node_modules", "oh-my-openagent", "package.json"),
     ]
   })
 
   afterEach(() => {
     rmSync(cacheRoot, { recursive: true, force: true })
-    mockState.candidates = []
+    rmSync(configRoot, { recursive: true, force: true })
+    rmSync(cachePackagesRoot, { recursive: true, force: true })
+    mockState.cacheCandidates = []
+    mockState.configCandidates = []
   })
 
   it("returns the version when the package is installed under oh-my-opencode", () => {
@@ -76,5 +108,22 @@ describe("getCachedVersion (GH-3257)", () => {
 
   it("returns null when neither candidate exists and fallbacks find nothing", () => {
     expect(getCachedVersion()).toBeNull()
+  })
+
+  it("falls back to the user config dir install when cache candidates are missing", () => {
+    const pkgDir = join(configRoot, "node_modules", "oh-my-openagent")
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "oh-my-openagent", version: "3.16.1" }))
+
+    expect(getCachedVersion()).toBe("3.16.1")
+  })
+
+  it("detects the versioned OpenCode cache layout", () => {
+    mockState.cacheCandidates = []
+    const pkgDir = join(cachePackagesRoot, "oh-my-openagent@latest", "node_modules", "oh-my-openagent")
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "oh-my-openagent", version: "3.16.2" }))
+
+    expect(getCachedVersion()).toBe("3.16.2")
   })
 })

--- a/src/hooks/auto-update-checker/checker/cached-version.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.ts
@@ -3,7 +3,12 @@ import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import { log } from "../../../shared/logger"
 import type { PackageJson } from "../types"
-import { INSTALLED_PACKAGE_JSON_CANDIDATES } from "../constants"
+import {
+  ACCEPTED_PACKAGE_NAMES,
+  CACHE_DIR,
+  CONFIG_DIR_PACKAGE_JSON_CANDIDATES,
+  INSTALLED_PACKAGE_JSON_CANDIDATES,
+} from "../constants"
 import { findPackageJsonUp } from "./package-json-locator"
 
 function readPackageVersion(packageJsonPath: string): string | null {
@@ -12,8 +17,34 @@ function readPackageVersion(packageJsonPath: string): string | null {
   return pkg.version ?? null
 }
 
+function getResolvedPackageJsonCandidates(): string[] {
+  const resolved = [
+    ...INSTALLED_PACKAGE_JSON_CANDIDATES,
+    ...CONFIG_DIR_PACKAGE_JSON_CANDIDATES,
+  ]
+
+  try {
+    const entries = fs.readdirSync(CACHE_DIR, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      for (const packageName of ACCEPTED_PACKAGE_NAMES) {
+        if (entry.name !== packageName && !entry.name.startsWith(`${packageName}@`)) continue
+
+        resolved.push(path.join(CACHE_DIR, entry.name, "node_modules", packageName, "package.json"))
+        resolved.push(path.join(CACHE_DIR, entry.name, "package.json"))
+      }
+    }
+  } catch {
+    // ignore cache dir enumeration failures and fall back to static candidates
+  }
+
+  return resolved
+}
+
 export function getCachedVersion(): string | null {
-  for (const candidate of INSTALLED_PACKAGE_JSON_CANDIDATES) {
+  for (const candidate of getResolvedPackageJsonCandidates()) {
     try {
       if (fs.existsSync(candidate)) {
         return readPackageVersion(candidate)

--- a/src/hooks/auto-update-checker/checker/config-paths.ts
+++ b/src/hooks/auto-update-checker/checker/config-paths.ts
@@ -10,6 +10,8 @@ import {
 export function getConfigPaths(directory: string): string[] {
   const userConfigDir = getUserConfigDir()
   const paths = [
+    path.join(directory, "opencode.json"),
+    path.join(directory, "opencode.jsonc"),
     path.join(directory, ".opencode", "opencode.json"),
     path.join(directory, ".opencode", "opencode.jsonc"),
     getUserOpencodeConfig(),

--- a/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -42,6 +42,7 @@ function runFindPluginEntry(
 describe("findPluginEntry", () => {
   let temporaryDirectory: string
   let configPath: string
+  let rootConfigPath: string
   let originalConfigDir: string | undefined
 
   beforeEach(() => {
@@ -50,6 +51,7 @@ describe("findPluginEntry", () => {
     const opencodeDirectory = path.join(temporaryDirectory, ".opencode")
     fs.mkdirSync(opencodeDirectory, { recursive: true })
     configPath = path.join(opencodeDirectory, "opencode.json")
+    rootConfigPath = path.join(temporaryDirectory, "opencode.json")
   })
 
   afterEach(() => {
@@ -74,6 +76,22 @@ describe("findPluginEntry", () => {
     expect(pluginInfo).not.toBeNull()
     expect(pluginInfo?.isPinned).toBe(false)
     expect(pluginInfo?.pinnedVersion).toBeNull()
+  })
+
+  test("reads project root opencode.json before .opencode config", async () => {
+    // #given project root config contains the active plugin entry
+    fs.writeFileSync(rootConfigPath, JSON.stringify({ plugin: [PLUGIN_NAME] }))
+    fs.writeFileSync(configPath, JSON.stringify({ plugin: ["some-other-plugin"] }))
+
+    // #when plugin entry is detected
+    const execution = runFindPluginEntry(temporaryDirectory)
+
+    // #then the project root config is recognized
+    expect(execution.status).toBe(0)
+    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
+    expect(pluginInfo).not.toBeNull()
+    expect(pluginInfo?.entry).toBe(PLUGIN_NAME)
+    expect(pluginInfo?.configPath).toBe(rootConfigPath)
   })
 
   test("returns unpinned for latest dist-tag", async () => {

--- a/src/hooks/auto-update-checker/constants.ts
+++ b/src/hooks/auto-update-checker/constants.ts
@@ -56,3 +56,7 @@ export const INSTALLED_PACKAGE_JSON = path.join(
 export const INSTALLED_PACKAGE_JSON_CANDIDATES = ACCEPTED_PACKAGE_NAMES.map(
   name => path.join(CACHE_DIR, "node_modules", name, "package.json")
 )
+
+export const CONFIG_DIR_PACKAGE_JSON_CANDIDATES = ACCEPTED_PACKAGE_NAMES.map(
+  name => path.join(getUserConfigDir(), "node_modules", name, "package.json")
+)


### PR DESCRIPTION
## Summary
- resolve startup toast version detection when OpenCode stores plugin metadata under versioned cache directories
- fall back to config-dir node_modules installs when cache metadata is not present in the legacy location
- recognize project-root opencode.json during auto-update checker config discovery so local file:// plugin installs are detected correctly

## Testing
- bun test src/hooks/auto-update-checker/checker/cached-version.test.ts src/hooks/auto-update-checker/checker/plugin-entry.test.ts src/hooks/auto-update-checker/constants.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes startup toast version detection so the correct plugin version is shown for local installs, versioned caches, and user-config installs.

- **Bug Fixes**
  - Enumerates `CACHE_DIR` for versioned cache dirs (e.g., `oh-my-openagent@latest`) and reads `package.json` from `node_modules` or the package root.
  - Falls back to user config `node_modules` when cache entries are missing.
  - Prefers project-root `opencode.json`/`opencode.jsonc` over `.opencode/opencode.json` to detect local `file://` plugins.
  - Supports both `oh-my-opencode` and `oh-my-openagent` during version resolution.

<sup>Written for commit da0a00681ddab40bdebed925cba99d68ceb5a741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

