### PR TITLE
fix(call_omo_agent): allow custom agents from user config

### DIFF
--- a/src/config/schema/agent-overrides.test.ts
+++ b/src/config/schema/agent-overrides.test.ts
@@ -1,0 +1,44 @@
+const { describe, test, expect } = require("bun:test")
+const { AgentOverridesSchema } = require("./agent-overrides")
+
+describe("AgentOverridesSchema", () => {
+  test("should preserve custom agent keys after parsing (#3229)", () => {
+    //#given
+    const input = {
+      sisyphus: { model: "anthropic/claude-opus-4-6" },
+      "technical-writer": {
+        model: "anthropic/claude-sonnet-4-6",
+        prompt_append: "You are a technical writer.",
+      },
+      scribe: {
+        model: "gitlab/duo-chat-sonnet-4-6",
+        description: "Documentation agent",
+      },
+    }
+
+    //#when
+    const parsed = AgentOverridesSchema.parse(input)
+
+    //#then
+    expect(parsed.sisyphus).toBeDefined()
+    expect(parsed["technical-writer"]).toBeDefined()
+    expect(parsed["technical-writer"]?.model).toBe("anthropic/claude-sonnet-4-6")
+    expect(parsed.scribe).toBeDefined()
+    expect(parsed.scribe?.description).toBe("Documentation agent")
+  })
+
+  test("should still validate custom agent keys against AgentOverrideConfigSchema", () => {
+    //#given
+    const input = {
+      "custom-agent": {
+        model: "provider/model",
+        temperature: 5, // invalid: max is 2
+      },
+    }
+
+    //#when & then
+    expect(() => AgentOverridesSchema.parse(input)).toThrow()
+  })
+})
+
+export {}

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -72,7 +72,7 @@ export const AgentOverridesSchema = z.object({
   explore: AgentOverrideConfigSchema.optional(),
   "multimodal-looker": AgentOverrideConfigSchema.optional(),
   atlas: AgentOverrideConfigSchema.optional(),
-})
+}).catchall(AgentOverrideConfigSchema.optional())
 
 export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>
 export type AgentOverrides = z.infer<typeof AgentOverridesSchema>

--- a/src/tools/call-omo-agent/constants.ts
+++ b/src/tools/call-omo-agent/constants.ts
@@ -1,12 +1,10 @@
-export const ALLOWED_AGENTS = [
-  "explore",
-  "librarian",
-  "oracle",
-  "hephaestus",
-  "metis",
-  "momus",
-  "multimodal-looker",
-] as const
+import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
+
+/**
+ * Built-in agents derived from AGENT_MODEL_REQUIREMENTS.
+ * Custom agents from user config are merged at runtime in createCallOmoAgent().
+ */
+export const BUILTIN_AGENTS = Object.keys(AGENT_MODEL_REQUIREMENTS)
 
 export const CALL_OMO_AGENT_DESCRIPTION = `Spawn explore/librarian agent. run_in_background REQUIRED (true=async with task_id, false=sync).
 

--- a/src/tools/call-omo-agent/constants.ts
+++ b/src/tools/call-omo-agent/constants.ts
@@ -6,7 +6,7 @@ import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
  */
 export const BUILTIN_AGENTS = Object.keys(AGENT_MODEL_REQUIREMENTS)
 
-export const CALL_OMO_AGENT_DESCRIPTION = `Spawn explore/librarian agent. run_in_background REQUIRED (true=async with task_id, false=sync).
+export const CALL_OMO_AGENT_DESCRIPTION = `Spawn a specialized agent. run_in_background REQUIRED (true=async with task_id, false=sync).
 
 Available: {agents}
 

--- a/src/tools/call-omo-agent/tools.test.ts
+++ b/src/tools/call-omo-agent/tools.test.ts
@@ -369,6 +369,67 @@ describe("createCallOmoAgent", () => {
     })
   })
 
+  test("should accept custom agents defined in agentOverrides (#3229)", async () => {
+    //#given
+    const launch = mock(() => Promise.resolve({
+      id: "task-custom",
+      sessionID: "sub-session",
+      description: "Custom agent task",
+      agent: "technical-writer",
+      status: "pending",
+    }))
+    const managerWithLaunch = {
+      launch,
+      getTask: mock(() => undefined),
+    }
+    const toolDef = createCallOmoAgent(
+      mockCtx,
+      managerWithLaunch,
+      [],
+      {
+        "technical-writer": {
+          model: "anthropic/claude-sonnet-4-6",
+          prompt_append: "You are a technical writer.",
+        },
+      },
+    )
+    const executeFunc = toolDef.execute as Function
+
+    //#when
+    const result = await executeFunc(
+      {
+        description: "Write docs",
+        prompt: "Document the API",
+        subagent_type: "technical-writer",
+        run_in_background: true,
+      },
+      { sessionID: "test", messageID: "msg", agent: "test", abort: new AbortController().signal }
+    )
+
+    //#then
+    expect(result).not.toContain("Invalid agent type")
+  })
+
+  test("should reject agents not in builtins nor in agentOverrides (#3229)", async () => {
+    //#given
+    const toolDef = createCallOmoAgent(mockCtx, mockBackgroundManager, [])
+    const executeFunc = toolDef.execute as Function
+
+    //#when
+    const result = await executeFunc(
+      {
+        description: "Test",
+        prompt: "Test prompt",
+        subagent_type: "nonexistent-agent",
+        run_in_background: true,
+      },
+      { sessionID: "test", messageID: "msg", agent: "test", abort: new AbortController().signal }
+    )
+
+    //#then
+    expect(result).toContain("Invalid agent type")
+  })
+
   test("should return a tool error when sync spawn depth validation fails", async () => {
     //#given
     reserveSubagentSpawnMock.mockRejectedValueOnce(new Error("Subagent spawn blocked: child depth 4 exceeds background_task.maxDepth=3."))

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -87,7 +87,10 @@ export function createCallOmoAgent(
   const allowedAgents = [...new Set([...BUILTIN_AGENTS, ...customAgentKeys])]
 
   const agentDescriptions = allowedAgents.map(
-    (name) => `- ${name}: Specialized agent for ${name} tasks`
+    (name) => {
+      const customDesc = agentOverrides?.[name as keyof AgentOverrides]?.description
+      return `- ${name}: ${customDesc ?? `Specialized agent for ${name} tasks`}`
+    }
   ).join("\n")
   const description = CALL_OMO_AGENT_DESCRIPTION.replace("{agents}", agentDescriptions)
 

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -101,7 +101,7 @@ export function createCallOmoAgent(
       prompt: tool.schema.string().describe("The task for the agent to perform"),
       subagent_type: tool.schema
         .string()
-        .describe("The type of specialized agent to use for this task (explore or librarian only)"),
+        .describe("The type of specialized agent to use for this task"),
       run_in_background: tool.schema
         .boolean()
         .describe("REQUIRED. true: run asynchronously (use background_output to get results), false: run synchronously and wait for completion"),
@@ -111,20 +111,19 @@ export function createCallOmoAgent(
       const toolCtx = toolContext as ToolContextWithMetadata
       log(`[call_omo_agent] Starting with agent: ${args.subagent_type}, background: ${args.run_in_background}`)
 
-      // Case-insensitive agent validation against built-in + custom agents
-      if (
-        !allowedAgents.some(
-          (name) => name.toLowerCase() === args.subagent_type.toLowerCase(),
-        )
-      ) {
+      // Case-insensitive validation — preserve the registered name's original casing
+      const matchedAgent = allowedAgents.find(
+        (name) => name.toLowerCase() === args.subagent_type.toLowerCase(),
+      )
+      if (!matchedAgent) {
         return `Error: Invalid agent type "${args.subagent_type}". Only ${allowedAgents.join(", ")} are allowed.`
       }
 
-      const normalizedAgent = args.subagent_type.toLowerCase() as AllowedAgentType
+      const normalizedAgent = matchedAgent as AllowedAgentType
       args = { ...args, subagent_type: normalizedAgent }
 
       // Check if agent is disabled
-      if (disabledAgents.some((disabled) => disabled.toLowerCase() === normalizedAgent)) {
+      if (disabledAgents.some((disabled) => disabled.toLowerCase() === normalizedAgent.toLowerCase())) {
         return `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your ${CONFIG_BASENAME}.json to use it.`
       }
 

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -1,5 +1,5 @@
 import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
-import { ALLOWED_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants"
+import { BUILTIN_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants"
 import type { AllowedAgentType, CallOmoAgentArgs, ToolContextWithMetadata } from "./types"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { CategoriesConfig, AgentOverrides } from "../../config/schema"
@@ -82,7 +82,11 @@ export function createCallOmoAgent(
   agentOverrides?: AgentOverrides,
   userCategories?: CategoriesConfig,
 ): ToolDefinition {
-  const agentDescriptions = ALLOWED_AGENTS.map(
+  // Merge built-in agents with user-configured custom agents
+  const customAgentKeys = agentOverrides ? Object.keys(agentOverrides) : []
+  const allowedAgents = [...new Set([...BUILTIN_AGENTS, ...customAgentKeys])]
+
+  const agentDescriptions = allowedAgents.map(
     (name) => `- ${name}: Specialized agent for ${name} tasks`
   ).join("\n")
   const description = CALL_OMO_AGENT_DESCRIPTION.replace("{agents}", agentDescriptions)
@@ -104,13 +108,13 @@ export function createCallOmoAgent(
       const toolCtx = toolContext as ToolContextWithMetadata
       log(`[call_omo_agent] Starting with agent: ${args.subagent_type}, background: ${args.run_in_background}`)
 
-      // Case-insensitive agent validation - allows "Explore", "EXPLORE", "explore" etc.
+      // Case-insensitive agent validation against built-in + custom agents
       if (
-        !ALLOWED_AGENTS.some(
+        !allowedAgents.some(
           (name) => name.toLowerCase() === args.subagent_type.toLowerCase(),
         )
       ) {
-        return `Error: Invalid agent type "${args.subagent_type}". Only ${ALLOWED_AGENTS.join(", ")} are allowed.`
+        return `Error: Invalid agent type "${args.subagent_type}". Only ${allowedAgents.join(", ")} are allowed.`
       }
 
       const normalizedAgent = args.subagent_type.toLowerCase() as AllowedAgentType

--- a/src/tools/call-omo-agent/types.ts
+++ b/src/tools/call-omo-agent/types.ts
@@ -1,6 +1,4 @@
-import type { ALLOWED_AGENTS } from "./constants"
-
-export type AllowedAgentType = (typeof ALLOWED_AGENTS)[number]
+export type AllowedAgentType = string
 
 export interface CallOmoAgentArgs {
   description: string


### PR DESCRIPTION
## Summary

- `call_omo_agent` rejects custom agents registered in `oh-my-openagent.jsonc` because `ALLOWED_AGENTS` is hardcoded to 7 built-in names
- `AgentOverridesSchema` strips custom keys during Zod parsing (no `.catchall()`)

## Changes

- Replace static `ALLOWED_AGENTS` array with dynamic union of `AGENT_MODEL_REQUIREMENTS` keys + user `agentOverrides` keys (`constants.ts`, `tools.ts`)
- Add `.catchall(AgentOverrideConfigSchema.optional())` to `AgentOverridesSchema` so custom agent names survive config parsing (`agent-overrides.ts`)
- Surface user-provided `description` field in tool prompt instead of generic template
- Add 4 tests: custom agent acceptance, rejection of unknown agents, schema preservation, schema validation

## Testing

```bash
bun test src/tools/call-omo-agent/tools.test.ts    # 12 pass
bun test src/config/schema/agent-overrides.test.ts  # 2 pass
```

## Related Issues

Closes #3229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable custom agents from `oh-my-openagent.jsonc` in `call_omo_agent`, fixing rejection of valid user-defined agents. Preserves agent casing and surfaces custom descriptions in the tool prompt (fixes #3229).

- **Bug Fixes**
  - Build allowed agent list dynamically from `AGENT_MODEL_REQUIREMENTS` + user `agentOverrides` (replaces `ALLOWED_AGENTS`); update prompt to list these agents and include custom `description`.
  - Add `.catchall(...)` to `AgentOverridesSchema` so custom agent keys survive while validating entries.
  - Case-insensitive matching with registered casing preserved; unknown agents return a clear error; remove hardcoded "explore/librarian only" from input description.
  - Added tests for custom agent acceptance, unknown agent rejection, and schema preservation/validation.

<sup>Written for commit 5cc7280c9066ff7a574bc50d8b9dc08f08309460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

