### PR TITLE
fix(todo-continuation): remove activity-based stagnation bypass

### DIFF
--- a/src/hooks/todo-continuation-enforcer/idle-event.test.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.test.ts
@@ -28,7 +28,6 @@ function createStateStore(): {
       getState: () => state,
       getExistingState: () => state,
       startPruneInterval: () => {},
-      recordActivity: () => {},
       trackContinuationProgress: () => progressUpdate,
       resetContinuationProgress: (sessionID: string) => {
         resetCalls.push(sessionID)

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -16,14 +16,6 @@ import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compactio
 import type { SessionStateStore } from "./session-state"
 import { startCountdown } from "./countdown"
 
-function shouldAllowActivityProgress(modelID: string | undefined): boolean {
-  if (!modelID) {
-    return false
-  }
-
-  return !modelID.toLowerCase().includes("codex")
-}
-
 export async function handleSessionIdle(args: {
   ctx: PluginInput
   sessionID: string
@@ -204,7 +196,6 @@ export async function handleSessionIdle(args: {
     sessionID,
     incompleteCount,
     todos,
-    { allowActivityProgress: shouldAllowActivityProgress(resolvedInfo?.model?.modelID) },
   )
   if (shouldStopForStagnation({ sessionID, incompleteCount, progressUpdate })) {
     return

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -2,19 +2,19 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import { getSessionAgent } from "../../features/claude-code-session-state"
 import { normalizeSDKResponse } from "../../shared"
-import { log } from "../../shared/logger"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { log } from "../../shared/logger"
 
-import { ABORT_WINDOW_MS, CONTINUATION_COOLDOWN_MS, DEFAULT_SKIP_AGENTS, FAILURE_RESET_WINDOW_MS, HOOK_NAME, MAX_CONSECUTIVE_FAILURES } from "./constants"
 import { isLastAssistantMessageAborted } from "./abort-detection"
+import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compaction-guard"
+import { ABORT_WINDOW_MS, CONTINUATION_COOLDOWN_MS, DEFAULT_SKIP_AGENTS, FAILURE_RESET_WINDOW_MS, HOOK_NAME, MAX_CONSECUTIVE_FAILURES } from "./constants"
+import { startCountdown } from "./countdown"
 import { hasUnansweredQuestion } from "./pending-question-detection"
+import { resolveLatestMessageInfo } from "./resolve-message-info"
+import type { SessionStateStore } from "./session-state"
 import { shouldStopForStagnation } from "./stagnation-detection"
 import { getIncompleteCount } from "./todo"
-import type { MessageInfo, MessageWithInfo, ResolvedMessageInfo, Todo } from "./types"
-import { resolveLatestMessageInfo } from "./resolve-message-info"
-import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compaction-guard"
-import type { SessionStateStore } from "./session-state"
-import { startCountdown } from "./countdown"
+import type { MessageWithInfo, ResolvedMessageInfo, Todo } from "./types"
 
 export async function handleSessionIdle(args: {
   ctx: PluginInput
@@ -132,7 +132,7 @@ export async function handleSessionIdle(args: {
   }
 
   const effectiveCooldown =
-    CONTINUATION_COOLDOWN_MS * Math.pow(2, Math.min(state.consecutiveFailures, 5))
+    CONTINUATION_COOLDOWN_MS * 2 ** Math.min(state.consecutiveFailures, 5)
   if (state.lastInjectedAt && Date.now() - state.lastInjectedAt < effectiveCooldown) {
     log(`[${HOOK_NAME}] Skipped: cooldown active`, { sessionID, effectiveCooldown, consecutiveFailures: state.consecutiveFailures })
     return

--- a/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -30,7 +30,6 @@ export function handleNonIdleEvent(args: {
         state.abortDetectedAt = undefined
         state.wasCancelled = false
         state.tokenLimitDetected = false
-        sessionStateStore.recordActivity(sessionID)
       }
       sessionStateStore.cancelCountdown(sessionID)
       return
@@ -41,7 +40,6 @@ export function handleNonIdleEvent(args: {
       if (state) {
         state.abortDetectedAt = undefined
         state.wasCancelled = false
-        sessionStateStore.recordActivity(sessionID)
       }
       sessionStateStore.cancelCountdown(sessionID)
       return
@@ -57,7 +55,6 @@ export function handleNonIdleEvent(args: {
       const state = sessionStateStore.getExistingState(targetSessionID)
       if (state) {
         state.abortDetectedAt = undefined
-        sessionStateStore.recordActivity(targetSessionID)
       }
       sessionStateStore.cancelCountdown(targetSessionID)
     }
@@ -71,7 +68,6 @@ export function handleNonIdleEvent(args: {
       if (state) {
         state.abortDetectedAt = undefined
         state.wasCancelled = false
-        sessionStateStore.recordActivity(sessionID)
       }
       sessionStateStore.cancelCountdown(sessionID)
     }
@@ -85,7 +81,6 @@ export function handleNonIdleEvent(args: {
       if (state) {
         state.abortDetectedAt = undefined
         state.wasCancelled = false
-        sessionStateStore.recordActivity(sessionID)
       }
       sessionStateStore.cancelCountdown(sessionID)
     }

--- a/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -1,5 +1,5 @@
-import { log } from "../../shared/logger"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
+import { log } from "../../shared/logger"
 
 import { COUNTDOWN_GRACE_PERIOD_MS, HOOK_NAME } from "./constants"
 import type { SessionStateStore } from "./session-state"

--- a/src/hooks/todo-continuation-enforcer/session-state.test.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.test.ts
@@ -144,9 +144,9 @@ describe("createSessionStateStore", () => {
     expect(stagnatedAgainUpdate.stagnationCount).toBe(1)
   })
 
-  test("given tool activity happens after a successful continuation without todo changes, keeps counting stagnation", () => {
+  test("given no todo changes after a successful continuation, keeps counting stagnation", () => {
     // given
-    const sessionID = "ses-activity-stagnation"
+    const sessionID = "ses-no-todo-change-stagnation"
     const state = sessionStateStore.getState(sessionID)
     const todos = [
       { id: "1", content: "Task 1", status: "pending", priority: "high" },

--- a/src/hooks/todo-continuation-enforcer/session-state.test.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.test.ts
@@ -144,9 +144,9 @@ describe("createSessionStateStore", () => {
     expect(stagnatedAgainUpdate.stagnationCount).toBe(1)
   })
 
-  test("given non-codex activity happens after a successful continuation, treats it as progress", () => {
+  test("given tool activity happens after a successful continuation without todo changes, keeps counting stagnation", () => {
     // given
-    const sessionID = "ses-non-codex-activity-progress"
+    const sessionID = "ses-activity-stagnation"
     const state = sessionStateStore.getState(sessionID)
     const todos = [
       { id: "1", content: "Task 1", status: "pending", priority: "high" },
@@ -154,40 +154,12 @@ describe("createSessionStateStore", () => {
 
     sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
     state.awaitingPostInjectionProgressCheck = true
-    sessionStateStore.recordActivity(sessionID)
 
     // when
     const progressUpdate = sessionStateStore.trackContinuationProgress(
       sessionID,
       1,
       todos,
-      { allowActivityProgress: true },
-    )
-
-    // then
-    expect(progressUpdate.hasProgressed).toBe(true)
-    expect(progressUpdate.progressSource).toBe("activity")
-    expect(progressUpdate.stagnationCount).toBe(0)
-  })
-
-  test("given codex activity happens after a successful continuation, keeps counting stagnation", () => {
-    // given
-    const sessionID = "ses-codex-activity-stagnation"
-    const state = sessionStateStore.getState(sessionID)
-    const todos = [
-      { id: "1", content: "Task 1", status: "pending", priority: "high" },
-    ]
-
-    sessionStateStore.trackContinuationProgress(sessionID, 1, todos)
-    state.awaitingPostInjectionProgressCheck = true
-    sessionStateStore.recordActivity(sessionID)
-
-    // when
-    const progressUpdate = sessionStateStore.trackContinuationProgress(
-      sessionID,
-      1,
-      todos,
-      { allowActivityProgress: false },
     )
 
     // then

--- a/src/hooks/todo-continuation-enforcer/session-state.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.ts
@@ -1,4 +1,4 @@
-import type { ContinuationProgressOptions, SessionState, Todo } from "./types"
+import type { SessionState, Todo } from "./types"
 
 type TimerHandle = number | { unref?: () => void }
 
@@ -16,8 +16,6 @@ interface TrackedSessionState {
   lastAccessedAt: number
   lastCompletedCount?: number
   lastTodoSnapshot?: string
-  activitySignalCount: number
-  lastObservedActivitySignalCount?: number
 }
 
 export interface ContinuationProgressUpdate {
@@ -25,19 +23,17 @@ export interface ContinuationProgressUpdate {
   previousStagnationCount: number
   stagnationCount: number
   hasProgressed: boolean
-  progressSource: "none" | "todo" | "activity"
+  progressSource: "none" | "todo"
 }
 
 export interface SessionStateStore {
   getState: (sessionID: string) => SessionState
   getExistingState: (sessionID: string) => SessionState | undefined
   startPruneInterval: () => void
-  recordActivity: (sessionID: string) => void
   trackContinuationProgress: (
     sessionID: string,
     incompleteCount: number,
     todos?: Todo[],
-    options?: ContinuationProgressOptions,
   ) => ContinuationProgressUpdate
   resetContinuationProgress: (sessionID: string) => void
   cancelCountdown: (sessionID: string) => void
@@ -113,7 +109,6 @@ export function createSessionStateStore(): SessionStateStore {
     const trackedSession: TrackedSessionState = {
       state: rawState,
       lastAccessedAt: Date.now(),
-      activitySignalCount: 0,
     }
     sessions.set(sessionID, trackedSession)
     return trackedSession
@@ -132,16 +127,10 @@ export function createSessionStateStore(): SessionStateStore {
     return undefined
   }
 
-  function recordActivity(sessionID: string): void {
-    const trackedSession = getTrackedSession(sessionID)
-    trackedSession.activitySignalCount += 1
-  }
-
   function trackContinuationProgress(
     sessionID: string,
     incompleteCount: number,
     todos?: Todo[],
-    options: ContinuationProgressOptions = {},
   ): ContinuationProgressUpdate {
     const trackedSession = getTrackedSession(sessionID)
     const state = trackedSession.state
@@ -149,7 +138,6 @@ export function createSessionStateStore(): SessionStateStore {
     const previousStagnationCount = state.stagnationCount
     const currentCompletedCount = todos?.filter((todo) => todo.status === "completed").length
     const currentTodoSnapshot = todos ? getTodoSnapshot(todos) : undefined
-    const currentActivitySignalCount = trackedSession.activitySignalCount
     const hasCompletedMoreTodos =
       currentCompletedCount !== undefined
       && trackedSession.lastCompletedCount !== undefined
@@ -158,10 +146,6 @@ export function createSessionStateStore(): SessionStateStore {
       currentTodoSnapshot !== undefined
       && trackedSession.lastTodoSnapshot !== undefined
       && currentTodoSnapshot !== trackedSession.lastTodoSnapshot
-    const hasObservedExternalActivity =
-      options.allowActivityProgress === true
-      && trackedSession.lastObservedActivitySignalCount !== undefined
-      && currentActivitySignalCount > trackedSession.lastObservedActivitySignalCount
     const hadSuccessfulInjectionAwaitingProgressCheck = state.awaitingPostInjectionProgressCheck === true
 
     state.lastIncompleteCount = incompleteCount
@@ -171,7 +155,6 @@ export function createSessionStateStore(): SessionStateStore {
     if (currentTodoSnapshot !== undefined) {
       trackedSession.lastTodoSnapshot = currentTodoSnapshot
     }
-    trackedSession.lastObservedActivitySignalCount = currentActivitySignalCount
 
     if (previousIncompleteCount === undefined) {
       state.stagnationCount = 0
@@ -184,13 +167,9 @@ export function createSessionStateStore(): SessionStateStore {
       }
     }
 
-    const progressSource = incompleteCount < previousIncompleteCount || hasCompletedMoreTodos || hasTodoSnapshotChanged
-      ? "todo"
-      : hasObservedExternalActivity
-        ? "activity"
-        : "none"
+    const hasProgressed = incompleteCount < previousIncompleteCount || hasCompletedMoreTodos || hasTodoSnapshotChanged
 
-    if (progressSource !== "none") {
+    if (hasProgressed) {
       state.stagnationCount = 0
       state.awaitingPostInjectionProgressCheck = false
       return {
@@ -198,7 +177,7 @@ export function createSessionStateStore(): SessionStateStore {
         previousStagnationCount,
         stagnationCount: state.stagnationCount,
         hasProgressed: true,
-        progressSource,
+        progressSource: "todo",
       }
     }
 
@@ -236,8 +215,6 @@ export function createSessionStateStore(): SessionStateStore {
     state.awaitingPostInjectionProgressCheck = false
     trackedSession.lastCompletedCount = undefined
     trackedSession.lastTodoSnapshot = undefined
-    trackedSession.activitySignalCount = 0
-    trackedSession.lastObservedActivitySignalCount = undefined
   }
 
   function cancelCountdown(sessionID: string): void {
@@ -282,7 +259,6 @@ export function createSessionStateStore(): SessionStateStore {
     getState,
     getExistingState,
     startPruneInterval,
-    recordActivity,
     trackContinuationProgress,
     resetContinuationProgress,
     cancelCountdown,

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -68,7 +68,3 @@ export interface ResolveLatestMessageInfoResult {
   encounteredCompaction: boolean
   latestMessageWasCompaction: boolean
 }
-
-export interface ContinuationProgressOptions {
-  allowActivityProgress?: boolean
-}


### PR DESCRIPTION
## Summary

Activity signals (tool calls like `compress`, `grep`, `bash`) were treated as "progress" by the stagnation detector in `trackContinuationProgress()`, resetting `stagnationCount` to 0 every cycle. This prevented `MAX_STAGNATION_COUNT` (3) from ever being reached, causing **infinite continuation loops** when models degrade to minimal responses in long sessions.

### Root Cause

The bug manifests when a model (observed with GLM-5.1 at ~100K tokens) can no longer produce substantive responses but still executes tool calls:

1. Continuation injected → `awaitingPostInjectionProgressCheck = true`
2. Model responds minimally but calls compress/grep → `activitySignalCount` increments
3. Next idle → `hasObservedExternalActivity = true` → `progressSource = "activity"` → `hasProgressed = true`
4. `stagnationCount` reset to 0 — never reaches 3
5. Continuation fires again → infinite loop with ~7s cycle time

### Fix

Removed all activity-based progress detection. Stagnation now only tracks actual todo state changes:
- Incomplete count decrease
- Completed count increase
- Todo snapshot change (status/content mutations)

Tool-level activity (compress, grep, bash, etc.) no longer resets the stagnation counter.

### Changes

| File | Change |
|------|--------|
| `session-state.ts` | Removed `activitySignalCount`, `lastObservedActivitySignalCount`, `recordActivity()`, `ContinuationProgressOptions`. Simplified progress to todo-only. |
| `non-idle-events.ts` | Removed all `recordActivity()` calls |
| `idle-event.ts` | Removed `shouldAllowActivityProgress()` and `allowActivityProgress` option |
| `types.ts` | Removed `ContinuationProgressOptions` interface |
| `session-state.test.ts` | Replaced 2 activity-based tests with 1 test verifying stagnation works correctly |

### Testing

- All existing unit tests pass (session-state, stagnation-detection, continuation-injection, pending-question-detection, compaction-guard, dispose)
- New test confirms: tool activity without todo changes correctly increments stagnation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove activity-based stagnation bypass to stop infinite continuation loops in long sessions. Progress is now detected only from todo changes, not tool calls.

- **Bug Fixes**
  - Stagnation no longer resets on tool activity; it only resets when incomplete count decreases, completed count increases, or the todo snapshot changes.

- **Refactors**
  - Removed `recordActivity()`, `ContinuationProgressOptions` (and `allowActivityProgress`/`shouldAllowActivityProgress()`), and all activity-related state; `progressSource` is now "todo" or "none" and idle-event cooldown/logs were simplified. Renamed the remaining test to reflect todo-only progress checks.

<sup>Written for commit 65c1283338032ba79c0413eb9f1df662f1dea9c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

