### PR TITLE
fix(delegate-task): apply getAgentConfigKey normalization to isPlanAgent

### DIFF
--- a/src/tools/delegate-task/constants.ts
+++ b/src/tools/delegate-task/constants.ts
@@ -325,7 +325,7 @@ export const PLAN_AGENT_NAMES = ["plan"]
  */
 export function isPlanAgent(agentName: string | undefined): boolean {
   if (!agentName) return false
-  const lowerName = agentName.toLowerCase().trim()
+  const lowerName = getAgentConfigKey(agentName).toLowerCase().trim()
   return PLAN_AGENT_NAMES.some(name => lowerName === name)
 }
 

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -191,7 +191,7 @@ describe("sisyphus-task", () => {
       expect(result).toBe(false)
     })
 
-    test("returns true for 'planner' (matches via includes('plan'))", () => {
+    test("returns false for 'planner' (no longer matches via substring)", () => {
       //#given / #when
       const result = isPlanAgent("planner")
 
@@ -251,6 +251,13 @@ describe("sisyphus-task", () => {
       //#given / #when / #then
       expect(PLAN_AGENT_NAMES).toEqual(["plan"])
     })
+
+    test("returns false for non-plan agent display names (regression: isPlanAgent display-name false-positive)", () => {
+      //#given / #when / #then
+      expect(isPlanAgent(getAgentDisplayName("metis"))).toBe(false)
+      expect(isPlanAgent(getAgentDisplayName("momus"))).toBe(false)
+      expect(isPlanAgent(getAgentDisplayName("atlas"))).toBe(false)
+    })
   })
 
   describe("isPlanFamily", () => {
@@ -294,6 +301,13 @@ describe("sisyphus-task", () => {
       const result = isPlanFamily(undefined)
       //#then
       expect(result).toBe(false)
+    })
+
+    test("returns false for non-plan-family agent display names (regression: isPlanFamily includes() false-positive)", () => {
+      //#given / #when / #then
+      expect(isPlanFamily(getAgentDisplayName("metis"))).toBe(false)
+      expect(isPlanFamily(getAgentDisplayName("momus"))).toBe(false)
+      expect(isPlanFamily(getAgentDisplayName("atlas"))).toBe(false)
     })
 
     test("PLAN_FAMILY_NAMES contains plan and prometheus", () => {


### PR DESCRIPTION
## Summary

`isPlanFamily` was already fixed (in a previous commit) to normalize display names via `getAgentConfigKey()`, but `isPlanAgent` still used raw `agentName.toLowerCase()` without normalization.

This PR applies the same fix to `isPlanAgent` for consistency and correctness.

## Changes

### `src/tools/delegate-task/constants.ts`
- `isPlanAgent`: normalize `agentName` through `getAgentConfigKey()` before comparison (same as `isPlanFamily`)

### `src/tools/delegate-task/tools.test.ts`
- Fix misleading test title: "returns true for 'planner' (matches via includes('plan'))" → describes the old bug, but assertion was already `false`. Corrected to "returns false for 'planner' (no longer matches via substring)"
- Add regression test for `isPlanAgent` with Metis/Momus/Atlas display names (all should return `false`)
- Add regression test for `isPlanFamily` with Metis/Momus/Atlas display names (all should return `false`)

## Root Cause (from #3312)

Four agents have "(Plan ...)" or "- Plan ..." in their display names:
| Config key | Display name |
|------------|--------------|
| atlas | "Atlas - Plan Executor" |
| metis | "Metis - Plan Consultant" |
| momus | "Momus - Plan Critic" |
| prometheus | "Prometheus - Plan Builder" |

Without `getAgentConfigKey()` normalization, display names containing "plan" as a substring could produce false-positives, and display names for legitimate plan-family agents (prometheus) would fail to match.

## Testing

```
bun test src/tools/delegate-task/tools.test.ts --filter 'isPlan'
# 129 pass, 0 fail
```

Fixes #3312

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize agent names in isPlanAgent using getAgentConfigKey to avoid display-name mismatches and keep behavior consistent with isPlanFamily. Fixes #3312.

- **Bug Fixes**
  - Apply getAgentConfigKey normalization in isPlanAgent before comparing to PLAN_AGENT_NAMES.
  - Correct test title for "planner" (returns false; no substring match).
  - Add regression tests to ensure Metis/Momus/Atlas display names are not treated as plan or plan-family.

<sup>Written for commit 23d125755f76ece2db06e3f19a1e2a9a5941cd0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

