### PR TITLE
fix(agent-display): remove zero-width sort prefixes from runtime names

### DIFF
--- a/src/cli/run/output-renderer.test.ts
+++ b/src/cli/run/output-renderer.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, mock, spyOn, test } from "bun:test"
+import { renderAgentHeader } from "./output-renderer"
+
+describe("renderAgentHeader", () => {
+  test("strips zero-width characters before printing the agent label", () => {
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(mock(() => true))
+
+    try {
+      renderAgentHeader("\u200B\u200BHephaestus - Deep Agent", "gpt-5.4", null, {
+        "Hephaestus - Deep Agent": "#ff00ff",
+      })
+
+      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("")
+      expect(output).toContain("Hephaestus - Deep Agent")
+      expect(output).not.toContain("\u200B\u200BHephaestus - Deep Agent")
+    } finally {
+      writeSpy.mockRestore()
+    }
+  })
+})

--- a/src/cli/run/output-renderer.ts
+++ b/src/cli/run/output-renderer.ts
@@ -1,4 +1,5 @@
 import pc from "picocolors"
+import { stripInvisibleAgentCharacters } from "../../shared/agent-display-names"
 
 export function renderAgentHeader(
   agent: string | null,
@@ -8,8 +9,9 @@ export function renderAgentHeader(
 ): void {
   if (!agent && !model) return
 
+  const cleanAgent = agent ? stripInvisibleAgentCharacters(agent) : null
   const agentLabel = agent
-    ? pc.bold(colorizeWithProfileColor(agent, agentColorsByName[agent]))
+    ? pc.bold(colorizeWithProfileColor(cleanAgent ?? agent, agentColorsByName[agent] ?? (cleanAgent ? agentColorsByName[cleanAgent] : undefined)))
     : ""
   const modelBase = model ?? ""
   const variantSuffix = variant ? ` (${variant})` : ""

--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -82,7 +82,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     expect(result["sisyphus"]).toBeUndefined()
   })
 
-  it("returns runtime core agent list names in canonical order", () => {
+  it("returns clean core agent display keys in canonical order", () => {
     // given
     const result = remapAgentKeysToDisplayNames({
       atlas: {},
@@ -116,7 +116,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then keys and names both use the same runtime-facing list names
+    // then keys stay human-readable while runtime names keep list ordering
     expect(Object.keys(result).slice(0, 4)).toEqual([
       getAgentListDisplayName("sisyphus"),
       getAgentListDisplayName("hephaestus"),

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -108,7 +108,7 @@ describe("applyCommandConfig", () => {
     expect(commandConfig["agents-global-skill"]?.description).toContain("Agents global skill");
   });
 
-  test("normalizes Atlas command agents to the runtime list name used by opencode command routing", async () => {
+  test("normalizes Atlas command agents to the clean display name used by opencode command routing", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {
@@ -133,7 +133,7 @@ describe("applyCommandConfig", () => {
     expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
   });
 
-  test("normalizes legacy display-name command agents to the runtime list name", async () => {
+  test("normalizes legacy display-name command agents to the clean display name", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { AGENT_DISPLAY_NAMES, getAgentConfigKey, getAgentDisplayName, getAgentListDisplayName, normalizeAgentForPrompt, normalizeAgentForPromptKey } from "./agent-display-names"
+import { AGENT_DISPLAY_NAMES, getAgentConfigKey, getAgentDisplayName, getAgentListDisplayName, getAgentRuntimeName, normalizeAgentForPrompt, normalizeAgentForPromptKey } from "./agent-display-names"
 
 describe("getAgentDisplayName", () => {
   it("returns display name for lowercase config key (new format)", () => {
@@ -194,15 +194,20 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns clean display names for the core agent list", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {
     expect(getAgentListDisplayName("oracle")).toBe("oracle")
+  })
+
+  it("keeps runtime names identical to clean display names", () => {
+    expect(getAgentRuntimeName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentRuntimeName("hephaestus")).toBe("Hephaestus - Deep Agent")
   })
 })
 

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -26,14 +26,7 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
-const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
-}
-
-const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g
+const INVISIBLE_AGENT_CHARACTERS_REGEX = /\u200B|\u200C|\u200D|\uFEFF/g
 
 export function stripInvisibleAgentCharacters(agentName: string): string {
   return agentName.replace(INVISIBLE_AGENT_CHARACTERS_REGEX, "")
@@ -44,10 +37,7 @@ export function stripAgentListSortPrefix(agentName: string): string {
 }
 
 export function getAgentRuntimeName(configKey: string): string {
-  const displayName = getAgentDisplayName(configKey)
-  const prefix = AGENT_LIST_SORT_PREFIXES[configKey.toLowerCase()]
-
-  return prefix ? `${prefix}${displayName}` : displayName
+  return getAgentDisplayName(configKey)
 }
 
 /**
@@ -56,25 +46,25 @@ export function getAgentRuntimeName(configKey: string): string {
  * Returns original key if not found.
  */
 export function getAgentDisplayName(configKey: string): string {
-  // Try exact match first
   const exactMatch = AGENT_DISPLAY_NAMES[configKey]
   if (exactMatch !== undefined) return exactMatch
-  
-  // Fall back to case-insensitive search
+
   const lowerKey = configKey.toLowerCase()
   for (const [k, v] of Object.entries(AGENT_DISPLAY_NAMES)) {
     if (k.toLowerCase() === lowerKey) return v
   }
-  
-  // Unknown agent: return original key
+
   return configKey
 }
 
 /**
- * Runtime-facing agent name used for OpenCode list ordering.
+ * List-facing agent display name.
+ *
+ * This must stay human-readable. Runtime sort prefixes belong only in the
+ * agent `name` field via getAgentRuntimeName().
  */
 export function getAgentListDisplayName(configKey: string): string {
-  return getAgentRuntimeName(configKey)
+  return getAgentDisplayName(configKey)
 }
 
 const REVERSE_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Summary

- Removes `AGENT_LIST_SORT_PREFIXES` entirely to prevent string corruption (like missing 'U' in 'Ultraworker') when OpenCode renders labels in its TUI.
- Updates `getAgentRuntimeName` to return identical clean strings as `getAgentDisplayName`.
- Implements a defense-in-depth layer in the CLI terminal output renderer (`stripInvisibleAgentCharacters`) to ensure no residual invisible characters are printed.

## Changes

- Modified `src/shared/agent-display-names.ts` to remove the ZWSP-based prefix injection, relying strictly on the existing `order` property injection via `CANONICAL_CORE_AGENT_ORDER` for agent list sorting.
- Modified `src/cli/run/output-renderer.ts` to aggressively clean the agent string before printing it with `picocolors`.
- Added new regression test `src/cli/run/output-renderer.test.ts`.
- Updated test snapshots in `src/shared/agent-display-names.test.ts`, `src/plugin-handlers/agent-key-remapper.test.ts` and `src/plugin-handlers/command-config-handler.test.ts` to assert that zero-width space characters are no longer present.

## Testing

```bash
bun run typecheck
bun test
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed zero-width sort prefixes from agent names to fix truncated TUI labels. Runtime and list display names are now clean and consistent, and the CLI strips invisible characters before printing.

- **Bug Fixes**
  - Removed ZWSP prefixes; `getAgentRuntimeName` and `getAgentListDisplayName` now match `getAgentDisplayName`.
  - Sorting relies only on `CANONICAL_CORE_AGENT_ORDER`.
  - CLI sanitizes labels via `stripInvisibleAgentCharacters` and falls back to color profiles by clean name before styling with `picocolors`; added a `renderAgentHeader` test and updated related tests to assert no zero-width chars.

<sup>Written for commit f5927e4a5de05f307509996b97e381df8d293e43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

