### PR TITLE
fix(background-agent): skip unavailable fallback models

### DIFF
--- a/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/src/features/background-agent/fallback-retry-handler.test.ts
@@ -3,10 +3,6 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
 const sharedLogMock = mock(() => {})
 const readConnectedProvidersCacheMock = mock(() => null)
 const readProviderModelsCacheMock = mock(() => null)
-const shouldRetryErrorMock = mock(() => true)
-const getNextFallbackMock = mock((chain: Array<{ model: string }>, attempt: number) => chain[attempt])
-const hasMoreFallbacksMock = mock((chain: Array<{ model: string }>, attempt: number) => attempt < chain.length)
-const selectFallbackProviderMock = mock((providers: string[]) => providers[0])
 const transformModelForProviderMock = mock((_provider: string, model: string) => model)
 
 import type { BackgroundTask } from "./types"
@@ -20,11 +16,9 @@ async function importFreshFallbackRetryHandlerModule() {
     readProviderModelsCache: readProviderModelsCacheMock,
   }))
 
-  mock.module("../../shared/model-error-classifier", () => ({
-    shouldRetryError: shouldRetryErrorMock,
-    getNextFallback: getNextFallbackMock,
-    hasMoreFallbacks: hasMoreFallbacksMock,
-    selectFallbackProvider: selectFallbackProviderMock,
+  mock.module("../../shared/connected-providers-cache", () => ({
+    readConnectedProvidersCache: readConnectedProvidersCacheMock,
+    readProviderModelsCache: readProviderModelsCacheMock,
   }))
 
   mock.module("../../shared/provider-model-id-transform", () => ({
@@ -32,17 +26,14 @@ async function importFreshFallbackRetryHandlerModule() {
   }))
 
   const retryHandlerModule = await import(`./fallback-retry-handler?test=${Date.now()}-${Math.random()}`)
-  mock.restore()
 
   return {
     tryFallbackRetry: retryHandlerModule.tryFallbackRetry,
-    shouldRetryError: shouldRetryErrorMock,
-    selectFallbackProvider: selectFallbackProviderMock,
     readProviderModelsCache: readProviderModelsCacheMock,
   }
 }
 
-const { tryFallbackRetry, shouldRetryError, selectFallbackProvider, readProviderModelsCache } =
+const { tryFallbackRetry, readProviderModelsCache } =
   await importFreshFallbackRetryHandlerModule()
 
 function createDeferredPromise(): {
@@ -130,9 +121,8 @@ describe("tryFallbackRetry", () => {
   })
 
   beforeEach(() => {
-    ;(shouldRetryError as any).mockImplementation(() => true)
-    ;(selectFallbackProvider as any).mockImplementation((providers: string[]) => providers[0])
     ;(readProviderModelsCache as any).mockReturnValue(null)
+    readConnectedProvidersCacheMock.mockReturnValue(null)
   })
 
   describe("#given retryable error with fallback chain", () => {
@@ -259,9 +249,12 @@ describe("tryFallbackRetry", () => {
   })
 
   describe("#given non-retryable error", () => {
-    test("returns false when shouldRetryError returns false", async () => {
-      ;(shouldRetryError as any).mockImplementation(() => false)
-      const args = createDefaultArgs()
+    test("returns false for non-retryable error message", async () => {
+      const args = createDefaultArgs({})
+      args.errorInfo = {
+        name: "UnknownError",
+        message: "Subscription quota exceeded. You can continue using free models.",
+      }
 
       const result = await tryFallbackRetry(args)
 
@@ -342,10 +335,28 @@ describe("tryFallbackRetry", () => {
 
   describe("#given disconnected fallback providers with connected preferred provider", () => {
     test("keeps fallback entry and selects connected preferred provider", async () => {
-      ;(readProviderModelsCache as any).mockReturnValueOnce({ connected: ["provider-a"] })
-      ;(selectFallbackProvider as any).mockImplementationOnce(
-        (_providers: string[], preferredProviderID?: string) => preferredProviderID ?? "provider-b",
-      )
+      readConnectedProvidersCacheMock.mockReturnValue(["provider-a"])
+      ;(readProviderModelsCache as any).mockReturnValue({ connected: ["provider-a"] })
+
+      const args = createDefaultArgs({
+        fallbackChain: [{ model: "fallback-model-1", providers: ["provider-b"], variant: undefined }],
+        model: { providerID: "provider-a", modelID: "original-model" },
+      })
+
+      const result = await tryFallbackRetry(args)
+
+      expect(result).toBe(true)
+      expect(args.task.model?.providerID).toBe("provider-a")
+      expect(args.task.model?.modelID).toBe("fallback-model-1")
+    })
+
+    test("resolves via preferred provider when available model cache is present", async () => {
+      ;(readProviderModelsCache as any).mockReturnValue({
+        connected: ["provider-a"],
+        models: {
+          "provider-a": [{ id: "fallback-model-1" }],
+        },
+      })
 
       const args = createDefaultArgs({
         fallbackChain: [{ model: "fallback-model-1", providers: ["provider-b"], variant: undefined }],

--- a/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/src/features/background-agent/fallback-retry-handler.test.ts
@@ -14,11 +14,8 @@ import type { ConcurrencyManager } from "./concurrency"
 import type { OpencodeClient, QueueItem } from "./constants"
 
 async function importFreshFallbackRetryHandlerModule() {
-  mock.module("../../shared/logger", () => ({
+  mock.module("../../shared", () => ({
     log: sharedLogMock,
-  }))
-
-  mock.module("../../shared/connected-providers-cache", () => ({
     readConnectedProvidersCache: readConnectedProvidersCacheMock,
     readProviderModelsCache: readProviderModelsCacheMock,
   }))
@@ -362,4 +359,5 @@ describe("tryFallbackRetry", () => {
       expect(args.task.model?.modelID).toBe("fallback-model-1")
     })
   })
+
 })

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -33,6 +33,15 @@ function buildAvailableModelsFromCache(): Set<string> {
   return out
 }
 
+function getProvidersForAvailabilityResolution(
+  providers: string[],
+  preferredProviderID?: string,
+): string[] {
+  if (!preferredProviderID) return providers
+  if (providers.some((provider) => provider.toLowerCase() === preferredProviderID.toLowerCase())) return providers
+  return [...providers, preferredProviderID]
+}
+
 export async function tryFallbackRetry(args: {
   task: BackgroundTask
   errorInfo: { name?: string; message?: string }
@@ -87,7 +96,12 @@ export async function tryFallbackRetry(args: {
     }
 
     if (availableModels.size > 0) {
-      const resolved = resolveFirstAvailableFallback([candidate], availableModels)
+      const resolved = resolveFirstAvailableFallback([
+        {
+          ...candidate,
+          providers: getProvidersForAvailabilityResolution(candidate.providers, task.model?.providerID),
+        },
+      ], availableModels)
       if (!resolved) {
         log("[background-agent] Skipping unavailable fallback:", {
           taskId: task.id,

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -3,6 +3,7 @@ import type { FallbackEntry } from "../../shared/model-requirements"
 import type { ConcurrencyManager } from "./concurrency"
 import type { OpencodeClient, QueueItem } from "./constants"
 import { log, readConnectedProvidersCache, readProviderModelsCache } from "../../shared"
+import { resolveFirstAvailableFallback } from "../../shared/fallback-model-availability"
 import {
   shouldRetryError,
   getNextFallback,
@@ -11,6 +12,26 @@ import {
 } from "../../shared/model-error-classifier"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
 import { abortWithTimeout } from "./abort-with-timeout"
+
+function buildAvailableModelsFromCache(): Set<string> {
+  const providerModelsCache = readProviderModelsCache()
+  if (!providerModelsCache?.models) return new Set<string>()
+
+  const connected = new Set(providerModelsCache.connected)
+  const out = new Set<string>()
+
+  for (const [providerID, models] of Object.entries(providerModelsCache.models)) {
+    if (!connected.has(providerID)) continue
+
+    for (const item of models) {
+      const modelID = typeof item === "string" ? item : item?.id
+      if (!modelID) continue
+      out.add(`${providerID}/${modelID}`)
+    }
+  }
+
+  return out
+}
 
 export async function tryFallbackRetry(args: {
   task: BackgroundTask
@@ -37,6 +58,7 @@ export async function tryFallbackRetry(args: {
   const connectedProviders = providerModelsCache?.connected ?? readConnectedProvidersCache()
   const connectedSet = connectedProviders ? new Set(connectedProviders.map(p => p.toLowerCase())) : null
   const preferredProvider = task.model?.providerID?.toLowerCase()
+  const availableModels = buildAvailableModelsFromCache()
 
   const isReachable = (entry: FallbackEntry): boolean => {
     if (!connectedSet) return true
@@ -48,6 +70,8 @@ export async function tryFallbackRetry(args: {
 
   let selectedAttemptCount = attemptCount
   let nextFallback: FallbackEntry | undefined
+  let resolvedProviderID: string | undefined
+  let resolvedModelID: string | undefined
   while (fallbackChain && selectedAttemptCount < fallbackChain.length) {
     const candidate = getNextFallback(fallbackChain, selectedAttemptCount)
     if (!candidate) break
@@ -61,15 +85,33 @@ export async function tryFallbackRetry(args: {
       })
       continue
     }
+
+    if (availableModels.size > 0) {
+      const resolved = resolveFirstAvailableFallback([candidate], availableModels)
+      if (!resolved) {
+        log("[background-agent] Skipping unavailable fallback:", {
+          taskId: task.id,
+          source,
+          model: candidate.model,
+          providers: candidate.providers,
+        })
+        continue
+      }
+
+      resolvedProviderID = resolved.provider
+      resolvedModelID = resolved.model.split("/").slice(1).join("/")
+    }
+
     nextFallback = candidate
     break
   }
   if (!nextFallback) return false
 
-  const providerID = selectFallbackProvider(
+  const providerID = resolvedProviderID ?? selectFallbackProvider(
     nextFallback.providers,
     task.model?.providerID,
   )
+  const transformedModelId = resolvedModelID ?? transformModelForProvider(providerID, nextFallback.model)
 
   log("[background-agent] Retryable error, attempting fallback:", {
     taskId: task.id,
@@ -94,7 +136,6 @@ export async function tryFallbackRetry(args: {
   const previousSessionID = task.sessionID
 
   task.attemptCount = selectedAttemptCount
-  const transformedModelId = transformModelForProvider(providerID, nextFallback.model)
   task.model = {
     providerID,
     modelID: transformedModelId,

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -332,6 +332,56 @@ describe("model fallback hook", () => {
     clearPendingModelFallback(sessionID)
   })
 
+  test("uses connected preferred provider with available model cache present", async () => {
+    //#given
+    const sessionID = "ses_model_fallback_preferred_provider_with_cache"
+    clearPendingModelFallback(sessionID)
+    readConnectedProvidersCacheMock.mockReturnValue(["provider-x"])
+    readProviderModelsCacheMock.mockReturnValue({
+      connected: ["provider-x"],
+      models: {
+        "provider-x": [{ id: "fallback-model" }],
+      },
+    })
+
+    const hook = createModelFallbackHook() as unknown as {
+      "chat.message"?: (
+        input: { sessionID: string },
+        output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
+      ) => Promise<void>
+    }
+
+    setSessionFallbackChain(sessionID, [
+      { providers: ["provider-y"], model: "fallback-model" },
+    ])
+
+    expect(
+      setPendingModelFallback(
+        sessionID,
+        "Sisyphus - Ultraworker",
+        "provider-x",
+        "current-model",
+      ),
+    ).toBe(true)
+
+    const output = {
+      message: {
+        model: { providerID: "provider-x", modelID: "current-model" },
+      },
+      parts: [{ type: "text", text: "continue" }],
+    }
+
+    //#when
+    await hook["chat.message"]?.({ sessionID }, output)
+
+    //#then
+    expect(output.message["model"]).toEqual({
+      providerID: "provider-x",
+      modelID: "fallback-model",
+    })
+    clearPendingModelFallback(sessionID)
+  })
+
   test("does not fall back to hardcoded agent chain when session explicitly stores no fallback chain [regression #2941]", () => {
     //#given
     const sessionID = "ses_model_fallback_explicit_none"

--- a/src/hooks/model-fallback/next-fallback.ts
+++ b/src/hooks/model-fallback/next-fallback.ts
@@ -1,5 +1,6 @@
 import type { FallbackEntry } from "../../shared/model-requirements"
 import { readConnectedProvidersCache, readProviderModelsCache } from "../../shared/connected-providers-cache"
+import { resolveFirstAvailableFallback } from "../../shared/fallback-model-availability"
 import { selectFallbackProvider } from "../../shared/model-error-classifier"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
 import { log } from "../../shared/logger"
@@ -29,6 +30,26 @@ function createReachabilityChecker(state: ModelFallbackState): (entry: FallbackE
   }
 }
 
+function buildAvailableModelsFromCache(): Set<string> {
+  const providerModelsCache = readProviderModelsCache()
+  if (!providerModelsCache?.models) return new Set<string>()
+
+  const connected = new Set(providerModelsCache.connected)
+  const out = new Set<string>()
+
+  for (const [providerID, models] of Object.entries(providerModelsCache.models)) {
+    if (!connected.has(providerID)) continue
+
+    for (const item of models) {
+      const modelID = typeof item === "string" ? item : item?.id
+      if (!modelID) continue
+      out.add(`${providerID}/${modelID}`)
+    }
+  }
+
+  return out
+}
+
 export function getNextReachableFallback(
   sessionID: string,
   state: ModelFallbackState,
@@ -43,6 +64,7 @@ export function getNextReachableFallback(
   thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
 } | null {
   const isReachable = createReachabilityChecker(state)
+  const availableModels = buildAvailableModelsFromCache()
 
   while (state.attemptCount < state.fallbackChain.length) {
     const attemptCount = state.attemptCount
@@ -54,8 +76,23 @@ export function getNextReachableFallback(
       continue
     }
 
-    const providerID = selectFallbackProvider(fallback.providers, state.providerID)
-    const modelID = transformModelForProvider(providerID, fallback.model)
+    let providerID: string
+    let modelID: string
+
+    if (availableModels.size > 0) {
+      const resolved = resolveFirstAvailableFallback([fallback], availableModels)
+      if (!resolved) {
+        log("[model-fallback] Skipping unavailable fallback for session: " + sessionID + ", attempt: " + attemptCount + ", model: " + fallback.model)
+        continue
+      }
+
+      providerID = resolved.provider
+      modelID = resolved.model.split("/").slice(1).join("/")
+    } else {
+      providerID = selectFallbackProvider(fallback.providers, state.providerID)
+      modelID = transformModelForProvider(providerID, fallback.model)
+    }
+
     const isNoOpFallback =
       providerID.toLowerCase() === state.providerID.toLowerCase()
       && canonicalizeModelID(modelID) === canonicalizeModelID(state.modelID)

--- a/src/hooks/model-fallback/next-fallback.ts
+++ b/src/hooks/model-fallback/next-fallback.ts
@@ -50,6 +50,15 @@ function buildAvailableModelsFromCache(): Set<string> {
   return out
 }
 
+function getProvidersForAvailabilityResolution(
+  providers: string[],
+  preferredProviderID?: string,
+): string[] {
+  if (!preferredProviderID) return providers
+  if (providers.some((provider) => provider.toLowerCase() === preferredProviderID.toLowerCase())) return providers
+  return [...providers, preferredProviderID]
+}
+
 export function getNextReachableFallback(
   sessionID: string,
   state: ModelFallbackState,
@@ -80,7 +89,12 @@ export function getNextReachableFallback(
     let modelID: string
 
     if (availableModels.size > 0) {
-      const resolved = resolveFirstAvailableFallback([fallback], availableModels)
+      const resolved = resolveFirstAvailableFallback([
+        {
+          ...fallback,
+          providers: getProvidersForAvailabilityResolution(fallback.providers, state.providerID),
+        },
+      ], availableModels)
       if (!resolved) {
         log("[model-fallback] Skipping unavailable fallback for session: " + sessionID + ", attempt: " + attemptCount + ", model: " + fallback.model)
         continue


### PR DESCRIPTION
## Summary

- skip fallback candidates that are not available in the current runtime model catalog
- use the runtime's connected-provider model cache when selecting fallback candidates
- keep the existing provider-based behavior when no model cache is available

## Changes

- update `model-fallback` candidate selection to prefer runtime-available fallback models
- update background fallback retry selection to do the same
- add targeted test coverage for unavailable fallback candidate handling

## Testing

```bash
bun test src/features/background-agent/fallback-retry-handler.test.ts src/features/background-agent/manager.polling.test.ts src/features/background-agent/session-idle-event-handler.test.ts
bun run typecheck
bun run build
```

Manual validation:
- reproduced unavailable fallback attempts in a no-override local setup
- confirmed the patched selection skips unavailable candidates instead of attempting them

## Related Issues

Closes #3400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip fallback models that aren’t available at runtime to avoid wasted background-agent retries. Use the provider-model cache to pick the first available fallback and prefer the connected preferred provider when possible; fall back to the old provider-based logic when no cache is present.

- **Bug Fixes**
  - Prefer runtime-available models using the provider-model cache; skip unavailable candidates.
  - Prefer the connected preferred provider when the model exists in cache; fall back to provider-based selection when no cache.
  - Apply the same logic in background retries and the model-fallback hook; add targeted tests.
  - Closes #3400.

<sup>Written for commit 77d86f2ca938777eb97067b40424cf74a390d485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

