### PR TITLE
fix(agent-display): remove ZWSP sort prefixes that truncate agent names in terminals

### DIFF
--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -194,11 +194,11 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns clean display names without ZWSP prefixes", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -26,11 +26,16 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
+// ZWSP sort prefixes removed — they caused agent name truncation in VS Code,
+// WezTerm, and other terminals that mishandle zero-width characters.
+// Sorting now relies exclusively on the `order` field injected by
+// CANONICAL_CORE_AGENT_ORDER in agent-priority-order.ts.
+// The map is kept (with empty values) so callers don't break.
 const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
+  sisyphus: "",
+  hephaestus: "",
+  prometheus: "",
+  atlas: "",
 }
 
 const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g


### PR DESCRIPTION
## Summary

- Set `AGENT_LIST_SORT_PREFIXES` values to empty strings to eliminate agent name truncation in VS Code, WezTerm, and Linux terminals
- Preserve stripping utilities (`stripInvisibleAgentCharacters`, `stripAgentListSortPrefix`) for backward compatibility with old sessions

Fixes #3418
Also addresses #3337, #3347, #3379 (same root cause)

## Problem

`AGENT_LIST_SORT_PREFIXES` prepends 1-4 `\u200B` (zero-width space) characters to core agent display names for UI list ordering. Terminals that don't treat ZWS as zero-width (VS Code integrated terminal, WezTerm, Linux emulators) clip the visible agent name, producing truncated labels like `ltraworker` instead of `Ultraworker`.

Ghostty handles ZWS correctly and is unaffected.

## Fix

The ZWSP prefixes are redundant — `CANONICAL_CORE_AGENT_ORDER` in `agent-priority-order.ts` already handles sorting via the `order` field injection. Setting prefix values to empty strings removes the visual corruption while keeping the map shape intact for callers.

## Changes

| File | Change |
|------|--------|
| `src/shared/agent-display-names.ts` | Set all ZWSP sort prefix values to `""` |
| `src/shared/agent-display-names.test.ts` | Update test expectations for prefix-free display names |

## Testing

```bash
bun run typecheck  # passes
bun test src/shared/agent-display-names.test.ts  # pre-existing test-setup failure on dev, unrelated
```

## PR Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove zero‑width space sort prefixes from core agent display names to stop truncation in VS Code, WezTerm, and Linux terminals. Sorting now relies on the canonical order field so names render cleanly. Fixes #3418; also addresses #3337, #3347, #3379.

- **Bug Fixes**
  - Set `AGENT_LIST_SORT_PREFIXES` to empty strings for core agents.
  - Keep `stripInvisibleAgentCharacters` and `stripAgentListSortPrefix` for backward compatibility.
  - Update tests to expect prefix-free display names.

<sup>Written for commit 12eb7d0dfa103c1965c643aae1b570e37cb4e30e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

