### PR TITLE
Fix primary agent model precedence

### DIFF
--- a/src/agents/builtin-agents/atlas-agent.ts
+++ b/src/agents/builtin-agents/atlas-agent.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentOverrides } from "../types"
 import type { CategoriesConfig, CategoryConfig } from "../../config/schema"
 import type { AvailableAgent, AvailableSkill } from "../dynamic-agent-prompt-builder"
-import { AGENT_MODEL_REQUIREMENTS } from "../../shared"
+import { AGENT_MODEL_REQUIREMENTS, normalizeModel } from "../../shared"
 import { applyOverrides } from "./agent-overrides"
 import { applyModelResolution } from "./model-resolution"
 import { createAtlasAgent } from "../atlas"
@@ -37,9 +37,10 @@ export function maybeCreateAtlasConfig(input: {
 
   const orchestratorOverride = agentOverrides["atlas"]
   const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
+  const hasUiSelectedModel = normalizeModel(uiSelectedModel) !== undefined
 
   const atlasResolution = applyModelResolution({
-    uiSelectedModel: orchestratorOverride?.model !== undefined ? undefined : uiSelectedModel,
+    uiSelectedModel,
     userModel: orchestratorOverride?.model,
     requirement: atlasRequirement,
     availableModels,
@@ -61,6 +62,13 @@ export function maybeCreateAtlasConfig(input: {
   }
 
   orchestratorConfig = applyOverrides(orchestratorConfig, orchestratorOverride, mergedCategories, directory)
+
+  if (hasUiSelectedModel) {
+    const { variant: _ignoredVariant, ...configWithoutVariant } = orchestratorConfig
+    orchestratorConfig = atlasResolvedVariant !== undefined
+      ? { ...configWithoutVariant, model: atlasModel, variant: atlasResolvedVariant }
+      : { ...configWithoutVariant, model: atlasModel }
+  }
 
   return orchestratorConfig
 }

--- a/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/src/agents/builtin-agents/sisyphus-agent.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentOverrides } from "../types"
 import type { CategoriesConfig, CategoryConfig } from "../../config/schema"
 import type { AvailableAgent, AvailableCategory, AvailableSkill } from "../dynamic-agent-prompt-builder"
-import { AGENT_MODEL_REQUIREMENTS, isAnyFallbackModelAvailable } from "../../shared"
+import { AGENT_MODEL_REQUIREMENTS, isAnyFallbackModelAvailable, normalizeModel } from "../../shared"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyOverrides } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
@@ -44,6 +44,7 @@ export function maybeCreateSisyphusConfig(input: {
   const sisyphusOverride = agentOverrides["sisyphus"]
   const sisyphusRequirement = AGENT_MODEL_REQUIREMENTS["sisyphus"]
   const hasSisyphusExplicitConfig = sisyphusOverride !== undefined
+  const hasUiSelectedModel = normalizeModel(uiSelectedModel) !== undefined
   const meetsSisyphusAnyModelRequirement =
     !sisyphusRequirement?.requiresAnyModel ||
     hasSisyphusExplicitConfig ||
@@ -53,7 +54,7 @@ export function maybeCreateSisyphusConfig(input: {
   if (disabledAgents.includes("sisyphus") || !meetsSisyphusAnyModelRequirement) return undefined
 
   let sisyphusResolution = applyModelResolution({
-    uiSelectedModel: sisyphusOverride?.model !== undefined ? undefined : uiSelectedModel,
+    uiSelectedModel,
     userModel: sisyphusOverride?.model,
     requirement: sisyphusRequirement,
     availableModels,
@@ -81,6 +82,13 @@ export function maybeCreateSisyphusConfig(input: {
   }
 
   sisyphusConfig = applyOverrides(sisyphusConfig, sisyphusOverride, mergedCategories, directory)
+
+  if (hasUiSelectedModel) {
+    const { variant: _ignoredVariant, ...configWithoutVariant } = sisyphusConfig
+    sisyphusConfig = sisyphusResolvedVariant !== undefined
+      ? { ...configWithoutVariant, model: sisyphusModel, variant: sisyphusResolvedVariant }
+      : { ...configWithoutVariant, model: sisyphusModel }
+  }
 
   const resolvedModel = sisyphusConfig.model ?? ""
   const gptDeny = getGptApplyPatchPermission(resolvedModel)

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -102,7 +102,7 @@ describe("createBuiltinAgents with model overrides", () => {
     }
   })
 
-  test("user config model takes priority over uiSelectedModel for sisyphus", async () => {
+  test("uiSelectedModel takes priority over sisyphus config model override", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
@@ -129,13 +129,47 @@ describe("createBuiltinAgents with model overrides", () => {
 
       // #then
       expect(agents.sisyphus).toBeDefined()
-      expect(agents.sisyphus.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+      expect(agents.sisyphus.model).toBe("openai/gpt-5.4")
     } finally {
       fetchSpy.mockRestore()
     }
   })
 
-  test("user config model takes priority over uiSelectedModel for atlas", async () => {
+  test("uiSelectedModel takes priority over sisyphus category model override", async () => {
+    // #given
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
+    )
+    const uiSelectedModel = "anthropic/claude-sonnet-4-6"
+    const overrides = {
+      sisyphus: { category: "ultrabrain" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents(
+        [],
+        overrides,
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        uiSelectedModel
+      )
+
+      // #then
+      expect(agents.sisyphus).toBeDefined()
+      expect(agents.sisyphus.model).toBe("anthropic/claude-sonnet-4-6")
+      expect(agents.sisyphus.variant).toBeUndefined()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("uiSelectedModel takes priority over atlas config model override", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
@@ -162,7 +196,41 @@ describe("createBuiltinAgents with model overrides", () => {
 
       // #then
       expect(agents.atlas).toBeDefined()
-      expect(agents.atlas.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+      expect(agents.atlas.model).toBe("openai/gpt-5.4")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("uiSelectedModel takes priority over atlas category model override", async () => {
+    // #given
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
+    )
+    const uiSelectedModel = "anthropic/claude-sonnet-4-6"
+    const overrides = {
+      atlas: { category: "ultrabrain" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents(
+        [],
+        overrides,
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        uiSelectedModel
+      )
+
+      // #then
+      expect(agents.atlas).toBeDefined()
+      expect(agents.atlas.model).toBe("anthropic/claude-sonnet-4-6")
+      expect(agents.atlas.variant).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
     }


### PR DESCRIPTION
## Summary
- let Atlas and Sisyphus keep the runtime-selected model when agent config or category overrides also define a model
- restore the resolved model and variant after applying overrides so primary-agent model selection is not clobbered
- add regression coverage for direct model overrides and category-based overrides in `src/agents/utils.test.ts`

## Testing
- bun test src/agents/utils.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix model precedence for primary agents so the UI-selected model always wins over agent and category overrides. Atlas and Sisyphus now keep the runtime-selected model and restore the resolved variant when applicable.

- **Bug Fixes**
  - Preserve `uiSelectedModel` for `atlas` and `sisyphus` even when overrides specify a model or category.
  - After applying overrides, re-apply the resolved model and variant (if any) to prevent clobbering.
  - Add regression tests for direct model overrides and category-based overrides to lock precedence.

<sup>Written for commit d62cdfe245f4ac4b8743e2c077311ac019ddccf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

