### PR TITLE
fix(session-recovery): add thinking_block_modified error detection and recovery

### DIFF
--- a/src/hooks/session-recovery/detect-error-type.test.ts
+++ b/src/hooks/session-recovery/detect-error-type.test.ts
@@ -36,6 +36,31 @@ describe("detectErrorType", () => {
     expect(result).toBe("thinking_disabled_violation")
   })
 
+  it("#given a Bedrock thinking block modified error #when detecting #then returns thinking_block_modified", () => {
+    //#given
+    const error = {
+      message:
+        "undefined: The model returned the following errors: messages.17.content.28: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.",
+    }
+
+    //#when
+    const result = detectErrorType(error)
+
+    //#then
+    expect(result).toBe("thinking_block_modified")
+  })
+
+  it("#given a simple thinking block modified error #when detecting #then returns thinking_block_modified", () => {
+    //#given
+    const error = { message: "thinking blocks cannot be modified" }
+
+    //#when
+    const result = detectErrorType(error)
+
+    //#then
+    expect(result).toBe("thinking_block_modified")
+  })
+
   it("#given an unrecognized error #when detecting #then returns null", () => {
     //#given
     const error = { message: "some random error" }

--- a/src/hooks/session-recovery/detect-error-type.ts
+++ b/src/hooks/session-recovery/detect-error-type.ts
@@ -2,6 +2,7 @@ export type RecoveryErrorType =
   | "tool_result_missing"
   | "thinking_block_order"
   | "thinking_disabled_violation"
+  | "thinking_block_modified"
   | "assistant_prefill_unsupported"
   | "unavailable_tool"
   | null
@@ -75,6 +76,11 @@ export function detectErrorType(error: unknown): RecoveryErrorType {
         (message.includes("expected") && message.includes("found")))
     ) {
       return "thinking_block_order"
+    }
+
+    // Thinking block signature corruption (Bedrock compaction)
+    if (message.includes("thinking") && message.includes("cannot be modified")) {
+      return "thinking_block_modified"
     }
 
     if (message.includes("thinking is disabled") && message.includes("cannot contain")) {

--- a/src/hooks/session-recovery/hook.ts
+++ b/src/hooks/session-recovery/hook.ts
@@ -99,6 +99,7 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
         unavailable_tool: "Tool Recovery",
         thinking_block_order: "Thinking Block Recovery",
         thinking_disabled_violation: "Thinking Strip Recovery",
+        thinking_block_modified: "Thinking Block Recovery",
         "assistant_prefill_unsupported": "Prefill Unsupported",
       }
       const toastMessages: Record<RecoveryErrorType & string, string> = {
@@ -106,6 +107,7 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
         unavailable_tool: "Recovering from unavailable tool call...",
         thinking_block_order: "Fixing message structure...",
         thinking_disabled_violation: "Stripping thinking blocks...",
+        thinking_block_modified: "Stripping corrupted thinking blocks...",
         "assistant_prefill_unsupported": "Prefill not supported; continuing without recovery.",
       }
 
@@ -134,6 +136,13 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
           await resumeSession(ctx.client, resumeConfig)
         }
       } else if (errorType === "thinking_disabled_violation") {
+        success = await recoverThinkingDisabledViolation(ctx.client, sessionID, failedMsg)
+        if (success && experimental?.auto_resume) {
+          const lastUser = findLastUserMessage(msgs ?? [])
+          const resumeConfig = extractResumeConfig(lastUser, sessionID)
+          await resumeSession(ctx.client, resumeConfig)
+        }
+      } else if (errorType === "thinking_block_modified") {
         success = await recoverThinkingDisabledViolation(ctx.client, sessionID, failedMsg)
         if (success && experimental?.auto_resume) {
           const lastUser = findLastUserMessage(msgs ?? [])


### PR DESCRIPTION
## Problem
- Amazon Bedrock can return `thinking` / `redacted_thinking` signature errors after compaction corrupts the latest assistant thinking block signatures.
- Session recovery already handles thinking block ordering and thinking-disabled violations, but it did not recognize this corruption case.
- Users with `experimental.auto_resume: true` were left without an automatic recovery path when the provider rejected the modified thinking blocks.

## Solution
- add a `thinking_block_modified` recovery error type and detect the Bedrock `thinking blocks cannot be modified` failure pattern
- wire the new error type into the session recovery hook with dedicated toast messaging
- reuse `recoverThinkingDisabledViolation` to strip corrupted thinking blocks, then auto-resume the session when enabled
- add regression tests for the full Bedrock error message and a simpler variant

## Testing
- `bun run typecheck`
- `bun test src/hooks/session-recovery/`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and recovers from Bedrock “thinking block modified” errors caused by compaction, restoring auto-resume when enabled and preventing stuck sessions.

- **Bug Fixes**
  - Added `thinking_block_modified` recovery type; detects Bedrock “thinking … cannot be modified” errors (full and simple variants).
  - Integrated with session recovery: shows dedicated toast, strips corrupted thinking blocks using existing logic, and auto-resumes when experimental.auto_resume is enabled; added regression tests.

<sup>Written for commit b6ad494f1fe7ec2b0ef17090f6bed29741924cbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

