### PR TITLE
Fix interceptor auth injection on Windows

### DIFF
--- a/src/shared/opencode-server-auth.ts
+++ b/src/shared/opencode-server-auth.ts
@@ -78,7 +78,7 @@ function tryInjectViaInterceptors(internal: UnknownRecord, auth: string): boolea
     return false
   }
 
-  use((request: Request): Request => {
+  requestInterceptors.use((request: Request): Request => {
     if (!request.headers.get("Authorization")) {
       request.headers.set("Authorization", auth)
     }

--- a/src/shared/opencode-server-auth.ts
+++ b/src/shared/opencode-server-auth.ts
@@ -78,7 +78,7 @@ function tryInjectViaInterceptors(internal: UnknownRecord, auth: string): boolea
     return false
   }
 
-  requestInterceptors.use((request: Request): Request => {
+  use.call(requestInterceptors, (request: Request): Request => {
     if (!request.headers.get("Authorization")) {
       request.headers.set("Authorization", auth)
     }


### PR DESCRIPTION
## Summary
- fix server auth interceptor injection to preserve the interceptor instance binding
- avoid calling the interceptor use method without its receiver
- unblock plugin initialization on Windows when auth injection reaches the interceptor path

## Validation
- reproduced the 	his._fns failure from the packaged plugin on Windows
- applied the equivalent source fix in src/shared/opencode-server-auth.ts
- ran `bun run typecheck`
- ran `bun run build`
- verified locally that the packaged plugin no longer throws the interceptor binding error during initialization