### PR TITLE
feat(shared): add sanitizeAgentNameForDisplay helper

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/AGENTS.md
+++ b/packages/omo-opencode/src/plugin-handlers/AGENTS.md
@@ -97,3 +97,9 @@ Final Config
 
 - `agents`, `categories`, `claude_code`: deep merged
 - `disabled_*` arrays: Set union
+
+## Display layer sanitization (additive helper, 2026-04-19)
+
+Display-layer callers that render `name` to end-user surfaces MAY use `sanitizeAgentNameForDisplay(agentName)` from `src/shared/agent-display-names.ts`. The helper strips invisible codepoints (U+200B, U+200C, U+200D, U+FEFF) from the string it returns.
+
+It does NOT modify ordering behavior. Core agent ordering still relies on the sort shim described above. The new helper is opt in. No existing caller is migrated silently.

--- a/packages/omo-opencode/src/shared/agent-display-names.test.ts
+++ b/packages/omo-opencode/src/shared/agent-display-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { AGENT_DISPLAY_NAMES, getAgentConfigKey, getAgentDisplayName, getAgentListDisplayName, normalizeAgentForPrompt, normalizeAgentForPromptKey, stripAgentListSortPrefix } from "./agent-display-names"
+import { AGENT_DISPLAY_NAMES, getAgentConfigKey, getAgentDisplayName, getAgentListDisplayName, normalizeAgentForPrompt, normalizeAgentForPromptKey, sanitizeAgentNameForDisplay, stripAgentListSortPrefix } from "./agent-display-names"
 
 describe("getAgentDisplayName", () => {
   it("returns display name for lowercase config key (new format)", () => {
@@ -291,5 +291,97 @@ describe("AGENT_DISPLAY_NAMES", () => {
       // then none should contain parentheses
       expect(httpHeaderUnsafe.test(displayName)).toBe(false)
     }
+  })
+})
+
+describe("sanitizeAgentNameForDisplay", () => {
+  it("strips U+200B from a single-prefix name and returns the clean display name", () => {
+    // given a name with a single leading ZWSP prefix
+    const input = "\u200BSisyphus - Ultraworker"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then the invisible prefix is gone
+    expect(result).toBe("Sisyphus - Ultraworker")
+  })
+
+  it("strips all four invisible codepoints (U+200B, U+200C, U+200D, U+FEFF)", () => {
+    // given a name with all four invisible codepoints prepended
+    const input = "\u200B\u200C\u200D\uFEFFAtlas - Plan Executor"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then every invisible codepoint is removed
+    expect(result).toBe("Atlas - Plan Executor")
+  })
+
+  it("passes clean names through unchanged", () => {
+    // given a name with no invisible codepoints
+    const input = "Hephaestus - Deep Agent"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then the input is returned unchanged
+    expect(result).toBe("Hephaestus - Deep Agent")
+  })
+
+  it("is idempotent (sanitize(sanitize(x)) === sanitize(x))", () => {
+    // given a name with repeated invisible prefixes
+    const input = "\u200B\u200BPrometheus - Plan Builder"
+
+    // when sanitized once and then again
+    const once = sanitizeAgentNameForDisplay(input)
+    const twice = sanitizeAgentNameForDisplay(once)
+
+    // then both results match and contain no invisible codepoints
+    expect(once).toBe(twice)
+    expect(/[\u200B\u200C\u200D\uFEFF]/.test(once)).toBe(false)
+  })
+
+  it("returns empty string for empty string input", () => {
+    // given an empty string
+    const input = ""
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then the empty string is returned
+    expect(result).toBe("")
+  })
+
+  it("returns empty string for a string made up entirely of invisible codepoints", () => {
+    // given a string containing only invisible codepoints
+    const input = "\u200B\u200C\u200D\uFEFF"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then the entire string is stripped away
+    expect(result).toBe("")
+  })
+
+  it("handles a long string with invisible codepoints scattered throughout", () => {
+    // given visible characters interleaved with invisible codepoints
+    const input = "a\u200Bb\u200Cc\u200Dd\uFEFFe\u200Bf"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then only the visible characters remain in order
+    expect(result).toBe("abcdef")
+  })
+
+  it("cleans a legacy display name with a ZWSP embedded mid-word", () => {
+    // given a legacy name with a ZWSP embedded mid-word
+    const input = "Sisyphus\u200B - Ultraworker"
+
+    // when sanitized for display
+    const result = sanitizeAgentNameForDisplay(input)
+
+    // then the embedded ZWSP is removed
+    expect(result).toBe("Sisyphus - Ultraworker")
   })
 })

--- a/packages/omo-opencode/src/shared/agent-display-names.ts
+++ b/packages/omo-opencode/src/shared/agent-display-names.ts
@@ -160,3 +160,12 @@ export function normalizeAgentForPromptKey(agentName: string | undefined): strin
 
   return resolveKnownAgentConfigKey(trimmed) ?? trimmed
 }
+
+/**
+ * Returns the agent name with invisible codepoints stripped, suitable for
+ * rendering to end-user surfaces (TUIs, HTML, logs). It is opt-in and does not
+ * participate in runtime agent ordering.
+ */
+export function sanitizeAgentNameForDisplay(agentName: string): string {
+  return stripInvisibleAgentCharacters(agentName)
+}


### PR DESCRIPTION
## Summary

Adds an opt-in display helper so downstream code can strip invisible codepoints (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`) from agent names before rendering them to an end-user surface.

The existing ordering contract is untouched. `getAgentRuntimeName`, `getAgentListDisplayName`, `AGENT_LIST_SORT_PREFIXES`, and `reorderAgentsByPriority` are unchanged.

## Changes

1. New export in `src/shared/agent-display-names.ts`: `sanitizeAgentNameForDisplay(agentName: string)`. It delegates to the existing `stripInvisibleAgentCharacters`, so there is no new regex and no new dependency.
2. New `describe("sanitizeAgentNameForDisplay", ...)` block in `src/shared/agent-display-names.test.ts` covering prefix stripping, all four invisible codepoints, passthrough, idempotency, empty strings, all-invisible strings, scattered invisibles, and mid-word ZWSP.
3. Additive note in `src/plugin-handlers/AGENTS.md` that points display-layer callers at the helper and reaffirms the existing ordering rules. No existing caller is migrated silently.

## Screenshots

Not applicable. This PR adds a library function and docs; there is no visual surface to capture.

## Testing

Validation used for this branch:

```bash
bun run typecheck
bun test src/shared/agent-display-names.test.ts
```

Result on the branch at the time of validation:

1. `typecheck` exited 0.
2. The targeted `agent-display-names.test.ts` run reported 38 pass / 0 fail.

Runtime smoke of the new helper:

```ts
import { sanitizeAgentNameForDisplay } from "./src/shared/agent-display-names.ts"
sanitizeAgentNameForDisplay("\u200BSisyphus - Ultraworker")
// => "Sisyphus - Ultraworker"
```

Status note: the current head only shows CLA, label automation, and GitGuardian. The older full CI pass was for a previous head, so this is waiting on a current CI rerun before I call build/test/typecheck green on GitHub.

## Upstream context

I originally filed `anomalyco/opencode#23376` for the OpenCode TUI rendering bug and opened `anomalyco/opencode#23377` as the first upstream fix. That PR was closed by automated cleanup before merge.

I refreshed the upstream fix against current OpenCode `dev` in `anomalyco/opencode#32470`. That PR fixes rendered-width truncation in OpenCode's TUI locale helpers by measuring display width on grapheme segments.

There is also `anomalyco/opencode#31880` for the same underlying bug, opened after `#23376` and `#23377`. This Oh My OpenAgent helper still makes sense either way: it is an opt-in display-layer sanitizer for this plugin, while the OpenCode PR fixes width/truncation math upstream.

## Scope

This PR is strictly additive and opt-in. No existing caller is migrated. The ordering contract in `src/plugin-handlers/AGENTS.md` is respected. No `getAgentSortKey`, no alternative ordering constant, no runtime sort shim.