### PR TITLE
Fix: Restrict max effort to claude-opus-4-7+ only

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,6 +1,8 @@
 import { isProviderUsingOAuth, log, normalizeModelID } from "../../shared"
 
-const OPUS_PATTERN = /claude-.*opus/i
+// Only claude-opus-4-7 (and future versions) support "max" effort
+// claude-opus-4.6 and earlier versions only support low | medium | high
+const OPUS_PATTERN = /claude-opus-4-[7-9]|claude-opus-4-\d{2,}/i
 const EFFORT_UNSUPPORTED_PATTERN = /claude-.*haiku/i
 const INTERNAL_SKIP_AGENTS = new Set(["title", "summary", "compaction"])
 
@@ -54,7 +56,7 @@ interface ChatParamsOutput {
 
 /**
  * Valid thinking budget levels per model tier.
- * Opus supports "max"; all other Claude models cap at "high".
+ * Only claude-opus-4-7+ supports "max"; all other Claude models cap at "high".
  */
 const MAX_VARIANT_BY_TIER: Record<string, string> = {
   opus: "max",


### PR DESCRIPTION
## Summary

Fixes the error: `Bad Request: {"error":{"message":"output_config.effort \"max\" is not supported by model claude-opus-4.6; supported values: [low medium high]"...}}`

## Problem

The `OPUS_PATTERN` regex in `src/hooks/anthropic-effort/hook.ts` was matching all models containing `claude-` followed by `opus`, including `claude-opus-4.6`. However, only `claude-opus-4-7` and later versions actually support the `max` effort level. Earlier versions like `4.6` only support `low`, `medium`, and `high`.

## Solution

Changed the pattern from:
```typescript
const OPUS_PATTERN = /claude-.*opus/i
```

To:
```typescript
const OPUS_PATTERN = /claude-opus-4-[7-9]|claude-opus-4-\d{2,}/i
```

This pattern now only matches:
- `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-4-9` (versions 7-9)
- `claude-opus-4-10`, `claude-opus-4-11`, etc. (double-digit versions and beyond)

And correctly excludes:
- `claude-opus-4-6` and earlier versions

## Testing

- `claude-opus-4.6` → will be clamped to `high` effort
- `claude-opus-4-7` → will use `max` effort
- `claude-opus-4-10` → will use `max` effort

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts "max" effort to `claude-opus-4-7+` models to prevent Bad Request errors on older Opus versions. Older models (e.g., `claude-opus-4.6`) now cap at "high".

- **Bug Fixes**
  - Updated `OPUS_PATTERN` to `/claude-opus-4-[7-9]|claude-opus-4-\d{2,}/i` so only `claude-opus-4-7+` uses `max`.
  - Ensures earlier Opus versions use `low | medium | high` only.

<sup>Written for commit ae0756c8a82ce7fffb446a13dd8676fee7688b2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

