### PR TITLE
fix(tools): handle context_info tool hallucination gracefully (fixes #2032)

### DIFF
--- a/src/plugin/tool-registry.test.ts
+++ b/src/plugin/tool-registry.test.ts
@@ -34,6 +34,7 @@ const toolFactories: NonNullable<Parameters<typeof createToolRegistry>[0]["toolF
   builtinTools: { bash: fakeTool, read: fakeTool },
   createBackgroundTools: mock(() => ({})),
   createCallOmoAgent: mock(() => fakeTool),
+  createContextInfoTool: mock(() => fakeTool),
   createLookAt: mock(() => fakeTool),
   createSkillMcpTool: mock(() => fakeTool),
   createSkillTool: mock(() => fakeTool),
@@ -109,6 +110,7 @@ describe("#given task_system configuration", () => {
     })
 
     expect(result.taskSystemEnabled).toBe(false)
+    expect(result.filteredTools).toHaveProperty("context_info")
     expect(result.filteredTools).not.toHaveProperty("task_create")
     expect(result.filteredTools).not.toHaveProperty("task_get")
     expect(result.filteredTools).not.toHaveProperty("task_list")
@@ -139,6 +141,7 @@ describe("#given task_system configuration", () => {
     })
 
     expect(result.taskSystemEnabled).toBe(true)
+    expect(result.filteredTools).toHaveProperty("context_info")
     expect(result.filteredTools).toHaveProperty("task_create")
     expect(result.filteredTools).toHaveProperty("task_get")
     expect(result.filteredTools).toHaveProperty("task_list")

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -13,6 +13,7 @@ import {
   builtinTools,
   createBackgroundTools,
   createCallOmoAgent,
+  createContextInfoTool,
   createLookAt,
   createSkillMcpTool,
   createSkillTool,
@@ -41,6 +42,7 @@ type ToolRegistryFactories = {
   builtinTools: typeof builtinTools
   createBackgroundTools: typeof createBackgroundTools
   createCallOmoAgent: typeof createCallOmoAgent
+  createContextInfoTool: typeof createContextInfoTool
   createLookAt: typeof createLookAt
   createSkillMcpTool: typeof createSkillMcpTool
   createSkillTool: typeof createSkillTool
@@ -62,6 +64,7 @@ const defaultToolRegistryFactories: ToolRegistryFactories = {
   builtinTools,
   createBackgroundTools,
   createCallOmoAgent,
+  createContextInfoTool,
   createLookAt,
   createSkillMcpTool,
   createSkillTool,
@@ -98,6 +101,7 @@ const LOW_PRIORITY_TOOL_ORDER = [
   "task_update",
   "background_output",
   "background_cancel",
+  "context_info",
   "edit",
   "ast_grep_replace",
   "ast_grep_search",
@@ -176,6 +180,7 @@ export function createToolRegistry(args: {
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
     (agent) => agent.toLowerCase() === "multimodal-looker",
   )
+  const contextInfo = factories.createContextInfoTool(ctx)
   const lookAt = isMultimodalLookerEnabled ? factories.createLookAt(ctx) : null
 
   const delegateTask = factories.createDelegateTask({
@@ -269,6 +274,7 @@ export function createToolRegistry(args: {
     ...factories.createSessionManagerTools(ctx),
     ...backgroundTools,
     call_omo_agent: callOmoAgent,
+    context_info: contextInfo,
     ...(lookAt ? { look_at: lookAt } : {}),
     task: delegateTask,
     skill_mcp: skillMcpTool,

--- a/src/tools/context-info/index.ts
+++ b/src/tools/context-info/index.ts
@@ -1,0 +1,1 @@
+export { createContextInfoTool } from "./tools"

--- a/src/tools/context-info/tools.test.ts
+++ b/src/tools/context-info/tools.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+
+import { createContextInfoTool } from "./tools"
+
+describe("createContextInfoTool", () => {
+  test("#given a hallucinated context_info call #when the tool executes #then it returns concise project context guidance", async () => {
+    const tool = createContextInfoTool({ directory: "/repo" } as never)
+
+    const result = await tool.execute({}, {
+      directory: "/runtime-repo",
+      sessionID: "ses-123",
+    } as never)
+
+    expect(result).toContain('"project_path": "/runtime-repo"')
+    expect(result).toContain('"tool": "context_info"')
+    expect(result).toContain("Use glob to find files")
+  })
+})

--- a/src/tools/context-info/tools.ts
+++ b/src/tools/context-info/tools.ts
@@ -1,0 +1,32 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+
+type RuntimeContext = {
+  directory?: string
+  sessionID?: string
+}
+
+export function createContextInfoTool(ctx: PluginInput): ToolDefinition {
+  return tool({
+    description:
+      "Compatibility tool for models that hallucinate a legacy context_info call. " +
+      "Returns a concise project context summary and reminds the model to use read, glob, grep, and bash for real inspection.",
+    args: {},
+    execute: async (_args, context) => {
+      const runtimeContext = context as RuntimeContext
+      const directory = runtimeContext.directory ?? ctx.directory
+      const sessionID = runtimeContext.sessionID
+
+      return JSON.stringify({
+        project_path: directory,
+        session_id: sessionID,
+        tool: "context_info",
+        compatibility_tool: true,
+        guidance: [
+          "This tool exists to handle legacy or hallucinated context_info calls gracefully.",
+          "Use glob to find files, read to inspect them, grep for content search, and bash for commands.",
+        ],
+      }, null, 2)
+    },
+  })
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,6 +35,7 @@ import type { BackgroundManager } from "../features/background-agent"
 type OpencodeClient = PluginInput["client"]
 
 export { createCallOmoAgent } from "./call-omo-agent"
+export { createContextInfoTool } from "./context-info"
 export { createLookAt } from "./look-at"
 export { createDelegateTask } from "./delegate-task"
 export {


### PR DESCRIPTION
## Summary
- add a lightweight `context_info` compatibility tool so hallucinated legacy tool calls stop triggering the verbose unavailable-tool error loop
- keep the tool low priority so it is trimmed before core inspection tools when `max_tools` is active
- cover registration and response behavior with focused tests

## Problem
Some models hallucinate a `context_info` tool that does not exist in the current tool registry. That missing tool path triggers OpenCode core's large unavailable-tool error dump before plugin recovery can smooth it over, which floods the chat and degrades UX.

## Fix
Register a dedicated `context_info` compatibility tool that returns a short project-context payload plus guidance to use `glob`, `read`, `grep`, and `bash` for real inspection. This converts the hallucinated call into a safe no-op style response instead of a repeated invalid-tool error, while still letting `max_tools` trim it early when space is tight.

## Changes
| File | Change |
|------|--------|
| `src/tools/context-info/tools.ts` | add the compatibility tool implementation |
| `src/tools/context-info/tools.test.ts` | add focused response coverage |
| `src/tools/index.ts` | export the new tool factory |
| `src/plugin/tool-registry.ts` | register `context_info` and mark it low priority for trimming |
| `src/plugin/tool-registry.test.ts` | assert the new tool is present in the registry |

Fixes #2032

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight `context_info` compatibility tool to turn hallucinated calls into a safe, concise response and avoid noisy unavailable-tool errors. Fixes #2032.

- **Bug Fixes**
  - Added `context_info` tool that returns `project_path`/`session_id` and guidance to use `glob`, `read`, `grep`, and `bash`.
  - Registered the tool and marked it low priority so `max_tools` trims it before core tools.
  - Added tests to cover registry inclusion and response output.

<sup>Written for commit e1aec87e684d0753c47c6bbd675bb76f3257b9ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

