### PR TITLE
fix(cli): fall back after SIGILL-style binary exits (fixes #1928)

### DIFF
--- a/src/plugin/tool-registry.test.ts
+++ b/src/plugin/tool-registry.test.ts
@@ -34,6 +34,7 @@ const toolFactories: NonNullable<Parameters<typeof createToolRegistry>[0]["toolF
   builtinTools: { bash: fakeTool, read: fakeTool },
   createBackgroundTools: mock(() => ({})),
   createCallOmoAgent: mock(() => fakeTool),
+  createContextInfoTool: mock(() => fakeTool),
   createLookAt: mock(() => fakeTool),
   createSkillMcpTool: mock(() => fakeTool),
   createSkillTool: mock(() => fakeTool),
@@ -109,6 +110,7 @@ describe("#given task_system configuration", () => {
     })
 
     expect(result.taskSystemEnabled).toBe(false)
+    expect(result.filteredTools).toHaveProperty("context_info")
     expect(result.filteredTools).not.toHaveProperty("task_create")
     expect(result.filteredTools).not.toHaveProperty("task_get")
     expect(result.filteredTools).not.toHaveProperty("task_list")
@@ -139,6 +141,7 @@ describe("#given task_system configuration", () => {
     })
 
     expect(result.taskSystemEnabled).toBe(true)
+    expect(result.filteredTools).toHaveProperty("context_info")
     expect(result.filteredTools).toHaveProperty("task_create")
     expect(result.filteredTools).toHaveProperty("task_get")
     expect(result.filteredTools).toHaveProperty("task_list")

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -13,6 +13,7 @@ import {
   builtinTools,
   createBackgroundTools,
   createCallOmoAgent,
+  createContextInfoTool,
   createLookAt,
   createSkillMcpTool,
   createSkillTool,
@@ -41,6 +42,7 @@ type ToolRegistryFactories = {
   builtinTools: typeof builtinTools
   createBackgroundTools: typeof createBackgroundTools
   createCallOmoAgent: typeof createCallOmoAgent
+  createContextInfoTool: typeof createContextInfoTool
   createLookAt: typeof createLookAt
   createSkillMcpTool: typeof createSkillMcpTool
   createSkillTool: typeof createSkillTool
@@ -62,6 +64,7 @@ const defaultToolRegistryFactories: ToolRegistryFactories = {
   builtinTools,
   createBackgroundTools,
   createCallOmoAgent,
+  createContextInfoTool,
   createLookAt,
   createSkillMcpTool,
   createSkillTool,
@@ -98,6 +101,7 @@ const LOW_PRIORITY_TOOL_ORDER = [
   "task_update",
   "background_output",
   "background_cancel",
+  "context_info",
   "edit",
   "ast_grep_replace",
   "ast_grep_search",
@@ -176,6 +180,7 @@ export function createToolRegistry(args: {
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
     (agent) => agent.toLowerCase() === "multimodal-looker",
   )
+  const contextInfo = factories.createContextInfoTool(ctx)
   const lookAt = isMultimodalLookerEnabled ? factories.createLookAt(ctx) : null
 
   const delegateTask = factories.createDelegateTask({
@@ -269,6 +274,7 @@ export function createToolRegistry(args: {
     ...factories.createSessionManagerTools(ctx),
     ...backgroundTools,
     call_omo_agent: callOmoAgent,
+    context_info: contextInfo,
     ...(lookAt ? { look_at: lookAt } : {}),
     task: delegateTask,
     skill_mcp: skillMcpTool,

--- a/src/tools/context-info/index.ts
+++ b/src/tools/context-info/index.ts
@@ -1,0 +1,1 @@
+export { createContextInfoTool } from "./tools"

--- a/src/tools/context-info/tools.test.ts
+++ b/src/tools/context-info/tools.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+
+import { createContextInfoTool } from "./tools"
+
+describe("createContextInfoTool", () => {
+  test("#given a hallucinated context_info call #when the tool executes #then it returns concise project context guidance", async () => {
+    const tool = createContextInfoTool({ directory: "/repo" } as never)
+
+    const result = await tool.execute({}, {
+      directory: "/runtime-repo",
+      sessionID: "ses-123",
+    } as never)
+
+    expect(result).toContain('"project_path": "/runtime-repo"')
+    expect(result).toContain('"tool": "context_info"')
+    expect(result).toContain("Use glob to find files")
+  })
+})

--- a/src/tools/context-info/tools.ts
+++ b/src/tools/context-info/tools.ts
@@ -1,0 +1,32 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+
+type RuntimeContext = {
+  directory?: string
+  sessionID?: string
+}
+
+export function createContextInfoTool(ctx: PluginInput): ToolDefinition {
+  return tool({
+    description:
+      "Compatibility tool for models that hallucinate a legacy context_info call. " +
+      "Returns a concise project context summary and reminds the model to use read, glob, grep, and bash for real inspection.",
+    args: {},
+    execute: async (_args, context) => {
+      const runtimeContext = context as RuntimeContext
+      const directory = runtimeContext.directory ?? ctx.directory
+      const sessionID = runtimeContext.sessionID
+
+      return JSON.stringify({
+        project_path: directory,
+        session_id: sessionID,
+        tool: "context_info",
+        compatibility_tool: true,
+        guidance: [
+          "This tool exists to handle legacy or hallucinated context_info calls gracefully.",
+          "Use glob to find files, read to inspect them, grep for content search, and bash for commands.",
+        ],
+      }, null, 2)
+    },
+  })
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,6 +35,7 @@ import type { BackgroundManager } from "../features/background-agent"
 type OpencodeClient = PluginInput["client"]
 
 export { createCallOmoAgent } from "./call-omo-agent"
+export { createContextInfoTool } from "./context-info"
 export { createLookAt } from "./look-at"
 export { createDelegateTask } from "./delegate-task"
 export {


### PR DESCRIPTION
## Summary
- Retry the baseline Linux x64 binary when the primary binary exits with a SIGILL-style failure
- Cover the fallback decision and platform-resolution paths with focused bin tests

## Problem
The wrapper already preferred baseline binaries when AVX2 was known to be unavailable, but some older Linux systems still surfaced illegal-instruction crashes as exit status `132` instead of a `SIGILL` signal. In that path, the wrapper treated the optimized binary as a normal failure and exited before trying the baseline package.

## Fix
Treat both `SIGILL` and exit status `132` as illegal-instruction failures when a fallback binary is available. The wrapper now retries the next candidate in that case, and the new tests lock the behavior down without changing unrelated CLI build logic.

## Changes
| File | Change |
|------|--------|
| `bin/oh-my-opencode.js` | Detects SIGILL-style exits and retries the baseline binary candidate |
| `bin/binary-fallback.test.ts` | Adds coverage for SIGILL and exit-code fallback behavior |
| `bin/platform.test.ts` | Keeps focused package-name coverage after test split |
| `bin/platform-resolution.test.ts` | Moves binary-path and candidate-order coverage into a dedicated test file |

Fixes #1928

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a compatibility `context_info` tool that returns project context and guidance when the legacy tool is called, preventing errors from hallucinated calls. Registered by default and covered by tests. Fixes #2032.

- **New Features**
  - Added `createContextInfoTool` that returns JSON with `project_path`, `session_id`, and guidance to use `glob`, `read`, `grep`, and `bash`.
  - Wired `context_info` into the tool registry (low priority) and exported it from `src/tools/index.ts`.
  - Ensured the tool is present regardless of task system settings; added tests for registry inclusion and execution output.

<sup>Written for commit e1aec87e684d0753c47c6bbd675bb76f3257b9ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

