### PR TITLE
fix(start-work): enforce hephaestus for GPT plan execution (fixes #1986)

### DIFF
--- a/src/hooks/start-work/resolve-start-work-agent.ts
+++ b/src/hooks/start-work/resolve-start-work-agent.ts
@@ -1,0 +1,31 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { isGpt5_4Model, isGptModel } from "../../agents/types"
+import { isAgentRegistered } from "../../features/claude-code-session-state"
+import { resolveRecentModelForSession } from "../atlas/recent-model-resolver"
+
+function resolveDefaultStartWorkAgent(): "atlas" | "sisyphus" {
+  return isAgentRegistered("atlas") ? "atlas" : "sisyphus"
+}
+
+function shouldUseHephaestus(modelID: string | undefined): boolean {
+  return typeof modelID === "string"
+    && isGptModel(modelID)
+    && !isGpt5_4Model(modelID)
+}
+
+export async function resolveStartWorkAgent(
+  ctx: PluginInput,
+  sessionID: string,
+): Promise<"atlas" | "sisyphus" | "hephaestus"> {
+  const fallbackAgent = resolveDefaultStartWorkAgent()
+  if (!isAgentRegistered("hephaestus")) {
+    return fallbackAgent
+  }
+
+  const recentModel = await resolveRecentModelForSession(ctx, sessionID)
+  if (shouldUseHephaestus(recentModel?.modelID)) {
+    return "hephaestus"
+  }
+
+  return fallbackAgent
+}

--- a/src/hooks/start-work/start-work-agent-selection.test.ts
+++ b/src/hooks/start-work/start-work-agent-selection.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { randomUUID } from "node:crypto"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createStartWorkHook } from "./index"
+import { clearBoulderState, readBoulderState } from "../../features/boulder-state"
+import * as sessionState from "../../features/claude-code-session-state"
+
+describe("start-work agent selection", () => {
+  let testDir: string
+
+  function createStartWorkPrompt(): string {
+    return `<command-instruction>
+You are starting a Sisyphus work session.
+</command-instruction>
+
+<session-context></session-context>`
+  }
+
+  function createMockPluginInput(model?: { providerID: string; modelID: string }) {
+    return {
+      directory: testDir,
+      client: {
+        session: {
+          messages: async () => model ? [{ info: { model } }] : [],
+        },
+      },
+    } as Parameters<typeof createStartWorkHook>[0]
+  }
+
+  beforeEach(() => {
+    sessionState._resetForTesting()
+    sessionState.registerAgentName("atlas")
+    sessionState.registerAgentName("sisyphus")
+    sessionState.registerAgentName("hephaestus")
+    testDir = join(tmpdir(), `start-work-agent-test-${randomUUID()}`)
+    mkdirSync(join(testDir, ".sisyphus", "plans"), { recursive: true })
+    writeFileSync(join(testDir, ".sisyphus", "plans", "worker-plan.md"), "# Plan\n- [ ] 1. Task")
+    clearBoulderState(testDir)
+  })
+
+  afterEach(() => {
+    sessionState._resetForTesting()
+    clearBoulderState(testDir)
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test("uses Hephaestus for GPT start-work sessions", async () => {
+    const hook = createStartWorkHook(
+      createMockPluginInput({ providerID: "openai", modelID: "gpt-5.3-codex" }),
+    )
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: createStartWorkPrompt() }],
+    }
+
+    await hook["chat.message"]({ sessionID: "ses-gpt-start-work" }, output)
+
+    expect(output.message.agent).toBe("hephaestus")
+    expect(sessionState.getSessionAgent("ses-gpt-start-work")).toBe("hephaestus")
+    expect(readBoulderState(testDir)?.agent).toBe("hephaestus")
+  })
+
+  test("keeps Atlas for GPT-5.4 start-work sessions", async () => {
+    const hook = createStartWorkHook(
+      createMockPluginInput({ providerID: "openai", modelID: "gpt-5.4" }),
+    )
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: createStartWorkPrompt() }],
+    }
+
+    await hook["chat.message"]({ sessionID: "ses-gpt54-start-work" }, output)
+
+    expect(output.message.agent).toBe("atlas")
+    expect(sessionState.getSessionAgent("ses-gpt54-start-work")).toBe("atlas")
+    expect(readBoulderState(testDir)?.agent).toBe("atlas")
+  })
+})

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -12,7 +12,6 @@ import {
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import {
-  isAgentRegistered,
   resolveRegisteredAgentName,
   updateSessionAgent,
 } from "../../features/claude-code-session-state"
@@ -20,6 +19,7 @@ import { detectWorktreePath } from "./worktree-detector"
 import { parseUserRequest } from "./parse-user-request"
 import { buildStartWorkContextInfo } from "./context-info-builder"
 import { createWorktreeActiveBlock } from "./worktree-block"
+import { resolveStartWorkAgent } from "./resolve-start-work-agent"
 
 export const HOOK_NAME = "start-work" as const
 const START_WORK_TEMPLATE_MARKER = "You are starting a Sisyphus work session."
@@ -79,9 +79,7 @@ export function createStartWorkHook(ctx: PluginInput) {
     }
 
     log(`[${HOOK_NAME}] Processing start-work command`, { sessionID: input.sessionID })
-    const activeAgent = isAgentRegistered("atlas")
-      ? "atlas"
-      : "sisyphus"
+    const activeAgent = await resolveStartWorkAgent(ctx, input.sessionID)
     updateSessionAgent(input.sessionID, activeAgent)
     if (output.message) {
       output.message["agent"] = resolveRegisteredAgentName(activeAgent) ?? activeAgent


### PR DESCRIPTION
## Summary
- route `/start-work` directly to Hephaestus when the active session is using a GPT model that should avoid Sisyphus
- persist the chosen worker agent into boulder state so follow-up plan execution stays on the enforced agent
- add focused regression coverage for GPT and GPT-5.4 start-work routing

## Problem
`/start-work` always handed plan execution to Atlas when it was registered. In GPT sessions this bypassed the existing Sisyphus-to-Hephaestus enforcement path, so plan execution could still fall back into Sisyphus-oriented orchestration instead of using Hephaestus.

## Fix
The start-work hook now resolves the recent session model before choosing its worker agent. GPT sessions that should avoid Sisyphus are routed straight to Hephaestus, while GPT-5.4 and non-GPT sessions keep the existing Atlas/Sisyphus fallback behavior.

## Changes
| File | Change |
|------|--------|
| `src/hooks/start-work/start-work-hook.ts` | Resolve the worker agent asynchronously before updating the session and message agent |
| `src/hooks/start-work/resolve-start-work-agent.ts` | Add focused start-work agent selection logic based on the recent session model |
| `src/hooks/start-work/start-work-agent-selection.test.ts` | Add regression tests for GPT and GPT-5.4 `/start-work` routing |

## Verification
- `lsp_diagnostics` clean on changed files
- `bun test src/hooks/start-work/index.test.ts src/hooks/start-work/start-work-agent-selection.test.ts` *(fails in this workspace because Bun cannot resolve repo dependencies like `js-yaml` and `@opencode-ai/plugin`)*
- `bun run build` *(fails in this workspace for the same unresolved dependency set)*

Fixes #1986

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->