### PR TITLE
fix(plugin-handlers): preserve native plan/build agents (fixes #2685)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1008,6 +1008,34 @@ describe("OhMyOpenCodeConfigSchema - git_master defaults (#2040)", () => {
   })
 })
 
+describe("SisyphusAgent preserve_native_agents", () => {
+  test("accepts build and plan entries", () => {
+    const result = OhMyOpenCodeConfigSchema.safeParse({
+      sisyphus_agent: {
+        preserve_native_agents: ["build", "plan"],
+      },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sisyphus_agent?.preserve_native_agents).toEqual([
+        "build",
+        "plan",
+      ])
+    }
+  })
+
+  test("rejects unsupported preserve_native_agents values", () => {
+    const result = OhMyOpenCodeConfigSchema.safeParse({
+      sisyphus_agent: {
+        preserve_native_agents: ["oracle"],
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
 describe("skills schema", () => {
   test("accepts skills.sources configuration", () => {
     //#given

--- a/src/config/schema/sisyphus-agent.ts
+++ b/src/config/schema/sisyphus-agent.ts
@@ -4,6 +4,7 @@ export const SisyphusAgentConfigSchema = z.object({
   disabled: z.boolean().optional(),
   default_builder_enabled: z.boolean().optional(),
   planner_enabled: z.boolean().optional(),
+  preserve_native_agents: z.array(z.enum(["build", "plan"])).optional(),
   replace_plan: z.boolean().optional(),
   tdd: z.boolean().default(true).optional(),
 })

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -451,6 +451,67 @@ describe("applyAgentConfig builtin override protection", () => {
     )
   })
 
+  test("keeps the native build agent visible when preserve_native_agents includes build", async () => {
+    const config = createBaseConfig()
+    ;(config as Record<string, unknown>).agent = {
+      build: {
+        name: "build",
+        prompt: "native build prompt",
+        mode: "primary",
+      },
+    }
+
+    const pluginConfig = createPluginConfig()
+    pluginConfig.sisyphus_agent = {
+      preserve_native_agents: ["build"],
+      planner_enabled: false,
+    }
+
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig,
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    expect(result.build).toEqual({
+      name: "build",
+      prompt: "native build prompt",
+      mode: "primary",
+    })
+    expect((result.build as Record<string, unknown>).hidden).toBeUndefined()
+  })
+
+  test("keeps the native plan agent when preserve_native_agents includes plan", async () => {
+    const config = createBaseConfig()
+    ;(config as Record<string, unknown>).agent = {
+      plan: {
+        name: "plan",
+        prompt: "native plan prompt",
+        mode: "primary",
+      },
+    }
+
+    const pluginConfig = createPluginConfig()
+    pluginConfig.sisyphus_agent = {
+      preserve_native_agents: ["plan"],
+      planner_enabled: false,
+    }
+
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig,
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    expect(result.plan).toEqual({
+      name: "plan",
+      prompt: "native plan prompt",
+      mode: "primary",
+    })
+  })
+
   describe("agent_definitions and opencode.json integration", () => {
     test("agent_definitions agents appear in output", async () => {
       // given

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -180,10 +180,15 @@ export async function applyAgentConfig(params: {
     );
 
   const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
+  const preservedNativeAgents = new Set(
+    params.pluginConfig.sisyphus_agent?.preserve_native_agents ?? [],
+  );
+  const preserveNativeBuild = preservedNativeAgents.has("build");
+  const preserveNativePlan = preservedNativeAgents.has("plan");
   const builderEnabled =
     params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
   const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
-  const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
+  const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? !preserveNativePlan;
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
 
@@ -247,7 +252,7 @@ export async function applyAgentConfig(params: {
       ? Object.fromEntries(
           Object.entries(configAgent)
             .filter(([key]) => {
-              if (key === "build") return false;
+              if (key === "build" && !preserveNativeBuild) return false;
               if (key === "plan" && shouldDemotePlan) return false;
               if (key in builtinAgents) return false;
               return true;
@@ -321,7 +326,9 @@ export async function applyAgentConfig(params: {
       ...filterDisabledAgents(filteredAgentDefinitionAgents),
       ...filterDisabledAgents(filteredOpencodeConfigAgents),
       ...filteredConfigAgents,
-      build: { ...migratedBuild, mode: "subagent", hidden: true },
+      ...(!preserveNativeBuild
+        ? { build: { ...migratedBuild, mode: "subagent", hidden: true } }
+        : {}),
       ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
     };
   } else {


### PR DESCRIPTION
## Summary
- add a dedicated `preserve_native_agents` config to keep OpenCode's native `plan` and `build` agents visible when oh-my-openagent is active
- wire the config hook so preserved native agents survive alongside plugin agents instead of being hidden or replaced
- cover the new schema and handler behavior with regression tests

## Problem
When the plugin enables Sisyphus, it reconstructs the OpenCode agent registry from plugin-managed agents. That path always hid the native `build` agent and replaced `plan` with Prometheus unless users knew about legacy, split configuration toggles. As a result, the native OpenCode planner and builder effectively disappeared from the picker.

## Fix
This change adds a single `sisyphus_agent.preserve_native_agents` option that accepts `build` and `plan`. The config hook now uses that option to keep the native OpenCode agents in the final registry, while preserving the existing `default_builder_enabled` and `replace_plan` behavior for backward compatibility.

## Changes
| File | Change |
|------|--------|
| `src/config/schema/sisyphus-agent.ts` | Add `preserve_native_agents` schema support |
| `src/config/schema.test.ts` | Add config validation coverage for preserved native agents |
| `src/plugin-handlers/agent-config-handler.ts` | Keep native `build`/`plan` agents when configured |
| `src/plugin-handlers/agent-config-handler.test.ts` | Add regression tests for preserved native agents |

Fixes #2685

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OpenCode’s native `plan` and `build` agents when `oh-my-openagent` is active by adding `sisyphus_agent.preserve_native_agents` and updating the handler logic. Fixes #2685 so the native planner and builder remain visible instead of being hidden or replaced.

- **New Features**
  - Add `sisyphus_agent.preserve_native_agents` to keep native `build` and/or `plan`.

- **Bug Fixes**
  - Update agent-config handler to retain preserved native agents and avoid auto-replacement.
  - Add schema and handler tests to guard the new behavior.

<sup>Written for commit fba4881d6efd86f331ede68475b2557e434e4a4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

