### PR TITLE
fix(atlas): strip ZWSP sort prefix from agent name before promptAsync

### DIFF
--- a/src/hooks/atlas/boulder-continuation-injector.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.ts
@@ -5,6 +5,7 @@ import {
   resolveRegisteredAgentName,
 } from "../../features/claude-code-session-state"
 import { log } from "../../shared/logger"
+import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { createInternalAgentTextPart, resolveInheritedPromptTools } from "../../shared"
 import { HOOK_NAME } from "./hook-name"
 import { BOULDER_CONTINUATION_PROMPT } from "./system-reminder-templates"
@@ -84,7 +85,7 @@ export async function injectBoulderContinuation(input: {
     await ctx.client.session.promptAsync({
       path: { id: sessionID },
       body: {
-        agent: continuationAgent,
+        agent: stripAgentListSortPrefix(continuationAgent),
         ...(launchModel ? { model: launchModel } : {}),
         ...(launchVariant ? { variant: launchVariant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -20,6 +20,7 @@ import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   getAgentConfigKey,
   normalizeAgentForPromptKey,
+  stripAgentListSortPrefix,
 } from "../../shared/agent-display-names"
 
 import {
@@ -184,10 +185,11 @@ ${todoList}`
       : undefined
     const launchVariant = model?.variant
 
+    const resolvedAgent = launchAgent ?? promptAgent
     await ctx.client.session.promptAsync({
       path: { id: sessionID },
       body: {
-        agent: launchAgent ?? promptAgent,
+        agent: resolvedAgent ? stripAgentListSortPrefix(resolvedAgent) : undefined,
         ...(launchModel ? { model: launchModel } : {}),
         ...(launchVariant ? { variant: launchVariant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),


### PR DESCRIPTION
## Summary

Strip ZWSP (U+200B) sort prefix from agent names before passing to `promptAsync` in boulder continuation and todo continuation injectors. This prevents "Agent not found" errors when the OpenCode server receives a prefixed display name it cannot match.

## Root Cause

`resolveRegisteredAgentName()` returns the original registered name including the ZWSP sort prefix (e.g., `"\u200B\u200B\u200B\u200BAtlas - Plan Executor"`). When this value is passed directly to `promptAsync`, the OpenCode server performs an exact string match against its agent registry and fails.

Commit `62c60ae9` fixed this pattern in 12 other code paths (sync-prompt-sender, background-task, tool-execute-before/after, etc.) but missed these two continuation injection points.

## Changes

- `src/hooks/atlas/boulder-continuation-injector.ts`: Apply `stripAgentListSortPrefix()` to `continuationAgent` before `promptAsync`
- `src/hooks/todo-continuation-enforcer/continuation-injection.ts`: Apply `stripAgentListSortPrefix()` to `resolvedAgent` before `promptAsync`

## Testing

- `bun run typecheck` — zero errors on changed files
- `bun test src/hooks/todo-continuation-enforcer/` — 94 pass, 0 fail
- `bun test src/hooks/atlas/` — 131 pass, 2 fail (pre-existing test isolation issue, both pass when run individually)

## Related Issues

Fixes #3494

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip the ZWSP (U+200B) sort prefix from agent names before calling `promptAsync` in Boulder and TODO continuation injectors. Fixes #3494 by preventing "Agent not found" on exact name matching.

- **Bug Fixes**
  - Apply `stripAgentListSortPrefix()` to `continuationAgent` in `atlas/boulder-continuation-injector.ts`.
  - Apply `stripAgentListSortPrefix()` to the resolved agent (`launchAgent ?? promptAgent`) in `todo-continuation-enforcer/continuation-injection.ts`.

<sup>Written for commit 4450a0b588fe61eb8945ffba12bb07af1c01fb62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

