### PR TITLE
fix(skill): avoid duplicate skill descriptions

### DIFF
--- a/src/tools/skill/async-description-refresh.test.ts
+++ b/src/tools/skill/async-description-refresh.test.ts
@@ -42,7 +42,7 @@ async function waitForRefresh(predicate: () => boolean): Promise<void> {
 }
 
 describe("skill tool - async native skill description refresh", () => {
-  it("updates description after async native skills resolve", async () => {
+  it("refreshes async native skills without duplicating them in the description", async () => {
     //#given
     let allCallCount = 0
     const tool = createSkillTool({
@@ -68,15 +68,15 @@ describe("skill tool - async native skill description refresh", () => {
       },
     })
 
-    expect(tool.description).toContain("seeded-skill")
+    expect(tool.description).not.toContain("seeded-skill")
     expect(tool.description).not.toContain("async-native-skill")
 
     //#when
-    await waitForRefresh(() => tool.description.includes("async-native-skill"))
+    await waitForRefresh(() => allCallCount > 0)
 
     //#then
     expect(allCallCount).toBeGreaterThanOrEqual(1)
-    expect(tool.description).toContain("seeded-skill")
-    expect(tool.description).toContain("async-native-skill")
+    expect(tool.description).not.toContain("seeded-skill")
+    expect(tool.description).not.toContain("async-native-skill")
   })
 })

--- a/src/tools/skill/description-formatter.ts
+++ b/src/tools/skill/description-formatter.ts
@@ -38,16 +38,25 @@ function formatSlashCommand(command: CommandInfo): string {
   return lines.join("\n")
 }
 
-export function formatCombinedDescription(skills?: SkillInfo[], commands?: CommandInfo[]): string {
+interface FormatCombinedDescriptionOptions {
+  includeSkills?: boolean
+}
+
+export function formatCombinedDescription(
+  skills?: SkillInfo[],
+  commands?: CommandInfo[],
+  options: FormatCombinedDescriptionOptions = {}
+): string {
   const availableSkills = skills ?? []
   const availableCommands = commands ?? []
+  const includeSkills = options.includeSkills ?? false
 
   if (availableSkills.length === 0 && availableCommands.length === 0) {
     return TOOL_DESCRIPTION_NO_SKILLS
   }
 
   const availableItems = [
-    ...sortByScopePriority(availableSkills).map(formatSkillCommand),
+    ...(includeSkills ? sortByScopePriority(availableSkills).map(formatSkillCommand) : []),
     ...sortByScopePriority(availableCommands).map(formatSlashCommand),
   ]
 
@@ -57,7 +66,7 @@ export function formatCombinedDescription(skills?: SkillInfo[], commands?: Comma
 
   return `${TOOL_DESCRIPTION_PREFIX}
 <available_items>
-Priority: project > user > opencode > builtin/plugin | Skills listed before commands
+Priority: project > user > opencode > builtin/plugin | Commands listed here; skills are listed separately by OpenCode
 Invoke via: skill(name="item-name") - omit leading slash for commands.
 ${availableItems.join("\n")}
 </available_items>`

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -69,7 +69,9 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     const skills = await getSkills()
     const commands = getCommands()
     const skillInfos = skills.map(loadedSkillToInfo)
-    cachedDescription = formatCombinedDescription(skillInfos, commands)
+    cachedDescription = formatCombinedDescription(skillInfos, commands, {
+      includeSkills: options.includeSkillsInDescription,
+    })
     return cachedDescription
   }
 
@@ -90,7 +92,9 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       }
     }
 
-    cachedDescription = formatCombinedDescription(skillInfos, commandsForDescription)
+    cachedDescription = formatCombinedDescription(skillInfos, commandsForDescription, {
+      includeSkills: options.includeSkillsInDescription,
+    })
     if (needsAsyncRefresh) {
       void buildDescription(true)
     }

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -26,6 +26,8 @@ export interface SkillLoadOptions {
   skills?: LoadedSkill[]
   /** Pre-discovered commands to use instead of discovering */
   commands?: CommandInfo[]
+  /** Include skills in the tool description. Disabled by default because OpenCode appends its own skill list. */
+  includeSkillsInDescription?: boolean
   /** MCP manager for querying skill-embedded MCP servers */
   mcpManager?: SkillMcpManager
   /** Session ID getter for MCP client identification */

--- a/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
+++ b/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
@@ -97,7 +97,7 @@ const mockContext: ToolContext = {
 }
 
 describe("skill tool - synchronous description", () => {
-  it("includes available_items immediately when skills are pre-provided", () => {
+  it("omits skills from available_items by default when skills are pre-provided", () => {
     // given
     const loadedSkills = [createMockSkill("test-skill")]
 
@@ -105,11 +105,11 @@ describe("skill tool - synchronous description", () => {
     const tool = createSkillTool({ skills: loadedSkills })
 
     // then
-    expect(tool.description).toContain("<available_items>")
-    expect(tool.description).toContain("test-skill")
+    expect(tool.description).not.toContain("<available_items>")
+    expect(tool.description).not.toContain("test-skill")
   })
 
-  it("includes all pre-provided skills in available_items immediately", () => {
+  it("can include pre-provided skills in available_items when explicitly requested", () => {
     // given
     const loadedSkills = [
       createMockSkill("playwright"),
@@ -118,7 +118,7 @@ describe("skill tool - synchronous description", () => {
     ]
 
     // when
-    const tool = createSkillTool({ skills: loadedSkills })
+    const tool = createSkillTool({ skills: loadedSkills, includeSkillsInDescription: true })
 
     // then
     expect(tool.description).toContain("<available_items>")
@@ -467,7 +467,7 @@ describe("skill tool - ordering and priority", () => {
     }
   }
 
-  it("shows skills as command items with slash prefix in available_items", () => {
+  it("omits skills from available_items when commands are also present", () => {
     //#given: mix of skills and commands
     const skills = [
       createMockSkillWithScope("builtin-skill", "builtin"),
@@ -481,17 +481,16 @@ describe("skill tool - ordering and priority", () => {
     //#when: creating tool with both
     const tool = createSkillTool({ skills, commands })
 
-    //#then: skills should appear as <command> items with / prefix, listed before regular commands
+    //#then: only commands should appear in available_items; OpenCode appends the skill list separately
     const desc = tool.description
-    expect(desc).toContain("<name>/builtin-skill</name>")
-    expect(desc).toContain("<name>/project-skill</name>")
+    expect(desc).not.toContain("<name>/builtin-skill</name>")
+    expect(desc).not.toContain("<name>/project-skill</name>")
+    expect(desc).toContain("<name>/project-cmd</name>")
+    expect(desc).toContain("<name>/builtin-cmd</name>")
     expect(desc).not.toContain("<skill>")
-    const skillCmdIndex = desc.indexOf("/project-skill")
-    const regularCmdIndex = desc.indexOf("/project-cmd")
-    expect(skillCmdIndex).toBeLessThan(regularCmdIndex)
   })
 
-  it("sorts skill-commands by priority: project > user > opencode > builtin", () => {
+  it("sorts skill-commands by priority when skills are explicitly included: project > user > opencode > builtin", () => {
     //#given: skills in random order
     const skills = [
       createMockSkillWithScope("builtin-skill", "builtin"),
@@ -501,7 +500,7 @@ describe("skill tool - ordering and priority", () => {
     ]
 
     //#when: creating tool
-    const tool = createSkillTool({ skills })
+    const tool = createSkillTool({ skills, includeSkillsInDescription: true })
 
     //#then: should be sorted by priority
     const desc = tool.description
@@ -549,7 +548,7 @@ describe("skill tool - ordering and priority", () => {
 
     //#then: should include priority info
     expect(tool.description).toContain("Priority: project > user > opencode > builtin/plugin")
-    expect(tool.description).toContain("Skills listed before commands")
+    expect(tool.description).toContain("Commands listed here; skills are listed separately by OpenCode")
   })
 
   it("uses <available_items> wrapper with unified command format", () => {
@@ -560,12 +559,12 @@ describe("skill tool - ordering and priority", () => {
     //#when: creating tool
     const tool = createSkillTool({ skills, commands })
 
-    //#then: should use unified wrapper with all items as commands
+    //#then: should use unified wrapper for commands without duplicating skills
     expect(tool.description).toContain("<available_items>")
     expect(tool.description).toContain("</available_items>")
     expect(tool.description).not.toContain("<skill>")
     expect(tool.description).toContain("<command>")
-    expect(tool.description).toContain("/test-skill")
+    expect(tool.description).not.toContain("/test-skill")
     expect(tool.description).toContain("/test-cmd")
   })
 })
@@ -690,7 +689,7 @@ describe("skill tool - dynamic description cache invalidation", () => {
 
       // then
       expect(refreshedResult).toContain("Skill: second-skill")
-      expect(refreshedTool.description).toContain("second-skill")
+      expect(refreshedTool.description).not.toContain("second-skill")
     } finally {
       process.chdir(originalDirectory)
       clearSkillCache()
@@ -718,7 +717,7 @@ describe("skill tool - browserProvider forwarding", () => {
     expect(result).toContain("Skill: agent-browser")
   })
 
-  it("description includes agent-browser when browserProvider is agent-browser", () => {
+  it("description omits agent-browser while execution still supports it", async () => {
     // given
     const agentBrowserSkill = createMockSkill("agent-browser")
 
@@ -729,12 +728,13 @@ describe("skill tool - browserProvider forwarding", () => {
     })
 
     // then
-    expect(tool.description).toContain("agent-browser")
+    expect(tool.description).not.toContain("agent-browser")
+    await expect(tool.execute({ name: "agent-browser" }, mockContext)).resolves.toContain("Skill: agent-browser")
   })
 })
 
 describe("skill tool - nativeSkills integration", () => {
-  it("includes native skills in the description even when skills are pre-seeded", async () => {
+  it("loads native skills even though descriptions omit skills by default", async () => {
     //#given
     const tool = createSkillTool({
       skills: [createMockSkill("seeded-skill")],
@@ -753,13 +753,12 @@ describe("skill tool - nativeSkills integration", () => {
     })
 
     //#when
-    expect(tool.description).toContain("seeded-skill")
-    expect(tool.description).toContain("native-visible-skill")
-    await tool.execute({ name: "native-visible-skill" }, mockContext)
+    const result = await tool.execute({ name: "native-visible-skill" }, mockContext)
 
     //#then
-    expect(tool.description).toContain("seeded-skill")
-    expect(tool.description).toContain("native-visible-skill")
+    expect(result).toContain("Skill: native-visible-skill")
+    expect(tool.description).not.toContain("seeded-skill")
+    expect(tool.description).not.toContain("native-visible-skill")
   })
 
   it("merges native skills exposed by PluginInput.skills.all()", async () => {


### PR DESCRIPTION
## Summary

- Stop listing skills in OMO's `<available_items>` by default because OpenCode already appends `## Available Skills` to the `skill` tool.
- Keep slash commands in `<available_items>` so OMO's command bridge remains discoverable.
- Add an explicit `includeSkillsInDescription` escape hatch for the old behavior.

Fixes #3250.

## Why

In OpenCode 1.14.22 + oh-my-opencode 3.17.4, the `skill` tool description can include the same skill list twice:

- OMO's `<available_items>` listed both skills and commands.
- OpenCode core then appended `## Available Skills` to the same `skill` tool.

In my local repro, disabling OMO's `skill` tool dropped a fresh greeting session from roughly 48.6k input tokens to 39,313 total tokens, confirming that the duplicate skill list costs several thousand tokens depending on installed skills.

## Validation

- `bun test src/tools/skill/zauc-mocks-skill-tools/tools.test.ts src/tools/skill/tools.factory.test.ts src/tools/skill/async-description-refresh.test.ts`
- `bun run typecheck`
- `bun run build`

I also attempted the full `bun test` suite. It currently fails on unrelated/environmental tests outside this change area, including missing system `zip` and existing non-skill suites; the skill-focused tests above pass cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate skill lists in the `skill` tool by omitting skills from `<available_items>` and keeping only slash commands. Adds an opt-in flag to include skills if needed, reducing prompt tokens.

- **Bug Fixes**
  - Omit skills from `<available_items>`; OpenCode lists skills separately.
  - Keep slash commands and update the priority note to reflect command-only listing.
  - Avoid duplicates during async/native refresh; descriptions no longer list seeded or discovered skills by default.

- **New Features**
  - Add `includeSkillsInDescription` to `createSkillTool` (`SkillLoadOptions`) to include skills in the description when explicitly requested.

<sup>Written for commit ae094a4caba8e9c13562b55a51403b4ea8dce6b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

