### PR TITLE
fix: dynamic import bun:sqlite to prevent plugin context crash

### DIFF
--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -1,8 +1,18 @@
-import { Database } from "bun:sqlite"
 import { join } from "node:path"
 import { existsSync } from "node:fs"
 import { getDataDir } from "../shared/data-path"
 import { log } from "../shared"
+
+type BunSqliteModule = typeof import("bun:sqlite")
+type BunDatabase = import("bun:sqlite").Database
+
+async function loadBunSqlite(): Promise<BunSqliteModule | null> {
+  try {
+    return await import("bun:sqlite" as never as string)
+  } catch {
+    return null
+  }
+}
 
 function getDbPath(): string {
   return join(getDataDir(), "opencode", "opencode.db")
@@ -11,7 +21,7 @@ function getDbPath(): string {
 const MAX_MICROTASK_RETRIES = 10
 
 function tryUpdateMessageModel(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant?: string,
@@ -30,7 +40,7 @@ function tryUpdateMessageModel(
 }
 
 function retryViaMicrotask(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant: string | undefined,
@@ -112,16 +122,22 @@ export function scheduleDeferredModelOverride(
   targetModel: { providerID: string; modelID: string },
   variant?: string,
 ): void {
-  queueMicrotask(() => {
+  queueMicrotask(async () => {
+    const mod = await loadBunSqlite()
+    if (!mod) {
+      log("[ultrawork-db-override] bun:sqlite unavailable, skipping deferred override")
+      return
+    }
+
     const dbPath = getDbPath()
     if (!existsSync(dbPath)) {
       log("[ultrawork-db-override] DB not found, skipping deferred override")
       return
     }
 
-    let db: InstanceType<typeof Database>
+    let db: BunDatabase
     try {
-      db = new Database(dbPath)
+      db = new mod.Database(dbPath)
     } catch (error) {
       log("[ultrawork-db-override] Failed to open DB, skipping deferred override", {
         messageId,


### PR DESCRIPTION
## Problem

`import { Database } from "bun:sqlite"` in `ultrawork-db-model-override.ts` is a **static import** that fails at module parse time in OpenCode's embedded JS runtime, which doesn't support the `bun:` protocol in plugin context. This causes the TUI to black screen/hang on startup.

Affects users on OpenCode >= 1.3.15 with Bun >= 1.3.12, across Windows, macOS, Linux, and Docker.

## Root Cause

The `bun:` protocol is not in the allowed scheme list (`file`, `data`, `node`, `electron`) for the default ESM loader. A static import triggers validation at parse time — before any code runs — blocking the entire plugin from loading.

## Solution

Replace the static import with a dynamic `await import("bun:sqlite" as never as string)` wrapped in try/catch:

- When `bun:sqlite` **is available** (native Bun runtime): works exactly as before
- When `bun:sqlite` **is unavailable** (OpenCode plugin context): logs a message and silently skips the deferred model override

The `as never as string` cast is the established pattern in production Bun codebases (e.g., [clarte](https://github.com/michaelabrt/clarte)) to bypass TypeScript's static analysis of the `bun:` protocol.

## Changes

- `src/plugin/ultrawork-db-model-override.ts`: Replace static `bun:sqlite` import with async dynamic import + graceful fallback
- No new dependencies
- No behavior change when running under native Bun
- Existing tests pass unchanged (6/6, they run under Bun where `bun:sqlite` works)
- Bundle verified: no static `import ... from "bun:sqlite"` in `dist/index.js`

## Verification

- `bunx tsc --noEmit` — clean
- `bun run build` — success
- `bun test src/plugin/ultrawork-db-model-override.test.ts` — 6/6 pass
- `grep 'import.*from.*"bun:sqlite"' dist/index.js` — no matches

Fixes #3475
Fixes #3143

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents plugin startup crash by replacing the static `bun:sqlite` import with a safe dynamic import in the deferred model override path. Native Bun behavior is unchanged; in unsupported runtimes, the override is skipped instead of crashing.

- **Bug Fixes**
  - Replaced static import with `await import("bun:sqlite")` and a graceful fallback.
  - Updated `src/plugin/ultrawork-db-model-override.ts` to log and skip when `bun:sqlite` isn’t available.
  - No new dependencies; no static `import ... from "bun:sqlite"` remains in the build.

<sup>Written for commit 7fc016d718f70017b1ffb1e69557a21e3d2c5547. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

