### PR TITLE
Fix #3607: ignore MSYSTEM for Windows shell detection

### DIFF
--- a/src/cli/run/on-complete-hook.test.ts
+++ b/src/cli/run/on-complete-hook.test.ts
@@ -47,6 +47,7 @@ describe("executeOnCompleteHook", () => {
     originalEnv = {
       SHELL: process.env.SHELL,
       PSModulePath: process.env.PSModulePath,
+      MSYSTEM: process.env.MSYSTEM,
       ComSpec: process.env.ComSpec,
     }
     logCalls = []
@@ -108,6 +109,36 @@ describe("executeOnCompleteHook", () => {
     // given
     Object.defineProperty(process, "platform", { value: "win32" })
     process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+    delete process.env.SHELL
+    const spawnCalls: Array<Parameters<typeof spawnWithWindowsHideModule.spawnWithWindowsHide>> = []
+    spyOn(spawnWithWindowsHideModule, "spawnWithWindowsHide").mockImplementation((
+      command,
+      options,
+    ) => {
+      spawnCalls.push([command, options])
+      return createProc(0)
+    })
+    const executeOnCompleteHook = await importFreshExecuteOnCompleteHook()
+
+    // when
+    await executeOnCompleteHook({
+      command: "Write-Host done",
+      sessionId: "session-123",
+      exitCode: 0,
+      durationMs: 5000,
+      messageCount: 10,
+    })
+
+    // then
+    const [args] = spawnCalls[0]
+    expect(args).toEqual(["powershell.exe", "-NoProfile", "-Command", "Write-Host done"])
+  })
+
+  it("keeps using powershell on Windows when MSYSTEM lingers without SHELL", async () => {
+    // given
+    Object.defineProperty(process, "platform", { value: "win32" })
+    process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+    process.env.MSYSTEM = "MINGW64"
     delete process.env.SHELL
     const spawnCalls: Array<Parameters<typeof spawnWithWindowsHideModule.spawnWithWindowsHide>> = []
     spyOn(spawnWithWindowsHideModule, "spawnWithWindowsHide").mockImplementation((

--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -320,7 +320,7 @@ describe("non-interactive-env hook", () => {
       expect(cmd).not.toContain("$env:")
     })
 
-    test("#given Windows Git Bash via MSYSTEM without SHELL #when git command executes #then uses unix syntax", async () => {
+    test("#given Windows PowerShell env with lingering MSYSTEM and no SHELL #when git command executes #then uses powershell syntax", async () => {
       delete process.env.SHELL
       process.env.MSYSTEM = "MINGW64"
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
@@ -337,9 +337,10 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
+      expect(cmd).toStartWith("$env:")
       expect(cmd).toContain("; git status")
-      expect(cmd).not.toContain("$env:")
+      expect(cmd).toContain("$env:GIT_EDITOR=':'")
+      expect(cmd).not.toContain("export ")
     })
 
     test("#given Windows platform #when chained git commands via bash tool #then uses cmd syntax", async () => {

--- a/src/shared/shell-env.test.ts
+++ b/src/shared/shell-env.test.ts
@@ -99,7 +99,7 @@ describe("shell-env", () => {
       expect(result).toBe("unix")
     })
 
-    test("#given MSYSTEM set on Windows without SHELL #when detectShellType is called #then returns unix", () => {
+    test("#given MSYSTEM and PSModulePath set on Windows without SHELL #when detectShellType is called #then returns powershell", () => {
       delete process.env.SHELL
       process.env.MSYSTEM = "MINGW64"
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
@@ -107,18 +107,18 @@ describe("shell-env", () => {
 
       const result = detectShellType()
 
-      expect(result).toBe("unix")
+      expect(result).toBe("powershell")
     })
 
-    test("#given MSYSTEM set to MSYS without SHELL #when detectShellType is called #then returns unix", () => {
+    test("#given MSYSTEM set on Windows without SHELL or PSModulePath #when detectShellType is called #then falls back to cmd", () => {
       delete process.env.SHELL
+      delete process.env.PSModulePath
       process.env.MSYSTEM = "MSYS"
-      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       Object.defineProperty(process, "platform", { value: "win32" })
 
       const result = detectShellType()
 
-      expect(result).toBe("unix")
+      expect(result).toBe("cmd")
     })
   })
 

--- a/src/shared/shell-env.ts
+++ b/src/shared/shell-env.ts
@@ -11,6 +11,11 @@ export type ShellType = "unix" | "powershell" | "cmd" | "csh"
  * Note: SHELL is checked before PSModulePath because on Windows, PSModulePath
  * is always set by the system even when the active shell is Git Bash or WSL.
  * An explicit SHELL variable indicates the user's chosen shell overrides that.
+ *
+ * MSYSTEM is intentionally NOT used for shell selection on Windows. Git for
+ * Windows commonly leaves it set in the environment even when OpenCode is
+ * executing commands via PowerShell or cmd.exe, so treating it as a Unix-shell
+ * signal produces invalid command prefixes like `export ...` in PowerShell.
  */
 export function detectShellType(): ShellType {
   if (process.env.SHELL) {
@@ -18,13 +23,6 @@ export function detectShellType(): ShellType {
     if (shell.includes("csh") || shell.includes("tcsh")) {
       return "csh"
     }
-    return "unix"
-  }
-
-  // Git Bash on Windows sets MSYSTEM (e.g. "MINGW64", "MINGW32", "MSYS")
-  // even when SHELL is not set. Detect this before PSModulePath which is
-  // always present on Windows regardless of the active shell.
-  if (process.env.MSYSTEM) {
     return "unix"
   }
 


### PR DESCRIPTION
## Summary

- fix Windows shell detection so lingering `MSYSTEM` no longer forces Unix syntax
- keep explicit Unix shells working by continuing to honor `SHELL` before `PSModulePath`
- add regression coverage for both `non-interactive-env` and `on-complete-hook`

## Changes

- remove the `MSYSTEM -> unix` branch from `src/shared/shell-env.ts`
- document why `MSYSTEM` is not a reliable execution-shell signal on Windows
- update shared shell detection tests to assert `powershell` or `cmd` when only `MSYSTEM` is present
- add regression tests proving Windows PowerShell still wins when `MSYSTEM` lingers in the environment

## Testing

```bash
bun test src/shared/shell-env.test.ts src/hooks/non-interactive-env/index.test.ts src/cli/run/on-complete-hook.test.ts
bun run typecheck
bun run build
```

## Related Issues

Closes #3607

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `MSYSTEM` for Windows shell detection to stop forcing Unix syntax when Git for Windows env vars linger. We now honor `SHELL` first, then `PSModulePath`, and otherwise fall back to `cmd`, preventing `export ...` in PowerShell (fixes #3607).

- **Bug Fixes**
  - Removed the `MSYSTEM -> unix` branch in `src/shared/shell-env.ts` and documented why it’s unreliable on Windows.
  - Preserved precedence: `SHELL` > `PSModulePath` > `cmd`; explicit Unix shells still work.
  - Updated tests in `shell-env`, `non-interactive-env`, and `on-complete-hook` to assert PowerShell when `MSYSTEM` lingers and to cover the `cmd` fallback.

<sup>Written for commit ee3e7fdc7890aa54e9c54b4b2baca6d9216642dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

