### PR TITLE
Add kimi-k2.6 to supplemental model capabilities

### DIFF
--- a/src/shared/model-capabilities/supplemental-entries.ts
+++ b/src/shared/model-capabilities/supplemental-entries.ts
@@ -17,4 +17,19 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 			output: 128000,
 		},
 	},
+	"kimi-k2.6": {
+		id: "kimi-k2.6",
+		family: "kimi",
+		reasoning: true,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 262144,
+			output: 128000,
+		},
+	},
 }


### PR DESCRIPTION
This PR adds kimi-k2.6 (Moonshot AI Kimi K2.6) to the supplemental model capabilities snapshot, eliminating the heuristic-backed compatibility fallback for users configuring moonshotai-cn/kimi-k2.6.

**Model specs (based on public documentation):**
- Family: kimi
- Context window: 262,144 tokens
- Supports reasoning, temperature control, and tool calling
- Multimodal input (text + image), text output
- Output limit: 128,000 tokens

Closes the Configured models rely on compatibility fallback warning for Kimi K2.6 users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `kimi-k2.6` to the supplemental model capabilities to avoid the heuristic compatibility fallback and stop warnings for `moonshotai-cn/kimi-k2.6`.
Includes context 262,144 tokens, output 128,000 tokens, multimodal input (text+image) with text output, and support for reasoning, temperature, and tool calling.

<sup>Written for commit b03dcfc3e3b3bf18c15e496ae518ef78ffe8ee94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

