### PR TITLE
fix(tool-execute-after): cap excessively long tool output to prevent TUI flooding (fixes #3586)

### DIFF
--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -181,5 +181,14 @@ export function createToolExecuteAfterHandler(args: {
     }
 
     await runToolExecuteAfterHooks()
+
+    // Cap excessively long error outputs that would flood the TUI with raw
+    // stack traces or framework internals. Normal outputs are handled by the
+    // tool-output-truncator hook for specific tools; this catch-all only fires
+    // for outputs that still exceed a safe display length after all hooks.
+    const MAX_ERROR_OUTPUT_CHARS = 3000
+    if (typeof output.output === "string" && output.output.length > MAX_ERROR_OUTPUT_CHARS) {
+      output.output = output.output.slice(0, MAX_ERROR_OUTPUT_CHARS) + "\n\n...(output truncated for display)"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Cap all tool output at 3000 characters to prevent raw error dumps from flooding the TUI

## Problem
When a tool fails (e.g., reading a non-existent file), the error message can contain long raw stack traces, framework internals, or serialized objects. The existing tool-output-truncator only handles specific tool types. For other tools, the full error is dumped into the TUI as a large, unreadable blob of text.

## Fix
Added a universal catch-all in `tool-execute-after.ts` that caps any tool output exceeding 3000 characters. This runs after all other hooks (including the tool-specific truncator), so it only fires on outputs that are still too long. The truncation is lightweight (string slice) and does not affect the token-aware truncation used for known tools.

## Changes
| File | Change |
|------|--------|
| `src/plugin/tool-execute-after.ts` | Add MAX_ERROR_OUTPUT_CHARS cap after all hooks run |

Fixes #3586

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps tool output to 3000 characters after all hooks to prevent TUI flooding from huge error dumps (fixes #3586).
Adds a simple catch-all in `src/plugin/tool-execute-after.ts` that slices long string outputs and appends a truncation notice without affecting existing token-aware truncation.

<sup>Written for commit 2c78cc68dab4326f1a53919ee949fd4be5269f12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

