### PR TITLE
open temp fd with r+ so fsyncSync doesn't EPERM on Windows

### DIFF
--- a/src/shared/write-file-atomically.ts
+++ b/src/shared/write-file-atomically.ts
@@ -3,7 +3,7 @@ import { closeSync, fsyncSync, openSync, renameSync, unlinkSync, writeFileSync }
 export function writeFileAtomically(filePath: string, content: string): void {
 	const tempPath = `${filePath}.tmp`
 	writeFileSync(tempPath, content, "utf-8")
-  const tempFileDescriptor = openSync(tempPath, "r")
+  const tempFileDescriptor = openSync(tempPath, "r+")
   try {
     fsyncSync(tempFileDescriptor)
   } finally {


### PR DESCRIPTION
## Summary

`writeFileAtomically` opened the temp file as read-only before calling `fsyncSync`.

On Windows that hits FlushFileBuffers, which needs `GENERIC_WRITE` on the handle, else returns `ACCESS_DENIED`.

The throw aborted the function before renameSync, so the target file never got updated, the migrations sidecar was never written, and config migrations re-ran on every launch — creating a new .bak each time.

## Changes

Switched from
`openSync(tempPath, "r");`
to
`openSync(tempPath, "r+");`
in `src/shared/write-file-atomically.ts`'s `writeFileAtomically`

## Related Issues

Closes #3643 (migration retriggers on every launch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes atomic file writes on Windows by opening the temp file with "r+" so `fsyncSync` succeeds. Prevents aborted renames and repeated config migrations that created new .bak files on each launch.

- **Bug Fixes**
  - Open temp FD with "r+" in `src/shared/write-file-atomically.ts`.
  - `fsyncSync` no longer throws `ACCESS_DENIED`; target file and sidecar update correctly. Closes #3643.

<sup>Written for commit 857dddb1ab0e222faef319608142641bfe936da8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

