### PR TITLE
feat(i18n): auto-apply concise locale prompt preference

### DIFF
--- a/src/agents/builtin-agents/agent-overrides.test.ts
+++ b/src/agents/builtin-agents/agent-overrides.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentConfig } from "@opencode-ai/sdk"
+import { applyOverrides } from "./agent-overrides"
+
+describe("applyOverrides", () => {
+  test("applies automatic locale prompt even without explicit overrides", () => {
+    const previousLang = process.env.LANG
+    process.env.LANG = "zh-CN.UTF-8"
+    try {
+      const base = { prompt: "Base prompt" } as AgentConfig
+      const result = applyOverrides(base, undefined, {})
+      expect(result.prompt).toContain("Language Preference")
+      expect(result.prompt).toContain("Simplified Chinese")
+    } finally {
+      process.env.LANG = previousLang
+    }
+  })
+})

--- a/src/agents/builtin-agents/agent-overrides.test.ts
+++ b/src/agents/builtin-agents/agent-overrides.test.ts
@@ -15,4 +15,16 @@ describe("applyOverrides", () => {
       process.env.LANG = previousLang
     }
   })
+
+  test("skips automatic locale prompt when prompt_append is explicitly controlled", () => {
+    const previousLang = process.env.LANG
+    process.env.LANG = "zh-CN.UTF-8"
+    try {
+      const base = { prompt: "Base prompt" } as AgentConfig
+      const result = applyOverrides(base, { prompt_append: "" }, {})
+      expect(result.prompt).toBe("Base prompt")
+    } finally {
+      process.env.LANG = previousLang
+    }
+  })
 })

--- a/src/agents/builtin-agents/agent-overrides.ts
+++ b/src/agents/builtin-agents/agent-overrides.ts
@@ -5,6 +5,10 @@ import { deepMerge, migrateAgentConfig } from "../../shared"
 import { applyAutomaticLocalePromptPreference } from "./auto-locale-prompt-append"
 import { resolvePromptAppend } from "./resolve-file-uri"
 
+function hasExplicitPromptAppend(value: unknown): boolean {
+  return typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, "prompt_append")
+}
+
 /**
  * Expands a category reference from an agent override into concrete config properties.
  * Category properties are applied unconditionally (overwriting factory defaults),
@@ -64,12 +68,17 @@ export function applyOverrides(
 ): AgentConfig {
   let result = config
   const overrideCategory = (override as Record<string, unknown> | undefined)?.category as string | undefined
+  const categoryConfig = overrideCategory ? mergedCategories[overrideCategory] : undefined
   if (overrideCategory) {
     result = applyCategoryOverride(result, overrideCategory, mergedCategories)
   }
 
   if (override) {
     result = mergeAgentConfig(result, override, directory)
+  }
+
+  if (hasExplicitPromptAppend(categoryConfig) || hasExplicitPromptAppend(override)) {
+    return result
   }
 
   return applyAutomaticLocalePromptPreference(result)

--- a/src/agents/builtin-agents/agent-overrides.ts
+++ b/src/agents/builtin-agents/agent-overrides.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentOverrideConfig } from "../types"
 import type { CategoryConfig } from "../../config/schema"
 import { deepMerge, migrateAgentConfig } from "../../shared"
+import { applyAutomaticLocalePromptPreference } from "./auto-locale-prompt-append"
 import { resolvePromptAppend } from "./resolve-file-uri"
 
 /**
@@ -71,5 +72,5 @@ export function applyOverrides(
     result = mergeAgentConfig(result, override, directory)
   }
 
-  return result
+  return applyAutomaticLocalePromptPreference(result)
 }

--- a/src/agents/builtin-agents/auto-locale-prompt-append.test.ts
+++ b/src/agents/builtin-agents/auto-locale-prompt-append.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { applyAutomaticLocalePromptPreference, buildAutomaticLocalePromptAppend, getAutoLocaleLanguageLabel } from "./auto-locale-prompt-append"
+
+describe("auto locale prompt append", () => {
+  test("returns no language label for english locales", () => {
+    expect(getAutoLocaleLanguageLabel("en-US")).toBeUndefined()
+    expect(getAutoLocaleLanguageLabel("en_GB.UTF-8")).toBeUndefined()
+  })
+
+  test("maps supported locales to a concise target language label", () => {
+    expect(getAutoLocaleLanguageLabel("zh-CN")).toBe("Simplified Chinese")
+    expect(getAutoLocaleLanguageLabel("ja-JP")).toBe("Japanese")
+    expect(getAutoLocaleLanguageLabel("pt-BR")).toBe("Brazilian Portuguese")
+  })
+
+  test("appends a short locale prompt only for non-english locales", () => {
+    const base = { prompt: "Base prompt" }
+    const zh = applyAutomaticLocalePromptPreference(base, "zh-CN")
+    const en = applyAutomaticLocalePromptPreference(base, "en-US")
+
+    expect(zh.prompt).toContain("default to concise Simplified Chinese")
+    expect(zh.prompt).toContain("Optimize for brevity")
+    expect(en.prompt).toBe("Base prompt")
+  })
+
+  test("builds a compact appendix", () => {
+    const appendix = buildAutomaticLocalePromptAppend("zh-CN")
+    expect(appendix).toBeDefined()
+    expect(appendix!.length).toBeLessThan(320)
+  })
+})

--- a/src/agents/builtin-agents/auto-locale-prompt-append.ts
+++ b/src/agents/builtin-agents/auto-locale-prompt-append.ts
@@ -1,0 +1,80 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+
+const LOCALE_LANGUAGE_LABELS: Record<string, string> = {
+  zh: "Simplified Chinese",
+  ja: "Japanese",
+  ko: "Korean",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  ru: "Russian",
+  "pt-br": "Brazilian Portuguese",
+  pt: "Portuguese",
+  it: "Italian",
+  tr: "Turkish",
+  pl: "Polish",
+  ar: "Arabic",
+  th: "Thai",
+}
+
+function normalizeLocale(input: string): string {
+  return input.trim().replace(/_/g, "-").toLowerCase()
+}
+
+function detectSystemLocale(): string | undefined {
+  const candidates = [
+    process.env.LC_ALL,
+    process.env.LC_MESSAGES,
+    process.env.LANG,
+    Intl.DateTimeFormat().resolvedOptions().locale,
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const normalized = normalizeLocale(candidate)
+    if (normalized && normalized !== "c" && normalized !== "posix") {
+      return normalized
+    }
+  }
+
+  return undefined
+}
+
+export function getAutoLocaleLanguageLabel(locale = detectSystemLocale()): string | undefined {
+  if (!locale) return undefined
+
+  const normalized = normalizeLocale(locale).split(".")[0]
+  if (normalized.startsWith("en")) return undefined
+
+  if (LOCALE_LANGUAGE_LABELS[normalized]) {
+    return LOCALE_LANGUAGE_LABELS[normalized]
+  }
+
+  const prefix = normalized.split("-")[0]
+  return LOCALE_LANGUAGE_LABELS[prefix]
+}
+
+export function buildAutomaticLocalePromptAppend(locale?: string): string | undefined {
+  const languageLabel = getAutoLocaleLanguageLabel(locale)
+  if (!languageLabel) return undefined
+
+  return [
+    "## Language Preference",
+    `- User-visible explanation text: default to concise ${languageLabel}.`,
+    "- Optimize for brevity: no bilingual duplication, no filler, no repeated paraphrase.",
+    "- Keep code, commands, paths, identifiers, schemas, logs, and exact upstream error text unchanged.",
+  ].join("\n")
+}
+
+export function applyAutomaticLocalePromptPreference<T extends AgentConfig>(config: T, locale?: string): T {
+  if (typeof config.prompt !== "string") return config
+
+  const appendix = buildAutomaticLocalePromptAppend(locale)
+  if (!appendix) return config
+  if (config.prompt.includes(appendix)) return config
+
+  return {
+    ...config,
+    prompt: `${config.prompt}\n${appendix}`,
+  }
+}

--- a/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/src/agents/builtin-agents/hephaestus-agent.ts
@@ -10,6 +10,10 @@ import { applyCategoryOverride, mergeAgentConfig } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
 
+function hasExplicitPromptAppend(value: unknown): boolean {
+  return typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, "prompt_append")
+}
+
 export function maybeCreateHephaestusConfig(input: {
   disabledAgents: string[]
   agentOverrides: AgentOverrides
@@ -93,6 +97,10 @@ export function maybeCreateHephaestusConfig(input: {
   const gptDeny = getGptApplyPatchPermission(resolvedModel)
   if (Object.keys(gptDeny).length > 0 && hephaestusConfig.permission) {
     Object.assign(hephaestusConfig.permission, gptDeny)
+  }
+
+  if (hasExplicitPromptAppend(hepOverrideCategory ? mergedCategories[hepOverrideCategory] : undefined) || hasExplicitPromptAppend(hephaestusOverride)) {
+    return hephaestusConfig
   }
 
   return applyAutomaticLocalePromptPreference(hephaestusConfig)

--- a/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/src/agents/builtin-agents/hephaestus-agent.ts
@@ -4,6 +4,7 @@ import type { CategoryConfig } from "../../config/schema"
 import type { AvailableAgent, AvailableCategory, AvailableSkill } from "../dynamic-agent-prompt-builder"
 import { AGENT_MODEL_REQUIREMENTS, isAnyProviderConnected } from "../../shared"
 import { createHephaestusAgent } from "../hephaestus"
+import { applyAutomaticLocalePromptPreference } from "./auto-locale-prompt-append"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyCategoryOverride, mergeAgentConfig } from "./agent-overrides"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
@@ -94,5 +95,5 @@ export function maybeCreateHephaestusConfig(input: {
     Object.assign(hephaestusConfig.permission, gptDeny)
   }
 
-  return hephaestusConfig
+  return applyAutomaticLocalePromptPreference(hephaestusConfig)
 }

--- a/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -1,4 +1,5 @@
 import type { CategoryConfig } from "../config/schema";
+import { applyAutomaticLocalePromptPreference } from "../agents/builtin-agents/auto-locale-prompt-append";
 import { PROMETHEUS_PERMISSION, getPrometheusPrompt } from "../agents/prometheus";
 import { resolvePromptAppend } from "../agents/builtin-agents/resolve-file-uri";
 import { AGENT_MODEL_REQUIREMENTS } from "../shared/model-requirements";
@@ -116,12 +117,12 @@ export async function buildPrometheusAgentConfig(params: {
   };
 
   const override = params.pluginPrometheusOverride;
-  if (!override) return base;
+  if (!override) return applyAutomaticLocalePromptPreference(base);
 
   const { prompt_append, ...restOverride } = override;
   const merged = { ...base, ...restOverride };
   if (prompt_append && typeof merged.prompt === "string") {
     merged.prompt = merged.prompt + "\n" + resolvePromptAppend(prompt_append);
   }
-  return merged;
+  return applyAutomaticLocalePromptPreference(merged);
 }

--- a/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -24,6 +24,10 @@ type PrometheusOverride = Record<string, unknown> & {
   prompt_append?: string;
 };
 
+function hasExplicitPromptAppend(value: unknown): boolean {
+  return typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, "prompt_append");
+}
+
 function isModelInFallbackChain(
   model: string | undefined,
   fallbackChain: FallbackEntry[] | undefined,
@@ -117,12 +121,17 @@ export async function buildPrometheusAgentConfig(params: {
   };
 
   const override = params.pluginPrometheusOverride;
-  if (!override) return applyAutomaticLocalePromptPreference(base);
+  if (!override) {
+    return hasExplicitPromptAppend(categoryConfig) ? base : applyAutomaticLocalePromptPreference(base);
+  }
 
   const { prompt_append, ...restOverride } = override;
   const merged = { ...base, ...restOverride };
   if (prompt_append && typeof merged.prompt === "string") {
     merged.prompt = merged.prompt + "\n" + resolvePromptAppend(prompt_append);
+  }
+  if (hasExplicitPromptAppend(categoryConfig) || hasExplicitPromptAppend(override)) {
+    return merged;
   }
   return applyAutomaticLocalePromptPreference(merged);
 }


### PR DESCRIPTION
Add a lightweight automatic locale-based language preference for user-visible explanation text.

The implementation is intentionally non-invasive:

- it only affects user-visible explanation text
- it keeps code, commands, paths, schemas, logs, and exact upstream error text unchanged
- it optimizes for brevity rather than bilingual verbosity
- it yields to explicit user configuration

What changed:

- add a small locale-to-language-label helper for built-in agents
- auto-append a compact language preference block when the system locale is non-English
- skip the automatic append when `prompt_append` is explicitly configured by the user or category
- cover the behavior with focused tests

Why:

Many users want better readability in their system language, but a heavy multilingual prompt strategy can increase prompt size and degrade runtime efficiency. This keeps the behavior small, predictable, and easy to override.

Notes:

- target branch: `dev`
- I did not run the full local Bun build/test workflow in this environment
- the tests added are intentionally small and deterministic

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-apply a compact locale-based language preference to built-in agents when the system locale is non-English. Keeps code and identifiers unchanged, and respects explicit `prompt_append`.

- **New Features**
  - Added `auto-locale-prompt-append` to detect locale and build a concise “Language Preference” block.
  - Automatically appends to `prompt` in `applyOverrides`, Hephaestus, and Prometheus when locale is non-English.
  - Skips auto-append if `prompt_append` is set on the agent or category.
  - English locales are a no-op; mappings include zh (Simplified Chinese), ja, ko, es, fr, de, ru, `pt-br`, pt, it, tr, pl, ar, th.
  - Added focused tests for mapping, append behavior, English no-op, and opt-out.

<sup>Written for commit 4dd8413c202efe9127fcf0d9358ed4945916bfd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

