### PR TITLE
fix(keyword-detector): rename delegate_task to task

### DIFF
--- a/src/hooks/keyword-detector/analyze/default.ts
+++ b/src/hooks/keyword-detector/analyze/default.ts
@@ -26,5 +26,5 @@ IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
 
 SYNTHESIZE findings before proceeding.
 ---
-MANDATORY delegate_task params: ALWAYS include load_skills and run_in_background when calling delegate_task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
-Example: delegate_task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`
+MANDATORY task params: ALWAYS include load_skills and run_in_background when calling task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
+Example: task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`

--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -13,7 +13,6 @@ import { SEARCH_PATTERN, SEARCH_MESSAGE } from "./search"
 import { ANALYZE_PATTERN, ANALYZE_MESSAGE } from "./analyze"
 import { TEAM_PATTERN, TEAM_MESSAGE } from "./team"
 import { HYPERPLAN_PATTERN, HYPERPLAN_MESSAGE } from "./hyperplan"
-import { ANALYZE_MESSAGE, ANALYZE_PATTERN } from "./analyze"
 
 // Hyperplan-ultrawork combo: strict adjacency, both word orders
 export const HYPERPLAN_ULTRAWORK_PATTERN =

--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -13,6 +13,7 @@ import { SEARCH_PATTERN, SEARCH_MESSAGE } from "./search"
 import { ANALYZE_PATTERN, ANALYZE_MESSAGE } from "./analyze"
 import { TEAM_PATTERN, TEAM_MESSAGE } from "./team"
 import { HYPERPLAN_PATTERN, HYPERPLAN_MESSAGE } from "./hyperplan"
+import { ANALYZE_MESSAGE, ANALYZE_PATTERN } from "./analyze"
 
 // Hyperplan-ultrawork combo: strict adjacency, both word orders
 export const HYPERPLAN_ULTRAWORK_PATTERN =


### PR DESCRIPTION
Move inline ANALYZE_PATTERN/ANALYZE_MESSAGE to dedicated constants file to eliminate duplication, and append delegate_task param guidance to analyze prompt.

## Summary

- Remove duplicated inline definition of `ANALYZE_PATTERN` and `ANALYZE_MESSAGE` from `constants.ts`, replacing with imports from `./analyze`
- Append `task` parameter mandate to `ANALYZE_MESSAGE` in `analyze/default.ts` so injected context includes proper subagent call guidance
- Rename `delegate_task` to `task`

## Changes

- **`src/hooks/keyword-detector/constants.ts`**: Deleted 18 lines of inline regex (`ANALYZE_PATTERN`) and template string (`ANALYZE_MESSAGE`); imported the constants from `./analyze` and referenced them directly in `KEYWORD_DETECTORS`
- **`src/hooks/keyword-detector/analyze/default.ts`**: Added `MANDATORY task params` block to `ANALYZE_MESSAGE`, requiring subagents to always pass `load_skills=[]` and `run_in_background=true` together

## Screenshots

N/A


## Testing

```bash
bun run typecheck
bun test
```

## Related Issues

Closes #3694

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the analyze keyword detector to import shared `ANALYZE_PATTERN`/`ANALYZE_MESSAGE`, and updated the analyze prompt to the `task` API with strict param rules. Calls must always include `run_in_background` and `load_skills`, selecting skills when relevant and using `[]` only when none apply.

- **Refactors**
  - Deduped analyze regex/message by importing from `./analyze`.
  - Updated analyze prompt: renamed `delegate_task` to `task`; documented required params (`run_in_background`, `load_skills`).

<sup>Written for commit d77477b79272bb534aaa70e965d8fd6fd3c698c1. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3695?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





