### PR TITLE
fix(keyword-detector): tighten search/analyze patterns to eliminate conversational false positives

### DIFF
--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -74,9 +74,12 @@ export function buildClaudeOpus47SisyphusPrompt(
     "Sisyphus",
     "Powerful AI Agent with orchestration capabilities from OhMyOpenCode",
   );
+  const browserQaInstruction = availableSkills.some((skill) => skill.name === "playwright")
+    ? "**Web / browser / UI work** → load the `playwright` skill and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED."
+    : "**Web / browser / UI work** → use the available browser automation surface and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED.";
 
   return `${agentIdentity}
-<role>
+<Role>
 You are **Sisyphus** - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
 
 **Identity**: SF Bay Area senior engineer. Work, delegate, verify, ship. **NO AI SLOP.**
@@ -86,7 +89,7 @@ You are **Sisyphus** - Powerful AI Agent with orchestration capabilities from Oh
 **Implementation Gate**: NEVER start implementing unless the user EXPLICITLY asks. ${todoHookNote} - but if no implementation request, NEVER start work.
 
 **Instruction priority**: User > defaults. Newer > older. Safety/type-safety constraints in <constraints> NEVER yield.
-</role>
+</Role>
 
 <self_knowledge>
 You are **Claude Opus 4.7** (\`claude-opus-4-7\`).
@@ -144,7 +147,7 @@ If you intend to call multiple tools and there are no dependencies between the t
 1. **BUILD the actual artifact** - run the build command, generate the binary, compile the bundle, deploy the service.
 2. **USE IT YOURSELF** with the RIGHT TOOL FOR THE SURFACE. **THE TOOL IS NOT OPTIONAL:**
    - **TUI / CLI work** → \`interactive_bash\` (tmux). LAUNCH THE BINARY IN A REAL TERMINAL. Send keystrokes. Run happy path. Try bad input. Hit \`--help\`. READ THE RENDERED OUTPUT. NO substitute. NO "I'll just read the source".
-   - **Web / browser / UI work** → load the \`playwright\` skill and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED.
+   - ${browserQaInstruction}
    - **HTTP API / service work** → \`curl\` or integration script against the RUNNING service. Reading the handler signature is NOT validation.
    - **Library / SDK work** → write a minimal driver script that imports + executes the new code end-to-end.
    - **Other surface** → ask yourself how a REAL USER would discover this works. Do exactly that.

--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -69,14 +69,14 @@ export function buildClaudeOpus47SisyphusPrompt(
   const todoHookNote = useTaskSystem
     ? "YOUR TASK CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TASK CONTINUATION])"
     : "YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION])";
+  const browserQaInstruction = availableSkills.some((skill) => skill.name === "playwright")
+    ? "**Web / browser / UI work** → load the `playwright` skill and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED."
+    : "**Web / browser / UI work** → use the available browser automation surface and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED.";
 
   const agentIdentity = buildAgentIdentitySection(
     "Sisyphus",
     "Powerful AI Agent with orchestration capabilities from OhMyOpenCode",
   );
-  const browserQaInstruction = availableSkills.some((skill) => skill.name === "playwright")
-    ? "**Web / browser / UI work** → load the `playwright` skill and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED."
-    : "**Web / browser / UI work** → use the available browser automation surface and DRIVE A REAL BROWSER. Open the page. Click the elements. Fill the forms. WATCH THE CONSOLE. Screenshot if helpful. Visual changes NOT RENDERED in a browser are NOT VALIDATED.";
 
   return `${agentIdentity}
 <Role>

--- a/src/hooks/keyword-detector/AGENTS.md
+++ b/src/hooks/keyword-detector/AGENTS.md
@@ -11,8 +11,8 @@
 | Keyword | Pattern | Effect |
 |---------|---------|--------|
 | `ultrawork` / `ulw` | `/\b(ultrawork|ulw)\b/i` | Full orchestration mode — parallel agents, deep exploration, relentless execution |
-| Search mode | `SEARCH_PATTERN` (from `search/`) | Web/doc search focus prompt injection |
-| Analyze mode | `ANALYZE_PATTERN` (from `analyze/`) | Deep analysis mode prompt injection |
+| Search mode | `SEARCH_PATTERN` (from `search/`) | Explicit search prompt injection; excludes casual phrases like `show me`, `where is`, standalone `find`, and multilingual where/show variants |
+| Analyze mode | `ANALYZE_PATTERN` (from `analyze/`) | Explicit analysis prompt injection; excludes conversational how/why/explain/understand phrases across supported languages |
 
 ## STRUCTURE
 
@@ -29,12 +29,10 @@ keyword-detector/
 │   └── isPlannerAgent.ts
 ├── search/
 │   ├── index.ts
-│   ├── pattern.ts     # SEARCH_PATTERN regex
-│   └── message.ts     # SEARCH_MESSAGE
+│   └── default.ts     # SEARCH_PATTERN regex + SEARCH_MESSAGE
 └── analyze/
     ├── index.ts
-    ├── pattern.ts     # ANALYZE_PATTERN regex
-    └── message.ts     # ANALYZE_MESSAGE
+    └── default.ts     # ANALYZE_PATTERN regex + ANALYZE_MESSAGE
 ```
 
 ## DETECTION LOGIC

--- a/src/hooks/keyword-detector/analyze/default.ts
+++ b/src/hooks/keyword-detector/analyze/default.ts
@@ -2,15 +2,15 @@
  * Analyze mode keyword detector.
  *
  * Triggers on analysis-related keywords across multiple languages:
- * - English: analyze, analyse, investigate, examine, research, study, deep-dive, inspect, audit, evaluate, assess, review, diagnose, scrutinize, dissect, debug, comprehend, interpret, breakdown, understand, why is, how does, how to
- * - Korean: 분석, 조사, 파악, 연구, 검토, 진단, 이해, 설명, 원인, 이유, 뜯어봐, 따져봐, 평가, 해석, 디버깅, 디버그, 어떻게, 왜, 살펴
- * - Japanese: 分析, 調査, 解析, 検討, 研究, 診断, 理解, 説明, 検証, 精査, 究明, デバッグ, なぜ, どう, 仕組み
- * - Chinese: 调查, 检查, 剖析, 深入, 诊断, 解释, 调试, 为什么, 原理, 搞清楚, 弄明白
- * - Vietnamese: phân tích, điều tra, nghiên cứu, kiểm tra, xem xét, chẩn đoán, giải thích, tìm hiểu, gỡ lỗi, tại sao
+ * - English: analyze, analyse, investigate, examine, audit, diagnose, scrutinize, dissect, breakdown, deep-dive, evaluate, assess, review, inspect, research, study, debug, comprehend, interpret
+ * - Korean: 분석, 조사, 파악, 연구, 검토, 진단, 평가, 해석, 디버깅, 디버그, 뜯어봐, 따져봐, 살펴
+ * - Japanese: 分析, 調査, 解析, 検討, 研究, 診断, 検証, 精査, 究明, デバッグ, 仕組み
+ * - Chinese: 分析, 调查, 检查, 剖析, 深入, 诊断, 调试, 原理, 搞清楚, 弄明白
+ * - Vietnamese: phân tích, điều tra, nghiên cứu, kiểm tra, xem xét, chẩn đoán, giải thích, tìm hiểu, gỡ lỗi
  */
 
 export const ANALYZE_PATTERN =
-  /\b(analyze|analyse|investigate|examine|research|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|debug|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|디버깅|디버그|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|デバッグ|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|调试|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi|tại sao/i
+  /\b(analyze|analyse|investigate|examine|audit|diagnose|scrutinize|dissect|breakdown|deep[\s-]?dive|evaluate|assess|review|inspect|research|study|debug|comprehend|interpret)\b|분석|조사|파악|연구|검토|진단|평가|해석|디버깅|디버그|뜯어봐|따져봐|살펴|分析|調査|解析|検討|研究|診断|検証|精査|究明|デバッグ|仕組み|调查|检查|剖析|深入|诊断|调试|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi/i
 
 export const ANALYZE_MESSAGE = `[analyze-mode]
 ANALYSIS MODE. Gather context before diving deep:

--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -7,6 +7,7 @@ export { ANALYZE_PATTERN, ANALYZE_MESSAGE } from "./analyze"
 
 import { getUltraworkMessage } from "./ultrawork"
 import { SEARCH_PATTERN, SEARCH_MESSAGE } from "./search"
+import { ANALYZE_PATTERN } from "./analyze"
 
 export type KeywordDetector = {
   pattern: RegExp
@@ -23,8 +24,7 @@ export const KEYWORD_DETECTORS: KeywordDetector[] = [
     message: SEARCH_MESSAGE,
   },
   {
-    pattern:
-      /\b(analyze|analyse|investigate|examine|research|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|debug|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|디버깅|디버그|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|デバッグ|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|调试|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi|tại sao/i,
+    pattern: ANALYZE_PATTERN,
     message: `[analyze-mode]
 ANALYSIS MODE. Gather context before diving deep:
 CONTEXT GATHERING (parallel):

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -1,10 +1,43 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
-import { createKeywordDetectorHook } from "./index"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { ANALYZE_PATTERN, SEARCH_PATTERN, createKeywordDetectorHook } from "./index"
 import { setMainSession, updateSessionAgent, clearSessionAgent, _resetForTesting } from "../../features/claude-code-session-state"
 import { ContextCollector } from "../../features/context-injector"
 import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
+
+type ToastOptions = { body: { title: string } }
+
+function createPluginInputForKeywordDetector(showToast: (options: ToastOptions) => Promise<void>): PluginInput {
+  const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+  Object.defineProperty(client.tui, "showToast", {
+    value: async (options?: { body?: { title?: string } }) => {
+      await showToast({ body: { title: options?.body?.title ?? "" } })
+      return {
+        data: true,
+        error: undefined,
+        request: new Request("http://localhost:4096/tui/show-toast"),
+        response: new Response(),
+      }
+    },
+  })
+
+  return {
+    client,
+    project: {
+      id: "keyword-detector-test-project",
+      worktree: "/tmp/keyword-detector-test",
+      time: { created: 0 },
+    },
+    directory: "/tmp/keyword-detector-test",
+    worktree: "/tmp/keyword-detector-test",
+    serverUrl: new URL("http://localhost:4096"),
+    $: {} as PluginInput["$"],
+  }
+}
 
 describe("keyword-detector message transform", () => {
   let logCalls: Array<{ msg: string; data?: unknown }>
@@ -26,13 +59,7 @@ describe("keyword-detector message transform", () => {
   })
 
   function createMockPluginInput() {
-    return {
-      client: {
-        tui: {
-          showToast: async () => {},
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async () => {})
   }
 
   test("should prepend ultrawork message to text part", async () => {
@@ -98,6 +125,96 @@ describe("keyword-detector message transform", () => {
   })
 })
 
+describe("keyword-detector tightened search and analyze patterns", () => {
+  test("should NOT match removed English search phrases", () => {
+    // given - conversational English phrases that used to trigger search mode
+    const phrases = ["show me the code", "where is the config", "find a solution", "seek feedback", "track progress", "pinpoint the typo", "hunt the issue"]
+
+    // when - each phrase is checked against the search pattern
+    const results = phrases.map(phrase => SEARCH_PATTERN.test(phrase))
+
+    // then - none should trigger search mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should NOT match removed Korean search phrases", () => {
+    // given - casual Korean search-adjacent phrases
+    const phrases = ["못 찾아", "보여줘", "어디 있어"]
+
+    // when - each phrase is checked against the search pattern
+    const results = phrases.map(phrase => SEARCH_PATTERN.test(phrase))
+
+    // then - none should trigger search mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should NOT match removed Japanese Chinese and Vietnamese search phrases", () => {
+    // given - casual where/show phrases across non-English languages
+    const phrases = ["どこにある", "在哪里", "ở đâu"]
+
+    // when - each phrase is checked against the search pattern
+    const results = phrases.map(phrase => SEARCH_PATTERN.test(phrase))
+
+    // then - none should trigger search mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should still match kept search phrases", () => {
+    // given - explicit search intent phrases across languages
+    const phrases = ["search the codebase", "locate the hook", "grep for callers", "검색 해줘", "찾아봐", "検索して", "查找", "tìm kiếm"]
+
+    // when - each phrase is checked against the search pattern
+    const results = phrases.map(phrase => SEARCH_PATTERN.test(phrase))
+
+    // then - all should still trigger search mode
+    expect(results).toEqual(phrases.map(() => true))
+  })
+
+  test("should NOT match removed English analyze phrases", () => {
+    // given - conversational English analysis-adjacent phrases
+    const phrases = ["how to do this", "why is this failing", "how does it work", "I do not understand"]
+
+    // when - each phrase is checked against the analyze pattern
+    const results = phrases.map(phrase => ANALYZE_PATTERN.test(phrase))
+
+    // then - none should trigger analyze mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should NOT match removed Korean analyze phrases", () => {
+    // given - daily Korean troubleshooting phrases
+    const phrases = ["왜 안돼", "어떻게 해", "이해가 안돼", "설명해줘", "원인이 뭐야", "이유가 뭐야"]
+
+    // when - each phrase is checked against the analyze pattern
+    const results = phrases.map(phrase => ANALYZE_PATTERN.test(phrase))
+
+    // then - none should trigger analyze mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should NOT match removed Japanese Chinese and Vietnamese analyze phrases", () => {
+    // given - casual why/how phrases across non-English languages
+    const phrases = ["なぜ失敗する", "どう使う", "为什么失败", "tại sao lỗi"]
+
+    // when - each phrase is checked against the analyze pattern
+    const results = phrases.map(phrase => ANALYZE_PATTERN.test(phrase))
+
+    // then - none should trigger analyze mode
+    expect(results).toEqual(phrases.map(() => false))
+  })
+
+  test("should still match kept analyze phrases", () => {
+    // given - explicit analysis intent phrases across languages
+    const phrases = ["analyze the architecture", "deep-dive into hooks", "diagnose the failure", "분석 해줘", "디버그", "分析", "原理", "phân tích"]
+
+    // when - each phrase is checked against the analyze pattern
+    const results = phrases.map(phrase => ANALYZE_PATTERN.test(phrase))
+
+    // then - all should still trigger analyze mode
+    expect(results).toEqual(phrases.map(() => true))
+  })
+})
+
 describe("keyword-detector session filtering", () => {
   let logCalls: Array<{ msg: string; data?: unknown }>
   let logSpy: ReturnType<typeof spyOn>
@@ -117,15 +234,9 @@ describe("keyword-detector session filtering", () => {
 
   function createMockPluginInput(options: { toastCalls?: string[] } = {}) {
     const toastCalls = options.toastCalls ?? []
-    return {
-      client: {
-        tui: {
-          showToast: async (opts: { body: { title: string } }) => {
-            toastCalls.push(opts.body.title)
-          },
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async options => {
+      toastCalls.push(options.body.title)
+    })
   }
 
   test("should skip non-ultrawork keywords in non-main session (using mainSessionID check)", async () => {
@@ -262,15 +373,9 @@ describe("keyword-detector word boundary", () => {
 
   function createMockPluginInput(options: { toastCalls?: string[] } = {}) {
     const toastCalls = options.toastCalls ?? []
-    return {
-      client: {
-        tui: {
-          showToast: async (opts: { body: { title: string } }) => {
-            toastCalls.push(opts.body.title)
-          },
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async options => {
+      toastCalls.push(options.body.title)
+    })
   }
 
   test("should NOT trigger ultrawork on partial matches like 'StatefulWidget' containing 'ulw'", async () => {
@@ -358,13 +463,7 @@ describe("keyword-detector system-reminder filtering", () => {
   })
 
   function createMockPluginInput() {
-    return {
-      client: {
-        tui: {
-          showToast: async () => {},
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async () => {})
   }
 
   test("should NOT trigger search mode from keywords inside <system-reminder> tags", async () => {
@@ -549,13 +648,7 @@ describe("keyword-detector agent-specific ultrawork messages", () => {
   })
 
   function createMockPluginInput() {
-    return {
-      client: {
-        tui: {
-          showToast: async () => {},
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async () => {})
   }
 
   test("should skip ultrawork injection when agent is prometheus", async () => {
@@ -766,13 +859,7 @@ describe("keyword-detector non-OMO agent skipping", () => {
   })
 
   function createMockPluginInput() {
-    return {
-      client: {
-        tui: {
-          showToast: async () => {},
-        },
-      },
-    } as unknown as PluginInput
+    return createPluginInputForKeywordDetector(async () => {})
   }
 
   test("should skip all keyword injection for OpenCode-Builder agent", async () => {

--- a/src/hooks/keyword-detector/search/default.ts
+++ b/src/hooks/keyword-detector/search/default.ts
@@ -2,15 +2,15 @@
  * Search mode keyword detector.
  *
  * Triggers on search-related keywords across multiple languages:
- * - English: search, find, locate, lookup, explore, discover, scan, grep, query, browse, detect, trace, seek, track, pinpoint, hunt, where is, show me, list all
- * - Korean: 검색, 찾아, 탐색, 조회, 스캔, 서치, 뒤져, 찾기, 어디, 추적, 탐지, 찾아봐, 찾아내, 보여줘, 목록
- * - Japanese: 検索, 探して, 見つけて, サーチ, 探索, スキャン, どこ, 発見, 捜索, 見つけ出す, 一覧
- * - Chinese: 搜索, 查找, 寻找, 查询, 检索, 定位, 扫描, 发现, 在哪里, 找出来, 列出
- * - Vietnamese: tìm kiếm, tra cứu, định vị, quét, phát hiện, truy tìm, tìm ra, ở đâu, liệt kê
+ * - English: search, locate, lookup, look up, explore, discover, scan, grep, query, browse, detect, trace
+ * - Korean: 검색, 탐색, 조회, 스캔, 서치, 뒤져, 찾기, 추적, 탐지, 찾아봐, 찾아내, 목록
+ * - Japanese: 検索, 探して, 見つけて, サーチ, 探索, スキャン, 発見, 捜索, 見つけ出す, 一覧
+ * - Chinese: 搜索, 查找, 寻找, 查询, 检索, 定位, 扫描, 发现, 找出来, 列出
+ * - Vietnamese: tìm kiếm, tra cứu, định vị, quét, phát hiện, truy tìm, tìm ra, liệt kê
  */
 
 export const SEARCH_PATTERN =
-  /\b(search|find|locate|lookup|look\s*up|explore|discover|scan|grep|query|browse|detect|trace|seek|track|pinpoint|hunt)\b|where\s+is|show\s+me|list\s+all|검색|찾아|탐색|조회|스캔|서치|뒤져|찾기|어디|추적|탐지|찾아봐|찾아내|보여줘|목록|検索|探して|見つけて|サーチ|探索|スキャン|どこ|発見|捜索|見つけ出す|一覧|搜索|查找|寻找|查询|检索|定位|扫描|发现|在哪里|找出来|列出|tìm kiếm|tra cứu|định vị|quét|phát hiện|truy tìm|tìm ra|ở đâu|liệt kê/i
+  /\b(search|locate|lookup|look\s*up|explore|discover|scan|grep|query|browse|detect|trace)\b|검색|탐색|조회|스캔|서치|뒤져|찾기|추적|탐지|찾아봐|찾아내|목록|検索|探して|見つけて|サーチ|探索|スキャン|発見|捜索|見つけ出す|一覧|搜索|查找|寻找|查询|检索|定位|扫描|发现|找出来|列出|tìm kiếm|tra cứu|định vị|quét|phát hiện|truy tìm|tìm ra|liệt kê/i
 
 export const SEARCH_MESSAGE = `[search-mode]
 MAXIMIZE SEARCH EFFORT. Launch multiple background agents IN PARALLEL:

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -1053,7 +1053,6 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should show countdown toast updates", async () => {
-    fakeTimers.restore()
     // given - session with incomplete todos
     const sessionID = "main-toast"
     setMainSession(sessionID)
@@ -1066,7 +1065,7 @@ describe("todo-continuation-enforcer", () => {
     })
 
     // then - multiple toast updates during countdown (2s countdown = 2 toasts: "2s" and "1s")
-    await wait(2500)
+    await fakeTimers.advanceBy(1500)
     expect(toastCalls.length).toBeGreaterThanOrEqual(2)
     expect(toastCalls[0].message).toContain("2s")
   }, { timeout: 15000 })


### PR DESCRIPTION
## Summary
Tightens keyword-detector search/analyze regexes so normal conversational prompts no longer activate mode injection.

## Problem
Audit data showed broad tokens like `show me`, `find`, `where is`, `how to`, `why is`, and multilingual everyday how/why/where phrases caused search/analyze modes to trigger on roughly 30-60% of normal conversational messages.

## Changes
| Pattern | Removed high-FP classes | Kept intentful triggers |
|---|---|---|
| Search | English presentation/location/general verbs; Korean/Japanese/Chinese/Vietnamese casual where/show/find variants | `search`, `locate`, `lookup`, `explore`, `scan`, `grep`, `query`, `detect`, `trace`, plus explicit multilingual search/list/scan terms |
| Analyze | English how/why/understand phrases; Korean/Japanese/Chinese/Vietnamese daily how/why/explain/cause/reason terms | `analyze`, `investigate`, `audit`, `diagnose`, `deep-dive`, `evaluate`, `review`, `debug`, plus explicit multilingual analysis/debug/research terms |

Also refactored `constants.ts` to reuse `ANALYZE_PATTERN` instead of maintaining a duplicate inline analyze regex.

## Testing
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/hooks/keyword-detector/search/default.ts src/hooks/keyword-detector/analyze/default.ts src/hooks/keyword-detector/constants.ts src/hooks/keyword-detector/index.test.ts` ✅
- `bun test src/hooks/keyword-detector/` ✅ 54 pass
- `bun run typecheck` ✅
- LSP diagnostics clean for changed source files; test file LSP reports stale workspace Bun type resolution while `tsc --noEmit` passes.

## Audit data
Before this tightening, audit samples found search/analyze patterns firing on ~30-60% of normal conversational messages due to daily phrasing rather than explicit mode intent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened keyword-detector patterns for search/analyze to stop casual conversation from triggering modes across EN/KR/JP/ZH/VI. Also aligned the Opus Sisyphus prompt with dev, including conditional browser QA via `playwright` and corrected `<Role>` tags.

- **Bug Fixes**
  - Narrowed `SEARCH_PATTERN` and `ANALYZE_PATTERN` to drop casual phrases (e.g., "show me", "where is", "how to/why") and multilingual equivalents; kept explicit intents like `search`, `grep`, `analyze`, `diagnose`, `debug`.
  - Added tests with negative/positive cases across languages, a TUI toast stub via `@opencode-ai/sdk`, and made the todo-continuation countdown deterministic with fake timers. Updated `AGENTS.md` to document the tighter trigger scope.
  - Restored/aligned Opus Sisyphus prompt contracts with a dynamic browser QA instruction that uses `playwright` when available and fixed `<Role>` tag casing.

- **Refactors**
  - Reused `ANALYZE_PATTERN` in `constants.ts` and consolidated pattern/message exports under `search/default.ts` and `analyze/default.ts`.

<sup>Written for commit 28059adc05ec9b17add67168b7f385ccc8c98ace. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3696?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

