### PR TITLE
fix: add --no-messages and tolerate exit code 2 in glob/grep tools

### DIFF
--- a/src/tools/glob/cli.test.ts
+++ b/src/tools/glob/cli.test.ts
@@ -47,6 +47,14 @@ describe("buildRgArgs", () => {
     expect(args).toContain("--follow")
   })
 
+  // given any options
+  // when building ripgrep args
+  // then should include --no-messages to suppress broken symlink warnings
+  it("includes --no-messages to suppress I/O warnings", () => {
+    const args = buildRgArgs({ pattern: "*.ts" })
+    expect(args).toContain("--no-messages")
+  })
+
   // given pattern with special characters
   // when building ripgrep args
   // then should include glob pattern correctly

--- a/src/tools/glob/cli.ts
+++ b/src/tools/glob/cli.ts
@@ -152,7 +152,7 @@ async function runRgFilesInternal(
     const stderr = await new Response(proc.stderr).text()
     const exitCode = await proc.exited
 
-    if (exitCode > 1 && stderr.trim()) {
+    if (exitCode > 2 && stderr.trim()) {
       return {
         files: [],
         totalFiles: 0,

--- a/src/tools/glob/constants.ts
+++ b/src/tools/glob/constants.ts
@@ -8,5 +8,6 @@ export const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024
 export const RG_FILES_FLAGS = [
   "--files",
   "--color=never",
+  "--no-messages",
   "--glob=!.git/*",
 ] as const

--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -197,7 +197,7 @@ async function runRgInternal(options: GrepOptions, resolvedCli?: ResolvedCli): P
     const truncated = stdout.length >= DEFAULT_MAX_OUTPUT_BYTES
     const outputToProcess = truncated ? stdout.substring(0, DEFAULT_MAX_OUTPUT_BYTES) : stdout
 
-    if (exitCode > 1 && stderr.trim()) {
+    if (exitCode > 2 && stderr.trim()) {
       return {
         matches: [],
         totalMatches: 0,

--- a/src/tools/grep/constants.ts
+++ b/src/tools/grep/constants.ts
@@ -10,6 +10,7 @@ export const RG_SAFETY_FLAGS = [
   "--no-follow",
   "--color=never",
   "--no-heading",
+  "--no-messages",
   "--line-number",
   "--with-filename",
 ] as const


### PR DESCRIPTION
## Summary

- Fix glob and grep tools failing when broken/dangling symlinks exist in the search path
- Ripgrep exit code 2 (partial I/O errors) was treated as fatal, discarding valid stdout results

## Changes

- **`src/tools/glob/constants.ts`**: Add `--no-messages` to `RG_FILES_FLAGS` to suppress non-fatal I/O warnings
- **`src/tools/glob/cli.ts`**: Change exit code check from `> 1` to `> 2` so broken symlinks don't discard valid results
- **`src/tools/grep/constants.ts`**: Add `--no-messages` to `RG_SAFETY_FLAGS` (same fix)
- **`src/tools/grep/cli.ts`**: Change exit code check from `> 1` to `> 2` (same fix)
- **`src/tools/glob/cli.test.ts`**: Add test verifying `--no-messages` is included in ripgrep args

## Testing

```bash
bun run typecheck
bun test src/tools/glob/cli.test.ts
```

All 19 glob CLI tests pass, typecheck clean.

## Related Issues

Closes #3726

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix glob and grep to handle broken/dangling symlinks without dropping valid results by adding `--no-messages` to ripgrep flags and treating exit code 2 as non‑fatal. Closes #3726.

<sup>Written for commit 7056fc13f336d95849609ebe5fe2cb20b8e8b7a3. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3727?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

