### PR TITLE
fix(schema): preserve custom agent overrides

### DIFF
--- a/src/config/schema/agent-overrides.test.ts
+++ b/src/config/schema/agent-overrides.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { AgentOverridesSchema } from "./agent-overrides"
+
+describe("AgentOverridesSchema", () => {
+  test("preserves custom agent keys after parsing", () => {
+    const input = {
+      sisyphus: { model: "anthropic/claude-opus-4-6" },
+      "technical-writer": {
+        model: "anthropic/claude-sonnet-4-6",
+        temperature: 0.3,
+        prompt_append: "You are a technical writer.",
+      },
+    }
+
+    const result = AgentOverridesSchema.safeParse(input)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sisyphus).toBeDefined()
+      expect(result.data["technical-writer"]).toBeDefined()
+      expect(result.data["technical-writer"]?.model).toBe("anthropic/claude-sonnet-4-6")
+      expect(result.data["technical-writer"]?.temperature).toBe(0.3)
+    }
+  })
+
+  test("validates custom agent keys against AgentOverrideConfigSchema", () => {
+    const input = {
+      "custom-agent": {
+        model: "provider/model",
+        temperature: 5, // invalid: max is 2
+      },
+    }
+
+    const result = AgentOverridesSchema.safeParse(input)
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -72,7 +72,7 @@ export const AgentOverridesSchema = z.object({
   explore: AgentOverrideConfigSchema.optional(),
   "multimodal-looker": AgentOverrideConfigSchema.optional(),
   atlas: AgentOverrideConfigSchema.optional(),
-})
+}).catchall(AgentOverrideConfigSchema.optional())
 
 export type AgentOverrideConfig = z.infer<typeof AgentOverrideConfigSchema>
 export type AgentOverrides = z.infer<typeof AgentOverridesSchema>


### PR DESCRIPTION
## Summary

- `AgentOverridesSchema` silently strips custom agent keys during Zod parsing because only 14 built-in names are defined
- Adding `.catchall(AgentOverrideConfigSchema.optional())` preserves user-defined agent configs while still validating them against the same schema as built-ins

## Problem

Users defining custom agents in `oh-my-opencode.jsonc`:

```jsonc
"agents": {
  "technical-writer": {
    "model": "anthropic/claude-sonnet-4-6",
    "temperature": 0.3
  }
}
```

The config parses "successfully" but `technical-writer` is silently dropped. The agent is still callable (via `agent-resolver.ts` dynamic discovery from [#2299](https://github.com/code-yeongyu/oh-my-openagent/pull/2299)), but runs with default settings instead of the user's configured model/temperature/prompt.

## Changes

- `agent-overrides.ts`: Add `.catchall(AgentOverrideConfigSchema.optional())` to `AgentOverridesSchema`
- `agent-overrides.test.ts`: Two tests — custom key preservation and validation of custom key values

## Testing

```bash
bun test src/config/schema/agent-overrides.test.ts    # 2 pass
bun run typecheck                                      # clean
```

## Related

- Closes [#3229](https://github.com/code-yeongyu/oh-my-openagent/issues/3229) (remaining schema-side root cause; agent invocation was fixed in [#2299](https://github.com/code-yeongyu/oh-my-openagent/pull/2299))
- Related to [#3228](https://github.com/code-yeongyu/oh-my-openagent/issues/3228) — `task(subagent_type)` model inheritance is a separate code path, not fixed here

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->