### PR TITLE
fix(resolve-file-uri): remove project boundary check for prompt file:// URIs

### DIFF
--- a/src/agents/builtin-agents/resolve-file-uri.test.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
-import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { resolvePromptAppend } from "./resolve-file-uri"
@@ -14,8 +14,6 @@ describe("resolvePromptAppend", () => {
   const relativeFilePath = join(configDir, "relative.txt")
   const spacedFilePath = join(fixtureRoot, "with space.txt")
   const homeFilePath = join(homeFixtureDir, "home.txt")
-  const escapedFilePath = join(fixtureRoot, "escaped.txt")
-  const linkedAbsolutePath = join(configDir, "linked-absolute.txt")
 
   beforeAll(() => {
     mkdirSync(fixtureRoot, { recursive: true })
@@ -26,8 +24,6 @@ describe("resolvePromptAppend", () => {
     writeFileSync(relativeFilePath, "relative-content", "utf8")
     writeFileSync(spacedFilePath, "encoded-content", "utf8")
     writeFileSync(homeFilePath, "home-content", "utf8")
-    writeFileSync(escapedFilePath, "escaped-content", "utf8")
-    symlinkSync(absoluteFilePath, linkedAbsolutePath)
   })
 
   afterAll(() => {
@@ -56,6 +52,17 @@ describe("resolvePromptAppend", () => {
     expect(resolved).toBe("absolute-content")
   })
 
+  test("resolves absolute file URI regardless of project boundary", () => {
+    //#given
+    const input = `file://${absoluteFilePath}`
+
+    //#when
+    const resolved = resolvePromptAppend(input, configDir)
+
+    //#then
+    expect(resolved).toBe("absolute-content")
+  })
+
   test("resolves relative file URI using configDir", () => {
     //#given
     const input = "file://./relative.txt"
@@ -69,13 +76,13 @@ describe("resolvePromptAppend", () => {
 
   test("resolves home directory URI path", () => {
     //#given
-    const input = "file://~/fixture-home/home.txt"
+    const input = `file://${homeFilePath}`
 
     //#when
-    const resolved = resolvePromptAppend(input, homeFixtureRoot)
+    const resolved = resolvePromptAppend(input)
 
     //#then
-    expect(resolved).toContain("[WARNING: Path rejected:")
+    expect(resolved).toBe("home-content")
   })
 
   test("resolves percent-encoded URI path", () => {
@@ -109,53 +116,5 @@ describe("resolvePromptAppend", () => {
 
     //#then
     expect(resolved).toContain("[WARNING: Could not resolve file URI")
-  })
-
-  test("rejects absolute file URI outside configDir", () => {
-    //#given
-    const input = `file://${absoluteFilePath}`
-
-    //#when
-    const resolved = resolvePromptAppend(input, configDir)
-
-    //#then
-    expect(resolved).toContain("[WARNING: Path rejected:")
-    expect(resolved).not.toContain("absolute-content")
-  })
-
-  test("rejects traversal file URI that escapes configDir", () => {
-    //#given
-    const input = "file://../escaped.txt"
-
-    //#when
-    const resolved = resolvePromptAppend(input, configDir)
-
-    //#then
-    expect(resolved).toContain("[WARNING: Path rejected:")
-    expect(resolved).not.toContain("escaped-content")
-  })
-
-  test("rejects symlink file URI that escapes configDir", () => {
-    //#given
-    const input = "file://./linked-absolute.txt"
-
-    //#when
-    const resolved = resolvePromptAppend(input, configDir)
-
-    //#then
-    expect(resolved).toContain("[WARNING: Path rejected:")
-    expect(resolved).not.toContain("absolute-content")
-  })
-
-  test("rejection warning explains the project boundary restriction (issue #3554)", () => {
-    //#given
-    const input = `file://${absoluteFilePath}`
-
-    //#when
-    const resolved = resolvePromptAppend(input, configDir)
-
-    //#then
-    expect(resolved).toContain("[WARNING: Path rejected:")
-    expect(resolved).toMatch(/outside project root/i)
   })
 })

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -1,8 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, resolve } from "node:path"
-import { isWithinProject } from "../../shared/contains-path"
-import { log } from "../../shared/logger"
 
 export function resolvePromptAppend(promptAppend: string, configDir?: string): string {
   if (!promptAppend.startsWith("file://")) return promptAppend
@@ -18,16 +16,6 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
       : resolve(configDir ?? process.cwd(), expanded)
   } catch {
     return `[WARNING: Malformed file URI (invalid percent-encoding): ${promptAppend}]`
-  }
-
-  const projectRoot = configDir ?? process.cwd()
-  if (!isWithinProject(filePath, projectRoot)) {
-    log("[resolve-file-uri] Rejected file URI outside project root", {
-      promptAppend,
-      filePath,
-      projectRoot,
-    })
-    return `[WARNING: Path rejected: ${promptAppend} (resolved outside project root ${projectRoot}; file:// prompts must reside within the project boundary)]`
   }
 
   if (!existsSync(filePath)) {


### PR DESCRIPTION
## Summary

Remove the `isWithinProject` boundary restriction from `resolvePromptAppend()` so that `file://` prompt URIs behave as documented — supporting absolute, home-relative (`~/`), and project-relative paths — instead of being silently rejected with a `[WARNING: Path rejected: ...]` placeholder.

## Root Cause

Since commit [`9865978`](https://github.com/code-yeongyu/oh-my-openagent/commit/98659783c0def8ecf60c4f6108c119a5f6435f73) ("fix(security): confine file resolution to project roots"), `resolvePromptAppend()` has called `isWithinProject(filePath, configDir ?? process.cwd())` and rejected any path that resolves outside the current working directory or config directory.

This contradicts the [configuration reference](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/docs/reference/configuration.md#file-uris-for-prompts) which explicitly documents support for all three forms:

> Paths can be absolute (`file:///abs/path`), relative to project root (`file://./rel/path`), or home-relative (`file://~/home/path`).

The same documentation also describes cross-project prompt sharing as a primary motivation for `file://` support. The boundary check makes this impossible when the prompt file lives in a shared global directory (e.g. `~/.config/opencode/prompts/`).

The check was added for security, but `prompt` and `prompt_append` are user-configured fields — the user is deliberately pointing to a file they want loaded into the agent prompt. Other parts of the codebase (skill loader, config discovery) already have their own `isWithinProject` guards where project isolation is genuinely needed.

## Changes

| File | Change |
|------|--------|
| `src/agents/builtin-agents/resolve-file-uri.ts` | Remove `isWithinProject` import, `log` import, and the boundary check block. |
| `src/agents/builtin-agents/resolve-file-uri.test.ts` | Remove 3 rejection tests, add 1 cross-boundary test, update home-directory test. |

## Verification

```
bun test src/agents/builtin-agents/resolve-file-uri.test.ts  → 8 pass / 0 fail
bun test src/agents/sisyphus-junior/index.test.ts             → 47 pass / 0 fail
bun run typecheck                                              → clean
```

## Related

- **#3554** — bug report describing the docs-vs-implementation gap
- **#3679** — improved the rejection warning but preserved the restriction
- **[Configuration Reference](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/docs/reference/configuration.md#file-uris-for-prompts)** — documents `file://` support for absolute / `~/` / relative paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the project boundary check from `resolvePromptAppend()` so `file://` prompt URIs can load absolute, home, and project‑relative files as documented. This removes false “[WARNING: Path rejected]” and enables cross‑project prompt sharing.

- **Bug Fixes**
  - Dropped project-root restriction and related logging in `resolvePromptAppend()` so absolute paths load regardless of `configDir`.
  - Kept warnings for malformed URIs and missing files; updated tests to remove boundary-rejection cases (absolute/traversal/symlink) and add cross‑boundary and home‑dir success cases.

<sup>Written for commit cee1fd1d91fb54c9cfcc7167223477c94f22ab23. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3752?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

