### PR TITLE
fix: resolve ${CLAUDE_PLUGIN_ROOT} in plugin commands, agents, and skills

### DIFF
--- a/src/features/claude-code-plugin-loader/agent-loader.ts
+++ b/src/features/claude-code-plugin-loader/agent-loader.ts
@@ -4,6 +4,7 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { log } from "../../shared/logger"
 import { parseToolsConfig } from "../../shared/parse-tools-config"
+import { resolvePluginPath } from "./plugin-path-resolver"
 import type { AgentFrontmatter, ClaudeCodeAgentConfig } from "../claude-code-agent-loader/types"
 import { mapClaudeModelToOpenCode } from "../claude-code-agent-loader/claude-model-mapper"
 import type { LoadedPlugin } from "./types"
@@ -38,7 +39,7 @@ export function loadPluginAgents(plugins: LoadedPlugin[]): Record<string, Claude
         const config: ClaudeCodeAgentConfig = {
           description: formattedDescription,
           mode: "subagent",
-          prompt: body.trim(),
+          prompt: resolvePluginPath(body.trim(), plugin.installPath),
           ...(modelString ? { model: modelString } : {}),
         }
 

--- a/src/features/claude-code-plugin-loader/command-loader.ts
+++ b/src/features/claude-code-plugin-loader/command-loader.ts
@@ -3,6 +3,7 @@ import { basename, join } from "path"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { sanitizeModelField } from "../../shared/model-sanitizer"
+import { resolvePluginPath } from "./plugin-path-resolver"
 import { log } from "../../shared/logger"
 import type { CommandDefinition, CommandFrontmatter } from "../claude-code-command-loader/types"
 import type { LoadedPlugin } from "./types"
@@ -26,7 +27,8 @@ export function loadPluginCommands(plugins: LoadedPlugin[]): Record<string, Comm
         const content = readFileSync(commandPath, "utf-8")
         const { data, body } = parseFrontmatter<CommandFrontmatter>(content)
 
-        const wrappedTemplate = `<command-instruction>\n${body.trim()}\n</command-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>`
+        const resolvedBody = resolvePluginPath(body, plugin.installPath)
+        const wrappedTemplate = `<command-instruction>\n${resolvedBody.trim()}\n</command-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>`
         const formattedDescription = `(plugin: ${plugin.name}) ${data.description || ""}`
 
         const definition = {

--- a/src/features/claude-code-plugin-loader/skill-loader.ts
+++ b/src/features/claude-code-plugin-loader/skill-loader.ts
@@ -4,6 +4,7 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import { resolveSymlink } from "../../shared/file-utils"
 import { sanitizeModelField } from "../../shared/model-sanitizer"
 import { resolveSkillPathReferences } from "../../shared/skill-path-resolver"
+import { resolvePluginPath } from "./plugin-path-resolver"
 import { log } from "../../shared/logger"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { SkillMetadata } from "../opencode-skill-loader/types"
@@ -39,7 +40,8 @@ export function loadPluginSkillsAsCommands(
         const formattedDescription = `(plugin: ${plugin.name} - Skill) ${originalDescription}`
 
         const resolvedBody = resolveSkillPathReferences(body.trim(), resolvedPath)
-        const wrappedTemplate = `<skill-instruction>\nBase directory for this skill: ${resolvedPath}/\nFile references (@path) in this skill are relative to this directory.\n\n${resolvedBody}\n</skill-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>`
+        const pluginResolvedBody = resolvePluginPath(resolvedBody, plugin.installPath)
+        const wrappedTemplate = `<skill-instruction>\nBase directory for this skill: ${resolvedPath}/\nFile references (@path) in this skill are relative to this directory.\n\n${pluginResolvedBody}\n</skill-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>`
 
         const definition = {
           name: namespacedName,


### PR DESCRIPTION
## Summary

When loading Claude Code plugins, `${CLAUDE_PLUGIN_ROOT}` is correctly resolved in hooks JSON config via `resolvePluginPath`. However, the markdown body content of **commands**, **agents**, and **skills** is passed through as-is without variable substitution.

This causes plugin commands (e.g. `codex:review`, `codex:rescue`) to fail when executed in OpenCode, because the generated bash command contains the literal `${CLAUDE_PLUGIN_ROOT}` string which is unset in the shell environment.

## Changes

Apply `resolvePluginPath` to the body content in three loaders:

- **`command-loader.ts`**: resolve command body before wrapping in template
- **`agent-loader.ts`**: resolve agent prompt body
- **`skill-loader.ts`**: resolve skill body after `@path` references are handled

## Reproduction

1. Install the OpenAI codex plugin (`openai/codex-plugin-cc`)
2. Start OpenCode (not Claude Code)
3. Run `/codex:review`
4. Observe error: `CLAUDE_PLUGIN_ROOT` is not set, scripts cannot be found

## Fix verification

After this change, `${CLAUDE_PLUGIN_ROOT}` in plugin markdown content is replaced with the actual `installPath` at load time, matching the existing behavior for hooks JSON config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin execution failures by resolving `${CLAUDE_PLUGIN_ROOT}` in command bodies, agent prompts, and skill content at load time. Plugins now run correctly in OpenCode without relying on shell env vars.

- **Bug Fixes**
  - Apply `resolvePluginPath` to command body before templating in `command-loader.ts`.
  - Apply `resolvePluginPath` to agent `prompt` in `agent-loader.ts`.
  - In `skill-loader.ts`, run `resolvePluginPath` after `@path` resolution and before templating.

<sup>Written for commit a26117d944b4cdf27653e5853c1301c2cacb23e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

