### PR TITLE
fix(hooks): do not clear sessionFirstMessageProcessed on session.idle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,17 +30,17 @@
         "zod": "^4.3.0",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.17.12",
-        "oh-my-opencode-darwin-x64": "3.17.12",
-        "oh-my-opencode-darwin-x64-baseline": "3.17.12",
-        "oh-my-opencode-linux-arm64": "3.17.12",
-        "oh-my-opencode-linux-arm64-musl": "3.17.12",
-        "oh-my-opencode-linux-x64": "3.17.12",
-        "oh-my-opencode-linux-x64-baseline": "3.17.12",
-        "oh-my-opencode-linux-x64-musl": "3.17.12",
-        "oh-my-opencode-linux-x64-musl-baseline": "3.17.12",
-        "oh-my-opencode-windows-x64": "3.17.12",
-        "oh-my-opencode-windows-x64-baseline": "3.17.12",
+        "oh-my-opencode-darwin-arm64": "3.17.13",
+        "oh-my-opencode-darwin-x64": "3.17.13",
+        "oh-my-opencode-darwin-x64-baseline": "3.17.13",
+        "oh-my-opencode-linux-arm64": "3.17.13",
+        "oh-my-opencode-linux-arm64-musl": "3.17.13",
+        "oh-my-opencode-linux-x64": "3.17.13",
+        "oh-my-opencode-linux-x64-baseline": "3.17.13",
+        "oh-my-opencode-linux-x64-musl": "3.17.13",
+        "oh-my-opencode-linux-x64-musl-baseline": "3.17.13",
+        "oh-my-opencode-windows-x64": "3.17.13",
+        "oh-my-opencode-windows-x64-baseline": "3.17.13",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -241,27 +241,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.17.12", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VNLtKIG1PPng1TXtexsvBSAdF9CnUEl2NW+0WCh+lsYMSiVocqjDx1OsWQc2dkWMXzFgAKZReHNH99X8wamCzg=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.17.13", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5n+eEhh7tfE62BT8cC2XjTXubcXQOEGNTCWSOZ7C1mrE9E5xbvPb/ctWLrGTIk9rkl5+MJW3IZ7HLniAphxCEA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.17.12", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xEYo9zD6i5xl8i/O4Vm4mCohcbEvrAm0+CTwnONgc1kqjsN+OmxQNawjZIeEudyUsRFX/Nup7RZvIzzHSTxbBA=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.17.13", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-PMy2e+gH7C3w1BHbtvHWKajxCbP2srV9N+Rv5nJ4Xh1SuSUO+8U+DlASsbCo6ArskP3IyJVRyykm34nLdkcu6w=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@3.17.12", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kftD+jN+ILw8UyMThrE7LS5/kEAx6z3qpylWqLiIGVm1s0hgpKjreLlpgZzmOBGbTHtXRvUlZ83V/303bJ0WKw=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@3.17.13", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-n1qw52wVqoqpoDrH/AnHq4YznzV8nPbrUtm/18aChklrLjGJafn0oVnhUVFfceqKKqsFtU6A4OgkRgTK46vhUQ=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.17.12", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-bLJcscvUvlPNpiTcKSDM0ZtOBf4iiHbwCXZwwK1qWRPuG4pTKCtdNHDiGQ5d8G7EaOL9WO5zNtnQ5WrmPOMUXA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.17.13", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JYpDFUbMj9NZRODA+cP63+hgi+G+uBp6Tqjy/FyK/xi0kIs+yIaR4dYni515mJ4SMfErPkDue2m0S/ljawTV3A=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.17.12", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-BWEQQZv/+mFvc/23KhkoDX1NaNYi8+NVaC8ETZjswmvqtCs6HvJruDBDJ0ORHKarVqHT8n9Ntu/dexx58wEcYQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.17.13", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wYHvdf0C+8gyw28NOhGAdR6UK8BIeL+BDTq6fC9FDmDY4xqQN8YiwGKj/vYChQJfPrI9fKhaZF++lIiJn23DpQ=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.17.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Jkx5L1mXtYDU1lyTcjP1E6tjEwx5/yAwrkDcAI8pDbswY3hfObZPF5Qvny1iz3abstlnMvh+y5kvb8bdN/pMKg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.17.13", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-3/kHPfRuAX7blK1onPEBn72TRM1yoWooVRMYNRfufXJz1lcCq+Oxgn2PfEbEit84XKWpGa9RGJ+m3Oc0Pe9seQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@3.17.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-DhGPVrmgc1UtX/4qhyWvUDs/Vyo427DiDKsPcaGEReUlvi/rl3qwHR72Bp+WbEeL66YJ8xWoOfb5wvx1K1qZNw=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@3.17.13", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-nl07YZIpPhh6sVc86YcO8bKVhUlh82RkmldzMBM/xJSGqoj2vLwq+Ab9LxmLqPZVh8BIzPhWf4qgJhLhy9UA3g=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.17.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ub/IANRmI5/5EUE7gD2iOixK4Gw8pXrKp2fCJszDuGs6FJYVVMv/vfAGXedTljYlhAegirKUgd+xoXQEIC+h+w=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.17.13", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-AfHEN9pp8a67N/sVglHSNADRHKag/4IstOtwCzhTqQw/T2NIvjuQGYvTLUzPcbyP1OH3V/TbpN+sEg/FUaWAkA=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@3.17.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-P3kU1kxlZrh3pUx1eyMm5IpZybjmxyDWqFVIl4grbTwImk9v9OldmNgPXELa/CR6ovNMZbJRbqQwn24DtiOC1w=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@3.17.13", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-d/xD1lod2rWq0/pgwECG45/yxO7smErlwFca2JDwTCgwCksDpl/aw/I0Js05a6cJaix+02pyPKhet/StxcLyzQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.17.12", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-d1SWspVURw9ojlGA4/IFPQPTk2GWf40W7KY2YXuNjq6pva0eQ5RCDaa4vJie00VXE4fUHHmY12ck1wGleWZ8Xg=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.17.13", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-HSPsItIqAIVqodIPhr6sL8+DNam53bJSTivrVQb7+S5yeIeQ6WkM22E7EkvZmuP0jGMYwWr6jZMgR8or1C2PfA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@3.17.12", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XkYh9mujhub87cz5bsMxRF0kVSus0BOsnt6A2z3KwzhjC2xt0rwSdO5VkFZ6niwrIzgLRYaAEZ7nVOjTNKP7pg=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@3.17.13", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-NjrXpTZcBTYZ490vt+6YJCTc3aaeW+4qNQ+NQ8o4eUH17ehnCUl/1SwORLx7DqkbxIM0JFkZm1oypTkEn0OsXQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/claude-code-hooks/session-hook-state.ts
+++ b/src/hooks/claude-code-hooks/session-hook-state.ts
@@ -7,7 +7,12 @@ export const sessionInterruptState = new Map<string, { interrupted: boolean }>()
 export function clearSessionHookState(sessionID: string): void {
 	sessionErrorState.delete(sessionID)
 	sessionInterruptState.delete(sessionID)
-	sessionFirstMessageProcessed.delete(sessionID)
+	// sessionFirstMessageProcessed must NOT be cleared on idle.
+	// It tracks whether the first message of a session has been processed,
+	// so that SessionStart hooks fire only once per session. Clearing it
+	// on idle (which fires after every model response) makes isFirstMessage
+	// always return true, causing SessionStart hooks to fire on every
+	// prompt instead of only the first one.
 }
 
 export function clearAllSessionHookState(): void {


### PR DESCRIPTION
# fix(hooks): do not clear sessionFirstMessageProcessed on session.idle

## Problem

SessionStart hooks fire on every user prompt instead of only at session start. This causes plugins (e.g., superpowers) that register `SessionStart` hooks to inject their context on every message, wasting tokens and cluttering the conversation.

## Root Cause

`clearSessionHookState(sessionID)` is called on every `session.idle` event (in `src/hooks/claude-code-hooks/handlers/session-event-handler.ts`). This function clears three state maps:

```typescript
function clearSessionHookState(sessionID: string) {
  sessionErrorState.delete(sessionID);
  sessionInterruptState.delete(sessionID);
  sessionFirstMessageProcessed.delete(sessionID); // <-- BUG
}
```

The first two (`sessionErrorState` and `sessionInterruptState`) are transient per-response state that should be cleared between turns. But `sessionFirstMessageProcessed` is a **session-level** flag that tracks whether the first message of a session has been processed. Clearing it on every `session.idle` causes `isFirstMessage` to always return `true`:

```typescript
// In chat-message-handler.ts:
const isFirstMessage = !sessionFirstMessageProcessed.has(input.sessionID);
sessionFirstMessageProcessed.add(input.sessionID);
```

Since `session.idle` fires after every model response, `sessionFirstMessageProcessed` is cleared before the next user prompt, making `isFirstMessage` always `true`. This causes `SessionStart` hooks to execute on every prompt instead of only the first one.

## Fix

Remove `sessionFirstMessageProcessed.delete(sessionID)` from `clearSessionHookState`. The `sessionFirstMessageProcessed` set should only be cleared when the session is fully deleted (in `clearAllSessionHookState`), not on every idle event.

### `src/hooks/claude-code-hooks/session-hook-state.ts`

```diff
 function clearSessionHookState(sessionID: string) {
   sessionErrorState.delete(sessionID);
   sessionInterruptState.delete(sessionID);
-  sessionFirstMessageProcessed.delete(sessionID);
+  // sessionFirstMessageProcessed should NOT be cleared on idle -
+  // it tracks whether the first message of a session has been processed.
+  // Clearing it on idle makes isFirstMessage always return true,
+  // causing SessionStart hooks to fire on every prompt instead of once.
 }
```

`clearAllSessionHookState()` (called on `session.deleted` and `dispose`) remains unchanged - it still clears `sessionFirstMessageProcessed` via `.clear()`, which is correct because the session is truly ending.

## Why This Is Correct

| State Map | Purpose | Cleared on idle? | Why? |
|-----------|---------|-------------------|------|
| `sessionErrorState` | Tracks per-response errors | Yes | Errors are transient between turns |
| `sessionInterruptState` | Tracks per-response interrupts | Yes | Interrupts are transient between turns |
| `sessionFirstMessageProcessed` | Tracks whether first message was processed | **No** | First-message status persists for the entire session |

The `session.idle` event fires after every model response. Clearing error and interrupt state between turns is correct - those are per-response concerns. But `sessionFirstMessageProcessed` is a session-level concern: once the first message has been processed, it should remain processed for the rest of the session.

## Related Issues

- #2394 - Added SessionStart/SessionEnd hook bridging (the feature this fix depends on)
- #594 - Opposite problem: hooks only firing once (fixed in #1618 by changing tag deduplication logic)

## Testing

1. Configure a plugin with a `SessionStart` hook (e.g., superpowers)
2. Start a new session - hook should fire on the first prompt
3. Send a second prompt - hook should NOT fire
4. Send additional prompts - hook should NOT fire
5. Start a new session - hook should fire again on the first prompt

Without this fix, step 3 and 4 would incorrectly fire the SessionStart hook.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `SessionStart` hooks from firing on every prompt by preserving the session-level first-message flag across turns. Hooks now run only once per session, and optional `oh-my-opencode-*` binaries are bumped to 3.17.13.

- **Bug Fixes**
  - Stop deleting `sessionFirstMessageProcessed` in `clearSessionHookState` (called on `session.idle`); only clear it in `clearAllSessionHookState` when the session ends.

<sup>Written for commit 1a43c9d120818a6a3f0fc932cebb5feb2fda46d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

