### PR TITLE
fix(electron): prevent desktop plugin load failures from Bun-only runtime paths

### DIFF
--- a/src/features/tmux-subagent/pane-state-querier.ts
+++ b/src/features/tmux-subagent/pane-state-querier.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 import type { WindowState, TmuxPaneInfo } from "./types"
 import { parsePaneStateOutput } from "./pane-state-parser"
 import { getTmuxPath } from "../../tools/interactive-bash/tmux-path-resolver"

--- a/src/hooks/comment-checker/cli.ts
+++ b/src/hooks/comment-checker/cli.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 import { createRequire } from "module"
 import { dirname, join } from "path"
 import { existsSync } from "fs"
@@ -206,8 +206,12 @@ export async function runCommentChecker(input: HookInput, cliPath?: string, cust
 
     try {
       // Write JSON to stdin
-      proc.stdin.write(jsonInput)
-      proc.stdin.end()
+      const stdin = proc.stdin as
+        | { write?: (chunk: string) => unknown; end?: () => unknown }
+        | null
+        | undefined
+      stdin?.write?.(jsonInput)
+      stdin?.end?.()
 
       const stdoutPromise = new Response(proc.stdout).text()
       const stderrPromise = new Response(proc.stderr).text()

--- a/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
+++ b/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as sharedModule from "../shared"
+import {
+  __resetBunSqliteImporterForTesting,
+  __setBunSqliteImporterForTesting,
+  scheduleDeferredModelOverride,
+} from "./ultrawork-db-model-override"
+
+function flushMicrotasks(depth: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let remaining = depth
+
+    function step() {
+      if (remaining <= 0) {
+        resolve()
+        return
+      }
+
+      remaining--
+      queueMicrotask(step)
+    }
+
+    queueMicrotask(step)
+  })
+}
+
+describe("scheduleDeferredModelOverride bun:sqlite unavailable", () => {
+  let logCalls: Array<[string, Record<string, unknown> | undefined]> = []
+
+  beforeEach(() => {
+    __setBunSqliteImporterForTesting(async () => null)
+
+    spyOn(sharedModule, "log").mockImplementation((message: string, metadata?: Record<string, unknown>) => {
+      logCalls.push([message, metadata])
+    })
+  })
+
+  afterEach(() => {
+    __resetBunSqliteImporterForTesting()
+    mock.restore()
+    logCalls = []
+  })
+
+  test("returns safely when bun:sqlite is unavailable", async () => {
+    expect(() => {
+      scheduleDeferredModelOverride("msg_unavailable", {
+        providerID: "anthropic",
+        modelID: "claude-opus-4-7",
+      })
+    }).not.toThrow()
+
+    await flushMicrotasks(5)
+
+    const messages = logCalls.map(([message]) => message)
+    expect(messages).toContain(
+      "[ultrawork-db-override] bun:sqlite unavailable (non-Bun runtime), skipping deferred override",
+    )
+  })
+})

--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -1,8 +1,26 @@
-import { Database } from "bun:sqlite"
 import { join } from "node:path"
 import { existsSync } from "node:fs"
 import { getDataDir } from "../shared/data-path"
 import { log } from "../shared"
+
+type BunDatabase = import("bun:sqlite").Database
+type SqliteModule = { Database: new (path: string) => BunDatabase }
+
+/** @internal test-only seam: override to simulate non-Bun runtime */
+let bunSqliteImporter: () => Promise<SqliteModule | null> = () =>
+  import("bun:sqlite").catch(() => null) as Promise<SqliteModule | null>
+
+/** @internal test-only */
+export function __setBunSqliteImporterForTesting(
+  impl: () => Promise<SqliteModule | null>,
+): void {
+  bunSqliteImporter = impl
+}
+
+/** @internal test-only */
+export function __resetBunSqliteImporterForTesting(): void {
+  bunSqliteImporter = () => import("bun:sqlite").catch(() => null) as Promise<SqliteModule | null>
+}
 
 function getDbPath(): string {
   return join(getDataDir(), "opencode", "opencode.db")
@@ -11,7 +29,7 @@ function getDbPath(): string {
 const MAX_MICROTASK_RETRIES = 10
 
 function tryUpdateMessageModel(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant?: string,
@@ -30,7 +48,7 @@ function tryUpdateMessageModel(
 }
 
 function retryViaMicrotask(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant: string | undefined,
@@ -112,14 +130,22 @@ export function scheduleDeferredModelOverride(
   targetModel: { providerID: string; modelID: string },
   variant?: string,
 ): void {
-  queueMicrotask(() => {
+  queueMicrotask(async () => {
+    const sqliteModule = await bunSqliteImporter()
+    if (sqliteModule === null) {
+      log("[ultrawork-db-override] bun:sqlite unavailable (non-Bun runtime), skipping deferred override")
+      return
+    }
+
+    const { Database } = sqliteModule
+
     const dbPath = getDbPath()
     if (!existsSync(dbPath)) {
       log("[ultrawork-db-override] DB not found, skipping deferred override")
       return
     }
 
-    let db: InstanceType<typeof Database>
+    let db: BunDatabase
     try {
       db = new Database(dbPath)
     } catch (error) {

--- a/src/shared/binary-downloader.ts
+++ b/src/shared/binary-downloader.ts
@@ -1,6 +1,6 @@
 import { chmodSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import * as path from "node:path";
-import { spawn } from "bun";
+import { spawn } from "./bun-spawn-shim";
 import { extractZip } from "./zip-extractor";
 
 export function getCachedBinaryPath(cacheDir: string, binaryName: string): string | null {

--- a/src/shared/bun-spawn-shim.ts
+++ b/src/shared/bun-spawn-shim.ts
@@ -1,0 +1,142 @@
+import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process"
+import { Readable } from "node:stream"
+
+type SpawnOptions = {
+  cwd?: string
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>
+  stdin?: "pipe" | "inherit" | "ignore"
+  stdout?: "pipe" | "inherit" | "ignore"
+  stderr?: "pipe" | "inherit" | "ignore"
+}
+
+type SpawnInput = string[] | ({ cmd: string[] } & SpawnOptions)
+
+type SpawnResult = {
+  readonly exitCode: number | null
+  readonly exited: Promise<number>
+  readonly stdout: ReadableStream<Uint8Array> | null
+  readonly stderr: ReadableStream<Uint8Array> | null
+  readonly stdin: NodeJS.WritableStream | null
+  readonly pid: number
+  kill(signal?: NodeJS.Signals): void
+}
+
+function isBunRuntime(): boolean {
+  return typeof globalThis.Bun !== "undefined"
+}
+
+function resolveSpawnInput(input: SpawnInput, options?: SpawnOptions): { cmd: string[]; opts: SpawnOptions } {
+  if (Array.isArray(input)) {
+    return { cmd: input, opts: options ?? {} }
+  }
+
+  return {
+    cmd: input.cmd,
+    opts: {
+      cwd: input.cwd,
+      env: input.env,
+      stdin: input.stdin,
+      stdout: input.stdout,
+      stderr: input.stderr,
+    },
+  }
+}
+
+function toReadableStream(stream: NodeJS.ReadableStream | null): ReadableStream<Uint8Array> | null {
+  if (!stream) return null
+  return Readable.toWeb(stream as Readable) as ReadableStream<Uint8Array>
+}
+
+function wrapNodeProcess(proc: ReturnType<typeof nodeSpawn>): SpawnResult {
+  let exitCode: number | null = null
+  let resolveExited: (code: number) => void = () => {}
+
+  const exited = new Promise<number>((resolve) => {
+    resolveExited = resolve
+  })
+
+  proc.on("exit", (code) => {
+    exitCode = code ?? 1
+    resolveExited(exitCode)
+  })
+
+  proc.on("error", () => {
+    if (exitCode === null) {
+      exitCode = 1
+      resolveExited(1)
+    }
+  })
+
+  return {
+    get exitCode() {
+      return exitCode
+    },
+    exited,
+    stdout: toReadableStream(proc.stdout),
+    stderr: toReadableStream(proc.stderr),
+    stdin: proc.stdin,
+    pid: proc.pid ?? -1,
+    kill(signal?: NodeJS.Signals): void {
+      try {
+        proc.kill(signal)
+      } catch {}
+    },
+  }
+}
+
+export function spawn(input: SpawnInput, options?: SpawnOptions): SpawnResult {
+  if (isBunRuntime()) {
+    const bun = globalThis.Bun as unknown as {
+      spawn: (input: SpawnInput, options?: SpawnOptions) => SpawnResult
+    }
+    return bun.spawn(input, options)
+  }
+
+  const { cmd, opts } = resolveSpawnInput(input, options)
+  const [bin, ...args] = cmd
+
+  const proc = nodeSpawn(bin, args, {
+    cwd: opts.cwd,
+    env: opts.env as NodeJS.ProcessEnv | undefined,
+    stdio: [opts.stdin ?? "pipe", opts.stdout ?? "pipe", opts.stderr ?? "pipe"],
+  })
+
+  return wrapNodeProcess(proc)
+}
+
+export function spawnSync(input: SpawnInput, options?: SpawnOptions): {
+  exitCode: number
+  stdout: Buffer | string
+  stderr: Buffer | string
+  success: boolean
+  pid: number
+} {
+  if (isBunRuntime()) {
+    const bun = globalThis.Bun as unknown as {
+      spawnSync: (input: SpawnInput, options?: SpawnOptions) => {
+        exitCode: number
+        stdout: Buffer | string
+        stderr: Buffer | string
+        success: boolean
+        pid: number
+      }
+    }
+    return bun.spawnSync(input, options)
+  }
+
+  const { cmd, opts } = resolveSpawnInput(input, options)
+  const [bin, ...args] = cmd
+  const result = nodeSpawnSync(bin, args, {
+    cwd: opts.cwd,
+    env: opts.env as NodeJS.ProcessEnv | undefined,
+    stdio: [opts.stdin ?? "pipe", opts.stdout ?? "pipe", opts.stderr ?? "pipe"],
+  })
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    success: (result.status ?? 1) === 0,
+    pid: -1,
+  }
+}

--- a/src/shared/spawn-with-windows-hide.ts
+++ b/src/shared/spawn-with-windows-hide.ts
@@ -1,4 +1,4 @@
-import { spawn as bunSpawn } from "bun"
+import { spawn as bunSpawn } from "./bun-spawn-shim"
 import { spawn as nodeSpawn, type ChildProcess } from "node:child_process"
 import { Readable } from "node:stream"
 
@@ -68,7 +68,14 @@ function wrapNodeProcess(proc: ChildProcess): SpawnedProcess {
 
 export function spawnWithWindowsHide(command: string[], options: SpawnOptions): SpawnedProcess {
   if (process.platform !== "win32") {
-    return bunSpawn(command, options)
+    const processResult = bunSpawn(command, options)
+    return {
+      exitCode: processResult.exitCode,
+      exited: processResult.exited,
+      stdout: processResult.stdout ?? undefined,
+      stderr: processResult.stderr ?? undefined,
+      kill: (signal?: NodeJS.Signals) => processResult.kill(signal),
+    }
   }
 
   const [cmd, ...args] = command

--- a/src/shared/tmux/tmux-utils/layout.ts
+++ b/src/shared/tmux/tmux-utils/layout.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../bun-spawn-shim"
 import type { TmuxLayout } from "../../../config/schema"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 

--- a/src/shared/tmux/tmux-utils/pane-close.ts
+++ b/src/shared/tmux/tmux-utils/pane-close.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../bun-spawn-shim"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import { isInsideTmux } from "./environment"
 

--- a/src/shared/tmux/tmux-utils/pane-dimensions.ts
+++ b/src/shared/tmux/tmux-utils/pane-dimensions.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../bun-spawn-shim"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 
 export interface PaneDimensions {

--- a/src/shared/tmux/tmux-utils/pane-replace.ts
+++ b/src/shared/tmux/tmux-utils/pane-replace.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../bun-spawn-shim"
 import type { TmuxConfig } from "../../../config/schema"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { SpawnPaneResult } from "../types"

--- a/src/shared/tmux/tmux-utils/pane-spawn.ts
+++ b/src/shared/tmux/tmux-utils/pane-spawn.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../bun-spawn-shim"
 import type { TmuxConfig } from "../../../config/schema"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { SpawnPaneResult } from "../types"

--- a/src/shared/zip-extractor.ts
+++ b/src/shared/zip-extractor.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "bun"
+import { spawn, spawnSync } from "./bun-spawn-shim"
 import { release } from "os"
 
 const WINDOWS_BUILD_WITH_TAR = 17134

--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 import { existsSync } from "fs"
 import {
 	getSgCliPath,

--- a/src/tools/glob/cli.ts
+++ b/src/tools/glob/cli.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path"
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 import {
   resolveGrepCli,
   type GrepBackend,

--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 import {
   resolveGrepCli,
   type GrepBackend,

--- a/src/tools/interactive-bash/tmux-path-resolver.ts
+++ b/src/tools/interactive-bash/tmux-path-resolver.ts
@@ -1,4 +1,4 @@
-import { spawn } from "bun"
+import { spawn } from "../../shared/bun-spawn-shim"
 
 let tmuxPath: string | null = null
 let initPromise: Promise<string | null> | null = null

--- a/src/tools/lsp/lsp-process.ts
+++ b/src/tools/lsp/lsp-process.ts
@@ -1,4 +1,4 @@
-import { spawn as bunSpawn } from "bun"
+import { spawn as bunSpawn } from "../../shared/bun-spawn-shim"
 import { spawn as nodeSpawn, type ChildProcess } from "node:child_process"
 import { existsSync, statSync } from "fs"
 import { log } from "../../shared/logger"


### PR DESCRIPTION
## Summary
- Replace Bun-only spawn imports with a Node/Electron-compatible spawn shim so Desktop runtime no longer crashes on `globalThis.Bun` destructuring.
- Lazy-load `bun:sqlite` in ultrawork DB override and safely no-op on non-Bun runtimes.
- Add regression coverage for the non-Bun `bun:sqlite` unavailable path.

## Why
- Fixes plugin load failures and missing OMO agents in Desktop runtime reported in #3794 and #3812.
- Preserves Bun runtime behavior while making Electron/Node load path safe.

## Scope
- Intentionally includes only issue-related files; unrelated local modifications are excluded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented plugin load failures in OpenCode Desktop by replacing Bun-only spawn usage with a cross-runtime shim and making `bun:sqlite` lazy and optional. Fixes missing OMO agents and startup crashes in Electron/Node environments reported in #3794 and #3812.

- **Bug Fixes**
  - Added `src/shared/bun-spawn-shim.ts` to provide Bun-compatible `spawn`/`spawnSync` backed by Node when `globalThis.Bun` is absent.
  - Swapped `import { spawn } from "bun"` across tools and tmux utilities to use the shim; updated Windows-hide wrapper to use the shim.
  - Lazy-loaded `bun:sqlite` in the ultrawork DB override and safely no-op on non-Bun runtimes with a clear log message.
  - Guarded CLI stdin writes to handle null streams on non-Bun runtimes.
  - Added a regression test for the non-Bun `bun:sqlite` unavailable path.

<sup>Written for commit f25db34a30b0626dba773632687370cc535d2b4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

