### PR TITLE
fix: load agents from oh-my-openagent config in mergeWithClaudeCodeAgents

### DIFF
--- a/src/tools/delegate-task/subagent-discovery.ts
+++ b/src/tools/delegate-task/subagent-discovery.ts
@@ -1,5 +1,9 @@
 import { getAgentConfigKey, getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { loadUserAgents, loadProjectAgents } from "../../features/claude-code-agent-loader"
+import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
+import { parseJsoncSafe } from "../../shared/jsonc-parser"
+import * as fs from "node:fs"
+import { join } from "node:path"
 
 export type AgentMode = "subagent" | "primary" | "all" | undefined
 
@@ -10,7 +14,63 @@ export type AgentInfo = {
 }
 
 export function sanitizeSubagentType(subagentType: string): string {
-  return subagentType.trim().replace(/^[\\\/"']+|[\\\/"']+$/g, "").trim()
+  return subagentType.trim().replace(/^[\/\"'\\]+|[\/\"'\\]+$/g, "").trim()
+}
+
+interface OmoConfigWithAgents {
+  agents?: Record<string, unknown>
+  agent?: Record<string, unknown>
+}
+
+function loadOmoConfigAgents(directory: string | undefined): Record<string, { mode?: string; model?: string }> {
+  const result: Record<string, { mode?: string; model?: string }> = Object.create(null)
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+
+  const configPaths = [
+    join(configDir, "oh-my-openagent.json"),
+    join(configDir, "oh-my-openagent.jsonc"),
+    join(configDir, "oh-my-opencode.json"),
+    join(configDir, "oh-my-opencode.jsonc"),
+  ]
+
+  if (directory) {
+    configPaths.push(
+      join(directory, ".opencode", "oh-my-openagent.json"),
+      join(directory, ".opencode", "oh-my-openagent.jsonc"),
+      join(directory, ".opencode", "oh-my-opencode.json"),
+      join(directory, ".opencode", "oh-my-opencode.jsonc"),
+    )
+  }
+
+  for (const configPath of configPaths) {
+    try {
+      if (!fs.existsSync(configPath)) continue
+
+      const content = fs.readFileSync(configPath, "utf-8")
+      const parseResult = parseJsoncSafe<OmoConfigWithAgents>(content)
+
+      if (!parseResult.data) continue
+
+      const agentsToLoad = parseResult.data.agents || parseResult.data.agent
+
+      if (agentsToLoad && typeof agentsToLoad === "object") {
+        for (const [agentName, agentData] of Object.entries(agentsToLoad)) {
+          if (Object.hasOwn(result, agentName)) continue
+          if (agentData && typeof agentData === "object") {
+            const agent = agentData as Record<string, unknown>
+            result[agentName] = {
+              mode: typeof agent.mode === "string" ? agent.mode : "subagent",
+              model: typeof agent.model === "string" ? agent.model : undefined,
+            }
+          }
+        }
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return result
 }
 
 export function mergeWithClaudeCodeAgents(
@@ -19,6 +79,7 @@ export function mergeWithClaudeCodeAgents(
 ): AgentInfo[] {
   const userAgentsRecord = loadUserAgents()
   const projectAgentsRecord = loadProjectAgents(directory)
+  const omoConfigAgentsRecord = loadOmoConfigAgents(directory)
 
   const toAgentInfoList = (record: Record<string, { mode?: string; model?: AgentInfo["model"] }>): AgentInfo[] =>
     Object.entries(record).map(([name, config]) => ({
@@ -38,8 +99,9 @@ export function mergeWithClaudeCodeAgents(
   for (const agent of serverAgents) addIfAbsent(agent)
   for (const agent of toAgentInfoList(projectAgentsRecord)) addIfAbsent(agent)
   for (const agent of toAgentInfoList(userAgentsRecord)) addIfAbsent(agent)
+  for (const agent of toAgentInfoList(omoConfigAgentsRecord)) addIfAbsent(agent)
 
-  return Array.from(mergedAgentMap.values())
+return Array.from(mergedAgentMap.values())
 }
 
 function buildComparableNames(agentName: string): Set<string> {


### PR DESCRIPTION
Fixes issue #3762

The task tool's subagent resolution was not loading agents from oh-my-openagent.json or oh-my-opencode.json config files. This fix adds a new loadOmoConfigAgents function that reads agent configs from these files and includes them in the agent merge process.

This addresses the issue where custom agents (Sisyphus, Hephaestus, etc.) were not available when using the task tool with subagent_type parameter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix subagent discovery so the task tool loads custom agents from `oh-my-openagent`/`oh-my-opencode` configs. Agents now resolve correctly when using `subagent_type`.

- **Bug Fixes**
  - Added `loadOmoConfigAgents` and merged into `mergeWithClaudeCodeAgents`. Scans user config (`getOpenCodeConfigDir`) and project `.opencode` for `oh-my-openagent(.json/.jsonc)` and `oh-my-opencode(.json/.jsonc)`; reads `agents` or `agent`; defaults `mode` to `subagent`; passes through `model` if set.
  - Expanded `sanitizeSubagentType` to strip leading/trailing slashes, backslashes, and quotes.

<sup>Written for commit dfe1f7a29b45e8caf4896b6f5aec8403182bbfde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

