### PR TITLE
fix(team-mode): sync atomic writes through writable handle

### DIFF
--- a/src/features/team-mode/team-state-store/locks.test.ts
+++ b/src/features/team-mode/team-state-store/locks.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
-import type { PathLike } from "node:fs"
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import type { Mode, OpenMode, PathLike } from "node:fs"
+import { mkdtemp, open, readdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -69,6 +69,29 @@ test("atomicWrite leaves no partial file when rename fails", async () => {
 
   const directoryEntries = await readdir(rootDirectory)
   expect(directoryEntries.some((entry) => entry.startsWith("target.txt.tmp."))).toBe(false)
+  await rm(rootDirectory, { recursive: true, force: true })
+})
+
+test("atomicWrite syncs temp files through a writable handle", async () => {
+  // given
+  const rootDirectory = await createTempDirectory("locks-atomic-writable-")
+  const targetPath = join(rootDirectory, "target.txt")
+  const openFlags: string[] = []
+
+  const { atomicWrite } = await import("./locks")
+
+  // when
+  await atomicWrite(targetPath, "new content", {
+    rename,
+    open: async (filePath: PathLike, flags?: OpenMode, mode?: Mode) => {
+      openFlags.push(String(flags))
+      return await open(filePath, flags, mode)
+    },
+  })
+
+  // then
+  expect(openFlags).toEqual(["wx"])
+  expect(await readFile(targetPath, "utf8")).toBe("new content")
   await rm(rootDirectory, { recursive: true, force: true })
 })
 

--- a/src/features/team-mode/team-state-store/locks.ts
+++ b/src/features/team-mode/team-state-store/locks.ts
@@ -1,11 +1,17 @@
 import { randomUUID } from "node:crypto"
-import { open, readFile, rename, rm, unlink, writeFile } from "node:fs/promises"
+import { open, readFile, rename, rm, unlink } from "node:fs/promises"
 
 import { tolerantFsync } from "../../../shared/tolerant-fsync"
 
 type LockOptions = {
   staleAfterMs?: number
   ownerTag?: string
+}
+
+type AtomicWriteDeps = {
+  open?: typeof open
+  rename?: typeof rename
+  rm?: typeof rm
 }
 
 const LOCK_RETRY_MS = 50
@@ -110,21 +116,24 @@ export async function reapStaleLock(lockPath: string): Promise<void> {
 export async function atomicWrite(
   filePath: string,
   content: string | Buffer,
-  deps: { rename: typeof rename } = { rename },
+  deps: AtomicWriteDeps = {},
 ): Promise<void> {
   const tmpPath = `${filePath}.tmp.${randomUUID()}`
+  const openFile = deps.open ?? open
+  const renameFile = deps.rename ?? rename
+  const removeFile = deps.rm ?? rm
 
   try {
-    await writeFile(tmpPath, content)
-    const fileHandle = await open(tmpPath, "r")
+    const fileHandle = await openFile(tmpPath, "wx")
     try {
+      await fileHandle.writeFile(content)
       await tolerantFsync(fileHandle, `atomicWrite:${filePath}`)
     } finally {
       await fileHandle.close()
     }
-    await deps.rename(tmpPath, filePath)
+    await renameFile(tmpPath, filePath)
   } catch (error) {
-    await rm(tmpPath, { force: true })
+    await removeFile(tmpPath, { force: true })
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- write team-mode atomic state files through an exclusive writable handle before fsyncing
- add regression coverage that verifies atomicWrite uses the writable handle path

## Why
Windows can reject fsync on a read-only file handle with `EPERM`, which prevents team-mode runtime state from being created.

## Verification
- RED: `pnpm dlx bun test src/features/team-mode/team-state-store/locks.test.ts` failed with `EPERM: operation not permitted, fsync`
- GREEN: `pnpm dlx bun test src/features/team-mode/team-state-store/locks.test.ts` -> 4 pass, 0 fail
- `pnpm dlx bun run typecheck` -> exit 0
- `pnpm dlx bun run build` -> exit 0
- `git diff --check` -> exit 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows EPERM errors in team‑mode atomic writes by creating temp files with an exclusive writable handle (`wx`), writing and fsyncing through it, then renaming to the target. Adds a regression test that captures the `wx` flag and allows injecting `open`, `rename`, and `rm` for tests.

<sup>Written for commit 75ba70803d063ab125641b8d2e9dc43217c5b203. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3838?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

