### PR TITLE
[codex] fix tool execute after hook boundary

### DIFF
--- a/src/plugin/tool-execute-after.test.ts
+++ b/src/plugin/tool-execute-after.test.ts
@@ -92,7 +92,6 @@ describe("createToolExecuteAfterHandler", () => {
     expect(output.title).toBe("stored title")
     expect(output.metadata).toEqual({ sessionId: "ses_native", agent: "hephaestus" })
   })
-
   it("#given native session linkage without model #when stored metadata exists #then required task metadata is preserved", async () => {
     // given
     const model = { providerID: "openai", modelID: "gpt-5.5" }
@@ -121,5 +120,30 @@ describe("createToolExecuteAfterHandler", () => {
     // then
     expect(output.title).toBe("stored title")
     expect(output.metadata).toEqual({ sessionId: "ses_native", agent: "hephaestus", model })
+  })
+
+  it("#given a non-extract hook throws #when tool.execute.after runs #then the handler absorbs the failure", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {
+        directoryAgentsInjector: {
+          "tool.execute.after": async () => {
+            throw new TypeError("output output is undefined")
+          },
+        },
+      } as never,
+    })
+
+    const output = { title: "result", output: "read output", metadata: {} }
+
+    // when
+    await handler(
+      { tool: "read", sessionID: "ses_parent", callID: "call_read" },
+      output
+    )
+
+    // then
+    expect(output).toEqual({ title: "result", output: "read output", metadata: {} })
   })
 })

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -182,6 +182,15 @@ export function createToolExecuteAfterHandler(args: {
       return
     }
 
-    await runToolExecuteAfterHooks()
+    try {
+      await runToolExecuteAfterHooks()
+    } catch (error) {
+      log("[tool-execute-after] Failed to process hooks", {
+        tool: input.tool,
+        sessionID: input.sessionID,
+        callID: input.callID ?? input.callId ?? input.call_id,
+        error,
+      })
+    }
   }
 }


### PR DESCRIPTION
## Summary

- wrap the regular `tool.execute.after` hook chain in an error boundary
- log hook-chain failures with tool, session, and call context instead of letting them crash the host process
- add regression coverage for a non-extract `read` hook throwing during after-hook processing

## Root Cause

The handler only caught failures for `extract` and `discard`. Other tools called `runToolExecuteAfterHooks()` directly, so a single hook failure could propagate out of the plugin and terminate the OpenCode host process.

Fixes #3814

## Verification

- `bun test src/plugin/tool-execute-after.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents host crashes when `tool.execute.after` hooks throw by guarding the hook chain and logging context instead. Fixes #3814.

- **Bug Fixes**
  - Wrapped the `tool.execute.after` hook chain in an error boundary.
  - Logs failures with tool, `sessionID`, call ID, and error details instead of crashing.
  - Added a regression test to ensure a non-`extract` `read` hook throwing is absorbed.

<sup>Written for commit d11613999a274e96af504e1eeff365240593dfef. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3840?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

