### PR TITLE
Update default model setup priorities

### DIFF
--- a/docs/examples/coding-focused.jsonc
+++ b/docs/examples/coding-focused.jsonc
@@ -52,19 +52,19 @@
 
   "categories": {
     // Trivial changes: fastest possible
-    "quick": { "model": "opencode/gpt-5-nano" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
 
     // Standard coding tasks: good quality, fast
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
 
     // Complex refactors: best quality
-    "unspecified-high": { "model": "openai/gpt-5.3-codex" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
 
     // Visual work
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Deep autonomous work
-    "deep": { "model": "openai/gpt-5.5" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
 
     // Architecture decisions
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },

--- a/docs/examples/default.jsonc
+++ b/docs/examples/default.jsonc
@@ -48,12 +48,12 @@
   },
 
   "categories": {
-    "quick": { "model": "opencode/gpt-5-nano" },
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
-    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
     "writing": { "model": "google/gemini-3-flash" },
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
-    "deep": { "model": "openai/gpt-5.5" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },
   },
 

--- a/docs/examples/planning-focused.jsonc
+++ b/docs/examples/planning-focused.jsonc
@@ -63,14 +63,14 @@
   },
 
   "categories": {
-    "quick": { "model": "opencode/gpt-5-nano" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
 
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
 
     // High-effort planning tasks: maximum reasoning
     "unspecified-high": {
       "model": "openai/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
 
     // Documentation from plans
@@ -80,7 +80,7 @@
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Deep research and analysis
-    "deep": { "model": "openai/gpt-5.5" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
 
     // Strategic reasoning
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -120,7 +120,7 @@ You don't need every provider. You need the right two.
 | Subscription | Cost | What You Get | Covers |
 |---|---|---|---|
 | **OpenCode Go** | $10/mo | `kimi-k2.5`, `kimi-k2.6`, `glm-5`, `glm-5.1`, `minimax-m2.5`, `minimax-m2.7`, `mimo-v2-pro`, `qwen3.5-plus`, `qwen3.6-plus` | Claude-family alternatives (Kimi, GLM), Gemini-family alternatives (Qwen), utility/retrieval (MiniMax) |
-| **OpenAI Plus/Pro** | $20+/mo | `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.3-codex` | GPT-native agents (Hephaestus, Oracle, Momus), dual-prompt agents' GPT path |
+| **OpenAI Plus/Pro** | $20+/mo | `gpt-5.2`, `gpt-5.4-mini-fast`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.3-codex` | GPT-native agents (Hephaestus, Oracle, Momus), category defaults, dual-prompt agents' GPT path |
 
 ### Why this specific combination
 
@@ -224,7 +224,7 @@ These agents are built for GPT's principle-driven style. Their prompts assume au
 |---|---|---|
 | **Hephaestus** | Autonomous deep worker | `openai\|github-copilot\|venice\|opencode\|vercel/gpt-5.5` (medium) — single-entry chain, requires one of those providers. The craftsman. |
 | **Oracle** | Architecture consultant | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (high) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `opencode-go\|vercel/glm-5.1` |
-| **Momus** | Ruthless reviewer | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/glm-5.1` |
+| **Momus** | Ruthless reviewer | `openai\|github-copilot\|opencode\|vercel/gpt-5.2` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/glm-5.1` |
 
 ### Utility Runners → Speed over Intelligence
 
@@ -312,10 +312,10 @@ When agents delegate work, they don't pick a model name — they pick a **catego
 | `visual-engineering` | Frontend, UI, CSS, design | `google/gemini-3.1-pro` (high) | Gemini → `zai-coding-plan/glm-5` → `claude-opus-4-7` (max) → `opencode-go/glm-5.1` → `kimi-for-coding/k2p5` |
 | `artistry` | Creative, novel approaches | `google/gemini-3.1-pro` (high) | Gemini → `claude-opus-4-7` (max) → `gpt-5.5` — requires Gemini family to activate |
 | `ultrabrain` | Maximum reasoning needed | `openai/gpt-5.5` (xhigh) | GPT-5.5 xhigh → `gemini-3.1-pro` (high) → `claude-opus-4-7` (max) → `opencode-go/glm-5.1` |
-| `deep` | Deep coding, complex logic | `openai/gpt-5.5` (medium) | GPT-5.5 → `claude-opus-4-7` (max) → `gemini-3.1-pro` (high) |
-| `quick` | Simple, fast tasks | `openai/gpt-5.4-mini` | GPT-5.4-mini → `claude-haiku-4-5` → `gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
-| `unspecified-high` | General complex work | `anthropic/claude-opus-4-7` (max) | Opus → `gpt-5.5` (high) → `zai-coding-plan/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `moonshotai/kimi-k2.5` |
-| `unspecified-low` | General standard work | `anthropic/claude-sonnet-4-6` | Sonnet → `gpt-5.3-codex` (medium) → `opencode-go/kimi-k2.6` → `google/gemini-3-flash` → `opencode-go/minimax-m2.7` |
+| `deep` | Deep coding, complex logic | `openai/gpt-5.3-codex` (high) | GPT-5.3-Codex → `claude-opus-4-7` (max) → `gemini-3.1-pro` (high) |
+| `quick` | Simple, fast tasks | `openai/gpt-5.4-mini-fast` (none) | GPT-5.4 Mini Fast → `claude-haiku-4-5` → `gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
+| `unspecified-high` | General complex work | `openai/gpt-5.5` (high) | GPT-5.5 high → `claude-opus-4-7` (max) → `zai-coding-plan/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `moonshotai/kimi-k2.5` |
+| `unspecified-low` | General standard work | `openai/gpt-5.5` (medium) | GPT-5.5 medium → `gpt-5.3-codex` (medium) → `claude-sonnet-4-6` → `opencode-go/kimi-k2.6` → `google/gemini-3-flash` → `opencode-go/minimax-m2.7` |
 | `writing` | Text, docs, prose | `kimi-for-coding/k2p5` | Kimi → `gemini-3-flash` → `opencode-go/kimi-k2.6` → `claude-sonnet-4-6` → `opencode-go/minimax-m2.7` |
 
 See the [Orchestration System Guide](./orchestration.md) for how agents dispatch tasks to categories.
@@ -360,11 +360,11 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
 
   "categories": {
     "visual-engineering": { "model": "opencode-go/qwen3.6-plus" },  // Qwen as Gemini alt
-    "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },
-    "quick": { "model": "openai/gpt-5.4-mini" },
-    "unspecified-low": { "model": "opencode-go/kimi-k2.6" },
-    "unspecified-high": { "model": "opencode-go/kimi-k2.6" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
     "writing": { "model": "opencode-go/kimi-k2.6" },
   },
 
@@ -393,8 +393,8 @@ Highest quality, highest cost. No surprises.
   },
   "categories": {
     "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
-    "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
-    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
   },
 }
 ```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -248,7 +248,7 @@ If Z.ai is your main provider, the most important fallbacks are:
 
 #### OpenCode Zen
 
-OpenCode Zen provides access to `opencode/` prefixed models including `opencode/claude-opus-4-7`, `opencode/gpt-5.5`, `opencode/gpt-5.3-codex`, `opencode/gpt-5-nano`, `opencode/glm-5`, `opencode/big-pickle`, `opencode/minimax-m2.7`, and `opencode/minimax-m2.7-highspeed`.
+OpenCode Zen provides access to `opencode/` prefixed models including `opencode/claude-opus-4-7`, `opencode/gpt-5.2`, `opencode/gpt-5.5`, `opencode/gpt-5.3-codex`, `opencode/gpt-5.4-mini-fast`, `opencode/gpt-5-nano`, `opencode/glm-5`, `opencode/big-pickle`, `opencode/minimax-m2.7`, and `opencode/minimax-m2.7-highspeed`.
 
 When OpenCode Zen is the best available provider, these are the most relevant source-backed examples:
 
@@ -302,9 +302,10 @@ Not all models behave the same way. Understanding which models are "similar" hel
 
 | Model             | Provider(s)                      | Notes                                             |
 | ----------------- | -------------------------------- | ------------------------------------------------- |
-| **GPT-5.3-codex** | openai, github-copilot, opencode | Deep coding powerhouse. Still available for deep category and explicit overrides. |
-| **GPT-5.5**       | openai, github-copilot, opencode | High intelligence. Default for Oracle, Hephaestus, and deep GPT-native fallbacks. |
-| **GPT-5.4 Mini**  | openai, github-copilot, opencode | Fast + strong reasoning. Default for quick category.     |
+| **GPT-5.2**       | openai, github-copilot, opencode | Plan-review reasoning. Default for Momus at xhigh effort. |
+| **GPT-5.3-codex** | openai, opencode                | Deep coding powerhouse. Default for the deep category at high effort. |
+| **GPT-5.5**       | openai, github-copilot, opencode | High intelligence. Default for Oracle, Hephaestus, unspecified-high, and unspecified-low. |
+| **GPT-5.4 Mini Fast** | openai, github-copilot, opencode | Fast + strong reasoning. Default for quick category with none reasoning effort. |
 | **GPT-5-Nano**    | opencode                         | Ultra-cheap, fast. Good for simple utility tasks. |
 
 **Different-Behavior Models**:
@@ -354,7 +355,7 @@ Priority: **Claude > GPT > Claude-like models**
 | -------------- | ---------------------- | -------------------------------------- | ------------------------------------------------------ |
 | **Hephaestus** | Deep autonomous worker | GPT-5.5 (medium) only                  | "Codex on steroids." No fallback. Requires GPT access. |
 | **Oracle**     | Architecture/debugging | openai\|github-copilot\|opencode/gpt-5.5 (high) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → opencode-go/glm-5.1 | High-IQ strategic backup. GPT preferred.               |
-| **Momus**      | High-accuracy reviewer | openai\|github-copilot\|opencode/gpt-5.5 (xhigh) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → opencode-go/glm-5.1 | Verification agent. GPT preferred.                     |
+| **Momus**      | High-accuracy reviewer | openai\|github-copilot\|opencode/gpt-5.2 (xhigh) → anthropic\|github-copilot\|opencode/claude-opus-4-7 (max) → google\|github-copilot\|opencode/gemini-3.1-pro (high) → opencode-go/glm-5.1 | Verification agent. GPT preferred.                     |
 
 **Utility Agents** (speed over intelligence):
 

--- a/docs/guide/orchestration.md
+++ b/docs/guide/orchestration.md
@@ -37,7 +37,7 @@ flowchart TB
         User[(" User")]
         Prometheus[" Prometheus<br/>(Planner)<br/>claude-opus-4-7 / gpt-5.5 / glm-5"]
         Metis[" Metis<br/>(Consultant)<br/>claude-opus-4-7 / gpt-5.5 / glm-5"]
-        Momus[" Momus<br/>(Reviewer)<br/>gpt-5.5 / claude-opus-4-7 / gemini-3.1-pro / glm-5"]
+        Momus[" Momus<br/>(Reviewer)<br/>gpt-5.2 / claude-opus-4-7 / gemini-3.1-pro / glm-5"]
     end
 
     subgraph Execution["Execution Layer (Orchestrator)"]
@@ -300,11 +300,11 @@ task({ category: "quick", prompt: "..." }); // "Just get it done fast"
 | -------------------- | ------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `visual-engineering` | `google/gemini-3.1-pro high`   | `gemini-3.1-pro` → `glm-5` → `claude-opus-4-7` → `glm-5` → `k2p5`                     | Frontend, UI/UX, design, styling, animation                 |
 | `ultrabrain`         | `openai/gpt-5.5 xhigh`         | `gpt-5.5` → `gemini-3.1-pro` → `claude-opus-4-7` → `glm-5`                             | Deep logical reasoning, complex architecture decisions      |
-| `deep`               | `openai/gpt-5.5 medium`        | `gpt-5.5` → `claude-opus-4-7` → `gemini-3.1-pro`                                       | Goal-oriented autonomous problem-solving, thorough research |
+| `deep`               | `openai/gpt-5.3-codex high`    | `gpt-5.3-codex` → `claude-opus-4-7` → `gemini-3.1-pro`                                  | Goal-oriented autonomous problem-solving, thorough research |
 | `artistry`           | `google/gemini-3.1-pro high`   | `gemini-3.1-pro` → `claude-opus-4-7` → `gpt-5.5`                                       | Highly creative or artistic tasks, novel ideas              |
-| `quick`              | `openai/gpt-5.4-mini`          | `gpt-5.4-mini` → `claude-haiku-4-5` → `gemini-3-flash` → `minimax-m2.7` → `gpt-5-nano` | Trivial tasks, single file changes, typo fixes              |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`  | `claude-sonnet-4-6` → `gpt-5.3-codex` → `kimi-k2.5` → `gemini-3-flash` → `minimax-m2.7` | Tasks that don't fit other categories, low effort           |
-| `unspecified-high`   | `anthropic/claude-opus-4-7 max` | `claude-opus-4-7` → `gpt-5.5` → `glm-5` → `k2p5` → `kimi-k2.5`                          | Tasks that don't fit other categories, high effort          |
+| `quick`              | `openai/gpt-5.4-mini-fast none` | `gpt-5.4-mini-fast` → `claude-haiku-4-5` → `gemini-3-flash` → `minimax-m2.7` → `gpt-5-nano` | Trivial tasks, single file changes, typo fixes           |
+| `unspecified-low`    | `openai/gpt-5.5 medium`        | `gpt-5.5` → `gpt-5.3-codex` → `claude-sonnet-4-6` → `kimi-k2.6` → `gemini-3-flash` → `minimax-m2.7` | Tasks that don't fit other categories, low effort |
+| `unspecified-high`   | `openai/gpt-5.5 high`          | `gpt-5.5` → `claude-opus-4-7` → `glm-5` → `k2p5` → `glm-5.1` → `kimi-k2.5`              | Tasks that don't fit other categories, high effort          |
 | `writing`            | `kimi-for-coding/k2p5`         | `gemini-3-flash` → `kimi-k2.5` → `claude-sonnet-4-6` → `minimax-m2.7`                  | Documentation, prose, technical writing                     |
 
 ### Skills: Domain-Specific Instructions

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -195,19 +195,19 @@ You can override specific agents or categories in your config:
     "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },
 
     // Autonomous research and execution
-    "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "deep": { "model": "openai/gpt-5.3-codex", "variant": "high" },
 
     // Creative and design work
     "artistry": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Quick tasks: fast and cheap
-    "quick": { "model": "openai/gpt-5.4-mini" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
 
     // Low-effort fallback: cheapest available
-    "unspecified-low": { "model": "openai/gpt-5.4-mini" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
 
     // High-effort fallback: best available
-    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
 
     // Prose and documentation
     "writing": { "model": "anthropic/claude-opus-4-7", "variant": "high" },

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -98,13 +98,13 @@ Here's a practical starting configuration:
 
   "categories": {
     // quick - trivial tasks
-    "quick": { "model": "opencode/gpt-5-nano" },
+    "quick": { "model": "openai/gpt-5.4-mini-fast", "variant": "none" },
 
     // unspecified-low - moderate tasks
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
+    "unspecified-low": { "model": "openai/gpt-5.5", "variant": "medium" },
 
     // unspecified-high - complex work
-    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+    "unspecified-high": { "model": "openai/gpt-5.5", "variant": "high" },
 
     // writing - docs/prose
     "writing": { "model": "google/gemini-3-flash" },
@@ -291,11 +291,11 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 | -------------------- | ------------------------------- | ---------------------------------------------- |
 | `visual-engineering` | `google/gemini-3.1-pro` (high)  | Frontend, UI/UX, design, animation             |
 | `ultrabrain`         | `openai/gpt-5.5` (xhigh)        | Deep logical reasoning, complex architecture   |
-| `deep`               | `openai/gpt-5.5` (medium)       | Autonomous problem-solving, thorough research  |
+| `deep`               | `openai/gpt-5.3-codex` (high)   | Autonomous problem-solving, thorough research  |
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Creative/unconventional approaches             |
-| `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks, typo fixes, single-file changes |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | General tasks, low effort                      |
-| `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | General tasks, high effort                   |
+| `quick`              | `openai/gpt-5.4-mini-fast` (none) | Trivial tasks, typo fixes, single-file changes |
+| `unspecified-low`    | `openai/gpt-5.5` (medium)       | General tasks, low effort                      |
+| `unspecified-high`   | `openai/gpt-5.5` (high)         | General tasks, high effort                     |
 | `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing        |
 
 > **Note**: Built-in defaults only apply if the category is present in your config. Otherwise the system default model is used.
@@ -365,7 +365,7 @@ Capability data comes from provider runtime metadata first. OmO also ships bundl
 | **multimodal-looker** | `gpt-5.5`           | `openai\|opencode/gpt-5.5 (medium)` → `opencode-go/kimi-k2.6` → `zai-coding-plan/glm-4.6v` → `openai\|github-copilot\|opencode/gpt-5-nano` |
 | **Prometheus**        | `claude-opus-4-7`   | `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `opencode-go/glm-5.1` → `google\|github-copilot\|opencode/gemini-3.1-pro` |
 | **Metis**             | `claude-opus-4-7`   | `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `opencode-go/glm-5.1` → `kimi-for-coding/k2p5` |
-| **Momus**             | `gpt-5.5`           | `openai\|github-copilot\|opencode/gpt-5.5 (xhigh)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `opencode-go/glm-5.1` |
+| **Momus**             | `gpt-5.2`           | `openai\|github-copilot\|opencode/gpt-5.2 (xhigh)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `opencode-go/glm-5.1` |
 | **Atlas**             | `claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/kimi-k2.6` → `openai\|github-copilot\|opencode/gpt-5.5 (medium)` → `opencode-go/minimax-m2.7` |
 
 #### Category Provider Chains
@@ -374,11 +374,11 @@ Capability data comes from provider runtime metadata first. OmO also ships bundl
 | ---------------------- | ------------------- | -------------------------------------------------------------- |
 | **visual-engineering** | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `zai-coding-plan\|opencode/glm-5` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `opencode-go/glm-5.1` → `kimi-for-coding/k2p5` |
 | **ultrabrain**         | `gpt-5.5`           | `openai\|opencode/gpt-5.5 (xhigh)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `opencode-go/glm-5.1` |
-| **deep**               | `gpt-5.5`           | `openai\|github-copilot\|venice\|opencode/gpt-5.5 (medium)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` |
+| **deep**               | `gpt-5.3-codex`     | `openai\|venice\|opencode/gpt-5.3-codex (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` |
 | **artistry**           | `gemini-3.1-pro`    | `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5` |
-| **quick**              | `gpt-5.4-mini`      | `openai\|github-copilot\|opencode/gpt-5.4-mini` → `anthropic\|github-copilot\|opencode/claude-haiku-4-5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
-| **unspecified-low**    | `claude-sonnet-4-6` | `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `openai\|opencode/gpt-5.3-codex (medium)` → `opencode-go/kimi-k2.6` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` |
-| **unspecified-high**   | `claude-opus-4-7`   | `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
+| **quick**              | `gpt-5.4-mini-fast` | `openai\|github-copilot\|opencode/gpt-5.4-mini-fast (none)` → `anthropic\|github-copilot\|opencode/claude-haiku-4-5` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
+| **unspecified-low**    | `gpt-5.5`           | `openai\|github-copilot\|opencode/gpt-5.5 (medium)` → `openai\|opencode/gpt-5.3-codex (medium)` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/kimi-k2.6` → `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/minimax-m2.7` |
+| **unspecified-high**   | `gpt-5.5`           | `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `zai-coding-plan\|opencode/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5.1` → `opencode/kimi-k2.5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix/kimi-k2.5` |
 | **writing**            | `gemini-3-flash`    | `google\|github-copilot\|opencode/gemini-3-flash` → `opencode-go/kimi-k2.6` → `anthropic\|github-copilot\|opencode/claude-sonnet-4-6` → `opencode-go/minimax-m2.7` |
 
 Run `bunx oh-my-opencode doctor --verbose` to see effective model resolution for your config.

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -22,7 +22,7 @@ Core-agent tab cycling is deterministic via injected runtime order field. The fi
 | -------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Prometheus** | `claude-opus-4-7` | Strategic planner with interview mode. Creates detailed work plans through iterative questioning. Fallback: `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `opencode-go/glm-5.1` → `google\|github-copilot\|opencode/gemini-3.1-pro`. |
 | **Metis**      | `claude-opus-4-7` | Plan consultant — pre-planning analysis. Identifies hidden intentions, ambiguities, and AI failure points. Fallback: `openai\|github-copilot\|opencode/gpt-5.5 (high)` → `opencode-go/glm-5.1` → `kimi-for-coding/k2p5`. |
-| **Momus**      | `gpt-5.5`         | Plan reviewer — validates plans against clarity, verifiability, and completeness standards. Fallback: `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `opencode-go/glm-5.1`. |
+| **Momus**      | `gpt-5.2`         | Plan reviewer — validates plans against clarity, verifiability, and completeness standards. Fallback: `anthropic\|github-copilot\|opencode/claude-opus-4-7 (max)` → `google\|github-copilot\|opencode/gemini-3.1-pro (high)` → `opencode-go/glm-5.1`. |
 
 ### Orchestration Agents
 
@@ -117,11 +117,11 @@ By combining these two concepts, you can generate optimal agents through `task`.
 | -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `visual-engineering` | `google/gemini-3.1-pro`         | Frontend, UI/UX, design, styling, animation                                                                                 |
 | `ultrabrain`         | `openai/gpt-5.5` (xhigh)        | Deep logical reasoning, complex architecture decisions requiring extensive analysis                                         |
-| `deep`               | `openai/gpt-5.5` (medium)       | Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one. |
+| `deep`               | `openai/gpt-5.3-codex` (high)   | Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one. |
 | `artistry`           | `google/gemini-3.1-pro` (high)  | Highly creative/artistic tasks, novel ideas                                                                                 |
-| `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks - single file changes, typo fixes, simple modifications                                                       |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | Tasks that don't fit other categories, low effort required                                                                  |
-| `unspecified-high`   | `anthropic/claude-opus-4-7` (max) | Tasks that don't fit other categories, high effort required                                                               |
+| `quick`              | `openai/gpt-5.4-mini-fast` (none) | Trivial tasks - single file changes, typo fixes, simple modifications                                                     |
+| `unspecified-low`    | `openai/gpt-5.5` (medium)       | Tasks that don't fit other categories, low effort required                                                                  |
+| `unspecified-high`   | `openai/gpt-5.5` (high)         | Tasks that don't fit other categories, high effort required                                                                 |
 | `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing                                                                                     |
 
 ### Usage

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -199,18 +199,18 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     })
   })
 
-  test("momus has valid fallbackChain with gpt-5.5 as primary", () => {
+  test("momus has valid fallbackChain with gpt-5.2 as primary", () => {
     // given - momus agent requirement
     const momus = AGENT_MODEL_REQUIREMENTS["momus"]
 
     // when - accessing Momus requirement
-    // then - fallbackChain exists with gpt-5.5 as first entry, variant xhigh
+    // then - fallbackChain exists with gpt-5.2 as first entry, variant xhigh
     expect(momus).toBeDefined()
     expect(momus.fallbackChain).toBeArray()
     expect(momus.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = momus.fallbackChain[0]
-    expect(primary.model).toBe("gpt-5.5")
+    expect(primary.model).toBe("gpt-5.2")
     expect(primary.variant).toBe("xhigh")
     expect(primary.providers[0]).toBe("openai")
   })
@@ -331,21 +331,21 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(primary.providers[0]).toBe("openai")
   })
 
-  test("deep has valid fallbackChain with gpt-5.5 as primary", () => {
+  test("deep has valid fallbackChain with gpt-5.3-codex as primary", () => {
     // given - deep category requirement
     const deep = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
     // when - accessing deep requirement
-    // then - fallbackChain exists with gpt-5.5 as first entry, medium variant
+    // then - fallbackChain exists with gpt-5.3-codex as first entry, high variant
     expect(deep).toBeDefined()
     expect(deep.fallbackChain).toBeArray()
     expect(deep.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = deep.fallbackChain[0]
-    expect(primary.variant).toBe("medium")
-    expect(primary.model).toBe("gpt-5.5")
+    expect(primary.variant).toBe("high")
+    expect(primary.model).toBe("gpt-5.3-codex")
     expect(primary.providers).toContain("openai")
-    expect(primary.providers).toContain("github-copilot")
+    expect(primary.providers).not.toContain("github-copilot")
   })
 
   test("visual-engineering has valid fallbackChain with gemini-3.1-pro high as primary", () => {
@@ -380,18 +380,19 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(fifth.model).toBe("k2p5")
   })
 
-  test("quick has valid fallbackChain with gpt-5.4-mini as primary and claude-haiku-4-5 as secondary", () => {
+  test("quick has valid fallbackChain with gpt-5.4-mini-fast none as primary and claude-haiku-4-5 as secondary", () => {
     // given - quick category requirement
     const quick = CATEGORY_MODEL_REQUIREMENTS["quick"]
 
     // when - accessing quick requirement
-    // then - fallbackChain exists with gpt-5.4-mini as first entry, haiku as second
+    // then - fallbackChain exists with gpt-5.4-mini-fast none as first entry, haiku as second
     expect(quick).toBeDefined()
     expect(quick.fallbackChain).toBeArray()
     expect(quick.fallbackChain.length).toBeGreaterThan(1)
 
     const primary = quick.fallbackChain[0]
-    expect(primary.model).toBe("gpt-5.4-mini")
+    expect(primary.model).toBe("gpt-5.4-mini-fast")
+    expect(primary.variant).toBe("none")
     expect(primary.providers).toContain("openai")
 
     const secondary = quick.fallbackChain[1]
@@ -399,40 +400,41 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(secondary.providers).toContain("anthropic")
   })
 
-  test("unspecified-low has valid fallbackChain with claude-sonnet-4-6 as primary", () => {
+  test("unspecified-low has valid fallbackChain with gpt-5.5 medium as primary", () => {
     // given - unspecified-low category requirement
     const unspecifiedLow = CATEGORY_MODEL_REQUIREMENTS["unspecified-low"]
 
     // when - accessing unspecified-low requirement
-    // then - fallbackChain exists with claude-sonnet-4-6 as first entry
+    // then - fallbackChain exists with gpt-5.5 medium as first entry
     expect(unspecifiedLow).toBeDefined()
     expect(unspecifiedLow.fallbackChain).toBeArray()
     expect(unspecifiedLow.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = unspecifiedLow.fallbackChain[0]
-    expect(primary.model).toBe("claude-sonnet-4-6")
-    expect(primary.providers[0]).toBe("anthropic")
+    expect(primary.model).toBe("gpt-5.5")
+    expect(primary.variant).toBe("medium")
+    expect(primary.providers[0]).toBe("openai")
   })
 
-  test("unspecified-high has claude-opus-4-7 as primary and gpt-5.5 as secondary", () => {
+  test("unspecified-high has gpt-5.5 high as primary and claude-opus-4-7 as secondary", () => {
     // #given - unspecified-high category requirement
     const unspecifiedHigh = CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]
 
     // #when - accessing unspecified-high requirement
-    // #then - claude-opus-4-7 is first and gpt-5.5 is second
+    // #then - gpt-5.5 is first and claude-opus-4-7 is second
     expect(unspecifiedHigh).toBeDefined()
     expect(unspecifiedHigh.fallbackChain).toBeArray()
     expect(unspecifiedHigh.fallbackChain.length).toBeGreaterThan(1)
 
     const primary = unspecifiedHigh.fallbackChain[0]
-    expect(primary.model).toBe("claude-opus-4-7")
-    expect(primary.variant).toBe("max")
-    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode", "vercel"])
+    expect(primary.model).toBe("gpt-5.5")
+    expect(primary.variant).toBe("high")
+    expect(primary.providers).toEqual(["openai", "github-copilot", "opencode", "vercel"])
 
     const secondary = unspecifiedHigh.fallbackChain[1]
-    expect(secondary.model).toBe("gpt-5.5")
-    expect(secondary.variant).toBe("high")
-    expect(secondary.providers).toEqual(["openai", "github-copilot", "opencode", "vercel"])
+    expect(secondary.model).toBe("claude-opus-4-7")
+    expect(secondary.variant).toBe("max")
+    expect(secondary.providers).toEqual(["anthropic", "github-copilot", "opencode", "vercel"])
   })
 
   test("artistry has valid fallbackChain with gemini-3.1-pro as primary", () => {

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -142,7 +142,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       {
         providers: ["openai", "github-copilot", "opencode", "vercel"],
-        model: "gpt-5.5",
+        model: "gpt-5.2",
         variant: "xhigh",
       },
       {
@@ -226,9 +226,9 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   deep: {
     fallbackChain: [
       {
-        providers: ["openai", "github-copilot", "venice", "opencode", "vercel"],
-        model: "gpt-5.5",
-        variant: "medium",
+        providers: ["openai", "venice", "opencode", "vercel"],
+        model: "gpt-5.3-codex",
+        variant: "high",
       },
       {
         providers: ["anthropic", "github-copilot", "opencode", "vercel"],
@@ -261,7 +261,8 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       {
         providers: ["openai", "github-copilot", "opencode", "vercel"],
-        model: "gpt-5.4-mini",
+        model: "gpt-5.4-mini-fast",
+        variant: "none",
       },
       {
         providers: ["anthropic", "github-copilot", "opencode", "vercel"],
@@ -278,13 +279,18 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "unspecified-low": {
     fallbackChain: [
       {
-        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
-        model: "claude-sonnet-4-6",
+        providers: ["openai", "github-copilot", "opencode", "vercel"],
+        model: "gpt-5.5",
+        variant: "medium",
       },
       {
         providers: ["openai", "opencode", "vercel"],
         model: "gpt-5.3-codex",
         variant: "medium",
+      },
+      {
+        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+        model: "claude-sonnet-4-6",
       },
       { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
       {
@@ -297,14 +303,14 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "unspecified-high": {
     fallbackChain: [
       {
-        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
-        model: "claude-opus-4-7",
-        variant: "max",
-      },
-      {
         providers: ["openai", "github-copilot", "opencode", "vercel"],
         model: "gpt-5.5",
         variant: "high",
+      },
+      {
+        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+        model: "claude-opus-4-7",
+        variant: "max",
       },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },

--- a/src/tools/delegate-task/anthropic-categories.ts
+++ b/src/tools/delegate-task/anthropic-categories.ts
@@ -15,7 +15,7 @@ This is NOT a default choice - it's for genuinely unclassifiable moderate-effort
 </Category_Context>
 
 <Caller_Warning>
-THIS CATEGORY USES A MID-TIER MODEL (claude-sonnet-4-6).
+THIS CATEGORY USES A MID-TIER MODEL (gpt-5.5 medium).
 
 **PROVIDE CLEAR STRUCTURE:**
 1. MUST DO: Enumerate required actions explicitly
@@ -41,13 +41,13 @@ If task is unclassifiable but moderate-effort, use unspecified-low instead.
 export const ANTHROPIC_CATEGORIES: BuiltinCategoryDefinition[] = [
   {
     name: "unspecified-low",
-    config: { model: "anthropic/claude-sonnet-4-6" },
+    config: { model: "openai/gpt-5.5", variant: "medium" },
     description: "Tasks that don't fit other categories, low effort required",
     promptAppend: UNSPECIFIED_LOW_CATEGORY_PROMPT_APPEND,
   },
   {
     name: "unspecified-high",
-    config: { model: "anthropic/claude-opus-4-7", variant: "max" },
+    config: { model: "openai/gpt-5.5", variant: "high" },
     description: "Tasks that don't fit other categories, high effort required",
     promptAppend: UNSPECIFIED_HIGH_CATEGORY_PROMPT_APPEND,
   },

--- a/src/tools/delegate-task/openai-categories.ts
+++ b/src/tools/delegate-task/openai-categories.ts
@@ -158,7 +158,7 @@ Approach:
 </Category_Context>
 
 <Caller_Warning>
-THIS CATEGORY USES A SMALLER/FASTER MODEL (gpt-5.4-mini).
+THIS CATEGORY USES A SMALLER/FASTER MODEL (gpt-5.4-mini-fast with none reasoning effort).
 
 The model executing this task is optimized for speed over depth. Your prompt MUST be:
 
@@ -202,14 +202,14 @@ export const OPENAI_CATEGORIES: BuiltinCategoryDefinition[] = [
   },
   {
     name: "deep",
-    config: { model: "openai/gpt-5.5", variant: "medium" },
+    config: { model: "openai/gpt-5.3-codex", variant: "high" },
     description: "Goal-oriented autonomous problem-solving on hairy problems requiring deep research. ONE goal + ONE deliverable per call — multiple goals must fan out as parallel `deep` calls, never bundled into one.",
     promptAppend: DEEP_CATEGORY_PROMPT_APPEND,
     resolvePromptAppend: resolveDeepCategoryPromptAppend,
   },
   {
     name: "quick",
-    config: { model: "openai/gpt-5.4-mini" },
+    config: { model: "openai/gpt-5.4-mini-fast", variant: "none" },
     description: "Trivial tasks - single file changes, typo fixes, simple modifications",
     promptAppend: QUICK_CATEGORY_PROMPT_APPEND,
   },

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -34,6 +34,7 @@ const TEST_AVAILABLE_MODELS = new Set([
   "google/gemini-3.1-pro",
   "google/gemini-3-flash",
   "openai/gpt-5.4-mini",
+  "openai/gpt-5.4-mini-fast",
   "openai/gpt-5.5",
   "openai/gpt-5.3-codex",
 ])
@@ -69,7 +70,7 @@ describe("sisyphus-task", () => {
       models: {
         anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
         google: ["gemini-3.1-pro", "gemini-3-flash"],
-        openai: ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"],
+        openai: ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4-mini-fast", "gpt-5.3-codex"],
       },
       connected: ["anthropic", "google", "openai"],
       updatedAt: "2026-01-01T00:00:00.000Z",
@@ -109,18 +110,18 @@ describe("sisyphus-task", () => {
 
       // when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("openai/gpt-5.5")
-      expect(category.variant).toBe("medium")
+      expect(category.model).toBe("openai/gpt-5.3-codex")
+      expect(category.variant).toBe("high")
     })
 
-    test("unspecified-high category uses claude-opus-4-7 max as primary", () => {
+    test("unspecified-high category uses gpt-5.5 high as primary", () => {
       // given
       const category = DEFAULT_CATEGORIES["unspecified-high"]
 
       // when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("anthropic/claude-opus-4-7")
-      expect(category.variant).toBe("max")
+      expect(category.model).toBe("openai/gpt-5.5")
+      expect(category.variant).toBe("high")
     })
   })
 
@@ -680,7 +681,7 @@ describe("sisyphus-task", () => {
       //#given - manager.launch returns before sessionID is available
       const { createDelegateTask } = require("./tools")
 
-      const tasks = new Map<string, { id: string; sessionID?: string; status: string; description: string; agent: string }>()
+      const tasks = new Map<string, { id: string; sessionId?: string; status: string; description: string; agent: string }>()
       const mockManager = {
         getTask: (id: string) => tasks.get(id),
         launch: async () => {
@@ -1081,7 +1082,7 @@ describe("sisyphus-task", () => {
         abort: new AbortController().signal,
       }
 
-      // when - unspecified-high uses claude-opus-4-7 max in DEFAULT_CATEGORIES
+      // when - unspecified-high uses gpt-5.5 high in DEFAULT_CATEGORIES
       await tool.execute(
         {
           description: "Test unspecified-high default variant",
@@ -1093,11 +1094,11 @@ describe("sisyphus-task", () => {
         toolContext
       )
 
-      // then - claude-opus-4-7 should be passed with max variant
+      // then - gpt-5.5 should be passed with high variant
       expect(launchInput.model).toEqual({
-        providerID: "anthropic",
-        modelID: "claude-opus-4-7",
-        variant: "max",
+        providerID: "openai",
+        modelID: "gpt-5.5",
+        variant: "high",
       })
     }, { timeout: 20000 })
 
@@ -1142,7 +1143,7 @@ describe("sisyphus-task", () => {
         abort: new AbortController().signal,
       }
 
-      // when - unspecified-high uses claude-opus-4-7 max in DEFAULT_CATEGORIES
+      // when - unspecified-high uses gpt-5.5 high in DEFAULT_CATEGORIES
       await tool.execute(
         {
           description: "Test unspecified-high sync variant",
@@ -1154,12 +1155,12 @@ describe("sisyphus-task", () => {
         toolContext
       )
 
-      // then - claude-opus-4-7 should be passed with max variant
+      // then - gpt-5.5 should be passed with high variant
       expect(promptBody.model).toEqual({
-        providerID: "anthropic",
-        modelID: "claude-opus-4-7",
+        providerID: "openai",
+        modelID: "gpt-5.5",
       })
-      expect(promptBody.variant).toBe("max")
+      expect(promptBody.variant).toBe("high")
     }, { timeout: 20000 })
   })
 
@@ -2761,10 +2762,11 @@ describe("sisyphus-task", () => {
         toolContext
       )
 
-      // then - model should be openai/gpt-5.4-mini from DEFAULT_CATEGORIES
+      // then - model should be openai/gpt-5.4-mini-fast from DEFAULT_CATEGORIES
       //         NOT anthropic/claude-sonnet-4-6 (system default)
       expect(launchInput.model.providerID).toBe("openai")
-      expect(launchInput.model.modelID).toBe("gpt-5.4-mini")
+      expect(launchInput.model.modelID).toBe("gpt-5.4-mini-fast")
+      expect(launchInput.model.variant).toBe("none")
     })
 
     test("category delegation ignores UI-selected (Kimi) system default model", async () => {
@@ -2828,7 +2830,8 @@ describe("sisyphus-task", () => {
 
       // then - category model must win (not Kimi)
       expect(launchInput.model.providerID).toBe("openai")
-      expect(launchInput.model.modelID).toBe("gpt-5.4-mini")
+      expect(launchInput.model.modelID).toBe("gpt-5.4-mini-fast")
+      expect(launchInput.model.variant).toBe("none")
     })
 
     test("sisyphus-junior model override takes precedence over category model", async () => {
@@ -3450,6 +3453,25 @@ describe("sisyphus-task", () => {
       expect(resolved!.config.variant).toBe("xhigh")
     })
 
+    test("requested built-in category model defaults stay aligned", () => {
+      // given - categories with explicit runtime defaults
+      const expectedDefaults = {
+        deep: { model: "openai/gpt-5.3-codex", variant: "high" },
+        quick: { model: "openai/gpt-5.4-mini-fast", variant: "none" },
+        "unspecified-low": { model: "openai/gpt-5.5", variant: "medium" },
+        "unspecified-high": { model: "openai/gpt-5.5", variant: "high" },
+      } satisfies Record<string, { model: string; variant: string }>
+
+      for (const [categoryName, expected] of Object.entries(expectedDefaults)) {
+        // when
+        const resolved = resolveCategoryConfig(categoryName, { systemDefaultModel: SYSTEM_DEFAULT_MODEL })
+
+        // then
+        expect(resolved?.config.model).toBe(expected.model)
+        expect(resolved?.config.variant).toBe(expected.variant)
+      }
+    })
+
     test("default model is used for category with default entry", () => {
       // given - unspecified-low has default model
       const categoryName = "unspecified-low"
@@ -3459,7 +3481,8 @@ describe("sisyphus-task", () => {
       
       // then - default model from DEFAULT_CATEGORIES is used
       expect(resolved).not.toBeNull()
-      expect(resolved!.config.model).toBe("anthropic/claude-sonnet-4-6")
+      expect(resolved!.config.model).toBe("openai/gpt-5.5")
+      expect(resolved!.config.variant).toBe("medium")
     })
 
     test("category built-in model takes precedence over inheritedModel for builtin category", () => {


### PR DESCRIPTION
## Summary
- Updates runtime defaults for Momus and the deep, quick, unspecified-low, and unspecified-high categories to the requested GPT model/effort priorities.
- Aligns delegate-task category presets, resolver tests, model requirement tests, docs, and examples with the new defaults.
- Confirms exact model IDs from the neighboring OpenCode catalog, including openai/gpt-5.2, openai/gpt-5.3-codex, and openai/gpt-5.4-mini-fast.

## Verification
- bun test src/shared/model-requirements.test.ts src/tools/delegate-task/tools.test.ts
- bun run typecheck
- bun run build
- Manual resolver QA via bun -e import of model requirements and resolveCategoryConfig

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates default model priorities across agents and categories to GPT-focused presets, improving alignment with current provider catalogs. Momus now defaults to `openai/gpt-5.2` (xhigh), and category defaults shift to `openai/gpt-5.3-codex`, `openai/gpt-5.4-mini-fast`, and `openai/gpt-5.5` as appropriate.

- **Refactors**
  - Runtime defaults:
    - Momus → `openai/gpt-5.2` (xhigh)
    - `deep` → `openai/gpt-5.3-codex` (high)
    - `quick` → `openai/gpt-5.4-mini-fast` (none)
    - `unspecified-low` → `openai/gpt-5.5` (medium)
    - `unspecified-high` → `openai/gpt-5.5` (high)
  - Updated delegate-task presets in `openai-categories.ts` and `anthropic-categories.ts` to match new defaults.
  - Adjusted resolver logic and tests (`model-requirements.test.ts`, `tools.test.ts`) to assert new primaries and variants.
  - Synced docs and examples with exact model IDs and variants (`openai/gpt-5.2`, `openai/gpt-5.3-codex`, `openai/gpt-5.4-mini-fast`, `openai/gpt-5.5`).

<sup>Written for commit 12c4795e1bddc5e465d4edcf7c27824947e37196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

