### PR TITLE
fix(tool-pair-validator): emit schema-compatible synthetic tool results

### DIFF
--- a/src/hooks/session-recovery/recover-tool-result-missing.test.ts
+++ b/src/hooks/session-recovery/recover-tool-result-missing.test.ts
@@ -82,8 +82,10 @@ describe("recoverToolResultMissing", () => {
       body: {
         parts: [{
           type: "tool_result",
+          toolUseId: "call_recovered",
           tool_use_id: "call_recovered",
-          content: "Operation cancelled by user (ESC pressed)",
+          isError: true,
+          content: [{ type: "text", text: "Operation cancelled by user (ESC pressed)" }],
         }],
       },
     })
@@ -123,8 +125,10 @@ describe("recoverToolResultMissing", () => {
       body: {
         parts: [{
           type: "tool_result",
+          toolUseId: "toolu_recovered",
           tool_use_id: "toolu_recovered",
-          content: "Operation cancelled by user (ESC pressed)",
+          isError: true,
+          content: [{ type: "text", text: "Operation cancelled by user (ESC pressed)" }],
         }],
       },
     })

--- a/src/hooks/session-recovery/recover-tool-result-missing.ts
+++ b/src/hooks/session-recovery/recover-tool-result-missing.ts
@@ -5,6 +5,14 @@ import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import { normalizeSDKResponse } from "../../shared"
 
 type Client = ReturnType<typeof createOpencodeClient>
+type ToolResultContent = { type: "text"; text: string }
+type ToolResultPart = {
+  type: "tool_result"
+  toolUseId: string
+  tool_use_id?: string
+  isError?: boolean
+  content: ToolResultContent[]
+}
 type ClientWithPromptAsync = {
   session: {
     promptAsync: (opts: { path: { id: string }; body: Record<string, unknown> }) => Promise<unknown>
@@ -90,8 +98,10 @@ export async function recoverToolResultMissing(
 
   const toolResultParts = toolUseIds.map((id) => ({
     type: "tool_result" as const,
+    toolUseId: id,
     tool_use_id: id,
-    content: "Operation cancelled by user (ESC pressed)",
+    isError: true,
+    content: [{ type: "text" as const, text: "Operation cancelled by user (ESC pressed)" }],
   }))
 
   const launchAgent = resumeConfig?.agent

--- a/src/hooks/session-recovery/recover-unavailable-tool.test.ts
+++ b/src/hooks/session-recovery/recover-unavailable-tool.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+import type { MessageData } from "./types"
+
+let sqliteBackend = false
+let storedParts: Array<{ type: string; id?: string; callID?: string; name?: string; tool?: string; [key: string]: unknown }> = []
+
+mock.module("../../shared/opencode-storage-detection", () => ({
+  isSqliteBackend: () => sqliteBackend,
+}))
+
+mock.module("./storage", () => ({
+  readParts: () => storedParts,
+}))
+
+const { recoverUnavailableTool } = await import("./recover-unavailable-tool")
+
+const failedAssistantMsg: MessageData = {
+  info: { id: "msg_failed", role: "assistant", error: 'No such tool: bash' },
+  parts: [],
+}
+
+function createMockClient(messages: MessageData[] = []) {
+  const promptAsync = mock(() => Promise.resolve({}))
+
+  return {
+    client: {
+      session: {
+        messages: mock(() => Promise.resolve({ data: messages })),
+        promptAsync,
+      },
+    } as never,
+    promptAsync,
+  }
+}
+
+describe("recoverUnavailableTool", () => {
+  beforeEach(() => {
+    sqliteBackend = false
+    storedParts = []
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("sends a schema-compatible recovered tool result for sqlite fallback", async () => {
+    //#given
+    sqliteBackend = true
+    const { client, promptAsync } = createMockClient([
+      {
+        info: { id: "msg_failed", role: "assistant" },
+        parts: [{ type: "tool", id: "prt_valid_call", callID: "call_recovered", name: "bash", input: {} }],
+      },
+    ])
+
+    //#when
+    const result = await recoverUnavailableTool(client, "ses_1", failedAssistantMsg)
+
+    //#then
+    expect(result).toBe(true)
+    expect(promptAsync).toHaveBeenCalledWith({
+      path: { id: "ses_1" },
+      body: {
+        parts: [{
+          type: "tool_result",
+          toolUseId: "call_recovered",
+          tool_use_id: "call_recovered",
+          isError: true,
+          content: [{ type: "text", text: '{"status":"error","error":"Tool not available. Please continue without this tool."}' }],
+        }],
+      },
+    })
+  })
+
+  it("sends a schema-compatible recovered tool result for stored parts fallback", async () => {
+    //#given
+    storedParts = [{
+      type: "tool",
+      id: "prt_stored_valid_call",
+      callID: "toolu_recovered",
+      tool: "bash",
+      state: { input: {} },
+    }]
+    const { client, promptAsync } = createMockClient()
+
+    //#when
+    const result = await recoverUnavailableTool(client, "ses_2", failedAssistantMsg)
+
+    //#then
+    expect(result).toBe(true)
+    expect(promptAsync).toHaveBeenCalledWith({
+      path: { id: "ses_2" },
+      body: {
+        parts: [{
+          type: "tool_result",
+          toolUseId: "toolu_recovered",
+          tool_use_id: "toolu_recovered",
+          isError: true,
+          content: [{ type: "text", text: '{"status":"error","error":"Tool not available. Please continue without this tool."}' }],
+        }],
+      },
+    })
+  })
+})

--- a/src/hooks/session-recovery/recover-unavailable-tool.ts
+++ b/src/hooks/session-recovery/recover-unavailable-tool.ts
@@ -9,8 +9,10 @@ type Client = ReturnType<typeof createOpencodeClient>
 
 interface ToolResultPart {
   type: "tool_result"
-  tool_use_id: string
-  content: string
+  toolUseId: string
+  tool_use_id?: string
+  isError?: boolean
+  content: Array<{ type: "text"; text: string }>
 }
 
 interface PromptWithToolResultInput {
@@ -90,8 +92,10 @@ export async function recoverUnavailableTool(
 
   const toolResultParts = targetToolUses.map((part) => ({
     type: "tool_result" as const,
+    toolUseId: part.id,
     tool_use_id: part.id,
-    content: '{"status":"error","error":"Tool not available. Please continue without this tool."}',
+    isError: true,
+    content: [{ type: "text" as const, text: '{"status":"error","error":"Tool not available. Please continue without this tool."}' }],
   }))
 
   try {

--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -13,8 +13,10 @@ type TestPart = {
   type: string
   id?: string
   callID?: string
+  toolUseId?: string
   tool_use_id?: string
-  content?: string
+  isError?: boolean
+  content?: string | Array<{ type: "text"; text: string }>
   text?: string
 }
 
@@ -64,7 +66,13 @@ describe("createToolPairValidatorHook", () => {
 
     //#then
     expect(messages[1]?.parts).toEqual([
-      { type: "tool_result", tool_use_id: "toolu_1", content: TOOL_RESULT_PLACEHOLDER },
+      {
+        type: "tool_result",
+        toolUseId: "toolu_1",
+        tool_use_id: "toolu_1",
+        isError: true,
+        content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+      },
       { type: "text", text: "continue" },
     ])
   })
@@ -98,8 +106,20 @@ describe("createToolPairValidatorHook", () => {
       {
         info: { role: "user" },
         parts: [
-          { type: "tool_result", tool_use_id: "toolu_1", content: TOOL_RESULT_PLACEHOLDER },
-          { type: "tool_result", tool_use_id: "toolu_2", content: TOOL_RESULT_PLACEHOLDER },
+          {
+            type: "tool_result",
+            toolUseId: "toolu_1",
+            tool_use_id: "toolu_1",
+            isError: true,
+            content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+          },
+          {
+            type: "tool_result",
+            toolUseId: "toolu_2",
+            tool_use_id: "toolu_2",
+            isError: true,
+            content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+          },
         ],
       },
     ])
@@ -121,7 +141,13 @@ describe("createToolPairValidatorHook", () => {
       { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_1" }] },
       {
         info: { role: "user" },
-        parts: [{ type: "tool_result", tool_use_id: "toolu_1", content: TOOL_RESULT_PLACEHOLDER }],
+        parts: [{
+          type: "tool_result",
+          toolUseId: "toolu_1",
+          tool_use_id: "toolu_1",
+          isError: true,
+          content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+        }],
       },
       { info: { role: "assistant" }, parts: [{ type: "text", text: "follow-up" }] },
     ])
@@ -149,8 +175,31 @@ describe("createToolPairValidatorHook", () => {
     //#then
     expect(messages[1]?.parts).toEqual([
       { type: "tool_result", tool_use_id: "toolu_1", content: "done" },
-      { type: "tool_result", tool_use_id: "call_2", content: TOOL_RESULT_PLACEHOLDER },
+      {
+        type: "tool_result",
+        toolUseId: "call_2",
+        tool_use_id: "call_2",
+        isError: true,
+        content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+      },
       { type: "text", text: "continue" },
+    ])
+  })
+
+  it("treats existing camelCase toolUseId results as already paired", async () => {
+    //#given
+    const messages = [
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_1" }] },
+      { info: { role: "user" }, parts: [{ type: "tool_result", toolUseId: "toolu_1", content: [{ type: "text", text: "done" }] }] },
+    ] satisfies TestMessage[]
+
+    //#when
+    await runTransform(messages)
+
+    //#then
+    expect(messages).toEqual([
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_1" }] },
+      { info: { role: "user" }, parts: [{ type: "tool_result", toolUseId: "toolu_1", content: [{ type: "text", text: "done" }] }] },
     ])
   })
 })

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -12,8 +12,10 @@ type ToolUsePart = {
 
 type ToolResultPart = {
   type: "tool_result"
-  tool_use_id: string
-  content: string
+  toolUseId: string
+  tool_use_id?: string
+  isError?: boolean
+  content: Array<{ type: "text"; text: string }>
   [key: string]: unknown
 }
 
@@ -51,9 +53,17 @@ function getToolUseID(part: TransformPart): string | null {
 }
 
 function getToolResultID(part: TransformPart): string | null {
-  const candidate = part as { type?: unknown; tool_use_id?: unknown }
+  const candidate = part as { type?: unknown; toolUseId?: unknown; tool_use_id?: unknown }
 
-  if (candidate.type === "tool_result" && typeof candidate.tool_use_id === "string" && candidate.tool_use_id.length > 0) {
+  if (candidate.type !== "tool_result") {
+    return null
+  }
+
+  if (typeof candidate.toolUseId === "string" && candidate.toolUseId.length > 0) {
+    return candidate.toolUseId
+  }
+
+  if (typeof candidate.tool_use_id === "string" && candidate.tool_use_id.length > 0) {
     return candidate.tool_use_id
   }
 
@@ -93,8 +103,10 @@ function extractToolResultIDs(parts: TransformPart[]): Set<string> {
 function createToolResultPart(toolUseID: string): ToolResultPart {
   return {
     type: "tool_result",
+    toolUseId: toolUseID,
     tool_use_id: toolUseID,
-    content: TOOL_RESULT_PLACEHOLDER,
+    isError: true,
+    content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
   }
 }
 

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -136,12 +136,20 @@ describe("createMessagesTransformHandler", () => {
     expect(messages).toHaveLength(5)
     expect(messages[2]).toEqual({
       info: { role: "user" },
-      parts: [{ type: "tool_result", tool_use_id: "toolu_01SRMQs3DUtVKWoSxC8bxxVA", content: "Tool output unavailable (context compacted)" }],
+      parts: [{
+        type: "tool_result",
+        toolUseId: "toolu_01SRMQs3DUtVKWoSxC8bxxVA",
+        tool_use_id: "toolu_01SRMQs3DUtVKWoSxC8bxxVA",
+        isError: true,
+        content: [{ type: "text", text: "Tool output unavailable (context compacted)" }],
+      }],
     })
     expect(messages[4]?.parts[0]).toEqual({
       type: "tool_result",
+      toolUseId: "toolu_01Lu5cHvRtEvzoifP1UVBVRb",
       tool_use_id: "toolu_01Lu5cHvRtEvzoifP1UVBVRb",
-      content: "Tool output unavailable (context compacted)",
+      isError: true,
+      content: [{ type: "text", text: "Tool output unavailable (context compacted)" }],
     })
     expect(messages[4]?.parts[1]).toEqual({ type: "text", text: "next" })
   })


### PR DESCRIPTION
## Summary

Fix Claude post-compaction recovery for orphaned `tool_use` blocks.

The current repair path synthesizes `tool_result` blocks in a shape that does not match the outgoing message schema used by Claude-compatible providers. In practice this can leave compacted or recovered sessions failing with errors like:

> `tool_use` ids were found without `tool_result` blocks immediately after

## What changed

- accept both `toolUseId` and legacy `tool_use_id` when reading repaired tool results
- emit schema-compatible synthetic `tool_result` blocks with:
  - `toolUseId`
  - `isError: true`
  - `content` as a content-block array
- align the reactive session-recovery helpers with the same tool-result shape
- add regression coverage for both the proactive transform hook and reactive recovery helpers

## Why

Anthropic is strict about `tool_use` / `tool_result` adjacency and structure. After compaction or recovery, OmO may try to repair missing tool results, but the synthesized repair object can fail to count as a valid `tool_result` in the outgoing request. That leaves the session unrecoverable even though a repair path exists.

## Repro

1. Use OmO with an Anthropic model such as `claude-opus-4-7`
2. Reach a compaction or recovery path with an assistant message containing `tool_use`
3. Continue the session after the matching `tool_result` is missing or no longer adjacent
4. Observe Anthropic reject the request with a 400 complaining that `tool_use` ids were found without matching `tool_result` blocks immediately after

## Validation

- `bun test src/hooks/tool-pair-validator/hook.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/session-recovery/recover-unavailable-tool.test.ts src/plugin/messages-transform.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix synthetic `tool_result` generation to match Claude/Anthropic schema, preventing 400s after compaction or recovery. Sessions now recover by emitting `tool_result` blocks with `toolUseId`, `isError: true`, and text content blocks.

- Bug Fixes
  - Emit schema-compatible `tool_result` parts and accept both `toolUseId` and legacy `tool_use_id`.
  - Update recovery paths for missing results and unavailable tools to send valid, adjacent `tool_result` blocks.
  - Add regression tests for validator, compaction transform, and recovery helpers.

<sup>Written for commit b357d3b9584d2a2300e7c29c804da7691f0dc53e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

