### PR TITLE
fix(model-error-classifier): mark OpenAI server_error patterns as retryable (fixes #3799)

### DIFF
--- a/src/shared/model-error-classifier.test.ts
+++ b/src/shared/model-error-classifier.test.ts
@@ -434,6 +434,34 @@ describe("model-error-classifier", () => {
     //#then
     expect(result).toBe(true)
   })
+
+  test("treats OpenAI streaming server_error envelopes as retryable (issue #3799)", () => {
+    //#given: OpenAI surfaces its mid-stream error with type 'server_error'
+    const error = {
+      name: undefined,
+      message: "{\"error\":{\"type\":\"server_error\",\"message\":\"server_error\"}}",
+    }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
+
+  test("treats the OpenAI prose 'An error occurred while processing' message as retryable (issue #3799)", () => {
+    //#given: the human-readable prose surfaced when OpenAI's stream fails
+    const error = {
+      name: undefined,
+      message: "An error occurred while processing your request. Please try again later.",
+    }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
 })
 
 export {}

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -80,6 +80,11 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "请求过于频繁",       // "too many requests"
   "暂时不可用",         // "temporarily unavailable"
   "服务不可用",         // "service unavailable"
+  // OpenAI streaming server_error events surface either as a literal "server_error"
+  // type or as the prose error sentence below. Without these patterns subagent
+  // streams stall instead of being retried (issue #3799).
+  "server_error",
+  "an error occurred while processing",
 ]
 
 /**


### PR DESCRIPTION
## Summary
GPT-5.5 streaming \`server_error\` events left main and subagent turns hung instead of retrying. Add two missing patterns so the runtime classifies them as retryable.

## Root Cause
The maintainer's investigation on issue #3799 traced this directly to \`src/shared/model-error-classifier.ts\`:

> When \`session.error\` fires with \`{ name: undefined, message: \"An error occurred while processing your request...\" }\`, the message does NOT match any entry in \`RETRYABLE_MESSAGE_PATTERNS\` (which checks for \"internal_server_error\", \"server_error\", \"service unavailable\" etc. — but not the full OpenAI prose message). So \`shouldRetryError\` returns \`false\`, \`tryFallbackRetry\` skips, and the \"no retry\" path runs.

The OpenAI SDK surfaces these errors in two shapes that both need to match:
1. JSON envelope: \`{\"error\":{\"type\":\"server_error\",\"message\":\"server_error\"}}\` — the literal token \`server_error\` appears in the error message
2. Prose: \`\"An error occurred while processing your request. Please try again later.\"\`

## Changes
| File | Change |
|------|--------|
| \`src/shared/model-error-classifier.ts\` | Add two patterns to \`RETRYABLE_MESSAGE_PATTERNS\`: \`\"server_error\"\` and \`\"an error occurred while processing\"\` |
| \`src/shared/model-error-classifier.test.ts\` | Two regression tests covering both shapes |

Net diff: +33 LOC (5 prod + 28 test).

## Reproduction (issue #3799)
- GPT-5.5 streaming response surfaces \`server_error\` mid-stream
- Before fix: \`shouldRetryError\` returns \`false\` → no retry, no fallback → task stalls until \`staleTimeoutMs\`
- After fix: classified retryable → \`tryFallbackRetry\` runs → either retries the same model or falls through to the configured fallback chain

## Verification
~~~
$ bun test src/shared/model-error-classifier.test.ts
 25 pass
 0 fail
 25 expect() calls
Ran 25 tests across 1 file. [101.00ms]
~~~

- 2 new regression tests cover both error shapes
- All 23 existing classifier tests still pass
- Typecheck: \`bun run typecheck\` clean

## Note
This is the minimal addition the maintainer recommended in the issue thread. Two adjacent suggestions in the same thread (a safety \`task.status = \"failed\"\` transition for the no-retry path, and a per-stream inactivity timer) are out of scope for this PR — they touch background-agent state and timing, not error classification, and deserve their own focused PRs.

Fixes #3799

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks OpenAI streaming server_error errors as retryable so turns don’t hang and fallback retries run. Fixes #3799.

- **Bug Fixes**
  - Added two retryable patterns: "server_error" and "an error occurred while processing".
  - Covers JSON envelope and prose error forms; added two regression tests.

<sup>Written for commit c85d2f9bc8b7ad998c7f8095a32895037cda6eb9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3868?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

