### PR TITLE
fix: pass resolved model to session.create so sub-agent sessions use the correct model

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -567,6 +567,15 @@ export class BackgroundManager {
         parentID: input.parentSessionId,
         title: `${input.description} (@${input.agent} subagent)`,
         ...(input.sessionPermission ? { permission: input.sessionPermission } : {}),
+        ...(input.model
+          ? {
+              model: {
+                id: input.model.modelID,
+                providerID: input.model.providerID,
+                ...(input.model.variant ? { variant: input.model.variant } : {}),
+              },
+            }
+          : {}),
       } as Record<string, unknown>,
       query: {
         directory: parentDirectory,

--- a/src/tools/call-omo-agent/session-creator.ts
+++ b/src/tools/call-omo-agent/session-creator.ts
@@ -1,5 +1,6 @@
 import type { CallOmoAgentArgs } from "./types"
 import type { PluginInput } from "@opencode-ai/plugin"
+import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import { subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared"
 
@@ -12,7 +13,8 @@ export async function createOrGetSession(
     abort: AbortSignal
     metadata?: (input: { title?: string; metadata?: Record<string, unknown> }) => void
   },
-  ctx: PluginInput
+  ctx: PluginInput,
+  model?: DelegatedModelConfig,
 ): Promise<{ sessionID: string; isNew: boolean }> {
   if (args.session_id) {
     log(`[call_omo_agent] Using existing session: ${args.session_id}`)
@@ -39,6 +41,15 @@ export async function createOrGetSession(
       body: {
         parentID: toolContext.sessionID,
         title: `${args.description} (@${args.subagent_type} subagent)`,
+        ...(model
+          ? {
+              model: {
+                id: model.modelID,
+                providerID: model.providerID,
+                ...(model.variant ? { variant: model.variant } : {}),
+              },
+            }
+          : {}),
       } as Record<string, unknown>,
       query: {
         directory: parentDirectory,

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -73,7 +73,7 @@ export async function executeSync(
   let appliedFallbackChain = false
 
   try {
-    const session = await deps.createOrGetSession(args, toolContext, ctx)
+    const session = await deps.createOrGetSession(args, toolContext, ctx, model)
     sessionID = session.sessionID
     createdSessionForExecution = session.isNew
     subagentSessions.add(sessionID)

--- a/src/tools/delegate-task/sync-session-creator.ts
+++ b/src/tools/delegate-task/sync-session-creator.ts
@@ -1,9 +1,16 @@
 import type { OpencodeClient } from "./types"
+import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import { QUESTION_DENIED_SESSION_PERMISSION } from "../../shared/question-denied-session-permission"
 
 export async function createSyncSession(
   client: OpencodeClient,
-  input: { parentSessionID: string; agentToUse: string; description: string; defaultDirectory: string }
+  input: {
+    parentSessionID: string
+    agentToUse: string
+    description: string
+    defaultDirectory: string
+    categoryModel?: DelegatedModelConfig
+  }
 ): Promise<{ ok: true; sessionID: string; parentDirectory: string } | { ok: false; error: string }> {
   const parentSession = client.session.get
     ? await client.session.get({ path: { id: input.parentSessionID } }).catch(() => null)
@@ -15,6 +22,15 @@ export async function createSyncSession(
       parentID: input.parentSessionID,
       title: `${input.description} (@${input.agentToUse} subagent)`,
       permission: QUESTION_DENIED_SESSION_PERMISSION,
+      ...(input.categoryModel
+        ? {
+            model: {
+              id: input.categoryModel.modelID,
+              providerID: input.categoryModel.providerID,
+              ...(input.categoryModel.variant ? { variant: input.categoryModel.variant } : {}),
+            },
+          }
+        : {}),
     } as Record<string, unknown>,
     query: {
       directory: parentDirectory,

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -64,6 +64,7 @@ export async function executeSyncTask(
       agentToUse,
       description: args.description,
       defaultDirectory: directory,
+      categoryModel,
     })
 
     if (!createSessionResult.ok) {
@@ -227,6 +228,7 @@ export async function executeSyncTask(
             agentToUse,
             description: args.description,
             defaultDirectory: directory,
+            categoryModel: nextFallbackModel,
           })
           if (!retrySessionResult.ok) {
             return retrySessionResult.error


### PR DESCRIPTION
## Summary

- Sub-agent sessions created via `task` tool or `call_omo_agent` tool were created **without a model**, relying only on a `promptAsync` body override that opencode core ignores
- This caused fallback to the client's system default model (e.g. a reasoning model), resulting in infinite thinking loops / hangs
- OpenCode's `session.create` API **does** support `model: { id, providerID, variant }` at creation time
- Fix: pass the resolved model to `session.create` across all sub-agent session creation paths

## Changes

- **sync-session-creator.ts**: Added `categoryModel` to input type; passes `model` in `session.create` body
- **sync-task.ts**: Passes `categoryModel` (and `nextFallbackModel` on retry) to `createSyncSession()`
- **session-creator.ts**: Added optional `model` parameter; passes it in `session.create` body
- **sync-executor.ts**: Passes the resolved `model` to `createOrGetSession()`
- **background-agent/manager.ts**: Passes `input.model` in `session.create` body for background tasks

## Root Cause

The plugin resolves the correct model via `resolveCategoryExecution()`, but only passes it as a `promptAsync` body override where opencode core ignores it. OpenCode's `session.create` v2 API accepts `model: { id, providerID, variant }` at creation time, which ensures each sub-agent session is created with the correct model regardless of `promptAsync` override behavior.

## Testing

```bash
bun run typecheck
bun test
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure sub-agent sessions are created with the resolved model to prevent fallback to default reasoning models and hangs. We now pass `model: { id, providerID, variant }` to `session.create` across task, `call_omo_agent`, and background paths.

- **Bug Fixes**
  - Pass the resolved model when creating sub-agent sessions to avoid default model fallback.
  - Update `delegate-task` (`createSyncSession`, including retries with `nextFallbackModel`), `call_omo_agent` (`createOrGetSession` and sync executor), and background task creation to include the model.

<sup>Written for commit 0b9cc80ecfc740135d256905613cd70e8e95bace. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

