### PR TITLE
feat(notification): switch to correct Ghostty tab on click

### DIFF
--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -71,7 +71,30 @@ export async function sendSessionNotification(
       if (terminalNotifierPath) {
         const bundleId = process.env.__CFBundleIdentifier
         try {
-          if (bundleId) {
+          if (bundleId === "com.mitchellh.ghostty") {
+            const escapedTitle = escapeAppleScriptText(title)
+            const focusScript = [
+              'tell application "Ghostty" to activate',
+              'tell application "Ghostty"',
+              `  set targetName to "${escapedTitle}"`,
+              '  repeat with w in every window',
+              '    repeat with t in every tab of w',
+              '      if name of t contains targetName then',
+              '        select tab t',
+              '        set index of w to 1',
+              '        return',
+              '      end if',
+              '    end repeat',
+              '  end repeat',
+              'end tell',
+            ].join("\n")
+            const osascriptPath = await getOsascriptPath()
+            if (osascriptPath) {
+              await ctx.$`${terminalNotifierPath} -title ${title} -message ${message} -execute ${osascriptPath + " -e " + "'" + focusScript + "'"}`.quiet()
+            } else {
+              await ctx.$`${terminalNotifierPath} -title ${title} -message ${message} -activate ${bundleId}`.quiet()
+            }
+          } else if (bundleId) {
             await ctx.$`${terminalNotifierPath} -title ${title} -message ${message} -activate ${bundleId}`.quiet()
           } else {
             await ctx.$`${terminalNotifierPath} -title ${title} -message ${message}`.quiet()


### PR DESCRIPTION
When clicking a macOS notification from OpenCode, activate Ghostty AND switch to the specific tab where the session is running.

Previously, terminal-notifier used `-activate` which only focused Ghostty without switching tabs. Now, for Ghostty specifically, we use `-execute` with an AppleScript that searches all windows for the tab matching the notification title, selects it, and brings its window to front.

Falls back to the original `-activate` behavior for non-Ghostty terminals.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Ghostty to the correct tab when you click a macOS notification, instead of just focusing the app. Non-Ghostty terminals keep the previous focus-only behavior.

- **New Features**
  - For Ghostty (`com.mitchellh.ghostty`), use `terminal-notifier -execute` with an AppleScript that finds the tab by notification title, selects it, and raises its window.
  - Fallback: if `osascript` isn’t available or the terminal isn’t Ghostty, use the previous `-activate` behavior.

<sup>Written for commit b8ddfe57acf5981fef0e906dea417306240eac20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

