### PR TITLE
fix(team-mode): only mark server running when actually in server mode

### DIFF
--- a/src/create-managers.test.ts
+++ b/src/create-managers.test.ts
@@ -76,7 +76,7 @@ function createTmuxConfig(enabled: boolean) {
   }
 }
 
-function createContext(directory: string): PluginInput {
+function createContext(directory: string, serverUrl?: URL): PluginInput {
   const shell = Object.assign(
     () => {
       throw new Error("shell should not be called in this test")
@@ -107,7 +107,7 @@ function createContext(directory: string): PluginInput {
     },
     directory,
     worktree: directory,
-    serverUrl: new URL("http://localhost:4096"),
+    serverUrl,
     $: shell,
     client: {} as PluginInput["client"],
   }
@@ -145,7 +145,7 @@ describe("createManagers", () => {
 
   it("#given tmux integration is enabled #when managers are created #then it marks the tmux server as running", () => {
     const args = {
-      ctx: createContext("/tmp"),
+      ctx: createContext("/tmp", new URL("http://localhost:4096")),
       pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
       tmuxConfig: createTmuxConfig(true),
       modelCacheState: createModelCacheState(),
@@ -158,9 +158,24 @@ describe("createManagers", () => {
     expect(markServerRunningInProcess).toHaveBeenCalledTimes(1)
   })
 
+  it("#given tmux integration is enabled but no server URL (normal CLI mode) #when managers are created #then it does not mark the server as running", () => {
+    const args = {
+      ctx: createContext("/tmp", undefined),
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(true),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+
+    createManagers(args)
+
+    expect(markServerRunningInProcess).not.toHaveBeenCalled()
+  })
+
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {
     const args = {
-      ctx: createContext("/tmp/project"),
+      ctx: createContext("/tmp/project", new URL("http://localhost:4096")),
       pluginConfig: OhMyOpenCodeConfigSchema.parse({
         openclaw: {
           enabled: true,

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -54,7 +54,10 @@ export function createManagers(args: {
   const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled } = args
   const deps = { ...defaultCreateManagersDeps, ...args.deps }
 
-  if (tmuxConfig.enabled) {
+  // Only mark server running if we have a server URL (running in server mode)
+  // This prevents team mode from incorrectly assuming a server exists when
+  // tmux is enabled but opencode is not running as a server (e.g., normal CLI mode)
+  if (tmuxConfig.enabled && ctx.serverUrl) {
     deps.markServerRunningInProcessFn()
   }
   const tmuxSessionManager = new deps.TmuxSessionManagerClass(ctx, tmuxConfig)


### PR DESCRIPTION
## Summary

Fixes a bug where team mode tmux visualization created broken panes when opencode was not running in server mode.

**Root Cause**: `markServerRunningInProcess()` was called whenever `tmuxConfig.enabled` was true, regardless of whether opencode was actually running as an HTTP server. This caused `isServerRunning()` to always return `true` without performing a health check, leading to:

1. Tmux panes being created when no server exists
2. `opencode attach` commands failing silently
3. Broken panes showing confusing error messages

**Fix**: Only call `markServerRunningInProcess()` when `ctx.serverUrl` exists, indicating opencode is running in server mode (`opencode serve` or `opencode web` commands).

## Changes

- `src/create-managers.ts`: Added `ctx.serverUrl` check before marking server as running
- `src/create-managers.test.ts`: Added test case for tmux enabled without server URL

## Test Plan

All tests pass (4 + 15 = 19 tests).

## Related

- Issue: #3894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team mode tmux creating panes and silent attach failures when the HTTP server isn’t running. We now only mark the server as running in actual server mode.

- **Bug Fixes**
  - Call `markServerRunningInProcess()` only when `ctx.serverUrl` exists (server mode); added a test for tmux enabled without a server URL.
  - Prevents broken panes and silent `opencode attach` failures (fixes #3894).

<sup>Written for commit 9af54c67efb37d56277bd34a0cf6b8ecd134d567. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

