### PR TITLE
fix(call-omo-agent): translate config-key subagent_type to display name before SDK dispatch

### DIFF
--- a/src/tools/call-omo-agent/background-agent-executor.test.ts
+++ b/src/tools/call-omo-agent/background-agent-executor.test.ts
@@ -152,4 +152,32 @@ describe("executeBackgroundAgent", () => {
     expect(secondResult).toContain("Task ID: task-2")
     expect(secondResult).not.toContain("interrupt")
   })
+
+  test("#given subagent_type is the lowercase config key 'hephaestus' #when executeBackgroundAgent runs #then BackgroundManager.launch receives the registered display name 'Hephaestus - Deep Agent'", async () => {
+    //#given
+    launchMock.mockClear()
+    launchMock.mockResolvedValueOnce({
+      id: "task-heph",
+      sessionId: "ses-heph",
+      description: "task",
+      agent: "Hephaestus - Deep Agent",
+      status: "pending",
+    })
+    getTaskMock.mockReturnValueOnce({
+      id: "task-heph",
+      sessionId: "ses-heph",
+      description: "task",
+      agent: "Hephaestus - Deep Agent",
+      status: "pending",
+    })
+    const args = { ...testArgs, subagent_type: "hephaestus" }
+
+    //#when
+    await executeBackgroundAgent(args, testContext, mockManager, mockClient)
+
+    //#then
+    const launchCall = launchMock.mock.calls.find(([input]) => (input as { agent: string }).agent !== undefined)
+    expect(launchCall).toBeDefined()
+    expect((launchCall![0] as { agent: string }).agent).toBe("Hephaestus - Deep Agent")
+  })
 })

--- a/src/tools/call-omo-agent/background-agent-executor.ts
+++ b/src/tools/call-omo-agent/background-agent-executor.ts
@@ -7,6 +7,7 @@ import type { CallOmoAgentArgs } from "./types"
 import type { ToolContextWithMetadata } from "./tool-context-with-metadata"
 import { getMessageDir } from "./message-storage-directory"
 import { getSessionTools } from "../../shared/session-tools-store"
+import { getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 
 export async function executeBackgroundAgent(
 	args: CallOmoAgentArgs,
@@ -39,7 +40,7 @@ export async function executeBackgroundAgent(
 		const task = await manager.launch({
 			description: args.description,
 			prompt: args.prompt,
-			agent: args.subagent_type,
+			agent: getAgentDisplayName(stripAgentListSortPrefix(args.subagent_type)),
 			parentSessionId: toolContext.sessionID,
 			parentMessageId: toolContext.messageID,
 			parentAgent,

--- a/src/tools/call-omo-agent/background-executor.test.ts
+++ b/src/tools/call-omo-agent/background-executor.test.ts
@@ -126,7 +126,7 @@ describe("executeBackground", () => {
     if (!launchArgs) {
       throw new Error("Expected launch arguments")
     }
-    expect(launchArgs.agent).toBe("hephaestus")
+    expect(launchArgs.agent).toBe("Hephaestus - Deep Agent")
   })
 
   test("keeps launched background task alive when parent aborts before session id resolves", async () => {
@@ -209,5 +209,49 @@ describe("executeBackground", () => {
     expect(secondResult).toContain("Background agent task launched successfully")
     expect(secondResult).toContain("Task ID: task-2")
     expect(secondResult).not.toContain("interrupt")
+  })
+
+  test("#given subagent_type is the lowercase config key 'hephaestus' #when executeBackground runs #then BackgroundManager.launch receives the registered display name", async () => {
+    //#given
+    launchMock.mockClear()
+    launchMock.mockResolvedValueOnce({
+      id: "test-task-id",
+      sessionId: "sub-session",
+      description: "Test task",
+      agent: "Hephaestus - Deep Agent",
+      status: "pending",
+    })
+
+    //#when
+    await executeBackground({ ...testArgs, subagent_type: "hephaestus" }, testContext, mockManager, mockClient)
+
+    //#then
+    const latestCall = [...launchMock.mock.calls].pop()
+    if (!latestCall) throw new Error("Expected background manager launch to be called")
+    const launchArgs = latestCall[0]
+    if (!launchArgs) throw new Error("Expected launch arguments")
+    expect(launchArgs.agent).toBe("Hephaestus - Deep Agent")
+  })
+
+  test("#given subagent_type is a same-keyed agent 'explore' #when executeBackground runs #then BackgroundManager.launch receives the unchanged key (regression guard)", async () => {
+    //#given
+    launchMock.mockClear()
+    launchMock.mockResolvedValueOnce({
+      id: "test-task-id",
+      sessionId: "sub-session",
+      description: "Test task",
+      agent: "explore",
+      status: "pending",
+    })
+
+    //#when
+    await executeBackground({ ...testArgs, subagent_type: "explore" }, testContext, mockManager, mockClient)
+
+    //#then
+    const latestCall = [...launchMock.mock.calls].pop()
+    if (!latestCall) throw new Error("Expected background manager launch to be called")
+    const launchArgs = latestCall[0]
+    if (!launchArgs) throw new Error("Expected launch arguments")
+    expect(launchArgs.agent).toBe("explore")
   })
 })

--- a/src/tools/call-omo-agent/background-executor.ts
+++ b/src/tools/call-omo-agent/background-executor.ts
@@ -9,6 +9,7 @@ import { getSessionAgent } from "../../features/claude-code-session-state"
 import { getMessageDir } from "./message-dir"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { sanitizeSubagentType } from "../delegate-task/subagent-discovery"
+import { getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 
 export async function executeBackground(
   args: CallOmoAgentArgs,
@@ -48,7 +49,7 @@ export async function executeBackground(
     const task = await manager.launch({
       description: args.description,
       prompt: args.prompt,
-      agent: sanitizeSubagentType(args.subagent_type),
+      agent: getAgentDisplayName(stripAgentListSortPrefix(sanitizeSubagentType(args.subagent_type))),
       parentSessionId: toolContext.sessionID,
       parentMessageId: toolContext.messageID,
       parentAgent,

--- a/src/tools/call-omo-agent/sync-executor.test.ts
+++ b/src/tools/call-omo-agent/sync-executor.test.ts
@@ -136,6 +136,69 @@ describe("executeSync", () => {
     expect(promptInput?.body.agent).toBe("Sisyphus - Ultraworker")
   })
 
+  test("#given subagent_type is the lowercase config key 'hephaestus' #when executeSync runs #then promptAsync receives the registered display name 'Hephaestus - Deep Agent'", async () => {
+    //#given
+    const executeSync = await importExecuteSync()
+    const deps = createDependencies()
+    const toolContext = createToolContext()
+    const recorder = createPromptAsyncRecorder()
+    const args = {
+      subagent_type: "hephaestus",
+      description: "task",
+      prompt: "do the thing",
+      run_in_background: false,
+    }
+
+    //#when
+    await executeSync(args, toolContext, createContext(recorder.promptAsync) as never, deps)
+
+    //#then — SDK rejects raw config keys with UnknownError; the dispatch must translate
+    const promptInput = recorder.getCapturedInput()
+    expect(promptInput?.body.agent).toBe("Hephaestus - Deep Agent")
+  })
+
+  test("#given subagent_type is the lowercase config key 'sisyphus-junior' #when executeSync runs #then promptAsync receives the registered display name 'Sisyphus-Junior'", async () => {
+    //#given
+    const executeSync = await importExecuteSync()
+    const deps = createDependencies()
+    const toolContext = createToolContext()
+    const recorder = createPromptAsyncRecorder()
+    const args = {
+      subagent_type: "sisyphus-junior",
+      description: "task",
+      prompt: "do the thing",
+      run_in_background: false,
+    }
+
+    //#when
+    await executeSync(args, toolContext, createContext(recorder.promptAsync) as never, deps)
+
+    //#then
+    const promptInput = recorder.getCapturedInput()
+    expect(promptInput?.body.agent).toBe("Sisyphus-Junior")
+  })
+
+  test("#given subagent_type is already a display name like 'explore' (config key == display name) #when executeSync runs #then promptAsync receives 'explore' unchanged", async () => {
+    //#given a same-keyed agent must not be double-translated
+    const executeSync = await importExecuteSync()
+    const deps = createDependencies()
+    const toolContext = createToolContext()
+    const recorder = createPromptAsyncRecorder()
+    const args = {
+      subagent_type: "explore",
+      description: "task",
+      prompt: "do the thing",
+      run_in_background: false,
+    }
+
+    //#when
+    await executeSync(args, toolContext, createContext(recorder.promptAsync) as never, deps)
+
+    //#then
+    const promptInput = recorder.getCapturedInput()
+    expect(promptInput?.body.agent).toBe("explore")
+  })
+
   test("returns processed response with task metadata footer", async () => {
     //#given
     const executeSync = await importExecuteSync()

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -5,7 +5,7 @@ import { getAgentToolRestrictions, log } from "../../shared"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { FallbackEntry } from "../../shared/model-requirements"
-import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import { getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { waitForCompletion } from "./completion-poller"
 import { processMessages } from "./message-processor"
 import { createOrGetSession } from "./session-creator"
@@ -105,7 +105,7 @@ export async function executeSync(
       await (ctx.client.session as unknown as SessionWithPromptAsync).promptAsync({
         path: { id: sessionID },
         body: {
-          agent: normalizedSubagentType,
+          agent: getAgentDisplayName(normalizedSubagentType),
           tools: {
             ...getAgentToolRestrictions(normalizedSubagentType),
             task: false,


### PR DESCRIPTION
## Summary

`call_omo_agent` accepts agents like `hephaestus`, `metis`, `momus`, `sisyphus-junior` per [`ALLOWED_AGENTS`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/call-omo-agent/constants.ts) (added in #1579), but **dispatch always fails for these agents** because the tool sends the raw config key (`hephaestus`) to the OpenCode SDK, which only registers display names (`Hephaestus - Deep Agent`).

In the TUI this surfaces as a toast labelled **`Unknown error`** (the SDK's `UnknownError` class name), then a 5-minute polling timeout in `completion-poller.ts` before the tool returns `Error: Agent task timed out after 5 minutes.`. With `run_in_background: true` the failure is instant — the SDK rejection comes back from `BackgroundManager.launch` immediately.

## Reproduction (before fix)

From any session that has `call_omo_agent` exposed (e.g. OpenCode-Builder), against a Hephaestus subagent:

```
call_omo_agent(subagent_type="hephaestus", run_in_background=true, description="ping", prompt="Reply pong.")
→  TUI toast: "UnknownError"
→  [call_omo_agent] session.error: 'Agent not found: "hephaestus". Available agents: ..., Hephaestus - Deep Agent, ...'
```

The same fault hits `metis`, `momus`, `sisyphus-junior`, `prometheus`, `atlas` — anywhere [`AGENT_DISPLAY_NAMES`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/shared/agent-display-names.ts) maps config key → distinct display name. Same-keyed agents (`explore`, `librarian`, `oracle`, `multimodal-looker`) work today because key == display name.

## Root cause

Three dispatch sites passed the raw config key:

- [`sync-executor.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/call-omo-agent/sync-executor.ts) — `agent: normalizedSubagentType` (sync path)
- [`background-executor.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/call-omo-agent/background-executor.ts) — `agent: sanitizeSubagentType(args.subagent_type)` (live background path imported by `tools.ts`)
- [`background-agent-executor.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/call-omo-agent/background-agent-executor.ts) — `agent: args.subagent_type` (parallel `executeBackgroundAgent` symbol that is currently only referenced by its own test file)

`delegate-task` already does the right thing (uses `getAgentDisplayName` in `subagent-discovery.ts`); `call_omo_agent`'s dispatch sites were missed.

## Fix

Translate via `getAgentDisplayName(stripAgentListSortPrefix(...))` at all three dispatch sites. The function is idempotent: same-keyed agents (`explore` → `explore`) are unchanged; ZWSP-prefixed display names are stripped first; quote/whitespace sanitization is preserved on the background path. Tool restrictions lookup (`getAgentToolRestrictions`) is case-insensitive and is left alone.

```diff
// sync-executor.ts
- agent: normalizedSubagentType,
+ agent: getAgentDisplayName(normalizedSubagentType),

// background-executor.ts (live, imported by tools.ts)
- agent: sanitizeSubagentType(args.subagent_type),
+ agent: getAgentDisplayName(stripAgentListSortPrefix(sanitizeSubagentType(args.subagent_type))),

// background-agent-executor.ts (parallel symbol; fixed for symmetry)
- agent: args.subagent_type,
+ agent: getAgentDisplayName(stripAgentListSortPrefix(args.subagent_type)),
```

## Tests (TDD)

Across `sync-executor.test.ts`, `background-executor.test.ts`, and `background-agent-executor.test.ts`:

| Case | Asserted dispatch `agent:` |
|---|---|
| `subagent_type: "hephaestus"` | `"Hephaestus - Deep Agent"` |
| `subagent_type: "sisyphus-junior"` | `"Sisyphus-Junior"` |
| `subagent_type: "explore"` (regression guard for same-keyed) | `"explore"` |
| `subagent_type: "\\hephaestus\\"` (sanitize+translate composition) | `"Hephaestus - Deep Agent"` |

The pre-existing `background-executor.test.ts` test "sanitizes subagent_type before passing to background manager launch" had its assertion flipped from `"hephaestus"` → `"Hephaestus - Deep Agent"` to encode the new contract while still verifying that quote-stripping is preserved.

Verified RED → GREEN locally; all 70 tests across the 10 files in `src/tools/call-omo-agent/` pass.

## End-to-end verification

Before fix, with `run_in_background: true`: tool returns immediately with `UnknownError` toast, plugin log shows `Agent not found: "hephaestus"`.
After fix, with `run_in_background: true`: `BackgroundManager.launch` receives `agent: "Hephaestus - Deep Agent"`, the SDK accepts it, the subagent session starts, and the tool returns the normal `Background agent task launched successfully... Task ID: ...` payload.
After fix, with `run_in_background: false`: `Hephaestus` responds with `pong` in seconds (validated live in an OpenCode-Builder session).

## Note on `background-agent-executor.ts`

The codebase contains both `background-executor.ts` and `background-agent-executor.ts` exporting different symbols (`executeBackground` vs `executeBackgroundAgent`). Only the former is wired into `tools.ts`; the latter has no callers besides its own test. The repo's `AGENTS.md` documents both files as if they form a router→launcher pair, but the actual code in `background-executor.ts` calls `manager.launch` directly without going through `executeBackgroundAgent`. This PR fixes both symbols for symmetry, but happy to drop the `background-agent-executor.ts` edits + tests (or to delete that file entirely) if you prefer.

## Related

- Closes the dispatch gap from #1579 (`ALLOWED_AGENTS` was expanded but dispatch sites were never updated)
- Likely improves #3774 reliability for non-same-keyed agents (Hephaestus, Metis, Momus, Sisyphus-Junior)