### PR TITLE
fix: use resolveRegisteredAgentName in ralph-loop continuation injector

### DIFF
--- a/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
+import {
+  registerAgentName,
+  _resetForTesting,
+} from "../../features/claude-code-session-state"
 
 describe("ralph-loop continuation prompt injector", () => {
+  beforeEach(() => {
+    _resetForTesting()
+    registerAgentName("\u200bSisyphus - Ultraworker")
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+  })
+
   test("#given inherited message agent has ZWSP prefix #when injecting continuation prompt #then promptAsync receives normalized agent", async () => {
     // given
     let promptBody: { agent?: string } | undefined
@@ -28,8 +41,8 @@ describe("ralph-loop continuation prompt injector", () => {
     })
 
     // then
-    expect(promptBody?.agent).toBe("sisyphus")
-    expect(promptBody?.agent).not.toContain("\u200b")
+    expect(promptBody?.agent).toBe("\u200bSisyphus - Ultraworker")
+    expect(promptBody?.agent).not.toContain("\u200b\u200b")
   })
 
   test("#given inherited message agent has no ZWSP prefix #when injecting continuation prompt #then promptAsync receives normalized agent", async () => {
@@ -58,7 +71,7 @@ describe("ralph-loop continuation prompt injector", () => {
     })
 
     // then
-    expect(promptBody?.agent).toBe("sisyphus")
+    expect(promptBody?.agent).toBe("\u200bSisyphus - Ultraworker")
   })
 
   test("#given inherited message model includes variant #when injecting continuation prompt #then promptAsync receives variant as a top-level field", async () => {

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -8,7 +8,7 @@ import {
 	normalizeSDKResponse,
 	resolveInheritedPromptTools,
 } from "../../shared"
-import { normalizeAgentForPromptKey } from "../../shared/agent-display-names"
+import { resolveRegisteredAgentName } from "../../features/claude-code-session-state"
 
 type MessageInfo = {
 	agent?: string
@@ -70,7 +70,7 @@ export async function injectContinuationPrompt(
 	}
 
 	const inheritedTools = resolveInheritedPromptTools(sourceSessionID, tools)
-	const cleanAgent = normalizeAgentForPromptKey(agent)
+	const cleanAgent = resolveRegisteredAgentName(agent)
 
 	const launchModel = model
 		? { providerID: model.providerID, modelID: model.modelID }


### PR DESCRIPTION
## Summary

- `continuation-prompt-injector.ts` used `normalizeAgentForPromptKey()` which converts display names to config keys (e.g. `"Sisyphus - Ultraworker"` → `"sisyphus"`)
- OpenCode's `promptAsync` API expects **registered display names**, not config keys, causing `Agent not found: "sisyphus"` errors during ralph-loop/ulw-loop continuation
- Replace with `resolveRegisteredAgentName()` which correctly resolves both config keys and display names to the registered agent name that OpenCode expects

## Test plan

- [x] `bun run typecheck` passes
- [ ] Run `/ulw-loop` or `/ralph-loop` and verify continuation prompt no longer throws `Agent not found`
- [ ] Verify agent name in `promptAsync` call matches registered display name (e.g. `"Sisyphus - Ultraworker"` with invisible prefix)

Fixes #3743

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `resolveRegisteredAgentName` in the ralph-loop continuation injector so OpenCode’s `promptAsync` receives the registered display name (not the config key), fixing “Agent not found” errors in `/ralph-loop` and `/ulw-loop` continuations (Fixes #3743). Tests now register the agent and assert the ZWSP‑prefixed display name.

<sup>Written for commit 2fb65433baf807d9fe8ebfba6228b0767f241edf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

