### PR TITLE
fix(auto-update): update OpenCode plugin sandbox

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -22,7 +22,7 @@ function createTemporaryDirectory(prefix: string): string {
   return directory
 }
 
-function writeJson(filePath: string, value: Record<string, string | Record<string, string>>): void {
+function writeJson(filePath: string, value: Record<string, unknown>): void {
   mkdirSync(dirname(filePath), { recursive: true })
   writeFileSync(filePath, JSON.stringify(value), "utf-8")
 }
@@ -47,6 +47,43 @@ afterEach(() => {
 
 describe("system loaded version", () => {
   describe("getLoadedPluginVersion", () => {
+    it("prefers the configured plugin sandbox over legacy flat installs", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-")
+      const cacheDir = join(cacheHome, "opencode")
+      const sandboxDir = join(cacheDir, "packages", `${PLUGIN_NAME}@latest`)
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      writeJson(join(configDir, "opencode.json"), {
+        plugin: [PLUGIN_NAME],
+      })
+      writeJson(join(sandboxDir, "package.json"), {
+        dependencies: { [PLUGIN_NAME]: "latest" },
+      })
+      writeJson(join(sandboxDir, "node_modules", PLUGIN_NAME, "package.json"), {
+        version: "6.7.8",
+      })
+      writeJson(join(configDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "1.2.3" },
+      })
+      writeJson(join(configDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "1.2.3",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.cacheDir).toBe(sandboxDir)
+      expect(loadedVersion.cachePackagePath).toBe(join(sandboxDir, "package.json"))
+      expect(loadedVersion.installedPackagePath).toBe(join(sandboxDir, "node_modules", PLUGIN_NAME, "package.json"))
+      expect(loadedVersion.expectedVersion).toBe(null)
+      expect(loadedVersion.loadedVersion).toBe("6.7.8")
+    })
+
     it("prefers the config directory when both installs exist", () => {
       //#given
       const configDir = createTemporaryDirectory("omo-config-")

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -4,12 +4,17 @@ import { join } from "node:path"
 import { resolveSymlink } from "../../../shared/file-utils"
 import { getLatestVersion } from "../../../hooks/auto-update-checker/checker"
 import { extractChannel } from "../../../hooks/auto-update-checker"
+import { resolveManagedPluginSandboxWorkspace } from "../../../hooks/auto-update-checker/plugin-sandbox"
 import { PACKAGE_NAME } from "../constants"
 import { ACCEPTED_PACKAGE_NAMES, getOpenCodeCacheDir, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
 
 interface PackageJsonShape {
   version?: string
   dependencies?: Record<string, string>
+}
+
+interface OpenCodeConfigShape {
+  plugin?: unknown
 }
 
 interface PackageCandidate {
@@ -76,6 +81,36 @@ function createPackageCandidates(rootDir: string): PackageCandidate[] {
   }))
 }
 
+function createInstallCandidate(rootDir: string): InstallCandidate {
+  return {
+    cacheDir: rootDir,
+    cachePackagePath: join(rootDir, "package.json"),
+    packageCandidates: createPackageCandidates(rootDir),
+  }
+}
+
+function getConfiguredPluginEntries(configPaths: ReturnType<typeof getOpenCodeConfigPaths>): string[] {
+  const entries: string[] = []
+
+  for (const configPath of [configPaths.configJson, configPaths.configJsonc]) {
+    const config = readPackageJson(configPath) as OpenCodeConfigShape | null
+    if (!Array.isArray(config?.plugin)) continue
+
+    for (const entry of config.plugin) {
+      if (typeof entry === "string") entries.push(entry)
+    }
+  }
+
+  return entries
+}
+
+function createSandboxInstallCandidates(entries: string[], cachePackagesDir: string): InstallCandidate[] {
+  return entries.flatMap((entry) => {
+    const workspace = resolveManagedPluginSandboxWorkspace(entry, cachePackagesDir)
+    return workspace ? [createInstallCandidate(workspace.workspaceDir)] : []
+  })
+}
+
 function selectInstalledPackage(candidate: InstallCandidate): PackageCandidate {
   return candidate.packageCandidates.find((packageCandidate) => existsSync(packageCandidate.installedPackagePath))
     ?? candidate.packageCandidates[0]
@@ -90,17 +125,12 @@ export function getLoadedPluginVersion(): LoadedVersionInfo {
   const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
   const configDir = resolveExistingDir(configPaths.configDir)
   const cacheDir = resolveExistingDir(resolveOpenCodeCacheDir())
+  const cachePackagesDir = resolveExistingDir(join(cacheDir, "packages"))
   const candidates: InstallCandidate[] = [
-    {
-      cacheDir: configDir,
-      cachePackagePath: join(configDir, "package.json"),
-      packageCandidates: createPackageCandidates(configDir),
-    },
-    {
-      cacheDir,
-      cachePackagePath: join(cacheDir, "package.json"),
-      packageCandidates: createPackageCandidates(cacheDir),
-    },
+    ...createSandboxInstallCandidates(getConfiguredPluginEntries(configPaths), cachePackagesDir),
+    createInstallCandidate(configDir),
+    createInstallCandidate(cachePackagesDir),
+    createInstallCandidate(cacheDir),
   ]
 
   const selectedCandidate = candidates.find((candidate) => candidate.packageCandidates.some((packageCandidate) => existsSync(packageCandidate.installedPackagePath)))

--- a/src/hooks/auto-update-checker/cache.ts
+++ b/src/hooks/auto-update-checker/cache.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { CACHE_DIR, PACKAGE_NAME, getUserConfigDir } from "./constants"
+import { CACHE_DIR, PACKAGE_NAME } from "./constants"
 import { log } from "../../shared/logger"
 
 interface BunLockfile {
@@ -43,9 +43,21 @@ function deleteBinaryBunLock(lockPath: string): boolean {
   }
 }
 
-function removeFromBunLock(packageName: string): boolean {
-  const textLockPath = path.join(CACHE_DIR, "bun.lock")
-  const binaryLockPath = path.join(CACHE_DIR, "bun.lockb")
+function removeFromNpmLock(workspaceDir: string): boolean {
+  const lockPath = path.join(workspaceDir, "package-lock.json")
+
+  try {
+    fs.unlinkSync(lockPath)
+    log("[auto-update-checker] Removed package-lock.json to force re-resolution")
+    return true
+  } catch {
+    return false
+  }
+}
+
+function removeFromBunLock(packageName: string, workspaceDir: string): boolean {
+  const textLockPath = path.join(workspaceDir, "bun.lock")
+  const binaryLockPath = path.join(workspaceDir, "bun.lockb")
 
   if (fs.existsSync(textLockPath)) {
     return removeFromTextBunLock(textLockPath, packageName)
@@ -59,13 +71,9 @@ function removeFromBunLock(packageName: string): boolean {
   return false
 }
 
-export function invalidatePackage(packageName: string = PACKAGE_NAME): boolean {
+export function invalidatePackage(packageName: string = PACKAGE_NAME, workspaceDir: string = CACHE_DIR): boolean {
   try {
-    const userConfigDir = getUserConfigDir()
-    const pkgDirs = [
-      path.join(userConfigDir, "node_modules", packageName),
-      path.join(CACHE_DIR, "node_modules", packageName),
-    ]
+    const pkgDirs = [path.join(workspaceDir, "node_modules", packageName)]
 
     let packageRemoved = false
     let lockRemoved = false
@@ -78,7 +86,7 @@ export function invalidatePackage(packageName: string = PACKAGE_NAME): boolean {
       }
     }
 
-    lockRemoved = removeFromBunLock(packageName)
+    lockRemoved = removeFromBunLock(packageName, workspaceDir) || removeFromNpmLock(workspaceDir)
 
     if (!packageRemoved && !lockRemoved) {
       log(`[auto-update-checker] Package not found, nothing to invalidate: ${packageName}`)

--- a/src/hooks/auto-update-checker/checker/sync-package-json.ts
+++ b/src/hooks/auto-update-checker/checker/sync-package-json.ts
@@ -49,14 +49,18 @@ function writeCachePackageJson(
   }
 }
 
-export function syncCachePackageJsonToIntent(pluginInfo: PluginEntryInfo): SyncResult {
-  const cachePackageJsonPath = path.join(CACHE_DIR, "package.json")
+export function syncCachePackageJsonToIntent(
+  pluginInfo: PluginEntryInfo,
+  workspaceDir: string = CACHE_DIR,
+  packageName: string = PACKAGE_NAME,
+): SyncResult {
+  const cachePackageJsonPath = path.join(workspaceDir, "package.json")
   const intentVersion = getIntentVersion(pluginInfo)
 
   if (!fs.existsSync(cachePackageJsonPath)) {
     log("[auto-update-checker] Cache package.json missing, creating workspace package.json", { intentVersion })
     return {
-      ...writeCachePackageJson(cachePackageJsonPath, { dependencies: { [PACKAGE_NAME]: intentVersion } }),
+      ...writeCachePackageJson(cachePackageJsonPath, { dependencies: { [packageName]: intentVersion } }),
       message: `Created cache package.json with: ${intentVersion}`,
     }
   }
@@ -78,22 +82,22 @@ export function syncCachePackageJsonToIntent(pluginInfo: PluginEntryInfo): SyncR
     return { synced: false, error: "parse_error", message: "Failed to parse cache package.json (malformed JSON)" }
   }
 
-  if (!pkgJson || !pkgJson.dependencies?.[PACKAGE_NAME]) {
+  if (!pkgJson || !pkgJson.dependencies?.[packageName]) {
     log("[auto-update-checker] Plugin missing from cache package.json dependencies, adding dependency", { intentVersion })
     const nextPkgJson = {
       ...(pkgJson ?? {}),
       dependencies: {
         ...(pkgJson?.dependencies ?? {}),
-        [PACKAGE_NAME]: intentVersion,
+        [packageName]: intentVersion,
       },
     }
     return {
       ...writeCachePackageJson(cachePackageJsonPath, nextPkgJson),
-      message: `Added ${PACKAGE_NAME}: ${intentVersion}`,
+      message: `Added ${packageName}: ${intentVersion}`,
     }
   }
 
-  const currentVersion = pkgJson.dependencies[PACKAGE_NAME]
+  const currentVersion = pkgJson.dependencies[packageName]
 
   if (currentVersion === intentVersion) {
     log("[auto-update-checker] Cache package.json already matches intent:", intentVersion)
@@ -113,7 +117,7 @@ export function syncCachePackageJsonToIntent(pluginInfo: PluginEntryInfo): SyncR
     )
   }
 
-  pkgJson.dependencies[PACKAGE_NAME] = intentVersion
+  pkgJson.dependencies[packageName] = intentVersion
   return {
     ...writeCachePackageJson(cachePackageJsonPath, pkgJson),
     message: `Updated: "${currentVersion}" → "${intentVersion}"`,

--- a/src/hooks/auto-update-checker/hook/background-update-check.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.ts
@@ -1,28 +1,26 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { runBunInstallWithDetails } from "../../../cli/config-manager"
 import { log } from "../../../shared/logger"
-import { getOpenCodeCacheDir, getOpenCodeConfigPaths } from "../../../shared"
+import { getOpenCodeCacheDir } from "../../../shared"
 import { invalidatePackage } from "../cache"
-import { PACKAGE_NAME } from "../constants"
+import { resolveManagedPluginSandboxWorkspace } from "../plugin-sandbox"
 import { extractChannel } from "../version-channel"
 import { findPluginEntry, getCachedVersion, getLatestVersion, syncCachePackageJsonToIntent } from "../checker"
 import { showAutoUpdatedToast, showUpdateAvailableToast } from "./update-toasts"
 
 type BackgroundUpdateCheckDeps = {
-  existsSync: typeof existsSync
   join: typeof join
   runBunInstallWithDetails: typeof runBunInstallWithDetails
   log: typeof log
   getOpenCodeCacheDir: typeof getOpenCodeCacheDir
-  getOpenCodeConfigPaths: typeof getOpenCodeConfigPaths
   invalidatePackage: typeof invalidatePackage
   extractChannel: typeof extractChannel
   findPluginEntry: typeof findPluginEntry
   getCachedVersion: typeof getCachedVersion
   getLatestVersion: typeof getLatestVersion
   syncCachePackageJsonToIntent: typeof syncCachePackageJsonToIntent
+  resolveManagedPluginSandboxWorkspace: typeof resolveManagedPluginSandboxWorkspace
   showUpdateAvailableToast: typeof showUpdateAvailableToast
   showAutoUpdatedToast: typeof showAutoUpdatedToast
 }
@@ -38,18 +36,17 @@ function getCacheWorkspaceDir(deps: BackgroundUpdateCheckDeps): string {
 }
 
 const defaultDeps: BackgroundUpdateCheckDeps = {
-  existsSync,
   join,
   runBunInstallWithDetails,
   log,
   getOpenCodeCacheDir,
-  getOpenCodeConfigPaths,
   invalidatePackage,
   extractChannel,
   findPluginEntry,
   getCachedVersion,
   getLatestVersion,
   syncCachePackageJsonToIntent,
+  resolveManagedPluginSandboxWorkspace,
   showUpdateAvailableToast,
   showAutoUpdatedToast,
 }
@@ -58,37 +55,22 @@ function getPinnedVersionToastMessage(latestVersion: string): string {
   return `Update available: ${latestVersion} (version pinned, update manually)`
 }
 
-/**
- * Resolves the active install workspace.
- * Same logic as doctor check: prefer config-dir if installed, fall back to cache-dir.
- */
-function resolveActiveInstallWorkspace(deps: BackgroundUpdateCheckDeps): string {
-  const configPaths = deps.getOpenCodeConfigPaths({ binary: "opencode" })
+function resolveActiveInstallWorkspace(
+  pluginEntry: string,
+  deps: BackgroundUpdateCheckDeps,
+): { packageName: string; workspaceDir: string } | null {
   const cacheDir = getCacheWorkspaceDir(deps)
-
-  const configInstallPath = deps.join(configPaths.configDir, "node_modules", PACKAGE_NAME, "package.json")
-  const cacheInstallPath = deps.join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
-
-  // Prefer config-dir if installed there, otherwise fall back to cache-dir
-  if (deps.existsSync(configInstallPath)) {
-    deps.log(`[auto-update-checker] Active workspace: config-dir (${configPaths.configDir})`)
-    return configPaths.configDir
+  const sandboxWorkspace = deps.resolveManagedPluginSandboxWorkspace(pluginEntry, cacheDir)
+  if (sandboxWorkspace) {
+    deps.log(`[auto-update-checker] Active workspace: plugin sandbox (${sandboxWorkspace.workspaceDir})`)
+    return {
+      packageName: sandboxWorkspace.packageName,
+      workspaceDir: sandboxWorkspace.workspaceDir,
+    }
   }
 
-  if (deps.existsSync(cacheInstallPath)) {
-    deps.log(`[auto-update-checker] Active workspace: cache-dir (${cacheDir})`)
-    return cacheDir
-  }
-
-  const cachePackageJsonPath = deps.join(cacheDir, "package.json")
-  if (deps.existsSync(cachePackageJsonPath)) {
-    deps.log(`[auto-update-checker] Active workspace: cache-dir (${cacheDir}, package.json present)`) 
-    return cacheDir
-  }
-
-  // Default to config-dir if neither exists (matches doctor behavior)
-  deps.log(`[auto-update-checker] Active workspace: config-dir (default, no install detected)`)
-  return configPaths.configDir
+  deps.log(`[auto-update-checker] Unsafe or unsupported plugin entry for auto-update: ${pluginEntry}`)
+  return null
 }
 
 async function runBunInstallSafe(workspaceDir: string, deps: BackgroundUpdateCheckDeps): Promise<boolean> {
@@ -103,19 +85,6 @@ async function runBunInstallSafe(workspaceDir: string, deps: BackgroundUpdateChe
     deps.log("[auto-update-checker] bun install error:", errorMessage)
     return false
   }
-}
-
-async function primeCacheWorkspace(
-  activeWorkspace: string,
-  deps: BackgroundUpdateCheckDeps,
-): Promise<boolean> {
-  const cacheWorkspace = getCacheWorkspaceDir(deps)
-  if (activeWorkspace === cacheWorkspace) {
-    return true
-  }
-
-  deps.log(`[auto-update-checker] Priming cache workspace after install: ${cacheWorkspace}`)
-  return runBunInstallSafe(cacheWorkspace, deps)
 }
 
 export function createBackgroundUpdateCheckRunner(
@@ -167,25 +136,27 @@ export function createBackgroundUpdateCheckRunner(
       return
     }
 
-    const syncResult = deps.syncCachePackageJsonToIntent(pluginInfo)
+    const activeWorkspace = resolveActiveInstallWorkspace(pluginInfo.entry, deps)
+    if (!activeWorkspace) {
+      await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+      return
+    }
+
+    const syncResult = deps.syncCachePackageJsonToIntent(
+      pluginInfo,
+      activeWorkspace.workspaceDir,
+      activeWorkspace.packageName,
+    )
     if (syncResult.error) {
       deps.log(`[auto-update-checker] Sync failed with error: ${syncResult.error}`, syncResult.message)
       await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
       return
     }
 
-    deps.invalidatePackage(PACKAGE_NAME)
-    const activeWorkspace = resolveActiveInstallWorkspace(deps)
-    const installSuccess = await runBunInstallSafe(activeWorkspace, deps)
+    deps.invalidatePackage(activeWorkspace.packageName, activeWorkspace.workspaceDir)
+    const installSuccess = await runBunInstallSafe(activeWorkspace.workspaceDir, deps)
 
     if (installSuccess) {
-      const cachePrimed = await primeCacheWorkspace(activeWorkspace, deps)
-      if (!cachePrimed) {
-        await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
-        deps.log("[auto-update-checker] cache workspace priming failed after install")
-        return
-      }
-
       await deps.showAutoUpdatedToast(ctx, currentVersion, latestVersion)
       deps.log(`[auto-update-checker] Update installed: ${currentVersion} → ${latestVersion}`)
       return

--- a/src/hooks/auto-update-checker/plugin-sandbox.test.ts
+++ b/src/hooks/auto-update-checker/plugin-sandbox.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test"
+import { join } from "node:path"
+import { resolveManagedPluginSandboxWorkspace } from "./plugin-sandbox"
+
+describe("resolveManagedPluginSandboxWorkspace", () => {
+  it("#given a bare legacy plugin entry #when resolving sandbox workspace #then it targets latest spec", () => {
+    const result = resolveManagedPluginSandboxWorkspace("oh-my-opencode", "/cache/packages")
+
+    expect(result).toEqual({
+      packageName: "oh-my-opencode",
+      spec: "oh-my-opencode@latest",
+      workspaceDir: join("/cache/packages", "oh-my-opencode@latest"),
+    })
+  })
+
+  it("#given a bare renamed plugin entry #when resolving sandbox workspace #then it preserves package name", () => {
+    const result = resolveManagedPluginSandboxWorkspace("oh-my-openagent", "/cache/packages")
+
+    expect(result).toEqual({
+      packageName: "oh-my-openagent",
+      spec: "oh-my-openagent@latest",
+      workspaceDir: join("/cache/packages", "oh-my-openagent@latest"),
+    })
+  })
+
+  it("#given an explicit safe dist tag #when resolving sandbox workspace #then it targets that sandbox", () => {
+    const result = resolveManagedPluginSandboxWorkspace("oh-my-openagent@beta", "/cache/packages")
+
+    expect(result).toEqual({
+      packageName: "oh-my-openagent",
+      spec: "oh-my-openagent@beta",
+      workspaceDir: join("/cache/packages", "oh-my-openagent@beta"),
+    })
+  })
+
+  for (const entry of [
+    "oh-my-openagent@../evil",
+    "oh-my-openagent@..\\evil",
+    "oh-my-openagent@file:///tmp/evil",
+    "oh-my-openagent@C:\\tmp\\evil",
+    "oh-my-openagent@",
+    "oh-my-openagent@bad\nversion",
+  ]) {
+    it(`#given unsafe entry ${JSON.stringify(entry)} #when resolving sandbox workspace #then it rejects it`, () => {
+      const result = resolveManagedPluginSandboxWorkspace(entry, "/cache/packages")
+
+      expect(result).toBeNull()
+    })
+  }
+})

--- a/src/hooks/auto-update-checker/plugin-sandbox.ts
+++ b/src/hooks/auto-update-checker/plugin-sandbox.ts
@@ -1,0 +1,78 @@
+import * as path from "node:path"
+import { ACCEPTED_PACKAGE_NAMES, CACHE_DIR } from "./constants"
+
+export interface ManagedPluginSandboxWorkspace {
+  packageName: string
+  spec: string
+  workspaceDir: string
+}
+
+const SAFE_REGISTRY_SPEC = /^[A-Za-z0-9._@-]+$/
+
+function containsPath(parent: string, child: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child))
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((char) => char.charCodeAt(0) < 32)
+}
+
+function getConfiguredPackage(entry: string): { packageName: string; version: string | null } | null {
+  for (const packageName of ACCEPTED_PACKAGE_NAMES) {
+    if (entry === packageName) {
+      return { packageName, version: null }
+    }
+
+    const prefix = `${packageName}@`
+    if (entry.startsWith(prefix)) {
+      return { packageName, version: entry.slice(prefix.length) }
+    }
+  }
+
+  return null
+}
+
+function isSafeRegistryVersion(version: string): boolean {
+  return version.length > 0
+    && !version.includes("/")
+    && !version.includes("\\")
+    && !version.includes(":")
+    && !hasControlCharacter(version)
+    && SAFE_REGISTRY_SPEC.test(version)
+}
+
+export function resolveManagedPluginSandboxWorkspace(
+  entry: string,
+  cachePackagesDir: string = CACHE_DIR,
+): ManagedPluginSandboxWorkspace | null {
+  if (hasControlCharacter(entry) || entry.includes("/") || entry.includes("\\")) {
+    return null
+  }
+
+  const configured = getConfiguredPackage(entry)
+  if (!configured) {
+    return null
+  }
+
+  const version = configured.version ?? "latest"
+  if (!isSafeRegistryVersion(version)) {
+    return null
+  }
+
+  const spec = `${configured.packageName}@${version}`
+  if (!SAFE_REGISTRY_SPEC.test(spec)) {
+    return null
+  }
+
+  const workspaceDir = path.join(cachePackagesDir, spec)
+  if (!containsPath(cachePackagesDir, workspaceDir)) {
+    return null
+  }
+
+  return {
+    packageName: configured.packageName,
+    spec,
+    workspaceDir,
+  }
+}

--- a/src/hooks/zauc-mocks-bg/background-update-check.test.ts
+++ b/src/hooks/zauc-mocks-bg/background-update-check.test.ts
@@ -9,7 +9,7 @@ let importCounter = 0
 
 function createPluginEntry(overrides?: Partial<PluginEntryInfo>): PluginEntryInfo {
   return {
-    entry: "oh-my-opencode@3.4.0",
+    entry: "oh-my-opencode",
     isPinned: false,
     pinnedVersion: null,
     configPath: "/test/opencode.json",
@@ -34,29 +34,27 @@ const mockSyncCachePackageJsonToIntent = mock((_pluginInfo: PluginEntryInfo): Sy
   synced: true,
   error: null,
 }))
+const mockResolveManagedPluginSandboxWorkspace = mock((entry: string, cachePackagesDir: string) => ({
+  packageName: "oh-my-opencode",
+  spec: entry === "oh-my-opencode" ? "oh-my-opencode@latest" : entry,
+  workspaceDir: `${cachePackagesDir}/${entry === "oh-my-opencode" ? "oh-my-opencode@latest" : entry}`,
+}))
 
 async function createRunner() {
   const { createBackgroundUpdateCheckRunner } = await import(`../auto-update-checker/hook/background-update-check?test=${importCounter++}`)
 
   return createBackgroundUpdateCheckRunner({
-    existsSync: () => false,
     join: (...parts) => parts.join("/"),
     runBunInstallWithDetails: mockRunBunInstallWithDetails as never,
     log: mockLog as never,
     getOpenCodeCacheDir: () => "/cache",
-    getOpenCodeConfigPaths: () => ({
-      configDir: "/config",
-      configJson: "/config/opencode.json",
-      configJsonc: "/config/opencode.jsonc",
-      packageJson: "/config/package.json",
-      omoConfig: "/config/oh-my-opencode.json",
-    }),
     invalidatePackage: mockInvalidatePackage as never,
     extractChannel: mockExtractChannel,
     findPluginEntry: mockFindPluginEntry,
     getCachedVersion: mockGetCachedVersion,
     getLatestVersion: mockGetLatestVersion,
     syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
+    resolveManagedPluginSandboxWorkspace: mockResolveManagedPluginSandboxWorkspace,
     showUpdateAvailableToast: mockShowUpdateAvailableToast as never,
     showAutoUpdatedToast: mockShowAutoUpdatedToast as never,
   })
@@ -79,6 +77,7 @@ describe("runBackgroundUpdateCheck", () => {
     mockShowAutoUpdatedToast.mockReset()
     mockLog.mockReset()
     mockSyncCachePackageJsonToIntent.mockReset()
+    mockResolveManagedPluginSandboxWorkspace.mockReset()
 
     mockFindPluginEntry.mockReturnValue(createPluginEntry())
     mockGetCachedVersion.mockReturnValue("3.4.0")
@@ -86,6 +85,11 @@ describe("runBackgroundUpdateCheck", () => {
     mockExtractChannel.mockReturnValue("latest")
     mockRunBunInstallWithDetails.mockResolvedValue({ success: true })
     mockSyncCachePackageJsonToIntent.mockImplementation((_pluginInfo) => ({ synced: true, error: null }))
+    mockResolveManagedPluginSandboxWorkspace.mockImplementation((entry, cachePackagesDir) => ({
+      packageName: "oh-my-opencode",
+      spec: entry === "oh-my-opencode" ? "oh-my-opencode@latest" : entry,
+      workspaceDir: `${cachePackagesDir}/${entry === "oh-my-opencode" ? "oh-my-opencode@latest" : entry}`,
+    }))
   })
 
   it("#given no plugin entry #when checking in background #then it returns early", async () => {
@@ -175,9 +179,9 @@ describe("runBackgroundUpdateCheck", () => {
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockSyncCachePackageJsonToIntent).toHaveBeenCalledTimes(1)
-    expect(mockInvalidatePackage).toHaveBeenCalledTimes(1)
-    expect(mockRunBunInstallWithDetails).toHaveBeenCalledTimes(2)
+    expect(mockSyncCachePackageJsonToIntent).toHaveBeenCalledWith(createPluginEntry(), "/cache/packages/oh-my-opencode@latest", "oh-my-opencode")
+    expect(mockInvalidatePackage).toHaveBeenCalledWith("oh-my-opencode", "/cache/packages/oh-my-opencode@latest")
+    expect(mockRunBunInstallWithDetails).toHaveBeenCalledWith({ outputMode: "pipe", workspaceDir: "/cache/packages/oh-my-opencode@latest" })
     expect(mockShowAutoUpdatedToast).toHaveBeenCalledWith(mockCtx, "3.4.0", "3.5.0")
     expect(mockShowUpdateAvailableToast).not.toHaveBeenCalled()
   })
@@ -202,7 +206,23 @@ describe("runBackgroundUpdateCheck", () => {
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(callOrder).toEqual(["sync", "invalidate", "install", "install"])
+    expect(callOrder).toEqual(["sync", "invalidate", "install"])
+  })
+
+  it("#given unsafe sandbox entry #when checking in background #then it skips install and shows notification", async () => {
+    // #given
+    const runBackgroundUpdateCheck = await createRunner()
+    mockFindPluginEntry.mockReturnValue(createPluginEntry({ entry: "oh-my-opencode@../../evil" }))
+    mockResolveManagedPluginSandboxWorkspace.mockReturnValue(null)
+
+    // #when
+    await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+
+    // #then
+    expect(mockSyncCachePackageJsonToIntent).not.toHaveBeenCalled()
+    expect(mockInvalidatePackage).not.toHaveBeenCalled()
+    expect(mockRunBunInstallWithDetails).not.toHaveBeenCalled()
+    expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(mockCtx, "3.5.0", getToastMessage)
   })
 
   it("#given install fails #when checking in background #then it falls back to notification only", async () => {

--- a/src/hooks/zauc-mocks-cache/cache.test.ts
+++ b/src/hooks/zauc-mocks-cache/cache.test.ts
@@ -103,6 +103,22 @@ describe("invalidatePackage", () => {
     expect(bunLock.packages?.["oh-my-opencode"]).toBeUndefined()
     expect(bunLock.packages?.other).toEqual({})
   })
+
+  it("invalidates an explicitly provided sandbox workspace", async () => {
+    const sandboxDir = join(TEST_OPENCODE_CACHE_DIR, "oh-my-openagent@latest")
+    mkdirSync(join(sandboxDir, "node_modules", "oh-my-openagent"), { recursive: true })
+    writeFileSync(join(sandboxDir, "node_modules", "oh-my-openagent", "package.json"), '{"name":"oh-my-openagent"}')
+    writeFileSync(join(sandboxDir, "package-lock.json"), "{}")
+
+    const { invalidatePackage } = await importFreshCacheModule()
+
+    const result = invalidatePackage("oh-my-openagent", sandboxDir)
+
+    expect(result).toBe(true)
+    expect(existsSync(join(sandboxDir, "node_modules", "oh-my-openagent"))).toBe(false)
+    expect(existsSync(join(sandboxDir, "package-lock.json"))).toBe(false)
+    expect(existsSync(join(TEST_OPENCODE_CACHE_DIR, "node_modules", "oh-my-opencode"))).toBe(true)
+  })
 })
 
 afterAll(() => {

--- a/src/hooks/zauc-mocks-ws/workspace-resolution.test.ts
+++ b/src/hooks/zauc-mocks-ws/workspace-resolution.test.ts
@@ -1,18 +1,18 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
 import { join } from "node:path"
 
 import type { PluginEntryInfo } from "../auto-update-checker/checker"
 import type { SyncResult } from "../auto-update-checker/checker/sync-package-json"
-import { PACKAGE_NAME } from "../auto-update-checker/constants"
+import type { ManagedPluginSandboxWorkspace } from "../auto-update-checker/plugin-sandbox"
 
 type ToastMessageGetter = (isUpdate: boolean, version?: string) => string
 let importCounter = 0
 
 function createPluginEntry(overrides?: Partial<PluginEntryInfo>): PluginEntryInfo {
   return {
-    entry: `${PACKAGE_NAME}@3.4.0`,
+    entry: "oh-my-openagent",
     isPinned: false,
     pinnedVersion: null,
     configPath: "/test/opencode.json",
@@ -23,7 +23,7 @@ function createPluginEntry(overrides?: Partial<PluginEntryInfo>): PluginEntryInf
 const TEST_DIR = join(import.meta.dir, "__test-workspace-resolution__")
 const TEST_CACHE_DIR = join(TEST_DIR, "cache")
 const TEST_CACHE_WORKSPACE_DIR = join(TEST_CACHE_DIR, "packages")
-const TEST_CONFIG_DIR = join(TEST_DIR, "config")
+const TEST_SANDBOX_DIR = join(TEST_CACHE_WORKSPACE_DIR, "oh-my-openagent@latest")
 
 const mockFindPluginEntry = mock((_directory: string): PluginEntryInfo | null => createPluginEntry())
 const mockGetCachedVersion = mock((): string | null => "3.4.0")
@@ -39,29 +39,29 @@ const mockShowAutoUpdatedToast = mock(
 const mockSyncCachePackageJsonToIntent = mock((_pluginInfo: PluginEntryInfo): SyncResult => ({ synced: true, error: null }))
 const mockRunBunInstallWithDetails = mock(async (_opts?: { outputMode?: string; workspaceDir?: string }) => ({ success: true }))
 const mockLog = mock(() => {})
+const mockResolveManagedPluginSandboxWorkspace = mock(
+  (_entry: string, _cachePackagesDir: string): ManagedPluginSandboxWorkspace | null => ({
+    packageName: "oh-my-openagent",
+    spec: "oh-my-openagent@latest",
+    workspaceDir: TEST_SANDBOX_DIR,
+  }),
+)
 
 async function createRunner() {
   const { createBackgroundUpdateCheckRunner } = await import(`../auto-update-checker/hook/background-update-check?test=${importCounter++}`)
 
   return createBackgroundUpdateCheckRunner({
-    existsSync,
     join,
     runBunInstallWithDetails: mockRunBunInstallWithDetails as never,
     log: mockLog as never,
     getOpenCodeCacheDir: () => TEST_CACHE_DIR,
-    getOpenCodeConfigPaths: () => ({
-      configDir: TEST_CONFIG_DIR,
-      configJson: join(TEST_CONFIG_DIR, "opencode.json"),
-      configJsonc: join(TEST_CONFIG_DIR, "opencode.jsonc"),
-      packageJson: join(TEST_CONFIG_DIR, "package.json"),
-      omoConfig: join(TEST_CONFIG_DIR, "oh-my-openagent.json"),
-    }),
     invalidatePackage: mockInvalidatePackage as never,
     extractChannel: mockExtractChannel,
     findPluginEntry: mockFindPluginEntry,
     getCachedVersion: mockGetCachedVersion,
     getLatestVersion: mockGetLatestVersion,
     syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
+    resolveManagedPluginSandboxWorkspace: mockResolveManagedPluginSandboxWorkspace,
     showUpdateAvailableToast: mockShowUpdateAvailableToast as never,
     showAutoUpdatedToast: mockShowAutoUpdatedToast as never,
   })
@@ -89,6 +89,7 @@ describe("workspace resolution", () => {
     mockShowAutoUpdatedToast.mockReset()
     mockSyncCachePackageJsonToIntent.mockReset()
     mockLog.mockReset()
+    mockResolveManagedPluginSandboxWorkspace.mockReset()
 
     mockFindPluginEntry.mockReturnValue(createPluginEntry())
     mockGetCachedVersion.mockReturnValue("3.4.0")
@@ -96,6 +97,11 @@ describe("workspace resolution", () => {
     mockExtractChannel.mockReturnValue("latest")
     mockRunBunInstallWithDetails.mockResolvedValue({ success: true })
     mockSyncCachePackageJsonToIntent.mockReturnValue({ synced: true, error: null })
+    mockResolveManagedPluginSandboxWorkspace.mockReturnValue({
+      packageName: "oh-my-openagent",
+      spec: "oh-my-openagent@latest",
+      workspaceDir: TEST_SANDBOX_DIR,
+    })
   })
 
   afterEach(() => {
@@ -104,91 +110,64 @@ describe("workspace resolution", () => {
     }
   })
 
-  it("#given config-dir install exists but cache-dir does not #when updating #then it installs to config-dir", async () => {
+  it("#given managed plugin entry #when updating #then it resolves sandbox below cache packages", async () => {
     // #given
     const runBackgroundUpdateCheck = await createRunner()
-    mkdirSync(join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME), { recursive: true })
-    writeFileSync(join(TEST_CONFIG_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
-    writeFileSync(
-      join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME, "package.json"),
-      JSON.stringify({ name: PACKAGE_NAME, version: "3.4.0" }, null, 2),
-    )
 
     // #when
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockRunBunInstallWithDetails.mock.calls[0]?.[0]?.workspaceDir).toBe(TEST_CONFIG_DIR)
+    expect(mockResolveManagedPluginSandboxWorkspace).toHaveBeenCalledWith("oh-my-openagent", TEST_CACHE_WORKSPACE_DIR)
   })
 
-  it("#given both config-dir and cache-dir installs exist #when updating #then it prefers config-dir", async () => {
+  it("#given managed plugin entry #when updating #then it syncs package json in sandbox workspace", async () => {
     // #given
     const runBackgroundUpdateCheck = await createRunner()
-    mkdirSync(join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME), { recursive: true })
-    writeFileSync(join(TEST_CONFIG_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
-    writeFileSync(
-      join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME, "package.json"),
-      JSON.stringify({ name: PACKAGE_NAME, version: "3.4.0" }, null, 2),
-    )
-    mkdirSync(join(TEST_CACHE_DIR, "node_modules", PACKAGE_NAME), { recursive: true })
-    writeFileSync(join(TEST_CACHE_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
-    writeFileSync(
-      join(TEST_CACHE_DIR, "node_modules", PACKAGE_NAME, "package.json"),
-      JSON.stringify({ name: PACKAGE_NAME, version: "3.4.0" }, null, 2),
-    )
 
     // #when
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockRunBunInstallWithDetails.mock.calls[0]?.[0]?.workspaceDir).toBe(TEST_CONFIG_DIR)
+    expect(mockSyncCachePackageJsonToIntent).toHaveBeenCalledWith(createPluginEntry(), TEST_SANDBOX_DIR, "oh-my-openagent")
   })
 
-  it("#given only cache-dir install exists #when updating #then it falls back to cache-dir", async () => {
+  it("#given managed plugin entry #when updating #then it invalidates sandbox package only", async () => {
     // #given
     const runBackgroundUpdateCheck = await createRunner()
-    mkdirSync(join(TEST_CACHE_WORKSPACE_DIR, "node_modules", PACKAGE_NAME), { recursive: true })
-    writeFileSync(join(TEST_CACHE_WORKSPACE_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
-    writeFileSync(
-      join(TEST_CACHE_WORKSPACE_DIR, "node_modules", PACKAGE_NAME, "package.json"),
-      JSON.stringify({ name: PACKAGE_NAME, version: "3.4.0" }, null, 2),
-    )
 
     // #when
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockRunBunInstallWithDetails.mock.calls[0]?.[0]?.workspaceDir).toBe(TEST_CACHE_WORKSPACE_DIR)
+    expect(mockInvalidatePackage).toHaveBeenCalledWith("oh-my-openagent", TEST_SANDBOX_DIR)
   })
 
-  it("#given cache workspace package.json exists without installed module #when updating #then it installs to cache-dir", async () => {
+  it("#given managed plugin entry #when updating #then it installs to sandbox workspace once", async () => {
     // #given
     const runner = await createRunner()
-    mkdirSync(TEST_CACHE_WORKSPACE_DIR, { recursive: true })
-    writeFileSync(join(TEST_CACHE_WORKSPACE_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
 
     // #when
     await runner(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockRunBunInstallWithDetails.mock.calls[0]?.[0]?.workspaceDir).toBe(TEST_CACHE_WORKSPACE_DIR)
+    expect(mockRunBunInstallWithDetails).toHaveBeenCalledTimes(1)
+    expect(mockRunBunInstallWithDetails).toHaveBeenCalledWith({ outputMode: "pipe", workspaceDir: TEST_SANDBOX_DIR })
   })
 
-  it("#given config-dir install exists #when updating #then it also primes the cache workspace", async () => {
+  it("#given unsafe plugin entry #when updating #then it skips workspace mutation", async () => {
     // #given
     const runBackgroundUpdateCheck = await createRunner()
-    mkdirSync(join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME), { recursive: true })
-    writeFileSync(join(TEST_CONFIG_DIR, "package.json"), JSON.stringify({ dependencies: { [PACKAGE_NAME]: "3.4.0" } }, null, 2))
-    writeFileSync(
-      join(TEST_CONFIG_DIR, "node_modules", PACKAGE_NAME, "package.json"),
-      JSON.stringify({ name: PACKAGE_NAME, version: "3.4.0" }, null, 2),
-    )
+    mockFindPluginEntry.mockReturnValue(createPluginEntry({ entry: "oh-my-openagent@../../evil" }))
+    mockResolveManagedPluginSandboxWorkspace.mockReturnValue(null)
 
     // #when
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
-    expect(mockRunBunInstallWithDetails.mock.calls[0]?.[0]?.workspaceDir).toBe(TEST_CONFIG_DIR)
-    expect(mockRunBunInstallWithDetails.mock.calls[1]?.[0]?.workspaceDir).toBe(TEST_CACHE_WORKSPACE_DIR)
+    expect(mockSyncCachePackageJsonToIntent).not.toHaveBeenCalled()
+    expect(mockInvalidatePackage).not.toHaveBeenCalled()
+    expect(mockRunBunInstallWithDetails).not.toHaveBeenCalled()
+    expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(mockCtx, "3.5.0", getToastMessage)
   })
 })

--- a/src/hooks/zauc-sync-mocks/sync-package-json.test.ts
+++ b/src/hooks/zauc-sync-mocks/sync-package-json.test.ts
@@ -149,6 +149,32 @@ describe("syncCachePackageJsonToIntent", () => {
     })
   })
 
+  describe("#given custom workspace and renamed package", () => {
+    it("#then writes the configured package dependency in that workspace", async () => {
+      const workspaceDir = join(CACHE_PACKAGES_DIR, "oh-my-openagent@latest")
+      rmSync(workspaceDir, { recursive: true, force: true })
+
+      const { syncCachePackageJsonToIntent } = await importFreshSyncPackageJsonModule()
+
+      const pluginInfo: PluginEntryInfo = {
+        entry: "oh-my-openagent",
+        isPinned: false,
+        pinnedVersion: null,
+        configPath: "/tmp/opencode.json",
+      }
+
+      const result = syncCachePackageJsonToIntent(pluginInfo, workspaceDir, "oh-my-openagent")
+
+      expect(result.synced).toBe(true)
+      expect(result.error).toBeNull()
+
+      const content = readFileSync(join(workspaceDir, "package.json"), "utf-8")
+      const pkg = JSON.parse(content) as { dependencies?: Record<string, string> }
+      expect(pkg.dependencies?.["oh-my-openagent"]).toBe("latest")
+      expect(pkg.dependencies?.["oh-my-opencode"]).toBeUndefined()
+    })
+  })
+
   describe("#given plugin not in cache package.json dependencies", () => {
     it("#then adds the plugin dependency and preserves existing dependencies", async () => {
       cleanupTestCache()


### PR DESCRIPTION
## Summary
- Resolve the OpenCode per-spec plugin sandbox for auto-updates, including bare `oh-my-opencode` -> `oh-my-opencode@latest` mapping.
- Run package sync, invalidation, and `bun install` inside the sandbox workspace OpenCode actually loads.
- Add tests for sandbox path resolution, workspace invalidation, and background update wiring.

## Verification
- `bun test src/hooks/auto-update-checker --bail`
- `bun run typecheck`
- `bun run build`
- LSP diagnostics on modified production files

## Notes
- Full `bun test` still has unrelated pre-existing/environment-sensitive failures outside auto-update coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-updates by validating plugin sandbox specs, installing strictly into that sandbox, and updating the doctor check to report the sandboxed version. Bare `oh-my-opencode` resolves to `oh-my-opencode@latest`; unsafe specs are skipped with a notice.

- **Bug Fixes**
  - Added strict sandbox resolver for `oh-my-opencode`/`oh-my-openagent` with safe dist-tags; rejects path/file/system specs.
  - Installed strictly into the sandbox under cache `packages/`; removed config-dir fallback and cache priming.
  - Scoped `package.json` sync and invalidation to the sandbox and resolved package name; clears `package-lock.json`/`bun.lock*` in that workspace.
  - Doctor now prefers the configured plugin sandbox and reports the version from `packages/<spec>` over legacy installs.
  - Updated tests for sandbox resolution, background flow (single install), workspace invalidation, custom workspace sync, and doctor behavior.

<sup>Written for commit a33bc189a9f8ccff08527410a197f934c913654c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

