### PR TITLE
fix(runtime-fallback): classify localized balance failures as quota exhaustion

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -97,6 +97,13 @@ export function extractErrorName(error: unknown): string | undefined {
   return undefined
 }
 
+function isLocalizedQuotaExhaustionMessage(message: string): boolean {
+  return (
+    (/预扣费额度失败/i.test(message) && /用户剩余额度/i.test(message)) ||
+    (/用户剩余额度/i.test(message) && /需要预扣费额度/i.test(message))
+  )
+}
+
 export function classifyErrorType(error: unknown): string | undefined {
   const message = getErrorMessage(error)
   const errorName = extractErrorName(error)?.toLowerCase()
@@ -135,7 +142,8 @@ export function classifyErrorType(error: unknown): string | undefined {
     /out\s+of\s+credits?/i.test(message) ||
     /payment.?required/i.test(message) ||
     /usage\s+limit/i.test(message) ||
-    /credit\s+balance.*too\s+low/i.test(message)
+    /credit\s+balance.*too\s+low/i.test(message) ||
+    isLocalizedQuotaExhaustionMessage(message)
   ) {
     return "quota_exceeded"
   }

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -73,4 +73,20 @@ describe("runtime-fallback quota error regressions", () => {
     // Volcano Engine quota errors trigger fallback to the next model
     expect(retryable).toBe(true)
   })
+
+  test("classifies UnifyLLM pre-charge balance failures as quota_exceeded", () => {
+    //#given
+    const error = {
+      message:
+        "预扣费额度失败, 用户剩余额度: 0.265718, 需要预扣费额度: 0.680208 (request id: test-request-id)",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

 - Classifies localized proxy-provider balance/pre-charge failures as `quota_exceeded`.
 - Allows runtime fallback to switch models immediately when providers return localized quota errors without a
  standard status code.
 - Observed with a UnifyLLM-style proxy response:

```text
预扣费额度失败, 用户剩余额度: 0.265718, 需要预扣费额度: 0.680208 (request id: ...)
```

## Changes

 - Added a localized quota exhaustion matcher for balance/pre-charge failure messages.
 - Added a regression test covering the localized pre-charge balance failure response.

## Testing

bun test src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts src/hooks/runtime-fallback/error-
classifier.test.ts src/hooks/runtime-fallback/provider-matrix.test.ts
bun run typecheck
bun run build

## Related Issues
<!-- Closes # -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies localized balance/pre‑charge failures from proxy providers as `quota_exceeded`. This lets runtime fallback switch models immediately when Chinese quota errors appear without standard status codes.

- **Bug Fixes**
  - Added localized matcher that flags messages with “预扣费额度失败”+“用户剩余额度” or “用户剩余额度”+“需要预扣费额度” as `quota_exceeded`.
  - Added regression test for UnifyLLM pre‑charge balance failure to ensure classification and retryability.

<sup>Written for commit 583fa2420f160288e1830eb3c680a1dbdff3ea0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

