### PR TITLE
fix: replace brittle setTimeout(50) with polling waitForCondition in spawner tests

### DIFF
--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -6,6 +6,25 @@ import {
   getSessionPromptParams,
 } from "../../shared/session-prompt-params-state"
 
+/**
+ * Poll until `fn()` returns true or timeout elapses.
+ * Replaces fixed `setTimeout(resolve, 50)` waits that cause flaky CI failures
+ * when the fire-and-forget prompt chain hasn't settled in time.
+ */
+async function waitForCondition(
+  fn: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitForCondition timed out after ${timeoutMs}ms`)
+    }
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
 describe("background-agent spawner agent-not-found fallback", () => {
   afterEach(() => {
     clearSessionPromptParams("session-fallback")
@@ -67,7 +86,7 @@ describe("background-agent spawner agent-not-found fallback", () => {
     await startTask(item as never, ctx as never)
 
     // Wait for the fire-and-forget prompt chain to settle
-    await new Promise(resolve => setTimeout(resolve, 50))
+    await waitForCondition(() => promptCalls.length >= 2)
 
     //#then
     // Should have called promptAsync twice: once with original agent, once with fallback
@@ -146,7 +165,7 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
     //#when
     await startTask(item as never, ctx as never)
-    await new Promise(resolve => setTimeout(resolve, 50))
+    await waitForCondition(() => onTaskError.mock.calls.length > 0)
 
     //#then
     // Only one attempt — no retry for non-agent errors
@@ -199,7 +218,7 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
     //#when
     await startTask(item as never, ctx as never)
-    await new Promise(resolve => setTimeout(resolve, 50))
+    await waitForCondition(() => onTaskError.mock.calls.length > 0)
 
     //#then
     // Verify retry was attempted (2 calls: original + fallback)
@@ -261,7 +280,7 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
     //#when
     await startTask(item as never, ctx as never)
-    await new Promise(resolve => setTimeout(resolve, 50))
+    await waitForCondition(() => promptCalls.length >= 2)
 
     //#then
     expect(promptCalls).toHaveLength(2)
@@ -324,7 +343,7 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
     //#when
     await startTask(item as never, ctx as never)
-    await new Promise(resolve => setTimeout(resolve, 50))
+    await waitForCondition(() => promptCalls.length >= 2)
 
     //#then
     expect(promptCalls).toHaveLength(2)


### PR DESCRIPTION
## Summary

Fixes #3935

The `agent-not-found fallback` tests in `spawner.test.ts` use a fire-and-forget pattern where `startTask()` launches a `promptAsync` promise chain with `void promptChain`. After the call, the test waits with `setTimeout(resolve, 50)` for the chain to settle.

On slower CI runners, 50ms is insufficient for the chain (throw → catch → retry → resolve) to complete, causing intermittent test failures.

## Changes

- Add `waitForCondition(fn, timeoutMs=2000, intervalMs=10)` polling helper
- Replace all 5 `setTimeout(resolve, 50)` waits with condition-based polling:
  - 3 tests poll `promptCalls.length >= 2` (retry success cases)
  - 2 tests poll `onTaskError.mock.calls.length > 0` (error callback cases)
- Unchanged: `setTimeout(resolve, 0)` waits in non-async-error tests (immediate resolution, no flakiness risk)

## Test plan

- [x] All 5 affected tests still test the same behavior — only the wait mechanism changed
- [ ] CI passes (typecheck + test)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fragile 50ms `setTimeout` waits in background-agent spawner fallback tests with a polling `waitForCondition` to eliminate CI flakiness and wait for the prompt chain to fully settle.

- **Bug Fixes**
  - Added `waitForCondition(fn, timeoutMs=2000, intervalMs=10)` to poll until a condition is met.
  - Replaced five `setTimeout(50)` waits with condition checks:
    - 3 tests wait for `promptCalls.length >= 2` (retry path).
    - 2 tests wait for `onTaskError.mock.calls.length > 0` (error path).
  - Left `setTimeout(0)` cases unchanged.

<sup>Written for commit a4fde03476c6d3082a2e7ec94b1cebedee9874ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

