### PR TITLE
fix(display): lowercase ultraworker to avoid ZWSP rendering glitch

### DIFF
--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -9,8 +9,8 @@ describe("getAgentDisplayName", () => {
     // when getAgentDisplayName called
     const result = getAgentDisplayName(configKey)
 
-    // then returns "Sisyphus - Ultraworker"
-    expect(result).toBe("Sisyphus - Ultraworker")
+    // then returns "Sisyphus - ultraworker"
+    expect(result).toBe("Sisyphus - ultraworker")
   })
 
   it("returns display name for uppercase config key (old format - case-insensitive)", () => {
@@ -20,8 +20,8 @@ describe("getAgentDisplayName", () => {
     // when getAgentDisplayName called
     const result = getAgentDisplayName(configKey)
 
-    // then returns "Sisyphus - Ultraworker" (case-insensitive lookup)
-    expect(result).toBe("Sisyphus - Ultraworker")
+    // then returns "Sisyphus - ultraworker" (case-insensitive lookup)
+    expect(result).toBe("Sisyphus - ultraworker")
   })
 
   it("returns original key for unknown agents (fallback)", () => {
@@ -137,10 +137,10 @@ describe("getAgentDisplayName", () => {
 
 describe("getAgentConfigKey", () => {
   it("resolves display name to config key", () => {
-    // given display name "Sisyphus - Ultraworker"
+    // given display name "Sisyphus - ultraworker"
     // when getAgentConfigKey called
     // then returns "sisyphus"
-    expect(getAgentConfigKey("Sisyphus - Ultraworker")).toBe("sisyphus")
+    expect(getAgentConfigKey("Sisyphus - ultraworker")).toBe("sisyphus")
   })
 
   it("resolves display name case-insensitively", () => {
@@ -195,7 +195,7 @@ describe("getAgentConfigKey", () => {
 
 describe("getAgentListDisplayName", () => {
   it("returns the canonical display name for the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - ultraworker")
     expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
     expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
     expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
@@ -222,14 +222,14 @@ describe("stripAgentListSortPrefix", () => {
 
 describe("normalizeAgentForPrompt", () => {
   it("strips core UI ordering prefixes back to canonical display names", () => {
-    expect(normalizeAgentForPrompt(getAgentListDisplayName("sisyphus"))).toBe("Sisyphus - Ultraworker")
+    expect(normalizeAgentForPrompt(getAgentListDisplayName("sisyphus"))).toBe("Sisyphus - ultraworker")
     expect(normalizeAgentForPrompt(getAgentListDisplayName("hephaestus"))).toBe("Hephaestus - Deep Agent")
     expect(normalizeAgentForPrompt(getAgentListDisplayName("prometheus"))).toBe("Prometheus - Plan Builder")
     expect(normalizeAgentForPrompt(getAgentListDisplayName("atlas"))).toBe("Atlas - Plan Executor")
   })
 
   it("removes zero-width characters before returning canonical names", () => {
-    expect(normalizeAgentForPrompt("Sisyphus\u200B - Ultraworker")).toBe("Sisyphus - Ultraworker")
+    expect(normalizeAgentForPrompt("Sisyphus\u200B - Ultraworker")).toBe("Sisyphus - ultraworker")
   })
 
   it("converts legacy parenthesized names to canonical display names", () => {
@@ -255,7 +255,7 @@ describe("AGENT_DISPLAY_NAMES", () => {
   it("contains all expected agent mappings", () => {
     // given expected mappings
     const expectedMappings = {
-      sisyphus: "Sisyphus - Ultraworker",
+      sisyphus: "Sisyphus - ultraworker",
       hephaestus: "Hephaestus - Deep Agent",
       prometheus: "Prometheus - Plan Builder",
       atlas: "Atlas - Plan Executor",

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -10,7 +10,7 @@
  * type selector dropdown. Use ` - ` (space-dash-space) instead of `(...)`.
  */
 export const AGENT_DISPLAY_NAMES: Record<string, string> = {
-  sisyphus: "Sisyphus - Ultraworker",
+  sisyphus: "Sisyphus - ultraworker",
   hephaestus: "Hephaestus - Deep Agent",
   prometheus: "Prometheus - Plan Builder",
   atlas: "Atlas - Plan Executor",


### PR DESCRIPTION
## Problem

The OpenCode TUI displays the Sisyphus agent as "Sisyphus - Itraworker" (or "Sisyphus - ltraworker") instead of "Sisyphus - Ultraworker".

## Root Cause

The agent sort shim (installAgentSortShim) injects zero-width space characters (ZWSP, U+200B) into agent names for UI ordering. When a display name has a capital letter immediately following the ZWSP boundary, the OpenCode TUI renderer can swallow the first visible character:

ZWSP + "Ultraworker" -> TUI renders as "ltraworker"

This is a rendering-layer issue in how the TUI handles ZWSP-adjacent capital characters.

## Fix

Change AGENT_DISPLAY_NAMES.sisyphus from "Sisyphus - Ultraworker" to "Sisyphus - ultraworker" (lowercase u).

Lowercase characters do not trigger the same ZWSP rendering glitch, so the display now renders correctly as "Sisyphus - ultraworker".

## Changes

- src/shared/agent-display-names.ts: Updated AGENT_DISPLAY_NAMES.sisyphus value
- src/shared/agent-display-names.test.ts: Updated all test assertions referencing the display name (9 assertions across 6 test cases)

## Testing

- All existing test assertions updated to match the new display name
- REVERSE_DISPLAY_NAMES is auto-generated from AGENT_DISPLAY_NAMES, no manual change needed
- LEGACY_DISPLAY_NAMES entries already use lowercase, no change needed

## Notes

This is a workaround for a TUI rendering behavior. A more robust fix would be at the rendering layer to handle ZWSP correctly, but this minimal change resolves the user-visible bug without any architectural changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI bug that rendered “Sisyphus - ltraworker” by changing the display name to “Sisyphus - ultraworker”. Lowercasing avoids the ZWSP + capital-letter rendering glitch in OpenCode.

- **Bug Fixes**
  - Updated `AGENT_DISPLAY_NAMES.sisyphus` to “Sisyphus - ultraworker” to bypass the zero‑width space issue that drops the first capital character.
  - Adjusted related tests; no other mappings or generated reverse maps require changes.

<sup>Written for commit cd39f8858edfed8593bb4aab57dfe1f82b9bee4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

