### PR TITLE
fix(doctor): fall back to bundled package.json for plugin version (fixes #3822)

### DIFF
--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, mock } from "bun:test"
 import { PLUGIN_NAME } from "../../../shared"
 import type { PluginInfo } from "./system-plugin"
 import type { OpenCodeBinaryInfo } from "./system-binary"
-import { checkSystem } from "./system"
+import { checkSystem, gatherSystemInfo } from "./system"
+import packageJson from "../../../../package.json" with { type: "json" }
 
 const mockFindOpenCodeBinary = mock<() => Promise<OpenCodeBinaryInfo | null>>(async () => ({
   binary: "opencode",
@@ -20,7 +21,14 @@ const mockGetPluginInfo = mock((): PluginInfo => ({
   configPath: null,
   isLocalDev: false,
 }))
-const mockGetLoadedPluginVersion = mock(() => ({
+interface LoadedPluginVersionMock {
+  cacheDir: string
+  cachePackagePath: string
+  installedPackagePath: string
+  expectedVersion: string | null
+  loadedVersion: string | null
+}
+const mockGetLoadedPluginVersion = mock<() => LoadedPluginVersionMock>(() => ({
   cacheDir: "/Users/test/Library/Caches/opencode with spaces",
   cachePackagePath: "/tmp/package.json",
   installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
@@ -194,6 +202,88 @@ describe("system check", () => {
 
       //#then
       expect(result.issues.some((issue) => issue.title === "Using legacy package name")).toBe(false)
+    })
+  })
+
+  describe("#given no pinned/expected/loaded versions are available (bunx install)", () => {
+    it("falls back to the bundled package.json version for pluginVersion", async () => {
+      //#given
+      mockGetPluginInfo.mockReturnValue({
+        registered: true,
+        entry: PLUGIN_NAME,
+        isPinned: false,
+        pinnedVersion: null,
+        configPath: null,
+        isLocalDev: false,
+      })
+      mockGetLoadedPluginVersion.mockReturnValue({
+        cacheDir: "/tmp/cache",
+        cachePackagePath: "/tmp/cache/package.json",
+        installedPackagePath: "/tmp/cache/node_modules/oh-my-opencode/package.json",
+        expectedVersion: null,
+        loadedVersion: null,
+      })
+
+      //#when
+      const systemInfo = await gatherSystemInfo(createSystemDeps())
+
+      //#then
+      expect(systemInfo.pluginVersion).toBe(packageJson.version)
+      expect(systemInfo.loadedVersion).toBe(packageJson.version)
+    })
+
+    it("renders Plugin expected/loaded with the bundled version in the report details", async () => {
+      //#given
+      mockGetPluginInfo.mockReturnValue({
+        registered: true,
+        entry: PLUGIN_NAME,
+        isPinned: false,
+        pinnedVersion: null,
+        configPath: null,
+        isLocalDev: false,
+      })
+      mockGetLoadedPluginVersion.mockReturnValue({
+        cacheDir: "/tmp/cache",
+        cachePackagePath: "/tmp/cache/package.json",
+        installedPackagePath: "/tmp/cache/node_modules/oh-my-opencode/package.json",
+        expectedVersion: null,
+        loadedVersion: null,
+      })
+
+      //#when
+      const result = await checkSystem(createSystemDeps())
+
+      //#then
+      expect(result.details).toContain(`Plugin expected: ${packageJson.version}`)
+      expect(result.details).toContain(`Plugin loaded: ${packageJson.version}`)
+    })
+  })
+
+  describe("#given expected/loaded versions are available", () => {
+    it("prefers the loaded version over the bundled fallback for pluginVersion", async () => {
+      //#given
+      mockGetPluginInfo.mockReturnValue({
+        registered: true,
+        entry: PLUGIN_NAME,
+        isPinned: false,
+        pinnedVersion: null,
+        configPath: null,
+        isLocalDev: false,
+      })
+      mockGetLoadedPluginVersion.mockReturnValue({
+        cacheDir: "/tmp/cache",
+        cachePackagePath: "/tmp/cache/package.json",
+        installedPackagePath: "/tmp/cache/node_modules/oh-my-opencode/package.json",
+        expectedVersion: "3.0.0",
+        loadedVersion: "3.1.0",
+      })
+
+      //#when
+      const systemInfo = await gatherSystemInfo(createSystemDeps())
+
+      //#then
+      expect(systemInfo.pluginVersion).toBe("3.0.0")
+      expect(systemInfo.loadedVersion).toBe("3.1.0")
     })
   })
 })

--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -229,10 +229,14 @@ describe("system check", () => {
 
       //#then
       expect(systemInfo.pluginVersion).toBe(packageJson.version)
-      expect(systemInfo.loadedVersion).toBe(packageJson.version)
+      // loadedVersion intentionally stays null when getLoadedPluginVersion()
+      // could not find a package on disk. Falsifying it to the bundled
+      // version would mask broken installs and corrupt the
+      // "Loaded plugin is outdated" comparison downstream.
+      expect(systemInfo.loadedVersion).toBeNull()
     })
 
-    it("renders Plugin expected/loaded with the bundled version in the report details", async () => {
+    it("renders Plugin expected with the bundled version and Plugin loaded as unknown in the report details", async () => {
       //#given
       mockGetPluginInfo.mockReturnValue({
         registered: true,
@@ -255,7 +259,9 @@ describe("system check", () => {
 
       //#then
       expect(result.details).toContain(`Plugin expected: ${packageJson.version}`)
-      expect(result.details).toContain(`Plugin loaded: ${packageJson.version}`)
+      // Plugin loaded keeps "unknown" so downstream "outdated" warnings
+      // do not fire spuriously against the bundled version.
+      expect(result.details).toContain(`Plugin loaded: unknown`)
     })
   })
 

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -73,7 +73,7 @@ export async function gatherSystemInfo(deps: SystemCheckDeps = defaultDeps): Pro
     opencodeVersion,
     opencodePath: binaryInfo?.path ?? null,
     pluginVersion,
-    loadedVersion: loadedInfo.loadedVersion ?? BUNDLED_VERSION,
+    loadedVersion: loadedInfo.loadedVersion,
     bunVersion: Bun.version,
     configPath: pluginInfo.configPath,
     configValid: isConfigValid(pluginInfo.configPath),

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -7,6 +7,9 @@ import { getPluginInfo } from "./system-plugin"
 import { getLatestPluginVersion, getLoadedPluginVersion, getSuggestedInstallTag } from "./system-loaded-version"
 import { parseJsonc } from "../../../shared"
 import { PUBLISHED_PACKAGE_NAME, PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../../shared/plugin-identity"
+import packageJson from "../../../../package.json" with { type: "json" }
+
+const BUNDLED_VERSION: string = packageJson.version
 
 interface SystemCheckDeps {
   findOpenCodeBinary: typeof findOpenCodeBinary
@@ -60,13 +63,17 @@ export async function gatherSystemInfo(deps: SystemCheckDeps = defaultDeps): Pro
   const loadedInfo = deps.getLoadedPluginVersion()
 
   const opencodeVersion = binaryInfo ? await deps.getOpenCodeVersion(binaryInfo.path) : null
-  const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion ?? loadedInfo.loadedVersion
+  const pluginVersion =
+    pluginInfo.pinnedVersion
+    ?? loadedInfo.expectedVersion
+    ?? loadedInfo.loadedVersion
+    ?? BUNDLED_VERSION
 
   return {
     opencodeVersion,
     opencodePath: binaryInfo?.path ?? null,
     pluginVersion,
-    loadedVersion: loadedInfo.loadedVersion,
+    loadedVersion: loadedInfo.loadedVersion ?? BUNDLED_VERSION,
     bunVersion: Bun.version,
     configPath: pluginInfo.configPath,
     configValid: isConfigValid(pluginInfo.configPath),


### PR DESCRIPTION
## Summary
`doctor` reports `Plugin expected/loaded: unknown` for bunx-based installs even though the running process clearly knows its real version. This fix adds a bundled-package.json fallback that mirrors the working pattern used by `bunx oh-my-opencode version`.

## Root Cause
`gatherSystemInfo()` in [`src/cli/doctor/checks/system.ts`](src/cli/doctor/checks/system.ts) derives `pluginVersion` from three filesystem-backed sources:

1. `pinnedVersion` — parsed from the `opencode.json` plugin entry (returns `null` for `@latest`)
2. `expectedVersion` — read from `~/.config/opencode/package.json` `dependencies`
3. `loadedVersion` — read from `~/.config/opencode/node_modules/<pkg>/package.json`

In a pure bunx install the package lives under `~/.bun/install/cache/oh-my-openagent@<ver>/...` and never lands in OpenCode's config-dir `node_modules`, so all three sources return `null` → details render `unknown` and `--status` shows `oh-my-openagent unknown`.

Meanwhile, `src/cli/cli-program.ts` reads the version via a bundled JSON import that always works:
```ts
import packageJson from "../../package.json" with { type: "json" }
```

## Changes
| File | Change |
|------|--------|
| `src/cli/doctor/checks/system.ts` | Import bundled `package.json`; append `BUNDLED_VERSION` to the `pluginVersion` fallback chain and fall `loadedVersion` back to it as well. |
| `src/cli/doctor/checks/system.test.ts` | Add 3 regression tests covering the bunx-install scenario plus precedence preservation. Tighten the loaded-plugin-version mock type to allow `null`. |

Diff: **+97 / -4** lines across 2 files.

## Reproduction (before fix)
```text
src\cli\doctor\checks\system.test.ts:
expect(received).toBe(expected)

Expected: "4.0.0"
Received: null

(fail) system check > #given no pinned/expected/loaded versions are available (bunx install) > falls back to the bundled package.json version for pluginVersion

expect(received).toContain(expected)
Expected to contain: "Plugin expected: 4.0.0"
Received: [ "OpenCode: 1.0.200", "Plugin expected: unknown", "Plugin loaded: unknown", "Bun: 1.3.11" ]
```

Manual reproduction also confirms the symptom via a direct call into `gatherSystemInfo()` with all version sources mocked to `null`: pre-fix returns `pluginVersion: null` / `loadedVersion: null` → renders `unknown`.

## Verification (after fix)
```text
bun test src/cli/doctor/checks/system.test.ts
 9 pass
 0 fail
 14 expect() calls
Ran 9 tests across 1 file. [139.00ms]

bun test src/cli/doctor/checks/system-binary.test.ts
 12 pass / 0 fail

bun test src/cli/doctor/checks/system-loaded-version.test.ts
 5 pass / 0 fail

bun run typecheck
$ tsc --noEmit          (clean)
```

Manual QA — `gatherSystemInfo()` with all version sources mocked to `null`:
```text
Bundled package.json version: 4.0.0
pluginVersion: 4.0.0
loadedVersion: 4.0.0
PASS: true
```

The new `#given expected/loaded versions are available` test confirms that the existing precedence is preserved when the derived sources are populated (e.g. `expectedVersion: "3.0.0"` still wins over the bundled version).

## Test
- Regression tests: `src/cli/doctor/checks/system.test.ts` (3 new cases, all in given/when/then style consistent with the surrounding suite).
- Related suite: `bun test src/cli/doctor/checks/system*.test.ts` — 26 pass.
- Typecheck: `bun run typecheck` — clean.

> Note: A few pre-existing test files in `src/cli/doctor/` fail when run together in shared mode (`config.test.ts` Windows path handling, `spawn-with-timeout.test.ts` slow-stderr capture, plus mock-module leakage from `format-default.test.ts`/`formatter.test.ts` polluting `system.test.ts`). These failures reproduce identically on `upstream/dev` without this change and are unrelated to this fix. Running each affected file in isolation — the way `script/run-ci-tests.ts` orchestrates CI — passes cleanly.

Fixes #3822

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `doctor` report showing unknown plugin version on `bunx` installs by falling back to the bundled repo `package.json` for Plugin expected. `Plugin loaded` remains unknown when no package is found to avoid false outdated warnings (fixes #3822).

- **Bug Fixes**
  - Use bundled version as the final fallback for pluginVersion; precedence: pinned > expected > loaded > bundled.
  - Add tests for `bunx` installs, details rendering, and precedence to ensure `Plugin expected` uses the bundled version while `Plugin loaded` stays `unknown`.

<sup>Written for commit f340ee9c9e3e948dfb68a09ea7d5e4b93b4146ab. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3946?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

