### PR TITLE
fix(background-agent): add OMO_DISABLE_PROCESS_CLEANUP env opt-out for global handlers (fixes #3856)

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -235,6 +235,103 @@ describe("#given process cleanup registration", () => {
     })
   })
 
+  describe("#given OMO_DISABLE_PROCESS_CLEANUP env var", () => {
+    let originalEnvValue: string | undefined
+
+    beforeEach(() => {
+      originalEnvValue = process.env.OMO_DISABLE_PROCESS_CLEANUP
+    })
+
+    afterEach(() => {
+      if (originalEnvValue === undefined) {
+        delete process.env.OMO_DISABLE_PROCESS_CLEANUP
+      } else {
+        process.env.OMO_DISABLE_PROCESS_CLEANUP = originalEnvValue
+      }
+    })
+
+    test("#given env var is set to 1 #when registerManagerForCleanup runs #then uncaughtException handler is NOT registered", () => {
+      const uncaughtExceptionListenersBefore = process.listeners("uncaughtException")
+      const unhandledRejectionListenersBefore = process.listeners("unhandledRejection")
+      process.env.OMO_DISABLE_PROCESS_CLEANUP = "1"
+      const manager = { shutdown: mock(() => {}) }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      expect(process.listeners("uncaughtException")).toHaveLength(uncaughtExceptionListenersBefore.length)
+      expect(process.listeners("unhandledRejection")).toHaveLength(unhandledRejectionListenersBefore.length)
+    })
+
+    test("#given env var is set to true #when registerManagerForCleanup runs #then handlers are NOT registered", () => {
+      const uncaughtExceptionListenersBefore = process.listeners("uncaughtException")
+      process.env.OMO_DISABLE_PROCESS_CLEANUP = "true"
+      const manager = { shutdown: mock(() => {}) }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      expect(process.listeners("uncaughtException")).toHaveLength(uncaughtExceptionListenersBefore.length)
+    })
+
+    test("#given env var is set to 0 #when registerManagerForCleanup runs #then handlers ARE registered", () => {
+      const uncaughtExceptionListenersBefore = process.listeners("uncaughtException")
+      process.env.OMO_DISABLE_PROCESS_CLEANUP = "0"
+      const manager = { shutdown: mock(() => {}) }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      expect(process.listeners("uncaughtException")).toHaveLength(uncaughtExceptionListenersBefore.length + 1)
+    })
+
+    test("#given env var is unset #when registerManagerForCleanup runs #then handlers ARE registered", () => {
+      const uncaughtExceptionListenersBefore = process.listeners("uncaughtException")
+      delete process.env.OMO_DISABLE_PROCESS_CLEANUP
+      const manager = { shutdown: mock(() => {}) }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      expect(process.listeners("uncaughtException")).toHaveLength(uncaughtExceptionListenersBefore.length + 1)
+    })
+
+    test("#given env var is set #when signals fire #then SIGINT/SIGTERM/beforeExit/exit handlers still run cleanup", () => {
+      const exitListenersBefore = process.listeners("exit")
+      process.env.OMO_DISABLE_PROCESS_CLEANUP = "yes"
+      const shutdown = mock(() => {})
+      const manager = { shutdown }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+      const exitListener = getNewListener("exit", exitListenersBefore)
+      exitListener()
+
+      expect(shutdown).toHaveBeenCalledTimes(1)
+    })
+
+    test("#given env var is set AND process emits uncaughtException #when event fires #then manager shutdown is NOT invoked by our handler", async () => {
+      process.env.OMO_DISABLE_PROCESS_CLEANUP = "1"
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      const shutdown = mock(() => {})
+      const manager = { shutdown }
+      registeredManagers.push(manager)
+
+      try {
+        registerManagerForCleanup(manager)
+
+        // Other listeners on uncaughtException may exist (e.g. node default).
+        // We assert that OUR handler did not run cleanup.
+        process.emit("uncaughtException", new Error("boom"))
+        await flushMicrotasks()
+
+        expect(shutdown).not.toHaveBeenCalled()
+      } finally {
+        exitSpy.mockRestore()
+      }
+    })
+  })
+
   describe("#given uncaught exception and rejection cleanup", () => {
     test("#given manager registered AND process emits uncaughtException #when event fires #then manager shuts down before process exits", async () => {
       const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -3,6 +3,26 @@ import { log } from "../../shared"
 type ProcessCleanupSignal = NodeJS.Signals | "beforeExit" | "exit"
 type ProcessCleanupErrorEvent = "uncaughtException" | "unhandledRejection"
 
+/**
+ * When set to a truthy value (1/true/yes/on), suppresses the global
+ * uncaughtException / unhandledRejection handlers that force-exit the host
+ * process. Use this when the plugin is installed but background-agent tasks
+ * are not actively in use, to avoid OpenCode dying on transient streaming
+ * errors propagated as unhandled rejections (see issue #3856).
+ *
+ * Signal handlers (SIGINT/SIGTERM/SIGBREAK/beforeExit/exit) remain registered
+ * because they are needed for graceful shutdown of any in-flight cleanup
+ * targets that were registered before the user noticed the issue.
+ */
+const PROCESS_CLEANUP_DISABLE_ENV = "OMO_DISABLE_PROCESS_CLEANUP"
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on"])
+
+function isProcessCleanupErrorHandlersDisabled(): boolean {
+  const raw = process.env[PROCESS_CLEANUP_DISABLE_ENV]
+  if (!raw) return false
+  return TRUTHY_ENV_VALUES.has(raw.trim().toLowerCase())
+}
+
 /** @internal test-only seam: prevents process.exitCode from contaminating bun test runner */
 let _scheduleForcedExitEnabled = true
 
@@ -116,6 +136,15 @@ export function registerManagerForCleanup(manager: CleanupTarget): void {
   }
   registerSignal("beforeExit", false)
   registerSignal("exit", false)
+
+  if (isProcessCleanupErrorHandlersDisabled()) {
+    log(
+      `[background-agent] ${PROCESS_CLEANUP_DISABLE_ENV} is set; skipping global uncaughtException/unhandledRejection handler registration. `
+        + "Signal handlers (SIGINT/SIGTERM/beforeExit/exit) remain active.",
+    )
+    return
+  }
+
   cleanupErrorHandlers.set("uncaughtException", registerErrorEvent("uncaughtException", cleanupAll))
   cleanupErrorHandlers.set("unhandledRejection", registerErrorEvent("unhandledRejection", cleanupAll))
 }


### PR DESCRIPTION
## Summary
Provide an env-var opt-out for the global `uncaughtException`/`unhandledRejection` handlers installed by `registerManagerForCleanup`. Users who load the plugin but don't actively use background-agent tasks can set `OMO_DISABLE_PROCESS_CLEANUP=1` to avoid the host process dying on transient streaming errors.

## Root Cause
[`src/features/background-agent/process-cleanup.ts`](src/features/background-agent/process-cleanup.ts) registers two `process.on(...)` listeners that call `scheduleForcedExit(handler(error), 1, true)` → `process.exit(1)` on any uncaught error or unhandled rejection — even ones from unrelated code paths (other plugins, opencode's own session processor, etc.).

The original issue reporter walked through a concrete failure: undici emits `SocketError { code: 'UND_ERR_SOCKET' }` when `api.githubcopilot.com` resets a mid-stream HTTP/2 response. That surfaces as an unhandled rejection in opencode's `session.processor` Effect runtime → our listener fires → opencode dies mid-response. Reproduced repeatedly on flaky networks / corporate proxies, with the user never invoking any background-agent functionality.

## Changes
| File | Change |
|------|--------|
| `src/features/background-agent/process-cleanup.ts` | Add `OMO_DISABLE_PROCESS_CLEANUP` env-var check (accepts `1`/`true`/`yes`/`on`, case-insensitive). When set, skip the error-event registration but keep SIGINT/SIGTERM/SIGBREAK/beforeExit/exit signal handlers active so graceful shutdown still works for whatever was already registered. Log a single line on the path so it's discoverable in `/tmp/oh-my-opencode.log`. |
| `src/features/background-agent/process-cleanup.test.ts` | Add 6 regression tests covering env-var truthy/falsy/unset states, signal-handler preservation, and end-to-end behavior under `uncaughtException`. |

Diff: **+126 lines / -0** across 2 files.

## Why opt-out rather than feature-gate or change the default

The original issue proposes three options:
1. Feature-gate handler registration behind background-agent activation
2. Provide an explicit env-var opt-out
3. Default to `process.exitCode = 1` (let the event loop drain naturally)

This PR implements **option #2** because it is the smallest, least-risky change for the impacted users and preserves the existing behavior for everyone running background agents (which depend on the forced-exit cleanup discipline from #3639). Option #1 ties the registration to internal lifecycle events that are harder to reason about; option #3 is a behavior change to the default path and warrants its own design discussion. Option #2 unblocks users *today* without touching the default.

## Reproduction (before fix)
```text
src\features\background-agent\process-cleanup.test.ts:
expect(received).toHaveLength(expected)
Expected length: 0
Received length: 1
(fail) #given env var is set to true #when registerManagerForCleanup runs #then handlers are NOT registered

expect(received).not.toHaveBeenCalled()
Expected number of calls: 0
Received number of calls: 1
(fail) #given env var is set AND process emits uncaughtException #when event fires #then manager shutdown is NOT invoked by our handler

 17 pass / 3 fail
```

Manual reproduction matches: setting `OMO_DISABLE_PROCESS_CLEANUP=1` and emitting `process.emit("uncaughtException", new Error("boom"))` still triggers the registered manager's `shutdown` because the env var is ignored pre-fix.

## Verification (after fix)
```text
bun test src/features/background-agent/process-cleanup.test.ts
 20 pass / 0 fail
 36 expect() calls
Ran 20 tests across 1 file. [161.00ms]

bun run typecheck
$ tsc --noEmit          (clean)
```

Manual QA via `bun --eval`:
```
env unset → handlers registered count: 1 PASS
env=1 → handlers registered count: 0 PASS
```

The existing 14 process-cleanup tests still pass unchanged, confirming the default path (`OMO_DISABLE_PROCESS_CLEANUP` unset) is unaffected.

## Documentation
The README already documents two similar env-var opt-outs (`OMO_SEND_ANONYMOUS_TELEMETRY`, `OMO_DISABLE_POSTHOG`). A doc note for `OMO_DISABLE_PROCESS_CLEANUP` can land in a follow-up if you'd like the same treatment — happy to add it to this PR if preferred, but kept it out for now to keep the diff focused on the behavioral fix.

## Test
- Regression tests: 6 new cases in `src/features/background-agent/process-cleanup.test.ts`, all in given/when/then style consistent with the surrounding suite.
- Related suite: `bun test src/features/background-agent/process-cleanup.test.ts` — 20 pass.
- Typecheck: `bun run typecheck` — clean.

Fixes #3856

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `OMO_DISABLE_PROCESS_CLEANUP` env opt-out to skip global `uncaughtException`/`unhandledRejection` handlers that force-exit the process, preventing crashes from unrelated transient errors. Default behavior is unchanged for users who don’t set the env var.

- **Bug Fixes**
  - Skip registering global error handlers when `OMO_DISABLE_PROCESS_CLEANUP` is truthy (`1`, `true`, `yes`, `on`).
  - Keep signal handlers (`SIGINT`, `SIGTERM`, `SIGBREAK`, `beforeExit`, `exit`) for graceful shutdown; log once when opt-out is used.

- **Migration**
  - Set `OMO_DISABLE_PROCESS_CLEANUP=1` if you load the plugin but don’t run background-agent tasks and see transient streaming errors.
  - No action needed otherwise.

<sup>Written for commit dd68f324d0919cd983aa46d264a9f16b70ca34ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

