### PR TITLE
fix(runtime-fallback): first-prompt watchdog for silently-stuck subagents

### DIFF
--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -47,3 +47,14 @@ export const RETRYABLE_ERROR_PATTERNS = [
  * Hook name for identification and logging
  */
 export const HOOK_NAME = "runtime-fallback"
+
+/**
+ * First-prompt watchdog: how long to wait for the first sign of progress
+ * (assistant text/reasoning/finish) from a subagent session before assuming
+ * the provider is silently stuck and dispatching the configured fallback.
+ *
+ * Tuned to be longer than typical first-token latency (well under 30s in
+ * practice) yet much shorter than the 30-minute outer poll timeout that
+ * would otherwise be the only safety net.
+ */
+export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 90_000

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+import type { AutoRetryHelpers } from "./auto-retry"
+import { subagentSessions } from "../../features/claude-code-session-state"
+import { createFirstPromptWatchdog } from "./first-prompt-watchdog"
+
+const WATCHDOG_MS = 40
+const SAFE_WAIT_AFTER_FIRE_MS = 120
+const SAFE_WAIT_BEFORE_FIRE_MS = 15
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function createContext(): RuntimeFallbackPluginInput {
+  return {
+    client: {
+      session: {
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        promptAsync: async () => ({}),
+      },
+      tui: {
+        showToast: async () => ({}),
+      },
+    },
+    directory: "/test/dir",
+  }
+}
+
+function createDeps(pluginConfig: Record<string, unknown> = {}): HookDeps {
+  return {
+    ctx: createContext(),
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 60,
+      timeout_seconds: 30,
+      notify_on_fallback: false,
+    },
+    options: undefined,
+    pluginConfig,
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+  }
+}
+
+interface RecordedCalls {
+  abort: Array<{ sessionID: string; source: string }>
+  autoRetry: Array<{ sessionID: string; newModel: string; resolvedAgent: string | undefined; source: string }>
+}
+
+function createHelpers(calls: RecordedCalls, resolvedAgentName?: string): AutoRetryHelpers {
+  return {
+    abortSessionRequest: async (sessionID: string, source: string) => {
+      calls.abort.push({ sessionID, source })
+    },
+    clearSessionFallbackTimeout: () => {},
+    scheduleSessionFallbackTimeout: () => {},
+    autoRetryWithFallback: async (sessionID, newModel, resolvedAgent, source) => {
+      calls.autoRetry.push({ sessionID, newModel, resolvedAgent, source })
+    },
+    resolveAgentForSessionFromContext: async () => resolvedAgentName,
+    cleanupStaleSessions: () => {},
+  }
+}
+
+const AGENT = "sisyphus-junior"
+const PRIMARY_MODEL = "openai/gpt-5.4-mini"
+const FALLBACK_MODEL = "anthropic/claude-haiku-4-5"
+const PLUGIN_CONFIG_WITH_FALLBACK = {
+  agents: {
+    [AGENT]: {
+      model: PRIMARY_MODEL,
+      fallback_models: [{ model: FALLBACK_MODEL }],
+    },
+  },
+}
+
+describe("first-prompt-watchdog", () => {
+  beforeEach(() => {
+    subagentSessions.clear()
+  })
+
+  afterEach(() => {
+    subagentSessions.clear()
+  })
+
+  it("#given a subagent stays silent past the threshold and has a fallback configured #when the watchdog fires #then it aborts the in-flight request and dispatches the fallback model", async () => {
+    // given
+    const sessionID = "session-silent-subagent"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toHaveLength(1)
+    expect(calls.autoRetry[0].sessionID).toBe(sessionID)
+    expect(calls.autoRetry[0].newModel).toBe(FALLBACK_MODEL)
+    expect(calls.autoRetry[0].source).toBe("first-prompt-watchdog")
+
+    watchdog.dispose()
+  })
+
+  it("#given a subagent produces assistant text before the threshold #when progress is observed #then the watchdog is cancelled and no fallback is dispatched", async () => {
+    // given
+    const sessionID = "session-makes-progress"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    watchdog.onAssistantProgress(sessionID)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given the session is not a subagent #when a user message is observed #then the watchdog never arms and nothing fires", async () => {
+    // given
+    const sessionID = "session-not-a-subagent"
+    // NOT added to subagentSessions
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given a subagent reaches a terminal session state before the threshold #when onSessionTerminal is called #then the watchdog is cancelled and no fallback is dispatched", async () => {
+    // given
+    const sessionID = "session-terminated-early"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_BEFORE_FIRE_MS)
+    watchdog.onSessionTerminal(sessionID)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given a subagent silent past the threshold with no fallback configured #when the watchdog fires #then it logs but does not abort or dispatch (lets PR #3950 quota-abort path handle it later if an error event arrives)", async () => {
+    // given
+    const sessionID = "session-no-fallback"
+    subagentSessions.add(sessionID)
+    const deps = createDeps({}) // empty pluginConfig → no fallback models
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+})

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -2,11 +2,18 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { subagentSessions } from "../../features/claude-code-session-state"
-import { createFirstPromptWatchdog } from "./first-prompt-watchdog"
+import { createFirstPromptWatchdog, observeEventForWatchdog, type FirstPromptWatchdog } from "./first-prompt-watchdog"
 
-const WATCHDOG_MS = 40
-const SAFE_WAIT_AFTER_FIRE_MS = 120
-const SAFE_WAIT_BEFORE_FIRE_MS = 15
+// Real timers are unavoidable here (bun:test has no built-in fake-timer API),
+// so margins are sized generously to survive a loaded CI runner. Specifically:
+//   - SAFE_WAIT_BEFORE_FIRE_MS must be << WATCHDOG_MS so the cancel call lands
+//     before the timer fires even with significant scheduler delay
+//     (margin: WATCHDOG_MS - SAFE_WAIT_BEFORE_FIRE_MS >= 60ms here).
+//   - SAFE_WAIT_AFTER_FIRE_MS must be >> WATCHDOG_MS so we conclusively
+//     observe whether the timer fired (margin: ~2.5x WATCHDOG_MS).
+const WATCHDOG_MS = 100
+const SAFE_WAIT_BEFORE_FIRE_MS = 40
+const SAFE_WAIT_AFTER_FIRE_MS = 250
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -178,7 +185,7 @@ describe("first-prompt-watchdog", () => {
     watchdog.dispose()
   })
 
-  it("#given a subagent silent past the threshold with no fallback configured #when the watchdog fires #then it logs but does not abort or dispatch (lets PR #3950 quota-abort path handle it later if an error event arrives)", async () => {
+  it("#given a subagent silent past the threshold with no fallback configured #when the watchdog fires #then it logs but does not abort or dispatch (lets the existing error-event paths handle it if one arrives later)", async () => {
     // given
     const sessionID = "session-no-fallback"
     subagentSessions.add(sessionID)
@@ -196,5 +203,137 @@ describe("first-prompt-watchdog", () => {
     expect(calls.autoRetry).toEqual([])
 
     watchdog.dispose()
+  })
+})
+
+interface RecordedWatchdogCalls {
+  user: Array<{ sessionID: string; model?: string; agent?: string }>
+  progress: string[]
+  terminal: string[]
+}
+
+function createRecordingWatchdog(calls: RecordedWatchdogCalls): FirstPromptWatchdog {
+  return {
+    onUserMessage(sessionID, model, agent) {
+      calls.user.push({ sessionID, model, agent })
+    },
+    onAssistantProgress(sessionID) {
+      calls.progress.push(sessionID)
+    },
+    onSessionTerminal(sessionID) {
+      calls.terminal.push(sessionID)
+    },
+    dispose() {},
+  }
+}
+
+describe("observeEventForWatchdog", () => {
+  const sessionID = "session-observed"
+
+  function freshCalls(): RecordedWatchdogCalls {
+    return { user: [], progress: [], terminal: [] }
+  }
+
+  it("#given a message.updated event with role=user #when observed #then onUserMessage is called with sessionID/model/agent", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "user", model: "openai/gpt-5.4-mini", agent: "sisyphus-junior" } },
+      },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.user).toEqual([{ sessionID, model: "openai/gpt-5.4-mini", agent: "sisyphus-junior" }])
+    expect(calls.progress).toEqual([])
+    expect(calls.terminal).toEqual([])
+  })
+
+  it.each([
+    ["text", { type: "text", text: "hello" }],
+    ["reasoning", { type: "reasoning", text: "thinking..." }],
+    ["tool", { type: "tool" }],
+    ["tool_use", { type: "tool_use", id: "t1", name: "Read" }],
+    ["tool_result", { type: "tool_result", tool_use_id: "t1" }],
+    ["tool-call", { type: "tool-call" }],
+    ["step-start", { type: "step-start" }],
+    ["file", { type: "file" }],
+  ])("#given a message.updated assistant event whose only part is type=%s #when observed #then onAssistantProgress is called (model is *working*, not silent)", (_label, part) => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant" }, parts: [part] },
+      },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.progress).toEqual([sessionID])
+  })
+
+  it("#given a message.updated assistant event with parts: [] and no error/finish #when observed #then no progress is signalled (no activity yet)", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant" }, parts: [] },
+      },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.progress).toEqual([])
+  })
+
+  it("#given a message.updated assistant event with info.error set #when observed #then onAssistantProgress is called (the existing error-handling path takes over from here)", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant", error: { name: "RateLimitError", message: "429" } } },
+      },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.progress).toEqual([sessionID])
+  })
+
+  it("#given a message.updated assistant event with info.finish set #when observed #then onAssistantProgress is called", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "assistant", finish: "stop" } },
+      },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.progress).toEqual([sessionID])
+  })
+
+  it.each([["session.idle"], ["session.stop"], ["session.deleted"], ["session.error"]])(
+    "#given a %s event #when observed #then onSessionTerminal is called",
+    (eventType) => {
+      const calls = freshCalls()
+      observeEventForWatchdog(
+        { type: eventType, properties: { sessionID } },
+        createRecordingWatchdog(calls),
+      )
+      expect(calls.terminal).toEqual([sessionID])
+    },
+  )
+
+  it("#given a session.deleted event whose sessionID is carried under properties.info.id #when observed #then onSessionTerminal is still called (matches event-handler shape)", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      { type: "session.deleted", properties: { info: { id: sessionID } } },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.terminal).toEqual([sessionID])
+  })
+
+  it("#given an unrelated event type #when observed #then no watchdog method is called", () => {
+    const calls = freshCalls()
+    observeEventForWatchdog(
+      { type: "session.created", properties: { info: { id: sessionID } } },
+      createRecordingWatchdog(calls),
+    )
+    expect(calls.user).toEqual([])
+    expect(calls.progress).toEqual([])
+    expect(calls.terminal).toEqual([])
   })
 })

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -1,0 +1,132 @@
+import type { HookDeps, RuntimeFallbackTimeout } from "./types"
+import type { AutoRetryHelpers } from "./auto-retry"
+import { HOOK_NAME, DEFAULT_FIRST_PROMPT_WATCHDOG_MS } from "./constants"
+import { log } from "../../shared/logger"
+import { subagentSessions } from "../../features/claude-code-session-state"
+import { createFallbackState } from "./fallback-state"
+import { getFallbackModelsForSession } from "./fallback-models"
+import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
+import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+
+const SOURCE = "first-prompt-watchdog"
+
+declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
+declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
+
+export interface FirstPromptWatchdog {
+  onUserMessage(sessionID: string, model?: string, agent?: string): void
+  onAssistantProgress(sessionID: string): void
+  onSessionTerminal(sessionID: string): void
+  dispose(): void
+}
+
+export function createFirstPromptWatchdog(
+  deps: HookDeps,
+  helpers: AutoRetryHelpers,
+  watchdogMs: number = DEFAULT_FIRST_PROMPT_WATCHDOG_MS,
+): FirstPromptWatchdog {
+  const timers = new Map<string, RuntimeFallbackTimeout>()
+  const armed = new Set<string>()
+
+  const cancel = (sessionID: string): void => {
+    const timer = timers.get(sessionID)
+    if (timer) {
+      clearTimeout(timer)
+      timers.delete(sessionID)
+    }
+    armed.delete(sessionID)
+  }
+
+  const fire = async (sessionID: string, model: string | undefined, agent: string | undefined): Promise<void> => {
+    timers.delete(sessionID)
+    armed.delete(sessionID)
+
+    if (!subagentSessions.has(sessionID)) {
+      log(`[${HOOK_NAME}] ${SOURCE}: session no longer a subagent at fire time, skipping`, { sessionID })
+      return
+    }
+
+    const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
+    const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, deps.pluginConfig)
+
+    if (fallbackModels.length === 0) {
+      log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms with no fallback configured`, {
+        sessionID,
+        model,
+        agent: resolvedAgent,
+      })
+      return
+    }
+
+    let state = deps.sessionStates.get(sessionID)
+    if (!state) {
+      const initialModel = resolveFallbackBootstrapModel({
+        sessionID,
+        source: SOURCE,
+        eventModel: model,
+        resolvedAgent,
+        pluginConfig: deps.pluginConfig,
+      })
+      if (!initialModel) {
+        log(`[${HOOK_NAME}] ${SOURCE}: no model info available, cannot dispatch fallback`, { sessionID })
+        return
+      }
+      state = createFallbackState(initialModel)
+      deps.sessionStates.set(sessionID, state)
+      deps.sessionLastAccess.set(sessionID, Date.now())
+    }
+
+    log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms, dispatching fallback`, {
+      sessionID,
+      model: state.currentModel,
+      fallbackCount: fallbackModels.length,
+    })
+
+    // Unlike the error-event path, the original request is still pending from
+    // OpenCode's perspective when the watchdog fires. Forcefully end it so the
+    // fallback prompt can take over cleanly. Network errors from abort are
+    // logged inside abortSessionRequest and do not block fallback dispatch.
+    await helpers.abortSessionRequest(sessionID, SOURCE)
+
+    await dispatchFallbackRetry(deps, helpers, {
+      sessionID,
+      state,
+      fallbackModels,
+      resolvedAgent,
+      source: SOURCE,
+    })
+  }
+
+  return {
+    onUserMessage(sessionID, model, agent) {
+      if (!sessionID) return
+      if (!subagentSessions.has(sessionID)) return
+      if (armed.has(sessionID)) return
+
+      armed.add(sessionID)
+      const timer = setTimeout(async () => {
+        await fire(sessionID, model, agent)
+      }, watchdogMs)
+      timers.set(sessionID, timer)
+
+      log(`[${HOOK_NAME}] ${SOURCE}: armed for subagent`, { sessionID, model, agent, watchdogMs })
+    },
+    onAssistantProgress(sessionID) {
+      if (!sessionID || !armed.has(sessionID)) return
+      cancel(sessionID)
+      log(`[${HOOK_NAME}] ${SOURCE}: cancelled (assistant progress observed)`, { sessionID })
+    },
+    onSessionTerminal(sessionID) {
+      if (!sessionID || !armed.has(sessionID)) return
+      cancel(sessionID)
+      log(`[${HOOK_NAME}] ${SOURCE}: cancelled (session terminal)`, { sessionID })
+    },
+    dispose() {
+      for (const timer of timers.values()) {
+        clearTimeout(timer)
+      }
+      timers.clear()
+      armed.clear()
+    },
+  }
+}

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -20,6 +20,67 @@ export interface FirstPromptWatchdog {
   dispose(): void
 }
 
+const TERMINAL_EVENT_TYPES = new Set([
+  "session.idle",
+  "session.stop",
+  "session.deleted",
+  "session.error",
+])
+
+/**
+ * Translate an OpenCode session event into the appropriate watchdog signal.
+ *
+ * Progress semantics for cancelling the watchdog:
+ *   - assistant `info.error` set: the existing message-update-handler will
+ *     deal with the error path; the watchdog has done its job.
+ *   - assistant `info.finish` set: the response completed.
+ *   - any assistant part with a known type (`text`, `reasoning`, `tool`,
+ *     `tool_use`, `tool_result`, `tool-call`, `step-start`, `file`, ...):
+ *     the model has started responding. A subagent that immediately runs
+ *     tools is *working*, not silent — so any part presence cancels.
+ */
+export function observeEventForWatchdog(
+  event: { type: string; properties?: unknown },
+  watchdog: FirstPromptWatchdog,
+): void {
+  const props = event.properties as Record<string, unknown> | undefined
+  if (!props) return
+
+  if (event.type === "message.updated") {
+    const info = props.info as Record<string, unknown> | undefined
+    const sessionID = info?.sessionID as string | undefined
+    const role = info?.role as string | undefined
+    if (!sessionID || !role) return
+
+    if (role === "user") {
+      const model = info?.model as string | undefined
+      const agent = info?.agent as string | undefined
+      watchdog.onUserMessage(sessionID, model, agent)
+      return
+    }
+
+    if (role === "assistant") {
+      const hasError = info?.error !== undefined
+      const hasFinish = info?.finish !== undefined
+      const eventParts = props.parts as Array<{ type?: string }> | undefined
+      const infoParts = info?.parts as Array<{ type?: string }> | undefined
+      const parts = eventParts ?? infoParts ?? []
+      const hasAnyPart = parts.some((part) => typeof part?.type === "string")
+      if (hasError || hasFinish || hasAnyPart) {
+        watchdog.onAssistantProgress(sessionID)
+      }
+    }
+    return
+  }
+
+  if (TERMINAL_EVENT_TYPES.has(event.type)) {
+    const sessionID =
+      (props.sessionID as string | undefined) ??
+      ((props.info as Record<string, unknown> | undefined)?.id as string | undefined)
+    if (sessionID) watchdog.onSessionTerminal(sessionID)
+  }
+}
+
 export function createFirstPromptWatchdog(
   deps: HookDeps,
   helpers: AutoRetryHelpers,

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -4,6 +4,7 @@ import { createAutoRetryHelpers } from "./auto-retry"
 import { createEventHandler } from "./event-handler"
 import { createMessageUpdateHandler } from "./message-update-handler"
 import { createChatMessageHandler } from "./chat-message-handler"
+import { createFirstPromptWatchdog } from "./first-prompt-watchdog"
 
 declare function setInterval(callback: () => void, delay?: number): RuntimeFallbackInterval
 declare function clearInterval(interval: RuntimeFallbackInterval): void
@@ -39,6 +40,56 @@ export function createRuntimeFallbackHook(
   const baseEventHandler = createEventHandler(deps, helpers)
   const messageUpdateHandler = createMessageUpdateHandler(deps, helpers)
   const chatMessageHandler = createChatMessageHandler(deps)
+  const firstPromptWatchdog = createFirstPromptWatchdog(deps, helpers)
+
+  const TERMINAL_EVENT_TYPES = new Set([
+    "session.idle",
+    "session.stop",
+    "session.deleted",
+    "session.error",
+  ])
+
+  const observeForWatchdog = (event: { type: string; properties?: unknown }): void => {
+    const props = event.properties as Record<string, unknown> | undefined
+    if (!props) return
+
+    if (event.type === "message.updated") {
+      const info = props.info as Record<string, unknown> | undefined
+      const sessionID = info?.sessionID as string | undefined
+      const role = info?.role as string | undefined
+      if (!sessionID || !role) return
+
+      if (role === "user") {
+        const model = info?.model as string | undefined
+        const agent = info?.agent as string | undefined
+        firstPromptWatchdog.onUserMessage(sessionID, model, agent)
+        return
+      }
+
+      if (role === "assistant") {
+        const hasError = info?.error !== undefined
+        const hasFinish = info?.finish !== undefined
+        const eventParts = props.parts as Array<{ type?: string; text?: string }> | undefined
+        const infoParts = info?.parts as Array<{ type?: string; text?: string }> | undefined
+        const parts = eventParts ?? infoParts ?? []
+        const hasContent = parts.some((part) => {
+          if (part.type !== "text" && part.type !== "reasoning") return false
+          return (part.text ?? "").trim().length > 0
+        })
+        if (hasError || hasFinish || hasContent) {
+          firstPromptWatchdog.onAssistantProgress(sessionID)
+        }
+      }
+      return
+    }
+
+    if (TERMINAL_EVENT_TYPES.has(event.type)) {
+      const sessionID =
+        (props.sessionID as string | undefined) ??
+        ((props.info as Record<string, unknown> | undefined)?.id as string | undefined)
+      if (sessionID) firstPromptWatchdog.onSessionTerminal(sessionID)
+    }
+  }
 
   let cleanupInterval: RuntimeFallbackInterval | null = null
   let intervalStarted = false
@@ -57,6 +108,10 @@ export function createRuntimeFallbackHook(
   const eventHandler = async ({ event }: { event: { type: string; properties?: unknown } }) => {
     ensureInterval()
 
+    if (config.enabled) {
+      observeForWatchdog(event)
+    }
+
     if (event.type === "message.updated") {
       if (!config.enabled) return
       const props = event.properties as Record<string, unknown> | undefined
@@ -74,6 +129,8 @@ export function createRuntimeFallbackHook(
     for (const fallbackTimeout of deps.sessionFallbackTimeouts.values()) {
       clearTimeout(fallbackTimeout)
     }
+
+    firstPromptWatchdog.dispose()
 
     deps.sessionStates.clear()
     deps.sessionLastAccess.clear()

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -4,7 +4,7 @@ import { createAutoRetryHelpers } from "./auto-retry"
 import { createEventHandler } from "./event-handler"
 import { createMessageUpdateHandler } from "./message-update-handler"
 import { createChatMessageHandler } from "./chat-message-handler"
-import { createFirstPromptWatchdog } from "./first-prompt-watchdog"
+import { createFirstPromptWatchdog, observeEventForWatchdog } from "./first-prompt-watchdog"
 
 declare function setInterval(callback: () => void, delay?: number): RuntimeFallbackInterval
 declare function clearInterval(interval: RuntimeFallbackInterval): void
@@ -42,55 +42,6 @@ export function createRuntimeFallbackHook(
   const chatMessageHandler = createChatMessageHandler(deps)
   const firstPromptWatchdog = createFirstPromptWatchdog(deps, helpers)
 
-  const TERMINAL_EVENT_TYPES = new Set([
-    "session.idle",
-    "session.stop",
-    "session.deleted",
-    "session.error",
-  ])
-
-  const observeForWatchdog = (event: { type: string; properties?: unknown }): void => {
-    const props = event.properties as Record<string, unknown> | undefined
-    if (!props) return
-
-    if (event.type === "message.updated") {
-      const info = props.info as Record<string, unknown> | undefined
-      const sessionID = info?.sessionID as string | undefined
-      const role = info?.role as string | undefined
-      if (!sessionID || !role) return
-
-      if (role === "user") {
-        const model = info?.model as string | undefined
-        const agent = info?.agent as string | undefined
-        firstPromptWatchdog.onUserMessage(sessionID, model, agent)
-        return
-      }
-
-      if (role === "assistant") {
-        const hasError = info?.error !== undefined
-        const hasFinish = info?.finish !== undefined
-        const eventParts = props.parts as Array<{ type?: string; text?: string }> | undefined
-        const infoParts = info?.parts as Array<{ type?: string; text?: string }> | undefined
-        const parts = eventParts ?? infoParts ?? []
-        const hasContent = parts.some((part) => {
-          if (part.type !== "text" && part.type !== "reasoning") return false
-          return (part.text ?? "").trim().length > 0
-        })
-        if (hasError || hasFinish || hasContent) {
-          firstPromptWatchdog.onAssistantProgress(sessionID)
-        }
-      }
-      return
-    }
-
-    if (TERMINAL_EVENT_TYPES.has(event.type)) {
-      const sessionID =
-        (props.sessionID as string | undefined) ??
-        ((props.info as Record<string, unknown> | undefined)?.id as string | undefined)
-      if (sessionID) firstPromptWatchdog.onSessionTerminal(sessionID)
-    }
-  }
-
   let cleanupInterval: RuntimeFallbackInterval | null = null
   let intervalStarted = false
 
@@ -109,7 +60,7 @@ export function createRuntimeFallbackHook(
     ensureInterval()
 
     if (config.enabled) {
-      observeForWatchdog(event)
+      observeEventForWatchdog(event, firstPromptWatchdog)
     }
 
     if (event.type === "message.updated") {

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -38,7 +38,18 @@ export function createSessionStatusHandler(
       // retry status message may not contain "retrying in" text alongside the error.
       const messageLower = retryMessage.toLowerCase()
       const matchesRetryablePattern = RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(messageLower))
-      if (!matchesRetryablePattern) return
+      if (!matchesRetryablePattern) {
+        // Diagnostic: capture the actual retry message content so we can extend
+        // RETRYABLE_ERROR_PATTERNS if a provider emits a phrasing we don't yet match.
+        if (retryMessage) {
+          log(`[${HOOK_NAME}] session.status retry with non-matching message`, {
+            sessionID,
+            attempt: status.attempt,
+            retryMessage,
+          })
+        }
+        return
+      }
     }
 
     const retryKey = `${extractRetryAttempt(status.attempt, retryMessage)}:${normalizeRetryStatusMessage(retryMessage)}`


### PR DESCRIPTION
## Summary

Fixes the silent-stuck failure mode where a subagent dispatched to a provider hits a rate limit / quota / outage, the SDK enters an internal retry loop that absorbs the error, and the runtime-fallback hook never sees an event to react on. Result today: subagent sits in `retry` status, the parent's `task` tool call hangs for the full 30-minute `DEFAULT_POLL_TIMEOUT_MS` budget, and the configured fallback chain is never even attempted. Observed in the wild on Momus and Sisyphus-Junior dispatches when OpenAI quota was exhausted while Anthropic was healthy.

## Root cause

The runtime-fallback subsystem is fully reactive — it acts on `message.updated` (with `info.error`), `session.error`, and `session.status: retry` (with a recognisable message). All three depend on the SDK surfacing the error. When the SDK retries 429s silently and presents an "in progress" face to OpenCode, none of those events fire, and the hook stays idle. The configured fallback model is never attempted because nothing pulls the trigger.

There is no proactive watchdog for the **initial** prompt to a subagent. All existing watchdogs (`scheduleSessionFallbackTimeout`, the outer poll timeout) protect either *post-fallback-dispatch* states or the *outer parent* timeout — nothing watches the most common failure mode: "we dispatched a subagent, the SDK accepted the prompt, no first response ever arrives."

## Fix

A small new module `first-prompt-watchdog.ts` that synthesises the missing trigger:

- **Arm**: on `message.updated` with `role === "user"` for a session in `subagentSessions`. 90s timer starts (`DEFAULT_FIRST_PROMPT_WATCHDOG_MS`).
- **Cancel**: on the first sign of progress — assistant message with text/reasoning content, `finish` field, or `error` field — or on any session terminal event (`session.idle` / `session.stop` / `session.deleted` / `session.error`).
- **Fire**: at the 90s mark, if not cancelled, abort the in-flight request and route into the existing `dispatchFallbackRetry` pipeline. Exactly equivalent to a `session.error` arriving on time, just simulated when the SDK fails to surface one.

### Design choices

- **Dispatch fallback, do not abort outright.** Network loss looks identical to a stuck SDK retry from the hook's vantage point. With fallback-dispatch behaviour, network loss gracefully degrades to today's baseline (both attempts fail, the 30-min outer timeout still ends things) instead of destructively aborting work that might have recovered when the network blip resolved.
- **Subagent-only.** Parent/user sessions can legitimately take >90s before first token. Subagent dispatches in practice produce first content much faster, so a 90s ceiling is safe and tight.
- **No new fallback mechanism.** The watchdog only synthesises the missing event; the actual swap-and-retry is the existing `dispatchFallbackRetry → prepareFallback → autoRetryWithFallback` flow.
- **Single threshold knob.** `DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 90_000` in `constants.ts`, exposed as the third arg to `createFirstPromptWatchdog` for testing.

### Bonus: diagnostic log

`session-status-handler.ts` had a silent return when a `session.status: retry` event arrives with a message that doesn't match `RETRYABLE_ERROR_PATTERNS`. Added a single log line capturing the raw `retryMessage` and `attempt` in that branch. Cost: one log line. Benefit: next time a provider emits a retry phrasing we don't recognise, we'll see what it actually said and can extend the patterns. No behaviour change.

## Test plan

- [x] New test file `first-prompt-watchdog.test.ts` with 5 cases:
  - Subagent silent past threshold + fallback configured → abort called + `autoRetryWithFallback` invoked with the fallback model.
  - Subagent produces assistant text before threshold → cancelled, no abort, no fallback dispatch.
  - Non-subagent session → never arms, no fire.
  - Subagent reaches session terminal before threshold → cancelled, no fire.
  - Subagent silent past threshold + no fallback configured → logs only, no abort, no dispatch (lets other safety nets handle).
- [x] `bun test src/hooks/runtime-fallback/` → 138/138 pass (133 pre-existing + 5 new).
- [x] `bun test src/hooks/runtime-fallback src/features/claude-code-session-state` → 160/160 pass.
- [x] `bunx tsc --noEmit` → clean.

## Relationship to PR #3950

Independent. PR #3950 fixes the case where an error event *did* arrive but `fallbackModels.length === 0`; this PR fixes the case where the error event *never* arrives. Different code paths, different scenarios, can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silently stuck subagents by adding a first‑prompt watchdog that triggers fallback if no progress is seen within 90s. Progress detection now includes any assistant part (text/reasoning/tools/etc.) to avoid false fires.

- **Bug Fixes**
  - First‑prompt watchdog: armed on subagent user messages; cancelled on assistant progress (error/finish or any part: text, reasoning, tool, tool_use, tool_result, tool-call, step-start, file) or on terminal session events; 90s threshold (`DEFAULT_FIRST_PROMPT_WATCHDOG_MS`).
  - On fire: aborts the in‑flight request and routes to the existing fallback flow; if no fallback is configured, logs only.
  - Event routing uses a new `observeEventForWatchdog` helper wired into `message.updated` and `session.*`.
  - Adds a log when `session.status: retry` has a message that doesn’t match `RETRYABLE_ERROR_PATTERNS`.

<sup>Written for commit 52414185861b296ad9478d44a3abf6de98f4b56e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

