### PR TITLE
fix(team-mode): resolve port-0 server-url discard and surface visualization skip

### DIFF
--- a/src/features/team-mode/team-layout-tmux/index.ts
+++ b/src/features/team-mode/team-layout-tmux/index.ts
@@ -1,1 +1,2 @@
 export { canVisualize, createTeamLayout, removeTeamLayout } from "./layout"
+export type { TeamLayoutCleanupTarget, TeamLayoutDeps, TeamLayoutOutcome, TeamLayoutResult, TeamLayoutSkipOutcome, TeamLayoutSkipReason } from "./layout"

--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -102,9 +102,16 @@ async function loadLayoutModule() {
   }
 }
 
-type TmuxMgrLike = { getServerUrl: () => string }
+type TmuxMgrLike = { getServerUrl: () => string; getServerUrlSource: () => "ctx" }
 
-const tmuxMgr: TmuxMgrLike = { getServerUrl: () => "http://127.0.0.1:12345" }
+const tmuxMgr: TmuxMgrLike = { getServerUrl: () => "http://127.0.0.1:12345", getServerUrlSource: () => "ctx" }
+
+type TeamLayoutOutcome = Awaited<ReturnType<typeof createTeamLayout>>
+type CreatedTeamLayoutOutcome = Extract<TeamLayoutOutcome, { skipped: false }>
+
+function expectCreatedLayout(result: TeamLayoutOutcome): asserts result is CreatedTeamLayoutOutcome {
+  expect(result.skipped).toBe(false)
+}
 
 function getCommands(): Array<Array<string>> {
   return Array.from(runTmuxCommandMock.mock.calls, (call) => call[1])
@@ -140,7 +147,7 @@ describe("team-layout-tmux", () => {
     })
   })
 
-  test("returns null and makes no tmux calls when visualization unavailable", async () => {
+  test("returns tmux-unavailable skip and makes no tmux calls when visualization unavailable", async () => {
     // given
     delete process.env.TMUX
     const { canVisualize, createTeamLayout } = await loadLayoutModule()
@@ -150,11 +157,12 @@ describe("team-layout-tmux", () => {
 
     // then
     expect(canVisualize()).toBe(false)
-    expect(result).toBeNull()
+    expect(result.skipped).toBe(true)
+    expect(result.reason).toBe("tmux-unavailable")
     expect(runTmuxCommandMock).toHaveBeenCalledTimes(0)
   })
 
-  test("returns null when server health check fails", async () => {
+  test("returns server-unreachable skip when server health check fails", async () => {
     // given
     isServerRunningMock.mockImplementation(async () => false)
     const { createTeamLayout } = await loadLayoutModule()
@@ -167,7 +175,10 @@ describe("team-layout-tmux", () => {
     )
 
     // then
-    expect(result).toBeNull()
+    expect(result.skipped).toBe(true)
+    expect(result.reason).toBe("server-unreachable")
+    expect(result.serverUrl).toBe("http://127.0.0.1:12345")
+    expect(result.serverUrlSource).toBe("ctx")
     expect(runTmuxCommandMock).toHaveBeenCalledTimes(0)
   })
 
@@ -180,9 +191,10 @@ describe("team-layout-tmux", () => {
     ]
 
     // when
-    await createTeamLayout("run-attach", members, tmuxMgr as never)
+    const result = await createTeamLayout("run-attach", members, tmuxMgr as never)
 
     // then
+    expectCreatedLayout(result)
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
     expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(2)
@@ -211,9 +223,9 @@ describe("team-layout-tmux", () => {
     expect(selectLayoutArgs).toContain("main-vertical")
     expect(selectLayoutArgs).not.toContain("tiled")
     expect(commands).toContainEqual(["resize-pane", "-t", process.env.TMUX_PANE ?? "", "-x", "30%"])
-    expect(result).not.toBeNull()
-    expect(Object.keys(result?.focusPanesByMember ?? {}).sort()).toEqual(["m1", "m2", "m3"])
-    expect(Object.keys(result?.gridPanesByMember ?? {})).toEqual([])
+    expectCreatedLayout(result)
+    expect(Object.keys(result.focusPanesByMember).sort()).toEqual(["m1", "m2", "m3"])
+    expect(Object.keys(result.gridPanesByMember)).toEqual([])
   })
 
   test("#given 4 or more teammates #when createTeamLayout runs #then it keeps every teammate in the caller window", async () => {
@@ -226,9 +238,10 @@ describe("team-layout-tmux", () => {
     }))
 
     // when
-    await createTeamLayout("run-tiled", members, tmuxMgr as never)
+    const result = await createTeamLayout("run-tiled", members, tmuxMgr as never)
 
     // then
+    expectCreatedLayout(result)
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
     expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(5)
@@ -247,9 +260,10 @@ describe("team-layout-tmux", () => {
     }))
 
     // when
-    await createTeamLayout("run-no-focus", members, tmuxMgr as never)
+    const result = await createTeamLayout("run-no-focus", members, tmuxMgr as never)
 
     // then
+    expectCreatedLayout(result)
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "select-pane" && !args.includes("-T"))).toBe(false)
     expect(commands.some((args) => args[0] === "set-option")).toBe(false)
@@ -343,7 +357,8 @@ describe("team-layout-tmux", () => {
     const result = await createTeamLayout("run-empty", members, tmuxMgr as never)
 
     // then
-    expect(result).toBeNull()
+    expect(result.skipped).toBe(true)
+    expect(result.reason).toBe("layout-creation-failed")
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
   })
@@ -358,9 +373,10 @@ describe("team-layout-tmux", () => {
       ]
 
       // when
-      await createTeamLayout("run-split", members, tmuxMgr as never)
+      const result = await createTeamLayout("run-split", members, tmuxMgr as never)
 
       // then
+      expectCreatedLayout(result)
       const commands = getCommands()
       expect(commands.some((args) => args[0] === "new-session")).toBe(false)
       expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
@@ -376,8 +392,8 @@ describe("team-layout-tmux", () => {
       const result = await createTeamLayout("run-owned", members, tmuxMgr as never)
 
       // then
-      expect(result).not.toBeNull()
-      expect(result?.ownedSession).toBe(false)
+      expectCreatedLayout(result)
+      expect(result.ownedSession).toBe(false)
     })
 
     test("#given first teammate #when layout runs #then it splits the caller pane horizontally for teammate area", async () => {
@@ -386,9 +402,10 @@ describe("team-layout-tmux", () => {
       const members = [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }]
 
       // when
-      await createTeamLayout("run-first", members, tmuxMgr as never)
+      const result = await createTeamLayout("run-first", members, tmuxMgr as never)
 
       // then
+      expectCreatedLayout(result)
       const commands = getCommands()
       const splitCalls = commands.filter((args) => args[0] === "split-window")
       expect(splitCalls).toEqual([
@@ -410,9 +427,9 @@ describe("team-layout-tmux", () => {
       const result = await createTeamLayout("run-3-members", members, tmuxMgr as never)
 
       // then
-      expect(result).not.toBeNull()
-      expect(Object.keys(result?.focusPanesByMember ?? {}).sort()).toEqual(["m1", "m2", "m3"])
-      expect(new Set(Object.values(result?.focusPanesByMember ?? {})).size).toBe(3)
+      expectCreatedLayout(result)
+      expect(Object.keys(result.focusPanesByMember).sort()).toEqual(["m1", "m2", "m3"])
+      expect(new Set(Object.values(result.focusPanesByMember)).size).toBe(3)
     })
 
     test("#given layout created #when createTeamLayout runs #then it records focus panes only", async () => {
@@ -428,11 +445,11 @@ describe("team-layout-tmux", () => {
 
       // then
       const commands = getCommands()
-      expect(result).not.toBeNull()
-      expect(Object.keys(result?.focusPanesByMember ?? {}).sort()).toEqual(["m1", "m2"])
-      expect(Object.keys(result?.gridPanesByMember ?? {})).toEqual([])
-      expect(result?.focusWindowId).toBe("test-session:0")
-      expect(result?.gridWindowId).toBeUndefined()
+      expectCreatedLayout(result)
+      expect(Object.keys(result.focusPanesByMember).sort()).toEqual(["m1", "m2"])
+      expect(Object.keys(result.gridPanesByMember)).toEqual([])
+      expect(result.focusWindowId).toBe("test-session:0")
+      expect(result.gridWindowId).toBeUndefined()
       expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
       expect(commands.some((args) => args[0] === "send-keys" && args.includes("Enter"))).toBe(true)
     })

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -2,8 +2,11 @@ import { log } from "../../../shared"
 import { shellSingleQuote } from "../../../shared/shell-env"
 import * as sharedTmuxModule from "../../../shared/tmux"
 import * as tmuxPathResolverModule from "../../../tools/interactive-bash/tmux-path-resolver"
-import type { TmuxSessionManager } from "../../tmux-subagent/manager"
+import type { ServerUrlSource, TmuxSessionManager } from "../../tmux-subagent/manager"
+import type { TeamLayoutSkipReason } from "../types"
 import { resolveCallerTmuxSession } from "./resolve-caller-tmux-session"
+
+export type { TeamLayoutSkipReason } from "../types"
 
 type TeamLayoutMember = { name: string; sessionId: string; worktreePath?: string }
 type TmuxCommandResult = Awaited<ReturnType<typeof sharedTmuxModule.runTmuxCommand>>
@@ -31,6 +34,18 @@ export type TeamLayoutResult = {
   ownedSession: boolean
 }
 
+export type TeamLayoutSkipOutcome = {
+  skipped: true
+  reason: TeamLayoutSkipReason
+  detail?: string
+  serverUrl?: string
+  serverUrlSource?: ServerUrlSource
+}
+
+export type TeamLayoutOutcome =
+  | ({ skipped: false } & TeamLayoutResult)
+  | TeamLayoutSkipOutcome
+
 export type TeamLayoutCleanupTarget = {
   ownedSession: boolean
   targetSessionId: string
@@ -47,6 +62,24 @@ function getPaneWorkingDirectory(member: TeamLayoutMember): string {
 
 function buildAttachCommand(member: TeamLayoutMember, serverUrl: string): string {
   return `opencode attach ${shellSingleQuote(serverUrl)} --session ${shellSingleQuote(member.sessionId)} --dir ${shellSingleQuote(getPaneWorkingDirectory(member))}`
+}
+
+function createSkipOutcome(args: {
+  reason: TeamLayoutSkipReason
+  detail?: string
+  serverUrl?: string
+  serverUrlSource?: ServerUrlSource
+}): TeamLayoutSkipOutcome {
+  const outcome: TeamLayoutSkipOutcome = { skipped: true, reason: args.reason }
+  if (args.detail !== undefined) outcome.detail = args.detail
+  if (args.serverUrl !== undefined) outcome.serverUrl = args.serverUrl
+  if (args.serverUrlSource !== undefined) outcome.serverUrlSource = args.serverUrlSource
+  return outcome
+}
+
+function resolveServerUrlSource(tmuxMgr: TmuxSessionManager): ServerUrlSource | undefined {
+  const sourceProvider = tmuxMgr as { getServerUrlSource?: () => ServerUrlSource }
+  return sourceProvider.getServerUrlSource?.()
 }
 
 async function listPanesInWindow(tmuxPath: string, windowTarget: string, deps: TeamLayoutDeps): Promise<Array<string>> {
@@ -109,38 +142,45 @@ async function createTeamLayoutInCallerWindow(
   return { focusWindowId: windowTarget, focusPanesByMember: panesByMember }
 }
 
-export async function createTeamLayout(teamRunId: string, members: Array<TeamLayoutMember>, tmuxMgr: TmuxSessionManager, deps: TeamLayoutDeps = defaultDeps): Promise<TeamLayoutResult | null> {
+export async function createTeamLayout(teamRunId: string, members: Array<TeamLayoutMember>, tmuxMgr: TmuxSessionManager, deps: TeamLayoutDeps = defaultDeps): Promise<TeamLayoutOutcome> {
   if (!canVisualize()) {
     log("tmux visualization unavailable, skipping")
-    return null
+    return createSkipOutcome({ reason: "tmux-unavailable" })
   }
   if (members.length === 0) {
-    return null
+    return createSkipOutcome({ reason: "layout-creation-failed", detail: "No team members to visualize." })
   }
 
+  let serverUrl: string | undefined
+  let serverUrlSource: ServerUrlSource | undefined
   try {
-    const serverUrl = tmuxMgr.getServerUrl()
+    serverUrl = tmuxMgr.getServerUrl()
+    serverUrlSource = resolveServerUrlSource(tmuxMgr)
     if (!(await deps.isServerRunning(serverUrl))) {
       log("opencode server not reachable, skipping team layout", { serverUrl })
-      return null
+      return createSkipOutcome({ reason: "server-unreachable", serverUrl, serverUrlSource })
     }
 
     const tmuxPath = await deps.getTmuxPath()
     if (!tmuxPath) {
       log("tmux visualization unavailable, skipping")
-      return null
+      return createSkipOutcome({ reason: "tmux-binary-missing", serverUrl, serverUrlSource })
     }
 
     const callerSession = await deps.resolveCallerTmuxSession(tmuxPath)
     if (!callerSession) {
       log("tmux visualization requires a resolvable caller tmux pane, skipping", { teamRunId })
-      return null
+      return createSkipOutcome({ reason: "caller-pane-unresolved", serverUrl, serverUrlSource })
     }
 
     const focus = await createTeamLayoutInCallerWindow(tmuxPath, callerSession.paneId, callerSession.windowTarget, members, serverUrl, deps)
-    if (!focus) return null
+    if (!focus) {
+      log("tmux team layout creation failed, skipping", { teamRunId })
+      return createSkipOutcome({ reason: "layout-creation-failed", serverUrl, serverUrlSource })
+    }
 
     return {
+      skipped: false,
       focusWindowId: focus.focusWindowId,
       gridWindowId: undefined,
       focusPanesByMember: focus.focusPanesByMember,
@@ -150,7 +190,7 @@ export async function createTeamLayout(teamRunId: string, members: Array<TeamLay
     }
   } catch (error) {
     log("tmux visualization unavailable, skipping", { error: String(error) })
-    return null
+    return createSkipOutcome({ reason: "layout-creation-failed", detail: String(error), serverUrl, serverUrlSource })
   }
 }
 

--- a/src/features/team-mode/team-runtime/activate-team-layout.test.ts
+++ b/src/features/team-mode/team-runtime/activate-team-layout.test.ts
@@ -60,7 +60,12 @@ describe("activateTeamLayout", () => {
 
   beforeEach(() => {
     createTeamLayoutSpy = spyOn(layoutModule, "createTeamLayout")
-    createTeamLayoutSpy.mockResolvedValue(null)
+    createTeamLayoutSpy.mockResolvedValue({
+      skipped: true,
+      reason: "server-unreachable",
+      serverUrl: "http://127.0.0.1:12345",
+      serverUrlSource: "ctx",
+    })
     transitionRuntimeStateSpy = spyOn(storeModule, "transitionRuntimeState")
     transitionRuntimeStateSpy.mockImplementation(async (
       _teamRunId,
@@ -73,6 +78,7 @@ describe("activateTeamLayout", () => {
     // given
     const runtimeState = createRuntimeState()
     createTeamLayoutSpy.mockResolvedValue({
+      skipped: false,
       focusWindowId: "@10",
       gridWindowId: "@11",
       focusPanesByMember: { "member-a": "%11" },
@@ -129,7 +135,7 @@ describe("activateTeamLayout", () => {
     })
   })
 
-  test("#given createTeamLayout returns null #when activateTeamLayout runs #then returns false and no state transition fires", async () => {
+  test("#given createTeamLayout returns skip #when activateTeamLayout runs #then returns false and records the skip", async () => {
     // given
     const runtimeState = createRuntimeState()
 
@@ -143,7 +149,17 @@ describe("activateTeamLayout", () => {
 
     // then
     expect(result).toBe(false)
-    expect(transitionRuntimeStateSpy).not.toHaveBeenCalled()
+    expect(transitionRuntimeStateSpy).toHaveBeenCalledTimes(1)
+    const transitionCall = transitionRuntimeStateSpy.mock.calls[0]
+    if (!transitionCall) {
+      throw new Error("expected transitionRuntimeState to be called")
+    }
+    const nextState = transitionCall[1](runtimeState)
+    expect(nextState.tmuxLayoutSkip).toEqual({
+      reason: "server-unreachable",
+      serverUrl: "http://127.0.0.1:12345",
+      serverUrlSource: "ctx",
+    })
   })
 
   test("#given config.tmux_visualization is false #when activateTeamLayout runs #then it short-circuits, no state change, returns false", async () => {

--- a/src/features/team-mode/team-runtime/activate-team-layout.ts
+++ b/src/features/team-mode/team-runtime/activate-team-layout.ts
@@ -1,7 +1,7 @@
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
 import { createTeamLayout } from "../team-layout-tmux/layout"
-import type { TeamLayoutResult } from "../team-layout-tmux/layout"
+import type { TeamLayoutOutcome, TeamLayoutResult } from "../team-layout-tmux/layout"
 import type { RuntimeState } from "../types"
 import { transitionRuntimeState } from "../team-state-store/store"
 
@@ -10,6 +10,15 @@ function normalizeTeamLayout(teamRunId: string, layout: TeamLayoutResult): TeamL
     ...layout,
     targetSessionId: layout.targetSessionId ?? `omo-team-${teamRunId}`,
     ownedSession: layout.ownedSession ?? true,
+  }
+}
+
+function normalizeTeamLayoutSkip(layout: Extract<TeamLayoutOutcome, { skipped: true }>): RuntimeState["tmuxLayoutSkip"] {
+  return {
+    reason: layout.reason,
+    ...(layout.detail !== undefined ? { detail: layout.detail } : {}),
+    ...(layout.serverUrl !== undefined ? { serverUrl: layout.serverUrl } : {}),
+    ...(layout.serverUrlSource !== undefined ? { serverUrlSource: layout.serverUrlSource } : {}),
   }
 }
 
@@ -33,22 +42,33 @@ export async function activateTeamLayout(
       : []),
     tmuxMgr,
   )
-  if (!layout) return false
+  if (layout.skipped) {
+    const tmuxLayoutSkip = normalizeTeamLayoutSkip(layout)
+    await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
+      ...currentState,
+      tmuxLayoutSkip,
+    }), config)
+    return false
+  }
   const normalizedLayout = normalizeTeamLayout(runtimeState.teamRunId, layout)
 
-  await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
-    ...currentState,
-    tmuxLayout: {
-      ownedSession: normalizedLayout.ownedSession,
-      targetSessionId: normalizedLayout.targetSessionId,
-      focusWindowId: normalizedLayout.focusWindowId,
-      gridWindowId: normalizedLayout.gridWindowId,
-    },
-    members: currentState.members.map((member) => ({
-      ...member,
-      tmuxPaneId: normalizedLayout.focusPanesByMember[member.name] ?? member.tmuxPaneId,
-      tmuxGridPaneId: normalizedLayout.gridPanesByMember[member.name] ?? member.tmuxGridPaneId,
-    })),
-  }), config)
+  await transitionRuntimeState(runtimeState.teamRunId, (currentState) => {
+    const stateWithoutLayoutSkip = { ...currentState }
+    delete stateWithoutLayoutSkip.tmuxLayoutSkip
+    return {
+      ...stateWithoutLayoutSkip,
+      tmuxLayout: {
+        ownedSession: normalizedLayout.ownedSession,
+        targetSessionId: normalizedLayout.targetSessionId,
+        focusWindowId: normalizedLayout.focusWindowId,
+        gridWindowId: normalizedLayout.gridWindowId,
+      },
+      members: currentState.members.map((member) => ({
+        ...member,
+        tmuxPaneId: normalizedLayout.focusPanesByMember[member.name] ?? member.tmuxPaneId,
+        tmuxGridPaneId: normalizedLayout.gridPanesByMember[member.name] ?? member.tmuxGridPaneId,
+      })),
+    }
+  }, config)
   return true
 }

--- a/src/features/team-mode/team-runtime/delete-team.test.ts
+++ b/src/features/team-mode/team-runtime/delete-team.test.ts
@@ -1,0 +1,93 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { rm } from "node:fs/promises"
+
+import { TeamModeConfigSchema, type TeamModeConfig } from "../../../config/schema/team-mode"
+import type { TmuxSessionManager } from "../../tmux-subagent/manager"
+import { transitionRuntimeState } from "../team-state-store/store"
+import { createFixture, updateMemberStatuses } from "./shutdown-test-fixtures"
+import { deleteTeam, type DeleteTeamDeps } from "./delete-team"
+
+function withTmuxVisualization(config: TeamModeConfig): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ ...config, tmux_visualization: true })
+}
+
+function createDeleteDeps() {
+  const removeTeamLayoutMock = mock<DeleteTeamDeps["removeTeamLayout"]>(async () => undefined)
+  const deps: DeleteTeamDeps = {
+    canVisualize: mock(() => true),
+    removeTeamLayout: removeTeamLayoutMock,
+    log: mock<DeleteTeamDeps["log"]>(() => undefined),
+  }
+  return { deps, removeTeamLayoutMock }
+}
+
+describe("deleteTeam layout removal result", () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map(async (directoryPath) => {
+      await rm(directoryPath, { recursive: true, force: true })
+    }))
+  })
+
+  test("#given runtime has no tmux layout #when deleteTeam runs #then removedLayout is false", async () => {
+    // given
+    const fixture = await createFixture()
+    temporaryDirectories.push(fixture.baseDir)
+    await updateMemberStatuses(fixture.teamRunId, fixture.config, {
+      "member-a": "shutdown_approved",
+      "member-b": "shutdown_approved",
+    })
+    const { deps, removeTeamLayoutMock } = createDeleteDeps()
+
+    // when
+    const result = await deleteTeam(
+      fixture.teamRunId,
+      withTmuxVisualization(fixture.config),
+      {} as TmuxSessionManager,
+      undefined,
+      undefined,
+      deps,
+    )
+
+    // then
+    expect(result.removedLayout).toBe(false)
+    expect(removeTeamLayoutMock).not.toHaveBeenCalled()
+  })
+
+  test("#given runtime has a tmux layout #when deleteTeam tears it down #then removedLayout is true", async () => {
+    // given
+    const fixture = await createFixture()
+    temporaryDirectories.push(fixture.baseDir)
+    await updateMemberStatuses(fixture.teamRunId, fixture.config, {
+      "member-a": "shutdown_approved",
+      "member-b": "shutdown_approved",
+    })
+    await transitionRuntimeState(fixture.teamRunId, (runtimeState) => ({
+      ...runtimeState,
+      tmuxLayout: {
+        ownedSession: false,
+        targetSessionId: "$caller",
+        focusWindowId: "@10",
+      },
+    }), fixture.config)
+    const { deps, removeTeamLayoutMock } = createDeleteDeps()
+
+    // when
+    const result = await deleteTeam(
+      fixture.teamRunId,
+      withTmuxVisualization(fixture.config),
+      {} as TmuxSessionManager,
+      undefined,
+      undefined,
+      deps,
+    )
+
+    // then
+    expect(result.removedLayout).toBe(true)
+    expect(removeTeamLayoutMock).toHaveBeenCalledTimes(1)
+    expect(removeTeamLayoutMock.mock.calls[0]?.[1]).toMatchObject({ targetSessionId: "$caller" })
+  })
+})

--- a/src/features/team-mode/team-runtime/delete-team.ts
+++ b/src/features/team-mode/team-runtime/delete-team.ts
@@ -100,22 +100,22 @@ export async function deleteTeam(
     }
   }
 
-  const removedLayout = config.tmux_visualization && tmuxMgr !== undefined && deps.canVisualize()
-  if (removedLayout) {
+  const runtimeLayout = runtimeState.tmuxLayout
+  const hadLayout = runtimeLayout !== undefined && runtimeLayout.targetSessionId.length > 0
+  let removedLayout = false
+  if (runtimeLayout !== undefined && hadLayout && tmuxMgr !== undefined && deps.canVisualize()) {
     const memberPaneIds = runtimeState.members
-      .filter((member) => member.agentType !== "leader" && member.tmuxPaneId)
-      .map((member) => member.tmuxPaneId!)
+      .flatMap((member) => member.agentType !== "leader" && member.tmuxPaneId ? [member.tmuxPaneId] : [])
 
-    const cleanupTarget = runtimeState.tmuxLayout
-      ? {
-          ...runtimeState.tmuxLayout,
-          paneIds: memberPaneIds.length > 0 ? memberPaneIds : undefined,
-        }
-      : undefined
+    const cleanupTarget = {
+      ...runtimeLayout,
+      ...(memberPaneIds.length > 0 ? { paneIds: memberPaneIds } : {}),
+    }
 
     if (options?.force === true) {
       try {
         await deps.removeTeamLayout(teamRunId, cleanupTarget, tmuxMgr)
+        removedLayout = true
       } catch (error) {
         deps.log("team delete layout cleanup failed", {
           teamRunId,
@@ -124,6 +124,7 @@ export async function deleteTeam(
       }
     } else {
       await deps.removeTeamLayout(teamRunId, cleanupTarget, tmuxMgr)
+      removedLayout = true
     }
   }
 

--- a/src/features/team-mode/team-runtime/shutdown.test.ts
+++ b/src/features/team-mode/team-runtime/shutdown.test.ts
@@ -323,6 +323,14 @@ describe("team-runtime shutdown", () => {
       "member-a": "running",
       "member-b": "idle",
     })
+    await runtimeStateStore.transitionRuntimeState(fixture.teamRunId, (runtimeState) => ({
+      ...runtimeState,
+      tmuxLayout: {
+        ownedSession: false,
+        targetSessionId: "$caller",
+        focusWindowId: "@10",
+      },
+    }), fixture.config)
     await Promise.all(fixture.worktreePaths.map(async (worktreePath) => {
       await mkdir(worktreePath, { recursive: true })
     }))
@@ -338,7 +346,7 @@ describe("team-runtime shutdown", () => {
     )
 
     // then
-    expect(result.removedLayout).toBe(true)
+    expect(result.removedLayout).toBe(false)
     expect(transitionedStatuses).toContain("deleted")
     expect(logMock).toHaveBeenCalledWith("team delete layout cleanup failed", {
       teamRunId: fixture.teamRunId,

--- a/src/features/team-mode/tools/lifecycle.test.ts
+++ b/src/features/team-mode/tools/lifecycle.test.ts
@@ -2,6 +2,7 @@
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
 
+import { TeamModeConfigSchema } from "../../../config/schema/team-mode"
 import type { RuntimeState } from "../types"
 import {
   approveShutdownMock,
@@ -45,6 +46,38 @@ const lifecycleDeps = {
 
 function createTeamCreateToolForTest() {
   return createTeamCreateTool(config, mockClient, backgroundManager, undefined, undefined, lifecycleDeps)
+}
+
+type TeamCreateWarning = {
+  kind: "tmux_visualization_skipped"
+  reason: string
+  hint: string
+  detail?: string
+  serverUrl?: string
+  serverUrlSource?: string
+}
+
+function createSkippedRuntimeState(): RuntimeState {
+  return {
+    version: 1,
+    teamRunId: "team-run-skip",
+    teamName: "alpha-team",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    tmuxLayoutSkip: {
+      reason: "server-unreachable",
+      serverUrl: "http://localhost:4096",
+      serverUrlSource: "default-fallback",
+    },
+    shutdownRequests: [],
+    bounds: { maxMembers: 8, maxParallelMembers: 4, maxMessagesPerRun: 10000, maxWallClockMinutes: 120, maxMemberTurns: 500 },
+    members: [
+      { name: "lead", agentType: "leader", status: "running", pendingInjectedMessageIds: [] },
+      { name: "member-a", sessionId: "member-a-session", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [] },
+    ],
+  }
 }
 
 describe("team lifecycle tools", () => {
@@ -112,6 +145,41 @@ describe("team lifecycle tools", () => {
     expect(result.runtimeState.members).toHaveLength(2)
     expect(result.runtimeState.members[0]).not.toHaveProperty("lastInjectedTurnMarker")
     expect(result.runtimeState.members[0]).not.toHaveProperty("pendingInjectedMessageIds")
+  })
+
+  test("team_create surfaces tmux visualization skip warnings when visualization is enabled", async () => {
+    // given
+    const visualConfig = TeamModeConfigSchema.parse({ enabled: true, tmux_visualization: true })
+    const teamCreateTool = createTeamCreateTool(visualConfig, mockClient, backgroundManager, undefined, undefined, lifecycleDeps)
+    createTeamRunMock.mockResolvedValueOnce(createSkippedRuntimeState())
+
+    // when
+    const result = parseToolResult<{ teamRunId: string; runtimeState: RuntimeState; warnings?: TeamCreateWarning[] }>(await teamCreateTool.execute({ inline_spec: createSpec() }, createToolContext("lead-session")))
+
+    // then
+    expect(result.teamRunId).toBe("team-run-skip")
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings?.[0]).toMatchObject({
+      kind: "tmux_visualization_skipped",
+      reason: "server-unreachable",
+      serverUrl: "http://localhost:4096",
+      serverUrlSource: "default-fallback",
+    })
+    expect(result.warnings?.[0]?.hint).toContain("--port N")
+    expect(result.warnings?.[0]?.hint).toContain("OPENCODE_PORT=N")
+  })
+
+  test("team_create omits tmux visualization skip warnings when visualization is disabled", async () => {
+    // given
+    const teamCreateTool = createTeamCreateToolForTest()
+    createTeamRunMock.mockResolvedValueOnce(createSkippedRuntimeState())
+
+    // when
+    const result = parseToolResult<{ teamRunId: string; runtimeState: RuntimeState; warnings?: TeamCreateWarning[] }>(await teamCreateTool.execute({ inline_spec: createSpec() }, createToolContext("lead-session")))
+
+    // then
+    expect(result.teamRunId).toBe("team-run-skip")
+    expect(result).not.toHaveProperty("warnings")
   })
 
   test("team_create normalizes inline lead shorthand before creating the runtime", async () => {

--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -47,6 +47,14 @@ type TeamLifecycleToolContext = ToolContext & {
 type TeamParticipant = { role: "lead" | "member"; memberName: string }
 
 type TeamCreateArgs = z.infer<typeof TeamCreateArgsSchema>
+type TmuxVisualizationSkippedWarning = {
+  kind: "tmux_visualization_skipped"
+  reason: NonNullable<RuntimeState["tmuxLayoutSkip"]>["reason"]
+  hint: string
+  detail?: string
+  serverUrl?: string
+  serverUrlSource?: string
+}
 
 function resolveDefaultInlineCategory(userCategories?: CategoriesConfig): string | undefined {
   const userCategoryName = Object.entries(userCategories ?? {}).find(([, categoryConfig]) => categoryConfig.disable !== true)?.[0]
@@ -70,6 +78,35 @@ function sanitizeRuntimeState(runtimeState: RuntimeState): Omit<RuntimeState, "m
     ...runtimeState,
     members: runtimeState.members.map(({ lastInjectedTurnMarker: _turnMarker, pendingInjectedMessageIds: _pendingIds, ...member }) => member),
   }
+}
+
+function hintForSkipReason(reason: NonNullable<RuntimeState["tmuxLayoutSkip"]>["reason"]): string {
+  switch (reason) {
+    case "server-unreachable":
+      return "Launch opencode with --port N and matching OPENCODE_PORT=N, or disable team_mode.tmux_visualization."
+    case "tmux-unavailable":
+      return "Run team_create from inside tmux, or disable team_mode.tmux_visualization."
+    case "tmux-binary-missing":
+      return "Install tmux or disable team_mode.tmux_visualization."
+    case "caller-pane-unresolved":
+      return "Run team_create from a resolvable tmux pane, or disable team_mode.tmux_visualization."
+    case "layout-creation-failed":
+      return "Check the tmux diagnostics log or disable team_mode.tmux_visualization."
+  }
+}
+
+function buildTeamCreateWarnings(config: TeamModeConfig, runtimeState: RuntimeState): TmuxVisualizationSkippedWarning[] {
+  if (!config.tmux_visualization || runtimeState.tmuxLayoutSkip === undefined) return []
+  const skip = runtimeState.tmuxLayoutSkip
+  const warning: TmuxVisualizationSkippedWarning = {
+    kind: "tmux_visualization_skipped",
+    reason: skip.reason,
+    hint: hintForSkipReason(skip.reason),
+  }
+  if (skip.detail !== undefined) warning.detail = skip.detail
+  if (skip.serverUrl !== undefined) warning.serverUrl = skip.serverUrl
+  if (skip.serverUrlSource !== undefined) warning.serverUrlSource = skip.serverUrlSource
+  return [warning]
 }
 
 function parseTeamCreateArgs(rawArgs: unknown): TeamCreateArgs {
@@ -224,7 +261,12 @@ export function createTeamCreateTool(
           parentMessageID: runtimeContext.messageID,
         },
       )
-      return JSON.stringify({ teamRunId: runtimeState.teamRunId, runtimeState: sanitizeRuntimeState(runtimeState) })
+      const warnings = buildTeamCreateWarnings(config, runtimeState)
+      return JSON.stringify({
+        teamRunId: runtimeState.teamRunId,
+        runtimeState: sanitizeRuntimeState(runtimeState),
+        ...(warnings.length > 0 ? { warnings } : {}),
+      })
     },
   })
 }

--- a/src/features/team-mode/types.ts
+++ b/src/features/team-mode/types.ts
@@ -23,6 +23,24 @@ export const RUNTIME_STATUSES = [
   "orphaned",
 ] as const
 
+export const TEAM_LAYOUT_SKIP_REASONS = [
+  "tmux-unavailable",
+  "server-unreachable",
+  "tmux-binary-missing",
+  "caller-pane-unresolved",
+  "layout-creation-failed",
+] as const
+
+export const SERVER_URL_SOURCES = [
+  "ctx",
+  "env-fallback",
+  "default-fallback",
+  "invalid-ctx-fallback",
+  "missing-ctx-fallback",
+] as const
+
+export type TeamLayoutSkipReason = typeof TEAM_LAYOUT_SKIP_REASONS[number]
+
 const MemberBaseSchema = z.object({
   name: z.string().min(1).regex(/^[a-z0-9-]+$/),
   cwd: z.string().optional(),
@@ -171,6 +189,13 @@ const RuntimeStateTmuxLayoutSchema = z.object({
   gridWindowId: z.string().optional(),
 }).strict()
 
+const RuntimeStateTmuxLayoutSkipSchema = z.object({
+  reason: z.enum(TEAM_LAYOUT_SKIP_REASONS),
+  detail: z.string().optional(),
+  serverUrl: z.string().optional(),
+  serverUrlSource: z.enum(SERVER_URL_SOURCES).optional(),
+}).strict()
+
 export const RuntimeStateSchema = z.object({
   version: z.literal(1),
   teamRunId: z.string().uuid(),
@@ -180,6 +205,7 @@ export const RuntimeStateSchema = z.object({
   status: z.enum(RUNTIME_STATUSES),
   leadSessionId: z.string().optional(),
   tmuxLayout: RuntimeStateTmuxLayoutSchema.optional(),
+  tmuxLayoutSkip: RuntimeStateTmuxLayoutSkipSchema.optional(),
   members: z.array(RuntimeStateMemberSchema),
   shutdownRequests: z.array(ShutdownRequestSchema).default([]),
   bounds: RuntimeBoundsSchema,

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -393,12 +393,13 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(getManagerInternals(manager).serverUrl).toBe('http://localhost:4096')
+      expect(manager?.getServerUrlSource()).toBe('default-fallback')
     })
 
     test('falls back to configured OPENCODE_PORT when serverUrl has port 0', async () => {
       // given
       const previousOpenCodePort = process.env.OPENCODE_PORT
-      process.env.OPENCODE_PORT = '5678'
+      process.env.OPENCODE_PORT = '5000'
       let manager: TmuxSessionManagerType | undefined
       try {
         mockIsInsideTmux.mockReturnValue(true)
@@ -424,7 +425,8 @@ describe('TmuxSessionManager', () => {
       }
 
       // then
-      expect(getManagerInternals(manager).serverUrl).toBe('http://localhost:5678')
+      expect(getManagerInternals(manager).serverUrl).toBe('http://localhost:5000')
+      expect(manager?.getServerUrlSource()).toBe('env-fallback')
     })
 
     test('ignores invalid OPENCODE_PORT when serverUrl has port 0', async () => {
@@ -457,6 +459,7 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(getManagerInternals(manager).serverUrl).toBe('http://localhost:4096')
+      expect(manager?.getServerUrlSource()).toBe('default-fallback')
     })
   })
 
@@ -477,6 +480,7 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(serverUrl).toBe('http://127.0.0.1:12345/')
+      expect(manager.getServerUrlSource()).toBe('ctx')
     })
 
     test('returns fallback when port is 0', async () => {
@@ -498,6 +502,32 @@ describe('TmuxSessionManager', () => {
       // then
       try {
         expect(serverUrl).toBe(`http://localhost:${process.env.OPENCODE_PORT ?? '4096'}`)
+        expect(manager.getServerUrlSource()).toBe('default-fallback')
+      } finally {
+        if (originalPort !== undefined) process.env.OPENCODE_PORT = originalPort
+      }
+    })
+
+    test('returns missing context source when ctx.serverUrl is absent', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const originalPort = process.env.OPENCODE_PORT
+      delete process.env.OPENCODE_PORT
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = cast<TmuxSessionManagerContext>({
+        ...createMockContext(),
+        serverUrl: undefined,
+      })
+      const config = createTmuxConfig({ enabled: true })
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // when
+      const serverUrl = manager.getServerUrl()
+
+      // then
+      try {
+        expect(serverUrl).toBe('http://localhost:4096')
+        expect(manager.getServerUrlSource()).toBe('missing-ctx-fallback')
       } finally {
         if (originalPort !== undefined) process.env.OPENCODE_PORT = originalPort
       }

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -22,6 +22,8 @@ import { isAttachableSessionStatus } from "./attachable-session-status"
 import { parseSessionStatusMap } from "./session-status-parser"
 type OpencodeClient = PluginInput["client"]
 
+export type ServerUrlSource = "ctx" | "env-fallback" | "default-fallback" | "invalid-ctx-fallback" | "missing-ctx-fallback"
+
 type SpawnStage =
   | "deferred.attach"
   | "deferred.isolated-container"
@@ -77,6 +79,7 @@ export class TmuxSessionManager {
   private tmuxConfig: TmuxConfig
   private projectDirectory: string
   private serverUrl: string
+  private serverUrlSource: ServerUrlSource
   private sourcePaneId: string | undefined
   private sessions = new Map<string, TrackedSession>()
   private pendingSessions = new Set<string>()
@@ -107,14 +110,17 @@ export class TmuxSessionManager {
       ? String(parsedPort)
       : "4096"
     const fallbackUrl = `http://localhost:${defaultPort}`
+    const fallbackUrlSource: ServerUrlSource = defaultPort === configuredPort ? "env-fallback" : "default-fallback"
     const rawServerUrl = ctx.serverUrl?.toString()
     try {
       if (rawServerUrl) {
         const parsed = new URL(rawServerUrl)
         const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
         this.serverUrl = port === '0' ? fallbackUrl : rawServerUrl
+        this.serverUrlSource = port === '0' ? fallbackUrlSource : "ctx"
       } else {
         this.serverUrl = fallbackUrl
+        this.serverUrlSource = "missing-ctx-fallback"
       }
     } catch (error) {
       this.deps.log("[tmux-session-manager] failed to parse server URL, using fallback", {
@@ -122,6 +128,7 @@ export class TmuxSessionManager {
         error: String(error),
       })
       this.serverUrl = fallbackUrl
+      this.serverUrlSource = "invalid-ctx-fallback"
     }
     this.sourcePaneId = this.deps.getCurrentPaneId()
     this.pollingManager = new TmuxPollingManager(
@@ -135,6 +142,7 @@ export class TmuxSessionManager {
       tmuxConfig: this.tmuxConfig,
       projectDirectory: this.projectDirectory,
       serverUrl: this.serverUrl,
+      serverUrlSource: this.serverUrlSource,
       sourcePaneId: this.sourcePaneId,
     })
   }
@@ -228,6 +236,10 @@ export class TmuxSessionManager {
 
   getServerUrl(): string {
     return this.serverUrl
+  }
+
+  getServerUrlSource(): ServerUrlSource {
+    return this.serverUrlSource
   }
 
   private removeTrackedSession(sessionId: string): void {


### PR DESCRIPTION
## Summary

- Replace all silent `return null` paths in `createTeamLayout` with a typed discriminated-union `TeamLayoutOutcome` so callers always know *why* visualization was skipped.
- Surface layout-skip events as structured `warnings[]` in the `team_create` tool response when `tmux_visualization` is enabled but a layout could not be created — giving users an actionable hint instead of silence.
- Fix `team_delete`'s `removedLayout` field so it reflects whether a layout was actually created at runtime, not whether it was merely configured.

## Root Cause

In default TUI mode (`opencode` with no `--port` / no `OPENCODE_PORT`), `TmuxSessionManager` falls back to `http://localhost:4096`. Because nothing is listening on `:4096` in that mode, `isServerRunning()` returns `false` and `createTeamLayout` returned `null` — with no log output surfaced to the user, no warning in the `team_create` response, and a misleading `removedLayout: true` from `team_delete`. The full silent-failure chain:

1. `TmuxSessionManager` constructor: when `ctx.serverUrl` port equals `'0'` (random-bind default), the real bound address is discarded and replaced by a hardcoded `localhost:4096` fallback.
2. `createTeamLayout`: `if (!await deps.isServerRunning(serverUrl)) { return null; }` — the `null` return propagates silently; the tool response omits any hint.
3. `team_delete`: `removedLayout` was derived from config flags (`tmux_visualization && tmuxMgr !== undefined && canVisualize()`), always `true` even when no layout existed.

This is the generalized recurrence of the `http://127.0.0.1:0/` case from #2729 (closed), which was not fully addressed in v4.

## Changes

- **`src/features/tmux-subagent/manager.ts`**: Expose `serverUrlSource: 'ctx' | 'env' | 'default'` on `TmuxSessionManager` so callers can distinguish whether the URL came from `ctx.serverUrl`, the `OPENCODE_PORT` env var, or the hardcoded `:4096` default. Preserves existing port-`'0'` fallback semantics; adds observability without behavior change.

- **`src/features/team-mode/team-layout-tmux/layout.ts`**: Change `createTeamLayout` return type from `TeamLayoutResult | null` to the discriminated union `TeamLayoutOutcome`:
  ```ts
  type TeamLayoutOutcome =
    | { skipped: false; layout: TeamLayoutResult }
    | { skipped: true; reason: SkipReason; detail?: string; serverUrl?: string; serverUrlSource?: string }

  type SkipReason =
    | 'tmux-unavailable'
    | 'server-unreachable'
    | 'tmux-binary-missing'
    | 'caller-pane-unresolved'
    | 'layout-creation-failed'
  ```
  Every former `return null` now returns a structured skip outcome.

- **`src/features/team-mode/tools/lifecycle.ts`**: When `tmux_visualization` is enabled and `createTeamLayout` returns `{ skipped: true }`, append a warning to the `team_create` response:
  ```ts
  warnings: [{
    kind: 'tmux_visualization_skipped',
    reason,       // e.g. 'server-unreachable'
    detail,       // e.g. the serverUrl that was checked
    serverUrl,
    hint          // for 'server-unreachable': "Launch opencode with --port N and OPENCODE_PORT=N, or set team_mode.tmux_visualization: false"
  }]
  ```

- **`src/features/team-mode/team-runtime/delete-team.ts`**: Derive `removedLayout` from actual runtime state (whether `tmuxLayout` was populated), not from config flags. Reports `false` when no layout was ever created.

- **`src/features/team-mode/types.ts`**: New `TeamLayoutOutcome`, `SkipReason`, and `TeamCreateWarning` types.

- **`src/features/team-mode/team-runtime/activate-team-layout.ts`**: Thread `TeamLayoutOutcome` skip reason through to runtime state so `delete-team.ts` can read it.

- **Test files** (`*.test.ts` co-located with each changed module): failing-before / passing-after regression coverage for each skip reason and for the corrected `removedLayout` behaviour.

## Screenshots

| Before | After |
|:---:|:---:|
| N/A — diagnostic/return-type changes, no visual impact | N/A — diagnostic/return-type changes, no visual impact |

## Testing

```bash
# Type-check (must be clean)
bun run typecheck

# Full build (must succeed)
bun run build

# Test suite covering changed modules
bun test bin script src --bail

# Targeted smoke for the affected subsystems
bun test src/features/tmux-subagent/ src/features/team-mode/ --bail
```

Expected on this branch: `bun run typecheck` clean, `bun run build` clean, `bun test src/features/tmux-subagent/ src/features/team-mode/` clean.

Note on full-suite: `bun test bin script src` reports **two pre-existing failures** on `upstream/dev@4aa2a01e` that are NOT introduced by this PR (verified independently in a fresh worktree):
- `src/plugin/chat-params.test.ts` — `createChatParamsHandler > falls back to default maxOutputTokens when stored and compatibility tokens are non-positive` — `logSpy` assertion fails only when run in full suite, passes when run in isolation or serially with the changed areas; pre-existing test-order/mock-pollution issue outside this PR's scope.
- `src/hooks/auto-update-checker/checker/plugin-entry.test.ts` — `findPluginEntry > returns null for unrelated plugin entry` — env-dependent, reads `~/.config/opencode.json` state.

This branch reports 1 fail vs upstream's 2 on the same gate; strictly equal-or-better.

## Related in-flight PRs

- **Complements #3896** (`fix: only mark server running when actually in server mode`):
  #3896 fixes `markServerRunningInProcess()` being called eagerly in CLI mode,
  which caused `isServerRunning()` to short-circuit to `true` without a real server.
  This PR is most impactful after #3896 lands — once the health check correctly
  returns `false`, this PR's `tmux_visualization_skipped` warning fires and tells
  the LLM why panes weren't created (instead of a silent `null`). No file overlap; no conflicts.

- **Independent of #3841** (`fix: treat busy sessions as attachable` / `prefer real tmux`):
  No file overlap. Note: #3841 has a pre-existing rebase conflict with `upstream/dev`
  in `src/shared/tmux/runner.ts` (upstream refactored to `isCmuxCompatEnvironment()`
  after #3841 branched). This PR does not touch that file.

- **Complements #2987** (`feat: add server_url_override config for tmux integration`):
  #2987 adds a user-facing escape hatch (`server_url_override`) for VPN/Tailscale
  scenarios. This PR fixes the silent-skip root cause; #2987's workaround
  remains useful for environments where opencode binds to an address the plugin
  cannot reach by default. They address different layers of the problem.

## Related Issues

Closes #3963

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent tmux team visualization skips by handling port-0 server URLs and returning structured skip reasons. Adds a `tmux_visualization_skipped` warning to `team_create` and makes `team_delete` report `removedLayout` based on actual runtime state (fixes #3963).

- **Bug Fixes**
  - `createTeamLayout` now returns a `TeamLayoutOutcome` union; replaces silent `null` with `{ skipped: true, reason, detail?, serverUrl?, serverUrlSource? }`.
  - `team_delete` derives `removedLayout` from runtime layout and successful teardown; no cleanup attempt when no layout existed.
  - Tracks server URL provenance via `getServerUrlSource()` to diagnose port `0` and `OPENCODE_PORT` fallback (`ctx`/`env-fallback`/`default-fallback`/`invalid-ctx-fallback`/`missing-ctx-fallback`).

- **New Features**
  - Persists `tmuxLayoutSkip` in runtime state; `team_create` surfaces a `warnings[]` entry with a clear hint when visualization is enabled but skipped.
  - Adds `TeamLayoutSkipReason`, `ServerUrlSource`, and related types; threads skip data through activation; tests cover all skip paths and corrected layout removal behavior.

<sup>Written for commit 87afba3a4c52286df866743d9a6b3fc32419a82e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


