### PR TITLE
fix(agents): add run_in_background to category task() examples in prompts (fixes #3960)

### DIFF
--- a/src/agents/dynamic-agent-category-skills-guide.ts
+++ b/src/agents/dynamic-agent-category-skills-guide.ts
@@ -102,6 +102,7 @@ Check the \`skill\` tool for available skills and their descriptions. For EVERY 
 task(
   category="[selected-category]",
   load_skills=["skill-1", "skill-2"],  // Include ALL relevant skills - ESPECIALLY user-installed ones
+  run_in_background=false,
   prompt="..."
 )
 \`\`\`
@@ -123,10 +124,10 @@ Any task involving UI, UX, CSS, styling, layout, animation, design, or frontend 
 
 \`\`\`typescript
 // CORRECT: Visual work → visual-engineering category
-task(category="visual-engineering", load_skills=["frontend-ui-ux"], prompt="Redesign the sidebar layout with new spacing...")
+task(category="visual-engineering", load_skills=["frontend-ui-ux"], run_in_background=false, prompt="Redesign the sidebar layout with new spacing...")
 
 // WRONG: Visual work in wrong category - WILL PRODUCE INFERIOR RESULTS
-task(category="quick", load_skills=[], prompt="Redesign the sidebar layout with new spacing...")
+task(category="quick", load_skills=[], run_in_background=false, prompt="Redesign the sidebar layout with new spacing...")
 \`\`\`
 
 | Task Domain | MUST Use Category |

--- a/src/agents/hephaestus/gpt-5-3-codex.ts
+++ b/src/agents/hephaestus/gpt-5-3-codex.ts
@@ -381,6 +381,7 @@ When delegating, ALWAYS check if relevant skills should be loaded:
 task(
   category="visual-engineering",
   load_skills=["frontend-ui-ux"],
+  run_in_background=false,
   prompt="1. TASK: Build the settings page... 2. EXPECTED OUTCOME: ..."
 )
 \`\`\`

--- a/src/agents/sisyphus/gemini.ts
+++ b/src/agents/sisyphus/gemini.ts
@@ -142,7 +142,7 @@ export function buildGeminiToolCallExamples(): string {
 **User**: "Add a new /health endpoint to the API"
 **CORRECT**:
 \`\`\`
-→ Call Task(category="quick", load_skills=["typescript-programmer"], prompt="...")
+→ Call Task(category="quick", load_skills=["typescript-programmer"], run_in_background=false, prompt="...")
 → (After agent completes) Read changed files to verify
 → Call LspDiagnostics on changed files
 → Report


### PR DESCRIPTION
## Summary
Three prompt-template files in `src/agents/` contained category-based `task()` code examples that omitted the required `run_in_background` parameter. Agents copying those patterns produced invalid `task()` calls that failed at the runtime validator. Add `run_in_background=false` to the four offending examples so every example in the prompts is a valid call.

## Root Cause
The `task` (delegate-task) tool schema declares `run_in_background` as a REQUIRED parameter; the runtime validator throws when it's omitted (\"'run_in_background' parameter is REQUIRED\"). However four examples in the agent prompts demonstrated the category-based pattern without the parameter:

- [`src/agents/dynamic-agent-category-skills-guide.ts`](src/agents/dynamic-agent-category-skills-guide.ts) — the canonical **Delegation Pattern** example (lines 102-107) plus the **Category Domain Matching** CORRECT/WRONG pair (lines 126/129)
- [`src/agents/hephaestus/gpt-5-3-codex.ts`](src/agents/hephaestus/gpt-5-3-codex.ts) — frontend task delegation example (lines 381-386)
- [`src/agents/sisyphus/gemini.ts`](src/agents/sisyphus/gemini.ts) — Example 4 DELEGATE (line 145)

`src/agents/atlas/shared-prompt.ts`, `src/agents/prometheus/gpt.ts`, and `src/agents/prometheus/gemini.ts` were already correct, as were the `subagent_type="explore"`/`subagent_type="librarian"` background-exploration examples in the affected files.

## Changes
| File | Change |
|------|--------|
| `src/agents/dynamic-agent-category-skills-guide.ts` | Add `run_in_background=false,` to the Delegation Pattern template and both Category Domain Matching examples |
| `src/agents/hephaestus/gpt-5-3-codex.ts` | Add `run_in_background=false,` to the frontend delegation example |
| `src/agents/sisyphus/gemini.ts` | Add `run_in_background=false,` to Example 4 DELEGATE |

Diff: **+5 / -3** lines across 3 files (pure string change in prompt templates, no logic impact).

## Reproduction (before fix)
Direct grep on `upstream/dev`:
~~~
$ git show upstream/dev:src/agents/dynamic-agent-category-skills-guide.ts | sed -n '102,107p'
task(
  category=\"[selected-category]\",
  load_skills=[\"skill-1\", \"skill-2\"],  // Include ALL relevant skills - ESPECIALLY user-installed ones
  prompt=\"...\"
)
~~~
The Delegation Pattern example clearly omits `run_in_background`. The reporter further confirmed that agents copying this pattern hit the runtime error \"'run_in_background' parameter is REQUIRED\".

## Verification (after fix)
~~~
$ sed -n '102,107p' src/agents/dynamic-agent-category-skills-guide.ts
task(
  category=\"[selected-category]\",
  load_skills=[\"skill-1\", \"skill-2\"],  // Include ALL relevant skills - ESPECIALLY user-installed ones
  run_in_background=false,
  prompt=\"...\"
)

$ bun test src/agents/
 373 pass
 0 fail
 1135 expect() calls
Ran 373 tests across 25 files. [1313.00ms]

$ bun run typecheck
$ tsc --noEmit          (clean)
~~~

## Test
- Related suite: `bun test src/agents/` — 373 pass, 0 fail.
- Typecheck: `bun run typecheck` — clean.
- No new tests were added: this is a pure-string fix to documentation rendered inside prompt templates. The existing agent prompt tests in `src/agents/` exercise prompt assembly and continued to pass with the change.

Fixes #3960

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `run_in_background=false` to category-based `task()` examples in agent prompt templates so copied calls meet the required schema and no longer fail validation. Fixes #3960.

- **Bug Fixes**
  - Updated examples in `src/agents/dynamic-agent-category-skills-guide.ts`, `src/agents/hephaestus/gpt-5-3-codex.ts`, and `src/agents/sisyphus/gemini.ts`.
  - Pure prompt string edits; no logic changes. Tests and typecheck pass.

<sup>Written for commit c4e88d63ea514c325f2e93dcb839c5bd96d1bd1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

