### PR TITLE
fix(background-agent): fall back to partInfo.input when state.input is unavailable for circuit breaker (fixes #3962)

### DIFF
--- a/src/features/background-agent/manager-circuit-breaker.test.ts
+++ b/src/features/background-agent/manager-circuit-breaker.test.ts
@@ -306,6 +306,106 @@ describe("BackgroundManager circuit breaker", () => {
     })
   })
 
+  describe("#given duplicate tool_use blocks arrive without state.input but with top-level input", () => {
+    test("#when 20 identical reads arrive #then circuit breaker still detects the loop", async () => {
+      // Regression for #3962: when a model (e.g. Kimi K2.6) generates duplicate
+      // tool_use blocks faster than the tool actually starts running, the
+      // updated events carry `input` on the part itself but `state.input`
+      // stays null/undefined. Before the fix, the signature alternated
+      // between "read::__unknown-input__" and "read::{filePath:...}" and the
+      // consecutive counter kept resetting to 1, so the breaker never fired.
+      const manager = createManager({
+        circuitBreaker: {
+          consecutiveThreshold: 20,
+        },
+      })
+      const task: BackgroundTask = {
+        id: "task-no-state-input-1",
+        sessionId: "session-no-state-input-1",
+        parentSessionId: "parent-1",
+        parentMessageId: "msg-1",
+        description: "Duplicate tool_use blocks",
+        prompt: "work",
+        agent: "explore",
+        status: "running",
+        startedAt: new Date(Date.now() - 60_000),
+        progress: {
+          toolCalls: 0,
+          lastUpdate: new Date(Date.now() - 60_000),
+        },
+      }
+      getTaskMap(manager).set(task.id, task)
+
+      for (let i = 0; i < 20; i++) {
+        manager.handleEvent({
+          type: "message.part.updated",
+          properties: {
+            part: {
+              sessionID: task.sessionId,
+              type: "tool",
+              tool: "read",
+              input: { filePath: "/src/hooks/thinking-block-validator/hook.ts" },
+            },
+          },
+        })
+      }
+
+      await flushAsyncWork()
+
+      expect(task.status).toBe("cancelled")
+      expect(task.error).toContain("read 20 consecutive times")
+    })
+
+    test("#when state.input is present #then it takes precedence over top-level input", async () => {
+      // Confirm the fallback order: state.input wins when both are present.
+      const manager = createManager({
+        circuitBreaker: {
+          consecutiveThreshold: 20,
+        },
+      })
+      const task: BackgroundTask = {
+        id: "task-state-input-wins-1",
+        sessionId: "session-state-input-wins-1",
+        parentSessionId: "parent-1",
+        parentMessageId: "msg-1",
+        description: "state.input precedence",
+        prompt: "work",
+        agent: "explore",
+        status: "running",
+        startedAt: new Date(Date.now() - 60_000),
+        progress: {
+          toolCalls: 0,
+          lastUpdate: new Date(Date.now() - 60_000),
+        },
+      }
+      getTaskMap(manager).set(task.id, task)
+
+      // 20 distinct state.input.filePath values but identical top-level input.
+      // If state.input takes precedence (correct), signatures differ and the
+      // loop does NOT trigger. If we erroneously preferred top-level input,
+      // signatures would all be identical and the breaker would fire.
+      for (let i = 0; i < 20; i++) {
+        manager.handleEvent({
+          type: "message.part.updated",
+          properties: {
+            part: {
+              sessionID: task.sessionId,
+              type: "tool",
+              tool: "read",
+              input: { filePath: "/src/same.ts" },
+              state: { status: "running", input: { filePath: `/src/file-${i}.ts` } },
+            },
+          },
+        })
+      }
+
+      await flushAsyncWork()
+
+      expect(task.status).toBe("running")
+      expect(task.progress?.toolCalls).toBe(20)
+    })
+  })
+
   describe("#given circuit breaker enabled is false", () => {
     test("#when repetitive tools arrive #then task keeps running", async () => {
       const manager = createManager({

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -105,6 +105,7 @@ interface MessagePartInfo {
   sessionID?: string
   type?: string
   tool?: string
+  input?: Record<string, unknown>
   state?: { status?: string; input?: Record<string, unknown> }
 }
 
@@ -1351,11 +1352,12 @@ The fallback retry session is now created and can be inspected directly.
          const circuitBreaker = this.cachedCircuitBreakerSettings ?? resolveCircuitBreakerSettings(this.config)
          this.cachedCircuitBreakerSettings = circuitBreaker
          if (partInfo.tool) {
+           const toolInput = partInfo.state?.input ?? partInfo.input
            task.progress.toolCallWindow = recordToolCall(
              task.progress.toolCallWindow,
              partInfo.tool,
              circuitBreaker,
-             partInfo.state?.input
+             toolInput
            )
 
            if (circuitBreaker.enabled) {


### PR DESCRIPTION
## Summary
The circuit breaker in `manager.ts` fails to detect repeated tool_use loops (Kimi K2.6 reading the same file 20+ times) because it tracks only `partInfo.state?.input`, which is `null` until the tool transitions to `running`. The signature-based deduplicator then alternates between `tool::__unknown-input__` and `tool::{actual-input}` on every event, repeatedly resetting `consecutiveCount` to 1 and never reaching the threshold.

Fall back to `partInfo.input` (the part's top-level input, available as soon as the tool_use block is emitted) when `state.input` is unavailable so the signature stays stable across the model's repeated emissions.

## Root Cause
[`src/features/background-agent/manager.ts`](src/features/background-agent/manager.ts) line 1354-1359 (inside the `message.part.updated` / `message.part.delta` handler):

\`\`\`typescript
task.progress.toolCallWindow = recordToolCall(
  task.progress.toolCallWindow,
  partInfo.tool,
  circuitBreaker,
  partInfo.state?.input  // <-- null until status=\"running\"
)
\`\`\`

The reporter traced the symptom: when Kimi K2.6 generates 20+ identical \`tool_use\` blocks, those parts arrive on \`message.part.updated\` with \`state\` still empty (no \`status\`, no \`input\`). \`recordToolCall\` receives \`undefined\`, falls into the \"unknown input\" branch in [\`loop-detector.ts:39-44\`](src/features/background-agent/loop-detector.ts), and produces signature \`read::__unknown-input__\`. The next event for the same part finally has \`state.input\` populated, signature flips to \`read::{filePath:...}\`, \`consecutiveCount\` resets to 1, and the cycle repeats — so the \`consecutiveThreshold: 20\` ceiling is never reached.

## Changes
| File | Change |
|------|--------|
| \`src/features/background-agent/manager.ts\` | Add \`input?: Record<string, unknown>\` to the local \`MessagePartInfo\` interface so the part's top-level \`input\` is typed. In the tool-call handler, prefer \`partInfo.state?.input\` then fall back to \`partInfo.input\`. |
| \`src/features/background-agent/manager-circuit-breaker.test.ts\` | Add 2 regression tests: (1) emit 20 part.updated events with only top-level input → assert the task is cancelled; (2) when both \`state.input\` and top-level \`input\` are present, \`state.input\` still takes precedence. |

Diff: **+103 / -1** lines across 2 files.

## Reproduction (before fix)
\`\`\`text
src\features\background-agent\manager-circuit-breaker.test.ts:
expect(received).toBe(expected)

Expected: \"cancelled\"
Received: \"running\"

(fail) BackgroundManager circuit breaker > #given duplicate tool_use blocks arrive without state.input but with top-level input > #when 20 identical reads arrive #then circuit breaker still detects the loop

 9 pass
 1 fail
\`\`\`

Without the fix, 20 identical \`{ tool: \"read\", input: { filePath: \"...\" } }\` events leave the task in \`running\` state — the breaker never fires.

## Verification (after fix)
\`\`\`text
bun test src/features/background-agent/manager-circuit-breaker.test.ts
 10 pass
 0 fail
 21 expect() calls
Ran 10 tests across 1 file. [511.00ms]

bun test src/features/background-agent/loop-detector.test.ts
 20 pass
 0 fail
 22 expect() calls

bun run typecheck
$ tsc --noEmit          (clean)
\`\`\`

The new \"state.input takes precedence\" test confirms the existing semantics are preserved: when both fields are populated, signatures still differentiate per-call.

## Test
- Regression tests: 2 new cases in \`manager-circuit-breaker.test.ts\` (one reproduces the bug, one guards the precedence semantics).
- Related suite: \`bun test src/features/background-agent/manager-circuit-breaker.test.ts loop-detector.test.ts\` — 30 pass, 0 fail.
- Typecheck: \`bun run typecheck\` — clean.

Fixes #3962

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the circuit breaker use top-level tool input when `state.input` isn’t available so repeated `tool_use` loops are detected. Fixes #3962 by preventing infinite reads when models emit input before tools start running.

- **Bug Fixes**
  - Prefer `state.input`; fall back to part-level `input` to keep signatures stable across events.
  - Typed `input` on `MessagePartInfo` and pass the resolved input to `recordToolCall`.
  - Added regression tests to cover top-level-only input and confirm `state.input` takes precedence.

<sup>Written for commit 5cd95cf57ea9d06754cb85f4d4b7137949c1269b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

