### PR TITLE
fix(delegate-task): honor user fallback_models when category primary is unreachable

### DIFF
--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -170,6 +170,50 @@ describe("resolveModelForDelegateTask", () => {
 				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "medium", matchedFallback: true })
 			})
 		})
+
+		describe("#when user primary model is unreachable and user fallback_models are provided", () => {
+			test("#then promotes the first reachable user fallback (regression: bug where fallback_models were ignored when userModel set)", () => {
+				const result = resolveModelForDelegateTask({
+					userModel: "opencode/gemini-3.1-pro high",
+					userFallbackModels: [
+						"amazon-bedrock/us.anthropic.claude-opus-4-7 max",
+						"opencode/claude-opus-4-7 max",
+						"openai/gpt-5.5",
+					],
+					availableModels: new Set([
+						"openai/gpt-5.5",
+						"openai/gpt-5.5-pro",
+						"amazon-bedrock/us.anthropic.claude-opus-4-7",
+					]),
+				})
+
+				expect(result).toEqual({
+					model: "amazon-bedrock/us.anthropic.claude-opus-4-7",
+					variant: "max",
+					matchedFallback: true,
+				})
+			})
+
+			test("#then keeps the user primary when it IS reachable (fast path preserved)", () => {
+				const result = resolveModelForDelegateTask({
+					userModel: "openai/gpt-5.5 xhigh",
+					userFallbackModels: ["openai/gpt-5.4"],
+					availableModels: new Set(["openai/gpt-5.5", "openai/gpt-5.4"]),
+				})
+
+				expect(result).toEqual({ model: "openai/gpt-5.5", variant: "xhigh" })
+			})
+
+			test("#then returns the user primary as-is when no user fallback is reachable either (trust-user legacy behavior)", () => {
+				const result = resolveModelForDelegateTask({
+					userModel: "opencode/gemini-3.1-pro high",
+					userFallbackModels: ["google/gemini-3.1-pro"],
+					availableModels: new Set(["openai/gpt-5.5"]),
+				})
+
+				expect(result).toEqual({ model: "opencode/gemini-3.1-pro", variant: "high" })
+			})
+		})
 	})
 
 	describe("#given provider cache exists and connected providers are known", () => {

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -57,10 +57,48 @@ export function resolveModelForDelegateTask(input: {
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     const parsed = parseUserFallbackModel(userModel)
-    if (parsed?.variant) {
-      return { model: parsed.baseModel, variant: parsed.variant }
+    const userResult = parsed?.variant
+      ? { model: parsed.baseModel, variant: parsed.variant }
+      : { model: userModel }
+
+    // When the availability cache is warm AND the user provided fallback_models,
+    // verify the user's explicit primary model is actually reachable. If it is
+    // not but one of their configured fallback_models is, promote that fallback
+    // instead of returning an unreachable model. Cold cache (no availability
+    // data yet) preserves the legacy "trust the user" behavior.
+    const userFallbackModels = input.userFallbackModels
+    if (
+      input.availableModels.size > 0 &&
+      userFallbackModels &&
+      userFallbackModels.length > 0
+    ) {
+      const providerHint = parsed?.providerHint
+      const primaryMatch = fuzzyMatchModel(userResult.model, input.availableModels, providerHint)
+      if (!primaryMatch) {
+        for (const fallbackModel of userFallbackModels) {
+          const parsedFallback = parseUserFallbackModel(fallbackModel)
+          if (!parsedFallback) continue
+          const fbMatch = fuzzyMatchModel(
+            parsedFallback.baseModel,
+            input.availableModels,
+            parsedFallback.providerHint,
+          )
+          if (fbMatch) {
+            log("[resolveModelForDelegateTask] user primary model unreachable; promoting user fallback_models entry", {
+              userPrimary: userResult.model,
+              selectedFallback: fbMatch,
+            })
+            return {
+              model: fbMatch,
+              variant: parsedFallback.variant,
+              matchedFallback: true,
+            }
+          }
+        }
+      }
     }
-    return { model: userModel }
+
+    return userResult
   }
 
   const connectedProviders = input.availableModels.size === 0 ? readConnectedProvidersCache() : null


### PR DESCRIPTION
## Summary

Fixes a silent-failure path in `resolveModelForDelegateTask` where a user-configured `categories.*.model` that is **not reachable** on the user's connected providers was returned verbatim, bypassing the user's own `fallback_models` array. The team-mode category member (e.g. hyperplan's `artistry`) then spawned targeting an unreachable model.

## The bug

[`src/tools/delegate-task/model-selection.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/delegate-task/model-selection.ts#L57-L64), lines 57-64 (pre-patch):

```ts
const userModel = normalizeModel(input.userModel)
if (userModel) {
  const parsed = parseUserFallbackModel(userModel)
  if (parsed?.variant) {
    return { model: parsed.baseModel, variant: parsed.variant }
  }
  return { model: userModel }
}
```

The moment `input.userModel` was set, the function returned it immediately — **never** checking reachability against `input.availableModels`, **never** iterating `input.userFallbackModels`. For a user with:

```jsonc
"categories": {
  "artistry": {
    "model": "opencode/gemini-3.1-pro",
    "fallback_models": [
      { "model": "amazon-bedrock/us.anthropic.claude-opus-4-7", "variant": "max" },
      { "model": "openai/gpt-5.5" }
    ]
  }
}
```

… and a provider set that includes `openai` + `amazon-bedrock` but not `opencode`-hosted gemini, the team member was launched against `opencode/gemini-3.1-pro` and the user's carefully-authored fallbacks were silently ignored. Runtime-fallback can't intercept this either because the provider rejects the model up-front.

## The fix

When the provider-models cache is warm (`availableModels.size > 0`) AND the user provided `fallback_models`, we now:

1. Verify the user's primary model is reachable via `fuzzyMatchModel`. If yes → return it (fast path, identical to old behavior).
2. If not reachable, iterate `userFallbackModels` and promote the first reachable entry, with `matchedFallback: true`.
3. If neither reachable, return `userResult` as-is — preserving the legacy "trust the user" behavior.

**Cold-cache first-run behavior is untouched** (`size > 0` guard). The existing pre-cache test at `model-selection.test.ts:42-55` still passes unchanged — deliberate: on first run we have no authoritative availability data and must honor user intent.

## Tests

Three new regression cases in [`model-selection.test.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/tools/delegate-task/model-selection.test.ts):

- `#when user primary model is unreachable and user fallback_models are provided` → `#then promotes the first reachable user fallback`
- `#then keeps the user primary when it IS reachable (fast path preserved)`
- `#then returns the user primary as-is when no user fallback is reachable either (trust-user legacy behavior)`

### Verification

```
bun test src/tools/delegate-task/model-selection.test.ts
→ 25 pass, 0 fail

bun test src/tools/delegate-task/
→ 393 pass, 0 fail

bun run typecheck
→ clean
```

## User impact

Users who observed hyperplan (or any team-mode category spawn) silently running with fewer members than requested — because one member's primary model wasn't reachable — will now see that member resolve via their configured fallbacks. No config change required on the user side; existing `fallback_models` entries now work as documented.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model selection so user `fallback_models` are used when the category’s primary model isn’t available on connected providers. This prevents team members from spawning with unreachable models and restores graceful fallback.

- **Bug Fixes**
  - In `resolveModelForDelegateTask`, when availability data exists and `userFallbackModels` are set, verify the primary; if unreachable, promote the first reachable fallback and set `matchedFallback: true`.
  - Preserve cold-cache behavior: return the user primary as-is when availability is unknown.
  - Add tests for: unreachable primary → reachable fallback, reachable primary retained, and both unreachable → primary kept.

<sup>Written for commit 711b75345b30b841045ffb52e89f00cead732886. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

