### PR TITLE
feat(agent-handoff): inject identity marker on mid-session agent change

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,17 +41,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.3.1",
-        "oh-my-opencode-darwin-x64": "4.3.1",
-        "oh-my-opencode-darwin-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-arm64": "4.3.1",
-        "oh-my-opencode-linux-arm64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64": "4.3.1",
-        "oh-my-opencode-linux-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-x64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.3.1",
-        "oh-my-opencode-windows-x64": "4.3.1",
-        "oh-my-opencode-windows-x64-baseline": "4.3.1",
+        "oh-my-opencode-darwin-arm64": "4.4.0",
+        "oh-my-opencode-darwin-x64": "4.4.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-arm64": "4.4.0",
+        "oh-my-opencode-linux-arm64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64": "4.4.0",
+        "oh-my-opencode-linux-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-x64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.4.0",
+        "oh-my-opencode-windows-x64": "4.4.0",
+        "oh-my-opencode-windows-x64-baseline": "4.4.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -399,27 +399,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wb+XTZ0Me3yBUejhhxXaiFpvZUmjT33EmgQPSrcwVIqpW4//DGpm4n9ptsSDm4ASaPaqG+v/dfNWmaXXS4FdqQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.4.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tGwtIIbxTDeeBqTkhBII4Mf/oBLavO1sSA2ZTlqNDY2srYu8677XRxq09+AF4aoexRB6JOyPOp3hpAwrRp+MHw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VnaFatAHVNpteFW/o/dHYVr6/NNDYnNnYgIupunUsO3J5beTFYJaPL5dq+1LRRQban9By9yMbOyXj7SGxGHmtQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VqqywGHjd5dLZEEYuqKJ2OiEK+NQFK5kskfnMsHaYf/sMlp7tv/RTDvtomtwk1KWXU3rW5acYSGxLxgMlpNBoA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Hd21GQR3pF5+4sTRSxypvQUUaSINke+fsbRtUWpun3uEDGpvpBfI3gcA+6ipM/VL0Qi35wvODU1W7Nl0welujA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tw4vJnLzbSPjdwYp+4vVnb/I2SysSptATylRmexiJGxAxpcAjqxk9yejzdHAhSALY/AlslKKzdpNJ7pGnFkiCA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-veU2mfOxDH11O+biZVahIF/Tlrp2cwvlmTpL0Cl8SHMBRUb8qhAHxN545e8Val3MSU6ydUXr0Ra5eAoazcAZ5g=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JWVfP9cze0y4eQZO9vs/5JQNmh6Bdfld0Vghwht75yQXTGIuzXw65ZjjB7/t5EMueVGt0xZJxFPGva1/Hk66Eg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rcuGLYeQ2uD60o5k54VCx/DiquIHxkACIK0KmK4IAjeNTfYpflfnEl/DfnsPpv7toWSI3XNOZwP4ig7ZfR72Pg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5ErkGwgH5o52mTZlwzc07pW7+0+S9hJXqeuqFZL5jAc8/UA0n+5pKOBT3tBF5CQdFFSNTX7FZeaCGaVQNtCvIg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dojsloeSYgu8wIZB2H7VoFDLm1sZvP+m00rWoQ6NqAW5/BlRfUtZql6JiVF31ofRzM8/UC0GJRwihtcg8piNLA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+eZA9R+zbFijTAknDT9wwR+JYCVUTVPdKnchTXLOhll+7Zyo9iVK/4Usa3s/UbWNXGz4fXbTk1ESiMQROF0Tlg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5lt3Rrkc3Y4idehke7JbMnawWZLZQjL5ghovjAlr9qsdgY5jsJEMAZW/TjgceAjTW0iAqSmtfVvVEtiPqLNk4w=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VhIsHJzVRsS+0jxY9e4ZCKvebcKIZj6Rw0pkxtYqm1xrZnPoiQzEkapoNJN2Jwr9ID2DubESl1ldOeqMhBRpSQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-26NV5DMaDETbecgw+LzjO/TpdzCnN0ZX/e74EQHFd0Z7ey7KK5p4x+dSBuY0F4NTZpFOQmbdZCJJOxyvDtUIHQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HltQLU4IGOuvVofESBLFxl6tfIkwuWWzPehoy6dkSE/OuqEzakTj85m7NDRIjmHyCLu2QVu/gKmf3wKoShEE4g=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-M+SJCWAc1QySELO3hmv3/vkRSfb7FPhUYVFi+34wBGFiywOK4jMOElyvCrEnxO3J1wGywEHgPWPaASs6f5ooIQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-baeGUFMCSFvBYjJsNY+bfu01AQdII9KG67LzgCCkFZKbARZJ6LR/1sGVNt4dxs3Bvdg3kYatpIvqozeiw1mYUA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-u38l63i/kq/vktaHsa7I+OBSoRXYWA8ExZ1tKv/d4adQuPzLfi9ruvTy+5fQ9GiDQZuRTlneenvrIYIfTJ4QYA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-MKjH5CIsMS8GDTimMpv9W+1SNgOaus9PeXC2H/hQd7BTkXZegN7JmH8mVJRLpHG4jDr432ky9O28ghRwqM76YQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-aeSyPkD/QDvc9x6l1q9VA4a1YwejefKzPPmuJKZAdWO6PSxdXN3nqx06+U2fR798KJbO4zNgg5vV331iMuvnqA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-VqVK+PK0dg0x+y1HxY2TVa13ulZbrYW4F2zA6JEV0nLNWRk0s7YnLQqXsm/bRNnfjsAFs+Frk5QS7mNorF79JQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/features/agent-handoff/index.ts
+++ b/src/features/agent-handoff/index.ts
@@ -1,0 +1,3 @@
+export { renderHandoffMarker } from "./marker"
+export type { HandoffContext } from "./marker"
+export { recordAgentObservation, clearAgentObservation } from "./state"

--- a/src/features/agent-handoff/marker.test.ts
+++ b/src/features/agent-handoff/marker.test.ts
@@ -34,4 +34,18 @@ describe("renderHandoffMarker", () => {
     expect(text).toContain('current="Hephaestus - Deep Agent"')
     expect(text).toContain("You are now Hephaestus - Deep Agent")
   })
+
+  test("XML-escapes agent names with quotes and angle brackets in attributes", () => {
+    const text = renderHandoffMarker({
+      prior: 'Sisyphus "The Boulder" <Pusher>',
+      current: 'Hephaestus & Forge',
+    })
+
+    expect(text).toContain('prior="Sisyphus &quot;The Boulder&quot; &lt;Pusher&gt;"')
+    expect(text).toContain('current="Hephaestus &amp; Forge"')
+    expect(text).toContain("<identity-handoff ")
+    expect(text).toContain("</identity-handoff>")
+    expect(text).toContain('You are now Hephaestus & Forge.')
+    expect(text).toContain('authored by Sisyphus "The Boulder" <Pusher>')
+  })
 })

--- a/src/features/agent-handoff/marker.test.ts
+++ b/src/features/agent-handoff/marker.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { renderHandoffMarker } from "./marker"
+
+describe("renderHandoffMarker", () => {
+  test("wraps the marker in an identity-handoff element with both names", () => {
+    const text = renderHandoffMarker({ prior: "sisyphus", current: "hephaestus" })
+
+    expect(text).toContain('<identity-handoff prior="sisyphus" current="hephaestus">')
+    expect(text).toContain("</identity-handoff>")
+  })
+
+  test("names the current agent in the imperative line", () => {
+    const text = renderHandoffMarker({ prior: "sisyphus", current: "hephaestus" })
+
+    expect(text).toContain("You are now hephaestus.")
+  })
+
+  test("names the prior agent in the history-reframing line", () => {
+    const text = renderHandoffMarker({ prior: "sisyphus", current: "hephaestus" })
+
+    expect(text).toContain("authored by sisyphus")
+  })
+
+  test("handles display-style agent names verbatim", () => {
+    const text = renderHandoffMarker({
+      prior: "Sisyphus - Ultraworker",
+      current: "Hephaestus - Deep Agent",
+    })
+
+    expect(text).toContain('prior="Sisyphus - Ultraworker"')
+    expect(text).toContain('current="Hephaestus - Deep Agent"')
+    expect(text).toContain("You are now Hephaestus - Deep Agent")
+  })
+})

--- a/src/features/agent-handoff/marker.ts
+++ b/src/features/agent-handoff/marker.ts
@@ -1,0 +1,19 @@
+export type HandoffContext = {
+  prior: string
+  current: string
+}
+
+/**
+ * Pure renderer of the identity-handoff marker injected when the active agent
+ * changes mid-session. The marker re-anchors the LLM so it stops treating
+ * prior assistant turns as its own output.
+ */
+export function renderHandoffMarker(ctx: HandoffContext): string {
+  return [
+    `<identity-handoff prior="${ctx.prior}" current="${ctx.current}">`,
+    `You are now ${ctx.current}.`,
+    `Prior assistant turns in this conversation were authored by ${ctx.prior}; read them as handoff context, not as your own past output.`,
+    `Apply the persona, tools, and policies configured for ${ctx.current} from this turn forward.`,
+    `</identity-handoff>`,
+  ].join("\n")
+}

--- a/src/features/agent-handoff/marker.ts
+++ b/src/features/agent-handoff/marker.ts
@@ -3,14 +3,24 @@ export type HandoffContext = {
   current: string
 }
 
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
 /**
  * Pure renderer of the identity-handoff marker injected when the active agent
  * changes mid-session. The marker re-anchors the LLM so it stops treating
  * prior assistant turns as its own output.
  */
 export function renderHandoffMarker(ctx: HandoffContext): string {
+  const prior = escapeXmlAttr(ctx.prior)
+  const current = escapeXmlAttr(ctx.current)
   return [
-    `<identity-handoff prior="${ctx.prior}" current="${ctx.current}">`,
+    `<identity-handoff prior="${prior}" current="${current}">`,
     `You are now ${ctx.current}.`,
     `Prior assistant turns in this conversation were authored by ${ctx.prior}; read them as handoff context, not as your own past output.`,
     `Apply the persona, tools, and policies configured for ${ctx.current} from this turn forward.`,

--- a/src/features/agent-handoff/state.test.ts
+++ b/src/features/agent-handoff/state.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="bun-types" />
+
+import { beforeEach, describe, expect, test } from "bun:test"
+
+import {
+  recordAgentObservation,
+  clearAgentObservation,
+  _resetAllForTests,
+} from "./state"
+
+describe("recordAgentObservation", () => {
+  beforeEach(() => {
+    _resetAllForTests()
+  })
+
+  test("first observation in a session returns undefined", () => {
+    const prior = recordAgentObservation("s1", "sisyphus")
+
+    expect(prior).toBeUndefined()
+  })
+
+  test("same agent on consecutive observations returns undefined", () => {
+    recordAgentObservation("s1", "sisyphus")
+    const prior = recordAgentObservation("s1", "sisyphus")
+
+    expect(prior).toBeUndefined()
+  })
+
+  test("changing agents returns the prior agent's display name", () => {
+    recordAgentObservation("s1", "sisyphus")
+    const prior = recordAgentObservation("s1", "hephaestus")
+
+    expect(prior).toBe("sisyphus")
+  })
+
+  test("subsequent transitions return the most recent prior agent", () => {
+    recordAgentObservation("s1", "sisyphus")
+    recordAgentObservation("s1", "hephaestus")
+    const prior = recordAgentObservation("s1", "atlas")
+
+    expect(prior).toBe("hephaestus")
+  })
+
+  test("normalizes display variants so 'Hephaestus - Deep Agent' equals 'hephaestus'", () => {
+    recordAgentObservation("s1", "hephaestus")
+    const prior = recordAgentObservation("s1", "Hephaestus - Deep Agent")
+
+    expect(prior).toBeUndefined()
+  })
+
+  test("observations are scoped per session", () => {
+    recordAgentObservation("s1", "sisyphus")
+    const prior = recordAgentObservation("s2", "hephaestus")
+
+    expect(prior).toBeUndefined()
+  })
+
+  test("clearAgentObservation removes the stored value", () => {
+    recordAgentObservation("s1", "sisyphus")
+    clearAgentObservation("s1")
+    const prior = recordAgentObservation("s1", "hephaestus")
+
+    expect(prior).toBeUndefined()
+  })
+})

--- a/src/features/agent-handoff/state.test.ts
+++ b/src/features/agent-handoff/state.test.ts
@@ -62,4 +62,58 @@ describe("recordAgentObservation", () => {
 
     expect(prior).toBeUndefined()
   })
+
+  describe("messageID dedup", () => {
+    test("second call with the same messageID is a no-op (dual-fire pattern)", () => {
+      // simulate opencode's dual-fire: first call has the real agent, second call ~5ms later has a stale default
+      recordAgentObservation("s1", "hephaestus", "msg_1")
+      const prior = recordAgentObservation("s1", "sisyphus", "msg_1")
+
+      // the second firing must not be treated as a transition
+      expect(prior).toBeUndefined()
+    })
+
+    test("the first call still updates state normally when a messageID is supplied", () => {
+      recordAgentObservation("s1", "sisyphus", "msg_0")
+      const prior = recordAgentObservation("s1", "hephaestus", "msg_1")
+
+      expect(prior).toBe("sisyphus")
+    })
+
+    test("the second call's stale agent value does NOT leak into state", () => {
+      // first turn: real=sisyphus, stale=sisyphus (same anyway)
+      recordAgentObservation("s1", "sisyphus", "msg_0")
+      recordAgentObservation("s1", "sisyphus", "msg_0")
+      // second turn: real=hephaestus, stale=sisyphus
+      recordAgentObservation("s1", "hephaestus", "msg_1")
+      const stalePrior = recordAgentObservation("s1", "sisyphus", "msg_1")
+      // third turn: real=hephaestus, stale=sisyphus
+      const realPrior = recordAgentObservation("s1", "hephaestus", "msg_2")
+
+      // stale firing was deduped, so msg_1's observation stayed at hephaestus,
+      // and msg_2's real firing sees hephaestus->hephaestus (no transition)
+      expect(stalePrior).toBeUndefined()
+      expect(realPrior).toBeUndefined()
+    })
+
+    test("when messageID is undefined, dedup is bypassed (test/mock path)", () => {
+      // legacy test path: no messageID means every call is treated as a fresh turn
+      recordAgentObservation("s1", "sisyphus")
+      const prior = recordAgentObservation("s1", "hephaestus")
+
+      expect(prior).toBe("sisyphus")
+    })
+
+    test("clearAgentObservation also resets the messageID dedup state", () => {
+      recordAgentObservation("s1", "sisyphus", "msg_0")
+      clearAgentObservation("s1")
+      // a fresh observation with the same messageID after clear should still record
+      const prior = recordAgentObservation("s1", "hephaestus", "msg_0")
+
+      expect(prior).toBeUndefined() // no prior because state was cleared
+      // and a second call now does transition
+      const prior2 = recordAgentObservation("s1", "atlas", "msg_1")
+      expect(prior2).toBe("hephaestus")
+    })
+  })
 })

--- a/src/features/agent-handoff/state.ts
+++ b/src/features/agent-handoff/state.ts
@@ -1,0 +1,41 @@
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+
+const lastObservedAgent = new Map<string, string>()
+
+/**
+ * Records the agent observed for this session on this turn and reports whether
+ * it represents a transition from the previously observed agent.
+ *
+ * Returns the prior agent's display name when a transition is detected,
+ * undefined otherwise (first turn of the session, or same agent as last turn).
+ *
+ * Comparison is normalized via getAgentConfigKey so display variants like
+ * "Hephaestus - Deep Agent" and "hephaestus" are treated as the same agent.
+ *
+ * This is intentionally separate from setSessionAgent / getSessionAgent in
+ * claude-code-session-state — that map is first-write-wins (it represents the
+ * session's primary agent), and several callers depend on that semantics.
+ */
+export function recordAgentObservation(
+  sessionID: string,
+  currentAgent: string,
+): string | undefined {
+  const prior = lastObservedAgent.get(sessionID)
+  lastObservedAgent.set(sessionID, currentAgent)
+
+  if (!prior) return undefined
+
+  const priorKey = getAgentConfigKey(prior)
+  const currentKey = getAgentConfigKey(currentAgent)
+  if (priorKey === currentKey) return undefined
+
+  return prior
+}
+
+export function clearAgentObservation(sessionID: string): void {
+  lastObservedAgent.delete(sessionID)
+}
+
+export function _resetAllForTests(): void {
+  lastObservedAgent.clear()
+}

--- a/src/features/agent-handoff/state.ts
+++ b/src/features/agent-handoff/state.ts
@@ -1,16 +1,26 @@
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 
 const lastObservedAgent = new Map<string, string>()
+const lastObservedMessageID = new Map<string, string>()
 
 /**
  * Records the agent observed for this session on this turn and reports whether
  * it represents a transition from the previously observed agent.
  *
  * Returns the prior agent's display name when a transition is detected,
- * undefined otherwise (first turn of the session, or same agent as last turn).
+ * undefined otherwise (first turn of the session, same agent as last turn, or
+ * a duplicate firing of chat.message for the same messageID).
  *
  * Comparison is normalized via getAgentConfigKey so display variants like
  * "Hephaestus - Deep Agent" and "hephaestus" are treated as the same agent.
+ *
+ * Why messageID dedup: opencode fires chat.message twice per user turn —
+ * once with the user-selected agent (canonical), once a few ms later with
+ * a session-default agent (internal, can't be told apart by other input).
+ * Both firings share the same messageID. We only record the first one to
+ * avoid emitting spurious transition markers in both directions on every
+ * turn. If messageID is undefined (test mocks, edge cases), every call is
+ * treated as a fresh turn and dedup is bypassed.
  *
  * This is intentionally separate from setSessionAgent / getSessionAgent in
  * claude-code-session-state — that map is first-write-wins (it represents the
@@ -19,7 +29,15 @@ const lastObservedAgent = new Map<string, string>()
 export function recordAgentObservation(
   sessionID: string,
   currentAgent: string,
+  messageID?: string,
 ): string | undefined {
+  if (messageID && lastObservedMessageID.get(sessionID) === messageID) {
+    return undefined
+  }
+  if (messageID) {
+    lastObservedMessageID.set(sessionID, messageID)
+  }
+
   const prior = lastObservedAgent.get(sessionID)
   lastObservedAgent.set(sessionID, currentAgent)
 
@@ -34,8 +52,10 @@ export function recordAgentObservation(
 
 export function clearAgentObservation(sessionID: string): void {
   lastObservedAgent.delete(sessionID)
+  lastObservedMessageID.delete(sessionID)
 }
 
 export function _resetAllForTests(): void {
   lastObservedAgent.clear()
+  lastObservedMessageID.clear()
 }

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -13,6 +13,7 @@ import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
 import { OMO_INTERNAL_INITIATOR_MARKER } from "../shared/internal-initiator-marker"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
+import { _resetAllForTests as resetAgentHandoffState } from "../features/agent-handoff/state"
 import { createChatMessageHandler } from "./chat-message"
 
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
@@ -81,6 +82,7 @@ afterEach(() => {
   clearSessionModel("test-session")
   clearSessionModel("main-session")
   clearSessionModel("subagent-session")
+  resetAgentHandoffState()
 })
 
 describe("createChatMessageHandler - synthetic/internal messages", () => {
@@ -831,5 +833,96 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
 
     //#then
     expect(getSessionAgent("test-session")).toBe("Hephaestus - Deep Agent")
+  })
+})
+
+describe("createChatMessageHandler - agent handoff marker", () => {
+  beforeEach(() => {
+    resetAgentHandoffState()
+  })
+
+  test("#given the first turn of a session #when handler runs #then no handoff marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("sisyphus")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given the same agent on two consecutive turns #when handler runs #then no marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    const firstInput = createMockInput("sisyphus")
+    const firstOutput = createMockOutput()
+    await handler(firstInput, firstOutput)
+
+    const secondInput = createMockInput("sisyphus")
+    const secondOutput = createMockOutput()
+
+    //#when
+    await handler(secondInput, secondOutput)
+
+    //#then
+    expect(secondOutput.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given the agent changes between turns #when handler runs #then a handoff marker is injected as the first part", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+
+    const input = createMockInput("hephaestus")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.parts.length).toBeGreaterThan(0)
+    expect(output.parts[0].type).toBe("text")
+    expect(output.parts[0].text).toContain('<identity-handoff prior="sisyphus" current="hephaestus">')
+    expect(output.parts[0].text).toContain("You are now hephaestus")
+    expect(output.parts[0].text).toContain("authored by sisyphus")
+  })
+
+  test("#given display variants of the same agent #when handler runs across turns #then no marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("hephaestus"), createMockOutput())
+
+    const input = createMockInput("Hephaestus - Deep Agent")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then - display variant resolves to same config key, so no transition
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given two consecutive agent changes #when handler runs #then each transition emits its own marker", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const transition1 = createMockOutput()
+    await handler(createMockInput("hephaestus"), transition1)
+    const transition2 = createMockOutput()
+
+    //#when
+    await handler(createMockInput("atlas"), transition2)
+
+    //#then
+    expect(transition1.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
+    expect(transition2.parts[0].text).toContain('prior="hephaestus" current="atlas"')
   })
 })

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -592,6 +592,7 @@ function createMockInput(agent?: string, model?: { providerID: string; modelID: 
     sessionID: "test-session",
     agent,
     model,
+    messageID: "msg_test",
   }
 }
 
@@ -924,5 +925,38 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     //#then
     expect(transition1.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
     expect(transition2.parts[0].text).toContain('prior="hephaestus" current="atlas"')
+  })
+
+  test("#given the injected marker part #when handler runs #then it carries id, sessionID, and messageID for the opencode schema", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const output = createMockOutput()
+
+    //#when
+    await handler(createMockInput("hephaestus"), output)
+
+    //#then
+    const marker = output.parts[0]
+    expect(marker.id).toMatch(/^prt_/)
+    expect((marker as { sessionID?: string }).sessionID).toBe("test-session")
+    expect((marker as { messageID?: string }).messageID).toBe("msg_test")
+    expect(marker.type).toBe("text")
+  })
+
+  test("#given messageID is missing on input #when handler runs across an agent transition #then injection is skipped silently", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const input = { sessionID: "test-session", agent: "hephaestus" }
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then - transition recorded, but no part injected (avoids invalid-part 500)
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
   })
 })

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -879,24 +879,30 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     expect(secondOutput.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
   })
 
-  test("#given the agent changes between turns #when handler runs #then a handoff marker is injected as the first part", async () => {
-    //#given
+  test("#given the agent changes between turns #when handler runs #then a handoff marker is prepended ahead of the existing user-message parts", async () => {
+    //#given - seed an existing user-message part so we can prove the marker is
+    // prepended (parts[0]) rather than appended; an append regression would
+    // leave the original user part at parts[0] and add the marker at parts[1].
     const args = createMockHandlerArgs()
     const handler = createChatMessageHandler(args)
     await handler(createMockInput("sisyphus"), createMockOutput())
 
     const input = createMockInput("hephaestus")
-    const output = createMockOutput()
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "hi, this is my message" }],
+    }
 
     //#when
     await handler(input, output)
 
-    //#then
-    expect(output.parts.length).toBeGreaterThan(0)
+    //#then - marker landed at index 0, user message slid to index 1
+    expect(output.parts).toHaveLength(2)
     expect(output.parts[0].type).toBe("text")
     expect(output.parts[0].text).toContain('<identity-handoff prior="sisyphus" current="hephaestus">')
     expect(output.parts[0].text).toContain("You are now hephaestus")
     expect(output.parts[0].text).toContain("authored by sisyphus")
+    expect(output.parts[1].text).toBe("hi, this is my message")
   })
 
   test("#given display variants of the same agent #when handler runs across turns #then no marker is injected", async () => {

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -587,12 +587,17 @@ describe("createChatMessageHandler - plain ultrawork keyword routing", () => {
   })
 })
 
-function createMockInput(agent?: string, model?: { providerID: string; modelID: string }) {
+let mockInputCounter = 0
+function createMockInput(
+  agent?: string,
+  model?: { providerID: string; modelID: string },
+  messageID?: string,
+) {
   return {
     sessionID: "test-session",
     agent,
     model,
-    messageID: "msg_test",
+    messageID: messageID ?? `msg_test_${++mockInputCounter}`,
   }
 }
 
@@ -932,17 +937,41 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     const args = createMockHandlerArgs()
     const handler = createChatMessageHandler(args)
     await handler(createMockInput("sisyphus"), createMockOutput())
+    const transitionInput = createMockInput("hephaestus")
     const output = createMockOutput()
 
     //#when
-    await handler(createMockInput("hephaestus"), output)
+    await handler(transitionInput, output)
 
     //#then
     const marker = output.parts[0]
     expect(marker.id).toMatch(/^prt_/)
     expect((marker as { sessionID?: string }).sessionID).toBe("test-session")
-    expect((marker as { messageID?: string }).messageID).toBe("msg_test")
+    expect((marker as { messageID?: string }).messageID).toBe(transitionInput.messageID)
     expect(marker.type).toBe("text")
+  })
+
+  test("#given the dual-fire pattern (two chat.message calls with the same messageID) #when handler runs #then only the first call injects a marker", async () => {
+    //#given - simulate opencode firing chat.message twice for a single user turn:
+    // call 1 has the user-selected agent (e.g. hephaestus), call 2 has a session-default agent (sisyphus)
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+
+    const sharedMessageID = "msg_dual_fire"
+    const realCall = createMockInput("hephaestus", undefined, sharedMessageID)
+    const staleCall = createMockInput("sisyphus", undefined, sharedMessageID)
+    const realOutput = createMockOutput()
+    const staleOutput = createMockOutput()
+
+    //#when
+    await handler(realCall, realOutput)
+    await handler(staleCall, staleOutput)
+
+    //#then - real call emits one marker; the stale duplicate emits none
+    expect(realOutput.parts.length).toBe(1)
+    expect(realOutput.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
+    expect(staleOutput.parts.length).toBe(0)
   })
 
   test("#given messageID is missing on input #when handler runs across an agent transition #then injection is skipped silently", async () => {

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -13,6 +13,7 @@ import { _resetForTesting, setMainSession, subagentSessions, registerAgentName, 
 import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
+import { _resetAllForTests as resetAgentHandoffState } from "../features/agent-handoff/state"
 import { unsafeTestValue } from "../../test-support/unsafe-test-value"
 
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
@@ -81,6 +82,7 @@ afterEach(() => {
   clearSessionModel("test-session")
   clearSessionModel("main-session")
   clearSessionModel("subagent-session")
+  resetAgentHandoffState()
 })
 
 describe("createChatMessageHandler - cache warning behavior", () => {
@@ -781,5 +783,96 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
 
     //#then
     expect(getSessionAgent("test-session")).toBe("Hephaestus - Deep Agent")
+  })
+})
+
+describe("createChatMessageHandler - agent handoff marker", () => {
+  beforeEach(() => {
+    resetAgentHandoffState()
+  })
+
+  test("#given the first turn of a session #when handler runs #then no handoff marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("sisyphus")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given the same agent on two consecutive turns #when handler runs #then no marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    const firstInput = createMockInput("sisyphus")
+    const firstOutput = createMockOutput()
+    await handler(firstInput, firstOutput)
+
+    const secondInput = createMockInput("sisyphus")
+    const secondOutput = createMockOutput()
+
+    //#when
+    await handler(secondInput, secondOutput)
+
+    //#then
+    expect(secondOutput.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given the agent changes between turns #when handler runs #then a handoff marker is injected as the first part", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+
+    const input = createMockInput("hephaestus")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.parts.length).toBeGreaterThan(0)
+    expect(output.parts[0].type).toBe("text")
+    expect(output.parts[0].text).toContain('<identity-handoff prior="sisyphus" current="hephaestus">')
+    expect(output.parts[0].text).toContain("You are now hephaestus")
+    expect(output.parts[0].text).toContain("authored by sisyphus")
+  })
+
+  test("#given display variants of the same agent #when handler runs across turns #then no marker is injected", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("hephaestus"), createMockOutput())
+
+    const input = createMockInput("Hephaestus - Deep Agent")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then - display variant resolves to same config key, so no transition
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
+  })
+
+  test("#given two consecutive agent changes #when handler runs #then each transition emits its own marker", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const transition1 = createMockOutput()
+    await handler(createMockInput("hephaestus"), transition1)
+    const transition2 = createMockOutput()
+
+    //#when
+    await handler(createMockInput("atlas"), transition2)
+
+    //#then
+    expect(transition1.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
+    expect(transition2.parts[0].text).toContain('prior="hephaestus" current="atlas"')
   })
 })

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -542,6 +542,7 @@ function createMockInput(agent?: string, model?: { providerID: string; modelID: 
     sessionID: "test-session",
     agent,
     model,
+    messageID: "msg_test",
   }
 }
 
@@ -874,5 +875,38 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     //#then
     expect(transition1.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
     expect(transition2.parts[0].text).toContain('prior="hephaestus" current="atlas"')
+  })
+
+  test("#given the injected marker part #when handler runs #then it carries id, sessionID, and messageID for the opencode schema", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const output = createMockOutput()
+
+    //#when
+    await handler(createMockInput("hephaestus"), output)
+
+    //#then
+    const marker = output.parts[0]
+    expect(marker.id).toMatch(/^prt_/)
+    expect((marker as { sessionID?: string }).sessionID).toBe("test-session")
+    expect((marker as { messageID?: string }).messageID).toBe("msg_test")
+    expect(marker.type).toBe("text")
+  })
+
+  test("#given messageID is missing on input #when handler runs across an agent transition #then injection is skipped silently", async () => {
+    //#given
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+    const input = { sessionID: "test-session", agent: "hephaestus" }
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then - transition recorded, but no part injected (avoids invalid-part 500)
+    expect(output.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
   })
 })

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -829,24 +829,30 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     expect(secondOutput.parts.some((p) => p.type === "text" && (p.text ?? "").includes("identity-handoff"))).toBe(false)
   })
 
-  test("#given the agent changes between turns #when handler runs #then a handoff marker is injected as the first part", async () => {
-    //#given
+  test("#given the agent changes between turns #when handler runs #then a handoff marker is prepended ahead of the existing user-message parts", async () => {
+    //#given - seed an existing user-message part so we can prove the marker is
+    // prepended (parts[0]) rather than appended; an append regression would
+    // leave the original user part at parts[0] and add the marker at parts[1].
     const args = createMockHandlerArgs()
     const handler = createChatMessageHandler(args)
     await handler(createMockInput("sisyphus"), createMockOutput())
 
     const input = createMockInput("hephaestus")
-    const output = createMockOutput()
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "hi, this is my message" }],
+    }
 
     //#when
     await handler(input, output)
 
-    //#then
-    expect(output.parts.length).toBeGreaterThan(0)
+    //#then - marker landed at index 0, user message slid to index 1
+    expect(output.parts).toHaveLength(2)
     expect(output.parts[0].type).toBe("text")
     expect(output.parts[0].text).toContain('<identity-handoff prior="sisyphus" current="hephaestus">')
     expect(output.parts[0].text).toContain("You are now hephaestus")
     expect(output.parts[0].text).toContain("authored by sisyphus")
+    expect(output.parts[1].text).toBe("hi, this is my message")
   })
 
   test("#given display variants of the same agent #when handler runs across turns #then no marker is injected", async () => {

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -537,12 +537,17 @@ describe("createChatMessageHandler - plain ultrawork keyword routing", () => {
   })
 })
 
-function createMockInput(agent?: string, model?: { providerID: string; modelID: string }) {
+let mockInputCounter = 0
+function createMockInput(
+  agent?: string,
+  model?: { providerID: string; modelID: string },
+  messageID?: string,
+) {
   return {
     sessionID: "test-session",
     agent,
     model,
-    messageID: "msg_test",
+    messageID: messageID ?? `msg_test_${++mockInputCounter}`,
   }
 }
 
@@ -882,17 +887,41 @@ describe("createChatMessageHandler - agent handoff marker", () => {
     const args = createMockHandlerArgs()
     const handler = createChatMessageHandler(args)
     await handler(createMockInput("sisyphus"), createMockOutput())
+    const transitionInput = createMockInput("hephaestus")
     const output = createMockOutput()
 
     //#when
-    await handler(createMockInput("hephaestus"), output)
+    await handler(transitionInput, output)
 
     //#then
     const marker = output.parts[0]
     expect(marker.id).toMatch(/^prt_/)
     expect((marker as { sessionID?: string }).sessionID).toBe("test-session")
-    expect((marker as { messageID?: string }).messageID).toBe("msg_test")
+    expect((marker as { messageID?: string }).messageID).toBe(transitionInput.messageID)
     expect(marker.type).toBe("text")
+  })
+
+  test("#given the dual-fire pattern (two chat.message calls with the same messageID) #when handler runs #then only the first call injects a marker", async () => {
+    //#given - simulate opencode firing chat.message twice for a single user turn:
+    // call 1 has the user-selected agent (e.g. hephaestus), call 2 has a session-default agent (sisyphus)
+    const args = createMockHandlerArgs()
+    const handler = createChatMessageHandler(args)
+    await handler(createMockInput("sisyphus"), createMockOutput())
+
+    const sharedMessageID = "msg_dual_fire"
+    const realCall = createMockInput("hephaestus", undefined, sharedMessageID)
+    const staleCall = createMockInput("sisyphus", undefined, sharedMessageID)
+    const realOutput = createMockOutput()
+    const staleOutput = createMockOutput()
+
+    //#when
+    await handler(realCall, realOutput)
+    await handler(staleCall, staleOutput)
+
+    //#then - real call emits one marker; the stale duplicate emits none
+    expect(realOutput.parts.length).toBe(1)
+    expect(realOutput.parts[0].text).toContain('prior="sisyphus" current="hephaestus"')
+    expect(staleOutput.parts.length).toBe(0)
   })
 
   test("#given messageID is missing on input #when handler runs across an agent transition #then injection is skipped silently", async () => {

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto"
+
 import type { OhMyOpenCodeConfig } from "../config"
 import type { CreatedHooks } from "../create-hooks"
 
@@ -28,6 +30,7 @@ export type ChatMessageInput = {
   sessionID: string
   agent?: string
   model?: { providerID: string; modelID: string }
+  messageID?: string
 }
 type StartWorkHookOutput = { parts: Array<{ type: string; text?: string }> }
 
@@ -207,12 +210,22 @@ export function createChatMessageHandler(args: {
     if (input.agent) {
       updateSessionAgent(input.sessionID, input.agent)
       const priorAgent = recordAgentObservation(input.sessionID, input.agent)
-      if (priorAgent) {
-        output.parts.unshift(
-          createInternalAgentTextPart(
+      // opencode rejects parts that don't carry id/sessionID/messageID, so we
+      // can only inject the marker during a real chat turn (where messageID
+      // is populated by the runtime). Without it, the transition was still
+      // recorded; we just skip the visible marker.
+      // The marker text is wrapped via createInternalAgentTextPart so that
+      // isSyntheticOrInternalTextPart (added in #4223) classifies the injection
+      // as internal routing rather than user content.
+      if (priorAgent && input.messageID) {
+        output.parts.unshift({
+          id: `prt_${randomUUID()}`,
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          ...createInternalAgentTextPart(
             renderHandoffMarker({ prior: priorAgent, current: input.agent }),
           ),
-        )
+        })
       }
     }
 

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -3,6 +3,7 @@ import type { CreatedHooks } from "../create-hooks"
 
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 import {
+  createInternalAgentTextPart,
   isModelCacheAvailable,
   isRealUserTextPart,
   isSyntheticOrInternalOnlyTextParts,
@@ -10,7 +11,8 @@ import {
 } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
 import { getSessionModel, setSessionModel } from "../shared/session-model-state"
-import { getMainSessionID, setSessionAgent, updateSessionAgent, subagentSessions } from "../features/claude-code-session-state"
+import { getMainSessionID, updateSessionAgent, subagentSessions } from "../features/claude-code-session-state"
+import { recordAgentObservation, renderHandoffMarker } from "../features/agent-handoff"
 import { NATIVE_LOOP_TRIGGERED_FLAG } from "./command-execute-before"
 import type { PluginContext } from "./types"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
@@ -204,6 +206,14 @@ export function createChatMessageHandler(args: {
 
     if (input.agent) {
       updateSessionAgent(input.sessionID, input.agent)
+      const priorAgent = recordAgentObservation(input.sessionID, input.agent)
+      if (priorAgent) {
+        output.parts.unshift(
+          createInternalAgentTextPart(
+            renderHandoffMarker({ prior: priorAgent, current: input.agent }),
+          ),
+        )
+      }
     }
 
     const isFirstMessage = firstMessageVariantGate.shouldOverride(input.sessionID)

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -209,7 +209,7 @@ export function createChatMessageHandler(args: {
 
     if (input.agent) {
       updateSessionAgent(input.sessionID, input.agent)
-      const priorAgent = recordAgentObservation(input.sessionID, input.agent)
+      const priorAgent = recordAgentObservation(input.sessionID, input.agent, input.messageID)
       // opencode rejects parts that don't carry id/sessionID/messageID, so we
       // can only inject the marker during a real chat turn (where messageID
       // is populated by the runtime). Without it, the transition was still

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto"
+
 import type { OhMyOpenCodeConfig } from "../config"
 import type { PluginContext } from "./types"
 
@@ -23,6 +25,7 @@ export type ChatMessageInput = {
   sessionID: string
   agent?: string
   model?: { providerID: string; modelID: string }
+  messageID?: string
 }
 type StartWorkHookOutput = { parts: Array<{ type: string; text?: string }> }
 
@@ -196,8 +199,15 @@ export function createChatMessageHandler(args: {
     if (input.agent) {
       setSessionAgent(input.sessionID, input.agent)
       const priorAgent = recordAgentObservation(input.sessionID, input.agent)
-      if (priorAgent) {
+      // opencode rejects parts that don't carry id/sessionID/messageID, so we
+      // can only inject the marker during a real chat turn (where messageID
+      // is populated by the runtime). Without it, the transition was still
+      // recorded; we just skip the visible marker.
+      if (priorAgent && input.messageID) {
         output.parts.unshift({
+          id: `prt_${randomUUID()}`,
+          sessionID: input.sessionID,
+          messageID: input.messageID,
           type: "text",
           text: renderHandoffMarker({ prior: priorAgent, current: input.agent }),
         })

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -7,6 +7,7 @@ import { getSessionModel, setSessionModel } from "../shared/session-model-state"
 import { getMainSessionID, setSessionAgent, subagentSessions } from "../features/claude-code-session-state"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
 import { NATIVE_LOOP_TRIGGERED_FLAG } from "./command-execute-before"
+import { recordAgentObservation, renderHandoffMarker } from "../features/agent-handoff"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
 
 import type { CreatedHooks } from "../create-hooks"
@@ -194,6 +195,13 @@ export function createChatMessageHandler(args: {
   ): Promise<void> => {
     if (input.agent) {
       setSessionAgent(input.sessionID, input.agent)
+      const priorAgent = recordAgentObservation(input.sessionID, input.agent)
+      if (priorAgent) {
+        output.parts.unshift({
+          type: "text",
+          text: renderHandoffMarker({ prior: priorAgent, current: input.agent }),
+        })
+      }
     }
 
     const isFirstMessage = firstMessageVariantGate.shouldOverride(input.sessionID)

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -198,7 +198,7 @@ export function createChatMessageHandler(args: {
   ): Promise<void> => {
     if (input.agent) {
       setSessionAgent(input.sessionID, input.agent)
-      const priorAgent = recordAgentObservation(input.sessionID, input.agent)
+      const priorAgent = recordAgentObservation(input.sessionID, input.agent, input.messageID)
       // opencode rejects parts that don't carry id/sessionID/messageID, so we
       // can only inject the marker during a real chat turn (where messageID
       // is populated by the runtime). Without it, the transition was still

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -12,6 +12,7 @@ import {
   syncSubagentSessions,
   updateSessionAgent,
 } from "../features/claude-code-session-state";
+import { clearAgentObservation } from "../features/agent-handoff";
 import {
   clearPendingModelFallback,
   clearSessionFallbackChain,
@@ -704,6 +705,7 @@ export function createEventHandler(args: {
       if (sessionID) {
         const wasSyncSubagentSession = syncSubagentSessions.has(sessionID);
         clearSessionAgent(sessionID);
+        clearAgentObservation(sessionID);
         lastHandledModelErrorMessageID.delete(sessionID);
         lastHandledRetryStatusKey.delete(sessionID);
         lastKnownModelBySession.delete(sessionID);

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -12,6 +12,7 @@ import {
   syncSubagentSessions,
   updateSessionAgent,
 } from "../features/claude-code-session-state";
+import { clearAgentObservation } from "../features/agent-handoff";
 import {
   clearPendingModelFallback,
   clearSessionFallbackChain,
@@ -523,6 +524,7 @@ export function createEventHandler(args: {
       if (sessionID) {
         const wasSyncSubagentSession = syncSubagentSessions.has(sessionID);
         clearSessionAgent(sessionID);
+        clearAgentObservation(sessionID);
         lastHandledModelErrorMessageID.delete(sessionID);
         lastHandledRetryStatusKey.delete(sessionID);
         lastKnownModelBySession.delete(sessionID);

--- a/src/shared/internal-initiator-marker.ts
+++ b/src/shared/internal-initiator-marker.ts
@@ -1,5 +1,13 @@
 export const OMO_INTERNAL_INITIATOR_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
 
+// Design: the same marker token serves two SEMANTICALLY DISTINCT contexts.
+// VISIBLE (createInternalAgentTextPart / no synthetic flag): PR #4003 handoff
+// markers — the agent MUST read its new identity, so `synthetic` is false.
+// HIDDEN (createInternalAgentContinuationTextPart / synthetic: true): PR #4223
+// internal retry/compaction prompts — invisible to the LLM as user input.
+// These MUST stay separate; if handoff markers were synthetic, the LLM
+// could not see its own identity change and would fail to switch roles.
+
 const INTERNAL_INITIATOR_MARKER_DETECT_PATTERN = /<!--\s*OMO_INTERNAL_INITIATOR\s*-->/
 const INTERNAL_INITIATOR_MARKER_PATTERN = /\n*<!--\s*OMO_INTERNAL_INITIATOR\s*-->\s*/g
 


### PR DESCRIPTION
## Summary

When a user Tab-switches the active agent mid-session (e.g. sisyphus → hephaestus), opencode does update `input.agent` for the next turn, but the LLM keeps introducing itself by the prior name because chat history still contains assistant turns authored under the old persona. This PR re-anchors the new agent on the first turn after a transition by injecting an `<identity-handoff>` marker as the leading text part.

## What's new

- New `src/features/agent-handoff/` module with:
  - `marker.ts` — pure renderer of the handoff text
  - `state.ts` — per-session `lastObservedAgent` map; `recordAgentObservation(sessionID, currentAgent)` returns the prior agent on a real transition, undefined otherwise
- `chat-message.ts` calls `recordAgentObservation` right after the existing `setSessionAgent` capture. On a real transition, the marker is unshifted to `parts[0]` so the LLM sees the identity reset before any user content this turn.

Example marker rendered into the user message:

```
<identity-handoff prior="sisyphus" current="hephaestus">
You are now hephaestus.
Prior assistant turns in this conversation were authored by sisyphus; read them as handoff context, not as your own past output.
Apply the persona, tools, and policies configured for hephaestus from this turn forward.
</identity-handoff>
```

## Design notes

- **Separate state from `setSessionAgent`/`getSessionAgent`**. Those are first-write-wins and 7+ callers (delegate-task, call-omo-agent, background-task, prometheus-md-only, no-sisyphus-gpt, …) depend on that as \"the session's primary agent identity\". Overloading them would silently change behavior in those paths. Handoff detection needs last-observed semantics, which is a different concept — kept in its own map.
- **Normalization** via `getAgentConfigKey`. Display variants like `\"Hephaestus - Deep Agent\"` resolve to the same key as `\"hephaestus\"`, so renames or UI display variations don't trip false transitions.
- **Idempotent within a turn**. The marker fires on transition only; identical agent on consecutive turns is a no-op.

## Tests

- **11 unit tests** in `src/features/agent-handoff/` cover marker rendering and the state machine (first turn, same-agent, transitions, display-variant normalization, session scoping, clear).
- **5 integration tests** appended to `src/plugin/chat-message.test.ts` exercise the wiring through the real handler — first turn doesn't fire, same agent doesn't fire, sisyphus→hephaestus fires correctly, display variants don't trip it, two consecutive changes emit two separate markers.
- A pre-existing `/start-work` integration test caught a real state-leak across describes; the file-level `afterEach` now resets the handoff map.

**Totals:** 41/41 pass across touched suites. `bun run typecheck`: pass. `bun run build`: pass.

## Out of scope

- `/switch_agent` slash command or an agent-self-switch tool — the SDK doesn't expose a way for a plugin tool to swap the active agent of an in-flight session; that would need an upstream opencode change adding `client.session.setAgent(...)`. The existing `call_omo_agent` and `delegate-task` tools already cover the cross-agent delegation use case via subagents.
- Removing the marker once the new agent has acknowledged it (current behavior: marker is in the conversation history permanently, like any other user message). If this proves noisy, a future change could squash it during compaction.

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run build\`
- [x] Agent-handoff + chat-message suites: 41/41 pass
- [ ] Local opencode smoke test: Tab from sisyphus to hephaestus mid-session, verify the next assistant turn introduces itself as Hephaestus and the marker is visible in the conversation
- [ ] CI \`test\` job: likely surfaces the same ~25 pre-existing failures observed on \`upstream/dev\` directly — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects an `<identity-handoff>` marker on mid-session agent switches, prepending it to the next user turn so the model resets identity. Handles opencode’s dual-fire and schema rules to avoid duplicate or invalid parts.

- New Features
  - Added `src/features/agent-handoff/` with `renderHandoffMarker` and per-session tracking via `recordAgentObservation`/`clearAgentObservation`.
  - `chat-message.ts` detects real transitions after `updateSessionAgent` and unshifts `createInternalAgentTextPart(renderHandoffMarker(...))` into `output.parts[0]`.
  - Normalizes with `getAgentConfigKey` so display variants don’t trigger false switches.

- Bug Fixes
  - Marker injection creates a valid text part with `id`/`sessionID`/`messageID`; if `messageID` is missing, skip injection.
  - Dedups by `messageID` to ignore the stale second call in the dual-fire pattern.
  - XML-escapes agent names to prevent markup corruption.
  - Clears observation state on `session.deleted` to prevent leaks.
  - Clarified visible vs hidden internal markers: handoff markers are internal but non-synthetic so the model reads the identity change.
  - Updated `bun.lock` to use `oh-my-opencode-*` 4.4.0 optional binaries for CI.

<sup>Written for commit 637be758eb8ee7f96d163ff15fd703c0e8a51bbe. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4003?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

