### PR TITLE
feat: add displayName config for i18n agent name overrides

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -307,6 +307,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -659,6 +662,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -1013,6 +1019,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -1365,6 +1374,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -1722,6 +1734,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -2074,6 +2089,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -2428,6 +2446,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -2780,6 +2801,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -3134,6 +3158,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -3486,6 +3513,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -3840,6 +3870,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -4192,6 +4225,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",
@@ -4546,6 +4582,9 @@
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
             },
+            "displayName": {
+              "type": "string"
+            },
             "permission": {
               "type": "object",
               "properties": {
@@ -4898,6 +4937,9 @@
             "color": {
               "type": "string",
               "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "displayName": {
+              "type": "string"
             },
             "permission": {
               "type": "object",

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -171,6 +171,7 @@ export type AgentOverrideConfig = Partial<AgentConfig> & {
   tools?: Record<string, boolean>;
   variant?: string;
   fallback_models?: string | (string | import("../config/schema/fallback-models").FallbackModelObject)[];
+  displayName?: string;
 };
 
 export type AgentOverrides = Partial<

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -24,6 +24,7 @@ export const AgentOverrideConfigSchema = z.object({
     .string()
     .regex(/^#[0-9A-Fa-f]{6}$/)
     .optional(),
+  displayName: z.string().optional(),
   permission: AgentPermissionSchema.optional(),
   /** Maximum tokens for response. Passed directly to OpenCode SDK. */
   maxTokens: z.number().optional(),

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -6,6 +6,7 @@ import {
   getAgentConfigKey,
   getAgentDisplayName,
   normalizeAgentForPromptKey,
+  registerDisplayNameOverride,
 } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
@@ -390,6 +391,16 @@ export async function applyAgentConfig(params: {
   }
 
   if (params.config.agent) {
+    const agentOverrides = params.pluginConfig.agents
+    if (agentOverrides) {
+      for (const [key, override] of Object.entries(agentOverrides)) {
+        const displayName = (override as Record<string, unknown> | undefined)?.displayName
+        if (typeof displayName === "string" && displayName.length > 0) {
+          registerDisplayNameOverride(key, displayName)
+        }
+      }
+    }
+
     params.config.agent = remapAgentKeysToDisplayNames(
       params.config.agent as Record<string, unknown>,
     );

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -44,12 +44,18 @@ export function stripAgentListSortPrefix(agentName: string): string {
  * Returns original key if not found.
  */
 export function getAgentDisplayName(configKey: string): string {
+  const overrideMatch = OVERRIDE_DISPLAY_NAMES[configKey]
+  if (overrideMatch !== undefined) return overrideMatch
+
+  const lowerKey = configKey.toLowerCase()
+  const overrideLower = OVERRIDE_DISPLAY_NAMES[lowerKey]
+  if (overrideLower !== undefined) return overrideLower
+
   // Try exact match first
   const exactMatch = AGENT_DISPLAY_NAMES[configKey]
   if (exactMatch !== undefined) return exactMatch
 
   // Fall back to case-insensitive search
-  const lowerKey = configKey.toLowerCase()
   for (const [k, v] of Object.entries(AGENT_DISPLAY_NAMES)) {
     if (k.toLowerCase() === lowerKey) return v
   }
@@ -71,6 +77,17 @@ export function getAgentListDisplayName(configKey: string): string {
   return getAgentDisplayName(configKey)
 }
 
+const OVERRIDE_DISPLAY_NAMES: Record<string, string> = {}
+
+export function registerDisplayNameOverride(configKey: string, displayName: string): void {
+  OVERRIDE_DISPLAY_NAMES[configKey] = displayName
+  REGISTERED_REVERSE[displayName.toLowerCase()] = configKey
+}
+
+let REGISTERED_REVERSE: Record<string, string> = Object.fromEntries(
+  Object.entries(AGENT_DISPLAY_NAMES).map(([key, displayName]) => [displayName.toLowerCase(), key]),
+)
+
 const REVERSE_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
   Object.entries(AGENT_DISPLAY_NAMES).map(([key, displayName]) => [displayName.toLowerCase(), key]),
 )
@@ -90,6 +107,8 @@ const LEGACY_DISPLAY_NAMES: Record<string, string> = {
 
 function resolveKnownAgentConfigKey(agentName: string): string | undefined {
   const lower = stripAgentListSortPrefix(agentName).trim().toLowerCase()
+  const registered = REGISTERED_REVERSE[lower]
+  if (registered !== undefined) return registered
   const reversed = REVERSE_DISPLAY_NAMES[lower]
   if (reversed !== undefined) return reversed
   const legacy = LEGACY_DISPLAY_NAMES[lower]


### PR DESCRIPTION
## Summary

Add an optional `displayName` field to the agent override config in `oh-my-openagent.json`, allowing users to **set localized names for agents** (e.g., Chinese, Japanese, Korean) that will appear in the TUI agent selector and all prompt sections.

## Motivation

Agent names like "Sisyphus - Ultraworker", "Hephaestus - Deep Agent", "Prometheus - Plan Builder" are currently hardcoded in English. Non-English users cannot understand them, and there was no way to customize these names without modifying plugin source code.

## Usage

```jsonc
{
  "agents": {
    "sisyphus": {
      "displayName": "总指挥"
    },
    "hephaestus": {
      "displayName": "工匠"
    },
    "prometheus": {
      "displayName": "规划师"
    },
    "atlas": {
      "displayName": "执行者"
    }
  }
}
```

Users from any language background can set names in their own language.

## Implementation

The change touches **4 files** (+33/-1):

1. **`src/config/schema/agent-overrides.ts`** - Add `displayName: z.string().optional()` to Zod schema
2. **`src/agents/types.ts`** - Add `displayName?: string` to `AgentOverrideConfig` type
3. **`src/shared/agent-display-names.ts`** - Add `registerDisplayNameOverride()` function and `REGISTERED_REVERSE` map; `getAgentDisplayName()` checks runtime overrides before the hardcoded map; `resolveKnownAgentConfigKey()` resolves override names back to config keys
4. **`src/plugin-handlers/agent-config-handler.ts`** - Wire registration from `params.pluginConfig.agents` before `remapAgentKeysToDisplayNames()`

## How it works

1. User sets `displayName` in agent override config
2. During agent initialization, `registerDisplayNameOverride()` stores the mapping
3. `getAgentDisplayName()` checks overrides first, then falls back to hardcoded `AGENT_DISPLAY_NAMES`
4. `remapAgentKeysToDisplayNames()` picks up the override via `getAgentListDisplayName()`, so the display name becomes the agent key in the OpenCode config
5. The reverse lookup (`getAgentConfigKey`) also resolves override names

## Testing

All 33 existing tests in `agent-display-names.test.ts` and 23 schema tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `displayName` to agent overrides so users can set localized agent names. These names appear in the TUI agent selector and all prompt sections.

- **New Features**
  - Optional `displayName` in `oh-my-openagent.json` under `agents.{key}` for localized names.
  - Overrides take priority over built-in names; reverse lookup maps display names back to config keys.
  - Updated JSON schema, Zod schema, and types; overrides are registered in the agent config handler before key remapping.

<sup>Written for commit 5d6ba9e91c9c06ffe96e4082d935fe4963801e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

