### PR TITLE
fix: respect default_agent in sort shim ordering

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -8,6 +8,7 @@ import {
   normalizeAgentForPromptKey,
 } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
+import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
   discoverConfigSourceSkills,
@@ -397,6 +398,11 @@ export async function applyAgentConfig(params: {
       params.config.agent as Record<string, unknown>,
       params.pluginConfig.agent_order,
     );
+  }
+
+  const resolvedDefault = (params.config as { default_agent?: string }).default_agent;
+  if (resolvedDefault) {
+    setDefaultAgentForSort(resolvedDefault);
   }
 
   const agentResult = params.config.agent as Record<string, unknown>;

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -400,9 +400,10 @@ export async function applyAgentConfig(params: {
     );
   }
 
-  const resolvedDefault = (params.config as { default_agent?: string }).default_agent;
-  if (resolvedDefault) {
-    setDefaultAgentForSort(resolvedDefault);
+  if (configuredDefaultAgent) {
+    setDefaultAgentForSort(
+      (params.config as { default_agent?: string }).default_agent ?? configuredDefaultAgent,
+    );
   }
 
   const agentResult = params.config.agent as Record<string, unknown>;

--- a/src/shared/agent-sort-shim.test.ts
+++ b/src/shared/agent-sort-shim.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeAll, describe, expect, test } from "bun:test"
 
-import { installAgentSortShim, setAgentSortOrder } from "./agent-sort-shim"
+import { installAgentSortShim, setAgentSortOrder, setDefaultAgentForSort } from "./agent-sort-shim"
 import { AGENT_DISPLAY_NAMES } from "./agent-display-names"
 
 type AgentListItem = {
@@ -221,6 +221,47 @@ describe("agent-sort-shim", () => {
 
         // then
         expect(result).toEqual([sisyphus, hephaestus, prometheus, atlas])
+      })
+    })
+  })
+
+  describe("#given a custom default_agent configured via setDefaultAgentForSort", () => {
+    describe("#when toSorted is called on core agents mixed with the custom default agent", () => {
+      test("#then the custom default agent sorts first, followed by core agents in canonical order", () => {
+        // given
+        setAgentSortOrder(undefined)
+        setDefaultAgentForSort("crystal")
+        const sisyphus = { name: "Sisyphus - Ultraworker" }
+        const hephaestus = { name: "Hephaestus - Deep Agent" }
+        const prometheus = { name: "Prometheus - Plan Builder" }
+        const atlas = { name: "Atlas - Plan Executor" }
+        const crystal = { name: "crystal" }
+        const input = [atlas, crystal, prometheus, hephaestus, sisyphus]
+
+        // when
+        const result = input.toSorted((a, b) => a.name.localeCompare(b.name))
+
+        // then
+        expect(result).toEqual([crystal, sisyphus, hephaestus, prometheus, atlas])
+      })
+    })
+
+    describe("#when setDefaultAgentForSort is called with a core agent name", () => {
+      test("#then that core agent sorts first, others follow in remaining canonical order", () => {
+        // given
+        setAgentSortOrder(undefined)
+        setDefaultAgentForSort("Hephaestus - Deep Agent")
+        const sisyphus = { name: "Sisyphus - Ultraworker" }
+        const hephaestus = { name: "Hephaestus - Deep Agent" }
+        const prometheus = { name: "Prometheus - Plan Builder" }
+        const atlas = { name: "Atlas - Plan Executor" }
+        const input = [atlas, prometheus, hephaestus, sisyphus]
+
+        // when
+        const result = input.toSorted((a, b) => a.name.localeCompare(b.name))
+
+        // then
+        expect(result).toEqual([hephaestus, sisyphus, prometheus, atlas])
       })
     })
   })

--- a/src/shared/agent-sort-shim.test.ts
+++ b/src/shared/agent-sort-shim.test.ts
@@ -265,4 +265,25 @@ describe("agent-sort-shim", () => {
       })
     })
   })
+
+  describe("#given agent_order configured without default_agent", () => {
+    describe("#when setAgentSortOrder sets a non-canonical order and setDefaultAgentForSort is NOT called", () => {
+      test("#then the custom agent_order is preserved without implicit override", () => {
+        // given
+        setAgentSortOrder(["hephaestus", "sisyphus", "prometheus", "atlas"])
+        // setDefaultAgentForSort is intentionally NOT called (user did not set default_agent)
+        const sisyphus = { name: "Sisyphus - Ultraworker" }
+        const hephaestus = { name: "Hephaestus - Deep Agent" }
+        const prometheus = { name: "Prometheus - Plan Builder" }
+        const atlas = { name: "Atlas - Plan Executor" }
+        const input = [atlas, sisyphus, prometheus, hephaestus]
+
+        // when
+        const result = input.toSorted((a, b) => a.name.localeCompare(b.name))
+
+        // then — Hephaestus must remain first per the user's agent_order
+        expect(result).toEqual([hephaestus, sisyphus, prometheus, atlas])
+      })
+    })
+  })
 })

--- a/src/shared/agent-sort-shim.ts
+++ b/src/shared/agent-sort-shim.ts
@@ -82,6 +82,17 @@ export function setAgentSortOrder(agentOrder: readonly string[] | undefined): vo
   agentRank = createAgentRank(agentOrder)
 }
 
+export function setDefaultAgentForSort(agentName: string | undefined): void {
+  if (!agentName) return
+  if (agentRank.get(agentName) === 0) return
+  const updated = new Map<string, number>()
+  updated.set(agentName, 0)
+  for (const [key, rank] of agentRank) {
+    if (key !== agentName) updated.set(key, rank + 1)
+  }
+  agentRank = updated
+}
+
 export function installAgentSortShim(): void {
   if (installed) return
 


### PR DESCRIPTION
## Prerequisites

- [x] I will write this issue in English
- [x] I have searched existing issues to avoid duplicates
- [x] I am using the latest version of oh-my-openagent
- [x] I have read the documentation

## Issue

Fixes #3900

## Problem

The sort shim (`installAgentSortShim`) always places core agents (sisyphus, hephaestus, prometheus, atlas) before any custom agent, assigning `UNRANKED` (MAX_SAFE_INTEGER) to agents not in the rank map. This overrides OpenCode's native `default_agent`-aware sort in `Agent.list()`, causing the TUI to always select Sisyphus on startup regardless of the user's `default_agent` configuration.

## Fix

Add `setDefaultAgentForSort(agentName)` to `agent-sort-shim.ts` which inserts the configured default agent at rank 0, shifting all other ranked agents up by 1. This is called from `applyAgentConfig` after resolving the effective `default_agent` value, so the sort shim respects the user's choice while preserving canonical ordering for remaining core agents.

## Changes

- `src/shared/agent-sort-shim.ts`: Add `setDefaultAgentForSort()` export
- `src/plugin-handlers/agent-config-handler.ts`: Call `setDefaultAgentForSort()` after resolving `default_agent`
- `src/shared/agent-sort-shim.test.ts`: Add tests for custom and core default agent scenarios

## Testing

```bash
bun test src/shared/agent-sort-shim.test.ts  # 12 tests pass
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the user’s `default_agent` in the sort shim so the TUI starts on their agent. If no `default_agent` is set, custom `agent_order` is preserved.

- **Bug Fixes**
  - Added `setDefaultAgentForSort(agentName)` to rank the configured default at 0.
  - Call it from `applyAgentConfig` only when the user explicitly sets `default_agent`.
  - Added tests for custom/core defaults and for `agent_order` without `default_agent`.

<sup>Written for commit f5e063b00a7966367fcd74e2daaeb150e58e903d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

