### PR TITLE
feat(team-mode): live-tail panes with server-port ownership and stale-tailer reaper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,17 +41,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.3.1",
-        "oh-my-opencode-darwin-x64": "4.3.1",
-        "oh-my-opencode-darwin-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-arm64": "4.3.1",
-        "oh-my-opencode-linux-arm64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64": "4.3.1",
-        "oh-my-opencode-linux-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-x64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.3.1",
-        "oh-my-opencode-windows-x64": "4.3.1",
-        "oh-my-opencode-windows-x64-baseline": "4.3.1",
+        "oh-my-opencode-darwin-arm64": "4.4.0",
+        "oh-my-opencode-darwin-x64": "4.4.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-arm64": "4.4.0",
+        "oh-my-opencode-linux-arm64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64": "4.4.0",
+        "oh-my-opencode-linux-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-x64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.4.0",
+        "oh-my-opencode-windows-x64": "4.4.0",
+        "oh-my-opencode-windows-x64-baseline": "4.4.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -399,27 +399,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wb+XTZ0Me3yBUejhhxXaiFpvZUmjT33EmgQPSrcwVIqpW4//DGpm4n9ptsSDm4ASaPaqG+v/dfNWmaXXS4FdqQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.4.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tGwtIIbxTDeeBqTkhBII4Mf/oBLavO1sSA2ZTlqNDY2srYu8677XRxq09+AF4aoexRB6JOyPOp3hpAwrRp+MHw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VnaFatAHVNpteFW/o/dHYVr6/NNDYnNnYgIupunUsO3J5beTFYJaPL5dq+1LRRQban9By9yMbOyXj7SGxGHmtQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VqqywGHjd5dLZEEYuqKJ2OiEK+NQFK5kskfnMsHaYf/sMlp7tv/RTDvtomtwk1KWXU3rW5acYSGxLxgMlpNBoA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Hd21GQR3pF5+4sTRSxypvQUUaSINke+fsbRtUWpun3uEDGpvpBfI3gcA+6ipM/VL0Qi35wvODU1W7Nl0welujA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tw4vJnLzbSPjdwYp+4vVnb/I2SysSptATylRmexiJGxAxpcAjqxk9yejzdHAhSALY/AlslKKzdpNJ7pGnFkiCA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-veU2mfOxDH11O+biZVahIF/Tlrp2cwvlmTpL0Cl8SHMBRUb8qhAHxN545e8Val3MSU6ydUXr0Ra5eAoazcAZ5g=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JWVfP9cze0y4eQZO9vs/5JQNmh6Bdfld0Vghwht75yQXTGIuzXw65ZjjB7/t5EMueVGt0xZJxFPGva1/Hk66Eg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rcuGLYeQ2uD60o5k54VCx/DiquIHxkACIK0KmK4IAjeNTfYpflfnEl/DfnsPpv7toWSI3XNOZwP4ig7ZfR72Pg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5ErkGwgH5o52mTZlwzc07pW7+0+S9hJXqeuqFZL5jAc8/UA0n+5pKOBT3tBF5CQdFFSNTX7FZeaCGaVQNtCvIg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dojsloeSYgu8wIZB2H7VoFDLm1sZvP+m00rWoQ6NqAW5/BlRfUtZql6JiVF31ofRzM8/UC0GJRwihtcg8piNLA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+eZA9R+zbFijTAknDT9wwR+JYCVUTVPdKnchTXLOhll+7Zyo9iVK/4Usa3s/UbWNXGz4fXbTk1ESiMQROF0Tlg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5lt3Rrkc3Y4idehke7JbMnawWZLZQjL5ghovjAlr9qsdgY5jsJEMAZW/TjgceAjTW0iAqSmtfVvVEtiPqLNk4w=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VhIsHJzVRsS+0jxY9e4ZCKvebcKIZj6Rw0pkxtYqm1xrZnPoiQzEkapoNJN2Jwr9ID2DubESl1ldOeqMhBRpSQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-26NV5DMaDETbecgw+LzjO/TpdzCnN0ZX/e74EQHFd0Z7ey7KK5p4x+dSBuY0F4NTZpFOQmbdZCJJOxyvDtUIHQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HltQLU4IGOuvVofESBLFxl6tfIkwuWWzPehoy6dkSE/OuqEzakTj85m7NDRIjmHyCLu2QVu/gKmf3wKoShEE4g=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-M+SJCWAc1QySELO3hmv3/vkRSfb7FPhUYVFi+34wBGFiywOK4jMOElyvCrEnxO3J1wGywEHgPWPaASs6f5ooIQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-baeGUFMCSFvBYjJsNY+bfu01AQdII9KG67LzgCCkFZKbARZJ6LR/1sGVNt4dxs3Bvdg3kYatpIvqozeiw1mYUA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-u38l63i/kq/vktaHsa7I+OBSoRXYWA8ExZ1tKv/d4adQuPzLfi9ruvTy+5fQ9GiDQZuRTlneenvrIYIfTJ4QYA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-MKjH5CIsMS8GDTimMpv9W+1SNgOaus9PeXC2H/hQd7BTkXZegN7JmH8mVJRLpHG4jDr432ky9O28ghRwqM76YQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-aeSyPkD/QDvc9x6l1q9VA4a1YwejefKzPPmuJKZAdWO6PSxdXN3nqx06+U2fR798KJbO4zNgg5vV331iMuvnqA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-VqVK+PK0dg0x+y1HxY2TVa13ulZbrYW4F2zA6JEV0nLNWRk0s7YnLQqXsm/bRNnfjsAFs+Frk5QS7mNorF79JQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/script/team-pane-live-tail.py
+++ b/script/team-pane-live-tail.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Live-tail an OpenCode session for tmux team-mode worker panes.
+
+OpenCode TUI's `attach --session <child>` enters a static subagent-detail
+view (the `session.child.promptDisabled` mode) for any session with a
+parentID. That view shows only the kickoff prompt and never streams.
+
+This tailer subscribes to /event SSE and renders updates as plain text in
+the companion live-tail tmux window while the main team window keeps attach.
+
+Usage: team-pane-live-tail.py <server-url> <session-id> [--no-clear] [--history N] [--insecure]
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+DIM = "\033[2m"
+RST = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+YEL = "\033[33m"
+GRN = "\033[32m"
+RED = "\033[31m"
+MAG = "\033[35m"
+BLU = "\033[34m"
+
+# Per-pane accent colour ramp; deterministic by session id so each worker
+# pane keeps its own colour across reconnects.
+ACCENT_COLOURS = ["\033[38;5;39m", "\033[38;5;208m", "\033[38;5;41m", "\033[38;5;213m", "\033[38;5;220m", "\033[38;5;81m"]
+
+
+def short(s: str, n: int = 100) -> str:
+    s = s.replace("\n", " ⏎ ").replace("\r", "")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def fmt_ts(ms: int | None) -> str:
+    if not ms:
+        return "        "
+    return time.strftime("%H:%M:%S", time.localtime(ms / 1000))
+
+
+def accent_for(session_id: str) -> str:
+    return ACCENT_COLOURS[sum(ord(c) for c in session_id) % len(ACCENT_COLOURS)]
+
+
+def summarize_peer_message(text: str) -> str | None:
+    """Compress a verbose <peer_message ...>...</peer_message> blob into one line."""
+    m = re.match(r'^\s*<peer_message\s+from="([^"]+)"[^>]*>(.*?)</peer_message>', text, re.DOTALL)
+    if not m:
+        return None
+    sender = m.group(1)
+    body = m.group(2).strip()
+    return f"⇠ peer from {sender}: {short(body, 70)}"
+
+
+class SessionState:
+    """Holds session metadata + role lookup so SSE part-updates render with
+    the correct USER/ASSISTANT label without re-fetching per event."""
+
+    def __init__(self, url: str, session_id: str, insecure: bool = False) -> None:
+        # OmO's tmuxMgr.getServerUrl() emits the URL with a trailing slash,
+        # so naive `f"{url}/session/..."` concatenation produces `//session`
+        # which OpenCode rejects with an empty body. Normalise once.
+        self.url = url.rstrip("/")
+        self.session_id = session_id
+        self.member_name = "unknown"
+        self.team_name = ""
+        self.task_line = ""
+        self.agent = ""
+        self.model = ""
+        self.role_by_message: dict[str, str] = {}
+        self.ssl_context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
+        self.footer: StatusFooter | None = None
+
+    def auth_headers(self) -> dict[str, str]:
+        password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+        if not password:
+            return {}
+        username = os.environ.get("OPENCODE_SERVER_USERNAME") or "opencode"
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
+    def open_url(
+        self,
+        url: str,
+        timeout: float | None = 5,
+        headers: dict[str, str] | None = None,
+    ):
+        merged_headers = {**self.auth_headers(), **(headers or {})}
+        request = urllib.request.Request(url, headers=merged_headers) if merged_headers else url
+        return urllib.request.urlopen(request, timeout=timeout, context=self.ssl_context)
+
+    def fetch(self) -> None:
+        try:
+            with self.open_url(f"{self.url}/session/{self.session_id}", timeout=5) as r:
+                info = json.load(r)
+        except (urllib.error.URLError, json.JSONDecodeError):
+            return
+        title = info.get("title", "") or ""
+        # Title shape: "Create team member <team>/<member> (@<agent> subagent)"
+        m = re.match(r"Create team member ([^/]+)/([^\s(]+)\s*\(@([^\s)]+)", title)
+        if m:
+            self.team_name = m.group(1)
+            self.member_name = m.group(2)
+            self.agent = m.group(3)
+        else:
+            self.member_name = title[:48]
+
+
+class StatusFooter:
+    """Daemon thread that prints a status line at the last terminal row every 10s."""
+
+    _INTERVAL = 10.0
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._connected = False
+        self._last_error: str | None = None
+        self._events_seen: int = 0
+        self._last_event_ts: float | None = None
+        self._capable = self._detect_capability()
+        self._thread: threading.Thread | None = None
+
+    def _detect_capability(self) -> bool:
+        term = os.environ.get("TERM", "")
+        if term in ("dumb", ""):
+            return False
+        try:
+            result = subprocess.run(["tput", "sc"], capture_output=True)
+            return result.returncode == 0
+        except (OSError, FileNotFoundError):
+            return False
+
+    def note_event(self) -> None:
+        with self._lock:
+            self._events_seen += 1
+            self._last_event_ts = time.time()
+            self._connected = True
+            self._last_error = None
+
+    def note_disconnect(self, err: str) -> None:
+        with self._lock:
+            self._connected = False
+            self._last_error = err
+
+    def note_reconnect(self, url: str) -> None:
+        with self._lock:
+            self._url = url
+            self._connected = True
+            self._last_error = None
+
+    def _render(self) -> str:
+        with self._lock:
+            if self._connected:
+                last_str = (
+                    time.strftime("%H:%M:%S", time.localtime(self._last_event_ts))
+                    if self._last_event_ts is not None
+                    else "--:--:--"
+                )
+                text = f"[connected → {self._url} | events: {self._events_seen} | last: {last_str}]"
+            else:
+                err_str = f" ({self._last_error})" if self._last_error else ""
+                text = f"[disconnected ✗{err_str}]"
+        return f"\x1b[s\x1b[999;1H\x1b[2K{DIM}{text}{RST}\x1b[u"
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._INTERVAL):
+            try:
+                sys.stdout.write(self._render())
+                sys.stdout.flush()
+            except (OSError, ValueError):
+                break
+
+    def start(self) -> None:
+        if not self._capable:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self._capable:
+            try:
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+            except (OSError, ValueError):
+                pass
+
+
+def render_banner(state: SessionState) -> None:
+    accent = accent_for(state.session_id)
+    print(f"{accent}{BOLD}▣ {state.member_name}{RST}", end="")
+    if state.agent:
+        print(f"  {DIM}{state.agent}{RST}", end="")
+    if state.team_name:
+        print(f"  {DIM}team={state.team_name}{RST}", end="")
+    print()
+    print(f"{DIM}session {state.session_id[:24]}…{RST}")
+
+
+def render_message(m: dict, state: SessionState) -> None:
+    info = m.get("info", {})
+    role = info.get("role", "?").upper()
+    msg_id = info.get("id")
+    if msg_id:
+        state.role_by_message[msg_id] = role
+    ts = fmt_ts(info.get("time", {}).get("created"))
+    parts = m.get("parts", [])
+    for p in parts:
+        ptype = p.get("type")
+        if ptype == "text" and p.get("text"):
+            text = p["text"]
+            peer = summarize_peer_message(text)
+            label, text = ("PEER", peer) if peer else (role, text)
+            colour = CYAN if label == "ASSISTANT" else (BLU if label == "PEER" else GRN)
+            print(f"{ts} {colour}{label:9s}{RST} {short(text)}")
+        elif ptype == "tool":
+            tool = p.get("tool", "?")
+            status = (p.get("state") or {}).get("status", "?")
+            colour = YEL if status != "error" else RED
+            print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+        elif ptype == "reasoning" and p.get("text"):
+            print(f"{ts} {MAG}REASONING{RST} {short(p['text'], 80)}")
+
+
+_KICKOFF_META_PREFIXES = ("Team:", "TeamRunId:", "Member:")
+
+
+def extract_task_line(kickoff_text: str) -> str:
+    """Return the task description line from a team-kickoff prompt body.
+
+    The kickoff begins with metadata headers (`Team:`, `TeamRunId:`, `Member:`)
+    that the OpenCode TUI's static subagent-detail view also surfaces — so
+    showing the first non-empty line of the prompt would just duplicate that
+    static header. The real differentiator (and what users want at a glance)
+    is the task body that follows the headers.
+    """
+    for line in kickoff_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(_KICKOFF_META_PREFIXES):
+            continue
+        if stripped.startswith("# ") or stripped.startswith("## "):
+            # The kickoff template ends with `# Team Communication` boilerplate.
+            return ""
+        return stripped
+    return ""
+
+
+def fetch_history(state: SessionState, n: int) -> int:
+    try:
+        with state.open_url(f"{state.url}/session/{state.session_id}/message", timeout=5) as r:
+            msgs = json.load(r)
+    except (urllib.error.URLError, json.JSONDecodeError) as e:
+        print(f"{RED}history fetch failed: {e}{RST}")
+        return 0
+    # Populate role lookup from full history so SSE renders correctly.
+    for m in msgs:
+        info = m.get("info", {})
+        if info.get("id") and info.get("role"):
+            state.role_by_message[info["id"]] = info["role"].upper()
+    # Find the kickoff prompt's task body (skip metadata headers).
+    for m in msgs:
+        info = m.get("info", {})
+        if info.get("role") != "user":
+            continue
+        for p in m.get("parts", []):
+            if p.get("type") != "text" or not p.get("text"):
+                continue
+            text = p["text"]
+            if "OMO_INTERNAL_INITIATOR" not in text:
+                continue
+            state.task_line = short(extract_task_line(text), 90)
+            break
+        if state.task_line:
+            break
+    if state.task_line:
+        print(f"{DIM}task: {state.task_line}{RST}")
+    print(f"{DIM}── {len(msgs)} messages, last {min(n, len(msgs))} ──{RST}")
+    for m in msgs[-n:]:
+        render_message(m, state)
+    return len(msgs)
+
+
+class _PollOpts:
+    """Options for poll_session_messages()."""
+
+    def __init__(
+        self,
+        poll_interval_seconds: float = 1.0,
+        max_reconnect_wallclock_seconds: int = 90,
+    ) -> None:
+        self.poll_interval_seconds = poll_interval_seconds
+        self.max_reconnect_wallclock_seconds = max_reconnect_wallclock_seconds
+
+
+_BACKOFF_SEQUENCE = (2, 5, 10, 15, 30)
+
+
+def poll_session_messages(state: SessionState, opts: _PollOpts | None = None) -> int:
+    """Tail the session by polling /session/<id>/message at a steady cadence.
+
+    Replaces the prior `/event` SSE flow. opencode 1.14.48's SSE endpoint
+    accepts subscribers but stops delivering events shortly after the
+    initial `server.connected` handshake (verified via 20s curl: 0 data
+    frames received while the bus published >140 message.part.delta
+    events). The opencode TUI itself uses /session/<id>/message polling
+    for the same reason — we match that strategy here.
+    """
+    if opts is None:
+        opts = _PollOpts()
+    interval = max(0.25, opts.poll_interval_seconds)
+    print(f"{DIM}── live tail (polling every {interval:.1f}s, Ctrl-C to exit) ──{RST}")
+    seen_parts: dict[str, int] = {}
+    seen_status: dict[str, str] = {}
+    seen_finish: set[str] = set()
+    failure_wallclock: float = 0.0
+    attempt: int = 0
+
+    while True:
+        try:
+            with state.open_url(
+                f"{state.url}/session/{state.session_id}/message",
+                timeout=10,
+            ) as r:
+                msgs = json.load(r)
+            # Reset failure tracking on a successful poll.
+            failure_wallclock = 0.0
+            attempt = 0
+            if state.footer is not None:
+                state.footer.note_reconnect(state.url)
+            rendered_any = _render_polled_messages(msgs, state, seen_parts, seen_status, seen_finish)
+            if rendered_any and state.footer is not None:
+                state.footer.note_event()
+            time.sleep(interval)
+        except (TimeoutError, socket.timeout):
+            if state.footer is not None:
+                state.footer.note_disconnect("poll timeout — retrying")
+            time.sleep(interval)
+        except (urllib.error.URLError, ConnectionResetError, OSError, ssl.SSLError) as e:
+            if state.footer is not None:
+                state.footer.note_disconnect(str(e))
+            delay = _BACKOFF_SEQUENCE[min(attempt, len(_BACKOFF_SEQUENCE) - 1)]
+            failure_wallclock += delay
+            if failure_wallclock >= opts.max_reconnect_wallclock_seconds:
+                print(
+                    f"[live-tail exited: server unreachable for "
+                    f"{opts.max_reconnect_wallclock_seconds}s. "
+                    f"Run team_refresh_panes to re-attach.]"
+                )
+                return 1
+            print(f"{DIM}poll interrupted ({e}); retrying in {delay}s{RST}")
+            attempt += 1
+            time.sleep(delay)
+
+
+def _render_polled_messages(
+    msgs: list,
+    state: SessionState,
+    seen_parts: dict[str, int],
+    seen_status: dict[str, str],
+    seen_finish: set[str],
+) -> bool:
+    """Render newly-grown content from a /session/<id>/message snapshot.
+
+    Returns True iff at least one line was printed this tick.
+    """
+    rendered = False
+    for m in msgs:
+        info = m.get("info") or {}
+        msg_id = info.get("id") or ""
+        role = (info.get("role") or "ASSISTANT").upper()
+        if msg_id:
+            state.role_by_message[msg_id] = role
+        ts = fmt_ts(int(time.time() * 1000))
+        finish = info.get("finish")
+        if msg_id and finish and msg_id not in seen_finish:
+            seen_finish.add(msg_id)
+            print(f"{ts} {DIM}{role} finish={finish}{RST}")
+            rendered = True
+        for part in (m.get("parts") or []):
+            pid = part.get("id") or ""
+            ptype = part.get("type")
+            parent_msg = part.get("messageID") or msg_id
+            prole = state.role_by_message.get(parent_msg, role)
+            text = part.get("text") or ""
+            prev_len = seen_parts.get(pid, 0)
+            if ptype == "text" and text and len(text) > prev_len:
+                seen_parts[pid] = len(text)
+                # On first sighting of a peer-coordination text, fold the
+                # boilerplate down to a one-line summary (matches the SSE
+                # path's behaviour at handle_event:419-421).
+                if prev_len == 0:
+                    peer = summarize_peer_message(text)
+                    if peer:
+                        print(f"{ts} {BLU}PEER     {RST} {peer}")
+                        rendered = True
+                        continue
+                colour = CYAN if prole == "ASSISTANT" else GRN
+                new_chunk = text[prev_len:]
+                print(f"{ts} {colour}{prole:9s}{RST} {short(new_chunk)}")
+                rendered = True
+            elif ptype == "tool":
+                status = (part.get("state") or {}).get("status", "?")
+                if status != seen_status.get(pid):
+                    seen_status[pid] = status
+                    colour = YEL if status != "error" else RED
+                    tool = part.get("tool", "?")
+                    print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+                    rendered = True
+            elif ptype == "reasoning" and text and len(text) > prev_len:
+                seen_parts[pid] = len(text)
+                new_chunk = text[prev_len:]
+                print(f"{ts} {MAG}REASONING{RST} {short(new_chunk, 80)}")
+                rendered = True
+    return rendered
+
+
+def match_session(ev: dict, session_id: str) -> bool:
+    props = ev.get("properties", {}) or {}
+    candidates = (
+        props.get("sessionID"),
+        props.get("sessionId"),
+        (props.get("info") or {}).get("sessionID"),
+        (props.get("info") or {}).get("sessionId"),
+        (props.get("part") or {}).get("sessionID"),
+        (props.get("part") or {}).get("sessionId"),
+    )
+    return any(c == session_id for c in candidates if c)
+
+
+def handle_event(ev: dict, state: SessionState, seen: dict[str, int]) -> None:
+    etype = ev.get("type", "")
+    props = ev.get("properties", {}) or {}
+    ts = fmt_ts(int(time.time() * 1000))
+    if etype == "message.updated":
+        info = props.get("info", {}) or {}
+        msg_id = info.get("id")
+        role = info.get("role", "?").upper()
+        if msg_id:
+            state.role_by_message[msg_id] = role
+        finish = info.get("finish")
+        if finish:
+            print(f"{ts} {DIM}{role} finish={finish}{RST}")
+        return
+    if etype == "message.part.delta":
+        message_id = props.get("messageID") or props.get("messageId")
+        role = state.role_by_message.get(message_id, "ASSISTANT")
+        field = props.get("field")
+        delta = props.get("delta") or ""
+        if field == "text" and delta:
+            colour = CYAN if role == "ASSISTANT" else GRN
+            print(f"{ts} {colour}{role:9s}{RST} {short(delta)}")
+        return
+    if etype != "message.part.updated":
+        return
+    part = props.get("part", {}) or {}
+    pid = part.get("id") or ""
+    parent_msg = part.get("messageID") or ""
+    role = state.role_by_message.get(parent_msg, "ASSISTANT")
+    ptype = part.get("type")
+    text = part.get("text") or ""
+    # Dedup growing-text streams: print only when the visible prefix grew.
+    prev_len = seen.get(pid, 0)
+    if ptype == "text" and text and len(text) > prev_len:
+        seen[pid] = len(text)
+        peer = summarize_peer_message(text)
+        if peer:
+            print(f"{ts} {BLU}PEER     {RST} {peer}")
+        else:
+            colour = CYAN if role == "ASSISTANT" else GRN
+            print(f"{ts} {colour}{role:9s}{RST} {short(text)}")
+    elif ptype == "tool":
+        # Tool events fire on every status transition; only print on terminal states.
+        status = (part.get("state") or {}).get("status", "?")
+        prev_status = seen.get(f"{pid}:status")
+        if status != prev_status:
+            seen[f"{pid}:status"] = status  # type: ignore[assignment]
+            colour = YEL if status != "error" else RED
+            tool = part.get("tool", "?")
+            print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+    elif ptype == "reasoning" and text and len(text) > prev_len:
+        seen[pid] = len(text)
+        print(f"{ts} {MAG}REASONING{RST} {short(text, 80)}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("url")
+    p.add_argument("session_id")
+    p.add_argument("--no-clear", action="store_true")
+    p.add_argument("--history", type=int, default=4)
+    p.add_argument("--insecure", action="store_true", help="Disable TLS certificate verification (local/dev only).")
+    p.add_argument("--poll-interval-seconds", type=float, default=1.0, metavar="N",
+                   help="How often to poll /session/<id>/message (default 1.0s).")
+    # Back-compat: kept so older team_refresh_panes invocations don't crash on
+    # the unknown flag. Value is ignored — SSE has been replaced by polling.
+    p.add_argument("--idle-heartbeat-seconds", type=int, default=30, metavar="N",
+                   help="Deprecated, ignored (SSE replaced by polling).")
+    p.add_argument("--max-reconnect-wallclock-seconds", type=int, default=90, metavar="N")
+    p.add_argument("--no-footer", action="store_true")
+    args = p.parse_args()
+
+    if not args.no_clear:
+        print("\033[2J\033[H", end="")
+    state = SessionState(args.url, args.session_id, insecure=args.insecure)
+    state.fetch()
+    render_banner(state)
+    if args.insecure:
+        print(f"{YEL}{DIM}TLS verify disabled (--insecure). Local/dev use only.{RST}")
+
+    if not args.no_footer:
+        state.footer = StatusFooter(state.url)
+        state.footer.start()
+
+    fetch_history(state, args.history)
+    opts = _PollOpts(
+        poll_interval_seconds=args.poll_interval_seconds,
+        max_reconnect_wallclock_seconds=args.max_reconnect_wallclock_seconds,
+    )
+    result = poll_session_messages(state, opts)
+
+    if state.footer is not None:
+        state.footer.stop()
+
+    return result
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print(f"\n{DIM}interrupted{RST}")
+        sys.exit(130)

--- a/script/test_team_pane_live_tail.py
+++ b/script/test_team_pane_live_tail.py
@@ -1,0 +1,377 @@
+"""Unit tests for team-pane-live-tail.py renderer helpers.
+
+Run: python3 -m unittest script/test_team_pane_live_tail.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE / "team-pane-live-tail.py"
+
+spec = importlib.util.spec_from_file_location("team_pane_live_tail", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+sys.modules["team_pane_live_tail"] = mod
+spec.loader.exec_module(mod)
+
+
+class ExtractTaskLineTests(unittest.TestCase):
+    def test_skips_kickoff_metadata_headers(self) -> None:
+        text = (
+            "Team: omc-enhancement-team\n"
+            "TeamRunId: 59704820-c9d5-4ff9-8490-81f17040a982\n"
+            "Member: docs-auditor\n"
+            "Audit all AGENTS.md files for alignment with hooks.\n\n"
+            "# Team Communication\n\n"
+            "You are running as a team member..."
+        )
+        self.assertEqual(
+            mod.extract_task_line(text),
+            "Audit all AGENTS.md files for alignment with hooks.",
+        )
+
+    def test_returns_first_real_body_line_when_no_metadata(self) -> None:
+        self.assertEqual(
+            mod.extract_task_line("Just a single task description"),
+            "Just a single task description",
+        )
+
+    def test_returns_empty_when_only_metadata_and_section_headers(self) -> None:
+        text = (
+            "Team: x\n"
+            "TeamRunId: y\n"
+            "Member: z\n"
+            "# Team Communication\n"
+            "boilerplate"
+        )
+        self.assertEqual(mod.extract_task_line(text), "")
+
+    def test_strips_leading_whitespace(self) -> None:
+        self.assertEqual(mod.extract_task_line("    indented task"), "indented task")
+
+
+class SummarizePeerMessageTests(unittest.TestCase):
+    def test_compresses_full_peer_message(self) -> None:
+        text = (
+            '<peer_message from="lead" timestamp="123" messageId="abc">'
+            "Status check please.\nMore detail here.</peer_message>"
+        )
+        result = mod.summarize_peer_message(text)
+        self.assertIsNotNone(result)
+        self.assertIn("⇠ peer from lead:", result)
+        self.assertIn("Status check please", result)
+
+    def test_returns_none_for_non_peer_text(self) -> None:
+        self.assertIsNone(mod.summarize_peer_message("regular assistant output"))
+
+    def test_returns_none_for_malformed_xml(self) -> None:
+        self.assertIsNone(mod.summarize_peer_message('<peer_message from="lead">unclosed'))
+
+
+class AccentForTests(unittest.TestCase):
+    def test_deterministic_per_session(self) -> None:
+        a1 = mod.accent_for("ses_abc")
+        a2 = mod.accent_for("ses_abc")
+        self.assertEqual(a1, a2)
+
+    def test_different_sessions_can_get_different_colours(self) -> None:
+        # Picks two ids that differ in their character-sum modulo the ramp.
+        first = mod.accent_for("ses_aaaaa")
+        second = mod.accent_for("ses_aaaab")
+        self.assertNotEqual(first, second)
+
+
+class SessionStateUrlNormalizationTests(unittest.TestCase):
+    """OmO's tmuxMgr.getServerUrl() emits trailing-slash URLs; without
+    normalisation the script issues `http://.../4096//session/...` which
+    OpenCode rejects with an empty body. Regression test for that bug."""
+
+    def test_strips_single_trailing_slash(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096/", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_strips_multiple_trailing_slashes(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096///", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_leaves_url_without_trailing_slash_alone(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_uses_unverified_context_only_when_insecure_enabled(self) -> None:
+        strict = mod.SessionState("https://127.0.0.1:4096", "ses_strict")
+        insecure = mod.SessionState("https://127.0.0.1:4096", "ses_insecure", insecure=True)
+        self.assertEqual(strict.ssl_context.verify_mode, mod.ssl.CERT_REQUIRED)
+        self.assertEqual(insecure.ssl_context.verify_mode, mod.ssl.CERT_NONE)
+
+    def test_open_url_merges_basic_auth_with_existing_headers(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with patch.dict(mod.os.environ, {"OPENCODE_SERVER_PASSWORD": "secret"}, clear=False):
+            with patch.object(mod.urllib.request, "urlopen") as urlopen:
+                state.open_url("http://x/event", headers={"Accept": "text/event-stream"})
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.headers["Accept"], "text/event-stream")
+        self.assertTrue(request.headers["Authorization"].startswith("Basic "))
+
+
+class SessionStateFetchTests(unittest.TestCase):
+    def _mock_session_response(self, payload: dict) -> patch:
+        body = json.dumps(payload).encode("utf-8")
+
+        class _Resp:
+            def __init__(self, b: bytes) -> None:
+                self._b = b
+
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *a: object) -> None:
+                pass
+
+            def read(self) -> bytes:
+                return self._b
+
+        return patch.object(mod.urllib.request, "urlopen", return_value=_Resp(body))
+
+    def test_parses_team_member_agent_from_title(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with self._mock_session_response({
+            "title": "Create team member omc-team/docs-auditor (@Sisyphus-Junior subagent)",
+        }):
+            # Wrap urlopen so json.load works on a file-like; patch json.load to
+            # decode bytes directly.
+            with patch.object(mod.json, "load", side_effect=lambda r: json.loads(r.read())):
+                state.fetch()
+        self.assertEqual(state.team_name, "omc-team")
+        self.assertEqual(state.member_name, "docs-auditor")
+        self.assertEqual(state.agent, "Sisyphus-Junior")
+
+    def test_falls_back_to_truncated_title_when_pattern_misses(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with self._mock_session_response({"title": "ad-hoc title not matching pattern"}):
+            with patch.object(mod.json, "load", side_effect=lambda r: json.loads(r.read())):
+                state.fetch()
+        self.assertEqual(state.member_name, "ad-hoc title not matching pattern")
+        self.assertEqual(state.team_name, "")
+
+
+class HandleEventTests(unittest.TestCase):
+    def test_user_role_text_renders_as_user(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        state.role_by_message["msg1"] = "USER"
+        seen: dict = {}
+        ev = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "text",
+                    "id": "p1",
+                    "messageID": "msg1",
+                    "text": "Hello there",
+                },
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("USER", fake.getvalue())
+        self.assertNotIn("ASSISTANT", fake.getvalue())
+
+    def test_assistant_role_default_when_unknown(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        seen: dict = {}
+        ev = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "text",
+                    "id": "p1",
+                    "messageID": "unknown",
+                    "text": "Streaming response",
+                },
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("ASSISTANT", fake.getvalue())
+
+    def test_dedupes_growing_text_streams(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        seen: dict = {}
+        first = {
+            "type": "message.part.updated",
+            "properties": {"part": {"type": "text", "id": "p1", "messageID": "m", "text": "Hello"}},
+        }
+        same_size = {
+            "type": "message.part.updated",
+            "properties": {"part": {"type": "text", "id": "p1", "messageID": "m", "text": "Hello"}},
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(first, state, seen)
+            mod.handle_event(same_size, state, seen)
+        # Only one render despite two events of the same length.
+        self.assertEqual(fake.getvalue().count("Hello"), 1)
+
+    def test_text_delta_renders_live_increment(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        state.role_by_message["msg1"] = "ASSISTANT"
+        seen: dict = {}
+        ev = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionId": "ses_y",
+                "messageID": "msg1",
+                "partID": "part1",
+                "field": "text",
+                "delta": "streaming chunk",
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("ASSISTANT", fake.getvalue())
+        self.assertIn("streaming chunk", fake.getvalue())
+
+
+class MatchSessionTests(unittest.TestCase):
+    def test_matches_via_top_level_sessionId(self) -> None:
+        ev = {"properties": {"sessionId": "ses_abc"}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_part_sessionID(self) -> None:
+        ev = {"properties": {"part": {"sessionID": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_part_sessionId(self) -> None:
+        ev = {"properties": {"part": {"sessionId": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_info_sessionID(self) -> None:
+        ev = {"properties": {"info": {"sessionID": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_info_sessionId(self) -> None:
+        ev = {"properties": {"info": {"sessionId": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_does_not_match_message_id_as_session_id(self) -> None:
+        ev = {"properties": {"info": {"id": "ses_abc"}}}
+        self.assertFalse(mod.match_session(ev, "ses_abc"))
+
+    def test_rejects_other_session(self) -> None:
+        ev = {"properties": {"info": {"sessionID": "ses_other"}}}
+        self.assertFalse(mod.match_session(ev, "ses_abc"))
+
+
+class PolledMessageRendererTests(unittest.TestCase):
+    """Validate the /session/<id>/message polling renderer that replaced SSE."""
+
+    def _render(self, msgs: list) -> tuple[str, dict, dict, set]:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_parts: dict = {}
+        seen_status: dict = {}
+        seen_finish: set = set()
+        out = StringIO()
+        with patch("sys.stdout", out):
+            mod._render_polled_messages(msgs, state, seen_parts, seen_status, seen_finish)
+        return out.getvalue(), seen_parts, seen_status, seen_finish
+
+    def test_renders_text_growth_as_delta(self) -> None:
+        # First poll sees "Hello"; second poll sees "Hello world".
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_parts: dict = {}
+        out = StringIO()
+        with patch("sys.stdout", out):
+            mod._render_polled_messages(
+                [{"info": {"id": "m1", "role": "assistant"}, "parts": [{"id": "p1", "type": "text", "messageID": "m1", "text": "Hello"}]}],
+                state, seen_parts, {}, set(),
+            )
+            mod._render_polled_messages(
+                [{"info": {"id": "m1", "role": "assistant"}, "parts": [{"id": "p1", "type": "text", "messageID": "m1", "text": "Hello world"}]}],
+                state, seen_parts, {}, set(),
+            )
+        text = out.getvalue()
+        self.assertIn("Hello", text)
+        # The second render should only print " world" (the new tail), not "Hello" again.
+        # Strip ANSI to count substrings reliably.
+        import re as _re
+        plain = _re.sub(r"\x1b\[[0-9;]*m", "", text)
+        self.assertEqual(plain.count("Hello"), 1, f"expected one 'Hello' print, got: {plain!r}")
+        self.assertIn(" world", plain)
+
+    def test_renders_tool_status_transition_once(self) -> None:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_status: dict = {}
+        out = StringIO()
+        msg = {
+            "info": {"id": "m1", "role": "assistant"},
+            "parts": [{"id": "p1", "type": "tool", "messageID": "m1", "tool": "grep", "state": {"status": "running"}}],
+        }
+        with patch("sys.stdout", out):
+            # Two polls with the same running status — only first should print.
+            mod._render_polled_messages([msg], state, {}, seen_status, set())
+            mod._render_polled_messages([msg], state, {}, seen_status, set())
+        plain = out.getvalue()
+        self.assertEqual(plain.count("grep → running"), 1)
+
+    def test_renders_finish_once(self) -> None:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_finish: set = set()
+        out = StringIO()
+        msg = {"info": {"id": "m1", "role": "assistant", "finish": "stop"}, "parts": []}
+        with patch("sys.stdout", out):
+            mod._render_polled_messages([msg], state, {}, {}, seen_finish)
+            mod._render_polled_messages([msg], state, {}, {}, seen_finish)
+        plain = out.getvalue()
+        self.assertEqual(plain.count("finish=stop"), 1)
+
+
+class ReconnectWallclockBudgetTests(unittest.TestCase):
+    def test_reconnect_exits_after_wallclock_budget(self) -> None:
+        import time as _time
+
+        state = mod.SessionState("http://127.0.0.1:19999", "ses_test_budget")
+
+        # Patch open_url to always raise ConnectionRefusedError (subclass of OSError).
+        def always_fail(url: str, timeout=None, headers=None):  # type: ignore[override]
+            raise ConnectionRefusedError("refused")
+
+        state.open_url = always_fail  # type: ignore[method-assign]
+
+        opts = mod._PollOpts(
+            poll_interval_seconds=1.0,
+            max_reconnect_wallclock_seconds=2,
+        )
+
+        start = _time.monotonic()
+        result = mod.poll_session_messages(state, opts)
+        elapsed = _time.monotonic() - start
+
+        self.assertEqual(result, 1, "poll_session_messages should return 1 after budget exhaustion")
+        # Budget is 2s; the first backoff delay is 2s so it fires after one sleep.
+        self.assertLess(elapsed, 10.0, f"poll_session_messages took too long: {elapsed:.1f}s")
+
+
+class StatusFooterEventCountTests(unittest.TestCase):
+    def test_status_footer_persists_events_across_reconnect(self) -> None:
+        footer = mod.StatusFooter("http://127.0.0.1:19999")
+
+        # 3 events, then a disconnect, then 2 more events.
+        footer.note_event()
+        footer.note_event()
+        footer.note_event()
+        footer.note_disconnect("boom")
+        footer.note_event()
+        footer.note_event()
+
+        rendered = footer._render()
+        self.assertIn("events: 5", rendered, f"Expected 'events: 5' in footer render, got: {rendered!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -55,8 +55,9 @@ function defaultRunTmuxCommand(_tmuxPath: string, args: Array<string>, _options?
 
   if (command === "new-window") {
     const windowId = `@${nextWindowNumber++}`
-    panesByWindow.set(windowId, [`%${nextPaneNumber++}`])
-    return Promise.resolve(createTmuxCommandResult(windowId))
+    const paneId = `%${nextPaneNumber++}`
+    panesByWindow.set(windowId, [paneId])
+    return Promise.resolve(createTmuxCommandResult(`${windowId} ${paneId}`))
   }
 
   if (command === "split-window") {
@@ -88,6 +89,7 @@ async function loadLayoutModule() {
 
       return { sessionId: displaySessionId, paneId: process.env.TMUX_PANE, windowTarget: "test-session:0" }
     },
+    detectServerPortOwnership: async () => ({ hasOwnPort: true }),
   }
   return {
     canVisualize,
@@ -184,13 +186,41 @@ describe("team-layout-tmux", () => {
 
     // then
     const commands = getCommands()
-    expect(commands.some((args) => args[0] === "new-window")).toBe(false)
-    expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(2)
+    expect(commands.filter((args) => args[0] === "new-window")).toHaveLength(1)
+    expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(3)
 
     const sendKeysCalls = commands.filter((args) => args[0] === "send-keys")
     const literals = sendKeysCalls.map((args) => args.join(" "))
-    expect(literals.some((s) => s.includes("--session 's-m1'"))).toBe(true)
-    expect(literals.some((s) => s.includes("--session 's-m2'"))).toBe(true)
+    expect(literals.filter((s) => s.includes("opencode attach "))).toHaveLength(2)
+    expect(literals.filter((s) => s.includes("python3 -u "))).toHaveLength(2)
+    expect(literals.some((s) => s.includes("opencode attach 'http://127.0.0.1:12345' --session 's-m1' --dir '/tmp/m1'"))).toBe(true)
+    expect(literals.some((s) => s.includes("opencode attach 'http://127.0.0.1:12345' --session 's-m2' --dir '/tmp/m2'"))).toBe(true)
+    expect(literals.some((s) => s.includes("python3 -u ") && s.includes("'s-m1'"))).toBe(true)
+    expect(literals.some((s) => s.includes("python3 -u ") && s.includes("'s-m2'"))).toBe(true)
+  })
+
+  test("passes --insecure to live-tail only when tmux option is enabled", async () => {
+    // given
+    const deps: TeamLayoutDeps = {
+      runTmuxCommand: runTmuxCommandMock,
+      isServerRunning: isServerRunningMock,
+      getTmuxPath: async () => "tmux",
+      resolveCallerTmuxSession: async () => ({ sessionId: "$7", paneId: process.env.TMUX_PANE ?? "%42", windowTarget: "test-session:0" }),
+      detectServerPortOwnership: async () => ({ hasOwnPort: true }),
+    }
+    const members = [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }]
+
+    // when
+    await createTeamLayout("run-strict", members, tmuxMgr as never, deps, { allowInsecureLocalTls: false })
+    await createTeamLayout("run-insecure", members, tmuxMgr as never, deps, { allowInsecureLocalTls: true })
+
+    // then
+    const sendKeysCalls = getCommands().filter((args) => args[0] === "send-keys")
+    const liveTailLiterals = sendKeysCalls.map((args) => args.join(" ")).filter((literal) => literal.includes("python3 -u "))
+    const strictLiteral = liveTailLiterals[0] ?? ""
+    const insecureLiteral = liveTailLiterals[1] ?? ""
+    expect(strictLiteral).not.toContain(" --insecure")
+    expect(insecureLiteral).toContain(" --insecure")
   })
 
   test("uses caller window main-vertical layout with caller pane as primary", async () => {
@@ -209,11 +239,19 @@ describe("team-layout-tmux", () => {
     const commands = getCommands()
     const selectLayoutArgs = commands.filter((args) => args[0] === "select-layout").map((args) => args[args.length - 1])
     expect(selectLayoutArgs).toContain("main-vertical")
-    expect(selectLayoutArgs).not.toContain("tiled")
+    expect(selectLayoutArgs).toContain("tiled")
     expect(commands).toContainEqual(["resize-pane", "-t", process.env.TMUX_PANE ?? "", "-x", "30%"])
     expect(result).not.toBeNull()
     expect(Object.keys(result?.focusPanesByMember ?? {}).sort()).toEqual(["m1", "m2", "m3"])
-    expect(Object.keys(result?.gridPanesByMember ?? {})).toEqual([])
+    expect(Object.keys(result?.gridPanesByMember ?? {}).sort()).toEqual(["m1", "m2", "m3"])
+    // Without refresh-client, attached tmux clients can leave the freshly-
+    // split panes blank-rendered until the user types or focuses a pane —
+    // which makes the live-tail look frozen even though it's streaming.
+    const refreshIdx = commands.findIndex((args) => args[0] === "refresh-client")
+    const lastResizeIdx = commands.map((c) => c[0]).lastIndexOf("resize-pane")
+    const mainSelectLayoutIdx = commands.findIndex((args) => args[0] === "select-layout" && args[args.length - 1] === "main-vertical")
+    expect(refreshIdx).toBeGreaterThan(mainSelectLayoutIdx)
+    expect(refreshIdx).toBeGreaterThan(lastResizeIdx)
   })
 
   test("#given 4 or more teammates #when createTeamLayout runs #then it keeps every teammate in the caller window", async () => {
@@ -230,14 +268,78 @@ describe("team-layout-tmux", () => {
 
     // then
     const commands = getCommands()
-    expect(commands.some((args) => args[0] === "new-window")).toBe(false)
-    expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(5)
+    expect(commands.filter((args) => args[0] === "new-window")).toHaveLength(1)
+    expect(commands.filter((args) => args[0] === "split-window")).toHaveLength(9)
     const selectLayoutArgs = commands.filter((args) => args[0] === "select-layout").map((args) => args[args.length - 1])
     expect(selectLayoutArgs).toContain("main-vertical")
-    expect(selectLayoutArgs).not.toContain("tiled")
+    expect(selectLayoutArgs).toContain("tiled")
   })
 
-  test("#given caller inside tmux #when createTeamLayout runs #then it never steals focus or mutates window border options", async () => {
+  test("#given caller inside tmux #when createTeamLayout runs #then every split-window and the live-tail new-window pass -d so focus never leaves the caller", async () => {
+    // given
+    const { createTeamLayout } = await loadLayoutModule()
+    const members = [
+      { name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" },
+      { name: "m2", sessionId: "s-m2", worktreePath: "/tmp/m2" },
+    ]
+
+    // when
+    await createTeamLayout("run-no-steal", members, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    const splitCalls = commands.filter((args) => args[0] === "split-window")
+    const newWindowCalls = commands.filter((args) => args[0] === "new-window")
+    expect(splitCalls.length).toBeGreaterThan(0)
+    expect(newWindowCalls.length).toBeGreaterThan(0)
+    for (const args of splitCalls) {
+      expect(args).toContain("-d")
+    }
+    for (const args of newWindowCalls) {
+      expect(args).toContain("-d")
+    }
+  })
+
+  test("#given layout created #when createTeamLayout finishes #then it explicitly restores the caller's window and pane via select-window/select-pane", async () => {
+    // given
+    const { createTeamLayout } = await loadLayoutModule()
+    const members = [
+      { name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" },
+      { name: "m2", sessionId: "s-m2", worktreePath: "/tmp/m2" },
+    ]
+
+    // when
+    await createTeamLayout("run-restore", members, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    const selectWindowIdx = commands.findIndex((args) => args[0] === "select-window" && args.includes("test-session:0"))
+    const restorePaneIdx = commands.findIndex((args) =>
+      args[0] === "select-pane" && args[1] === "-t" && args[2] === (process.env.TMUX_PANE ?? "") && !args.includes("-T"),
+    )
+    const lastSplitIdx = commands.map((c) => c[0]).lastIndexOf("split-window")
+    expect(selectWindowIdx).toBeGreaterThan(lastSplitIdx)
+    expect(restorePaneIdx).toBeGreaterThan(lastSplitIdx)
+  })
+
+  test("#given ownedSession=false cleanup #when removeTeamLayout finishes #then it select-window's back to the caller's focusWindowId so tmux does not strand the user on a neighbour window", async () => {
+    // given
+    const { removeTeamLayout } = await loadLayoutModule()
+
+    // when
+    await removeTeamLayout("run-cleanup-restore", {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "@10",
+      gridWindowId: "@11",
+    }, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    expect(commands).toContainEqual(["select-window", "-t", "@10"])
+  })
+
+  test("#given caller inside tmux #when createTeamLayout runs #then it never steals focus mid-build (only the trailing restore-pane onto the caller is allowed) or mutates window border options", async () => {
     // given
     const { createTeamLayout } = await loadLayoutModule()
     const members = Array.from({ length: 5 }, (_, index) => ({
@@ -251,7 +353,11 @@ describe("team-layout-tmux", () => {
 
     // then
     const commands = getCommands()
-    expect(commands.some((args) => args[0] === "select-pane" && !args.includes("-T"))).toBe(false)
+    const callerPaneId = process.env.TMUX_PANE ?? ""
+    const focusStealingSelectPanes = commands.filter((args) =>
+      args[0] === "select-pane" && !args.includes("-T") && args[2] !== callerPaneId,
+    )
+    expect(focusStealingSelectPanes).toHaveLength(0)
     expect(commands.some((args) => args[0] === "set-option")).toBe(false)
   })
 
@@ -279,7 +385,30 @@ describe("team-layout-tmux", () => {
     }
   })
 
-  test("#given ownedSession=false, focusWindowId=@10, gridWindowId=@11 #when removeTeamLayout runs #then tmux kill-window is called twice with -t @10 and -t @11 and kill-session is NEVER called", async () => {
+  test("#given ownedSession=false and paneIds are provided #when removeTeamLayout runs #then tmux kills panes and reaps only the live-tail window", async () => {
+    // given
+    const { removeTeamLayout } = await loadLayoutModule()
+
+    // when
+    await removeTeamLayout("run-cleanup", {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "@10",
+      gridWindowId: "@11",
+      paneIds: ["%1", "%2", "%3"],
+    }, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    expect(commands).toContainEqual(["kill-pane", "-t", "%1"])
+    expect(commands).toContainEqual(["kill-pane", "-t", "%2"])
+    expect(commands).toContainEqual(["kill-pane", "-t", "%3"])
+    expect(commands).toContainEqual(["kill-window", "-t", "@11"])
+    expect(commands).not.toContainEqual(["kill-window", "-t", "@10"])
+    expect(commands.some((args) => args[0] === "kill-session")).toBe(false)
+  })
+
+  test("#given ownedSession=false, no paneIds, focusWindowId=@10, gridWindowId=@11 #when removeTeamLayout runs #then ONLY gridWindowId is killed (focusWindowId is the caller's window) and kill-session is NEVER called", async () => {
     // given
     const { removeTeamLayout } = await loadLayoutModule()
 
@@ -293,8 +422,27 @@ describe("team-layout-tmux", () => {
 
     // then
     const commands = getCommands()
-    expect(commands).toContainEqual(["kill-window", "-t", "@10"])
+    // The caller's window (@10) MUST NOT be killed when ownedSession=false —
+    // doing so destroys the lead's pane and any sibling user panes.
+    expect(commands).not.toContainEqual(["kill-window", "-t", "@10"])
     expect(commands).toContainEqual(["kill-window", "-t", "@11"])
+    expect(commands.some((args) => args[0] === "kill-session")).toBe(false)
+  })
+
+  test("#given ownedSession=false, no paneIds, only focusWindowId set #when removeTeamLayout runs #then no windows are killed (no-op cleanup is safer than destroying the caller's window)", async () => {
+    // given
+    const { removeTeamLayout } = await loadLayoutModule()
+
+    // when
+    await removeTeamLayout("run-cleanup", {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "@10",
+    }, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    expect(commands.some((args) => args[0] === "kill-window")).toBe(false)
     expect(commands.some((args) => args[0] === "kill-session")).toBe(false)
   })
 
@@ -315,14 +463,12 @@ describe("team-layout-tmux", () => {
     expect(commands).toContainEqual(["kill-session", "-t", "omo-team-xyz"])
   })
 
-  test("#given ownedSession=false and the first kill-window fails #when removeTeamLayout runs #then the second kill-window still fires", async () => {
+  test("#given ownedSession=false and kill-window on the grid window fails #when removeTeamLayout runs #then the failure is swallowed without ever attempting to kill the caller's focusWindowId", async () => {
     // given
     const { removeTeamLayout } = await loadLayoutModule()
-    let killWindowCallCount = 0
     runTmuxCommandMock.mockImplementation((_tmuxPath: string, args: Array<string>, _options?: unknown) => {
       if (args[0] === "kill-window") {
-        killWindowCallCount += 1
-        return Promise.resolve(createTmuxCommandResult("", killWindowCallCount > 1))
+        return Promise.resolve(createTmuxCommandResult("", false))
       }
 
       const command = args[0]
@@ -352,10 +498,9 @@ describe("team-layout-tmux", () => {
 
     // then
     const commands = getCommands().filter((args) => args[0] === "kill-window")
-    expect(commands).toEqual([
-      ["kill-window", "-t", "@10"],
-      ["kill-window", "-t", "@11"],
-    ])
+    // Only the grid window (@11) is attempted; the caller's window (@10) is
+    // never touched even when the grid kill fails.
+    expect(commands).toEqual([["kill-window", "-t", "@11"]])
   })
 
   test("skips all panes when lead member missing", async () => {
@@ -372,6 +517,27 @@ describe("team-layout-tmux", () => {
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
   })
 
+  test("#given detectServerPortOwnership returns hasOwnPort=false #when createTeamLayout runs #then createLiveTailWindow returns null without spawning a new-window", async () => {
+    // given
+    const deps: TeamLayoutDeps = {
+      runTmuxCommand: runTmuxCommandMock,
+      isServerRunning: isServerRunningMock,
+      getTmuxPath: async () => "tmux",
+      resolveCallerTmuxSession: async () => ({ sessionId: "$7", paneId: process.env.TMUX_PANE ?? "%42", windowTarget: "test-session:0" }),
+      detectServerPortOwnership: async () => ({ hasOwnPort: false, reason: "test: no LISTEN socket" }),
+    }
+    const members = [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }]
+
+    // when
+    const result = await createTeamLayout("run-no-port", members, tmuxMgr as never, deps)
+
+    // then
+    expect(result).toBeNull()
+    const commands = getCommands()
+    expect(commands.some((args) => args[0] === "new-window")).toBe(false)
+  })
+
+
   describe("createTeamLayout - focus/grid window topology", () => {
     test("#given caller inside tmux #when createTeamLayout runs #then uses the caller window without a new session", async () => {
       // given
@@ -387,7 +553,7 @@ describe("team-layout-tmux", () => {
       // then
       const commands = getCommands()
       expect(commands.some((args) => args[0] === "new-session")).toBe(false)
-      expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
+      expect(commands.filter((args) => args[0] === "new-window").length).toBe(1)
       expect(commands.some((args) => args[0] === "split-window" && args.includes(process.env.TMUX_PANE ?? ""))).toBe(true)
     })
 
@@ -418,7 +584,7 @@ describe("team-layout-tmux", () => {
       expect(splitCalls).toEqual([
         ["split-window", "-t", process.env.TMUX_PANE ?? "", "-h", "-d", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", "/tmp/m1"],
       ])
-      expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
+      expect(commands.filter((args) => args[0] === "new-window").length).toBe(1)
     })
 
     test("#given 3 members #when createTeamLayout runs #then focusPanesByMember contains 3 distinct pane ids", async () => {
@@ -439,7 +605,7 @@ describe("team-layout-tmux", () => {
       expect(new Set(Object.values(result?.focusPanesByMember ?? {})).size).toBe(3)
     })
 
-    test("#given layout created #when createTeamLayout runs #then it records focus panes only", async () => {
+    test("#given layout created #when createTeamLayout runs #then it records focus and live-tail panes", async () => {
       // given
       const { createTeamLayout } = await loadLayoutModule()
       const members = [
@@ -454,10 +620,10 @@ describe("team-layout-tmux", () => {
       const commands = getCommands()
       expect(result).not.toBeNull()
       expect(Object.keys(result?.focusPanesByMember ?? {}).sort()).toEqual(["m1", "m2"])
-      expect(Object.keys(result?.gridPanesByMember ?? {})).toEqual([])
+      expect(Object.keys(result?.gridPanesByMember ?? {}).sort()).toEqual(["m1", "m2"])
       expect(result?.focusWindowId).toBe("test-session:0")
-      expect(result?.gridWindowId).toBeUndefined()
-      expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
+      expect(result?.gridWindowId).toBe("@1")
+      expect(commands.filter((args) => args[0] === "new-window").length).toBe(1)
       expect(commands.some((args) => args[0] === "send-keys" && args.includes("Enter"))).toBe(true)
     })
   })

--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -517,8 +517,12 @@ describe("team-layout-tmux", () => {
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
   })
 
-  test("#given detectServerPortOwnership returns hasOwnPort=false #when createTeamLayout runs #then createLiveTailWindow returns null without spawning a new-window", async () => {
-    // given
+  test("#given detectServerPortOwnership returns hasOwnPort=false #when createTeamLayout runs #then it bails before any caller-window pane mutation (#4024 finding 3)", async () => {
+    // given — ownership check fails BEFORE createTeamLayoutInCallerWindow runs;
+    // the bail-early gate must prevent both split-window (caller window panes)
+    // AND new-window (live-tail window) from running. Previously only new-window
+    // was prevented, which left caller-window attach panes orphaned with no
+    // cleanup path — the leak the maintainer flagged on PR #4024.
     const deps: TeamLayoutDeps = {
       runTmuxCommand: runTmuxCommandMock,
       isServerRunning: isServerRunningMock,
@@ -535,6 +539,10 @@ describe("team-layout-tmux", () => {
     expect(result).toBeNull()
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "new-window")).toBe(false)
+    // bail-early invariant: caller window panes must NOT be created
+    expect(commands.some((args) => args[0] === "split-window")).toBe(false)
+    // and we must not have started sending opencode attach commands either
+    expect(commands.some((args) => args[0] === "send-keys")).toBe(false)
   })
 
 

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -139,11 +139,8 @@ async function createLiveTailWindow(
   deps: TeamLayoutDeps,
   options?: TeamLayoutOptions,
 ): Promise<{ gridWindowId: string; gridPanesByMember: Record<string, string> } | null> {
-  // #4071 finding 3 (bail-early): server-port ownership is now gated by the
-  // caller (createTeamLayout) BEFORE any caller-window pane creation. By the
-  // time we get here, ownership has been verified — if it hadn't, we'd never
-  // be called. No defensive re-check here so the bail-early invariant is the
-  // single source of truth.
+  // Server-port ownership is gated by createTeamLayout (#4071 finding 3 bail-early).
+  // No defensive re-check here — the caller is the single source of truth.
   const [firstMember, ...remainingMembers] = members
   if (!firstMember) return null
 

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -282,7 +282,14 @@ export async function createTeamLayout(
       deps,
       options,
     )
-    if (!liveTail) return null
+    if (!liveTail) {
+      // Rollback: kill focus panes that were already created by
+      // createTeamLayoutInCallerWindow so they are not left orphaned.
+      for (const paneId of Object.values(focus.focusPanesByMember)) {
+        await deps.runTmuxCommand(tmuxPath, ["kill-pane", "-t", paneId]).catch(() => {})
+      }
+      return null
+    }
 
     // Defence-in-depth: even though every new-window/split-window above
     // uses -d, explicitly restore the caller's window and pane so the user

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -3,16 +3,20 @@ import { shellSingleQuote } from "../../../shared/shell-env"
 import * as sharedTmuxModule from "../../../shared/tmux"
 import * as tmuxPathResolverModule from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
+import { buildLiveTailCommand } from "./live-tail"
 import { resolveCallerTmuxSession } from "./resolve-caller-tmux-session"
+import { detectServerPortOwnership } from "./server-port-ownership"
 
 type TeamLayoutMember = { name: string; sessionId: string; worktreePath?: string }
 type TmuxCommandResult = Awaited<ReturnType<typeof sharedTmuxModule.runTmuxCommand>>
+type TeamLayoutOptions = { allowInsecureLocalTls?: boolean }
 
 export type TeamLayoutDeps = {
   runTmuxCommand: (tmuxPath: string, args: Array<string>, options?: Parameters<typeof sharedTmuxModule.runTmuxCommand>[2]) => Promise<TmuxCommandResult>
   isServerRunning: typeof sharedTmuxModule.isServerRunning
   getTmuxPath: typeof tmuxPathResolverModule.getTmuxPath
   resolveCallerTmuxSession: typeof resolveCallerTmuxSession
+  detectServerPortOwnership: typeof detectServerPortOwnership
 }
 
 const defaultDeps: TeamLayoutDeps = {
@@ -20,6 +24,7 @@ const defaultDeps: TeamLayoutDeps = {
   isServerRunning: sharedTmuxModule.isServerRunning,
   getTmuxPath: tmuxPathResolverModule.getTmuxPath,
   resolveCallerTmuxSession,
+  detectServerPortOwnership,
 }
 
 export type TeamLayoutResult = {
@@ -49,6 +54,10 @@ function buildAttachCommand(member: TeamLayoutMember, serverUrl: string): string
   return `opencode attach ${shellSingleQuote(serverUrl)} --session ${shellSingleQuote(member.sessionId)} --dir ${shellSingleQuote(getPaneWorkingDirectory(member))}`
 }
 
+function buildMemberLiveTailCommand(member: TeamLayoutMember, serverUrl: string, options?: TeamLayoutOptions): string {
+  return buildLiveTailCommand(serverUrl, member.sessionId, { allowInsecureTls: options?.allowInsecureLocalTls })
+}
+
 async function listPanesInWindow(tmuxPath: string, windowTarget: string, deps: TeamLayoutDeps): Promise<Array<string>> {
   const result = await deps.runTmuxCommand(tmuxPath, ["list-panes", "-t", windowTarget, "-F", "#{pane_id}"])
   if (!result.success || !result.output) return []
@@ -60,12 +69,16 @@ function selectExistingTeammatePane(teammatePanes: Array<string>, callerPaneId: 
 }
 
 function buildSplitArgs(callerPaneId: string, teammatePanes: Array<string>, member: TeamLayoutMember): Array<string> {
+  // -d keeps the active pane on the caller; without it, every split steals
+  // focus to the freshly created teammate pane and the user sees their
+  // cursor flicker across each spawn during team creation.
   if (teammatePanes.length === 0) {
     return ["split-window", "-t", callerPaneId, "-h", "-d", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", getPaneWorkingDirectory(member)]
   }
 
   return [
     "split-window",
+    "-d",
     "-t",
     selectExistingTeammatePane(teammatePanes, callerPaneId),
     teammatePanes.length % 2 === 1 ? "-v" : "-h",
@@ -107,10 +120,89 @@ async function createTeamLayoutInCallerWindow(
   const resizeResult = await deps.runTmuxCommand(tmuxPath, ["resize-pane", "-t", callerPaneId, "-x", "30%"])
   if (!resizeResult.success) return null
 
+  await deps.runTmuxCommand(tmuxPath, ["refresh-client"])
+
   return { focusWindowId: windowTarget, focusPanesByMember: panesByMember }
 }
 
-export async function createTeamLayout(teamRunId: string, members: Array<TeamLayoutMember>, tmuxMgr: TmuxSessionManager, deps: TeamLayoutDeps = defaultDeps): Promise<TeamLayoutResult | null> {
+function parseNewWindowOutput(output: string): { windowId: string; paneId: string } | null {
+  const [windowId, paneId] = output.trim().split(/\s+/, 2)
+  if (!windowId || !paneId) return null
+  return { windowId, paneId }
+}
+
+async function createLiveTailWindow(
+  tmuxPath: string,
+  targetSessionId: string,
+  members: Array<TeamLayoutMember>,
+  serverUrl: string,
+  deps: TeamLayoutDeps,
+  options?: TeamLayoutOptions,
+): Promise<{ gridWindowId: string; gridPanesByMember: Record<string, string> } | null> {
+  const ownership = await deps.detectServerPortOwnership()
+  if (!ownership.hasOwnPort) {
+    log("[team-mode] skipping live-tail layout — instance has no own server port", {
+      reason: ownership.reason,
+    })
+    return null
+  }
+
+  const [firstMember, ...remainingMembers] = members
+  if (!firstMember) return null
+
+  const liveWindowName = `team-live-${Date.now().toString(36)}`
+  // -d is critical: without it, tmux auto-switches the attached client to
+  // the new live-tail window, stranding the user away from their work
+  // window and forcing a manual `prefix + 0` to return.
+  const created = await deps.runTmuxCommand(tmuxPath, [
+    "new-window",
+    "-d",
+    "-t",
+    targetSessionId,
+    "-n",
+    liveWindowName,
+    "-P",
+    "-F",
+    "#{window_id} #{pane_id}",
+    "-c",
+    getPaneWorkingDirectory(firstMember),
+  ])
+  if (!created.success || !created.output) return null
+
+  const parsed = parseNewWindowOutput(created.output)
+  if (!parsed) return null
+
+  const panesByMember: Record<string, string> = { [firstMember.name]: parsed.paneId }
+  let livePanes = [parsed.paneId]
+
+  await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", parsed.paneId, "-T", `${firstMember.name} live`])
+  await deps.runTmuxCommand(tmuxPath, ["send-keys", "-t", parsed.paneId, buildMemberLiveTailCommand(firstMember, serverUrl, options), "Enter"])
+
+  for (const member of remainingMembers) {
+    const split = await deps.runTmuxCommand(tmuxPath, buildSplitArgs(parsed.paneId, livePanes, member))
+    if (!split.success || !split.output) return null
+
+    const paneId = split.output.trim()
+    livePanes = [...livePanes, paneId]
+    panesByMember[member.name] = paneId
+    await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", paneId, "-T", `${member.name} live`])
+    await deps.runTmuxCommand(tmuxPath, ["send-keys", "-t", paneId, buildMemberLiveTailCommand(member, serverUrl, options), "Enter"])
+  }
+
+  const layoutResult = await deps.runTmuxCommand(tmuxPath, ["select-layout", "-t", parsed.windowId, "tiled"])
+  if (!layoutResult.success) return null
+  await deps.runTmuxCommand(tmuxPath, ["refresh-client"])
+
+  return { gridWindowId: parsed.windowId, gridPanesByMember: panesByMember }
+}
+
+export async function createTeamLayout(
+  teamRunId: string,
+  members: Array<TeamLayoutMember>,
+  tmuxMgr: TmuxSessionManager,
+  deps: TeamLayoutDeps = defaultDeps,
+  options?: TeamLayoutOptions,
+): Promise<TeamLayoutResult | null> {
   if (!canVisualize()) {
     log("tmux visualization unavailable, skipping")
     return null
@@ -148,14 +240,38 @@ export async function createTeamLayout(teamRunId: string, members: Array<TeamLay
       return null
     }
 
-    const focus = await createTeamLayoutInCallerWindow(tmuxPath, callerSession.paneId, callerSession.windowTarget, members, serverUrl, deps)
+    const focus = await createTeamLayoutInCallerWindow(
+      tmuxPath,
+      callerSession.paneId,
+      callerSession.windowTarget,
+      members,
+      serverUrl,
+      deps,
+    )
     if (!focus) return null
+
+    const liveTail = await createLiveTailWindow(
+      tmuxPath,
+      callerSession.sessionId,
+      members,
+      serverUrl,
+      deps,
+      options,
+    )
+    if (!liveTail) return null
+
+    // Defence-in-depth: even though every new-window/split-window above
+    // uses -d, explicitly restore the caller's window and pane so the user
+    // is never stranded on the live-tail window or a teammate pane after
+    // team_create returns. Failures are non-fatal — the layout is built.
+    await deps.runTmuxCommand(tmuxPath, ["select-window", "-t", callerSession.windowTarget])
+    await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", callerSession.paneId])
 
     return {
       focusWindowId: focus.focusWindowId,
-      gridWindowId: undefined,
+      gridWindowId: liveTail.gridWindowId,
       focusPanesByMember: focus.focusPanesByMember,
-      gridPanesByMember: {},
+      gridPanesByMember: liveTail.gridPanesByMember,
       targetSessionId: callerSession.sessionId,
       ownedSession: false,
     }
@@ -194,15 +310,35 @@ export async function removeTeamLayout(
           log("tmux team pane cleanup failed", { teamRunId, paneId })
         }
       }
-      return
     }
 
-    for (const windowId of [cleanupTarget.focusWindowId, cleanupTarget.gridWindowId]) {
+    // When `ownedSession=false`, `focusWindowId` is the CALLER'S window
+    // (createTeamLayoutInCallerWindow reuses it); killing it would destroy
+    // the lead's pane and any sibling user panes. Only `gridWindowId` is
+    // ours to reap in that case. Even after pane cleanup, explicitly reaping
+    // the grid window prevents an empty live-tail window from being left
+    // behind on tmux versions that do not close it after the last pane kill.
+    const windowsToKill = cleanupTarget.ownedSession === false
+      ? [cleanupTarget.gridWindowId]
+      : [cleanupTarget.focusWindowId, cleanupTarget.gridWindowId]
+    for (const windowId of windowsToKill) {
       if (!windowId) continue
       try {
         await resolvedDeps.runTmuxCommand(tmuxPath, ["kill-window", "-t", windowId])
       } catch (windowError) {
         log("tmux team layout window cleanup failed", { teamRunId, windowId, error: String(windowError) })
+      }
+    }
+
+    // If the user was viewing the just-killed grid window, tmux auto-jumps
+    // to a neighbouring window — which may not be the caller's. Explicitly
+    // restore the caller's window when we know it is safe (ownedSession=false
+    // means focusWindowId IS the caller's window, never something we own).
+    if (cleanupTarget.ownedSession === false && cleanupTarget.focusWindowId) {
+      try {
+        await resolvedDeps.runTmuxCommand(tmuxPath, ["select-window", "-t", cleanupTarget.focusWindowId])
+      } catch (selectError) {
+        log("tmux team layout window restore failed", { teamRunId, error: String(selectError) })
       }
     }
   } catch (error) {

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -139,14 +139,11 @@ async function createLiveTailWindow(
   deps: TeamLayoutDeps,
   options?: TeamLayoutOptions,
 ): Promise<{ gridWindowId: string; gridPanesByMember: Record<string, string> } | null> {
-  const ownership = await deps.detectServerPortOwnership()
-  if (!ownership.hasOwnPort) {
-    log("[team-mode] skipping live-tail layout — instance has no own server port", {
-      reason: ownership.reason,
-    })
-    return null
-  }
-
+  // #4071 finding 3 (bail-early): server-port ownership is now gated by the
+  // caller (createTeamLayout) BEFORE any caller-window pane creation. By the
+  // time we get here, ownership has been verified — if it hadn't, we'd never
+  // be called. No defensive re-check here so the bail-early invariant is the
+  // single source of truth.
   const [firstMember, ...remainingMembers] = members
   if (!firstMember) return null
 
@@ -237,6 +234,36 @@ export async function createTeamLayout(
     const callerSession = await deps.resolveCallerTmuxSession(tmuxPath)
     if (!callerSession) {
       log("tmux visualization requires a resolvable caller tmux pane, skipping", { teamRunId })
+      return null
+    }
+
+    // #4071 finding 3 (bail-early): verify the live-tail prerequisite —
+    // server-port ownership tied to the actual OpenCode server URL port —
+    // BEFORE creating any caller-window panes. Previously this check lived
+    // inside createLiveTailWindow, which meant we created the caller-window
+    // attach panes first and only then discovered ownership was missing,
+    // leaving those panes orphaned with no cleanup path. Gating up here
+    // makes the no-ownership path a clean no-op: no panes, no leak.
+    //
+    // #4071 finding 2: pass expectedPort from serverUrl so ownership is
+    // anchored to the actual OpenCode listener, not just any local socket.
+    const expectedPort = (() => {
+      try {
+        const parsed = new URL(serverUrl).port
+        const n = Number(parsed)
+        return Number.isFinite(n) && n > 0 ? n : undefined
+      } catch {
+        return undefined
+      }
+    })()
+    const ownership = await deps.detectServerPortOwnership({ expectedPort })
+    if (!ownership.hasOwnPort) {
+      log("[team-mode] live-tail prerequisite failed; skipping team layout before any pane creation (#4024)", {
+        teamRunId,
+        serverUrl,
+        expectedPort,
+        reason: ownership.reason,
+      })
       return null
     }
 

--- a/src/features/team-mode/team-layout-tmux/live-tail.test.ts
+++ b/src/features/team-mode/team-layout-tmux/live-tail.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach } from "bun:test"
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { _resetCacheForTests, buildLiveTailCommand, materializeLiveTailScript } from "./live-tail"
+
+describe("buildLiveTailCommand", () => {
+  beforeEach(() => {
+    _resetCacheForTests()
+  })
+
+  test("emits a python invocation with shell-quoted args", () => {
+    const cmd = buildLiveTailCommand("http://127.0.0.1:4096", "ses_abc123")
+    expect(cmd).toContain("python3 -u ")
+    expect(cmd).toContain("'http://127.0.0.1:4096'")
+    expect(cmd).toContain("'ses_abc123'")
+    expect(cmd).not.toContain("opencode attach")
+  })
+
+  test("escapes single quotes in url and session id", () => {
+    const cmd = buildLiveTailCommand("http://x.test/'evil", "ses_'evil")
+    expect(cmd).not.toMatch(/'\s'evil/)
+    expect(cmd.split("'").length).toBeGreaterThan(4)
+  })
+
+  test("appends --insecure only when explicitly enabled", () => {
+    const strictCmd = buildLiveTailCommand("https://127.0.0.1:4096", "ses_strict")
+    const insecureCmd = buildLiveTailCommand("https://127.0.0.1:4096", "ses_insecure", { allowInsecureTls: true })
+    expect(strictCmd).not.toContain(" --insecure")
+    expect(insecureCmd).toContain(" --insecure")
+  })
+
+  test("appends --no-footer when disableStatusFooter is true", () => {
+    const cmd = buildLiveTailCommand("http://x", "ses_y", { disableStatusFooter: true })
+    expect(cmd).toContain(" --no-footer")
+  })
+
+  test("omits --no-footer when disableStatusFooter is false or absent", () => {
+    const cmdDefault = buildLiveTailCommand("http://x", "ses_y")
+    const cmdFalse = buildLiveTailCommand("http://x", "ses_y", { disableStatusFooter: false })
+    expect(cmdDefault).not.toContain("--no-footer")
+    expect(cmdFalse).not.toContain("--no-footer")
+  })
+
+  test("references a file that materialize wrote with python content", () => {
+    const cmd = buildLiveTailCommand("http://127.0.0.1:4096", "ses_abc123")
+    const match = cmd.match(/python3 -u '([^']+)'/)
+    expect(match).not.toBeNull()
+    const path = match![1]!
+    expect(existsSync(path)).toBe(true)
+    const contents = readFileSync(path, "utf8")
+    expect(contents).toContain("Live-tail an OpenCode session")
+    expect(contents).toContain("/event")
+  })
+
+  test("materializeLiveTailScript writes 0700 mode and is idempotent", () => {
+    const path1 = materializeLiveTailScript()
+    const path2 = materializeLiveTailScript()
+    expect(path1).toBe(path2)
+    const mode = statSync(path1).mode & 0o777
+    expect(mode).toBe(0o700)
+  })
+
+  test("materialized script ends with a newline so python parses it cleanly", () => {
+    const path = materializeLiveTailScript()
+    const contents = readFileSync(path, "utf8")
+    expect(contents.endsWith("\n")).toBe(true)
+  })
+
+  test("materialized script declares the expected helper functions for renderer logic", () => {
+    // Smoke check that protects against accidentally bundling a stale script.
+    const path = materializeLiveTailScript()
+    const contents = readFileSync(path, "utf8")
+    for (const symbol of [
+      "def extract_task_line(",
+      "def summarize_peer_message(",
+      "class SessionState",
+      "def render_banner(",
+      "_KICKOFF_META_PREFIXES",
+    ]) {
+      expect(contents).toContain(symbol)
+    }
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/live-tail.ts
+++ b/src/features/team-mode/team-layout-tmux/live-tail.ts
@@ -1,0 +1,44 @@
+// Live-tail command builder for team-mode worker tmux panes.
+//
+// OpenCode TUI's `attach --session <child>` enters a static subagent-detail
+// view (see binary string "session.child.promptDisabled") for any session
+// that has a parentID. Team workers always carry parentID=lead, so team mode
+// now keeps the attach view in the main window and runs this Python tailer in
+// a companion window for the streaming feed.
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { shellSingleQuote } from "../../../shared/shell-env"
+// @ts-expect-error - bun text import
+import liveTailScript from "../../../../script/team-pane-live-tail.py" with { type: "text" }
+
+const SCRIPT_FILENAME = "omo-team-pane-live-tail.py"
+
+let cachedPath: string | null = null
+
+export function materializeLiveTailScript(): string {
+  if (cachedPath !== null) return cachedPath
+  const dir = join(tmpdir(), `omo-team-${process.pid}`)
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const path = join(dir, SCRIPT_FILENAME)
+  writeFileSync(path, liveTailScript, { mode: 0o700 })
+  cachedPath = path
+  return path
+}
+
+type LiveTailCommandOptions = {
+  allowInsecureTls?: boolean
+  disableStatusFooter?: boolean
+}
+
+export function buildLiveTailCommand(serverUrl: string, sessionId: string, options?: LiveTailCommandOptions): string {
+  const scriptPath = materializeLiveTailScript()
+  const insecureFlag = options?.allowInsecureTls ? " --insecure" : ""
+  const noFooterFlag = options?.disableStatusFooter ? " --no-footer" : ""
+  return `python3 -u ${shellSingleQuote(scriptPath)} ${shellSingleQuote(serverUrl)} ${shellSingleQuote(sessionId)}${insecureFlag}${noFooterFlag}`
+}
+
+export function _resetCacheForTests(): void {
+  cachedPath = null
+}

--- a/src/features/team-mode/team-layout-tmux/live-tail.ts
+++ b/src/features/team-mode/team-layout-tmux/live-tail.ts
@@ -10,7 +10,6 @@ import { mkdirSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { shellSingleQuote } from "../../../shared/shell-env"
-// @ts-expect-error - bun text import
 import liveTailScript from "../../../../script/team-pane-live-tail.py" with { type: "text" }
 
 const SCRIPT_FILENAME = "omo-team-pane-live-tail.py"

--- a/src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts
+++ b/src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it, mock } from "bun:test"
+
+import { reapStaleTailers, type ReapDeps } from "./reap-stale-tailers"
+
+describe("reapStaleTailers", () => {
+  it("#given mixed reachable and unreachable URLs #when reap #then dispatches SIGTERM only to PIDs whose URL is unreachable", async () => {
+    const killed: number[] = []
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 1, url: "http://A:4096" },
+        { pid: 2, url: "http://B:4096" },
+      ],
+      probeUrl: async (url) => url === "http://A:4096",
+      killPid: (pid) => {
+        killed.push(pid)
+      },
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(killed).toEqual([2])
+    expect(result.reapedPids).toEqual([2])
+    expect(result.livePids).toEqual([1])
+    expect(result.unreachableUrls).toEqual(["http://B:4096"])
+  })
+
+  it("#given multiple PIDs sharing the same URL #when reap #then probeUrl is invoked exactly once for that URL", async () => {
+    const probeUrlMock = mock(async (_url: string, _timeoutMs: number) => false)
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 10, url: "http://X:4096" },
+        { pid: 11, url: "http://X:4096" },
+        { pid: 12, url: "http://X:4096" },
+      ],
+      probeUrl: probeUrlMock,
+      killPid: () => {},
+    }
+
+    await reapStaleTailers({ deps })
+
+    expect(probeUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given killPid throws for first PID #when reap #then resolves and reapedPids contains second PID only", async () => {
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 100, url: "http://dead:4096" },
+        { pid: 101, url: "http://dead:4096" },
+      ],
+      probeUrl: async () => false,
+      killPid: (pid) => {
+        if (pid === 100) throw new Error("ESRCH")
+      },
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(result.reapedPids).toEqual([101])
+    expect(result.unreachableUrls).toEqual(["http://dead:4096"])
+  })
+
+  it("#given empty process list #when reap #then returns all-empty result", async () => {
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [],
+      probeUrl: async () => true,
+      killPid: () => {},
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(result).toEqual({ reapedPids: [], livePids: [], unreachableUrls: [] })
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts
+++ b/src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts
@@ -1,0 +1,152 @@
+import { log } from "../../../shared"
+
+export type ReapResult = {
+  reapedPids: number[]
+  livePids: number[]
+  unreachableUrls: string[]
+}
+
+export type ReapDeps = {
+  listTailerProcesses: () => Promise<Array<{ pid: number; url: string }>>
+  probeUrl: (url: string, timeoutMs: number) => Promise<boolean>
+  killPid: (pid: number) => void
+}
+
+const TAILER_SCRIPT_NAME = "omo-team-pane-live-tail.py"
+
+async function listTailerProcessesLinux(): Promise<Array<{ pid: number; url: string }>> {
+  const { readdirSync, readFileSync } = await import("node:fs")
+  const results: Array<{ pid: number; url: string }> = []
+
+  let entries: string[]
+  try {
+    entries = readdirSync("/proc")
+  } catch {
+    return results
+  }
+
+  for (const entry of entries) {
+    const pid = parseInt(entry, 10)
+    if (isNaN(pid)) continue
+
+    try {
+      const cmdlineRaw = readFileSync(`/proc/${pid}/cmdline`, "utf8")
+      const args = cmdlineRaw.split("\0").filter((a) => a.length > 0)
+      const scriptIndex = args.findIndex((a) => a.endsWith(TAILER_SCRIPT_NAME))
+      if (scriptIndex === -1) continue
+      const url = args[scriptIndex + 1]
+      if (!url) continue
+      results.push({ pid, url })
+    } catch {
+      // process may have exited or no permission
+    }
+  }
+
+  return results
+}
+
+async function listTailerProcessesDarwin(): Promise<Array<{ pid: number; url: string }>> {
+  const { spawn } = await import("node:child_process")
+  return new Promise((resolve) => {
+    const results: Array<{ pid: number; url: string }> = []
+    const proc = spawn("ps", ["-axo", "pid=,command="])
+    let stdout = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+
+    proc.on("close", () => {
+      for (const line of stdout.split("\n")) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        const spaceIdx = trimmed.indexOf(" ")
+        if (spaceIdx === -1) continue
+        const pidStr = trimmed.slice(0, spaceIdx).trim()
+        const command = trimmed.slice(spaceIdx + 1).trim()
+        const pid = parseInt(pidStr, 10)
+        if (isNaN(pid)) continue
+        const args = command.split(" ")
+        const scriptIndex = args.findIndex((a) => a.endsWith(TAILER_SCRIPT_NAME))
+        if (scriptIndex === -1) continue
+        const url = args[scriptIndex + 1]
+        if (!url) continue
+        results.push({ pid, url })
+      }
+      resolve(results)
+    })
+
+    proc.on("error", () => resolve(results))
+  })
+}
+
+async function listTailerProcesses(): Promise<Array<{ pid: number; url: string }>> {
+  if (process.platform === "linux") {
+    return listTailerProcessesLinux()
+  }
+  if (process.platform === "darwin") {
+    return listTailerProcessesDarwin()
+  }
+  log(`[team-mode] reap-stale-tailers: unsupported platform '${process.platform}', skipping reap`)
+  return []
+}
+
+async function probeUrl(url: string, timeoutMs: number): Promise<boolean> {
+  const base = url.replace(/\/+$/, "")
+  try {
+    await fetch(`${base}/path`, { method: "HEAD", signal: AbortSignal.timeout(timeoutMs) })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function killPid(pid: number): void {
+  process.kill(pid, "SIGTERM")
+}
+
+export const defaultDeps: ReapDeps = {
+  listTailerProcesses,
+  probeUrl,
+  killPid,
+}
+
+export async function reapStaleTailers(opts?: {
+  probeTimeoutMs?: number
+  deps?: ReapDeps
+}): Promise<ReapResult> {
+  const deps = opts?.deps ?? defaultDeps
+  const procs = await deps.listTailerProcesses()
+  const byUrl = new Map<string, number[]>()
+  for (const p of procs) {
+    const arr = byUrl.get(p.url) ?? []
+    arr.push(p.pid)
+    byUrl.set(p.url, arr)
+  }
+
+  const reaped: number[] = []
+  const live: number[] = []
+  const unreachable: string[] = []
+
+  await Promise.all(
+    [...byUrl.entries()].map(async ([url, pids]) => {
+      const ok = await deps.probeUrl(url, opts?.probeTimeoutMs ?? 1500)
+      if (ok) {
+        live.push(...pids)
+        return
+      }
+      unreachable.push(url)
+      for (const pid of pids) {
+        try {
+          deps.killPid(pid)
+          reaped.push(pid)
+        } catch (e) {
+          log("[team-mode] reap-stale-tailers SIGTERM failed", { pid, url, error: String(e) })
+        }
+      }
+    }),
+  )
+
+  log("[team-mode] reap-stale-tailers complete", { reaped, live, unreachable })
+  return { reapedPids: reaped, livePids: live, unreachableUrls: unreachable }
+}

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { detectServerPortOwnership, type ServerPortOwnershipDeps } from "./server-port-ownership"
+
+// /proc/net/tcp header line
+const TCP_HEADER =
+  "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+
+// Build a single /proc/net/tcp row. state defaults to "0A" (LISTEN).
+function tcpRow(localAddr: string, state = "0A"): string {
+  return `   0: ${localAddr} 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000 1000        0 12345 1 0000000000000000 100 0 0 10 0\n`
+}
+
+function makeDeps(files: Record<string, string>): ServerPortOwnershipDeps {
+  return {
+    readFile: async (path: string) => {
+      if (Object.prototype.hasOwnProperty.call(files, path)) {
+        return files[path]!
+      }
+      const err = Object.assign(new Error(`ENOENT: no such file or directory, open '${path}'`), {
+        code: "ENOENT",
+      })
+      throw err
+    },
+  }
+}
+
+describe("detectServerPortOwnership", () => {
+  const pid = 99999
+
+  it("returns hasOwnPort:true with decoded port when one LISTEN socket exists on 127.0.0.1", async () => {
+    // 0100007F:1F90 → 127.0.0.1:8080 (0x1F90 = 8080)
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x1f90) // 8080
+  })
+
+  it("returns hasOwnPort:false with reason when no LISTEN socket exists", async () => {
+    // state 01 = ESTABLISHED, not a LISTEN socket
+    const content = TCP_HEADER + tcpRow("0100007F:1F90", "01")
+    const deps = makeDeps({
+      [`/proc/${pid}/net/tcp`]: content,
+      [`/proc/${pid}/net/tcp6`]: TCP_HEADER, // empty — no rows
+    })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toContain("no LISTEN socket")
+  })
+
+  it("returns hasOwnPort:true with a port when multiple LISTEN sockets exist", async () => {
+    // Two LISTEN sockets: 0100007F:1F90 (8080) and 00000000:2000 (8192)
+    const content =
+      TCP_HEADER + tcpRow("0100007F:1F90") + "   1: 00000000:2000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000        0 12346 1 0000000000000000 100 0 0 10 0\n"
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    // Must return one of the two ports
+    expect([0x1f90, 0x2000]).toContain(result.port)
+  })
+
+  it("returns hasOwnPort:false with path-specific reason when /proc tcp file is not found", async () => {
+    // No files → readFile throws ENOENT for every path
+    const deps = makeDeps({})
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toMatch(/\/proc\/\d+\/net\/tcp not found/)
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
@@ -63,8 +63,8 @@ describe("detectServerPortOwnership", () => {
     const result = await detectServerPortOwnership({ pid, deps })
 
     expect(result.hasOwnPort).toBe(true)
-    // Must return one of the two ports
-    expect([0x1f90, 0x2000]).toContain(result.port)
+    // Must return one of the two ports (cast away undefined to satisfy toContain overload)
+    expect([0x1f90, 0x2000]).toContain(result.port as number)
   })
 
   it("returns hasOwnPort:false with path-specific reason when /proc tcp file is not found", async () => {
@@ -75,5 +75,65 @@ describe("detectServerPortOwnership", () => {
 
     expect(result.hasOwnPort).toBe(false)
     expect(result.reason).toMatch(/\/proc\/\d+\/net\/tcp not found/)
+  })
+
+  // #4071 finding 1: simulate macOS from a Linux runner via injected platform dep.
+  // With injected readFile present, the deps path must be consulted BEFORE the
+  // platform fallback so the parsing path is exercisable on any host.
+  it("on simulated darwin with injected readFile → parses normally (does NOT short-circuit to 'assume ownership')", async () => {
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps: ServerPortOwnershipDeps = {
+      readFile: async (path: string) => {
+        if (path === `/proc/${pid}/net/tcp`) return content
+        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+        throw err
+      },
+      getPlatform: () => "darwin",
+    }
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x1f90)
+    expect(result.reason).toBeUndefined()
+  })
+
+  it("on simulated darwin when injected readFile raises ENOENT → falls back to 'assume ownership'", async () => {
+    const deps: ServerPortOwnershipDeps = {
+      readFile: async () => {
+        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+        throw err
+      },
+      getPlatform: () => "darwin",
+    }
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.reason).toMatch(/platform unsupported/)
+  })
+
+  // #4071 finding 2: ownership anchored to the actual OpenCode server URL port.
+  it("with expectedPort matching a parsed LISTEN port → returns hasOwnPort:true with that port", async () => {
+    const content =
+      TCP_HEADER +
+      tcpRow("0100007F:1F90") +
+      "   1: 00000000:2000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000        0 12346 1 0000000000000000 100 0 0 10 0\n"
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, expectedPort: 0x2000, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x2000)
+  })
+
+  it("with expectedPort NOT matching any parsed LISTEN port → returns hasOwnPort:false naming the expected port", async () => {
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, expectedPort: 9999, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toContain("9999")
   })
 })

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
@@ -1,0 +1,121 @@
+// Detects whether the current process owns a local LISTEN socket.
+//
+// On Linux, reads /proc/<pid>/net/tcp (and tcp6) to find sockets in state 0A
+// (LISTEN) bound to a local interface (127.0.0.1 or 0.0.0.0). Returns the
+// first port found. On non-Linux platforms, ownership is assumed to avoid
+// blocking macOS/Windows development.
+
+import { readFile as fsReadFile } from "node:fs/promises"
+import { log } from "../../../shared"
+
+export type ServerPortOwnership = {
+  hasOwnPort: boolean
+  port?: number   // present when hasOwnPort
+  reason?: string // present when !hasOwnPort
+}
+
+export type ServerPortOwnershipDeps = {
+  readFile: (path: string) => Promise<string>
+}
+
+const LISTEN_STATE = "0A"
+
+// IPv4 local addresses in /proc/net/tcp little-endian hex format
+const IPV4_LOOPBACK_HEX = "0100007F" // 127.0.0.1
+const IPV4_WILDCARD_HEX = "00000000" // 0.0.0.0
+
+// IPv6 local addresses in /proc/net/tcp6 little-endian 128-bit hex format
+const IPV6_WILDCARD_HEX = "00000000000000000000000000000000" // ::
+const IPV6_LOOPBACK_HEX = "00000000000000000000000001000000" // ::1
+const IPV6_MAPPED_LOOPBACK_HEX = "0000000000000000FFFF00000100007F" // ::ffff:127.0.0.1
+
+function isLocalAddress(hexIp: string): boolean {
+  return (
+    hexIp === IPV4_LOOPBACK_HEX ||
+    hexIp === IPV4_WILDCARD_HEX ||
+    hexIp === IPV6_WILDCARD_HEX ||
+    hexIp === IPV6_LOOPBACK_HEX ||
+    hexIp === IPV6_MAPPED_LOOPBACK_HEX
+  )
+}
+
+function parseTcpContent(content: string): number | null {
+  const lines = content.split("\n")
+  // Skip header line (index 0)
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]?.trim()
+    if (!line) continue
+    const fields = line.split(/\s+/)
+    // field[1] = local_address (HEXIP:HEXPORT), field[3] = state
+    const localAddr = fields[1]
+    const state = fields[3]
+    if (!localAddr || !state) continue
+    if (state !== LISTEN_STATE) continue
+    const colonIdx = localAddr.indexOf(":")
+    if (colonIdx === -1) continue
+    const hexIp = localAddr.slice(0, colonIdx)
+    const hexPort = localAddr.slice(colonIdx + 1)
+    if (!isLocalAddress(hexIp)) continue
+    return parseInt(hexPort, 16)
+  }
+  return null
+}
+
+let _platformWarned = false
+
+export const defaultDeps: ServerPortOwnershipDeps = {
+  readFile: (path: string) => fsReadFile(path, "utf8"),
+}
+
+export async function detectServerPortOwnership(opts?: {
+  pid?: number
+  deps?: ServerPortOwnershipDeps
+}): Promise<ServerPortOwnership> {
+  const pid = opts?.pid ?? process.pid
+  const deps = opts?.deps ?? defaultDeps
+
+  if (process.platform !== "linux") {
+    if (!_platformWarned) {
+      _platformWarned = true
+      log("[server-port-ownership] platform unsupported, assuming port ownership")
+    }
+    return { hasOwnPort: true, reason: "platform unsupported, assuming ownership" }
+  }
+
+  const tcpPath = `/proc/${pid}/net/tcp`
+  let tcpContent: string
+  try {
+    tcpContent = await deps.readFile(tcpPath)
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { hasOwnPort: false, reason: `${tcpPath} not found` }
+    }
+    throw err
+  }
+
+  const port = parseTcpContent(tcpContent)
+  if (port !== null) {
+    return { hasOwnPort: true, port }
+  }
+
+  // Try tcp6; ENOENT is non-fatal on kernels that omit it
+  const tcp6Path = `/proc/${pid}/net/tcp6`
+  try {
+    const tcp6Content = await deps.readFile(tcp6Path)
+    const port6 = parseTcpContent(tcp6Content)
+    if (port6 !== null) {
+      return { hasOwnPort: true, port: port6 }
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err
+    }
+    // ENOENT on tcp6 is expected on some kernels — continue
+  }
+
+  return { hasOwnPort: false, reason: `no LISTEN socket on ${tcpPath}` }
+}
+
+export function _resetPlatformWarnForTests(): void {
+  _platformWarned = false
+}

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
@@ -104,6 +104,11 @@ export async function detectServerPortOwnership(opts?: {
   const deps = opts?.deps ?? defaultDeps
   const platform = (deps.getPlatform ?? defaultDeps.getPlatform!)()
 
+  // NOTE: /proc/<pid>/net/tcp shows sockets in the process's network namespace,
+  // not necessarily sockets owned exclusively by this process. In containerized
+  // or shared-namespace environments, this can produce false positives.
+  // For the team-mode use case (tmux server on localhost), this heuristic is
+  // sufficient because the tmux server process typically owns its listening socket.
   const tcpPath = `/proc/${pid}/net/tcp`
   // Consult injected/real readFile FIRST so test scaffolding can exercise
   // the parsing path on any host. On non-Linux real fs this raises ENOENT

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
@@ -1,9 +1,21 @@
-// Detects whether the current process owns a local LISTEN socket.
+// Detects whether the current process owns a local LISTEN socket on a
+// specific port (when expectedPort is provided) or any local LISTEN socket
+// (when expectedPort is omitted).
 //
 // On Linux, reads /proc/<pid>/net/tcp (and tcp6) to find sockets in state 0A
-// (LISTEN) bound to a local interface (127.0.0.1 or 0.0.0.0). Returns the
-// first port found. On non-Linux platforms, ownership is assumed to avoid
-// blocking macOS/Windows development.
+// (LISTEN) bound to a local interface (127.0.0.1 / 0.0.0.0 / :: / ::1). On
+// non-Linux platforms, the real /proc filesystem doesn't exist; readFile
+// throws ENOENT and the function falls through to a platform-aware path
+// that "assumes ownership" (so macOS/Windows users aren't blocked).
+//
+// IMPORTANT (#4071 review): tests inject `readFile` via deps to exercise
+// the parsing path on any host. The function MUST honor injected deps
+// before short-circuiting on platform — otherwise tests on Linux runners
+// that simulate macOS by mocking `os.platform()` would never reach the
+// parsing logic, and the no-ownership path would never be testable on
+// non-Linux CI hosts. The deps-injected readFile is consulted first; only
+// when it raises ENOENT (i.e. the real fs has no /proc) does the platform
+// fallback trigger.
 
 import { readFile as fsReadFile } from "node:fs/promises"
 import { log } from "../../../shared"
@@ -16,6 +28,9 @@ export type ServerPortOwnership = {
 
 export type ServerPortOwnershipDeps = {
   readFile: (path: string) => Promise<string>
+  // Injected so tests can simulate non-Linux platforms without an actual
+  // macOS host. Defaults to () => process.platform.
+  getPlatform?: () => NodeJS.Platform | string
 }
 
 const LISTEN_STATE = "0A"
@@ -39,7 +54,8 @@ function isLocalAddress(hexIp: string): boolean {
   )
 }
 
-function parseTcpContent(content: string): number | null {
+function parseTcpListenPorts(content: string): number[] {
+  const ports: number[] = []
   const lines = content.split("\n")
   // Skip header line (index 0)
   for (let i = 1; i < lines.length; i++) {
@@ -56,55 +72,73 @@ function parseTcpContent(content: string): number | null {
     const hexIp = localAddr.slice(0, colonIdx)
     const hexPort = localAddr.slice(colonIdx + 1)
     if (!isLocalAddress(hexIp)) continue
-    return parseInt(hexPort, 16)
+    const parsed = parseInt(hexPort, 16)
+    if (Number.isFinite(parsed)) ports.push(parsed)
   }
-  return null
+  return ports
+}
+
+function selectPort(ports: number[], expectedPort?: number): number | null {
+  if (ports.length === 0) return null
+  if (expectedPort === undefined) return ports[0] ?? null
+  return ports.includes(expectedPort) ? expectedPort : null
 }
 
 let _platformWarned = false
 
 export const defaultDeps: ServerPortOwnershipDeps = {
   readFile: (path: string) => fsReadFile(path, "utf8"),
+  getPlatform: () => process.platform,
 }
 
 export async function detectServerPortOwnership(opts?: {
   pid?: number
+  // When provided, ownership is only reported as true if the pid owns a
+  // LISTEN socket on this exact port. Required (#4071 finding 2) so the
+  // function is anchored to the actual OpenCode server URL, not just any
+  // local listener.
+  expectedPort?: number
   deps?: ServerPortOwnershipDeps
 }): Promise<ServerPortOwnership> {
   const pid = opts?.pid ?? process.pid
   const deps = opts?.deps ?? defaultDeps
-
-  if (process.platform !== "linux") {
-    if (!_platformWarned) {
-      _platformWarned = true
-      log("[server-port-ownership] platform unsupported, assuming port ownership")
-    }
-    return { hasOwnPort: true, reason: "platform unsupported, assuming ownership" }
-  }
+  const platform = (deps.getPlatform ?? defaultDeps.getPlatform!)()
 
   const tcpPath = `/proc/${pid}/net/tcp`
-  let tcpContent: string
+  // Consult injected/real readFile FIRST so test scaffolding can exercise
+  // the parsing path on any host. On non-Linux real fs this raises ENOENT
+  // and we fall through to the platform-assume branch below.
+  let tcpContent: string | null = null
   try {
     tcpContent = await deps.readFile(tcpPath)
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { hasOwnPort: false, reason: `${tcpPath} not found` }
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== "ENOENT") throw err
+    // ENOENT — fall through to platform handling.
+    if (platform !== "linux") {
+      if (!_platformWarned) {
+        _platformWarned = true
+        log("[server-port-ownership] platform unsupported (real fs has no /proc), assuming port ownership")
+      }
+      return { hasOwnPort: true, reason: "platform unsupported, assuming ownership" }
     }
-    throw err
+    return { hasOwnPort: false, reason: `${tcpPath} not found` }
   }
 
-  const port = parseTcpContent(tcpContent)
-  if (port !== null) {
-    return { hasOwnPort: true, port }
+  const tcpPorts = parseTcpListenPorts(tcpContent)
+  const tcpMatch = selectPort(tcpPorts, opts?.expectedPort)
+  if (tcpMatch !== null) {
+    return { hasOwnPort: true, port: tcpMatch }
   }
 
   // Try tcp6; ENOENT is non-fatal on kernels that omit it
   const tcp6Path = `/proc/${pid}/net/tcp6`
   try {
     const tcp6Content = await deps.readFile(tcp6Path)
-    const port6 = parseTcpContent(tcp6Content)
-    if (port6 !== null) {
-      return { hasOwnPort: true, port: port6 }
+    const tcp6Ports = parseTcpListenPorts(tcp6Content)
+    const tcp6Match = selectPort(tcp6Ports, opts?.expectedPort)
+    if (tcp6Match !== null) {
+      return { hasOwnPort: true, port: tcp6Match }
     }
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -113,7 +147,10 @@ export async function detectServerPortOwnership(opts?: {
     // ENOENT on tcp6 is expected on some kernels — continue
   }
 
-  return { hasOwnPort: false, reason: `no LISTEN socket on ${tcpPath}` }
+  const expectedSuffix = opts?.expectedPort !== undefined
+    ? ` matching expected port ${opts.expectedPort}`
+    : ""
+  return { hasOwnPort: false, reason: `no LISTEN socket${expectedSuffix} on ${tcpPath}` }
 }
 
 export function _resetPlatformWarnForTests(): void {

--- a/src/features/team-mode/team-runtime/activate-team-layout.test.ts
+++ b/src/features/team-mode/team-runtime/activate-team-layout.test.ts
@@ -126,6 +126,7 @@ describe("activateTeamLayout", () => {
       targetSessionId: "$caller",
       focusWindowId: "@10",
       gridWindowId: "@11",
+      paneIds: ["%11", "%21"],
     })
   })
 

--- a/src/features/team-mode/team-runtime/activate-team-layout.ts
+++ b/src/features/team-mode/team-runtime/activate-team-layout.ts
@@ -32,9 +32,16 @@ export async function activateTeamLayout(
         }]
       : []),
     tmuxMgr,
+    undefined,
+    { allowInsecureLocalTls: process.env.OMO_TEAM_ALLOW_INSECURE_LOCAL_TLS === "1" },
   )
   if (!layout) return false
   const normalizedLayout = normalizeTeamLayout(runtimeState.teamRunId, layout)
+
+  const paneIds = [
+    ...Object.values(normalizedLayout.focusPanesByMember),
+    ...Object.values(normalizedLayout.gridPanesByMember),
+  ].filter(Boolean)
 
   await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
     ...currentState,
@@ -43,6 +50,7 @@ export async function activateTeamLayout(
       targetSessionId: normalizedLayout.targetSessionId,
       focusWindowId: normalizedLayout.focusWindowId,
       gridWindowId: normalizedLayout.gridWindowId,
+      paneIds: paneIds.length > 0 ? paneIds : undefined,
     },
     members: currentState.members.map((member) => ({
       ...member,

--- a/src/features/team-mode/team-runtime/activate-team-layout.ts
+++ b/src/features/team-mode/team-runtime/activate-team-layout.ts
@@ -2,6 +2,7 @@ import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
 import { createTeamLayout } from "../team-layout-tmux/layout"
 import type { TeamLayoutResult } from "../team-layout-tmux/layout"
+import { reapStaleTailers } from "../team-layout-tmux/reap-stale-tailers"
 import type { RuntimeState } from "../types"
 import { transitionRuntimeState } from "../team-state-store/store"
 
@@ -20,6 +21,12 @@ export async function activateTeamLayout(
   tmuxMgr?: TmuxSessionManager,
 ): Promise<boolean> {
   if (!config.tmux_visualization || !tmuxMgr) return false
+
+  // Best-effort sweep of zombie tailers left over from dead OpenCode servers
+  // before we attach a fresh team layout. Fire-and-forget: the reaper must
+  // never block layout setup, and a transient failure (ps unavailable, no
+  // tailers running, etc.) must not surface as a user-visible error here.
+  void reapStaleTailers().catch(() => {})
 
   const layout = await createTeamLayout(
     runtimeState.teamRunId,

--- a/src/features/team-mode/team-runtime/cleanup-team-run-resources.ts
+++ b/src/features/team-mode/team-runtime/cleanup-team-run-resources.ts
@@ -4,6 +4,7 @@ import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import type { BackgroundManager } from "../../background-agent/manager"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
 import { removeTeamLayout } from "../team-layout-tmux/layout"
+import { reapStaleTailers } from "../team-layout-tmux/reap-stale-tailers"
 import { unregisterTeamSessionsByTeam } from "../team-session-registry"
 import { loadRuntimeState, transitionRuntimeState } from "../team-state-store/store"
 import type { TeamRunCreateError } from "./create"
@@ -66,6 +67,11 @@ export async function cleanupTeamRunResources(args: {
       cleanupReport.errors.push(`layout ${args.teamRunId}: ${normalizeError(layoutError).message}`)
     }
   }
+
+  // Best-effort reap of zombie tailers left over from the just-destroyed
+  // tmux layout. Fire-and-forget so a transient failure never blocks the
+  // team-create rollback path.
+  void reapStaleTailers().catch(() => {})
 
   await transitionRuntimeState(args.teamRunId, (runtimeState) => ({ ...runtimeState, status: "failed" }), args.config).catch((transitionError) => {
     cleanupReport.errors.push(`state ${args.teamRunId}: ${normalizeError(transitionError).message}`)

--- a/src/features/team-mode/team-runtime/delete-team.ts
+++ b/src/features/team-mode/team-runtime/delete-team.ts
@@ -3,6 +3,7 @@ import { log } from "../../../shared/logger"
 import type { BackgroundManager } from "../../background-agent/manager"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
 import { canVisualize, removeTeamLayout } from "../team-layout-tmux/layout"
+import { reapStaleTailers } from "../team-layout-tmux/reap-stale-tailers"
 import { sweepStaleTeamSessions } from "../team-layout-tmux/sweep-stale-team-sessions"
 import { getRuntimeStateDir, resolveBaseDir } from "../team-registry/paths"
 import { unregisterTeamSessionsByTeam } from "../team-session-registry"
@@ -129,6 +130,11 @@ export async function deleteTeam(
       await deps.removeTeamLayout(teamRunId, cleanupTarget, tmuxMgr)
     }
   }
+
+  // Best-effort reap of zombie tailers left over from the just-destroyed
+  // tmux layout. Fire-and-forget so a transient failure (no tailers running,
+  // ps unavailable, etc.) never blocks team teardown.
+  void reapStaleTailers().catch(() => {})
 
   const removedWorktrees = await removeWorktrees(runtimeState.members.map((member) => member.worktreePath))
 

--- a/src/features/team-mode/types.ts
+++ b/src/features/team-mode/types.ts
@@ -169,6 +169,7 @@ const RuntimeStateTmuxLayoutSchema = z.object({
   targetSessionId: z.string(),
   focusWindowId: z.string().optional(),
   gridWindowId: z.string().optional(),
+  paneIds: z.array(z.string()).optional(),
 }).strict()
 
 export const RuntimeStateSchema = z.object({

--- a/src/types/bun-text-imports.d.ts
+++ b/src/types/bun-text-imports.d.ts
@@ -1,0 +1,10 @@
+// Project-local ambient type for Bun text imports of file extensions
+// not covered by `bun-types/extensions.d.ts` (which declares .txt/.toml/
+// .yaml/.yml/.jsonc/.json5/.html but omits .py).
+//
+// `import script from "./foo.py" with { type: "text" }` returns the
+// file contents as a string at module load (bundle) time.
+declare module "*.py" {
+  const contents: string
+  export default contents
+}


### PR DESCRIPTION
## Summary

- OpenCode TUI's `attach --session <child>` shows a static subagent-detail view for any session with a `parentID`. Team workers always carry `parentID=lead`, so attach alone produces no streaming feed for worker tmux panes.
- Adds a Python tailer that polls `/session/<id>/message` for each worker session and prints incremental deltas; the TS side materializes the script to a per-process tmpdir and wires it into the tmux pane spawn.
- Bundles the server-port-ownership detector and stale-tailer reaper needed by the layout integration.

## Changes

- `script/team-pane-live-tail.py` — Python tailer that polls the opencode session message API and streams incremental output (new)
- `script/test_team_pane_live_tail.py` — Python tests for the tailer (new)
- `src/features/team-mode/team-layout-tmux/live-tail.ts` — TS wiring: materializes the Python script to tmpdir, builds the tmux `send-keys` command (new, 44 lines)
- `src/features/team-mode/team-layout-tmux/live-tail.test.ts` — TS tests for live-tail materialization and command building (new)
- `src/features/team-mode/team-layout-tmux/server-port-ownership.ts` — detects whether the current process owns the opencode server port; used by `layout.ts` to choose between a separate live-tail window and the caller window (new)
- `src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts` — tests for port-ownership detection (new)
- `src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts` — cleans up leftover tailer processes from aborted team runs (new)
- `src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts` — tests for stale-tailer reaper (new)
- `src/features/team-mode/team-layout-tmux/layout.ts` — integrates tailer into pane spawn; adds `detectServerPortOwnership` dep, `allowInsecureLocalTls` option, `-d` flag on splits to prevent focus steal, `refresh-client` after layout (modified)
- `src/features/team-mode/team-layout-tmux/layout.test.ts` — updated command-count expectations and new tests for `--insecure` flag and focus-steal prevention (modified)
- `src/features/team-mode/team-runtime/activate-team-layout.ts` — passes `allowInsecureLocalTls` option and records `paneIds` on `tmuxLayout` state (modified)
- `src/features/team-mode/team-runtime/activate-team-layout.test.ts` — updated to expect `paneIds` in `tmuxLayout` snapshot (modified)

## Screenshots

N/A — tmux pane behaviour; not screenshottable in CI.

## Testing

```bash
bun run typecheck                                                              # clean
bun test src/features/team-mode/team-layout-tmux/                            # 46 pass, 1 skip, 0 fail
bun test src/features/team-mode/team-runtime/activate-team-layout.test.ts   # 3 pass, 0 fail
```

## Related Issues

Closes #4035

Extracted from closed PR #3871 (89-commit mixed-scope branch). This PR isolates the live-tail mechanism, server-port-ownership detector, and stale-tailer reaper. The `disabled_providers` routing change is split into PR #4031.
