### PR TITLE
fix(process-cleanup): call process.exit() after SIGTERM cleanup

### DIFF
--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -40,7 +40,7 @@ function registerProcessSignal(
   const listener = () => {
     const cleanupResult = handler()
     if (exitAfter) {
-      scheduleForcedExit(cleanupResult, 0)
+      scheduleForcedExit(cleanupResult, 0, true)
     }
   }
   process.on(signal, listener)


### PR DESCRIPTION
## Summary

- Fix graceful shutdown hanging on SIGTERM/SIGINT signals
- `scheduleForcedExit` was called without `exitAfterCleanup=true`, leaving process alive after cleanup

## Root Cause

After cleanup completed, the 6s timeout was cleared but `process.exit()` was never called. Process stayed alive waiting for event loop to drain, causing systemd to timeout and SIGKILL.

## Benchmark (systemctl stop)

| Metric | Before | After |
|--------|--------|-------|
| Stop time | 10s+ (timeout) | ~30ms |

### Test Results (3 runs on production service)

| Test | Time |
|------|------|
| 1 | 30ms |
| 2 | 28ms |
| 3 | 27ms |

## Change

One-line fix: pass `exitAfterCleanup = true` for SIGTERM/SIGINT signals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hanging shutdown on SIGTERM/SIGINT by exiting the process immediately after cleanup. Services now stop in ~30ms instead of timing out.

- **Bug Fixes**
  - Pass `exitAfterCleanup=true` to `scheduleForcedExit` so `process.exit()` runs after cleanup
  - Observed stop time ~30ms (was 10s+)

<sup>Written for commit ec49d6af3f4007fbfffba1f1cd52b4a9c8237541. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

