### PR TITLE
fix(json-error-recovery): add todowrite and todoread to exclude list

### DIFF
--- a/src/hooks/json-error-recovery/hook.ts
+++ b/src/hooks/json-error-recovery/hook.ts
@@ -9,6 +9,8 @@ export const JSON_ERROR_TOOL_EXCLUDE_LIST = [
   "look_at",
   "grep_app_searchgithub",
   "websearch_web_search_exa",
+  "todowrite",
+  "todoread",
 ] as const
 
 export const JSON_ERROR_PATTERNS = [


### PR DESCRIPTION
I hit a false positive with the `json-error-recovery` hook today and wanted to share what I found, with a small fix.

## The problem

I use the built-in `todowrite` tool a lot. At some point one of my todo items contained the phrase "JSON parse error" (because that's what I was debugging at that moment). The `json-error-recovery` hook scanned the output of `todowrite`, found that text, and appended the `[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]` reminder — even though nothing was actually wrong. The AI agent then got confused thinking there was a real parse error when there wasn't.

## Root cause

Looking at the source, `JSON_ERROR_TOOL_EXCLUDE_LIST` includes tools that return arbitrary/uncontrolled text content (bash output, file contents, web pages, etc.). But `todowrite` and `todoread` fall into the same category — they return whatever text the user put in their todos, which could contain JSON-error-related phrases for perfectly legitimate reasons.

The hook does `input.tool.toLowerCase()` on line 47 to check against the exclude set, so lowercase `todowrite` and `todoread` should match correctly regardless of how OpenCode capitalizes them.

## What this PR does

Adds `todowrite` and `todoread` to `JSON_ERROR_TOOL_EXCLUDE_LIST`. That's it — 2 lines.

## Questions I'm not 100% sure about

There might be other tools in the same boat that I haven't thought of. I kept the change minimal to what I actually observed. Happy to add more if you think they fit the same pattern.

Also, longer-term, I wonder if the hook could check something like whether the tool call actually *failed* (e.g., an `isError` flag on the output), rather than pattern-matching the output text. That would make it more robust and reduce the need to maintain an exclude list. But that's a bigger change and maybe out of scope here — happy to hear thoughts.

## Tests

Existing tests still pass (11/11). No test changes needed since the existing test only checks that `read`, `bash`, and `webfetch` are in the list — it doesn't assert an exact count.

Closes #4028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false JSON parse error reminders when todo items contain that phrase. The `json-error-recovery` hook now excludes `todowrite` and `todoread` by adding them to `JSON_ERROR_TOOL_EXCLUDE_LIST`.

<sup>Written for commit c76ac27ebd6e6a6d498aec3616e12320e8e3c14c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

