### PR TITLE
fix(tool-pair-validator): skip placeholder repair for subagent sessions

### DIFF
--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -6,6 +6,7 @@ declare const expect: <T>(value: T) => {
 }
 
 import { createToolPairValidatorHook } from "./hook"
+import { _resetForTesting, subagentSessions } from "../../features/claude-code-session-state/state"
 
 const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)"
 
@@ -19,7 +20,7 @@ type TestPart = {
 }
 
 type TestMessage = {
-  info: { role: "assistant" | "user" }
+  info: { role: "assistant" | "user"; sessionID?: string }
   parts: TestPart[]
 }
 
@@ -152,5 +153,47 @@ describe("createToolPairValidatorHook", () => {
       { type: "tool_result", tool_use_id: "call_2", content: TOOL_RESULT_PLACEHOLDER },
       { type: "text", text: "continue" },
     ])
+  })
+
+  it("leaves tracked subagent sessions unchanged while normal sessions still repair", async () => {
+    //#given
+    _resetForTesting()
+    subagentSessions.add("ses_background_1")
+    const backgroundMessages = [
+      {
+        info: { role: "assistant", sessionID: "ses_background_1" },
+        parts: [{ type: "tool_use", id: "toolu_background_1" }],
+      },
+      {
+        info: { role: "assistant", sessionID: "ses_background_1" },
+        parts: [{ type: "text", text: "background agent keeps reasoning" }],
+      },
+    ] satisfies TestMessage[]
+    const originalBackgroundMessages = JSON.parse(JSON.stringify(backgroundMessages))
+    const mainMessages = [
+      {
+        info: { role: "assistant", sessionID: "ses_main_1" },
+        parts: [{ type: "tool_use", id: "toolu_main_1" }],
+      },
+      {
+        info: { role: "user", sessionID: "ses_main_1" },
+        parts: [{ type: "text", text: "continue main session" }],
+      },
+    ] satisfies TestMessage[]
+
+    try {
+      //#when
+      await runTransform(backgroundMessages)
+      await runTransform(mainMessages)
+
+      //#then
+      expect(backgroundMessages).toEqual(originalBackgroundMessages)
+      expect(mainMessages[1]?.parts).toEqual([
+        { type: "tool_result", tool_use_id: "toolu_main_1", content: TOOL_RESULT_PLACEHOLDER },
+        { type: "text", text: "continue main session" },
+      ])
+    } finally {
+      _resetForTesting()
+    }
   })
 })

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from "@opencode-ai/sdk"
 
+import { subagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared/logger"
 
 const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)"
@@ -134,6 +135,11 @@ function getMessageID(message: TransformMessageInfo): string | undefined {
   return typeof candidate.id === "string" ? candidate.id : undefined
 }
 
+function getMessageSessionID(message: TransformMessageInfo): string | undefined {
+  const candidate = message as { sessionID?: unknown }
+  return typeof candidate.sessionID === "string" ? candidate.sessionID : undefined
+}
+
 function repairMissingToolResults(messages: MessageWithParts[], assistantIndex: number): void {
   const assistantMessage = messages[assistantIndex]
   const toolUseIDs = extractUniqueToolUseIDs(assistantMessage.parts)
@@ -173,7 +179,15 @@ export function createToolPairValidatorHook(): MessagesTransformHook {
   return {
     "experimental.chat.messages.transform": async (_input, output) => {
       for (let i = 0; i < output.messages.length; i++) {
-        if (output.messages[i].info.role !== "assistant") {
+        const messageInfo = output.messages[i].info
+
+        if (messageInfo.role !== "assistant") {
+          continue
+        }
+
+        const sessionID = getMessageSessionID(messageInfo)
+        if (sessionID && subagentSessions.has(sessionID)) {
+          log("[tool-pair-validator] Skipping repair for subagent session", { sessionID })
           continue
         }
 


### PR DESCRIPTION
## Summary

- The `tool-pair-validator` hook inserts a synthetic placeholder tool_result when an assistant message contains an orphan tool_use. This is the right behavior for the main session (compaction can strip tool_results), but it corrupts background sub-agent sessions where the orphan is expected and the synthetic placeholder breaks downstream consumers.
- Skip the placeholder repair when the transformed message belongs to a tracked subagent session, while keeping the existing main-session repair path intact.

## Changes

- `src/hooks/tool-pair-validator/hook.ts`: read the session id from the transformed message via a small `getMessageSessionID` helper; bail out of `repairMissingToolResults` if the session is tracked in `subagentSessions`. Import the registry from `src/features/claude-code-session-state`.
- `src/hooks/tool-pair-validator/hook.test.ts`: new regression test asserting that a transformed assistant message owned by a tracked subagent session is left untouched, plus the existing main-session repair coverage stays green.

## Rationale (from commit body)

> **Constraint:** code-yeongyu/oh-my-openagent#3996 reports background Oracle sessions hanging after synthetic placeholder tool_result insertion.
> **Rejected alternative:** disable `tool-pair-validator` globally — would regress main-session compaction/orphaned tool_use repair.
> **Confidence:** high
> **Scope-risk:** narrow
> **Directive:** Keep subagent skip coverage and normal repair coverage together when changing tool-pair validation.

## Testing

```bash
bun test src/hooks/tool-pair-validator/hook.test.ts src/plugin/messages-transform.test.ts
# 12 pass, 0 fail
bun run typecheck
# clean
```

Not tested end-to-end against a live Oracle background task — that would need a real session reproduction, which I don't have a deterministic setup for. The unit coverage exercises both the subagent-skip path and the main-session repair path.

## Related Issues

Closes #3996
