### PR TITLE
perf(ci): shard CI test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,34 @@ jobs:
             echo "PR targets '${BASE_REF}' branch - OK"
           fi
 
-  test:
+  test-isolated:
+    name: Isolated tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          BUN_INSTALL_ALLOW_SCRIPTS: "@ast-grep/napi"
+
+      - name: Run isolated tests
+        run: bun run script/run-ci-tests.ts --phase=isolated --shard-count=4 --shard-index=${{ matrix.shard }}
+
+  test-shared:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,16 +68,24 @@ jobs:
         with:
           bun-version: "1.3.12"
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
         env:
           BUN_INSTALL_ALLOW_SCRIPTS: "@ast-grep/napi"
 
-      - name: Build plugin
-        run: bun run build
+      - name: Run shared tests
+        run: bun run script/run-ci-tests.ts --phase=shared
 
-      - name: Run tests
-        run: bun run script/run-ci-tests.ts
+  test:
+    runs-on: ubuntu-latest
+    needs: [test-isolated, test-shared]
+    steps:
+      - run: echo "All test shards passed"
 
   typecheck:
     runs-on: ubuntu-latest
@@ -60,6 +95,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.12"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -86,6 +126,11 @@ jobs:
         with:
           bun-version: "1.3.12"
 
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.12-${{ hashFiles('bun.lock') }}
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
         env:
@@ -98,6 +143,9 @@ jobs:
         run: |
           test -f dist/index.js || (echo "ERROR: dist/index.js not found!" && exit 1)
           test -f dist/index.d.ts || (echo "ERROR: dist/index.d.ts not found!" && exit 1)
+
+      - name: Verify dist bundle tests
+        run: bun test src/shared/dist-bundle-bun-globals.test.ts
 
       - name: Auto-commit schema changes
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [test-isolated, test-shared]
+    if: ${{ always() }}
     steps:
-      - run: echo "All test shards passed"
+      - name: Verify test shards passed
+        env:
+          ISOLATED_RESULT: ${{ needs.test-isolated.result }}
+          SHARED_RESULT: ${{ needs.test-shared.result }}
+        run: |
+          if [ "$ISOLATED_RESULT" != "success" ] || [ "$SHARED_RESULT" != "success" ]; then
+            echo "::error::test-isolated=${ISOLATED_RESULT}, test-shared=${SHARED_RESULT}"
+            exit 1
+          fi
+          echo "All test shards passed"
 
   typecheck:
     runs-on: ubuntu-latest

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -3,19 +3,30 @@
 import { describe, expect, test } from "bun:test"
 import { readFileSync } from "node:fs"
 
-const workflowPaths = [
-  new URL("../.github/workflows/ci.yml", import.meta.url),
-  new URL("../.github/workflows/publish.yml", import.meta.url),
+const workflowChecks = [
+  {
+    path: new URL("../.github/workflows/ci.yml", import.meta.url),
+    testRuns: [
+      "run: bun run script/run-ci-tests.ts --phase=isolated --shard-count=4 --shard-index=${{ matrix.shard }}",
+      "run: bun run script/run-ci-tests.ts --phase=shared",
+      "run: bun test src/shared/dist-bundle-bun-globals.test.ts",
+    ],
+  },
+  {
+    path: new URL("../.github/workflows/publish.yml", import.meta.url),
+    testRuns: ["run: bun run script/run-ci-tests.ts"],
+  },
 ]
 
 describe("test workflows", () => {
   test("use pure bun test for workflows", () => {
-    for (const workflowPath of workflowPaths) {
+    for (const workflowCheck of workflowChecks) {
       // #given
-      const workflow = readFileSync(workflowPath, "utf8")
+      const workflow = readFileSync(workflowCheck.path, "utf8")
 
-      expect(workflow).toContain("- name: Run tests")
-      expect(workflow).toMatch(/run: bun (test|run script\/run-ci-tests\.ts)/)
+      for (const testRun of workflowCheck.testRuns) {
+        expect(workflow).toContain(testRun)
+      }
     }
   })
 })

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -9,6 +9,10 @@ const workflowChecks = [
     testRuns: [
       "run: bun run script/run-ci-tests.ts --phase=isolated --shard-count=4 --shard-index=${{ matrix.shard }}",
       "run: bun run script/run-ci-tests.ts --phase=shared",
+      "if: ${{ always() }}",
+      "ISOLATED_RESULT: ${{ needs.test-isolated.result }}",
+      "SHARED_RESULT: ${{ needs.test-shared.result }}",
+      "echo \"::error::test-isolated=${ISOLATED_RESULT}, test-shared=${SHARED_RESULT}\"",
       "run: bun test src/shared/dist-bundle-bun-globals.test.ts",
     ],
   },

--- a/script/run-ci-tests.test.ts
+++ b/script/run-ci-tests.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { selectCiTestTargets } from "./run-ci-tests"
 
 describe("test script isolation", () => {
   test("#given mock.module tests in the suite #then bun run test uses the isolated CI runner", async () => {
@@ -7,5 +8,38 @@ describe("test script isolation", () => {
 
     //#then
     expect(packageJson.scripts.test).toBe("bun run script/run-ci-tests.ts")
+  })
+
+  test("#given isolated test shards #when selecting targets #then shards are deterministic and complete", () => {
+    // given
+    const ciTestPlan = {
+      isolatedModuleMockFiles: [],
+      isolatedTestTargets: ["a.test.ts", "b.test.ts", "c.test.ts", "d.test.ts", "e.test.ts"],
+      sharedTestFiles: ["shared.test.ts"],
+    }
+
+    // when
+    const shardOne = selectCiTestTargets(ciTestPlan, { phase: "isolated", shardCount: 2, shardIndex: 0 })
+    const shardTwo = selectCiTestTargets(ciTestPlan, { phase: "isolated", shardCount: 2, shardIndex: 1 })
+
+    // then
+    expect(shardOne).toEqual({ isolatedTestTargets: ["a.test.ts", "c.test.ts", "e.test.ts"], sharedTestFiles: [] })
+    expect(shardTwo).toEqual({ isolatedTestTargets: ["b.test.ts", "d.test.ts"], sharedTestFiles: [] })
+    expect([...shardOne.isolatedTestTargets, ...shardTwo.isolatedTestTargets].sort()).toEqual(ciTestPlan.isolatedTestTargets)
+  })
+
+  test("#given shared phase #when selecting targets #then only shared tests run", () => {
+    // given
+    const ciTestPlan = {
+      isolatedModuleMockFiles: [],
+      isolatedTestTargets: ["isolated.test.ts"],
+      sharedTestFiles: ["shared.test.ts"],
+    }
+
+    // when
+    const selectedTargets = selectCiTestTargets(ciTestPlan, { phase: "shared", shardCount: 1, shardIndex: 0 })
+
+    // then
+    expect(selectedTargets).toEqual({ isolatedTestTargets: [], sharedTestFiles: ["shared.test.ts"] })
   })
 })

--- a/script/run-ci-tests.ts
+++ b/script/run-ci-tests.ts
@@ -6,6 +6,19 @@ type CiTestPlan = {
   sharedTestFiles: string[]
 }
 
+type CiTestPhase = "all" | "isolated" | "shared"
+
+type CiTestRunOptions = {
+  phase: CiTestPhase
+  shardCount: number
+  shardIndex: number
+}
+
+type CiTestTargetSelection = {
+  isolatedTestTargets: string[]
+  sharedTestFiles: string[]
+}
+
 const TEST_ROOTS = ["bin", "script", "src"] as const
 const MODULE_MOCK_PATTERN = "mock.module("
 const ALWAYS_ISOLATED_TEST_FILES = [
@@ -62,6 +75,86 @@ function collapseNestedTargets(isolatedTargets: string[]): string[] {
   })
 }
 
+function readFlagValue(args: string[], flagName: string): string | null {
+  const prefix = `${flagName}=`
+  const flag = args.find((arg) => arg.startsWith(prefix))
+
+  return flag?.slice(prefix.length) ?? null
+}
+
+function parsePhase(rawPhase: string | null): CiTestPhase {
+  if (rawPhase === null) {
+    return "all"
+  }
+
+  if (rawPhase === "all" || rawPhase === "isolated" || rawPhase === "shared") {
+    return rawPhase
+  }
+
+  throw new Error(`Invalid --phase value: ${rawPhase}. Expected all, isolated, or shared.`)
+}
+
+function parsePositiveIntegerFlag(args: string[], flagName: string, defaultValue: number): number {
+  const rawValue = readFlagValue(args, flagName)
+  if (rawValue === null) {
+    return defaultValue
+  }
+
+  const parsedValue = Number(rawValue)
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) {
+    throw new Error(`Invalid ${flagName} value: ${rawValue}. Expected a positive integer.`)
+  }
+
+  return parsedValue
+}
+
+function parseNonNegativeIntegerFlag(args: string[], flagName: string, defaultValue: number): number {
+  const rawValue = readFlagValue(args, flagName)
+  if (rawValue === null) {
+    return defaultValue
+  }
+
+  const parsedValue = Number(rawValue)
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`Invalid ${flagName} value: ${rawValue}. Expected a non-negative integer.`)
+  }
+
+  return parsedValue
+}
+
+function parseCiTestRunOptions(args: string[]): CiTestRunOptions {
+  const phase = parsePhase(readFlagValue(args, "--phase"))
+  const shardCount = parsePositiveIntegerFlag(args, "--shard-count", 1)
+  const shardIndex = parseNonNegativeIntegerFlag(args, "--shard-index", 0)
+
+  if (shardIndex >= shardCount) {
+    throw new Error(`Invalid --shard-index value: ${shardIndex}. Expected a value less than --shard-count ${shardCount}.`)
+  }
+
+  if (shardCount > 1 && phase !== "isolated") {
+    throw new Error("Test sharding is only supported with --phase=isolated.")
+  }
+
+  return { phase, shardCount, shardIndex }
+}
+
+function selectShard(testTargets: string[], shardCount: number, shardIndex: number): string[] {
+  if (shardCount === 1) {
+    return testTargets
+  }
+
+  return testTargets.filter((_, index) => index % shardCount === shardIndex)
+}
+
+export function selectCiTestTargets(ciTestPlan: CiTestPlan, options: CiTestRunOptions): CiTestTargetSelection {
+  const isolatedTestTargets = options.phase === "shared"
+    ? []
+    : selectShard(ciTestPlan.isolatedTestTargets, options.shardCount, options.shardIndex)
+  const sharedTestFiles = options.phase === "isolated" ? [] : ciTestPlan.sharedTestFiles
+
+  return { isolatedTestTargets, sharedTestFiles }
+}
+
 export async function createCiTestPlan(rootDirectory: string = process.cwd()): Promise<CiTestPlan> {
   const allTestFiles = await collectTestFiles(rootDirectory)
   const isolatedModuleMockFiles: string[] = []
@@ -97,16 +190,15 @@ async function runBunTest(testFiles: string[], label: string): Promise<void> {
   }
 
   console.log(`::group::${label}`)
-  
-  // For directory paths, exclude _auc* directories which are separate isolated targets
-  const args = testFiles.map(tf => {
-    if (tf.includes('/') && !tf.endsWith('.test.ts')) {
-      // It's a directory path, add negation glob
-      return [tf, '!_auc-*/**/*.test.ts']
+
+  const args = testFiles.map((testFile) => {
+    if (testFile.includes("/") && !testFile.endsWith(".test.ts")) {
+      return [testFile, "!_auc-*/**/*.test.ts"]
     }
-    return tf
+
+    return testFile
   }).flat()
-  
+
   const command = ["bun", "test", ...args]
   const spawnedProcess = Bun.spawn(command, {
     cwd: process.cwd(),
@@ -123,17 +215,25 @@ async function runBunTest(testFiles: string[], label: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  const options = parseCiTestRunOptions(process.argv.slice(2))
   const ciTestPlan = await createCiTestPlan()
+  const selectedTargets = selectCiTestTargets(ciTestPlan, options)
 
   console.log(
     `Detected ${ciTestPlan.isolatedModuleMockFiles.length} mock.module() test files, ${ciTestPlan.isolatedTestTargets.length} isolated targets, and ${ciTestPlan.sharedTestFiles.length} shared test files.`,
   )
 
-  for (const isolatedTestTarget of ciTestPlan.isolatedTestTargets) {
+  if (options.phase === "isolated" && options.shardCount > 1) {
+    console.log(
+      `Running isolated test shard ${options.shardIndex + 1}/${options.shardCount} with ${selectedTargets.isolatedTestTargets.length} targets.`,
+    )
+  }
+
+  for (const isolatedTestTarget of selectedTargets.isolatedTestTargets) {
     await runBunTest([isolatedTestTarget], `Isolated ${isolatedTestTarget}`)
   }
 
-  await runBunTest(ciTestPlan.sharedTestFiles, "Shared Bun test suite")
+  await runBunTest(selectedTargets.sharedTestFiles, "Shared Bun test suite")
 }
 
 export const moduleMockPattern = MODULE_MOCK_PATTERN


### PR DESCRIPTION
## Summary
- Add explicit phase and shard options to the CI test runner so isolated mock-heavy targets can run across CI matrix jobs.
- Split CI test execution into isolated shard jobs and one shared-suite job while keeping the aggregate `test` check stable and fail-closed.
- Move dist-bundle verification to the build job after `dist/` is generated, so the test path no longer performs a duplicate build.

## Performance impact

### Before
- Local baseline full runner: `bun run script/run-ci-tests.ts` completed in `3:02.05`.
- The runner plan was `95 mock.module() test files`, `110 isolated targets`, and `593 shared test files`.
- CI test job shape was serial: `bun run build` first, then every isolated target one-by-one, then the shared suite.

### After
- Local default full runner still passes and completed in `160s` with a working Node path.
- PR CI isolated shards completed in parallel:
  - `Isolated tests (0)`: `56s`
  - `Isolated tests (1)`: `56s`
  - `Isolated tests (2)`: `59s`
  - `Isolated tests (3)`: `1m7s`
- The isolated phase critical path is now the slowest shard (`1m7s`) instead of the serial sum of all isolated shards (`~3m58` from this PR CI run), about a 72% reduction for that phase.
- The shared suite now runs once as its own job (`2m51s` in this PR CI), so the aggregate `test` check completes after the isolated matrix and shared suite finish.
- The build job still runs the full build and dist-bundle verification (`1m2s` in this PR CI), but it is no longer duplicated before tests.

### How time was reduced
- `script/run-ci-tests.ts` now supports `--phase=isolated|shared|all`, `--shard-count`, and `--shard-index`.
- CI uses a 4-way matrix only for isolated targets, which are already separate OS processes and safe to distribute.
- The shared suite remains unsharded and runs exactly once.
- Dist-bundle tests moved to the build job, where `dist/` exists naturally.
- Bun install cache was added to CI jobs to reduce dependency setup time on cache hits.

## No behavior change guarantee
- No product/runtime source files changed. The diff is limited to CI workflow, test runner script, and their tests.
- The default runner behavior is still `all`: isolated targets run first, then the shared suite.
- `--print-plan` output is unchanged; this was verified by diffing the plan before and after passing shard flags.
- Dist-bundle tests are not removed or skipped. They now run in the build job after `bun run build` creates `dist/`.
- The stable aggregate `test` check is preserved and now explicitly fails if `test-isolated` or `test-shared` fails or is cancelled, so branch protection cannot be satisfied by a skipped aggregate job.
- Local verification covered typecheck, script typecheck, build, dist-bundle tests, focused workflow/runner tests, isolated shards, shared suite, and the default runner surface.

## Test-case constraint guarantee
- The `mock.module(` detection rule is unchanged.
- The `ALWAYS_ISOLATED_TEST_FILES` list is unchanged.
- The plan still reports the same counts: `95 mock.module() test files`, `110 isolated targets`, `593 shared test files`.
- Sharding only partitions `isolatedTestTargets` by deterministic index modulo. It does not change which targets are isolated.
- `script/run-ci-tests.test.ts` asserts shard determinism and complete coverage across shards.
- `script/publish-workflow.test.ts` asserts the CI workflow still invokes the Bun test runner commands for isolated, shared, and dist-bundle verification, and that the aggregate `test` job uses `always()` plus `needs.*.result` checks to fail closed.
- The shared test suite remains a single unsharded Bun process, preserving existing cross-file ordering and global-state leak detection semantics.

## Testing
- `bun test script/publish-workflow.test.ts script/run-ci-tests.test.ts`
- `bun run typecheck`
- `bun run typecheck:script`
- `bun run build`
- `bun test src/shared/dist-bundle-bun-globals.test.ts`
- `bun run script/run-ci-tests.ts --phase=isolated --shard-count=4 --shard-index=0..3`
- `PATH=/Users/yeongyu/.local/share/fnm/aliases/default/bin:$PATH bun run script/run-ci-tests.ts --phase=shared`
- `PATH=/Users/yeongyu/.local/share/fnm/aliases/default/bin:$PATH bun run script/run-ci-tests.ts`

## Notes
- Local `/opt/homebrew/bin/node` was broken during verification due missing Homebrew dylibs. Re-running Node-dependent tests with the working fnm Node path passed; GitHub CI was unaffected and passed.