### PR TITLE
fix(background-output): add retry logic for race condition

### DIFF
--- a/src/tools/background-task/create-background-output.ts
+++ b/src/tools/background-task/create-background-output.ts
@@ -74,7 +74,15 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
     async execute(args: BackgroundOutputArgs, toolContext) {
       try {
         const ctx = toolContext as ToolContextWithMetadata
-        const task = manager.getTask(args.task_id)
+        let task = manager.getTask(args.task_id)
+
+        // Race condition fix: notification may arrive before task state is fully visible.
+        // Retry once after brief delay if task not found initially.
+        if (!task) {
+          await delay(100)
+          task = manager.getTask(args.task_id)
+        }
+
         if (!task) {
           return formatTaskNotFoundMessage(args.task_id)
         }


### PR DESCRIPTION
## Summary
- Add 100ms retry when task not found immediately after completion notification
- Fixes race condition where `background_output` called before task indexed

## Problem
When `background_output` is called immediately after receiving task completion notification, the task may not be indexed yet in the output manager, causing "Task not found" error.

## Solution
Added retry logic with 100ms delay when task not found. If task still not found after retry, returns original error.

## Testing
- Fired background task
- Called `background_output` immediately after notification
- First internal attempt hit race condition (expected)
- Retry succeeded - task found and result returned

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in `background_output`. Adds a single 100ms retry when a task isn’t found right after a completion notification to avoid intermittent “Task not found” errors.

<sup>Written for commit addeb885d0ac423b86a68f42909537e788c83634. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

