### PR TITLE
fix(keyword-detector): update stale delegate_task references to task

### DIFF
--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -61,8 +61,8 @@ IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
 
 SYNTHESIZE findings before proceeding.
 ---
-MANDATORY delegate_task params: ALWAYS include load_skills and run_in_background when calling delegate_task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
-Example: delegate_task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`,
+MANDATORY task params: ALWAYS include load_skills and run_in_background when calling task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
+Example: task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`,
   },
   {
     type: "team",

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -912,7 +912,7 @@ describe("keyword-detector team mode", () => {
     expect(textPart!.text).toContain("team_create")
     expect(textPart!.text).toContain("team_task_create")
     expect(textPart!.text).toContain("team_send_message")
-    expect(textPart!.text).toContain("NEVER substitute with delegate_task")
+    expect(textPart!.text).toContain("NEVER substitute with task")
     expect(textPart!.text).toContain("for this task")
   })
 

--- a/src/hooks/keyword-detector/team/default.ts
+++ b/src/hooks/keyword-detector/team/default.ts
@@ -14,4 +14,4 @@ export const TEAM_PATTERN =
   /\bteam[\s_-]?mode\b|(?<![가-힣])(?:팀\s*모드|팀으로)/i
 
 export const TEAM_MESSAGE = `[team-mode]
-Team mode reference detected. If user wants team-mode work, MUST orchestrate via team_* tools (team_create -> team_task_create + team_send_message). NEVER substitute with delegate_task - it is not equivalent. If team_* tools are unavailable (team_mode disabled in config), instruct user to set team_mode.enabled=true and restart opencode.`
+Team mode reference detected. If user wants team-mode work, MUST orchestrate via team_* tools (team_create -> team_task_create + team_send_message). NEVER substitute with task - it is not equivalent. If team_* tools are unavailable (team_mode disabled in config), instruct user to set team_mode.enabled=true and restart opencode.`

--- a/src/hooks/rules-injector/injector.test.ts
+++ b/src/hooks/rules-injector/injector.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RULES_INJECTOR_STORAGE } from "./constants";
 import { createRuleInjectionProcessor } from "./injector";
+import { clearProjectRootCache } from "./project-root-finder";
 
 type StatSnapshot = { mtimeMs: number; size: number };
 
@@ -89,7 +90,7 @@ function getInjectedRulesPath(sessionID: string): string {
   return join(RULES_INJECTOR_STORAGE, `${sessionID}.json`);
 }
 
-describe("createRuleInjectionProcessor", () => {
+describe("createRuleInjectionProcessor", { sequential: true }, () => {
   let testRoot: string;
   let projectRoot: string;
   let homeRoot: string;
@@ -122,6 +123,7 @@ describe("createRuleInjectionProcessor", () => {
     statSnapshots = [];
     trackedReadFileCount = 0;
     mockedHomeDir = homeRoot;
+    clearProjectRootCache();
   });
 
   afterEach(() => {

--- a/src/hooks/rules-injector/injector.ts
+++ b/src/hooks/rules-injector/injector.ts
@@ -42,8 +42,6 @@ interface ParsedRuleEntry {
   body: string;
 }
 
-const parsedRuleCache = new Map<string, ParsedRuleEntry>();
-
 function resolveFilePath(
   workspaceDirectory: string,
   path: string
@@ -89,6 +87,8 @@ export function createRuleInjectionProcessor(deps: {
     isDuplicateByContentHash: isDuplicateByContentHashImpl = isDuplicateByContentHash,
     saveInjectedRules: saveInjectedRulesImpl = saveInjectedRules,
   } = deps;
+
+  const parsedRuleCache = new Map<string, ParsedRuleEntry>();
 
   function getParsedRule(filePath: string, realPath: string): { metadata: RuleMetadata; body: string } {
     try {


### PR DESCRIPTION
Tool was renamed from `delegate_task` to `task` back in Feb but three references in the keyword-detector prompts never got updated. Two in the injected instructions (analyze/team mode) and one in the test assertion for team mode. Also cleaned up a couple stale module-level caches in the injector that were causing test contamination since the CI runner change.