### PR TITLE
fix(session-recovery): persist dedupe across stale repeated session.error

### DIFF
--- a/src/hooks/session-recovery/hook.test.ts
+++ b/src/hooks/session-recovery/hook.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { createSessionRecoveryHook } from "./hook"
+
+type RecoverableInfo = Parameters<ReturnType<typeof createSessionRecoveryHook>["handleSessionRecovery"]>[0]
+
+function createPrefillErrorInfo(): RecoverableInfo {
+  return {
+    id: "msg_failed_prefill",
+    role: "assistant",
+    sessionID: "ses_recovery_dedupe",
+    error: { message: "This model does not support assistant message prefill." },
+  }
+}
+
+function createCountingCtx() {
+  const counts = { abort: 0, messages: 0, promptAsync: 0, toast: 0 }
+  const info = createPrefillErrorInfo()
+  const ctx = {
+    client: {
+      session: {
+        abort: async () => {
+          counts.abort++
+          return {}
+        },
+        messages: async () => {
+          counts.messages++
+          return {
+            data: [
+              {
+                info: {
+                  id: info.id,
+                  role: "assistant",
+                  error: info.error,
+                },
+              },
+            ],
+          }
+        },
+        promptAsync: async () => {
+          counts.promptAsync++
+          return {}
+        },
+      },
+      tui: {
+        showToast: async () => {
+          counts.toast++
+          return {}
+        },
+      },
+    },
+    directory: "/tmp/session-recovery-dedupe-test",
+  }
+  return { ctx, counts, info }
+}
+
+describe("session-recovery hook persistent dedupe", () => {
+  test("#given the same recoverable session.error fires twice for the same assistant message id #when handleSessionRecovery is called twice in sequence #then recovery side effects run only once", async () => {
+    // given
+    const { ctx, counts, info } = createCountingCtx()
+    const hook = createSessionRecoveryHook(ctx as never)
+
+    // when
+    await hook.handleSessionRecovery(info)
+    await hook.handleSessionRecovery(info)
+
+    // then
+    expect(counts.abort).toBe(1)
+    expect(counts.toast).toBe(1)
+    expect(counts.promptAsync).toBe(0)
+  })
+
+  test("#given a recovered assistant message id is later reused by a stale duplicate session.error #when handleSessionRecovery is called for that stale duplicate #then recovery is suppressed", async () => {
+    // given
+    const { ctx, counts, info } = createCountingCtx()
+    const hook = createSessionRecoveryHook(ctx as never)
+
+    // when
+    await hook.handleSessionRecovery(info)
+    await Promise.resolve()
+    const result = await hook.handleSessionRecovery(info)
+
+    // then
+    expect(result).toBe(false)
+    expect(counts.abort).toBe(1)
+  })
+})

--- a/src/hooks/session-recovery/hook.ts
+++ b/src/hooks/session-recovery/hook.ts
@@ -151,8 +151,13 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
       log("[session-recovery] Recovery failed:", err)
       return false
     } finally {
-      processingErrors.delete(assistantMsgID)
-
+      // Keep assistantMsgID in processingErrors permanently so that a
+      // stale duplicate session.error for the SAME assistant message
+      // does not retrigger recovery (and a second resumeSession
+      // promptAsync injection) after the first attempt resolves.
+      // Successful recovery starts a new assistant message on the next
+      // turn with a different id, so this dedupe never blocks future
+      // legitimate errors.
       if (sessionID && onRecoveryCompleteCallback) {
         onRecoveryCompleteCallback(sessionID)
       }


### PR DESCRIPTION
## Summary

`processingErrors` in `src/hooks/session-recovery/hook.ts` was emptied inside a finally block. As a result, a second `session.error` fired for the same assistant message id after the first recovery resolves re-runs:

- `session.abort`
- session message history fetch
- the user-visible recovery toast
- any `auto_resume` `resumeSession` (which calls `promptAsync` through the shared gate)

That re-fire path is exactly the duplicate internal prompt injection pattern OMO already pinned everywhere else (PR #4034). It surfaces in stale event re-emission and polling-driven retries.

## Fix

- Drop the in-flight `processingErrors.delete` so the dedupe is permanent for the plugin lifetime.
- A genuinely new failure starts a new assistant message with a different id, so this never blocks future legitimate errors. Same-id duplicates collapse into a single recovery attempt.

## Test

- Add `src/hooks/session-recovery/hook.test.ts` asserting that two sequential `handleSessionRecovery` calls for the same recoverable info trigger `session.abort`, the recovery toast, and any internal `promptAsync` at most once.
- Test was confirmed RED on `origin/dev` before the fix and GREEN after.

## Verification

- `bun test src/hooks/session-recovery src/hooks/ralph-loop src/hooks/todo-continuation-enforcer src/features/background-agent src/shared/prompt-async-gate.test.ts src/shared/prompt-async-route-audit.test.ts --timeout 15000`: 798 pass / 0 fail.
- `bun run typecheck`: exit 0.
- `bun run build`: success (bundle + node-require shim + tsc d.ts + cli bundle + JSON schema).
- `bun test --timeout 30000`: 6816 pass / 0 fail / 1 skip across 708 files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist dedupe for repeated `session.error` on the same assistant message to stop duplicate recovery actions and internal prompt injections.

- **Bug Fixes**
  - Keep processed assistant message IDs in `processingErrors` instead of deleting them, so same-id duplicates never retrigger recovery.
  - Added `src/hooks/session-recovery/hook.test.ts` to verify `handleSessionRecovery` runs `session.abort`, toast, and any internal `promptAsync` at most once.

<sup>Written for commit 8e9dea949ba1af53e1520b7017dcf2c3ec71bd94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

