### PR TITLE
fix(team-mode): skip tmux layout when opencode server unreachable

### DIFF
--- a/src/create-managers.test.ts
+++ b/src/create-managers.test.ts
@@ -175,6 +175,28 @@ describe("createManagers", () => {
     expect(markServerRunningInProcess).toHaveBeenCalledTimes(1)
   })
 
+  it("#given tmux is enabled but ctx.serverUrl is undefined #when managers are created #then it does NOT mark the server as running (issue #3894)", () => {
+    // Vanilla `opencode` (no `opencode serve` / `opencode web`) leaves
+    // ctx.serverUrl undefined. Marking the server as in-process running
+    // would short-circuit isServerRunning() in createTeamLayout, letting
+    // it spawn tmux panes whose `opencode attach` then fails because no
+    // server is actually listening on the fallback port.
+    const ctx = createContext("/tmp")
+    const ctxWithoutServerUrl = { ...ctx, serverUrl: undefined as unknown as URL }
+    const args = {
+      ctx: ctxWithoutServerUrl,
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(true),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+
+    createManagers(args)
+
+    expect(markServerRunningInProcess).not.toHaveBeenCalled()
+  })
+
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {
     const args = {
       ctx: createContext("/tmp/project"),

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -57,7 +57,15 @@ export function createManagers(args: {
   const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled } = args
   const deps = { ...defaultCreateManagersDeps, ...args.deps }
 
-  if (tmuxConfig.enabled) {
+  // Only mark the server as in-process when the SDK actually exposes a
+  // serverUrl. `tmuxConfig.enabled` alone is not proof of a running server —
+  // a vanilla `opencode` session (no `opencode serve`/`opencode web`) leaves
+  // `ctx.serverUrl` undefined, and marking it running would make
+  // `isServerRunning` short-circuit to true. That bypasses the guard in
+  // `createTeamLayout` and lets it spawn tmux panes whose `opencode attach`
+  // command then fails because nothing is actually listening on the
+  // fallback port (issue #3894).
+  if (tmuxConfig.enabled && ctx.serverUrl) {
     deps.markServerRunningInProcessFn()
   }
   const tmuxSessionManager = new deps.TmuxSessionManagerClass(ctx, tmuxConfig)


### PR DESCRIPTION
## Summary

- `createManagers` was calling `markServerRunningInProcess()` whenever `tmuxConfig.enabled` was true, regardless of whether an opencode server was actually running.
- That made `isServerRunning()` short-circuit to `true`, bypassing the existing guard in `createTeamLayout` (`src/features/team-mode/team-layout-tmux/layout.ts:215`) that is supposed to skip pane creation when the server is unreachable.
- Fix: only mark the server as in-process running when the SDK actually provides `ctx.serverUrl`. When it does not, `isServerRunning()` falls back to a real HTTP probe, the existing guard fires, and no panes are spawned.

## Changes

- `src/create-managers.ts` — gate `markServerRunningInProcess()` on `ctx.serverUrl` being defined, not just on `tmuxConfig.enabled`.
- `src/create-managers.test.ts` — add regression test for the `tmuxConfig.enabled=true` + `ctx.serverUrl=undefined` case (the vanilla `opencode` scenario in the issue).

## Testing

```bash
bun run typecheck            # clean
bun test src/create-managers.test.ts src/features/team-mode/team-layout-tmux/layout.test.ts src/shared/tmux/tmux-utils.test.ts
# 37 pass, 0 fail
```

Repro from the issue (vanilla `opencode`, no `opencode serve`):
- Before: `team_create({ teamName: "..." })` spawns tmux panes whose `opencode attach` prints `Error: Unable to connect`.
- After: `createTeamLayout` returns `null` early with the existing log message `opencode server not reachable, skipping team layout`; no panes are created.

The happy-path is unchanged — when the plugin runs inside a real opencode server process (`ctx.serverUrl` is defined, e.g. under `opencode serve`/`opencode web`), the in-process flag is still set and the existing fast-path is preserved.

## Related Issues

Closes #3894


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip tmux team layout when the opencode server is unreachable by only marking the server as running if `ctx.serverUrl` is present. Fixes #3894; avoids spawning panes whose `opencode attach` fails in vanilla `opencode`.

- **Bug Fixes**
  - Gate `markServerRunningInProcess()` on `ctx.serverUrl` instead of `tmuxConfig.enabled`.
  - Add regression test for `tmuxConfig.enabled=true` with `ctx.serverUrl` undefined.

<sup>Written for commit bd3928e1582d6b6edf8f507fb74d46c11db437be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

