### PR TITLE
fix(hooks): do not clear sessionFirstMessageProcessed on session.idle (supersedes #3790)

### DIFF
--- a/src/hooks/claude-code-hooks/session-hook-state.ts
+++ b/src/hooks/claude-code-hooks/session-hook-state.ts
@@ -7,7 +7,12 @@ export const sessionInterruptState = new Map<string, { interrupted: boolean }>()
 export function clearSessionHookState(sessionID: string): void {
 	sessionErrorState.delete(sessionID)
 	sessionInterruptState.delete(sessionID)
-	sessionFirstMessageProcessed.delete(sessionID)
+	// sessionFirstMessageProcessed must NOT be cleared on idle.
+	// It tracks whether the first message of a session has been processed,
+	// so that SessionStart hooks fire only once per session. Clearing it
+	// on idle (which fires after every model response) makes isFirstMessage
+	// always return true, causing SessionStart hooks to fire on every
+	// prompt instead of only the first one.
 }
 
 export function clearAllSessionHookState(): void {


### PR DESCRIPTION
Supersedes #3790 by @leijc with the unrelated `bun.lock` commit dropped during rebase. Only the actual one-line fix + comment remains.

## Summary

`clearSessionHookState(sessionID)` is invoked on every `session.idle` event. It clears three state maps. Two of them (`sessionErrorState`, `sessionInterruptState`) are correctly transient per-response state. `sessionFirstMessageProcessed` is session-level — it gates "is this the first message in the session" so that Claude Code SessionStart hooks fire exactly once per session.

Clearing it on every idle makes `isFirstMessage` always return `true` in `chat-message-handler.ts`, so plugins that register SessionStart hooks (e.g. superpowers) inject their context on every user message rather than only at session start — wasting tokens and cluttering the conversation.

## Fix

Stop clearing `sessionFirstMessageProcessed` from `clearSessionHookState`. Add an inline comment explaining why so it does not regress.

## Verification

- `bun test src/hooks/claude-code-hooks --timeout 15000` 69 pass / 0 fail.
- `bun run typecheck` exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent SessionStart hooks from firing on every user prompt by not clearing `sessionFirstMessageProcessed` on `session.idle`. This keeps session-start context injection to once per session and saves tokens.

- **Bug Fixes**
  - Removed deletion of `sessionFirstMessageProcessed` in `clearSessionHookState` and added an inline comment; `sessionErrorState` and `sessionInterruptState` still clear on idle.

<sup>Written for commit 9f6b68118e7fc350c1bdeaf91bf76e65567bbf31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

