### PR TITLE
fix(doctor): detect oh-my-openagent version from resolved package.json

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -129,6 +129,46 @@ describe("system loaded version", () => {
       expect(loadedVersion.loadedVersion).toBe("5.6.7")
     })
 
+    it("falls back to require.resolve when neither config nor cache directory has an install", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.loadedVersion).not.toBeNull()
+      expect(loadedVersion.loadedVersion).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+      expect(loadedVersion.installedPackagePath).toContain("package.json")
+    })
+
+    it("prefers candidate install path over require.resolve fallback when candidate exists", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      writeJson(join(configDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "7.7.7" },
+      })
+      writeJson(join(configDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "7.7.7",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.installedPackagePath).toBe(join(configDir, "node_modules", PACKAGE_NAME, "package.json"))
+      expect(loadedVersion.loadedVersion).toBe("7.7.7")
+    })
+
     it("resolves symlinked config directories before selecting install path", () => {
       //#given
       const realConfigDir = createTemporaryDirectory("omo-real-config-")

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { resolveSymlink } from "../../../shared/file-utils"
@@ -86,6 +87,25 @@ function getExpectedVersion(cachePackage: PackageJsonShape | null, packageName: 
     ?? normalizeVersion(cachePackage?.dependencies?.[PACKAGE_NAME])
 }
 
+function resolveInstalledPackageJsonPath(): { packageName: string; packageJsonPath: string } | null {
+  try {
+    const require = createRequire(import.meta.url)
+    for (const packageName of ACCEPTED_PACKAGE_NAMES) {
+      try {
+        const packageJsonPath = require.resolve(`${packageName}/package.json`)
+        if (existsSync(packageJsonPath)) {
+          return { packageName, packageJsonPath }
+        }
+      } catch {
+        continue
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
 export function getLoadedPluginVersion(): LoadedVersionInfo {
   const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
   const configDir = resolveExistingDir(configPaths.configDir)
@@ -108,12 +128,17 @@ export function getLoadedPluginVersion(): LoadedVersionInfo {
 
   const { cacheDir: selectedDir, cachePackagePath } = selectedCandidate
   const selectedPackage = selectInstalledPackage(selectedCandidate)
-  const installedPackagePath = selectedPackage.installedPackagePath
+  const candidateInstalledPath = selectedPackage.installedPackagePath
+  const candidateExists = existsSync(candidateInstalledPath)
+
+  const resolvedFallback = candidateExists ? null : resolveInstalledPackageJsonPath()
+  const installedPackagePath = resolvedFallback?.packageJsonPath ?? candidateInstalledPath
+  const resolvedPackageName = resolvedFallback?.packageName ?? selectedPackage.packageName
 
   const cachePackage = readPackageJson(cachePackagePath)
   const installedPackage = readPackageJson(installedPackagePath)
 
-  const expectedVersion = getExpectedVersion(cachePackage, selectedPackage.packageName)
+  const expectedVersion = getExpectedVersion(cachePackage, resolvedPackageName)
   const loadedVersion = normalizeVersion(installedPackage?.version)
 
   return {


### PR DESCRIPTION
## Summary

- Doctor reported `unknown` for the plugin version whenever the package was installed outside the OpenCode config dir or XDG cache dir (e.g. `bunx oh-my-openagent` keeps its install in an ephemeral cache).
- Adds a `require.resolve("<pkg>/package.json")` fallback so the running plugin's actual `package.json` is found via Node's module resolution.

## Changes

- `src/cli/doctor/checks/system-loaded-version.ts`: when neither the config-dir nor cache-dir candidate has a `node_modules/<pkg>/package.json`, fall back to `createRequire(import.meta.url).resolve("<pkg>/package.json")` for each name in `ACCEPTED_PACKAGE_NAMES` (`oh-my-opencode`, `oh-my-openagent`). Fallback only triggers when the existing candidates are absent, so current behavior is preserved.
- `src/cli/doctor/checks/system-loaded-version.test.ts`: two new tests cover the fallback path (no install in either candidate dir) and confirm the candidate path still wins when present.

## Testing

```bash
bun run typecheck
bun test src/cli/doctor/
```

Results locally:
- typecheck: pass
- `bun test src/cli/doctor/`: 79 pass, 0 fail (2 new tests added in `system-loaded-version.test.ts`, total 7 in that file)

## Related Issues

Closes #3822

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doctor now detects the plugin version even when the package is outside the config or XDG cache dirs (e.g., `bunx oh-my-openagent`). It falls back to Node’s `require.resolve("<pkg>/package.json")` to locate the loaded plugin (`oh-my-openagent`/`oh-my-opencode`), fixing #3822.

- **Bug Fixes**
  - Use `require.resolve` only when neither candidate install path exists, preserving current behavior.
  - Added tests for the fallback path and for preferring candidate paths when present.

<sup>Written for commit 78ae240206c989c14e80e7a58c84973c6a74f24e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

