### PR TITLE
fix(tmux-subagent): pane creation regression after 4.0.0 (#3839)

### DIFF
--- a/src/features/tmux-subagent/attachable-session-status.test.ts
+++ b/src/features/tmux-subagent/attachable-session-status.test.ts
@@ -1,0 +1,64 @@
+/// <reference path="../../../bun-test.d.ts" />
+
+import { describe, expect, it } from "bun:test"
+import { isAttachableSessionStatus } from "./attachable-session-status"
+
+describe("isAttachableSessionStatus", () => {
+  it("accepts idle as attachable", () => {
+    // given
+    const status = "idle"
+
+    // when
+    const result = isAttachableSessionStatus(status)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  it("accepts running as attachable", () => {
+    // given
+    const status = "running"
+
+    // when
+    const result = isAttachableSessionStatus(status)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  it("accepts busy as attachable (regression #3839)", () => {
+    // given — opencode reports a fresh subagent session as `busy` while the
+    // task() loop is still streaming its first prompt. Excluding `busy` made
+    // `waitForSessionReady` time out before the pane was ever spawned, which
+    // produced the 4.0.0 "tmux pane creation fails silently" regression.
+    const status = "busy"
+
+    // when
+    const result = isAttachableSessionStatus(status)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  it("rejects unknown statuses", () => {
+    // given
+    const status = "starting"
+
+    // when
+    const result = isAttachableSessionStatus(status)
+
+    // then
+    expect(result).toBe(false)
+  })
+
+  it("rejects undefined", () => {
+    // given
+    const status = undefined
+
+    // when
+    const result = isAttachableSessionStatus(status)
+
+    // then
+    expect(result).toBe(false)
+  })
+})

--- a/src/features/tmux-subagent/attachable-session-status.ts
+++ b/src/features/tmux-subagent/attachable-session-status.ts
@@ -1,4 +1,4 @@
-const ATTACHABLE_SESSION_STATUSES = ["idle", "running"] as const
+const ATTACHABLE_SESSION_STATUSES = ["idle", "running", "busy"] as const
 
 export type AttachableSessionStatus = (typeof ATTACHABLE_SESSION_STATUSES)[number]
 


### PR DESCRIPTION
## Summary

- **Root cause:** `ATTACHABLE_SESSION_STATUSES` in `src/features/tmux-subagent/attachable-session-status.ts:1` only accepts `idle` and `running`. opencode reports a freshly-created subagent session as `busy` for the entire duration of its first prompt, so `waitForSessionReady` (`src/features/tmux-subagent/session-ready-waiter.ts:24`) never sees an attachable state, exhausts its 10s budget, and the tmux pane spawn is silently skipped. This is the exact deadlock several reporters pinpointed on #3839 (#issuecomment chain by `piano4889` and `lang-911`).
- **Why 3.17.15 worked:** 3.17.15 spawned the pane first and only monitored the session afterwards, so the status filter never had a chance to block pane creation.
- **Fix:** add `"busy"` to `ATTACHABLE_SESSION_STATUSES`. `waitForSessionReady` now resolves as soon as `/session/status` reports the session, after which the existing pane-spawn / readiness path runs unchanged.

## Why this is distinct from #4052

PR #4052 (`fix/3505-attach-retry-until-session-ready`) moves the `waitForSessionReady` call to *before* `executeActions` in `session-created-handler.ts`. That fixes the *flash-and-close* failure mode for sessions that do reach `idle`/`running`, but it does not change what counts as ready. When `waitForSessionReady` itself filters out the `busy` state, #4052 still times out before spawning the pane on this code path — the silent failure persists. Both fixes are needed; they target different parts of the same handler chain.

## Changes

| File | Change |
|------|--------|
| `src/features/tmux-subagent/attachable-session-status.ts` | Add `"busy"` to `ATTACHABLE_SESSION_STATUSES` |
| `src/features/tmux-subagent/attachable-session-status.test.ts` | New unit suite covering the regression case + existing accepted/rejected statuses |

## Testing

```
bun test src/features/tmux-subagent/
# 132 pass, 0 fail
bun run typecheck
# clean
```

The new suite includes `accepts busy as attachable (regression #3839)` so any future tightening of the filter that re-introduces this regression will fail loudly.

## Risk

Minimal. `busy` is a state opencode reports for live sessions, so accepting it as attachable is consistent with the runtime semantics of `opencode attach`. Downstream consumers of `isAttachableSessionStatus` (`manager.ts`, `session-ready-waiter.ts`) only use it to decide whether to proceed with pane spawn — accepting more states means we spawn the pane earlier, never later.

## Related Issues

Closes #3839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `busy` subagent sessions as attachable so tmux panes spawn again instead of silently failing. Includes tests to prevent regressions. Fixes #3839.

- **Bug Fixes**
  - Add `busy` to `ATTACHABLE_SESSION_STATUSES` so `waitForSessionReady` resolves when `/session/status` reports `busy`.
  - Add unit tests covering `idle`, `running`, `busy`, and invalid statuses (includes the regression case).

<sup>Written for commit f566144a3e49ba2c0c13787046927373c32fe03e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

