### PR TITLE
fix(team-mode): surface startup signal on fresh install (#3893)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -142,4 +142,49 @@ describe("oh-my-openagent plugin module", () => {
     expect(pluginModule.id).toBe("oh-my-openagent")
     expect(typeof pluginModule.server).toBe("function")
   })
+
+  // Regression test for issue #3893: fresh installs with
+  // `team_mode.enabled: true` had no observable signal that the config was
+  // picked up. Plugin must emit both a stderr-visible console.warn and an
+  // internal log entry on successful team-mode init.
+  it("emits a user-visible signal when team_mode is enabled on a fresh install", async () => {
+    // given a fresh-install config that only opts into team_mode
+    const teamModeConfig = {
+      enabled: true,
+      tmux_visualization: false,
+      max_parallel_members: 4,
+      max_members: 8,
+      max_messages_per_run: 10000,
+      max_wall_clock_minutes: 120,
+      max_member_turns: 500,
+      message_payload_max_bytes: 32768,
+      recipient_unread_max_bytes: 262144,
+      mailbox_poll_interval_ms: 3000,
+    }
+    mockLoadPluginConfig.mockReturnValue({ team_mode: teamModeConfig })
+    const consoleWarn = mock(() => {})
+    const originalConsoleWarn = console.warn
+    console.warn = consoleWarn as unknown as typeof console.warn
+
+    // when the plugin boots
+    try {
+      await pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0])
+    } finally {
+      console.warn = originalConsoleWarn
+    }
+
+    // then a stderr-visible "[team-mode] enabled" message is emitted so the
+    // user can verify the config landed (issue #3893).
+    const warnCalls = consoleWarn.mock.calls.map((call) => String(call[0] ?? ""))
+    const enabledWarn = warnCalls.find((message) => message.startsWith("[team-mode] enabled"))
+    expect(enabledWarn).toBeDefined()
+    expect(enabledWarn).toContain("base_dir=")
+
+    // and the internal log records the enabled state for diagnostics.
+    const logCalls = mockLog.mock.calls.map((call) => String(call[0] ?? ""))
+    expect(logCalls).toContain("[team-mode] enabled")
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,16 +101,31 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
       try {
         const { ensureBaseDirs, resolveBaseDir } = await import("./features/team-mode/team-registry/paths")
         const { checkTeamModeDependencies } = await import("./features/team-mode/deps")
-        await checkTeamModeDependencies(teamModeConfig)
-        await ensureBaseDirs(resolveBaseDir(teamModeConfig))
+        const teamModeDeps = await checkTeamModeDependencies(teamModeConfig)
+        const baseDir = resolveBaseDir(teamModeConfig)
+        await ensureBaseDirs(baseDir)
         if (pluginConfig.disabled_skills?.includes("team-mode")) {
           console.warn(
             "[team-mode] enabled=true but team-mode skill is disabled; skill docs hidden but tools still registered (D-29)",
           )
         }
+        // Emit a positive startup signal so users on fresh installs can verify
+        // that `team_mode.enabled: true` was picked up. Without this, the only
+        // observable evidence is the `team_*` tool list inside an agent prompt
+        // (see issue #3893). console.warn goes to opencode's stderr/log surface.
+        console.warn(
+          `[team-mode] enabled (tmux=${teamModeDeps.tmuxAvailable ? "ok" : "missing"}, git=${teamModeDeps.gitAvailable ? "ok" : "missing"}, base_dir=${baseDir})`,
+        )
+        deps.log("[team-mode] enabled", { baseDir, deps: teamModeDeps })
       } catch (err) {
         console.warn("[team-mode] init failed:", err)
       }
+    } else if (pluginConfig.team_mode) {
+      // Explicit `team_mode: { enabled: false }` (or any other shape) — log to
+      // help users distinguish "config not parsed" from "intentionally off".
+      deps.log("[team-mode] disabled (team_mode.enabled is not true)", {
+        team_mode: pluginConfig.team_mode,
+      })
     }
     const tmuxIntegrationEnabled = deps.isTmuxIntegrationEnabled(pluginConfig)
     if (tmuxIntegrationEnabled) {


### PR DESCRIPTION
## Summary

- On a fresh install, setting `team_mode.enabled: true` in `oh-my-openagent.json` produces no observable signal: opencode's log shows no `team` entries, and the `team_*` tools are only visible inside an agent prompt (not via `/skills` or `/team`).
- The plugin **does** initialize team-mode correctly — `loadPluginConfig` parses the block, `checkTeamModeDependencies` runs, `ensureBaseDirs` creates `~/.omo/`. The init block in `src/index.ts` just had no positive-path log, so users on fresh installs had no way to verify their config landed.
- Fix: emit a single stderr-visible `[team-mode] enabled (...)` message plus an internal `log()` entry on successful init, mirroring the existing failure-path `console.warn`.

## Changes

- `src/index.ts` — after `checkTeamModeDependencies()` + `ensureBaseDirs()` succeed, emit `console.warn("[team-mode] enabled (tmux=…, git=…, base_dir=…)")` and `log("[team-mode] enabled", { baseDir, deps })`. Also log on the `team_mode` present-but-disabled branch so users can distinguish "config not parsed" from "intentionally off". No behavior change for the team-mode tool/hook/skill wiring — purely diagnostic.
- `src/index.test.ts` — regression test (`emits a user-visible signal when team_mode is enabled on a fresh install`) asserting both the `console.warn` and internal `log` are called when `loadPluginConfig` returns a `team_mode.enabled: true` config.

## Testing

```bash
bun run typecheck                                                    # clean
bun test src/index.test.ts                                           # 4 pass, 0 fail
bun test src/__tests__/perf/plugin-init-team-mode-resume-defer.test.ts  # 1 pass (and the new log line is visible in test output)
bun test src/cli/doctor/checks/                                      # 56 pass, 0 fail
```

Manual repro from the issue (fresh `opencode` install + `oh-my-openagent@latest`, no prior `~/.config/opencode/oh-my-openagent.json`):

- Before: `oh-my-openagent.json` with `team_mode.enabled: true` is silent on startup — the only way to confirm activation is to start an agent session and look for `team_*` tools in the prompt.
- After: opencode stderr shows `[team-mode] enabled (tmux=ok, git=ok, base_dir=/home/user/.omo)` immediately at plugin boot, and `/tmp/oh-my-opencode.log` records `[team-mode] enabled`.

Scope: 2 files, +62 / -2. Doesn't touch the team-mode tools, hooks, skill, or doctor check — only the plugin-entry init logging.

## Related Issues

Closes #3893

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a clear startup signal when `team_mode.enabled: true` on fresh installs by writing a stderr-visible “[team-mode] enabled (...)” and an internal log, so users can verify activation. Addresses #3893.

- **Bug Fixes**
  - After successful init, emit `console.warn("[team-mode] enabled (tmux=…, git=…, base_dir=…)")` and `log("[team-mode] enabled", …)`; also log when `team_mode` is present but disabled.
  - Add a regression test to ensure both the warning and log fire when team mode is enabled.

<sup>Written for commit 9596f7a485d65d28cf0398292a21297574c3de42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

