### PR TITLE
fix(process-cleanup): call process.exit() after signal cleanup completes

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -84,10 +84,11 @@ describe("#given process cleanup registration", () => {
       expect(shutdown).toHaveBeenCalledTimes(1)
     })
 
-    test("#when cleanup finishes after SIGINT #then the fallback exit timer is cleared", async () => {
+    test("#when cleanup finishes after SIGINT #then the fallback exit timer is cleared and process.exit is called", async () => {
       const sigintListenersBefore = process.listeners("SIGINT")
       const setTimeoutSpy = spyOn(globalThis, "setTimeout")
       const clearTimeoutSpy = spyOn(globalThis, "clearTimeout")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       // Re-enable forced exit so we can verify setTimeout/clearTimeout are called
       __enableScheduledForcedExitForTesting()
 
@@ -108,9 +109,60 @@ describe("#given process cleanup registration", () => {
 
         expect(setTimeoutSpy).toHaveBeenCalledTimes(1)
         expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledWith(0)
       } finally {
         setTimeoutSpy.mockRestore()
         clearTimeoutSpy.mockRestore()
+        exitSpy.mockRestore()
+        __disableScheduledForcedExitForTesting()
+        process.exitCode = 0
+      }
+    })
+    test("#when SIGINT fires and cleanup resolves #then process.exit(0) is called", async () => {
+      const sigintListenersBefore = process.listeners("SIGINT")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      __enableScheduledForcedExitForTesting()
+
+      try {
+        const manager = { shutdown: mock(async () => {}) }
+        registeredManagers.push(manager)
+
+        registerManagerForCleanup(manager)
+
+        const sigintListener = getNewListener("SIGINT", sigintListenersBefore)
+        sigintListener()
+        await flushMicrotasks()
+
+        expect(manager.shutdown).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledWith(0)
+      } finally {
+        exitSpy.mockRestore()
+        __disableScheduledForcedExitForTesting()
+        process.exitCode = 0
+      }
+    })
+
+    test("#when SIGTERM fires and cleanup resolves #then process.exit(0) is called", async () => {
+      const sigtermListenersBefore = process.listeners("SIGTERM")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      __enableScheduledForcedExitForTesting()
+
+      try {
+        const manager = { shutdown: mock(async () => {}) }
+        registeredManagers.push(manager)
+
+        registerManagerForCleanup(manager)
+
+        const sigtermListener = getNewListener("SIGTERM", sigtermListenersBefore)
+        sigtermListener()
+        await flushMicrotasks()
+
+        expect(manager.shutdown).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledWith(0)
+      } finally {
+        exitSpy.mockRestore()
         __disableScheduledForcedExitForTesting()
         process.exitCode = 0
       }

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -60,7 +60,7 @@ function registerProcessSignal(
   const listener = () => {
     const cleanupResult = handler()
     if (exitAfter) {
-      scheduleForcedExit(cleanupResult, 0)
+      scheduleForcedExit(cleanupResult, 0, true)
     }
   }
   process.on(signal, listener)


### PR DESCRIPTION
## Summary

- Fix process hanging indefinitely on SIGINT/SIGTERM when cleanup completes quickly (<6s)

Fixes #4058

## Problem

Signal handlers (SIGINT/SIGTERM) register listeners that suppress the default process termination behavior. `scheduleForcedExit` was called with `exitAfterCleanup=false` (the default). When cleanup finished before the 6-second forced exit timer, the timer was cleared but `process.exit()` was never called — leaving the host process hanging until a SIGKILL.

Paradoxically, *slow* cleanup (>6s) worked because the forced exit timer would fire `process.exit()` before cleanup resolved.

## Fix

Pass `exitAfterCleanup=true` to `scheduleForcedExit` for signal handlers, matching the existing behavior for error handlers (`uncaughtException`/`unhandledRejection`) which already pass `true`.

One-line change: `process-cleanup.ts:63`.