### PR TITLE
fix(team-mode): surface port-0 fallback and silent layout skip (#3963)

### DIFF
--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -121,7 +121,17 @@ export async function createTeamLayout(teamRunId: string, members: Array<TeamLay
   try {
     const serverUrl = tmuxMgr.getServerUrl()
     if (!(await deps.isServerRunning(serverUrl))) {
-      log("opencode server not reachable, skipping team layout", { serverUrl })
+      const ctxServerUrl = tmuxMgr.getCtxServerUrl?.()
+      log("opencode server not reachable, skipping team layout (see issue #3963)", {
+        kind: "warning",
+        teamRunId,
+        serverUrl,
+        ctxServerUrl: ctxServerUrl && ctxServerUrl !== serverUrl ? ctxServerUrl : undefined,
+        hint:
+          ctxServerUrl && ctxServerUrl !== serverUrl
+            ? "ctx.serverUrl was discarded (likely port 0); launch opencode with --port N and OPENCODE_PORT=N to bind a real port"
+            : "no opencode server is listening on the fallback URL",
+      })
       return null
     }
 

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -468,6 +468,69 @@ describe('TmuxSessionManager', () => {
       // then
       expect(getManagerInternals(manager).serverUrl).toBe('http://localhost:4096')
     })
+
+    test('logs a structured warning when ctx.serverUrl has port 0 (#3963)', async () => {
+      // given
+      const previousOpenCodePort = process.env.OPENCODE_PORT
+      delete process.env.OPENCODE_PORT
+      const logCalls: Array<{ message: string; data?: unknown }> = []
+      const trackingDeps: TmuxUtilDeps = {
+        ...mockTmuxDeps,
+        log: (message, data) => { logCalls.push({ message, data }) },
+      }
+      try {
+        mockIsInsideTmux.mockReturnValue(true)
+        const { TmuxSessionManager } = await import('./manager')
+        const ctx = {
+          ...createMockContext(),
+          serverUrl: new URL('http://127.0.0.1:0/'),
+        }
+        const config = createTmuxConfig({ enabled: true })
+
+        // when
+        const manager = new TmuxSessionManager(ctx, config, trackingDeps)
+
+        // then
+        const warning = logCalls.find((entry) => entry.message.includes('ctx.serverUrl has port 0'))
+        expect(warning).toBeDefined()
+        expect(warning?.data).toMatchObject({
+          kind: 'warning',
+          ctxServerUrl: 'http://127.0.0.1:0/',
+          fallbackUrl: 'http://localhost:4096',
+        })
+        expect(manager.getCtxServerUrl()).toBe('http://127.0.0.1:0/')
+      } finally {
+        if (previousOpenCodePort === undefined) {
+          delete process.env.OPENCODE_PORT
+        } else {
+          process.env.OPENCODE_PORT = previousOpenCodePort
+        }
+      }
+    })
+
+    test('does not warn when ctx.serverUrl has a real port', async () => {
+      // given
+      const logCalls: Array<{ message: string; data?: unknown }> = []
+      const trackingDeps: TmuxUtilDeps = {
+        ...mockTmuxDeps,
+        log: (message, data) => { logCalls.push({ message, data }) },
+      }
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        ...createMockContext(),
+        serverUrl: new URL('http://127.0.0.1:12345/'),
+      }
+      const config = createTmuxConfig({ enabled: true })
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, trackingDeps)
+
+      // then
+      const warning = logCalls.find((entry) => entry.message.includes('ctx.serverUrl has port 0'))
+      expect(warning).toBeUndefined()
+      expect(manager.getCtxServerUrl()).toBe('http://127.0.0.1:12345/')
+    })
   })
 
   describe('getServerUrl', () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -90,6 +90,7 @@ export class TmuxSessionManager {
   private tmuxConfig: TmuxConfig
   private projectDirectory: string
   private serverUrl: string
+  private ctxServerUrl: string | undefined
   private sourcePaneId: string | undefined
   private sessions = new Map<string, TrackedSession>()
   private pendingSessions = new Set<string>()
@@ -122,11 +123,22 @@ export class TmuxSessionManager {
       : "4096"
     const fallbackUrl = `http://localhost:${defaultPort}`
     const rawServerUrl = ctx.serverUrl?.toString()
+    this.ctxServerUrl = rawServerUrl
     try {
       if (rawServerUrl) {
         const parsed = new URL(rawServerUrl)
         const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
-        this.serverUrl = port === '0' ? fallbackUrl : rawServerUrl
+        if (port === '0') {
+          this.deps.log(
+            "[tmux-session-manager] ctx.serverUrl has port 0; falling back. " +
+              "team_mode tmux visualization will silently skip if nothing is listening on the fallback URL. " +
+              "Launch opencode with --port N and OPENCODE_PORT=N to bind a real port (see issue #3963).",
+            { kind: "warning", ctxServerUrl: rawServerUrl, fallbackUrl },
+          )
+          this.serverUrl = fallbackUrl
+        } else {
+          this.serverUrl = rawServerUrl
+        }
       } else {
         this.serverUrl = fallbackUrl
       }
@@ -254,6 +266,10 @@ export class TmuxSessionManager {
 
   getServerUrl(): string {
     return this.serverUrl
+  }
+
+  getCtxServerUrl(): string | undefined {
+    return this.ctxServerUrl
   }
 
   private removeTrackedSession(sessionId: string): void {


### PR DESCRIPTION
## Summary

Closes the silent-failure UX gap reported in #3963.

When `ctx.serverUrl` has a port string of `"0"` (the default for `opencode --port 0` random-bind in default TUI mode), `TmuxSessionManager` silently replaces it with the `localhost:4096` fallback, and `createTeamLayout` then skips pane creation without surfacing any signal — no warning in the `team_create` tool response, nothing in user-facing opencode logs. The user observes `team_create` "succeeding" with no panes ever appearing.

This PR keeps the existing fallback resolution (no behavior change there — that's covered by PR #2987 which adds `server_url_override`, and option A from the issue is risky to apply here) and instead **makes the failure path loud**:

- `TmuxSessionManager` now retains the raw `ctx.serverUrl` on the instance and exposes it via `getCtxServerUrl()`.
- On the `port === '0'` fallback branch, the constructor emits a structured warning log naming both the discarded `ctxServerUrl` and the `fallbackUrl` it landed on, plus a one-line hint pointing to the `--port N` / `OPENCODE_PORT=N` workaround.
- `createTeamLayout`'s `"opencode server not reachable, skipping team layout"` log is upgraded to a structured warning that includes `teamRunId`, `serverUrl`, `ctxServerUrl` (when different — i.e. the port-0 fallback case), and an actionable hint distinguishing the two skip causes.

## Why this minimum-surface fix

The issue reporter offers three options (A: honor `ctx.serverUrl` unconditionally; B: loud warning; C: fix the misleading `removedLayout: true`). This PR delivers **option B** because:

- **Option A** changes behavior that existing tests (`manager.test.ts` lines 376–470) and downstream callers depend on; without a signal from opencode that the bound port is *actually* listening, trusting a port-0 URL would cause `isServerRunning` to immediately fail in spawned panes (same downstream problem as #3894, which #4047 just merged a guard for).
- **Option C** is a separate concern in `cleanup-team-run-resources.ts` and can be PR'd independently.
- **Option B** closes the diagnosability gap the reporter cares most about, with zero risk to working configurations and no API breakage. The `getCtxServerUrl()` getter is optional-chained at the call site so existing manager implementations stay source-compatible.

## Test plan

- [x] `bun test src/features/tmux-subagent/manager.test.ts` — 61 pass, 0 fail (includes 2 new tests asserting the warning fires on port 0 and is absent for real ports)
- [x] `bun test src/features/team-mode/team-layout-tmux/layout.test.ts` — 15 pass, 0 fail (no regression on the layout fallback path)
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual repro of #3963: launch `opencode` in a tmux session with no `--port`, enable `team_mode.tmux_visualization: true`, call `team_create`. Before this PR: silent skip, no log entry. After this PR: structured warning in `~/.local/share/opencode/log/*.log` with `kind: "warning"`, `ctxServerUrl: "http://127.0.0.1:0/"`, and the actionable hint.

## Related

- #3963 (this PR addresses)
- #2987 — adds `server_url_override` config (orthogonal workaround; complementary to this surfacing fix)
- #3894 / #4047 — downstream panes-spawned-but-attach-fails case (different symptom, already fixed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the port-0 server URL fallback visible with structured warnings so tmux team layout skips are no longer silent. Keeps the existing fallback behavior while adding clear, actionable logs (addresses #3963).

- **Bug Fixes**
  - Emit a structured warning when `ctx.serverUrl` has port `0`, including `ctxServerUrl`, `fallbackUrl`, and a hint to use `--port N`/`OPENCODE_PORT=N`.
  - Retain the raw `ctx.serverUrl` on the manager and expose it via `getCtxServerUrl()` for diagnostics.
  - Upgrade the `createTeamLayout` skip log to a warning with `teamRunId`, `serverUrl`, and `ctxServerUrl` (when different), with tailored hints for the skip cause.

<sup>Written for commit ced95c4bfa11564c02a4760fdc831131c93d4b95. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

