### PR TITLE
fix(team-mode): surface member error to main agent (#3923)

### DIFF
--- a/src/hooks/team-session-events/team-member-error-handler.test.ts
+++ b/src/hooks/team-session-events/team-member-error-handler.test.ts
@@ -198,6 +198,70 @@ describe("createTeamMemberErrorHandler", () => {
     expect(wrongRuntimeState.members[0]?.status).toBe("running")
   })
 
+  test("injects a member_error announcement into the lead inbox when a non-lead member errors", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const runtimeStateWithLeader: RuntimeState = {
+      version: 1,
+      teamRunId,
+      teamName: "team-alpha",
+      specSource: "project",
+      createdAt: 1,
+      status: "active",
+      leadSessionId: "lead-session",
+      members: [
+        {
+          name: "lead",
+          sessionId: "lead-session",
+          agentType: "leader",
+          status: "running",
+          pendingInjectedMessageIds: [],
+        },
+        {
+          name: "worker",
+          sessionId: "member-session",
+          agentType: "general-purpose",
+          status: "running",
+          pendingInjectedMessageIds: [],
+        },
+      ],
+      shutdownRequests: [],
+      bounds: {
+        maxMembers: 8,
+        maxParallelMembers: 4,
+        maxMessagesPerRun: 10000,
+        maxWallClockMinutes: 120,
+        maxMemberTurns: 500,
+      },
+    }
+    await seedRuntimeState(runtimeStateWithLeader, config)
+    const handler = createTeamMemberErrorHandler(config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: { sessionID: "member-session", error: new Error("task exploded") },
+      },
+    })
+
+    // then — lead inbox must contain an announcement about the failed member
+    const leadInboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "lead")
+    const leadInboxEntries = await readdir(leadInboxDir)
+    expect(leadInboxEntries.some((entry) => entry.endsWith(".json"))).toBe(true)
+
+    const { listUnreadMessages } = await import("../../features/team-mode/team-mailbox/inbox")
+    const unread = await listUnreadMessages(teamRunId, "lead", config)
+    expect(unread).toHaveLength(1)
+    expect(unread[0]?.kind).toBe("announcement")
+    expect(unread[0]?.from).toBe("system")
+    expect(unread[0]?.to).toBe("lead")
+    expect(unread[0]?.body).toContain("worker")
+    expect(unread[0]?.body).toContain("task exploded")
+  })
+
   test("requeues pending live-delivery messages when the recipient session errors before idle ack", async () => {
     // given
     const baseDir = await createTemporaryBaseDir()

--- a/src/hooks/team-session-events/team-member-error-handler.ts
+++ b/src/hooks/team-session-events/team-member-error-handler.ts
@@ -1,11 +1,15 @@
+import { randomUUID } from "node:crypto"
+
 import type { TeamModeConfig } from "../../config/schema/team-mode"
 import { findResolvedMemberSession } from "../../features/team-mode/member-session-resolution"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
 import {
   releaseDeliveryReservation,
   reserveMessageForDelivery,
 } from "../../features/team-mode/team-mailbox/reservation"
 import { loadRuntimeState, transitionRuntimeState } from "../../features/team-mode/team-state-store/store"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+import { isRecord } from "../../shared/record-type-guard"
 import { log } from "../../shared/logger"
 
 type HookInput = { event: { type: string; properties?: unknown } }
@@ -13,6 +17,18 @@ export type HookImpl = (input: HookInput) => Promise<void>
 
 function getErroredSessionID(properties: unknown): string | undefined {
   return resolveSessionEventID(properties)
+}
+
+function extractErrorText(properties: unknown): string {
+  const props = isRecord(properties) ? properties : undefined
+  const errorValue = props?.["error"]
+  if (errorValue instanceof Error) {
+    return errorValue.message
+  }
+  if (typeof errorValue === "string" && errorValue.length > 0) {
+    return errorValue
+  }
+  return "unknown error"
 }
 
 async function requeuePendingLiveDeliveries(
@@ -61,6 +77,35 @@ export function createTeamMemberErrorHandler(config: TeamModeConfig): HookImpl {
             : member
         )),
       }), config)
+
+      const leaderMember = runtimeState.members.find((member) => member.agentType === "leader")
+      if (leaderMember !== undefined && leaderMember.name !== runtimeMember.memberName) {
+        const errorText = extractErrorText(event.properties)
+        const errorBody = `Team member "${runtimeMember.memberName}" has entered an error state and will not complete its task.\nError: ${errorText}`
+        try {
+          await sendMessage(
+            {
+              version: 1,
+              messageId: randomUUID(),
+              from: "system",
+              to: leaderMember.name,
+              kind: "announcement",
+              body: errorBody,
+              timestamp: Date.now(),
+            },
+            runtimeState.teamRunId,
+            config,
+            { isLead: true, activeMembers: runtimeState.members.map((m) => m.name) },
+          )
+        } catch (sendError) {
+          log("team member error handler: failed to notify lead of member error", {
+            event: "team-mode-member-error-notify-failed",
+            teamRunId: runtimeState.teamRunId,
+            memberName: runtimeMember.memberName,
+            error: sendError instanceof Error ? sendError.message : String(sendError),
+          })
+        }
+      }
 
       log("team member session errored", {
         event: "team-mode-member-errored",


### PR DESCRIPTION
## Summary

**Root cause**: When a team member session emits a `session.error` event, `createTeamMemberErrorHandler` correctly marks the member as `errored` in the runtime state — but it never wrote anything into the **lead agent's mailbox inbox**. The coordinator/lead agent only polls its own inbox for messages; it had no mechanism to learn about the failure and would wait indefinitely.

**Chosen approach**: After the existing state transition to `errored`, the handler now:
1. Identifies the leader member (`agentType === "leader"`) from the runtime state
2. Sends an `announcement` message (from `"system"`) into the leader's inbox containing the failed member's name and the underlying error text extracted from `event.properties.error`
3. The send is wrapped in its own try/catch so a mailbox write failure cannot suppress the already-persisted state transition or the existing log line

The fix is intentionally narrow — it reuses the existing `sendMessage` path (same infrastructure as regular peer messages), requires no new types or abstractions, and is safely skipped if there is no distinct leader member or if the leader itself is the erroring member.

## Test plan

- [x] All 5 tests in `team-member-error-handler.test.ts` pass (4 existing + 1 new regression)
- [x] New regression test: seeds a runtime state with a `leader` + `worker` member, fires `session.error` on the worker session, then asserts the lead's inbox contains exactly one `announcement` from `"system"` whose body names the failed member and includes the error text (`"task exploded"`)
- [x] `bunx tsc --noEmit` exits clean (zero errors)
- [x] Diff is 109 lines total (under the 150-line constraint)

## Related

Closes #3923

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface team member errors to the leader by sending a system announcement to the leader’s inbox, so the coordinator stops polling and surfaces the failure. Prevents runs from stalling when a worker errors mid-task.

- **Bug Fixes**
  - On `session.error`, keep the state transition to `errored` and send an inbox `announcement` to the leader via `sendMessage`.
  - Include the failed member’s name and the error text from `event.properties.error`; fall back to “unknown error”.
  - Skip notification if there’s no leader or the leader is the one that errored. Wrap the send in try/catch and log on failure.
  - Added a regression test that asserts the leader receives exactly one system announcement with the member name and error text.

<sup>Written for commit 2bf5038215dbe0e52e8d53199f6898acfa993fa6. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4064?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

