### PR TITLE
fix(team-mode): reject team_create from hard-reject agents (#3987)

### DIFF
--- a/src/features/team-mode/tools/lifecycle.test.ts
+++ b/src/features/team-mode/tools/lifecycle.test.ts
@@ -284,6 +284,34 @@ describe("team lifecycle tools", () => {
     expect(hasRuntime(created.teamRunId)).toBe(false)
   })
 
+  test("team_create denies a hard-reject caller even when spec has an explicit lead field", async () => {
+    // given
+    const teamCreateTool = createTeamCreateToolForTest()
+    const prometheusContext = {
+      ...createToolContext("lead-session"),
+      agent: "prometheus",
+    }
+    const inlineSpec = {
+      name: "alpha-team",
+      lead: { kind: "subagent_type", subagent_type: "sisyphus" },
+      members: [{ kind: "category", name: "member-a", category: "quick", prompt: "Do the assigned work" }],
+    }
+
+    // when
+    let errorMessage = ""
+    try {
+      await teamCreateTool.execute({ inline_spec: inlineSpec }, prometheusContext)
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    // then
+    expect(errorMessage).toContain("team_create denied")
+    expect(errorMessage).toContain("prometheus")
+    expect(errorMessage).toContain("hard-reject")
+    expect(createTeamRunMock).not.toHaveBeenCalled()
+  })
+
   test("team_reject_shutdown records the rejection reason", async () => {
     // given
     const createTool = createTeamCreateToolForTest()

--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -8,7 +8,9 @@ import { mergeCategories } from "../../../shared/merge-categories"
 import type { OpencodeClient } from "../../../tools/delegate-task/types"
 import type { BackgroundManager } from "../../background-agent/manager"
 import type { TmuxSessionManager } from "../../tmux-subagent/manager"
+import { getAgentConfigKey } from "../../../shared/agent-display-names"
 import { resolveCallerTeamLead } from "../resolve-caller-team-lead"
+import { AGENT_ELIGIBILITY_REGISTRY } from "../types"
 import { loadTeamSpec, normalizeTeamSpecInput } from "../team-registry/loader"
 import { validateSpec } from "../team-registry/validator"
 import { createTeamRun } from "../team-runtime/create"
@@ -197,6 +199,13 @@ export function createTeamCreateTool(
       if (!leadSessionId) throw new Error("team_create requires leadSessionId or tool context sessionID")
       const projectRoot = typeof runtimeContext.directory === "string" ? runtimeContext.directory : process.cwd()
       const callerTeamLead = resolveCallerTeamLead(runtimeContext.agent)
+      if (callerTeamLead.displayName !== undefined) {
+        const callerAgentKey = getAgentConfigKey(callerTeamLead.displayName)
+        const callerRegistryEntry = AGENT_ELIGIBILITY_REGISTRY[callerAgentKey]
+        if (callerRegistryEntry?.verdict === "hard-reject") {
+          throw new Error(`team_create denied: caller '${callerAgentKey}' is a hard-reject agent and cannot create teams regardless of an explicit 'lead' in the spec. ${callerRegistryEntry.rejectionMessage ?? `Agent '${callerAgentKey}' is not eligible to lead a team.`}`)
+        }
+      }
       const defaultCategoryName = resolveDefaultInlineCategory(executorConfig?.userCategories)
       const spec = args.teamName
         ? await deps.loadTeamSpec(args.teamName, config, projectRoot, { callerTeamLead })


### PR DESCRIPTION
## Summary

When a hard-reject agent (e.g. `prometheus`) called `team_create` with an explicit `lead` field in the spec, the eligibility check inside `shouldReuseCallerLeadSession` was bypassed entirely — it only ran in the branch where no lead was configured. As a result, the config-defined lead member was spawned as a new child session instead of reusing the caller session, `registerTeamSession` was never called for the caller, and the caller's session ID was absent from the team session registry. Later, when members replied via `team_send_message`, `deliverLive` routed messages to the spawned lead session, making the original caller an orphan that could send but never receive.

The fix (Option A — Strict) moves the hard-reject eligibility guard to the very top of `team_create.execute`, before any team-run state mutates. The guard resolves the caller's agent type via `getAgentConfigKey(callerTeamLead.displayName)`, looks it up in `AGENT_ELIGIBILITY_REGISTRY`, and throws an actionable error if the verdict is `"hard-reject"`. This runs unconditionally regardless of whether the spec contains an explicit `lead` field, closing the bypass path.

## Test plan

- [x] Added one focused test: `team_create denies a hard-reject caller even when spec has an explicit lead field` — uses `agent: "prometheus"` with an inline spec containing an explicit `lead`, asserts the error message contains `"team_create denied"`, `"prometheus"`, and `"hard-reject"`, and confirms `createTeamRunMock` was never called
- [x] `bun test src/features/team-mode/tools/lifecycle.test.ts` → 15 pass, 0 fail
- [x] `bunx tsc --noEmit` → 0 errors

## Related

Closes #3987

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `team_create` when the caller is a hard‑reject agent, even if the spec sets an explicit `lead`, preventing orphaned caller sessions and misrouted messages. The guard now runs at the start of `team_create.execute` and returns a clear error naming the agent.

- **Bug Fixes**
  - Moved caller eligibility check to the top of `team_create.execute`; deny `"hard-reject"` agents via `AGENT_ELIGIBILITY_REGISTRY` and `getAgentConfigKey`.
  - Added a test to confirm denial with an explicit `lead` and that no team run is created.

<sup>Written for commit 4c3600546740f3124613b319a088c8cabcbf2ceb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

