### PR TITLE
fix(tmux-subagent): drain terminal probe replies during delegated pane startup (#2887)

### DIFF
--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -255,6 +255,30 @@ describe("team-layout-tmux", () => {
     expect(commands.some((args) => args[0] === "set-option")).toBe(false)
   })
 
+  test("#given delegated pane startup #when split-window is called #then -d flag is always present to prevent terminal probe replies leaking into caller pane (fix #2887)", async () => {
+    // given
+    const { createTeamLayout } = await loadLayoutModule()
+    const members = [
+      { name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" },
+      { name: "m2", sessionId: "s-m2", worktreePath: "/tmp/m2" },
+      { name: "m3", sessionId: "s-m3", worktreePath: "/tmp/m3" },
+    ]
+
+    // when
+    await createTeamLayout("run-probe-drain", members, tmuxMgr as never)
+
+    // then: every split-window call must carry -d so focus never bounces to the
+    // new pane; without -d, terminal capability probe replies (DA1/DA2, OSC color)
+    // emitted during pane startup are misrouted to the caller pane's stdin and
+    // appear as literal garbage text in the main OpenCode chat input.
+    const commands = getCommands()
+    const splitWindowCalls = commands.filter((args) => args[0] === "split-window")
+    expect(splitWindowCalls.length).toBeGreaterThan(0)
+    for (const splitArgs of splitWindowCalls) {
+      expect(splitArgs).toContain("-d")
+    }
+  })
+
   test("#given ownedSession=false, focusWindowId=@10, gridWindowId=@11 #when removeTeamLayout runs #then tmux kill-window is called twice with -t @10 and -t @11 and kill-session is NEVER called", async () => {
     // given
     const { removeTeamLayout } = await loadLayoutModule()
@@ -392,7 +416,7 @@ describe("team-layout-tmux", () => {
       const commands = getCommands()
       const splitCalls = commands.filter((args) => args[0] === "split-window")
       expect(splitCalls).toEqual([
-        ["split-window", "-t", process.env.TMUX_PANE ?? "", "-h", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", "/tmp/m1"],
+        ["split-window", "-t", process.env.TMUX_PANE ?? "", "-h", "-d", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", "/tmp/m1"],
       ])
       expect(commands.filter((args) => args[0] === "new-window").length).toBe(0)
     })

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -61,7 +61,7 @@ function selectExistingTeammatePane(teammatePanes: Array<string>, callerPaneId: 
 
 function buildSplitArgs(callerPaneId: string, teammatePanes: Array<string>, member: TeamLayoutMember): Array<string> {
   if (teammatePanes.length === 0) {
-    return ["split-window", "-t", callerPaneId, "-h", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", getPaneWorkingDirectory(member)]
+    return ["split-window", "-t", callerPaneId, "-h", "-d", "-l", "70%", "-P", "-F", "#{pane_id}", "-c", getPaneWorkingDirectory(member)]
   }
 
   return [
@@ -69,6 +69,7 @@ function buildSplitArgs(callerPaneId: string, teammatePanes: Array<string>, memb
     "-t",
     selectExistingTeammatePane(teammatePanes, callerPaneId),
     teammatePanes.length % 2 === 1 ? "-v" : "-h",
+    "-d",
     "-P",
     "-F",
     "#{pane_id}",


### PR DESCRIPTION
## Summary

**Root cause:** `buildSplitArgs` in `src/features/team-mode/team-layout-tmux/layout.ts` called `split-window` without the `-d` (detached / don't-switch-focus) flag. Without `-d`, tmux briefly grants focus to the newly created pane during creation. The outer terminal, seeing its active pane change, sends DA1/DA2 capability probe replies and OSC color probe replies into what it believes is the active pane. Due to a focus-handoff race, those bytes land in the **caller** pane's stdin buffer instead of being consumed by the delegated pane, and appear as literal garbage text in the main OpenCode chat input (e.g. `414/21212a2/6969717/98989f9f/b3b3f2f2/...`).

**Fix:** Add `-d` to every `split-window` call in `buildSplitArgs` — both the first-teammate branch (horizontal split) and the subsequent-teammate branch. This matches the flag already used in `pane-spawn.ts` for inline subagent panes, keeping the caller pane focused throughout the delegated pane lifecycle so probe replies are consumed by the correct target.

**Changed files:**
- `src/features/team-mode/team-layout-tmux/layout.ts`: +`-d` to both `split-window` code paths in `buildSplitArgs`
- `src/features/team-mode/team-layout-tmux/layout.test.ts`: update existing exact-args snapshot + add one new test asserting `-d` is present on every `split-window` call

## Test plan

- [x] `bun test src/features/team-mode/team-layout-tmux/layout.test.ts` — 16/16 pass (was 15/16 before fix; existing snapshot updated)
- [x] `bun test src/shared/tmux/` — 82/82 pass
- [x] `bunx tsc --noEmit` — zero errors
- [x] New test `#given delegated pane startup #when split-window is called #then -d flag is always present` guards the invariant going forward

## Limitations

This fix covers the **team-layout** code path (`createTeamLayout`). The subagent inline pane path (`spawnTmuxPane` in `pane-spawn.ts`) already uses `-d` and was not affected. The bug cannot be fully reproduced in a unit-test environment (requires a live tmux session with a real outer terminal emitting probe sequences), so the test asserts the structural invariant rather than end-to-end probe suppression.

If the issue also manifests on the isolated-window or isolated-session code paths (`spawnTmuxWindow` / `spawnTmuxSession`), those already use `-d` / `new-window -d` / `new-session -d` and should not be affected.

## Related

Closes #2887

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents garbage probe bytes from showing in the chat by keeping focus on the caller pane when creating delegated tmux panes. Adds the `-d` flag to all `split-window` calls in team layout to fix #2887.

- **Bug Fixes**
  - Root cause: `split-window` ran without `-d`, tmux briefly switched focus, and DA1/DA2/OSC probe replies leaked into the caller pane.
  - Change: add `-d` to both `buildSplitArgs` code paths; behavior now matches inline subagent panes.
  - Tests: updated snapshot and added a test asserting every `split-window` includes `-d`; all tests pass.
  - Scope: team-layout path only; other window/session paths already used `-d`.

<sup>Written for commit e25f3ca7364d70ef23e11573d368b16f9f264b5e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4066?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

