### PR TITLE
fix(team-mode): preserve team membership across model fallback (#3898)

### DIFF
--- a/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/src/features/background-agent/fallback-retry-handler.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
-import { tryFallbackRetry, type FallbackRetryHandlerDeps } from "./fallback-retry-handler"
+import { tryFallbackRetry, TeamModeFallbackError, type FallbackRetryHandlerDeps } from "./fallback-retry-handler"
 import type { FallbackEntry } from "../../shared/model-requirements"
 
 const sharedLogMock = mock(() => {})
@@ -431,6 +431,43 @@ describe("tryFallbackRetry", () => {
       expect(result).toBe(true)
       expect(args.task.model?.providerID).toBe("provider-a")
       expect(args.task.model?.modelID).toBe("fallback-model-1")
+    })
+  })
+
+  describe("#team-mode fallback", () => {
+    test("throws TeamModeFallbackError when teamRunId is set but onSessionCreated is absent", async () => {
+      // given: a team-mode task that somehow lost its onSessionCreated callback —
+      // without it the fallback session would not be registered in the team-session
+      // registry and every team tool call would silently fail with "not in team"
+      const args = createDefaultArgs({
+        teamRunId: "team-run-abc",
+        onSessionCreated: undefined,
+      })
+
+      // when / then: a bounded structured error must surface instead
+      await expect(tryFallbackRetry(args)).rejects.toThrow(TeamModeFallbackError)
+      await expect(tryFallbackRetry(createDefaultArgs({ teamRunId: "team-run-abc", onSessionCreated: undefined }))).rejects.toThrow(
+        "team-mode fallback denied: cannot preserve team context",
+      )
+    })
+
+    test("proceeds normally when teamRunId and onSessionCreated are both present", async () => {
+      // given: a properly-formed team-mode task with its session registration callback
+      const onSessionCreated = mock(async () => {})
+      const args = createDefaultArgs({
+        teamRunId: "team-run-abc",
+        onSessionCreated,
+      })
+
+      // when
+      const result = await tryFallbackRetry(args)
+
+      // then: fallback is queued and the retry input preserves both team fields
+      expect(result).toBe(true)
+      const key = `${args.task.model!.providerID}/${args.task.model!.modelID}`
+      const retryInput = args.queuesByKey.get(key)?.[0]?.input
+      expect(retryInput?.teamRunId).toBe("team-run-abc")
+      expect(retryInput?.onSessionCreated).toBe(onSessionCreated)
     })
   })
 })

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -13,6 +13,13 @@ import { transformModelForProvider } from "../../shared/provider-model-id-transf
 import { abortWithTimeout } from "./abort-with-timeout"
 import { ensureCurrentAttempt, scheduleRetryAttempt } from "./attempt-lifecycle"
 
+export class TeamModeFallbackError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TeamModeFallbackError"
+  }
+}
+
 function canonicalizeModelID(modelID: string): string {
   return modelID.toLowerCase().replace(/\./g, "-")
 }
@@ -182,6 +189,21 @@ export async function tryFallbackRetry(args: {
     failedError: errorInfo.message,
     nextModel: `${providerID}/${transformedModelId}`,
   })
+
+  // Guard: a team-mode task (teamRunId set) MUST carry an onSessionCreated callback so
+  // the fallback session gets registered in the team-session registry under the original
+  // member slot. Without it the new session would not appear as a team participant and
+  // every subsequent team tool call would throw "not in team". Fail with a bounded
+  // structured error instead of silently entering that confusing runtime state.
+  if (task.teamRunId && !task.onSessionCreated) {
+    deps.log("[background-agent] team-mode fallback denied: task has teamRunId but no onSessionCreated; cannot preserve team membership", {
+      taskId: task.id,
+      teamRunId: task.teamRunId,
+    })
+    throw new TeamModeFallbackError(
+      `team-mode fallback denied: cannot preserve team context for task ${task.id} (teamRunId=${task.teamRunId})`,
+    )
+  }
 
   const key = task.model ? `${task.model.providerID}/${task.model.modelID}` : task.agent
   const queue = queuesByKey.get(key) ?? []


### PR DESCRIPTION
## Summary (root cause + chosen approach)

**Root cause:** When a team-mode subagent task hits a rate-limit error and `tryFallbackRetry` queues a retry with a new model, the retry input correctly carries `teamRunId` and `onSessionCreated`. However, if `onSessionCreated` is absent (e.g. a task created outside the normal team-spawn path), the new fallback session gets a fresh session ID that is never registered in the team-session registry. Every subsequent `team_send_message` / `team_status` call from that session then fails with "not in team" — the membership lookup in `team-tool-gating` finds no registry entry and no matching runtime-state entry.

**Chosen approach (bounded structured error guard):**

Add a pre-queue check in `tryFallbackRetry`: if `task.teamRunId` is set but `task.onSessionCreated` is absent, throw a `TeamModeFallbackError` (new exported class) instead of silently launching an unregistered session. This surfaces the problem as a clear, catchable, structured error rather than a confusing mid-flight "not in team" runtime failure. When both fields are present (the normal case — `create.ts` always sets them together), the fallback proceeds exactly as before.

## Test plan

- [x] New test: `throws TeamModeFallbackError when teamRunId is set but onSessionCreated is absent` — asserts the bounded error is thrown instead of "not in team" confusion
- [x] New test: `proceeds normally when teamRunId and onSessionCreated are both present` — asserts fallback is queued and both team fields (`teamRunId`, `onSessionCreated`) are preserved in the retry input
- [x] Existing test `preserves team identity and session callback in retry input` (line 246) — still passes, confirming no regression on the happy path
- [x] `bun test src/features/background-agent/fallback-retry-handler.test.ts` — 26/26 pass
- [x] `bun test src/hooks/team-tool-gating/hook.test.ts src/features/team-mode/team-session-registry.test.ts` — 19/19 pass
- [x] `bunx tsc --noEmit` — clean

## Related

Closes #3898. Related to #3886 (fallback loop bounds), #3738 (ordered provider fallback), #3737, #3720.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team-mode fallbacks so agents stay in the team after switching models, preventing "not in team" errors. Closes #3898.

- **Bug Fixes**
  - Preserve team membership across model fallback by requiring `onSessionCreated` when `teamRunId` is set.
  - Add `TeamModeFallbackError` and throw when preservation isn’t possible, instead of starting an unregistered session.
  - Carry `teamRunId` and `onSessionCreated` into the retry input so the fallback subagent remains a team participant.

<sup>Written for commit b516d5d41ef55c219a0dba1816cb0958a3acd70c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4067?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

