### PR TITLE
docs(agents): add required run_in_background to task() delegation examples (#3960)

### DIFF
--- a/src/agents/dynamic-agent-category-skills-guide.ts
+++ b/src/agents/dynamic-agent-category-skills-guide.ts
@@ -102,6 +102,7 @@ Check the \`skill\` tool for available skills and their descriptions. For EVERY 
 task(
   category="[selected-category]",
   load_skills=["skill-1", "skill-2"],  // Include ALL relevant skills - ESPECIALLY user-installed ones
+  run_in_background=false,
   prompt="..."
 )
 \`\`\`
@@ -123,7 +124,7 @@ Any task involving UI, UX, CSS, styling, layout, animation, design, or frontend 
 
 \`\`\`typescript
 // CORRECT: Visual work → visual-engineering category
-task(category="visual-engineering", load_skills=["frontend-ui-ux"], prompt="Redesign the sidebar layout with new spacing...")
+task(category="visual-engineering", load_skills=["frontend-ui-ux"], run_in_background=false, prompt="Redesign the sidebar layout with new spacing...")
 
 // WRONG: Visual work in wrong category - WILL PRODUCE INFERIOR RESULTS
 task(category="quick", load_skills=[], prompt="Redesign the sidebar layout with new spacing...")

--- a/src/agents/hephaestus/gpt-5-3-codex.ts
+++ b/src/agents/hephaestus/gpt-5-3-codex.ts
@@ -381,6 +381,7 @@ When delegating, ALWAYS check if relevant skills should be loaded:
 task(
   category="visual-engineering",
   load_skills=["frontend-ui-ux"],
+  run_in_background=false,
   prompt="1. TASK: Build the settings page... 2. EXPECTED OUTCOME: ..."
 )
 \`\`\`

--- a/src/agents/sisyphus/gemini.ts
+++ b/src/agents/sisyphus/gemini.ts
@@ -142,7 +142,7 @@ export function buildGeminiToolCallExamples(): string {
 **User**: "Add a new /health endpoint to the API"
 **CORRECT**:
 \`\`\`
-→ Call Task(category="quick", load_skills=["typescript-programmer"], prompt="...")
+→ Call Task(category="quick", load_skills=["typescript-programmer"], run_in_background=false, prompt="...")
 → (After agent completes) Read changed files to verify
 → Call LspDiagnostics on changed files
 → Report


### PR DESCRIPTION
## Summary

Three prompt template files in `src/agents/` omitted `run_in_background=false,` from their `task()` delegation examples (`dynamic-agent-category-skills-guide.ts`, `hephaestus/gpt-5-3-codex.ts`, and `sisyphus/gemini.ts`), while the `task()` tool schema declares it as a required parameter. Agents that copied these examples produced invalid `task()` calls that hard-failed on the missing parameter. This PR adds `run_in_background=false,` to each affected example, matching the already-correct style in `src/agents/atlas/shared-prompt.ts`. Pure string change — no logic, no schema edits.

## Test plan

- [x] `bun test src/agents/` — 383 passed, 0 failed
- [x] `bunx tsc --noEmit` — clean, zero errors
- [x] Diff is 4 insertions / 2 deletions across 3 files (well under 30-line budget)

## Related

Fixes #3960

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the required `run_in_background=false` to all `task()` delegation examples in agent prompt templates to match the `task()` tool schema and prevent invalid calls when users copy examples. Docs-only updates in `src/agents/dynamic-agent-category-skills-guide.ts`, `src/agents/hephaestus/gpt-5-3-codex.ts`, and `src/agents/sisyphus/gemini.ts`.

<sup>Written for commit 5f0ff0aae8f3cc9b106a30baa27fb6eb0f28e0f9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4069?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

