### PR TITLE
fix(prometheus-md-only): replace SYSTEM DIRECTIVE marker with XML tag in external prompts (#4036)

### DIFF
--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -11,11 +11,20 @@ export const ALLOWED_PATH_PREFIX = ".omo"
 
 export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
 
+/**
+ * XML-tag wrapper used to mark the planning-context boundary in prompts
+ * forwarded to external LLMs via task(). This format intentionally avoids
+ * the `[SYSTEM DIRECTIVE: ...]` bracket syntax that Azure OpenAI Prompt Shield
+ * flags as indirect prompt injection in user-role content (#4036).
+ */
+export const PLANNING_CONTEXT_OPEN = `<planning-context source="prometheus-read-only">`
+export const PLANNING_CONTEXT_CLOSE = `</planning-context>`
+
 export const PLANNING_CONSULT_WARNING = `
 
 ---
 
-${createSystemDirective(SystemDirectiveTypes.PROMETHEUS_READ_ONLY)}
+${PLANNING_CONTEXT_OPEN}
 
 You are being invoked by ${getAgentDisplayName("prometheus")}, a planning agent restricted to .omo/*.md plan files only.
 
@@ -27,6 +36,8 @@ You are being invoked by ${getAgentDisplayName("prometheus")}, a planning agent 
 
 **YOUR ROLE**: Provide consultation, research, and analysis to assist with planning.
 Return your findings and recommendations. The actual implementation will be handled separately after planning is complete.
+
+${PLANNING_CONTEXT_CLOSE}
 
 ---
 

--- a/src/hooks/prometheus-md-only/hook.ts
+++ b/src/hooks/prometheus-md-only/hook.ts
@@ -1,8 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { HOOK_NAME, BLOCKED_TOOLS, PLANNING_CONSULT_WARNING, PROMETHEUS_WORKFLOW_REMINDER } from "./constants"
+import { HOOK_NAME, BLOCKED_TOOLS, PLANNING_CONSULT_WARNING, PLANNING_CONTEXT_OPEN, PROMETHEUS_WORKFLOW_REMINDER } from "./constants"
 import { log } from "../../shared/logger"
 import { replaceToolArgs } from "../../shared/replace-tool-args"
-import { SYSTEM_DIRECTIVE_PREFIX } from "../../shared/system-directive"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { getAgentFromSession } from "./agent-resolution"
 import { isPrometheusAgent } from "./agent-matcher"
@@ -27,7 +26,7 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
       // Inject planning-only warning for task tools called by Prometheus
        if (TASK_TOOLS.includes(toolName)) {
          const prompt = output.args.prompt as string | undefined
-         if (prompt && !prompt.includes(SYSTEM_DIRECTIVE_PREFIX)) {
+         if (prompt && !prompt.includes(PLANNING_CONTEXT_OPEN)) {
            replaceToolArgs(output, { prompt: PLANNING_CONSULT_WARNING + prompt })
           log(`[${HOOK_NAME}] Injected planning warning to ${toolName}`, {
             sessionID: input.sessionID,

--- a/src/hooks/prometheus-md-only/index.test.ts
+++ b/src/hooks/prometheus-md-only/index.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { randomUUID } from "node:crypto"
 import { SYSTEM_DIRECTIVE_PREFIX } from "../../shared/system-directive"
+import { PLANNING_CONTEXT_OPEN } from "./constants"
 import { clearSessionAgent, setSessionAgent } from "../../features/claude-code-session-state"
 // Force stable (JSON) mode for tests that rely on message file storage
 mock.module("../../shared/opencode-storage-detection", () => ({
@@ -411,12 +412,13 @@ describe("prometheus-md-only", () => {
       // when
       await hook["tool.execute.before"](input, output)
 
-      // then
-      expect(output.args.prompt).toContain(SYSTEM_DIRECTIVE_PREFIX)
+      // then — XML tag used, not bracket directive (#4036)
+      expect(output.args.prompt).toContain(PLANNING_CONTEXT_OPEN)
+      expect(output.args.prompt).not.toContain("[SYSTEM DIRECTIVE:")
       expect(output.args.prompt).toContain("DO NOT modify any files")
     })
 
-    test("should inject planning warning when Prometheus calls task", async () => {
+    test("should inject planning warning when Prometheus calls task (research)", async () => {
       // given
       const hook = createPrometheusMdOnlyHook(createMockPluginInput())
       const input = {
@@ -432,7 +434,8 @@ describe("prometheus-md-only", () => {
       await hook["tool.execute.before"](input, output)
 
       // then
-      expect(output.args.prompt).toContain(SYSTEM_DIRECTIVE_PREFIX)
+      expect(output.args.prompt).toContain(PLANNING_CONTEXT_OPEN)
+      expect(output.args.prompt).not.toContain("[SYSTEM DIRECTIVE:")
     })
 
     test("should inject planning warning when Prometheus calls call_omo_agent", async () => {
@@ -451,7 +454,8 @@ describe("prometheus-md-only", () => {
       await hook["tool.execute.before"](input, output)
 
       // then
-      expect(output.args.prompt).toContain(SYSTEM_DIRECTIVE_PREFIX)
+      expect(output.args.prompt).toContain(PLANNING_CONTEXT_OPEN)
+      expect(output.args.prompt).not.toContain("[SYSTEM DIRECTIVE:")
     })
 
     test("should not double-inject warning if already present", async () => {
@@ -462,7 +466,7 @@ describe("prometheus-md-only", () => {
         sessionID: TEST_SESSION_ID,
         callID: "call-1",
       }
-      const promptWithWarning = `Some prompt ${SYSTEM_DIRECTIVE_PREFIX} already here`
+      const promptWithWarning = `Some prompt ${PLANNING_CONTEXT_OPEN} already here`
       const output = {
         args: { prompt: promptWithWarning },
       }
@@ -471,8 +475,28 @@ describe("prometheus-md-only", () => {
       await hook["tool.execute.before"](input, output)
 
       // then
-      const occurrences = (output.args.prompt as string).split(SYSTEM_DIRECTIVE_PREFIX).length - 1
+      const occurrences = (output.args.prompt as string).split(PLANNING_CONTEXT_OPEN).length - 1
       expect(occurrences).toBe(1)
+    })
+
+    test("regression #4036: task() prompt must not contain [SYSTEM DIRECTIVE: for Azure Prompt Shield safety", async () => {
+      // given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "task",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { prompt: "Analyze the codebase architecture" },
+      }
+
+      // when
+      await hook["tool.execute.before"](input, output)
+
+      // then — the bracket-enclosed directive must NOT appear in the forwarded prompt
+      // because Azure OpenAI Prompt Shield flags it as indirect prompt injection
+      expect(output.args.prompt as string).not.toContain("[SYSTEM DIRECTIVE:")
     })
   })
 


### PR DESCRIPTION
## Summary

**Root cause**: `PLANNING_CONSULT_WARNING` is prepended to `output.args.prompt` in `hook.ts` when Prometheus calls `task()` or `call_omo_agent`. This string opens with `[SYSTEM DIRECTIVE: OH-MY-OPENCODE - PROMETHEUS READ-ONLY]` — the exact bracket-enclosed pattern that Azure OpenAI Prompt Shield classifies as indirect prompt injection in user-role content. On GPT-5.4 served through Azure OpenAI, the model refuses the entire request before any planning work executes.

**Why Option A (minimal string replacement in constants.ts)**: The `[SYSTEM DIRECTIVE: ...]` marker was designed solely for internal hook-to-hook filtering via `isSystemDirective()` in `src/shared/system-directive.ts`. `PLANNING_CONSULT_WARNING` is only ever appended to external LLM prompts (the `task()` boundary) — it is never read back by `isSystemDirective()` consumers. There is no coupling risk. Replacing the header in-place in `constants.ts` is the smallest correct fix: one file changed, zero internal filtering broken.

**Why not Option B (model-aware strip in hook.ts)**: Requires model detection logic, adds complexity, and is fragile — the Azure issue is not model-specific but API-gateway-specific. Any future Azure-deployed model would re-introduce the bug.

**Why not Option C (safe output path in createSystemDirective)**: Systemic change to a shared utility used by ralph-loop, atlas, keyword-detector, and others. Broad blast radius for a targeted bug.

**What changed**:
- `constants.ts`: Introduced `PLANNING_CONTEXT_OPEN`/`PLANNING_CONTEXT_CLOSE` XML tag constants. Replaced the `createSystemDirective(SystemDirectiveTypes.PROMETHEUS_READ_ONLY)` header in `PLANNING_CONSULT_WARNING` with `<planning-context source="prometheus-read-only">` / `</planning-context>`. `PROMETHEUS_WORKFLOW_REMINDER` is unchanged — it is assigned to `output.message` (internal hook message), never forwarded to external LLM APIs.
- `hook.ts`: Updated double-injection guard to check `PLANNING_CONTEXT_OPEN` instead of `SYSTEM_DIRECTIVE_PREFIX` (since the latter no longer appears in the prepended string). Removed the now-unused `SYSTEM_DIRECTIVE_PREFIX` import.
- `index.test.ts`: Updated 3 existing tests that asserted `SYSTEM_DIRECTIVE_PREFIX` in `output.args.prompt` to assert `PLANNING_CONTEXT_OPEN` instead (and add `not.toContain("[SYSTEM DIRECTIVE:")`). Updated double-injection test to use the new guard string. Added focused regression test for #4036.

## Test plan

- [x] `bun test src/hooks/prometheus-md-only/` — 36 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean, zero errors
- [x] Regression test: after `hook["tool.execute.before"]` runs on a `task()` invocation, `output.args.prompt` does **not** contain `[SYSTEM DIRECTIVE:`
- [x] Existing behaviour preserved: warning body (`DO NOT modify any files`, `CRITICAL CONSTRAINTS`) still present in injected prompt
- [x] Double-injection guard still works (second call does not re-prepend the warning)
- [x] `PROMETHEUS_WORKFLOW_REMINDER` (internal `output.message` path) untouched — its `[SYSTEM DIRECTIVE:]` header is never forwarded to external LLMs

## Limitations

- The secondary Azure issue noted by the reporter (deployment-name routing via `isGptModel()`) is **not** addressed here — that is a separate concern in model resolution and out of scope for this fix.
- Claude models are unaffected by this change (XML tags are benign to Claude's prompt handling).

## Related

Closes #4036

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the bracketed system directive in Prometheus external prompts with a neutral XML tag to avoid Azure OpenAI Prompt Shield blocks. Fixes #4036 while keeping internal directive filtering intact.

- **Bug Fixes**
  - Swap `[SYSTEM DIRECTIVE: ...]` in `PLANNING_CONSULT_WARNING` for `<planning-context source="prometheus-read-only">`/`</planning-context>` via `PLANNING_CONTEXT_OPEN`/`PLANNING_CONTEXT_CLOSE`.
  - Update double-injection guard in `hook.ts` to check `PLANNING_CONTEXT_OPEN`; remove unused `SYSTEM_DIRECTIVE_PREFIX` import.
  - Update tests to expect the XML tag, ensure prompts do not contain `[SYSTEM DIRECTIVE:`, and add a regression test for `task()` prompts.

<sup>Written for commit 9791019366fa16dc7067e4b4b4d809dc59f617d8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4070?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

