### PR TITLE
fix(plugin-handlers): apply hooks configs from external plugins to dispatchToHooks

### DIFF
--- a/src/hooks/claude-code-hooks/config.test.ts
+++ b/src/hooks/claude-code-hooks/config.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-const { clearClaudeHooksConfigCache, loadClaudeHooksConfig } = await import("./config")
+const { clearClaudeHooksConfigCache, loadClaudeHooksConfig, setPluginHooksConfigs } = await import("./config")
 
 describe("loadClaudeHooksConfig", () => {
   const originalDateNow = Date.now

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -8,10 +8,16 @@ import { applyHookConfig } from "./hook-config-handler";
 import { applyMcpConfig } from "./mcp-config-handler";
 import { applyProviderConfig } from "./provider-config-handler";
 import { loadPluginComponents } from "./plugin-components-loader";
+import type { PluginComponents } from "./plugin-components-loader";
 import { applyToolConfig } from "./tool-config-handler";
-import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
+import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger";
+import { setPluginHooksConfigs } from "../hooks/claude-code-hooks/config";
 
 export { resolveCategoryConfig } from "./category-config-resolver";
+
+function applyHooksConfig(params: { pluginComponents: PluginComponents }): void {
+  setPluginHooksConfigs(params.pluginComponents.hooksConfigs);
+}
 
 export interface ConfigHandlerDeps {
   ctx: { directory: string; client?: any };
@@ -43,6 +49,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     applyToolConfig({ config, pluginConfig, agentResult });
     await applyMcpConfig({ config, pluginConfig, ctx, pluginComponents });
     await applyCommandConfig({ config, pluginConfig, ctx, pluginComponents });
+    applyHooksConfig({ pluginComponents });
 
     config.formatter = formatterConfig;
 


### PR DESCRIPTION
## Summary

- External plugins' `hooksConfigs` (loaded via `loadPluginHooksConfigs` into `PluginComponents`) were correctly loaded but never applied to the Claude Code hooks dispatch pipeline.
- Added `setPluginHooksConfigs()` to `src/hooks/claude-code-hooks/config.ts` — stores plugin-provided hook configs and clears the TTL cache so the next `loadClaudeHooksConfig()` call merges them in alongside file-based settings.
- Added `applyHooksConfig()` in `src/plugin-handlers/config-handler.ts` and call it after `applyCommandConfig`, completing the same pattern as `applyAgentConfig` / `applyToolConfig` / `applyMcpConfig` / `applyCommandConfig`.

## Test plan

- [ ] New tests in `src/hooks/claude-code-hooks/config.test.ts`:
  - Plugin `PreToolUse` hooks appear in `loadClaudeHooksConfig` result after `setPluginHooksConfigs` is called.
  - Plugin `Stop` hooks are merged alongside file-based `Stop` hooks (both sources present).
  - Calling `setPluginHooksConfigs([])` removes previously registered plugin hooks from subsequent loads.
- [ ] All 48 existing `config-handler.test.ts` tests pass.
- [ ] All 5 `config.test.ts` tests pass (2 pre-existing + 3 new).
- [ ] `bunx tsc --noEmit` clean.
- [ ] Full suite: 6963 pass, 1 pre-existing fail (unrelated `plugin-entry.test.ts`), 6 skip.

## Related

Fixes #4001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where hooks from external plugins were loaded but not applied to the Claude Code dispatch pipeline, so plugin PreToolUse/PostToolUse/Stop hooks now run (Fixes #4001). We now merge plugin-provided hooks into `loadClaudeHooksConfig` and apply them from the config handler.

- **Bug Fixes**
  - Added `setPluginHooksConfigs` in `src/hooks/claude-code-hooks/config.ts` to store/normalize plugin hooks and clear the cache.
  - Merged plugin hooks during `loadClaudeHooksConfig`, and wired `applyHooksConfig` in `src/plugin-handlers/config-handler.ts` to pass `pluginComponents`.
  - Updated tests to cover inclusion, merge with file-based hooks, and removal via `setPluginHooksConfigs([])`.

<sup>Written for commit ceb13fc1e426e3d9fecd23654a1a177585858135. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4078?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

