### PR TITLE
refactor(keyword-detector): consolidate analyze pattern/message into analyze/default and document delegate_task params (#3694)

### DIFF
--- a/src/hooks/keyword-detector/analyze/default.ts
+++ b/src/hooks/keyword-detector/analyze/default.ts
@@ -24,4 +24,7 @@ IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
 - **Oracle**: Conventional problems (architecture, debugging, complex logic)
 - **Artistry**: Non-conventional problems (different approach needed)
 
-SYNTHESIZE findings before proceeding.`
+SYNTHESIZE findings before proceeding.
+---
+MANDATORY delegate_task params: ALWAYS include load_skills and run_in_background when calling delegate_task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
+Example: delegate_task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`

--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -10,6 +10,7 @@ export { HYPERPLAN_PATTERN, HYPERPLAN_MESSAGE } from "./hyperplan"
 import type { KeywordType } from "../../config/schema/keyword-detector"
 import { getUltraworkMessage } from "./ultrawork"
 import { SEARCH_PATTERN, SEARCH_MESSAGE } from "./search"
+import { ANALYZE_PATTERN, ANALYZE_MESSAGE } from "./analyze"
 import { TEAM_PATTERN, TEAM_MESSAGE } from "./team"
 import { HYPERPLAN_PATTERN, HYPERPLAN_MESSAGE } from "./hyperplan"
 
@@ -46,23 +47,8 @@ export const KEYWORD_DETECTORS: KeywordDetector[] = [
   },
   {
     type: "analyze",
-    pattern:
-      /\b(analyze|analyse|investigate|examine|research|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|debug|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|디버깅|디버그|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|デバッグ|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|调试|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi|tại sao/i,
-    message: `[analyze-mode]
-ANALYSIS MODE. Gather context before diving deep:
-CONTEXT GATHERING (parallel):
-- 1-2 explore agents (codebase patterns, implementations)
-- 1-2 librarian agents (if external library involved)
-- Direct tools: Grep, AST-grep, LSP for targeted searches
-
-IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:
-- **Oracle**: Conventional problems (architecture, debugging, complex logic)
-- **Artistry**: Non-conventional problems (different approach needed)
-
-SYNTHESIZE findings before proceeding.
----
-MANDATORY delegate_task params: ALWAYS include load_skills and run_in_background when calling delegate_task. Evaluate available skills before dispatch - pass task-appropriate skills when relevant, pass [] ONLY when no skill matches the task domain.
-Example: delegate_task(subagent_type="explore", prompt="...", run_in_background=true, load_skills=[])`,
+    pattern: ANALYZE_PATTERN,
+    message: ANALYZE_MESSAGE,
   },
   {
     type: "team",


### PR DESCRIPTION
## Summary

- Removed 18 lines of inline `ANALYZE_PATTERN` regex and `ANALYZE_MESSAGE` template from `constants.ts`; these were exact duplicates of what `analyze/default.ts` already exported
- Added `import { ANALYZE_PATTERN, ANALYZE_MESSAGE } from "./analyze"` to `constants.ts` and replaced the inline detector entries with references to the imported constants — matching the established pattern already used by `search`, `team`, and `hyperplan`
- Appended the mandatory `delegate_task` parameter guidance block to `ANALYZE_MESSAGE` in `analyze/default.ts`, making it the single source of truth

## Test plan

- [x] `bun test src/hooks/keyword-detector/` — 86 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean, no errors
- [x] Existing test `should tell analyze-mode agents to evaluate skills before delegating` validates the appended delegate_task guidance is present in the message

## Related

Closes #3694

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the analyze keyword detector per Linear #3694 by importing its pattern and message from a single source in analyze/default, removing duplicates in constants.ts. Adds mandatory delegate_task parameter guidance to the analyze message to standardize agent calls and make analyze/default.ts the single source of truth.

<sup>Written for commit 57ab749b372e279f0f45f629aebbcb08d832a9ee. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4079?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

