### PR TITLE
fix(slash-commands): inject command content exactly once (#3724)

### DIFF
--- a/src/hooks/auto-slash-command/index.test.ts
+++ b/src/hooks/auto-slash-command/index.test.ts
@@ -406,6 +406,25 @@ describe("createAutoSlashCommandHook", () => {
       ])
     })
 
+    it("should not duplicate injection when parts already contain auto-slash-command tags (#3724)", async () => {
+      //#given - parts already have tags (as if chat.message hook already ran)
+      const hook = createAutoSlashCommandHook()
+      const input = createCommandInput("ralph-loop")
+      const alreadyTagged = "<auto-slash-command>\n/ralph-loop Command\n## Command Instructions\ntemplate content\n</auto-slash-command>"
+      const output: CommandExecuteBeforeOutput = {
+        parts: [{ type: "text", text: alreadyTagged }],
+      }
+
+      //#when
+      await hook["command.execute.before"](input, output)
+
+      //#then - parts unchanged, no second injection
+      expect(output.parts).toHaveLength(1)
+      expect(output.parts[0].text).toBe(alreadyTagged)
+      const tagCount = (output.parts[0].text?.split("<auto-slash-command>").length ?? 1) - 1
+      expect(tagCount).toBe(1)
+    })
+
   })
   describe("skills as slash commands", () => {
     function createTestSkill(name: string, template: string): LoadedSkill {


### PR DESCRIPTION
## Summary

- `command.execute.before` hook now checks whether any output part already contains `<auto-slash-command>` tags before injecting command content
- This prevents duplication when both `chat.message` and `command.execute.before` fire for the same slash command invocation (both paths called `executeSlashCommand` independently and injected into `output.parts`)
- The `chat.message` handler already had this guard (lines 96-101 of `hook.ts`); this PR applies the same pattern to `command.execute.before`

## Test plan

- [ ] New regression test: `should not duplicate injection when parts already contain auto-slash-command tags (#3724)` verifies that when `output.parts` already contains tagged content, `command.execute.before` leaves it unchanged (1 part, 1 tag occurrence)
- [ ] All 66 existing tests in `src/hooks/auto-slash-command/` pass
- [ ] `bunx tsc --noEmit` clean

## Related

Closes #3724

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate slash-command injection by guarding `command.execute.before` so it skips when `output.parts` already contains `<auto-slash-command>` tags. Adds a regression test to ensure only one injection when both `chat.message` and `command.execute.before` run for the same command.

<sup>Written for commit 6c54123ec16598018ce15bbc11e477ae3fed9d9c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4083?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

