### PR TITLE
fix(claude-code-session-state): clear session-agent map on delete and sync cleanup

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -5063,6 +5063,27 @@ describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
 
     manager.shutdown()
   })
+
+  test("should clear session agent state for deleted sessions to prevent map leak", async () => {
+    //#given
+    const { setSessionAgent } = await import("../claude-code-session-state")
+    resetClaudeCodeSessionState()
+    const manager = createBackgroundManager()
+    const sessionID = "session-deleted-agent-leak"
+    setSessionAgent(sessionID, "sisyphus-junior")
+    expect(getSessionAgent(sessionID)).toBe("sisyphus-junior")
+
+    //#when
+    manager.handleEvent({
+      type: "session.deleted",
+      properties: { info: { id: sessionID } },
+    })
+
+    //#then
+    expect(getSessionAgent(sessionID)).toBeUndefined()
+
+    manager.shutdown()
+  })
 })
 
 describe("BackgroundManager.handleEvent - session.error", () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1660,6 +1660,7 @@ The fallback retry session is now created and can be inspected directly.
 
       if (tasksToCancel.size === 0) {
         this.clearTaskHistoryWhenParentTasksGone(sessionID)
+        clearSessionAgent(sessionID)
         return
       }
 
@@ -1698,6 +1699,7 @@ The fallback retry session is now created and can be inspected directly.
 
       this.rootDescendantCounts.delete(sessionID)
       clearDelegatedChildSessionBootstrap(sessionID)
+      clearSessionAgent(sessionID)
       SessionCategoryRegistry.remove(sessionID)
     }
 

--- a/src/tools/call-omo-agent/sync-executor.test.ts
+++ b/src/tools/call-omo-agent/sync-executor.test.ts
@@ -394,6 +394,8 @@ describe("executeSync", () => {
       expect(observed[0]?.bootstrap?.tools?.question).toBe(false)
       expect(observed[0]?.bootstrap?.fallbackChain?.[0]?.model).toBe("gpt-5.4")
       expect(getDelegatedChildSessionBootstrap("ses-call-bootstrap")).toBeUndefined()
+      // session-agent state for a sync session we created must be cleared after dispatch
+      expect(getSessionAgent("ses-call-bootstrap")).toBeUndefined()
     } finally {
       clearAllDelegatedChildSessionBootstrap()
       clearSessionTools()

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
+import { clearSessionAgent, setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { promptAsyncAfterSessionIdle } from "../../hooks/shared/prompt-async-gate"
 import { getAgentToolRestrictions, log } from "../../shared"
 import { getAgentDisplayName, stripAgentListSortPrefix } from "../../shared/agent-display-names"
@@ -187,6 +187,7 @@ export async function executeSync(
       subagentSessions.delete(sessionID)
       syncSubagentSessions.delete(sessionID)
       deleteSessionTools(sessionID)
+      clearSessionAgent(sessionID)
     }
   }
 }


### PR DESCRIPTION
## Why

External review of merged PR #4074 flagged a memory hygiene gap: the new `setSessionAgent` calls for delegated child sessions had matching cleanup only in the cancel/binding-failure early-return paths, not for the steady-state `session.deleted` lifecycle or the `call_omo_agent` sync executor `finally` block. The map grows monotonically for the life of the plugin instance — bounded but unbounded over time.

Verdict was `APPROVE_WITH_NITS — small, bounded, fixable in a one-line follow-up`. This PR is that follow-up.

## What

Two paired cleanup sites that close the leak without touching the happy-path delegation flow:

- `BackgroundManager.handleEvent("session.deleted")` — call `clearSessionAgent(sessionID)` on both the no-task early return and the cascade tail, alongside the existing `clearDelegatedChildSessionBootstrap` and `SessionCategoryRegistry.remove`.
- `sync-executor.ts` — call `clearSessionAgent(sessionID)` inside the `createdSessionForExecution` branch of the `finally`, alongside the existing `subagentSessions.delete`, `syncSubagentSessions.delete`, and `deleteSessionTools` cleanup.

## Tests

- `BackgroundManager.handleEvent - session.deleted cascade > should clear session agent state for deleted sessions to prevent map leak` — explicit red test now green.
- `executeSync > registers child-session bootstrap and tracked prompt state before sync prompt dispatch` — existing test extended to assert post-dispatch session-agent cleanup for created sessions.

Local gates: `bun test` 7000 pass / 1 skip / 0 fail, `bun run typecheck` ok, `bun run build` ok. The single `pane-close-runner` test discipline flake observed in one of two runs is pre-existing on `dev` and unrelated to these files.

## Scope guarantees

- No production code touched outside the two cleanup sites.
- No behavior change for sessions that complete normally without being deleted.
- Reused-session path is untouched: `createdSessionForExecution=false` does not call `clearSessionAgent`, preserving caller-owned state.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak by clearing session-agent mappings when sessions are deleted and after sync executor cleanup. Prevents unbounded growth of the session-agent map in long-running plugin instances.

- **Bug Fixes**
  - In `BackgroundManager.handleEvent("session.deleted")`, call `clearSessionAgent(sessionID)` in both the no-task early return and the cascade tail.
  - In `executeSync`’s `finally`, call `clearSessionAgent(sessionID)` when the executor created the session.

<sup>Written for commit 2b8782de85736508140132bf3440750305d3d401. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4088?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

