### PR TITLE
fix(skill-mcp): respect env allowlist for skill env

### DIFF
--- a/src/features/skill-mcp-manager/env-cleaner.test.ts
+++ b/src/features/skill-mcp-manager/env-cleaner.test.ts
@@ -1,6 +1,10 @@
 /// <reference types="bun-types" />
 
 import { describe, it, expect, afterEach } from "bun:test"
+import {
+  resetAdditionalAllowedMcpEnvVars,
+  setAdditionalAllowedMcpEnvVars,
+} from "../claude-code-mcp-loader/configure-allowed-env-vars"
 import { createCleanMcpEnvironment, EXCLUDED_ENV_PATTERNS } from "./env-cleaner"
 
 describe("createCleanMcpEnvironment", () => {
@@ -8,6 +12,8 @@ describe("createCleanMcpEnvironment", () => {
   const originalEnv = { ...process.env }
 
   afterEach(() => {
+    resetAdditionalAllowedMcpEnvVars()
+
     // Restore original environment
     for (const key of Object.keys(process.env)) {
       if (!(key in originalEnv)) {
@@ -159,6 +165,33 @@ describe("createCleanMcpEnvironment", () => {
       expect(cleanEnv.CUSTOM_SECRET).toBeUndefined()
       expect(cleanEnv.SAFE_VAR).toBe("safe-value")
       expect(cleanEnv.PATH).toBe("/usr/bin")
+    })
+
+    it("preserves allowlisted custom env even when the name matches secret filters", () => {
+      // given - user config explicitly allowlists the secret env for this skill MCP
+      process.env.TELEGRAM_BOT_TOKEN = "ambient-token-that-should-stay-filtered"
+      setAdditionalAllowedMcpEnvVars(["TELEGRAM_BOT_TOKEN"])
+      const customEnv = {
+        TELEGRAM_BOT_TOKEN: "skill-configured-token",
+      }
+
+      // when
+      const cleanEnv = createCleanMcpEnvironment(customEnv)
+
+      // then
+      expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBe("skill-configured-token")
+    })
+
+    it("does not preserve ambient secrets just because they are allowlisted for skill env passthrough", () => {
+      // given - allowlist should only unblock explicitly configured skill MCP env values here
+      process.env.TELEGRAM_BOT_TOKEN = "ambient-token"
+      setAdditionalAllowedMcpEnvVars(["TELEGRAM_BOT_TOKEN"])
+
+      // when
+      const cleanEnv = createCleanMcpEnvironment()
+
+      // then
+      expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBeUndefined()
     })
   })
 

--- a/src/features/skill-mcp-manager/env-cleaner.ts
+++ b/src/features/skill-mcp-manager/env-cleaner.ts
@@ -1,3 +1,5 @@
+import { isAllowedMcpEnvVar } from "../claude-code-mcp-loader/configure-allowed-env-vars"
+
 // Filters npm/pnpm/yarn config env vars that break MCP servers in pnpm projects (#456)
 // Also filters secret-containing env vars to prevent exposure to malicious stdio MCP servers (#B-02)
 export const EXCLUDED_ENV_PATTERNS: RegExp[] = [
@@ -39,6 +41,7 @@ export function createCleanMcpEnvironment(
   customEnv: Record<string, string> = {}
 ): Record<string, string> {
   const mergedEnv: Record<string, string> = {}
+  const customEnvKeys = new Set(Object.keys(customEnv))
 
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue
@@ -50,7 +53,8 @@ export function createCleanMcpEnvironment(
   const cleanEnv: Record<string, string> = {}
   for (const [key, value] of Object.entries(mergedEnv)) {
     const shouldExclude = EXCLUDED_ENV_PATTERNS.some((pattern) => pattern.test(key))
-    if (!shouldExclude) {
+    const isAllowlistedCustomEnv = customEnvKeys.has(key) && isAllowedMcpEnvVar(key)
+    if (!shouldExclude || isAllowlistedCustomEnv) {
       cleanEnv[key] = value
     }
   }


### PR DESCRIPTION
## Summary
- allow `mcp_env_allowlist` to unblock explicitly configured skill MCP env entries
- keep ambient process secrets filtered even when the same name is allowlisted
- add regression coverage for `TELEGRAM_BOT_TOKEN`-style skill env passthrough

Fixes #3995

## Testing
- bun test src/features/skill-mcp-manager/env-cleaner.test.ts
- bun run typecheck


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `mcp_env_allowlist` in the skill MCP environment cleaner. Allowlisted vars set in skill config now survive filtering, while ambient process secrets with the same names stay blocked.

- **Bug Fixes**
  - Preserve allowlisted custom env values (e.g., `TELEGRAM_BOT_TOKEN`) during cleaning.
  - Do not pass through matching ambient process secrets.
  - Added regression tests for allowlist passthrough and ambient blocking.

<sup>Written for commit 83fdd4da76a65ca4dbfa2163b5f720325ded0e39. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4089?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

