### PR TITLE
fix(websearch): use bearer auth for Exa MCP

### DIFF
--- a/src/mcp/websearch.test.ts
+++ b/src/mcp/websearch.test.ts
@@ -54,3 +54,36 @@ describe("createWebsearchConfig Tavily handling", () => {
     expect(config?.url).toBe("https://mcp.tavily.com/mcp/")
   })
 })
+
+describe("createWebsearchConfig Exa handling", () => {
+  test("keeps EXA_API_KEY out of URL query params and sends bearer auth header", () => {
+    process.env.EXA_API_KEY = "exa-secret"
+
+    const config = createWebsearchConfig({ provider: "exa" })
+
+    expect(config).toEqual({
+      type: "remote",
+      url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
+      enabled: true,
+      headers: {
+        Authorization: "Bearer exa-secret",
+      },
+      oauth: false,
+    })
+    expect(config?.url).not.toContain("exaApiKey")
+    expect(config?.headers).not.toHaveProperty("x-api-key")
+  })
+
+  test("uses unauthenticated Exa URL when EXA_API_KEY is missing", () => {
+    delete process.env.EXA_API_KEY
+
+    const config = createWebsearchConfig({ provider: "exa" })
+
+    expect(config).toEqual({
+      type: "remote",
+      url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
+      enabled: true,
+      oauth: false,
+    })
+  })
+})

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -32,11 +32,9 @@ export function createWebsearchConfig(config?: WebsearchConfig): RemoteMcpConfig
 
   return {
     type: "remote" as const,
-    url: process.env.EXA_API_KEY
-      ? `https://mcp.exa.ai/mcp?tools=web_search_exa&exaApiKey=${encodeURIComponent(process.env.EXA_API_KEY)}`
-      : "https://mcp.exa.ai/mcp?tools=web_search_exa",
+    url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
     enabled: true,
-    ...(process.env.EXA_API_KEY ? { headers: { "x-api-key": process.env.EXA_API_KEY } } : {}),
+    ...(process.env.EXA_API_KEY ? { headers: { Authorization: `Bearer ${process.env.EXA_API_KEY}` } } : {}),
     oauth: false as const,
   }
 }


### PR DESCRIPTION
## Summary
- send `EXA_API_KEY` as `Authorization: Bearer <key>` for the built-in Exa websearch MCP
- remove the `exaApiKey` URL query credential so MCP SDK endpoint resolution cannot drop it
- add regression coverage for authenticated and unauthenticated Exa config

Fixes #3763

## Testing
- bun test src/mcp/websearch.test.ts src/mcp/zauc-mocks-mcp-index/index.test.ts src/plugin-handlers/mcp-config-handler.test.ts
- bun run typecheck


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Exa websearch MCP to Authorization bearer auth and remove the API key from the URL. This prevents SDK URL resolution from dropping auth and avoids falling back to free limits (fixes #3763).

- Bug Fixes
  - Send `EXA_API_KEY` as `Authorization: Bearer <key>`; remove `exaApiKey` query param and `x-api-key` header.
  - Keep the Exa URL stable and add regression tests for both authenticated and unauthenticated configs.

<sup>Written for commit a68213d5329ffc8c81b707d67d2d92723b785a2b. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4090?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

