### PR TITLE
fix(prompt-async-gate): timeout isSessionActive to prevent infinite hang on stale SDK status

### DIFF
--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -1674,11 +1674,17 @@ session_id: ses_untrusted_999
       writeBoulderState(TEST_DIR, state)
 
       const originalSetTimeout = globalThis.setTimeout
-      const scheduledDelays: number[] = []
+      const originalClearTimeout = globalThis.clearTimeout
+      const activeTimers = new Map<ReturnType<typeof setTimeout>, number>()
       globalThis.setTimeout = ((_handler: Parameters<typeof setTimeout>[0], timeout?: number, ..._args: unknown[]) => {
-        scheduledDelays.push(timeout ?? 0)
-        return originalSetTimeout(() => undefined, 0)
+        const id = originalSetTimeout(() => undefined, 0)
+        activeTimers.set(id, timeout ?? 0)
+        return id
       }) as typeof setTimeout
+      globalThis.clearTimeout = ((id: ReturnType<typeof setTimeout>) => {
+        activeTimers.delete(id)
+        originalClearTimeout(id)
+      }) as typeof clearTimeout
 
       try {
         const mockInput = createMockPluginInput()
@@ -1702,10 +1708,12 @@ session_id: ses_untrusted_999
         })
 
         // then - stale idle is consumed, not converted into another scheduled continuation
+        const scheduledDelays = Array.from(activeTimers.values())
         expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
         expect(scheduledDelays.filter((delay) => delay >= 5_000 && delay !== DEFAULT_PROMPT_DISPATCH_TIMEOUT_MS)).toHaveLength(0)
       } finally {
         globalThis.setTimeout = originalSetTimeout
+        globalThis.clearTimeout = originalClearTimeout
       }
     })
 
@@ -2519,7 +2527,9 @@ session_id: ses_untrusted_999
             capturedTimers.delete(id)
             return
           }
-          originalClearTimeout(id)
+          if (id !== undefined) {
+            originalClearTimeout(id)
+          }
         }) as typeof clearTimeout
       })
 

--- a/src/hooks/shared/prompt-async-gate.test.ts
+++ b/src/hooks/shared/prompt-async-gate.test.ts
@@ -476,6 +476,34 @@ describe("promptAsyncAfterSessionIdle", () => {
     expect(promptCalls).toBe(1)
   })
 
+  test("#given session.status never resolves #when promptAsync is requested #then isSessionActive times out and dispatch is attempted", async () => {
+    // given
+    let promptCalls = 0
+    const client = {
+      session: {
+        status: async () => new Promise(() => {}),
+        promptAsync: async () => {
+          promptCalls += 1
+        },
+      },
+    }
+
+    // when
+    const result = await promptAsyncAfterSessionIdle({
+      client,
+      sessionID: "ses_status_hang",
+      input: { path: { id: "ses_status_hang" }, body: { parts: [] } },
+      source: "test:status-hang",
+      settleMs: 0,
+      postDispatchHoldMs: 0,
+      dispatchTimeoutMs: 50,
+    })
+
+    // then
+    expect(result.status).toBe("dispatched")
+    expect(promptCalls).toBe(1)
+  }, 2000)
+
   test("#given SDK prompt depends on its session receiver #when the gate dispatches #then method binding is preserved", async () => {
     // given
     const session = {

--- a/src/shared/prompt-async-gate.ts
+++ b/src/shared/prompt-async-gate.ts
@@ -169,7 +169,19 @@ async function dispatchAfterSessionIdle<TInput>(args: {
       await settleAfterSessionIdle(settleMs)
     }
 
-    if (canReadStatus && await isSessionActive(client, sessionID)) {
+    let sessionActive = false
+    if (canReadStatus) {
+      try {
+        sessionActive = await withDispatchTimeout(
+          isSessionActive(client, sessionID),
+          Math.min(dispatchTimeoutMs, 5000),
+          `[prompt-async-gate] ${sessionName} isSessionActive`,
+        )
+      } catch {
+        sessionActive = false
+      }
+    }
+    if (sessionActive) {
       log(`[prompt-async-gate] ${sessionName} skipped because session is active`, { sessionID, source })
       return { status: "active" }
     }


### PR DESCRIPTION
## Problem
`promptAsyncAfterSessionIdle` calls `isSessionActive` to check whether the target session is busy before dispatching an internal prompt. `isSessionActive` relies on the OpenCode SDK's `session.status()`, which can hang indefinitely in certain race conditions between the plugin and the CLI. When `status()` never resolves, the internal prompt dispatch also hangs forever, making the session unresponsive.

## Fix
Wrap the `isSessionActive` call inside `withDispatchTimeout`, capped at `min(dispatchTimeoutMs, 5000)`. If the status check times out, treat the session as **inactive** so the prompt can proceed rather than blocking forever.

## Regression test
Added a new test case in `prompt-async-gate.test.ts`:
- `session.status` returns a never-resolving Promise
- `promptAsyncAfterSessionIdle` must still attempt dispatch after the timeout expires
- Before the fix, the test itself timed out (and production hung); after the fix it passes.

## Verification
- [x] `bun test src/hooks/shared/prompt-async-gate.test.ts` — 14 pass, 0 fail
- [x] `bun test src/shared/prompt-async-route-audit.test.ts` — 6 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite hangs when `session.status()` stalls by timing out `isSessionActive` in the prompt async gate. If the check times out, the session is treated as inactive so internal prompts can proceed.

- **Bug Fixes**
  - Wrapped `isSessionActive` with `withDispatchTimeout` (capped at `min(dispatchTimeoutMs, 5000)`), treating timeouts as inactive.
  - Tests: added a regression for non-resolving `session.status()` and updated the `atlas` timer mock to track active timers and honor `clearTimeout`, avoiding false positives from cancelled safety timeouts.

<sup>Written for commit fcd0011a6b8cad14e4e57b0278e746c6520d8b76. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4093?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

