### PR TITLE
fix(dynamic-truncator): bound session.messages fetch to stop forever-hang on Read (#4086)

### DIFF
--- a/src/shared/dynamic-truncator.test.ts
+++ b/src/shared/dynamic-truncator.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it, afterEach } from "bun:test"
 
-import { getContextWindowUsage, invalidateContextWindowUsageCache } from "./dynamic-truncator"
+import {
+  _setContextWindowUsageFetchTimeoutMsForTesting,
+  getContextWindowUsage,
+  invalidateContextWindowUsageCache,
+} from "./dynamic-truncator"
 
 const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT"
 const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT"
@@ -89,6 +93,114 @@ function createCountingContextUsageMockContext(inputTokens: number) {
 describe("getContextWindowUsage", () => {
   afterEach(() => {
     resetContextLimitEnv()
+    _setContextWindowUsageFetchTimeoutMsForTesting(undefined)
+  })
+
+  describe("#given client.session.messages never settles", () => {
+    describe("#when getContextWindowUsage is called with a fast fetch timeout", () => {
+      it("#then returns null instead of hanging forever", async () => {
+        // given
+        _setContextWindowUsageFetchTimeoutMsForTesting(50)
+        const ctx = {
+          client: {
+            session: {
+              messages: () => new Promise<never>(() => {}),
+            },
+          },
+        }
+
+        // when
+        const start = Date.now()
+        const usage = await getContextWindowUsage(ctx as never, "ses_hang_messages", {
+          anthropicContext1MEnabled: false,
+        })
+        const elapsed = Date.now() - start
+
+        // then
+        expect(usage).toBeNull()
+        expect(elapsed).toBeLessThan(2000)
+      })
+
+      it("#then a parallel concurrent caller also resolves to null instead of hanging on the cached promise", async () => {
+        // given
+        _setContextWindowUsageFetchTimeoutMsForTesting(50)
+        const ctx = {
+          client: {
+            session: {
+              messages: () => new Promise<never>(() => {}),
+            },
+          },
+        }
+
+        // when
+        const start = Date.now()
+        const [first, second] = await Promise.all([
+          getContextWindowUsage(ctx as never, "ses_hang_messages_parallel", {
+            anthropicContext1MEnabled: false,
+          }),
+          getContextWindowUsage(ctx as never, "ses_hang_messages_parallel", {
+            anthropicContext1MEnabled: false,
+          }),
+        ])
+        const elapsed = Date.now() - start
+
+        // then
+        expect(first).toBeNull()
+        expect(second).toBeNull()
+        expect(elapsed).toBeLessThan(2000)
+      })
+
+      it("#then a follow-up call after invalidation retries fresh instead of being poisoned by the timeout", async () => {
+        // given
+        _setContextWindowUsageFetchTimeoutMsForTesting(50)
+        let messagesCalls = 0
+        let shouldHang = true
+        const ctx = {
+          client: {
+            session: {
+              messages: () => {
+                messagesCalls += 1
+                if (shouldHang) {
+                  return new Promise<never>(() => {})
+                }
+                return Promise.resolve({
+                  data: [
+                    {
+                      info: {
+                        role: "assistant",
+                        providerID: "anthropic",
+                        modelID: "claude-sonnet-4-5",
+                        tokens: {
+                          input: 100000,
+                          output: 0,
+                          reasoning: 0,
+                          cache: { read: 0, write: 0 },
+                        },
+                      },
+                    },
+                  ],
+                })
+              },
+            },
+          },
+        }
+
+        // when
+        const firstUsage = await getContextWindowUsage(ctx as never, "ses_hang_then_recover", {
+          anthropicContext1MEnabled: false,
+        })
+        invalidateContextWindowUsageCache(ctx as never, "ses_hang_then_recover")
+        shouldHang = false
+        const secondUsage = await getContextWindowUsage(ctx as never, "ses_hang_then_recover", {
+          anthropicContext1MEnabled: false,
+        })
+
+        // then
+        expect(firstUsage).toBeNull()
+        expect(secondUsage?.remainingTokens).toBe(100000)
+        expect(messagesCalls).toBe(2)
+      })
+    })
   })
 
   it("uses 1M limit when model cache flag is enabled", async () => {

--- a/src/shared/dynamic-truncator.ts
+++ b/src/shared/dynamic-truncator.ts
@@ -3,10 +3,20 @@ import {
 	resolveActualContextLimit,
 	type ContextLimitModelCacheState,
 } from "./context-limit-resolver"
+import { log } from "./logger"
 import { normalizeSDKResponse } from "./normalize-sdk-response"
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const DEFAULT_TARGET_MAX_TOKENS = 50_000;
+// Hard ceiling on how long `session.messages()` is allowed to block inside
+// `fetchContextWindowUsage`. Without it, a stuck OpenCode RPC (observed when
+// `session.processor` enters an "Aborted process" loop) would leave the cached
+// promise pending forever and every hook that calls `truncator.truncate(...)`
+// would hang on it (issue #4086).
+export const DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS = 5_000;
+
+declare function setTimeout(callback: () => void, delay?: number): ReturnType<typeof globalThis.setTimeout>
+declare function clearTimeout(timeout: ReturnType<typeof globalThis.setTimeout>): void
 
 interface AssistantMessageInfo {
 	role: "assistant";
@@ -33,6 +43,16 @@ type ContextWindowUsage = {
 type ContextWindowUsageClient = Pick<PluginInput["client"], "session">
 
 const usageCacheByClient = new WeakMap<object, Map<string, Map<string, Promise<ContextWindowUsage | null>>>>()
+
+// Test-only override for the fetch timeout used by `fetchContextWindowUsage`.
+// `undefined` means "use the production default".
+let contextWindowUsageFetchTimeoutMsForTesting: number | undefined = undefined
+
+export function _setContextWindowUsageFetchTimeoutMsForTesting(
+	ms: number | undefined,
+): void {
+	contextWindowUsageFetchTimeoutMsForTesting = ms
+}
 
 function createModelCacheKey(modelCacheState?: ContextLimitModelCacheState): string {
 	if (!modelCacheState) {
@@ -184,15 +204,41 @@ export async function getContextWindowUsage(
 	return usagePromise
 }
 
+function withFetchTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+	if (timeoutMs <= 0) {
+		return operation
+	}
+	let timeoutID: ReturnType<typeof globalThis.setTimeout> | undefined
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeoutID = setTimeout(
+			() =>
+				reject(
+					new Error(
+						`[dynamic-truncator] session.messages timed out after ${timeoutMs}ms`,
+					),
+				),
+			timeoutMs,
+		)
+	})
+	return Promise.race([operation, timeoutPromise]).finally(() => {
+		if (timeoutID !== undefined) clearTimeout(timeoutID)
+	})
+}
+
 async function fetchContextWindowUsage(
 	ctx: PluginInput,
 	sessionID: string,
 	modelCacheState?: ContextLimitModelCacheState,
 ): Promise<ContextWindowUsage | null> {
+	const fetchTimeoutMs =
+		contextWindowUsageFetchTimeoutMsForTesting ?? DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS
 	try {
-		const response = await ctx.client.session.messages({
-			path: { id: sessionID },
-		});
+		const response = await withFetchTimeout(
+			ctx.client.session.messages({
+				path: { id: sessionID },
+			}),
+			fetchTimeoutMs,
+		);
 
 		const messages = normalizeSDKResponse(response, [] as MessageWrapper[], { preferResponseOnMissingData: true })
 
@@ -228,7 +274,11 @@ async function fetchContextWindowUsage(
 			remainingTokens,
 			usagePercentage: usedTokens / actualLimit,
 		};
-	} catch {
+	} catch (error) {
+		log("[dynamic-truncator] fetchContextWindowUsage failed; falling back to null", {
+			sessionID,
+			error: error instanceof Error ? error.message : String(error),
+		})
 		return null;
 	}
 }


### PR DESCRIPTION
## Summary

`getContextWindowUsage` caches the *promise* of `fetchContextWindowUsage`
per session. When `ctx.client.session.messages(...)` never settles
(observed once `session.processor` enters an "Aborted process" loop on
the OpenCode side), the cached pending promise wedges every concurrent
and later caller on that session. Five hooks share one
`createDynamicTruncator(ctx)` (`directory-agents-injector`,
`directory-readme-injector`, `rules-injector`, `tool-output-truncator`,
plus indirect callers), so the user-facing tool chain hangs forever on
the next `Read` and ESC cannot interrupt it. Reporters in #4086 land on
this consistently when reading `AGENTS.md` files (which trigger
`directory-agents-injector` via the directory walk).

This PR adds a 5 s hard ceiling on the underlying `session.messages`
call and treats a timeout the same as the existing "context usage
unavailable" path (`null` → static truncation fallback). No happy-path
behavior changes; existing cache reuse + invalidation semantics are
preserved.

Fixes #4086.

## Changes

- `src/shared/dynamic-truncator.ts`
  - Add `DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS = 5_000` exported
    constant.
  - Add private `withFetchTimeout()` racing the promise against a
    `setTimeout`-driven rejection (mirrors `withDispatchTimeout` shape
    in `prompt-async-gate.ts`).
  - Wrap the `ctx.client.session.messages({ path })` call in
    `withFetchTimeout`. On timeout/error the existing `try/catch` now
    logs the failure (so `/tmp/oh-my-opencode.log` shows it) and
    returns `null`.
  - Add `_setContextWindowUsageFetchTimeoutMsForTesting(ms)` following
    the existing `_setXxxForTesting` pattern used by
    `opencode-http-api.ts` and `prompt-async-gate.ts`.
- `src/shared/dynamic-truncator.test.ts`
  - Three new BDD cases under `#given client.session.messages never settles`:
    1. single caller resolves to `null` within the timeout instead of
       hanging,
    2. parallel concurrent callers on the same cached promise both
       unblock,
    3. invalidate + retry rehydrates fresh (no poisoned cache).
  - `afterEach` resets the test-override.
  - All 8 pre-existing tests in the file still pass (happy paths, cache
    reuse, invalidation, env/model fallback).

## Testing

- `bun test src/shared/dynamic-truncator.test.ts` → 11 pass.
- `bun test src/shared/prompt-async-route-audit.test.ts` → 6 pass.
- `bun test` (full suite) → 7009 pass, 1 skip, 1 pre-existing flake in
  `closeTmuxPane` `mock.module` test (reproduces on dev without this
  change; isolated run passes both times).
- `bun run typecheck` ✅
- `bun run build` ✅ (esm bundle + tsc + schema regen)
- Manual harness (`.debugging/manual-qa.ts`, not committed) simulates
  the real hook fan-out: five concurrent `getContextWindowUsage` calls,
  one `truncator.truncate()` on an 800 kB string, and an
  invalidate+retry — all complete in ~51 ms instead of hanging.

## Related Issues

- Fixes #4086 (OpenCode hangs with Oh My OpenAgent plugin enabled, but
  works with `--pure`.
EOF
)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Read hangs by adding a 5s timeout to `session.messages` in the dynamic truncator. On timeout, we return `null` to trigger static truncation while preserving cache behavior; fixes #4086.

- Bug Fixes
  - Added `DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS = 5_000` and `withFetchTimeout` to bound `ctx.client.session.messages({ path: { id } })`.
  - On timeout/error, log the failure and return `null` (same as “usage unavailable” path).
  - Introduced `_setContextWindowUsageFetchTimeoutMsForTesting` and tests for never-settling calls, concurrent callers unblocking, and clean invalidate+retry.

<sup>Written for commit 67ead7bf6dcf6eb9275b5f795054f2a2ed50ab79. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4094?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

