### PR TITLE
feat(thinking): switch to adaptive thinking type for Opus 4.7 compatibility

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -168,11 +168,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -235,11 +243,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -398,11 +414,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -524,11 +548,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -591,11 +623,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -754,11 +794,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -880,11 +928,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -947,11 +1003,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -1110,11 +1174,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -1236,11 +1308,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -1303,11 +1383,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -1466,11 +1554,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -1595,11 +1691,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -1662,11 +1766,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -1825,11 +1937,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -1951,11 +2071,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -2018,11 +2146,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -2181,11 +2317,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -2307,11 +2451,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -2374,11 +2526,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -2537,11 +2697,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -2663,11 +2831,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -2730,11 +2906,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -2893,11 +3077,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -3019,11 +3211,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -3086,11 +3286,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -3249,11 +3457,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -3375,11 +3591,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -3442,11 +3666,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -3605,11 +3837,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -3731,11 +3971,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -3798,11 +4046,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -3961,11 +4217,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -4087,11 +4351,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -4154,11 +4426,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -4317,11 +4597,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -4443,11 +4731,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -4510,11 +4806,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -4673,11 +4977,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -4799,11 +5111,19 @@
                             "type": "string",
                             "enum": [
                               "enabled",
-                              "disabled"
+                              "disabled",
+                              "adaptive"
                             ]
                           },
                           "budgetTokens": {
                             "type": "number"
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "summarized",
+                              "omitted"
+                            ]
                           }
                         },
                         "required": [
@@ -4866,11 +5186,19 @@
                                 "type": "string",
                                 "enum": [
                                   "enabled",
-                                  "disabled"
+                                  "disabled",
+                                  "adaptive"
                                 ]
                               },
                               "budgetTokens": {
                                 "type": "number"
+                              },
+                              "display": {
+                                "type": "string",
+                                "enum": [
+                                  "summarized",
+                                  "omitted"
+                                ]
                               }
                             },
                             "required": [
@@ -5029,11 +5357,19 @@
                   "type": "string",
                   "enum": [
                     "enabled",
-                    "disabled"
+                    "disabled",
+                    "adaptive"
                   ]
                 },
                 "budgetTokens": {
                   "type": "number"
+                },
+                "display": {
+                  "type": "string",
+                  "enum": [
+                    "summarized",
+                    "omitted"
+                  ]
                 }
               },
               "required": [
@@ -5156,11 +5492,19 @@
                           "type": "string",
                           "enum": [
                             "enabled",
-                            "disabled"
+                            "disabled",
+                            "adaptive"
                           ]
                         },
                         "budgetTokens": {
                           "type": "number"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "summarized",
+                            "omitted"
+                          ]
                         }
                       },
                       "required": [
@@ -5223,11 +5567,19 @@
                               "type": "string",
                               "enum": [
                                 "enabled",
-                                "disabled"
+                                "disabled",
+                                "adaptive"
                               ]
                             },
                             "budgetTokens": {
                               "type": "number"
+                            },
+                            "display": {
+                              "type": "string",
+                              "enum": [
+                                "summarized",
+                                "omitted"
+                              ]
                             }
                           },
                           "required": [
@@ -5386,11 +5738,19 @@
                 "type": "string",
                 "enum": [
                   "enabled",
-                  "disabled"
+                  "disabled",
+                  "adaptive"
                 ]
               },
               "budgetTokens": {
                 "type": "number"
+              },
+              "display": {
+                "type": "string",
+                "enum": [
+                  "summarized",
+                  "omitted"
+                ]
               }
             },
             "required": [
@@ -5521,11 +5881,19 @@
                           "type": "string",
                           "enum": [
                             "enabled",
-                            "disabled"
+                            "disabled",
+                            "adaptive"
                           ]
                         },
                         "budgetTokens": {
                           "type": "number"
+                        },
+                        "display": {
+                          "type": "string",
+                          "enum": [
+                            "summarized",
+                            "omitted"
+                          ]
                         }
                       },
                       "required": [
@@ -5588,11 +5956,19 @@
                               "type": "string",
                               "enum": [
                                 "enabled",
-                                "disabled"
+                                "disabled",
+                                "adaptive"
                               ]
                             },
                             "budgetTokens": {
                               "type": "number"
+                            },
+                            "display": {
+                              "type": "string",
+                              "enum": [
+                                "summarized",
+                                "omitted"
+                              ]
                             }
                           },
                           "required": [
@@ -5634,11 +6010,19 @@
                 "type": "string",
                 "enum": [
                   "enabled",
-                  "disabled"
+                  "disabled",
+                  "adaptive"
                 ]
               },
               "budgetTokens": {
                 "type": "number"
+              },
+              "display": {
+                "type": "string",
+                "enum": [
+                  "summarized",
+                  "omitted"
+                ]
               }
             },
             "required": [

--- a/packages/model-core/src/fallback-model-object.ts
+++ b/packages/model-core/src/fallback-model-object.ts
@@ -5,5 +5,9 @@ export type FallbackModelObject = {
   readonly temperature?: number
   readonly top_p?: number
   readonly maxTokens?: number
-  readonly thinking?: { readonly type: "enabled" | "disabled"; readonly budgetTokens?: number }
+  readonly thinking?: {
+    readonly type: "enabled" | "disabled" | "adaptive"
+    readonly budgetTokens?: number
+    readonly display?: "summarized" | "omitted"
+  }
 }

--- a/packages/model-core/src/model-requirements.ts
+++ b/packages/model-core/src/model-requirements.ts
@@ -6,7 +6,7 @@ export type FallbackEntry = {
   temperature?: number;
   top_p?: number;
   maxTokens?: number;
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number };
+  thinking?: { type: "enabled" | "disabled" | "adaptive"; budgetTokens?: number; display?: "summarized" | "omitted" };
 };
 
 export type ModelRequirement = {

--- a/packages/model-core/src/model-resolution-types.ts
+++ b/packages/model-core/src/model-resolution-types.ts
@@ -8,7 +8,7 @@ export interface DelegatedModelConfig {
   temperature?: number
   top_p?: number
   maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+  thinking?: { type: "enabled" | "disabled" | "adaptive"; budgetTokens?: number; display?: "summarized" | "omitted" }
 }
 
 export type ModelResolutionRequest = {

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -307,7 +307,7 @@ export function createMetisAgent(model: string): AgentConfig {
     temperature: 0.3,
     ...metisRestrictions,
     prompt: METIS_SYSTEM_PROMPT,
-    thinking: { type: "enabled", budgetTokens: 32000 },
+    thinking: { type: "adaptive", display: "summarized" },
   } as AgentConfig
 }
 createMetisAgent.mode = MODE

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -412,7 +412,7 @@ export function createMomusAgent(model: string): AgentConfig {
 
   return {
     ...base,
-    thinking: { type: "enabled", budgetTokens: 32000 },
+    thinking: { type: "adaptive", display: "summarized" },
   } as AgentConfig;
 }
 createMomusAgent.mode = MODE;

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -585,7 +585,7 @@ export function createOracleAgent(model: string): AgentConfig {
 
   return {
     ...base,
-    thinking: { type: "enabled", budgetTokens: 32000 },
+    thinking: { type: "adaptive", display: "summarized" },
   } as AgentConfig;
 }
 createOracleAgent.mode = MODE;

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -151,7 +151,7 @@ export function createSisyphusJuniorAgentWithOverrides(
 
   return {
     ...base,
-    thinking: { type: "enabled", budgetTokens: 32000 },
+    thinking: { type: "adaptive", display: "summarized" },
   } as AgentConfig
 }
 

--- a/src/agents/sisyphus-junior/index.test.ts
+++ b/src/agents/sisyphus-junior/index.test.ts
@@ -165,7 +165,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 
       // then
       expect(result.reasoningEffort).toBeUndefined()
-      expect(result.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+      expect(result.thinking).toEqual({ type: "adaptive", display: "summarized" })
     })
 
     test("#given GLM reasoning model #when agent is created #then skips injected thinking", () => {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -598,7 +598,7 @@ export function createSisyphusAgent(
         ...getFrontierToolSchemaPermission(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
-      thinking: { type: "enabled", budgetTokens: 32000 },
+      thinking: { type: "adaptive", display: "summarized" },
     };
   }
 
@@ -654,6 +654,6 @@ export function createSisyphusAgent(
     return { ...base, reasoningEffort: "medium" };
   }
 
-  return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } };
+  return { ...base, thinking: { type: "adaptive", display: "summarized" } };
 }
 createSisyphusAgent.mode = MODE;

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -146,7 +146,7 @@ describe("createBuiltinAgents with model overrides", () => {
 
       // #then
       expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
-      expect(agents.sisyphus.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+      expect(agents.sisyphus.thinking).toEqual({ type: "adaptive", display: "summarized" })
       expect(agents.sisyphus.reasoningEffort).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
@@ -375,7 +375,7 @@ describe("createBuiltinAgents with model overrides", () => {
 
     // #then
     expect(agents.oracle.model).toBe("anthropic/claude-sonnet-4")
-    expect(agents.oracle.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+    expect(agents.oracle.thinking).toEqual({ type: "adaptive", display: "summarized" })
     expect(agents.oracle.reasoningEffort).toBeUndefined()
     expect(agents.oracle.textVerbosity).toBeUndefined()
     providerModelsSpy.mockRestore()

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -32,8 +32,9 @@ export const AgentOverrideConfigSchema = z.object({
   /** Extended thinking configuration (Anthropic). Overrides category and default settings. */
   thinking: z
     .object({
-      type: z.enum(["enabled", "disabled"]),
+      type: z.enum(["enabled", "disabled", "adaptive"]),
       budgetTokens: z.number().optional(),
+      display: z.enum(["summarized", "omitted"]).optional(),
     })
     .optional(),
   /** Reasoning effort level (OpenAI). Overrides category and default settings. */

--- a/src/config/schema/categories.ts
+++ b/src/config/schema/categories.ts
@@ -12,8 +12,9 @@ export const CategoryConfigSchema = z.object({
   maxTokens: z.number().optional(),
   thinking: z
     .object({
-      type: z.enum(["enabled", "disabled"]),
+      type: z.enum(["enabled", "disabled", "adaptive"]),
       budgetTokens: z.number().optional(),
+      display: z.enum(["summarized", "omitted"]).optional(),
     })
     .optional(),
   reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]).optional(),

--- a/src/config/schema/fallback-models.ts
+++ b/src/config/schema/fallback-models.ts
@@ -9,8 +9,9 @@ export const FallbackModelObjectSchema = z.object({
   maxTokens: z.number().optional(),
   thinking: z
     .object({
-      type: z.enum(["enabled", "disabled"]),
+      type: z.enum(["enabled", "disabled", "adaptive"]),
       budgetTokens: z.number().optional(),
+      display: z.enum(["summarized", "omitted"]).optional(),
     })
     .optional(),
 })

--- a/src/features/team-mode/member-session-routing.ts
+++ b/src/features/team-mode/member-session-routing.ts
@@ -9,7 +9,7 @@ type PromptGenerationModel = {
   temperature?: number
   top_p?: number
   maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+  thinking?: { type: "enabled" | "disabled" | "adaptive"; budgetTokens?: number; display?: "summarized" | "omitted" }
 }
 
 export type TeamMemberPromptBody = {

--- a/src/features/team-mode/types.ts
+++ b/src/features/team-mode/types.ts
@@ -126,8 +126,9 @@ const RuntimeStateMemberModelSchema = z.object({
   top_p: z.number().optional(),
   maxTokens: z.number().optional(),
   thinking: z.object({
-    type: z.enum(["enabled", "disabled"]),
+    type: z.enum(["enabled", "disabled", "adaptive"]),
     budgetTokens: z.number().int().positive().optional(),
+    display: z.enum(["summarized", "omitted"]).optional(),
   }).optional(),
 }).strict()
 

--- a/src/hooks/model-fallback/next-fallback.ts
+++ b/src/hooks/model-fallback/next-fallback.ts
@@ -40,7 +40,7 @@ export function getNextReachableFallback(
   temperature?: number
   top_p?: number
   maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+  thinking?: { type: "enabled" | "disabled" | "adaptive"; budgetTokens?: number; display?: "summarized" | "omitted" }
 } | null {
   const isReachable = createReachabilityChecker(state)
 

--- a/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -16,7 +16,7 @@ type PrometheusOverride = Record<string, unknown> & {
   variant?: string;
   reasoningEffort?: string;
   textVerbosity?: string;
-  thinking?: { type: string; budgetTokens?: number };
+  thinking?: { type: string; budgetTokens?: number; display?: string };
   temperature?: number;
   top_p?: number;
   maxTokens?: number;

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -179,14 +179,14 @@ describe("parseFallbackModelObjectEntry", () => {
     const result = parseFallbackModelObjectEntry(
       {
         model: "anthropic/claude-sonnet-4-6",
-        thinking: { type: "enabled", budgetTokens: 10000 },
+        thinking: { type: "adaptive", display: "omitted" },
       },
       undefined,
     )
     expect(result).toEqual({
       providers: ["anthropic"],
       model: "claude-sonnet-4-6",
-      thinking: { type: "enabled", budgetTokens: 10000 },
+      thinking: { type: "adaptive", display: "omitted" },
     })
   })
 

--- a/src/shared/model-resolution-types.ts
+++ b/src/shared/model-resolution-types.ts
@@ -1,6 +1,6 @@
 export type {
   DelegatedModelConfig,
-  ModelResolutionRequest,
   ModelResolutionProvenance,
+  ModelResolutionRequest,
   ModelResolutionResult,
 } from "@oh-my-opencode/model-core"

--- a/src/shared/session-prompt-params-helpers.ts
+++ b/src/shared/session-prompt-params-helpers.ts
@@ -5,7 +5,7 @@ type PromptParamModel = {
   top_p?: number
   reasoningEffort?: string
   maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+  thinking?: { type: "enabled" | "disabled" | "adaptive"; budgetTokens?: number; display?: "summarized" | "omitted" }
 }
 
 export function applySessionPromptParams(


### PR DESCRIPTION
Adds support for Opus 4.7's `adaptive` thinking type across all agents (sisyphus, sisyphus-junior, oracle, metis, momus) and the JSON schema.

## Why

Opus 4.7 introduced `adaptive` as a valid value for `thinking.type` alongside `enabled` and `disabled`. Without this, configs using `adaptive` fail Zod validation, and the JSON schema autocomplete blocks the value.

## What

- Add `"adaptive"` to the thinking-type enums in `agent-overrides.ts`, `categories.ts`, and `fallback-models.ts` schemas
- Wire through to `metis`, `momus`, `oracle`, `sisyphus`, and `sisyphus-junior` agent configs
- Regenerate `assets/oh-my-opencode.schema.json`

## Test plan

- Existing agent tests pass on this branch.
- Schema regeneration verified via `bun run build:schema`.

Running on this fork (sjawhar/oh-my-opencode) since the v4.0 release without issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for Opus 4.7 adaptive thinking with a new display option, and switches all built‑in agents to summarized adaptive by default. Regenerated schema/types and aligned Sisyphus’s Opus 4.7 path and tests with upstream behavior.

- New Features
  - Accept `thinking.type: "adaptive"` and optional `thinking.display` ("summarized" | "omitted") across Zod schemas, `@oh-my-opencode/model-core` types, team‑mode, plugin overrides, and fallback chains; regenerate `assets/oh-my-opencode.schema.json`; default `metis`, `momus`, `oracle`, `sisyphus`, and `sisyphus-junior` to `{ type: "adaptive", display: "summarized" }`.

- Bug Fixes
  - Apply adaptive thinking to Sisyphus’s Opus 4.7 branch and update tests (including look-at assertions) to match current upstream behavior.

<sup>Written for commit 33b2b3af6e1967ab9048f728e261c4bb0fb58821. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4097?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

