### PR TITLE
fix(tmux): skip layout enforcement when closing isolated container pane

### DIFF
--- a/src/features/tmux-subagent/action-executor.ts
+++ b/src/features/tmux-subagent/action-executor.ts
@@ -61,13 +61,30 @@ async function enforceLayoutAndMainPane(ctx: ExecuteContext): Promise<void> {
   await enforceMainPane(latestState, ctx.config)
 }
 
+/**
+ * Returns true when the pane lives in the source window's tracked layout.
+ *
+ * The wrapper enforces the user's main-vertical layout against the source pane
+ * after destructive actions. That is correct when the affected pane was part of
+ * the source window (its removal changes the user's split arrangement) but
+ * actively harmful when the pane lived in a separate window — closing an
+ * isolated container in another window should not scramble the user's main
+ * window layout. Callers route both cases through the same close action, so we
+ * detect the relationship from `windowState`.
+ */
+function isPaneInSourceWindow(paneId: string, windowState: WindowState): boolean {
+  if (windowState.mainPane?.paneId === paneId) return true
+  return windowState.agentPanes.some((pane) => pane.paneId === paneId)
+}
+
 export async function executeAction(
   action: PaneAction,
   ctx: ExecuteContext
 ): Promise<ActionResult> {
   if (action.type === "close") {
+    const closingPaneInSourceWindow = isPaneInSourceWindow(action.paneId, ctx.windowState)
     const success = await closeTmuxPane(action.paneId)
-    if (success) {
+    if (success && closingPaneInSourceWindow) {
       await enforceLayoutAndMainPane(ctx)
     }
     return { success }


### PR DESCRIPTION
Skips `applyLayout()` when closing an isolated container pane, avoiding spurious layout commands against a pane that's about to be killed.

## Why

When a subagent pane was closed in isolated mode, `applyLayout()` ran against the closing pane and then failed (the pane was gone), polluting logs with errors and occasionally racing with the actual close.

## What

- `action-executor.ts`: detect isolated-close action and skip layout enforcement.
- New `action-executor-isolated-close.test.ts` with regression coverage.

## Test plan

- New isolated-close test verifies `applyLayout` is NOT invoked when the action is an isolated-pane close.
- Manual testing in the fork over several weeks — clean close, no spurious errors.

This is separate from #3105 (different file, different code path). #3105 has been closed in favor of this approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip layout enforcement when closing an isolated container pane. This prevents `applyLayout()` against panes being killed, avoids scrambling the source window layout, and eliminates noisy errors and races in the tmux subagent.

- **Bug Fixes**
  - Detect if the closing pane is in the source window via `windowState` and only enforce layout after a successful close; skip for isolated windows or failed closes.

<sup>Written for commit e8a7e2a94d52949d8c3614d1af664bdbac73d0fc. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

