### PR TITLE
fix(skill): pass directory to getAllSkills + fix async test timing

### DIFF
--- a/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/src/features/opencode-skill-loader/skill-discovery.ts
@@ -12,7 +12,8 @@ export function clearSkillCache(): void {
 export async function getAllSkills(options?: SkillResolutionOptions): Promise<LoadedSkill[]> {
 	const browserProvider = options?.browserProvider ?? "playwright"
 	const teamModeEnabled = options?.teamModeEnabled ?? false
-	const cacheKey = `${browserProvider}:${teamModeEnabled ? "team-on" : "team-off"}`
+	const directory = options?.directory ?? ""
+	const cacheKey = `${directory}:${browserProvider}:${teamModeEnabled ? "team-on" : "team-off"}`
 	const hasDisabledSkills = options?.disabledSkills && options.disabledSkills.size > 0
 
 	// Skip cache if disabledSkills is provided (varies between calls)

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -273,6 +273,7 @@ export function createToolRegistry(args: {
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
   })
   const skillTool = factories.createSkillTool({
+    directory: ctx.directory,
     commands,
     skills: skillContext.mergedSkills,
     mcpManager: managers.skillMcpManager,

--- a/src/tools/skill/async-description-refresh.test.ts
+++ b/src/tools/skill/async-description-refresh.test.ts
@@ -1,6 +1,10 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { createSkillTool } from "./tools"
 import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
 
 function requireFresh<T>(modulePath: string): T {
@@ -11,7 +15,7 @@ function requireFresh<T>(modulePath: string): T {
   return require(modulePath) as T
 }
 
-function createSkillTool(...args: Parameters<typeof import("./tools").createSkillTool>): ReturnType<typeof import("./tools").createSkillTool> {
+function createFreshSkillTool(...args: Parameters<typeof import("./tools").createSkillTool>): ReturnType<typeof import("./tools").createSkillTool> {
   return requireFresh<typeof import("./tools")>("./tools").createSkillTool(...args)
 }
 
@@ -35,17 +39,28 @@ async function waitForRefresh(predicate: () => boolean): Promise<void> {
       return
     }
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 10))
+    await new Promise<void>((resolve) => setTimeout(resolve, 50))
   }
 
   throw new Error("Timed out waiting for async skill description refresh")
 }
 
 describe("skill tool - async native skill description refresh", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "skill-async-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
   it("updates description after async native skills resolve", async () => {
     //#given
     let allCallCount = 0
-    const tool = createSkillTool({
+    const tool = createFreshSkillTool({
+      directory: testDir,
       skills: [createMockSkill("seeded-skill")],
       commands: [],
       nativeSkills: {

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -25,7 +25,7 @@ import {
   mergeNativeSkills,
 } from "./native-skills"
 
-export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition {
+export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
   let cachedDescription: string | null = null
 
   const getSkills = async (context?: ToolContext): Promise<LoadedSkill[]> => {
@@ -37,6 +37,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       disabledSkills: options?.disabledSkills,
       browserProvider: options?.browserProvider,
       teamModeEnabled: options?.teamModeEnabled,
+      directory: options.directory,
     })) ?? []
     const allSkills = options.skills ? [...options.skills] : discovered
 
@@ -191,4 +192,4 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
   })
 }
 
-export const skill: ToolDefinition = createSkillTool()
+export const skill: ToolDefinition = createSkillTool({ directory: process.cwd() })

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -33,6 +33,8 @@ export interface SkillLoadOptions {
   /** Git master configuration for watermark/co-author settings */
   gitMasterConfig?: GitMasterConfig
   disabledSkills?: Set<string>
+  /** Project directory for skill discovery and base directory resolution. Must be ctx.directory from PluginContext — process.cwd() is unsafe in OpenCode. */
+  directory: string
   /** Browser automation provider for provider-gated skill filtering */
   browserProvider?: BrowserAutomationProvider
   /** Whether team mode built-in docs should be exposed */


### PR DESCRIPTION
Re-attempt of #3098 (closed without comment) — this is needed for our fork to operate, so refiling rebased onto current dev with the test-timing fix included.

## Why

\`getAllSkills\` was called without \`directory\`, which caused project-scoped skills to be silently missed in some session setups. The fix threads the \`directory\` param through.

The previous PR (#3098) was closed without explanation. Happy to address whatever the original concern was if it's flagged.

## What

- \`tool-registry.ts\`: pass \`directory\` to \`getAllSkills\` call site.
- \`tools.ts\`: thread the param.
- \`types.ts\`: extend the interface.
- \`async-description-refresh.test.ts\`: fix flaky timing assertion that was masking the issue.

## Test plan

- Updated test passes consistently (was flaky on slower CI runners).
- Existing skill-tool tests still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes skill discovery and caching by project directory so project-scoped skills are found and caches don’t leak across projects. Also stabilizes the async description refresh test.

- **Bug Fixes**
  - Thread `directory` from plugin context to `createSkillTool` and into `getAllSkills`; include it in the discovery cache key.
  - Make `directory` required in `SkillLoadOptions`; exported `skill` uses `process.cwd()`.
  - Deflake `async-description-refresh` by using a temp dir and a 50ms poll interval.

- **Migration**
  - If you call `createSkillTool` directly, pass `{ directory: <projectDir> }`.

<sup>Written for commit d2d154137743356113b3692f8dbfba706cf6668c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4102?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

