### PR TITLE
fix: prevent idle recovery fanout and slash duplication

### DIFF
--- a/src/hooks/auto-slash-command/hook.ts
+++ b/src/hooks/auto-slash-command/hook.ts
@@ -56,6 +56,16 @@ function getCommandExecutionEventID(input: CommandExecuteBeforeInput): string | 
   return null
 }
 
+function partsContainAutoSlashCommandTags(parts: Array<{ text?: string }>): boolean {
+  return parts.some((part) =>
+    typeof part.text === "string"
+    && (
+      part.text.includes(AUTO_SLASH_COMMAND_TAG_OPEN)
+      || part.text.includes(AUTO_SLASH_COMMAND_TAG_CLOSE)
+    )
+  )
+}
+
 export interface AutoSlashCommandHookOptions {
   skills?: LoadedSkill[]
   pluginsEnabled?: boolean
@@ -153,6 +163,10 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
       input: CommandExecuteBeforeInput,
       output: CommandExecuteBeforeOutput
     ): Promise<void> => {
+      if (partsContainAutoSlashCommandTags(output.parts)) {
+        return
+      }
+
       const eventID = getCommandExecutionEventID(input)
       const commandKey = eventID
         ? `${input.sessionID}:event:${eventID}`

--- a/src/hooks/auto-slash-command/index.test.ts
+++ b/src/hooks/auto-slash-command/index.test.ts
@@ -355,6 +355,22 @@ describe("createAutoSlashCommandHook", () => {
       expect(output.parts[0].text).toContain("/ralph-loop Command")
     })
 
+    it("should not duplicate injection when command output is already tagged", async () => {
+      //#given
+      const hook = createAutoSlashCommandHook()
+      const input = createCommandInput("ralph-loop")
+      const taggedContent = "<auto-slash-command>\n/ralph-loop Command\n</auto-slash-command>"
+      const output = createCommandOutput(taggedContent)
+
+      //#when
+      await hook["command.execute.before"](input, output)
+
+      //#then
+      expect(output.parts).toHaveLength(1)
+      expect(output.parts[0]?.text).toBe(taggedContent)
+      expect(output.parts[0]?.text?.split("<auto-slash-command>").length).toBe(2)
+    })
+
     it("should inject template for known builtin commands like ulw-loop", async () => {
       //#given
       const hook = createAutoSlashCommandHook()

--- a/src/hooks/session-recovery/hook.test.ts
+++ b/src/hooks/session-recovery/hook.test.ts
@@ -210,4 +210,56 @@ describe("session-recovery hook interrupted idle recovery", () => {
     // then
     expect(result).toBe(false)
   })
+
+  test("#given a newer user turn follows an unfinished assistant turn #when idle recovery runs #then it does not recover the stale assistant", async () => {
+    // given
+    const promptAsyncCalls: PromptAsyncCall[] = []
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                info: {
+                  id: "msg_stale_assistant",
+                  role: "assistant",
+                  sessionID: "ses_stale_after_user",
+                  finish: "tool-calls",
+                },
+                parts: [
+                  {
+                    type: "tool_use",
+                    id: "toolu_stale_pending",
+                    name: "bash",
+                    input: {},
+                    state: { status: "pending" },
+                  },
+                ],
+              },
+              {
+                info: {
+                  id: "msg_newer_user",
+                  role: "user",
+                },
+                parts: [{ type: "text", text: "new prompt after interrupted turn" }],
+              },
+            ],
+          }),
+          promptAsync: async (call: PromptAsyncCall) => {
+            promptAsyncCalls.push(call)
+            return {}
+          },
+        },
+      },
+      directory: "/tmp/session-recovery-newer-user-test",
+    }
+    const hook = createSessionRecoveryHook(ctx as never)
+
+    // when
+    const result = await hook.handleInterruptedToolResultsOnIdle("ses_stale_after_user")
+
+    // then
+    expect(result).toBe(false)
+    expect(promptAsyncCalls).toHaveLength(0)
+  })
 })

--- a/src/hooks/session-recovery/hook.ts
+++ b/src/hooks/session-recovery/hook.ts
@@ -95,7 +95,11 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
   const findLatestAssistantMessage = (messages: MessageData[]): MessageData | undefined => {
     for (let index = messages.length - 1; index >= 0; index--) {
       const message = messages[index]
-      if (message?.info?.role === "assistant") {
+      const role = message?.info?.role
+      if (role === "user") {
+        return undefined
+      }
+      if (role === "assistant") {
         return message
       }
     }

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -425,6 +425,11 @@ describe("createEventHandler - idle deduplication", () => {
 						return true
 					},
 				},
+				backgroundNotificationHook: {
+					event: async () => {
+						callOrder.push("backgroundNotificationHook")
+					},
+				},
 				todoContinuationEnforcer: {
 					handler: async (input: EventInput) => {
 						if (input.event.type === "session.idle") {
@@ -446,6 +451,123 @@ describe("createEventHandler - idle deduplication", () => {
 		}))
 
 		expect(callOrder).toEqual(["sessionRecovery"])
+	})
+
+	it("#given idle recovery handles a real idle #when another real idle arrives immediately #then dedup state does not suppress the later idle", async () => {
+		//#given
+		const originalDateNow = Date.now
+		Date.now = () => 40_000
+		const dispatchCalls: EventInput[] = []
+		let recoveryCalls = 0
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp" }),
+			pluginConfig: asPluginConfig({}),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers(),
+			hooks: createEventHandlerHooks({
+				sessionRecovery: {
+					handleInterruptedToolResultsOnIdle: async () => {
+						recoveryCalls += 1
+						return recoveryCalls === 1
+					},
+				},
+				autoUpdateChecker: {
+					event: async (input: EventInput) => {
+						if (input.event.type === "session.idle") {
+							dispatchCalls.push(input)
+						}
+					},
+				},
+			}),
+		})
+
+		try {
+			//#when
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: "ses_recovered_then_real" },
+				},
+			}))
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: "ses_recovered_then_real" },
+				},
+			}))
+
+			//#then
+			expect(recoveryCalls).toBe(2)
+			expect(dispatchCalls).toHaveLength(1)
+			expect((dispatchCalls[0]?.event.properties as { sessionID?: string } | undefined)?.sessionID).toBe(
+				"ses_recovered_then_real",
+			)
+		} finally {
+			Date.now = originalDateNow
+		}
+	})
+
+	it("#given idle recovery handles a real idle #when a synthetic idle arrives immediately #then dedup state does not suppress the synthetic idle", async () => {
+		//#given
+		const originalDateNow = Date.now
+		Date.now = () => 50_000
+		const dispatchCalls: EventInput[] = []
+		let recoveryCalls = 0
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({ directory: "/tmp" }),
+			pluginConfig: asPluginConfig({}),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers(),
+			hooks: createEventHandlerHooks({
+				sessionRecovery: {
+					handleInterruptedToolResultsOnIdle: async () => {
+						recoveryCalls += 1
+						return recoveryCalls === 1
+					},
+				},
+				autoUpdateChecker: {
+					event: async (input: EventInput) => {
+						if (input.event.type === "session.idle") {
+							dispatchCalls.push(input)
+						}
+					},
+				},
+			}),
+		})
+
+		try {
+			//#when
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: "ses_recovered_then_synthetic" },
+				},
+			}))
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.status",
+					properties: {
+						sessionID: "ses_recovered_then_synthetic",
+						status: { type: "idle" },
+					},
+				},
+			}))
+
+			//#then
+			expect(recoveryCalls).toBe(2)
+			expect(dispatchCalls).toHaveLength(1)
+			expect((dispatchCalls[0]?.event.properties as { sessionID?: string } | undefined)?.sessionID).toBe(
+				"ses_recovered_then_synthetic",
+			)
+		} finally {
+			Date.now = originalDateNow
+		}
 	})
 
 	it("keeps other session dedup state untouched when bypassing synthetic-idle for current session", async () => {

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -562,6 +562,7 @@ export function createEventHandler(args: {
       now: Date.now(),
       dedupWindowMs: DEDUP_WINDOW_MS,
     });
+    const syntheticIdle = normalizeSessionStatusToIdle(input);
 
     if (input.event.type === "session.idle") {
       const sessionID = getEventSessionID(input);
@@ -577,15 +578,20 @@ export function createEventHandler(args: {
             recentAnyIdles.delete(sessionID);
           }
         }
+      }
+      const recovered = await recoverInterruptedToolResultsOnIdleEvent(input);
+      if (recovered) {
+        return;
+      }
+      if (sessionID) {
+        const now = Date.now();
         recentRealIdles.set(sessionID, now);
         if (!shouldDispatchIdleEvent(sessionID, now)) {
           return;
         }
       }
-    }
-
-    if (input.event.type === "session.idle") {
-      const recovered = await recoverInterruptedToolResultsOnIdleEvent(input);
+    } else if (syntheticIdle) {
+      const recovered = await recoverInterruptedToolResultsOnIdleEvent(syntheticIdle as EventInput);
       if (recovered) {
         return;
       }
@@ -593,7 +599,6 @@ export function createEventHandler(args: {
 
     await dispatchToHooks(input);
 
-    const syntheticIdle = normalizeSessionStatusToIdle(input);
     if (syntheticIdle) {
       const sessionID = (syntheticIdle.event.properties as Record<string, unknown>)?.sessionID as string;
       const now = Date.now();
@@ -606,20 +611,17 @@ export function createEventHandler(args: {
       if (!shouldDispatchIdleEvent(sessionID, now)) {
         return;
       }
-      const recovered = await recoverInterruptedToolResultsOnIdleEvent(syntheticIdle as EventInput);
-      if (!recovered) {
-        await dispatchToHooks(syntheticIdle as EventInput);
-        if (pluginConfig.openclaw) {
-          await dispatchOpenClawEvent({
-            config: pluginConfig.openclaw,
-            rawEvent: "session.idle",
-            context: {
-              sessionId: sessionID,
-              projectPath: pluginContext.directory,
-              tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
-            },
-          });
-        }
+      await dispatchToHooks(syntheticIdle as EventInput);
+      if (pluginConfig.openclaw) {
+        await dispatchOpenClawEvent({
+          config: pluginConfig.openclaw,
+          rawEvent: "session.idle",
+          context: {
+            sessionId: sessionID,
+            projectPath: pluginContext.directory,
+            tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
+          },
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

- run interrupted-tool idle recovery before normal real/synthetic idle hook fanout, so background/todo/other idle hooks cannot also inject after recovery handles the same edge
- avoid poisoning real/synthetic idle dedupe state when recovery consumes a real idle event
- stop interrupted idle recovery at a newer user turn so stale pre-user assistant tool state is not recovered
- prevent slash command `command.execute.before` from injecting a second template when output is already wrapped in `<auto-slash-command>` tags

## Debugging Evidence

- Investigated the hanging session shape from `ses_1cb9c3013ffesUOy5H3QOIya4K`: OpenCode 1.15.x can expose false-safe idle while assistant/tool state is still malformed, so OMO must recover before any generic idle wake/continuation hook observes that edge.
- Compared against `v3.17.15..origin/dev`: central `promptAsyncAfterSessionIdle` / `promptAfterSessionIdle` is already the one production dispatch axis; the remaining regressions were idle fanout ordering and stale-message boundaries. Slash duplication is older: issue #3724 reports OMO 3.17.6.
- Swept related open items: #3724/#4083 for slash duplication, #4085 for compact/resume synthetic continue, #4092/#4093 for prompt-gate status hangs, and promptAsync acceptance/durability issues around child/fallback routes.
- Sibling OpenCode inspection confirmed `session.promptAsync` returns before durable user-message acceptance; keeping OMO internal sends behind the shared gate remains the right invariant.

## Tests

- Red before fix: `bun test src/hooks/auto-slash-command/index.test.ts --test-name-pattern "already tagged" --bail` failed with `Expected length: 1`, `Received length: 2`.
- `bun test src/hooks/auto-slash-command/index.test.ts --test-name-pattern "already tagged" --bail`
- `bun test src/plugin/event.test.ts src/hooks/session-recovery/hook.test.ts --bail`
- `bun test src/hooks/shared/prompt-async-gate.test.ts src/shared/prompt-async-route-audit.test.ts src/hooks/auto-slash-command/index.test.ts src/plugin/event.test.ts src/hooks/session-recovery/hook.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/features/background-agent/task-completion-cleanup.test.ts --bail`
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/hooks/auto-slash-command/hook.ts src/hooks/auto-slash-command/index.test.ts src/hooks/session-recovery/hook.ts src/hooks/session-recovery/hook.test.ts src/plugin/event.ts src/plugin/event.test.ts`
- `bun run typecheck`
- `bun run build`
- no-space validation worktree: `bun install --frozen-lockfile && bun test` -> 7038 pass, 1 skip, 0 fail across 725 files

## Manual QA

- Imported the real `src/plugin/event.ts` and `src/hooks/auto-slash-command/hook.ts` with `bun --eval`.
- Synthetic idle recovery scenario produced `eventCallOrder: ["sessionRecovery"]`, proving background/todo idle hooks did not observe the recovered synthetic idle.
- Already-tagged slash command output stayed at `slashParts: 1`, `slashTagCount: 1`.

Fixes #3724


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run interrupted-tool idle recovery before idle hook fanout, tighten idle dedupe, and stop recovery when a newer user turn exists; also prevent duplicate slash command templates when output is already wrapped in <auto-slash-command> tags. Fixes #3724.

- Bug Fixes
  - Run recovery before dispatch for both real and synthetic idles to avoid background/todo hooks observing a recoverable edge.
  - Do not poison idle dedupe: subsequent real/synthetic idles after a recovery are not suppressed.
  - Stop recovery when a newer user message is present, preventing stale assistant/tool state restore.
  - Skip `command.execute.before` template injection when parts already include `<auto-slash-command>` tags.

<sup>Written for commit 8bc49775634d915d30a5e9581f613f7b35924538. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

