### PR TITLE
fix: inject agent variant from config into chat.params message

### DIFF
--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -34,6 +34,22 @@ export function createPluginInterface(args: {
     tool: tools,
 
     "chat.params": async (input: unknown, output: unknown) => {
+      const chatParamsInput = input as {
+        agent?: string | { name?: string }
+        message?: { variant?: string }
+      }
+      if (chatParamsInput.agent && pluginConfig?.agents) {
+        const agentName =
+          typeof chatParamsInput.agent === "string"
+            ? chatParamsInput.agent
+            : chatParamsInput.agent?.name
+        if (agentName && pluginConfig.agents[agentName]?.variant) {
+          if (chatParamsInput.message && !chatParamsInput.message.variant) {
+            chatParamsInput.message.variant =
+              pluginConfig.agents[agentName].variant
+          }
+        }
+      }
       const handler = createChatParamsHandler({
         anthropicEffort: hooks.anthropicEffort,
         client: ctx.client,

--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -72,7 +72,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "deepseek",
     includes: ["deepseek"],
-    variants: ["low", "medium", "high"],
+    variants: ["low", "medium", "high", "max"],
     reasoningEfforts: ["high", "max"],
     reasoningEffortAliases: {
       low: "high",


### PR DESCRIPTION
## Problem

The plugin reads the agent's `variant` from `oh-my-openagent.json` config (e.g. `"agents"."sisyphus"."variant": "max"`) but never injects it into the message before the `chat.params` handler processes it. The configured variant is silently dropped and the model always starts with `"default"`.

## Root Cause

`createChatParamsHandler` reads `input.message.variant` to determine the desired variant, but nobody ever writes the agent config's variant into that field. The function `applyAgentVariant` exists in `src/shared/agent-variant.ts` but is never called anywhere in the codebase.

## Changes

1. **`src/plugin-interface.ts`**: In the `chat.params` inline handler, inject `input.message.variant` from `pluginConfig.agents[name].variant` before delegating to `createChatParamsHandler`. This ensures the configured variant flows through to the model compatibility resolver.

2. **`src/shared/model-capability-heuristics.ts`**: Added `"max"` to the deepseek family variants list. Deepseek V4 Flash supports `"max"` as a reasoning variant, but it was missing from `HEURISTIC_MODEL_FAMILY_REGISTRY`, causing it to be silently downgraded to `"high"`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the agent variant from `oh-my-openagent.json` to `chat.params` so chats use the intended model variant. Also add `max` to DeepSeek variants to prevent unwanted downgrades.

- **Bug Fixes**
  - Inject `pluginConfig.agents[agentName].variant` into `input.message.variant` in `src/plugin-interface.ts` before calling `createChatParamsHandler`.
  - Add `"max"` to DeepSeek family `variants` in `src/shared/model-capability-heuristics.ts` so reasoning variants are honored.

<sup>Written for commit 000c6081e81bae1174033becfd253cfcaf7b903a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4110?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

