### PR TITLE
fix(runtime-fallback): classify more provider quota error names

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -109,7 +109,7 @@ export function classifyErrorType(error: unknown): string | undefined {
   // Normalize by stripping underscores and dashes so snake_case / kebab-case
   // provider error names (e.g. "insufficient_quota", "RESOURCE_EXHAUSTED")
   // match the existing alphanumeric .includes() checks below.
-  const errorName = extractErrorName(error)?.toLowerCase().replace(/[_-]/g, "")
+  const errorName = extractErrorName(error)?.toLowerCase()?.replace(/[_-]/g, "")
 
   if (
     errorName?.includes("ailoadapikeyerror") ||

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -106,10 +106,13 @@ function isLocalizedQuotaExhaustionMessage(message: string): boolean {
 
 export function classifyErrorType(error: unknown): string | undefined {
   const message = getErrorMessage(error)
-  const errorName = extractErrorName(error)?.toLowerCase()
+  // Normalize by stripping underscores and dashes so snake_case / kebab-case
+  // provider error names (e.g. "insufficient_quota", "RESOURCE_EXHAUSTED")
+  // match the existing alphanumeric .includes() checks below.
+  const errorName = extractErrorName(error)?.toLowerCase().replace(/[_-]/g, "")
 
   if (
-    errorName?.includes("ai_loadapikeyerror") ||
+    errorName?.includes("ailoadapikeyerror") ||
     errorName?.includes("loadapi") ||
     (/api.?key.?is.?missing/i.test(message) && /environment variable/i.test(message))
   ) {
@@ -132,6 +135,7 @@ export function classifyErrorType(error: unknown): string | undefined {
     errorName?.includes("quotaexceeded") ||
     errorName?.includes("insufficientquota") ||
     errorName?.includes("billingerror") ||
+    errorName?.includes("resourceexhausted") ||
     /quota.?exceeded/i.test(message) ||
     /exceeded.*quota/i.test(message) ||
     /usage\s*quota/i.test(message) ||
@@ -139,6 +143,7 @@ export function classifyErrorType(error: unknown): string | undefined {
     /insufficient.?(?:quota|balance|funds?)/i.test(message) ||
     /billing.?(?:hard.?)?limit/i.test(message) ||
     /exhausted\s+your\s+capacity/i.test(message) ||
+    /resource.?exhausted/i.test(message) ||
     /out\s+of\s+credits?/i.test(message) ||
     /payment.?required/i.test(message) ||
     /usage\s+limit/i.test(message) ||

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -89,4 +89,52 @@ describe("runtime-fallback quota error regressions", () => {
     expect(errorType).toBe("quota_exceeded")
     expect(retryable).toBe(true)
   })
+
+  test("classifies Google RESOURCE_EXHAUSTED (gRPC code 8) as quota_exceeded", () => {
+    //#given
+    const error = {
+      name: "RESOURCE_EXHAUSTED",
+      message: "Quota exceeded for quota metric 'Generate Content' and limit 'Generate Content quota per minute'.",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies Google ResourceExhausted message without HTTP status as quota_exceeded", () => {
+    //#given
+    const error = {
+      name: "GoogleGenerativeAIError",
+      message: "Resource exhausted: Please try again later.",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies snake_case OpenAI insufficient_quota error name as quota_exceeded", () => {
+    //#given
+    const error = {
+      name: "insufficient_quota",
+      message: "You exceeded your current quota, please check your plan and billing details.",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
 })

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -90,11 +90,14 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(true)
   })
 
-  test("classifies Google RESOURCE_EXHAUSTED (gRPC code 8) as quota_exceeded", () => {
+  test("classifies Google RESOURCE_EXHAUSTED (gRPC code 8) as quota_exceeded via error name only", () => {
     //#given
+    // Bare provider error: only the error name carries the quota signal.
+    // Message is intentionally generic so the test fails if the new
+    // `resourceexhausted` name allow-list entry is removed.
     const error = {
       name: "RESOURCE_EXHAUSTED",
-      message: "Quota exceeded for quota metric 'Generate Content' and limit 'Generate Content quota per minute'.",
+      message: "Request failed.",
     }
 
     //#when
@@ -122,11 +125,14 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(true)
   })
 
-  test("classifies snake_case OpenAI insufficient_quota error name as quota_exceeded", () => {
+  test("classifies snake_case OpenAI insufficient_quota error name as quota_exceeded via name only", () => {
     //#given
+    // Bare provider error: only the snake_case error name carries the quota signal.
+    // Message is intentionally generic so the test fails if the underscore
+    // normalization (`insufficient_quota` -> `insufficientquota`) regresses.
     const error = {
       name: "insufficient_quota",
-      message: "You exceeded your current quota, please check your plan and billing details.",
+      message: "Request failed.",
     }
 
     //#when


### PR DESCRIPTION
Closes #3937.

## Summary

Adds three small classification gaps to `classifyErrorType` so that quota-exhaustion errors from a wider range of providers trigger configured fallback chains instead of looping retry attempts.

## Root cause

`classifyErrorType` matches provider error names via lowercased alphanumeric substrings (e.g. `errorName.includes("insufficientquota")`). That check is broken for three real-world surfaces:

| Provider | Error name | Why current code missed it |
| --- | --- | --- |
| Google Generative AI | `RESOURCE_EXHAUSTED` (gRPC code 8) | name not in allow-list; message pattern absent |
| Google Generative AI | `ResourceExhausted` | name not in allow-list |
| OpenAI | `insufficient_quota` (snake_case) | `.includes("insufficientquota")` returns false because the underscore breaks the substring match |
| Anthropic / others | `rate_limit_exceeded` | same snake_case underscore issue |

When a quota error is not classified as `"quota_exceeded"`, the runtime-fallback path skips dispatching the configured fallback model and just keeps retrying the same dead model.

## Changes

- Normalize error names by stripping `_` and `-` once at the top of `classifyErrorType`, so snake_case / SCREAMING_SNAKE_CASE provider names match the existing alphanumeric `.includes()` checks. The single underscore-bearing literal (`ai_loadapikeyerror`) is updated to `ailoadapikeyerror` so previously matched names still resolve.
- Add `resourceexhausted` to the quota error-name allow-list (Google).
- Add `/resource.?exhausted/i` to the quota message-pattern list (also Google, when the provider sets a generic error name but puts the signal in the message).

## How I verified

- Three new regression tests in `src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` cover:
  - Google `RESOURCE_EXHAUSTED` (gRPC error name + quota-shaped message)
  - Google `ResourceExhausted` message form without HTTP status
  - OpenAI snake_case `insufficient_quota` error name
- All targeted suites pass:
  - `bun test src/hooks/runtime-fallback/` → 172 pass / 0 fail / 308 expect() calls / 16 files
- `bunx tsc --noEmit` clean on the touched files (filtered against the same zod/v4/locales noise everyone else hits).

## Risk

Minimal. The normalization only adds matches that were previously missed — no existing match is removed (verified by leaving the prior tests untouched). The one underscore-bearing literal was rewritten to its underscore-stripped form for behavior parity.

## Checklist

- [x] My code follows the existing style of the codebase
- [x] I have added/updated tests for my changes
- [x] All tests pass locally
- [x] I have not introduced any new TypeScript errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes quota error classification so runtime fallbacks trigger instead of looping retries. Addresses #3937 by recognizing Google and snake_case provider error names like RESOURCE_EXHAUSTED and insufficient_quota.

- Bug Fixes
  - Normalize error names by stripping "_" and "-" in classifyErrorType; updated literal to `ailoadapikeyerror` and added explicit optional chaining on `.replace()`.
  - Add `resourceexhausted` to the quota allow-list and a `/resource.?exhausted/i` message check for Google Generative AI.
  - Add three regression tests (Google RESOURCE_EXHAUSTED, ResourceExhausted message form, OpenAI insufficient_quota) and tighten fixtures with generic messages so only the new match paths make them pass.

<sup>Written for commit a8ccffdd7c7a91300c5bd25b66607b4e17eaf474. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

