### PR TITLE
fix(non-interactive-env): use powershell syntax on Windows regardless of SHELL/MSYSTEM (#3607)

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -370,7 +370,11 @@ describe("non-interactive-env hook", () => {
       expect(cmd).not.toContain("export ")
     })
 
-    test("#given Windows Git Bash environment with SHELL #when git command executes #then uses unix syntax", async () => {
+    test("#given Windows Git Bash SHELL=/usr/bin/bash #when git command executes #then uses powershell syntax (#3607)", async () => {
+      // Regression for #3607: OpenCode on Windows runs the bash tool through
+      // PowerShell by default, regardless of a Unix-shaped SHELL set by Git
+      // Bash. The export prefix is invalid PowerShell, so we must use
+      // PowerShell syntax even when SHELL points at /usr/bin/bash.
       delete process.env.PSModulePath
       process.env.SHELL = "/usr/bin/bash"
       Object.defineProperty(process, "platform", { value: "win32" })
@@ -386,12 +390,15 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
+      expect(cmd).toStartWith("$env:")
       expect(cmd).toContain("; git status")
-      expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
     })
 
-    test("#given Windows Git Bash via MSYSTEM without SHELL #when git command executes #then uses unix syntax", async () => {
+    test("#given Windows MSYSTEM=MINGW64 without SHELL #when git command executes #then uses powershell syntax (#3607)", async () => {
+      // Regression for #3607: MSYSTEM is permanently set on systems with Git
+      // Bash installed, but OpenCode on Windows still spawns PowerShell.
+      // MSYSTEM alone must not select Unix env-prefix syntax.
       delete process.env.SHELL
       process.env.MSYSTEM = "MINGW64"
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
@@ -408,9 +415,9 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
+      expect(cmd).toStartWith("$env:")
       expect(cmd).toContain("; git status")
-      expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
     })
 
     test("#given Windows platform #when chained git commands via bash tool #then uses cmd syntax", async () => {
@@ -437,8 +444,13 @@ describe("non-interactive-env hook", () => {
       expect(cmd).not.toContain("$env:")
     })
 
-    test("#given SHELL=/bin/bash on win32 #when git command executes #then uses unix syntax", async () => {
-      // Git Bash or WSL sets SHELL env var - should override platform detection
+    test("#given SHELL=/bin/bash on win32 #when git command executes #then uses powershell syntax (#3607)", async () => {
+      // Regression for #3607: a Unix-shaped SHELL value (Git Bash sets
+      // SHELL=/bin/bash or /usr/bin/bash) does NOT mean OpenCode will run
+      // the bash tool in a Unix shell on Windows — OpenCode spawns
+      // PowerShell, so the env prefix must use PowerShell syntax.
+      // WSL is not affected by this assertion because in WSL,
+      // process.platform === "linux", not "win32".
       delete process.env.PSModulePath
       process.env.SHELL = "/bin/bash"
       Object.defineProperty(process, "platform", { value: "win32" })
@@ -454,9 +466,9 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
+      expect(cmd).toStartWith("$env:")
       expect(cmd).toContain("; git status")
-      expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
     })
 
     test("#given PSModulePath set on non-Windows #when git command executes #then uses powershell syntax", async () => {

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -41,18 +41,28 @@ function detectWindowsShellType(shellPath: string | undefined): ShellType | unde
 }
 
 function detectCommandShellType(): ShellType {
-  if (process.platform === "win32" && process.env.SHELL) {
-    const shellType = detectWindowsShellType(process.env.SHELL)
-    if (shellType) {
-      return shellType
+  if (process.platform !== "win32") {
+    return detectShellType()
+  }
+
+  // OpenCode on Windows runs the bash tool through a Windows shell
+  // (PowerShell by default, with cmd as the user-overridable fallback),
+  // regardless of MSYSTEM or a Unix-shaped SHELL value set by Git Bash.
+  // Map any explicit Windows shell we can recognize; otherwise default
+  // to PowerShell so the prepended env-var syntax matches the shell that
+  // actually executes the command. See #3607.
+  const fromShell = detectWindowsShellType(process.env.SHELL)
+  if (fromShell) {
+    return fromShell
+  }
+  if (!process.env.SHELL && !process.env.MSYSTEM) {
+    const fromComSpec = detectWindowsShellType(process.env.ComSpec)
+    if (fromComSpec) {
+      return fromComSpec
     }
+    return "cmd"
   }
-
-  if (process.platform === "win32" && !process.env.SHELL && !process.env.MSYSTEM) {
-    return detectWindowsShellType(process.env.ComSpec) ?? "cmd"
-  }
-
-  return detectShellType()
+  return "powershell"
 }
 
 export function createNonInteractiveEnvHook(_ctx: PluginInput) {


### PR DESCRIPTION
Closes #3607.

## Summary

On Windows, `detectCommandShellType()` returned `"unix"` for two common environments — Git Bash sets `SHELL=/usr/bin/bash` (and `MSYSTEM=MINGW64`) permanently, but OpenCode actually spawns the bash tool through PowerShell. The hook then prepended `export KEY=val;` to git commands, which PowerShell rejects:

> `export : 无法将"export"项识别为 cmdlet...`

## Fix

`detectCommandShellType()` now short-circuits on `process.platform === "win32"` and resolves to a Windows-compatible shell:

- Recognized Windows shell via `SHELL` (`cmd.exe`, `powershell.exe`, `pwsh.exe`) — use it.
- `SHELL` and `MSYSTEM` both unset — fall back to `ComSpec` then to cmd.
- Anything else on win32 (Unix-shaped SHELL, MSYSTEM-only) — use PowerShell, matching what OpenCode actually spawns.

`detectShellType()` itself is unchanged; non-Windows callers are unaffected.

## Three test updates

Three existing tests previously asserted the buggy behavior:

- `Windows Git Bash environment with SHELL → unix syntax`
- `Windows Git Bash via MSYSTEM without SHELL → unix syntax`
- `SHELL=/bin/bash on win32 → unix syntax`

These are flipped to assert PowerShell syntax with a \`(#3607)\` marker and a comment noting that WSL is not affected (in WSL \`process.platform === 'linux'\`, not \`'win32'\`).

## Note on the issue thread

The sisyphus-bot triage on #3607 framed this as a policy choice between (A) forcing Windows env-prefix syntax and (B) resolving against the OpenCode-configured shell. This PR implements **option (A)** as the minimal surgical fix; option (B) remains a follow-up if the maintainer prefers that direction.

## Verification

- \`bun test src/hooks/non-interactive-env/\` → 24 pass / 0 fail
- \`bunx tsc --noEmit\` → clean (filtered against the same zod/v4/locales noise)
- Diff: +41/-19 across 2 files

## Checklist

- [x] My code follows the existing style of the codebase
- [x] I have updated tests for the new behavior and added a regression marker
- [x] All tests pass locally
- [x] No new TypeScript errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shell detection on Windows so env prefixes use PowerShell (or cmd) syntax instead of Unix, preventing errors when Git Bash sets Unix-like SHELL/MSYSTEM. Closes #3607.

- **Bug Fixes**
  - On win32, detectCommandShellType() now resolves to a Windows shell: use recognized SHELL (cmd/powershell/pwsh); if no SHELL/MSYSTEM, fall back to ComSpec then cmd; otherwise default to PowerShell.
  - Updated 3 tests to expect PowerShell syntax on Windows; non-Windows (including WSL) unchanged.

<sup>Written for commit 2bd7946001cef667fa89b2d1598e4a000cc74108. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4114?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

