### PR TITLE
fix: add google provider to Claude whitelist for Antigravity support

### DIFF
--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -51,6 +51,17 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(1_000_000)
   })
 
+  it("returns GA 1M for Antigravity Claude models served by google", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    const actualLimit = resolveActualContextLimit("google", "claude-sonnet-4-6", {
+      anthropicContext1MEnabled: false,
+    })
+
+    expect(actualLimit).toBe(1_000_000)
+  })
+
   it("uses cached limit for GA Anthropic models when cache exists", () => {
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -10,7 +10,7 @@ export type ContextLimitModelCacheState = {
 
 function isAnthropicProvider(providerID: string): boolean {
   const normalized = providerID.toLowerCase()
-  return normalized === "anthropic" || normalized === "google-vertex-anthropic" || normalized === "aws-bedrock-anthropic"
+  return normalized === "anthropic" || normalized === "google-vertex-anthropic" || normalized === "aws-bedrock-anthropic" || normalized === "google"
 }
 
 function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState): number {

--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -5,7 +5,7 @@ const EFFORT_UNSUPPORTED_PATTERN = /claude-.*haiku/i
 const INTERNAL_SKIP_AGENTS = new Set(["title", "summary", "compaction"])
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
-  if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
+  if (["anthropic", "google-vertex-anthropic", "opencode", "google"].includes(providerID)) return true
   if (providerID === "github-copilot" && modelID.toLowerCase().includes("claude")) return true
   return false
 }

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -153,6 +153,22 @@ describe("createAnthropicEffortHook", () => {
       expect(output.options.effort).toBeUndefined()
     })
 
+    it("treats google provider Claude models as Claude-compatible", async () => {
+      // given
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "google",
+        modelID: "claude-sonnet-4-6",
+      })
+
+      // when
+      await hook["chat.params"](input, output)
+
+      // then
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
     it("#given github-copilot + claude opus model #then effort clamped to high (constrained provider)", async () => {
       // given
       const hook = createAnthropicEffortHook()


### PR DESCRIPTION
google auth 사용이 권장은 아니지만 적어도 install 과정에 언급되면 지원은 해줘야 된다고 생각합니다.

## Problem

The installation guide documents **Google Gemini (Antigravity OAuth)** as a supported provider, including Claude models like `google/antigravity-claude-opus-4-5-thinking`. However, the `google` provider was missing from internal whitelists, causing:

1. **Opus effort/clamping hooks to be skipped** — `isClaudeProvider()` returns `false` for `google`, so the `chat.params` effort hook early-returns before applying Opus-specific `effort: "max"` clamping.
2. **Context limit resolution to fall through** — `isAnthropicProvider()` returns `false` for `google`, so Claude models routed through Antigravity do not get proper 200K/1M context window resolution.

## Fix

- Add `"google"` to `isClaudeProvider` whitelist in `src/hooks/anthropic-effort/hook.ts`
- Add `"google"` to `isAnthropicProvider` whitelist in `src/shared/context-limit-resolver.ts`

## Impact

Users with `google/antigravity-claude-*` models will now:
- Receive proper `effort: "max"` clamping for Opus models
- Get correct context window limits (200K/1M) instead of falling through to generic cache lookup

This aligns the code behavior with the documented installation guide support for Antigravity OAuth.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `google` to Anthropic/Claude provider checks so Antigravity-routed Claude models (e.g., `google/antigravity-claude-*`) get effort clamping and the GA 1M context limit. Adds tests to lock this behavior and align with the Antigravity OAuth install guide.

- **Bug Fixes**
  - Treat `google` as Claude-compatible in `src/hooks/anthropic-effort/hook.ts` so effort clamping applies.
  - Treat `google` as Anthropic-compatible in `packages/model-core/src/context-limit-resolver.ts` so GA context limit resolution applies.
  - Add tests in `packages/model-core/src/context-limit-resolver.test.ts` and `src/hooks/anthropic-effort/index.test.ts`.

<sup>Written for commit 1adea6a49cb8147a7cef68bada426c0f220e36da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





