### PR TITLE
fix: inject agent variant from config into chat.params message

### DIFF
--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -49,6 +49,24 @@ function createMockParams(overrides: {
   }
 }
 
+const originalXdgDataHome = process.env.XDG_DATA_HOME
+let globalTempDataDir: string
+
+beforeAll(() => {
+  globalTempDataDir = path.join(tmpdir(), `anthropic-effort-global-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(globalTempDataDir, { recursive: true })
+  process.env.XDG_DATA_HOME = globalTempDataDir
+})
+
+afterAll(() => {
+  if (originalXdgDataHome === undefined) {
+    delete process.env.XDG_DATA_HOME
+  } else {
+    process.env.XDG_DATA_HOME = originalXdgDataHome
+  }
+  rmSync(globalTempDataDir, { recursive: true, force: true })
+})
+
 describe("createAnthropicEffortHook", () => {
   describe("opus family with variant max", () => {
     it("injects effort max for anthropic opus-4-6", async () => {

--- a/src/plugin-interface.test.ts
+++ b/src/plugin-interface.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -302,5 +302,71 @@ describe("createPluginInterface - backward compatibility", () => {
 
     // then
     expect(getSessionAgent("ses-legacy-zwsp")).toBe("Hephaestus - Deep Agent")
+  })
+})
+
+describe("createPluginInterface - chat.params variant injection", () => {
+  test("injects variant from agent config into chat.params message", async () => {
+    // given
+    const pluginInterface = createPluginInterface({
+      ctx: { client: {} } as never,
+      pluginConfig: {
+        agents: {
+          oracle: { variant: "high" },
+        },
+      } as never,
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {} as never,
+      hooks: {
+        anthropicEffort: { "chat.params": async () => {} },
+      } as never,
+      tools: {},
+    })
+
+    const input = { agent: "oracle", message: {} }
+    const output = {}
+
+    // when
+    await pluginInterface["chat.params"]?.(input as never, output as never)
+
+    // then
+    expect((input.message as Record<string, unknown>).variant).toBe("high")
+  })
+
+  test("does not overwrite existing variant in chat.params message", async () => {
+    // given
+    const pluginInterface = createPluginInterface({
+      ctx: { client: {} } as never,
+      pluginConfig: {
+        agents: {
+          oracle: { variant: "high" },
+        },
+      } as never,
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {} as never,
+      hooks: {
+        anthropicEffort: { "chat.params": async () => {} },
+      } as never,
+      tools: {},
+    })
+
+    const input = { agent: "oracle", message: { variant: "max" } }
+    const output = {}
+
+    // when
+    await pluginInterface["chat.params"]?.(input as never, output as never)
+
+    // then
+    expect((input.message as Record<string, unknown>).variant).toBe("max")
   })
 })

--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -1,5 +1,6 @@
 import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 import type { OhMyOpenCodeConfig } from "./config"
+import type { AgentOverrides } from "./config/schema/agent-overrides"
 
 import { createChatParamsHandler } from "./plugin/chat-params"
 import { createChatHeadersHandler } from "./plugin/chat-headers"
@@ -34,6 +35,22 @@ export function createPluginInterface(args: {
     tool: tools,
 
     "chat.params": async (input: unknown, output: unknown) => {
+      const chatParamsInput = input as {
+        agent?: string | { name?: string }
+        message?: { variant?: string }
+      }
+      if (chatParamsInput.agent && pluginConfig?.agents) {
+        const agentName =
+          typeof chatParamsInput.agent === "string"
+            ? chatParamsInput.agent
+            : chatParamsInput.agent?.name
+        if (agentName && pluginConfig.agents[agentName as keyof AgentOverrides]?.variant) {
+          if (chatParamsInput.message && !chatParamsInput.message.variant) {
+            chatParamsInput.message.variant =
+              pluginConfig.agents[agentName as keyof AgentOverrides]!.variant
+          }
+        }
+      }
       const handler = createChatParamsHandler({
         anthropicEffort: hooks.anthropicEffort,
         client: ctx.client,

--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -72,7 +72,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "deepseek",
     includes: ["deepseek"],
-    variants: ["low", "medium", "high"],
+    variants: ["low", "medium", "high", "max"],
     reasoningEfforts: ["high", "max"],
     reasoningEffortAliases: {
       low: "high",

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -257,7 +257,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
-      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
+      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Llama", modelID: "llama-4-maverick", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -277,15 +277,28 @@ describe("resolveCompatibleModelSettings", () => {
       })
 
       test(`${name} (${modelID}): downgrades unsupported variant`, () => {
+        const highest = expectedVariants[expectedVariants.length - 1]
+        // If "max" is supported, test with an invalid variant like "super-max-invalid"
+        // Wait, "super-max-invalid" is not a recognized variant string so it gets dropped (undefined).
+        // Let's use a known variant that is higher than the supported ones.
+        // Actually, if the model supports "max", there is no "higher" variant to downgrade from.
+        // So we can just skip the downgrade test or assert it keeps "max".
+        const desiredVariant = expectedVariants.includes("max") ? "super-max-invalid" : "max"
+        
         const result = resolveCompatibleModelSettings({
           providerID: "any-provider",
           modelID,
-          desired: { variant: "max" },
+          desired: { variant: desiredVariant },
         })
 
-        const highest = expectedVariants[expectedVariants.length - 1]
-        expect(result.variant).toBe(highest)
-        expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        if (expectedVariants.includes("max")) {
+            // For invalid variant "super-max-invalid", it gets dropped entirely.
+            expect(result.variant).toBeUndefined()
+            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        } else {
+            expect(result.variant).toBe(highest)
+            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        }
       })
 
       test(`${name} (${modelID}): ${hasReasoningEffort ? "keeps" : "drops"} reasoningEffort`, () => {


### PR DESCRIPTION
Fixes #4125

### What this PR does
Fixes an issue where the agent `variant` defined in `oh-my-opencode.json` wasn't properly propagating into the OpenCode `chat.params` message. As a result, the model was ignoring the requested effort variant.

- **Injects configured variant**: Automatically injects `pluginConfig.agents[agentName].variant` into `chatParamsInput.message.variant` before the parameters handler processes it (only if not already explicitly set).
- **DeepSeek variants**: Adds `"max"` to the valid variant list in `model-capability-heuristics.ts` to fully support DeepSeek's max reasoning effort.
- **Type safety**: Uses proper `as keyof AgentOverrides` casting consistent with the rest of the codebase.
- **Test coverage**: Adds unit tests in `plugin-interface.test.ts` to guarantee variant injection works without overwriting pre-existing overrides.

### PR Checklist
- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Tested locally with OpenCode
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent variant propagation by injecting the configured `variant` from `oh-my-opencode.json` into `chat.params` so models honor the requested reasoning effort, including DeepSeek “max”.

- **Bug Fixes**
  - Injects `pluginConfig.agents[agent].variant` into `chat.params.message` when missing; never overwrites an existing value.
  - Adds `"max"` to DeepSeek valid variants in `model-capability-heuristics.ts`.
  - Adds tests for variant injection and DeepSeek `max` compatibility; uses `as keyof AgentOverrides` for safer config access.

<sup>Written for commit 5a6947b56951b4c95685eb0fcd3031e52cb25ab0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

