### PR TITLE
fix(hooks): guard session-notification against missing ctx.$ (refs #3997)

### DIFF
--- a/src/hooks/session-notification-sender.test.ts
+++ b/src/hooks/session-notification-sender.test.ts
@@ -78,6 +78,36 @@ describe("session-notification-sender", () => {
 	})
 
 	describe("#given sendSessionNotification", () => {
+		describe("#when ctx.$ is unavailable", () => {
+			test("#then it returns early without throwing when ctx has no $", async () => {
+				const cmuxSpy = spyOn(utils, "getCmuxPath")
+				const mockCtx = unsafeTestValue<PluginInput>({})
+
+				await expect(sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")).resolves.toBeUndefined()
+				expect(cmuxSpy).not.toHaveBeenCalled()
+			})
+
+			test("#then it returns early without throwing when ctx.$ is not a function", async () => {
+				const cmuxSpy = spyOn(utils, "getCmuxPath")
+				const mockCtx = unsafeTestValue<PluginInput>({
+					$: "not-a-function",
+				})
+
+				await expect(sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")).resolves.toBeUndefined()
+				expect(cmuxSpy).not.toHaveBeenCalled()
+			})
+
+			test("#then it remains non-throwing across sender APIs", async () => {
+				const afplaySpy = spyOn(utils, "getAfplayPath")
+				const mockCtx = unsafeTestValue<PluginInput>({})
+
+				await expect(sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")).resolves.toBeUndefined()
+				await expect(sender.playSessionNotificationSound(mockCtx, "darwin", "/sound.aiff")).resolves.toBeUndefined()
+
+				expect(afplaySpy).not.toHaveBeenCalled()
+			})
+		})
+
 		describe("#when calling ctx.$ for notifications", () => {
 			test("#then should call .quiet() on all shell commands to suppress stdout/stderr", async () => {
 				const quietCalls: string[] = []

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -1,5 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { platform } from "os"
+import { log } from "../shared"
 import {
   getCmuxPath,
   getOsascriptPath,
@@ -38,6 +39,19 @@ type ShellCommand = Promise<unknown> & {
   nothrow?: () => ShellCommand
 }
 
+let hasLoggedUnavailableShellHelper = false
+
+function canRunNotificationCommand(ctx: PluginInput): boolean {
+  if (typeof ctx?.$ === "function") return true
+
+  if (!hasLoggedUnavailableShellHelper) {
+    hasLoggedUnavailableShellHelper = true
+    log("[session-notification] ctx.$ unavailable; skipping notification command execution")
+  }
+
+  return false
+}
+
 async function runQuietNothrow(command: ShellCommand): Promise<void> {
   const safeCommand = typeof command.nothrow === "function" ? command.nothrow() : command
   if (typeof safeCommand.quiet === "function") {
@@ -54,6 +68,8 @@ export async function sendSessionNotification(
   title: string,
   message: string
 ): Promise<void> {
+  if (!canRunNotificationCommand(ctx)) return
+
   switch (platform) {
     case "darwin": {
       // Try cmux first - native UNUserNotificationCenter, properly attributed
@@ -113,6 +129,8 @@ export async function playSessionNotificationSound(
   platform: Platform,
   soundPath: string
 ): Promise<void> {
+  if (!canRunNotificationCommand(ctx)) return
+
   switch (platform) {
     case "darwin": {
       const afplayPath = await getAfplayPath()


### PR DESCRIPTION
## Problem

Issue #3997 reports sidecar exit code 1 after first request, with `TypeError: ctx.$ is not a function` in session notification sending.

I validated current `dev` and found `src/features/background-agent/process-cleanup.ts` is already log-only (`registerErrorEvent` detaches and logs, no `scheduleForcedExit(..., 1, true)` path for uncaughtException/unhandledRejection anymore).

So the original owner triage on #3997 was based on pre-rewrite code. Current state:
- `dev` no longer force-exits on uncaughtException/unhandledRejection in process-cleanup
- published npm is still `4.1.2`, which matches reporter environment and predates the log-only rewrite
- notification sender still directly calls `ctx.$` in multiple branches, so a missing/mis-shaped shell helper can throw

## Root Cause (ctx.$ path)

`sendSessionNotification` and `playSessionNotificationSound` assumed `ctx.$` is always callable and directly invoked command templates.

When notification hooks run in contexts where shell helper injection is missing or torn down, this throws `TypeError: ctx.$ is not a function`.

## Changes

- `src/hooks/session-notification-sender.ts`
  - Added a defensive guard (`canRunNotificationCommand`) used by both:
    - `sendSessionNotification`
    - `playSessionNotificationSound`
  - If `typeof ctx?.$ !== "function"`, it logs one warning and returns early.
  - This prevents notification helper faults from escalating into runtime crashes.

- `src/hooks/session-notification-sender.test.ts`
  - Added regression coverage:
    - ctx without `$` returns without throw
    - ctx with non-function `$` returns without throw
    - sender + sound APIs both remain non-throwing with missing `$`
  - Existing valid-shell path tests remain intact.

## Why no process-cleanup changes in this PR

Current `dev` already contains the process-cleanup lifecycle rewrite (`fix(process-cleanup): stop force-exiting opencode on transient unhandled errors`), with tests that assert log-only behavior for uncaughtException.

Changing it again here would be redundant and risk widening scope.

## Verification

- `bun run typecheck` ✅
- `bun test src/hooks/session-notification-sender.test.ts` ✅
- `bun test` ✅
- `bun run build` ✅

Refs #3997.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes during session notifications by guarding against missing `ctx.$`. If the shell helper isn’t available, we log once and skip running commands, addressing the error seen in #3997.

- **Bug Fixes**
  - Added `canRunNotificationCommand` to verify `ctx.$` is a function; otherwise log once and return early.
  - Applied guard to `sendSessionNotification` and `playSessionNotificationSound`.
  - Added tests covering missing and non-function `$`, ensuring both APIs return without throwing.

<sup>Written for commit 397ed1048a42a9a5eed6b7d1df63f68cba24c5e0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

