### PR TITLE
fix(anthropic-effort): clamp pre-set effort=max for constrained providers regardless of variant (fixes #3563)

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -76,23 +76,35 @@ export function createAnthropicEffortHook() {
       const { agent, model, message } = input
       if (!model?.modelID || !model?.providerID) return
       if (isEffortUnsupportedModel(model.modelID)) return
-      if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
-      if (output.options.effort !== undefined) return
 
       const opus = isOpusModel(model.modelID)
       const constrained = isConstrainedProvider(model.providerID)
+
+      if (output.options.effort !== undefined) {
+        if (output.options.effort === "max" && constrained) {
+          const clamped = clampVariant("max", opus, constrained)
+          output.options.effort = clamped
+          ;(message as { variant?: string }).variant = clamped
+          log("anthropic-effort: clamped pre-set effort max→high", {
+            sessionID: input.sessionID,
+            provider: model.providerID,
+            model: model.modelID,
+            reason: "constrained-provider",
+          })
+        }
+        return
+      }
+
+      if (message.variant !== "max") return
+
       const clamped = clampVariant(message.variant, opus, constrained)
       output.options.effort = clamped
 
       const shouldOverrideMessageVariant = !opus || constrained
 
       if (shouldOverrideMessageVariant) {
-        // Override the variant so OpenCode doesn't pass "max" to the API.
-        // Non-Opus models cap at high; Anthropic OAuth (Claude Pro/Max) also
-        // caps at high even on Opus because the OAuth API only accepts
-        // low | medium | high.
         ;(message as { variant?: string }).variant = clamped
         log("anthropic-effort: clamped variant max→high", {
           sessionID: input.sessionID,

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -221,6 +221,80 @@ describe("createAnthropicEffortHook", () => {
     })
   })
 
+  describe("#given pre-set effort via session params — regression for #3563", () => {
+    it("#given pre-set effort=max + variant=max + github-copilot Opus #when hook runs #then effort and variant are both clamped to high", async () => {
+      // given
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "github-copilot",
+        modelID: "claude-opus-4-7",
+        variant: "max",
+        existingOptions: { effort: "max" },
+      })
+
+      // when
+      await hook["chat.params"](input, output)
+
+      // then
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
+    it("#given pre-set effort=max + variant=high + github-copilot Opus #when hook runs #then effort and variant are both clamped to high", async () => {
+      // given — this is the cubic violation case from PR #3608:
+      // message.variant is NOT "max", but pre-set effort IS "max"
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "github-copilot",
+        modelID: "claude-opus-4-7",
+        variant: "high",
+        existingOptions: { effort: "max" },
+      })
+
+      // when
+      await hook["chat.params"](input, output)
+
+      // then — constrained provider must clamp pre-set effort=max regardless of variant
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
+    it("#given pre-set effort=max + non-constrained Opus #when hook runs #then effort stays max", async () => {
+      // given — anthropic (non-OAuth, non-constrained) Opus with pre-set effort=max
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "anthropic",
+        modelID: "claude-opus-4-7",
+        variant: "max",
+        existingOptions: { effort: "max" },
+      })
+
+      // when
+      await hook["chat.params"](input, output)
+
+      // then — non-constrained Opus keeps max
+      expect(output.options.effort).toBe("max")
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("#given pre-set effort=high + github-copilot Opus #when hook runs #then effort stays high", async () => {
+      // given — legitimate pre-set effort=high should not be overwritten
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "github-copilot",
+        modelID: "claude-opus-4-7",
+        variant: "max",
+        existingOptions: { effort: "high" },
+      })
+
+      // when
+      await hook["chat.params"](input, output)
+
+      // then — high is already valid for constrained providers, don't touch it
+      expect(output.options.effort).toBe("high")
+    })
+  })
+
   describe("#given anthropic OAuth auth (Claude Pro/Max) — regression for #3429", () => {
     let tempDataDir: string
     const originalXdgDataHome = process.env.XDG_DATA_HOME


### PR DESCRIPTION
## Summary

Every Opus model + github-copilot (or Anthropic OAuth) user crashes with `invalid_reasoning_effort` when `output.options.effort` is pre-set to `"max"` via session params or model-requirements fallback chains. The anthropic-effort hook's early-return at `output.options.effort !== undefined` (line 82) exits before the constrained-provider clamp runs, so `"max"` reaches the API verbatim.

## Changes

**`src/hooks/anthropic-effort/hook.ts`** — Restructure the guard order:

1. Keep `isEffortUnsupportedModel` (Haiku skip) first
2. Move `isClaudeProvider` and `shouldSkipForInternalAgent` checks before any effort logic
3. Compute `opus` and `constrained` flags early
4. **NEW: Handle pre-set effort BEFORE the `message.variant !== "max"` early-return** — if `output.options.effort === "max"` and provider is constrained, clamp it to `"high"` and update `message.variant` accordingly
5. Only then fall through to the existing hook-injected effort path (gated on `message.variant === "max"`)

This directly addresses the cubic violation from PR #3608, where the pre-set effort clamp block was placed AFTER the `message.variant !== "max"` return, meaning pre-set `effort="max"` with `variant="high"` would bypass clamping entirely.

## Testing

- `bun run typecheck` — passed
- `bun test` — 7058 pass, 0 fail (1 pre-existing flaky logger test)
- `bun run build` — passed

4 new regression tests added:
1. Pre-set `effort=max` + `variant=max` + github-copilot Opus → clamped to `"high"`
2. Pre-set `effort=max` + `variant=high` + github-copilot Opus → clamped to `"high"` **(the cubic violation case from #3608)**
3. Pre-set `effort=max` + non-constrained Opus → `"max"` preserved (no regression)
4. Pre-set `effort=high` + github-copilot Opus → `"high"` preserved (don't overwrite valid pre-set)

## Why PR #3608 was closed

Cubic identified: _"Pre-set `output.options.effort = "max"` is still not clamped for constrained providers when `message.variant` is not `"max"` because the new clamp block is gated behind an earlier variant-based return."_

This PR fixes that by moving the pre-set effort handling **before** the `message.variant !== "max"` early-return, so the clamp runs regardless of what `message.variant` is set to.

## Related Issues

Closes #3563

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamps pre-set `effort="max"` to `high` for constrained providers regardless of `message.variant`, preventing `invalid_reasoning_effort` errors on Opus with `github-copilot` and Anthropic OAuth. Fixes #3563.

- **Bug Fixes**
  - Move pre-set effort handling before the `message.variant !== "max"` early-return in `src/hooks/anthropic-effort/hook.ts`.
  - For constrained providers (`github-copilot`, Anthropic OAuth), clamp `effort="max"` to `high` and sync `message.variant`.
  - Preserve `max` on non-constrained Opus and do not overwrite valid pre-set values.
  - Add 4 regression tests covering these cases.

<sup>Written for commit 63a302109465f1379a1aac22c3c46707ebfd55e8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

