### PR TITLE
fix(websearch): use Bearer auth for Exa MCP

### DIFF
--- a/src/mcp/websearch.test.ts
+++ b/src/mcp/websearch.test.ts
@@ -54,3 +54,36 @@ describe("createWebsearchConfig Tavily handling", () => {
     expect(config?.url).toBe("https://mcp.tavily.com/mcp/")
   })
 })
+
+describe("createWebsearchConfig Exa handling", () => {
+  test("keeps EXA_API_KEY out of URL query params and sends bearer auth header", () => {
+    process.env.EXA_API_KEY = "exa-secret"
+
+    const config = createWebsearchConfig({ provider: "exa" })
+
+    expect(config).toEqual({
+      type: "remote",
+      url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
+      enabled: true,
+      headers: {
+        Authorization: "Bearer exa-secret",
+      },
+      oauth: false,
+    })
+    expect(config?.url).not.toContain("exaApiKey")
+    expect(config?.headers).not.toHaveProperty("x-api-key")
+  })
+
+  test("uses unauthenticated Exa URL when EXA_API_KEY is missing", () => {
+    delete process.env.EXA_API_KEY
+
+    const config = createWebsearchConfig({ provider: "exa" })
+
+    expect(config).toEqual({
+      type: "remote",
+      url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
+      enabled: true,
+      oauth: false,
+    })
+  })
+})

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -32,11 +32,9 @@ export function createWebsearchConfig(config?: WebsearchConfig): RemoteMcpConfig
 
   return {
     type: "remote" as const,
-    url: process.env.EXA_API_KEY
-      ? `https://mcp.exa.ai/mcp?tools=web_search_exa&exaApiKey=${encodeURIComponent(process.env.EXA_API_KEY)}`
-      : "https://mcp.exa.ai/mcp?tools=web_search_exa",
+    url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
     enabled: true,
-    ...(process.env.EXA_API_KEY ? { headers: { "x-api-key": process.env.EXA_API_KEY } } : {}),
+    ...(process.env.EXA_API_KEY ? { headers: { Authorization: `Bearer ${process.env.EXA_API_KEY}` } } : {}),
     oauth: false as const,
   }
 }


### PR DESCRIPTION
## Summary

Relands #4090 by @Neo1228 (CLA unsigned by original author). Switches Exa MCP authentication from query-param (`?exaApiKey=...`) to `Authorization: Bearer` header.

## Problem (Issue #3763)

The MCP SDK's SSE endpoint resolution discards query parameters when the server replies with a relative path, causing `EXA_API_KEY` to be silently lost. Users hit the rate-limited free tier even with a valid key configured.

## Changes

- Remove `exaApiKey` query parameter from Exa MCP URL
- Remove legacy `x-api-key` header
- Add `Authorization: Bearer ${EXA_API_KEY}` header (consistent with Tavily pattern)
- Add tests for both authenticated and unauthenticated Exa paths

## Testing

- `bun run typecheck` ✅
- `bun test src/mcp/websearch.test.ts` ✅ (4 pass, 0 fail)
- `bun run build` ✅

## Credit

Original fix by @Neo1228 in #4090. Relanded under maintainer authorship due to CLA requirement.

Fixes #3763
Closes #4090

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Exa MCP auth from a URL query param to an `Authorization: Bearer` header so the API key isn’t dropped during SSE redirects. Fixes #3763 and ensures paid-tier requests are used when `EXA_API_KEY` is set.

- **Bug Fixes**
  - Remove `exaApiKey` from the URL and legacy `x-api-key` header.
  - Send `Authorization: Bearer ${EXA_API_KEY}` (matches the Tavily pattern).
  - Add tests for both authenticated and unauthenticated Exa paths.

<sup>Written for commit 5ae0db042d70b61a83112d0b5688899a0435cabc. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

