### PR TITLE
fix(shared): return GA 1M context limit for Anthropic 4.6/4.7 models without cached entry

### DIFF
--- a/src/hooks/preemptive-compaction.aws-bedrock.test.ts
+++ b/src/hooks/preemptive-compaction.aws-bedrock.test.ts
@@ -42,7 +42,7 @@ describe("preemptive-compaction aws-bedrock-anthropic", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 1000,
               reasoning: 0,
               cache: { read: 10000, write: 0 },

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -142,7 +142,7 @@ describe("preemptive-compaction", () => {
     const hook = createPreemptiveCompactionHook(ctx as never, {} as never)
     const sessionID = "ses_high"
 
-    // 170K input + 10K cache = 180K → 90% of 200K
+    // 800K input + 10K cache = 810K → 81% of 1M (GA limit for 4.6 models)
     await hook.event({
       event: {
         type: "message.updated",
@@ -154,7 +154,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 1000,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -190,7 +190,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 1000,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -267,7 +267,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -313,7 +313,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -357,7 +357,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -386,7 +386,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -504,7 +504,7 @@ describe("preemptive-compaction", () => {
               modelID: "claude-sonnet-4-6",
               finish: true,
               tokens: {
-                input: 170000,
+                input: 800000,
                 output: 0,
                 reasoning: 0,
                 cache: { read: 10000, write: 0 },
@@ -544,7 +544,7 @@ describe("preemptive-compaction", () => {
                 modelID: "claude-sonnet-4-6",
                 finish: true,
                 tokens: {
-                  input: 170000,
+                  input: 800000,
                   output: 0,
                   reasoning: 0,
                   cache: { read: 10000, write: 0 },
@@ -576,7 +576,7 @@ describe("preemptive-compaction", () => {
     const hook = createPreemptiveCompactionHook(ctx as never, {} as never)
     const sessionID = "ses_recompact"
 
-    // given - first compaction cycle
+    // given - first compaction cycle (810K > 78% of 1M GA limit)
     await hook.event({
       event: {
         type: "message.updated",
@@ -588,7 +588,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -619,7 +619,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -657,7 +657,7 @@ describe("preemptive-compaction", () => {
             modelID: "claude-sonnet-4-6",
             finish: true,
             tokens: {
-              input: 170000,
+              input: 800000,
               output: 0,
               reasoning: 0,
               cache: { read: 10000, write: 0 },

--- a/src/shared/context-limit-resolver.test.ts
+++ b/src/shared/context-limit-resolver.test.ts
@@ -158,6 +158,76 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(200_000)
   })
 
+  it("returns GA 1M for claude-sonnet-4-6 without cached limit (GA context window)", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-6", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for claude-opus-4-6 without cached limit (GA context window)", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4-6", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for claude-opus-4-7 without cached limit (GA context window)", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4-7", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for claude-sonnet-4-6-high without cached limit (GA context window)", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-6-high", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for GA models on google-vertex-anthropic without cached limit", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("google-vertex-anthropic", "claude-sonnet-4-6", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
   it("returns null for non-Anthropic providers without a cached limit", () => {
     // given
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]

--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -1,6 +1,7 @@
 import process from "node:process"
 
 const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000
+const ANTHROPIC_GA_1M_LIMIT = 1_000_000
 export type ContextLimitModelCacheState = {
   anthropicContext1MEnabled: boolean
   modelContextLimitsCache?: Map<string, number>
@@ -15,11 +16,11 @@ function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState):
   return (modelCacheState?.anthropicContext1MEnabled ?? false) ||
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
-    ? 1_000_000
+    ? ANTHROPIC_GA_1M_LIMIT
     : DEFAULT_ANTHROPIC_ACTUAL_LIMIT
 }
 
-function supportsCachedAnthropicLimit(modelID: string): boolean {
+function hasGA1MContext(modelID: string): boolean {
   return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7)(?:-high)?$/.test(modelID)
 }
 
@@ -30,10 +31,12 @@ export function resolveActualContextLimit(
 ): number | null {
   if (isAnthropicProvider(providerID)) {
     const explicit1M = getAnthropicActualLimit(modelCacheState)
-    if (explicit1M === 1_000_000) return explicit1M
+    if (explicit1M === ANTHROPIC_GA_1M_LIMIT) return explicit1M
 
     const cachedLimit = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
-    if (cachedLimit && supportsCachedAnthropicLimit(modelID)) return cachedLimit
+    if (cachedLimit && hasGA1MContext(modelID)) return cachedLimit
+
+    if (hasGA1MContext(modelID)) return ANTHROPIC_GA_1M_LIMIT
 
     return DEFAULT_ANTHROPIC_ACTUAL_LIMIT
   }


### PR DESCRIPTION
## Summary

`resolveActualContextLimit` was falling back to 200K for Claude Opus 4.6, Sonnet 4.6, and 4.7 models when no `modelContextLimitsCache` entry existed. Since March 13, 2026, Anthropic made 1M context GA for these models — no beta header required, no opt-in needed. The 200K fallback is now incorrect and causes premature compaction, over-truncation, and misleading context-window monitoring.

## Root Cause

The function recognized 4.6/4.7 models as cache-eligible (`hasGA1MContext`), but only used the cache value when present. When no cache entry existed (the common case for users without explicit `models.*.limit.context` config), it fell through to `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000`.

## Fix

Add a fallback after the cache check: if the model has GA 1M context (`hasGA1MContext` returns true) but no cache entry, return `ANTHROPIC_GA_1M_LIMIT` (1M) instead of falling through to the 200K default. The 200K default still applies to older models (Sonnet 4.5, Opus 4.5, etc.).

## Changes

| File | Change |
|------|--------|
| `src/shared/context-limit-resolver.ts` | Add `ANTHROPIC_GA_1M_LIMIT` constant, rename `supportsCachedAnthropicLimit` to `hasGA1MContext`, add no-cache fallback for GA models |
| `src/shared/context-limit-resolver.test.ts` | Add 5 regression tests for GA 1M fallback (sonnet-4-6, opus-4-6, opus-4-7, sonnet-4-6-high, vertex provider) |
| `src/hooks/preemptive-compaction.test.ts` | Raise token counts from 170K to 800K so compaction triggers at 78% of 1M (not 200K) |
| `src/hooks/preemptive-compaction.aws-bedrock.test.ts` | Same token count adjustment |

## Evidence

- [Anthropic blog: "1M context is now generally available for Opus 4.6 and Sonnet 4.6"](https://claude.com/blog/1m-context-ga) (March 13, 2026)
- [Anthropic docs: Context window = 1M tokens](https://docs.anthropic.com/en/about-claude/models/overview) for Opus 4.6, Sonnet 4.6, Opus 4.7
- [Anthropic release notes](https://docs.anthropic.com/en/release-notes/api): "No beta header required. Requests over 200K tokens work automatically."
- PR #3464 was closed based on the incorrect assumption that "4.6 models have 200K context by default, with 1M available as an opt-in beta" — this was true before March 13, 2026 but is no longer accurate.

## Testing

- `bun run typecheck` passed
- `bun test` passed (7076 pass, 1 unrelated skip, 1 pre-existing flaky logger test)
- `bun run build` passed

Fixes #3450

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the correct 1M context limit for Anthropic 4.6/4.7 models when no cached entry exists, instead of falling back to 200K. This prevents premature compaction and over-truncation and fixes context-window monitoring. Fixes #3450.

- **Bug Fixes**
  - For GA models (4.6/4.7), if no cached limit exists, return 1,000,000 via `hasGA1MContext` and `ANTHROPIC_GA_1M_LIMIT` (applies to `anthropic` and `google-vertex-anthropic`).
  - Kept 200,000 default for older Anthropic models.
  - Updated preemptive compaction tests to 800K/810K thresholds and added regression tests for Sonnet/Opus 4.6/4.7, including `-high`.

<sup>Written for commit 35df9119197c8d96548d7ab76b19b6b9d98af5a0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

