### PR TITLE
fix: discover skills from host config.skills.paths set by other plugins

### DIFF
--- a/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
+++ b/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
@@ -122,4 +122,50 @@ describe("applyAgentConfig .agents skills", () => {
     expect(discoveredSkills.map(skill => skill.name)).toContain("project-agent-skill")
     expect(discoveredSkills.map(skill => skill.name)).toContain("global-agent-skill")
   })
+
+  test("discovers skills from host config.skills.paths set by other plugins", async () => {
+    // given - second call to discoverConfigSourceSkills returns host config skills
+    discoverConfigSourceSkillsSpy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          name: "host-config-skill",
+          definition: { name: "host-config-skill", template: "host-template" },
+          scope: "config",
+        },
+      ])
+
+    // when
+    await applyAgentConfig({
+      config: {
+        model: "anthropic/claude-opus-4-6",
+        agent: {},
+        skills: { paths: ["/host/skills"] },
+      },
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp/project" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    const discoveredSkills = createBuiltinAgentsSpy.mock.calls[0]?.[6] as Array<{ name: string }>
+    expect(discoveredSkills.map(skill => skill.name)).toContain("host-config-skill")
+  })
+
+  test("calls discoverConfigSourceSkills twice when host config has skills", async () => {
+    // when
+    await applyAgentConfig({
+      config: {
+        model: "anthropic/claude-opus-4-6",
+        agent: {},
+        skills: { paths: ["/host/skills"] },
+      },
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp/project" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then - called twice: once for pluginConfig.skills, once for host config.skills
+    expect(discoverConfigSourceSkillsSpy).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -35,6 +35,7 @@ import {
 } from "./agent-override-protection";
 import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
 import { buildPlanDemoteConfig } from "./plan-model-inheritance";
+import { adaptHostSkillConfig } from "../shared/host-skill-config";
 
 type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
   build?: Record<string, unknown>;
@@ -61,8 +62,10 @@ export async function applyAgentConfig(params: {
   ) as typeof params.pluginConfig.disabled_agents;
 
   const includeClaudeSkillsForAwareness = params.pluginConfig.claude_code?.skills ?? true;
+  const hostSkillConfig = adaptHostSkillConfig(params.config.skills);
   const [
     discoveredConfigSourceSkills,
+    discoveredHostConfigSkills,
     discoveredUserSkills,
     discoveredProjectSkills,
     discoveredProjectAgentsSkills,
@@ -72,6 +75,10 @@ export async function applyAgentConfig(params: {
   ] = await Promise.all([
     discoverConfigSourceSkills({
       config: params.pluginConfig.skills,
+      configDir: params.ctx.directory,
+    }),
+    discoverConfigSourceSkills({
+      config: hostSkillConfig,
       configDir: params.ctx.directory,
     }),
     includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
@@ -88,6 +95,7 @@ export async function applyAgentConfig(params: {
 
   const allDiscoveredSkills = [
     ...discoveredConfigSourceSkills,
+    ...discoveredHostConfigSkills,
     ...discoveredOpencodeProjectSkills,
     ...discoveredProjectSkills,
     ...discoveredProjectAgentsSkills,

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -157,4 +157,37 @@ describe("applyCommandConfig", () => {
     const commandConfig = config.command as Record<string, { agent?: string }>;
     expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
   });
+
+  test("includes host config skills declared in config.skills.paths by other plugins", async () => {
+    // given - second call to discoverConfigSourceSkills returns host config skills
+    discoverConfigSourceSkillsSpy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          name: "host-config-skill",
+          definition: {
+            name: "host-config-skill",
+            description: "Host config skill",
+            template: "template",
+          },
+          scope: "config",
+        },
+      ]);
+    const config: Record<string, unknown> = {
+      command: {},
+      skills: { paths: ["/host/skills"] },
+    };
+
+    // when
+    await applyCommandConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    });
+
+    // then
+    const commandConfig = config.command as Record<string, { description?: string }>;
+    expect(commandConfig["host-config-skill"]?.description).toContain("Host config skill");
+  });
 });

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -26,6 +26,7 @@ import {
   log,
 } from "../shared";
 import type { PluginComponents } from "./plugin-components-loader";
+import { adaptHostSkillConfig } from "../shared/host-skill-config";
 
 export async function applyCommandConfig(params: {
   config: Record<string, unknown>;
@@ -47,8 +48,10 @@ export async function applyCommandConfig(params: {
     log(getSkillPluginConflictWarning(externalSkillPlugin.pluginName));
   }
 
+  const hostSkillConfig = adaptHostSkillConfig(params.config.skills);
   const [
     configSourceSkills,
+    hostConfigSkills,
     userCommands,
     projectCommands,
     opencodeGlobalCommands,
@@ -62,6 +65,10 @@ export async function applyCommandConfig(params: {
   ] = await Promise.all([
     discoverConfigSourceSkills({
       config: params.pluginConfig.skills,
+      configDir: params.ctx.directory,
+    }),
+    discoverConfigSourceSkills({
+      config: hostSkillConfig,
       configDir: params.ctx.directory,
     }),
     includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
@@ -79,6 +86,7 @@ export async function applyCommandConfig(params: {
   params.config.command = {
     ...builtinCommands,
     ...skillsToCommandDefinitionRecord(configSourceSkills),
+    ...skillsToCommandDefinitionRecord(hostConfigSkills),
     ...userCommands,
     ...userSkills,
     ...globalAgentsSkills,

--- a/src/shared/host-skill-config.test.ts
+++ b/src/shared/host-skill-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test"
+
+import { adaptHostSkillConfig } from "./host-skill-config"
+
+describe("adaptHostSkillConfig", () => {
+  test("converts paths and urls into SkillsConfig sources", () => {
+    // given
+    const hostConfig = {
+      paths: ["/host/skills", "/other/skills"],
+      urls: ["https://example.com/skills/"],
+    }
+
+    // when
+    const result = adaptHostSkillConfig(hostConfig)
+
+    // then
+    expect(result).toEqual({
+      sources: ["/host/skills", "/other/skills", "https://example.com/skills/"],
+    })
+  })
+
+  test("filters blank and whitespace-only entries", () => {
+    // given
+    const hostConfig = {
+      paths: ["", "   ", "/real/skills"],
+      urls: ["\n", "https://example.com/skills/"],
+    }
+
+    // when
+    const result = adaptHostSkillConfig(hostConfig)
+
+    // then
+    expect(result).toEqual({
+      sources: ["/real/skills", "https://example.com/skills/"],
+    })
+  })
+
+  test("returns undefined when no usable sources remain", () => {
+    // when
+    const result = adaptHostSkillConfig({ paths: ["", "  "], urls: ["\t"] })
+
+    // then
+    expect(result).toBeUndefined()
+  })
+
+  test("returns undefined for null input", () => {
+    expect(adaptHostSkillConfig(null)).toBeUndefined()
+  })
+
+  test("returns undefined for undefined input", () => {
+    expect(adaptHostSkillConfig(undefined)).toBeUndefined()
+  })
+
+  test("returns undefined for non-object input", () => {
+    expect(adaptHostSkillConfig("string")).toBeUndefined()
+  })
+
+  test("handles missing paths or urls gracefully", () => {
+    // when - only paths
+    const pathsOnly = adaptHostSkillConfig({ paths: ["/skills"] })
+    expect(pathsOnly).toEqual({ sources: ["/skills"] })
+
+    // when - only urls
+    const urlsOnly = adaptHostSkillConfig({ urls: ["https://example.com/skills/"] })
+    expect(urlsOnly).toEqual({ sources: ["https://example.com/skills/"] })
+  })
+
+  test("ignores non-string array elements", () => {
+    // given
+    const hostConfig = {
+      paths: ["/valid", 42, null, true, "/also-valid"],
+    }
+
+    // when
+    const result = adaptHostSkillConfig(hostConfig)
+
+    // then
+    expect(result).toEqual({ sources: ["/valid", "/also-valid"] })
+  })
+})

--- a/src/shared/host-skill-config.ts
+++ b/src/shared/host-skill-config.ts
@@ -1,0 +1,28 @@
+import type { SkillsConfig } from "../config/schema/skills"
+
+type HostSkillConfig = {
+  paths?: unknown
+  urls?: unknown
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+export function adaptHostSkillConfig(value: unknown): SkillsConfig | undefined {
+  if (!value || typeof value !== "object") return undefined
+
+  const hostSkillConfig = value as HostSkillConfig
+  const sources = [
+    ...toStringArray(hostSkillConfig.paths),
+    ...toStringArray(hostSkillConfig.urls),
+  ]
+
+  if (sources.length === 0) return undefined
+
+  return { sources } as SkillsConfig
+}


### PR DESCRIPTION
## Summary

When another plugin (e.g. superpowers) injects skill directories via `config.skills.paths` in the config hook, oh-my-openagent's skill discovery didn't scan those paths. This caused skills shipped by other plugins to become invisible when OMO was active.

Fixes #3396

## Root Cause

The config hook receives a `config` object that other plugins have already mutated. Superpowers sets `config.skills.paths` to register its skill directories. However, OMO's `agent-config-handler` and `command-config-handler` only called `discoverConfigSourceSkills` with OMO's own `pluginConfig.skills` — never reading the host config object.

## Fix

1. **New module** `src/shared/host-skill-config.ts` — `adaptHostSkillConfig()` converts the host `config.skills` object (with `paths`/`urls` arrays) into the `SkillsConfig` format consumed by `discoverConfigSourceSkills`. Filters blank/whitespace entries and non-string values.

2. **agent-config-handler.ts** — adds a second `discoverConfigSourceSkills()` call in the parallel `Promise.all` array, using the adapted host config. Host config skills are merged after OMO config skills but before opencode-project skills (lowest config precedence).

3. **command-config-handler.ts** — mirrors the agent-config-handler change so host config skills also appear as slash commands.

## Why not drive an existing PR?

- **PR #3473** (EnochLi15): Correct approach but overengineered — creates a `hostSkillConfigStore` singleton when the host config is already available in the config hook params. Also CONFLICTING + test failures.
- **PR #2840** (ventsislav-georgiev): Reads `skills.paths` from static `opencode.json` files, not from the config object mutated by other plugins at runtime. Doesn't solve the inter-plugin communication problem.
- **PR #3395** (aschina): Closed (CLA not signed). Had the correct approach but cubic flagged a timing issue.

This PR is a minimal, clean implementation that avoids the timing concern (the config hook runs after other plugins have already mutated the config object) and the unnecessary store pattern.

## Testing

- `bun run typecheck` — pass
- `bun test src/shared/host-skill-config.test.ts` — 8 tests pass
- `bun test src/plugin-handlers/agent-config-handler-agents-skills.test.ts` — 4 tests pass (2 new)
- `bun test src/plugin-handlers/command-config-handler.test.ts` — 4 tests pass (1 new)
- `bun run build` — pass

## Related Issues

Fixes #3396
Supersedes #3473, #2840, #3395

Co-authored-by: EnochLi15 (prior art from #3473)
Co-authored-by: aschina (prior art from #3395)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing skills injected by other plugins via `config.skills.paths` so they are discovered for agents and slash commands. Ensures skills from the host config show up alongside plugin-defined skills. Fixes #3396.

- **Bug Fixes**
  - Added `adaptHostSkillConfig()` to convert host `skills.paths`/`skills.urls` into `SkillsConfig` and filter invalid entries.
  - `agent-config-handler`: discovers host config skills in a second `discoverConfigSourceSkills` call; merges after plugin skills and before project/opencode skills.
  - `command-config-handler`: mirrors the change so host config skills become slash commands.
  - Tests added for the adapter and both handlers.

<sup>Written for commit ecb87608e683b11a460af400cf064dc947db5644. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

