### PR TITLE
fix(shell-env): add csh shell support to detection and env prefix

### DIFF
--- a/src/features/opencode-skill-loader/git-master-template-injection.test.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.test.ts
@@ -231,6 +231,18 @@ describe("#given buildShellAwareGitPrefix", () => {
 		})
 	})
 
+	describe("#when shell type is csh", () => {
+		it("#then returns csh setenv syntax", () => {
+			const result = buildShellAwareGitPrefix("GIT_MASTER=1", "csh")
+			expect(result).toBe("setenv GIT_MASTER 1;")
+		})
+
+		it("#then handles multiple env vars", () => {
+			const result = buildShellAwareGitPrefix("CI=true GIT_MASTER=1", "csh")
+			expect(result).toBe("setenv CI true; setenv GIT_MASTER 1;")
+		})
+	})
+
 	describe("#when prefix is empty", () => {
 		it("#then returns empty string", () => {
 			const result = buildShellAwareGitPrefix("", "powershell")
@@ -317,6 +329,63 @@ describe("#given PowerShell shell detection in injectGitMasterConfig", () => {
 			expect(result).toContain("GIT_MASTER=1 git status")
 			expect(result).toContain("```bash")
 			expect(result).not.toContain("$env:")
+		})
+	})
+
+	describe("#when shell is csh (SHELL set to /bin/csh)", () => {
+		it("#then emits setenv prefix syntax in csh code block", () => {
+			process.env.SHELL = "/bin/csh"
+			delete process.env.PSModulePath
+			delete process.env.MSYSTEM
+			Object.defineProperty(process, "platform", { value: "linux" })
+
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			expect(result).toContain("setenv GIT_MASTER 1;")
+			expect(result).toContain("```csh")
+			expect(result).not.toContain("```bash\nsetenv")
+		})
+
+		it("#then does NOT prefix bash code blocks with setenv syntax", () => {
+			process.env.SHELL = "/bin/csh"
+			delete process.env.PSModulePath
+			delete process.env.MSYSTEM
+			Object.defineProperty(process, "platform", { value: "linux" })
+
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			const bashBlockMatch = result.match(/```bash\r?\n([\s\S]*?)```/g)
+			if (bashBlockMatch) {
+				for (const block of bashBlockMatch) {
+					expect(block).not.toContain("setenv")
+				}
+			}
+		})
+	})
+
+	describe("#when shell is tcsh (SHELL set to /usr/local/bin/tcsh)", () => {
+		it("#then emits setenv prefix syntax in csh code block", () => {
+			process.env.SHELL = "/usr/local/bin/tcsh"
+			delete process.env.PSModulePath
+			delete process.env.MSYSTEM
+			Object.defineProperty(process, "platform", { value: "darwin" })
+
+			const result = injectGitMasterConfig(SAMPLE_TEMPLATE, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "GIT_MASTER=1",
+			})
+
+			expect(result).toContain("setenv GIT_MASTER 1;")
+			expect(result).toContain("```csh")
 		})
 	})
 })

--- a/src/features/opencode-skill-loader/git-master-template-injection.ts
+++ b/src/features/opencode-skill-loader/git-master-template-injection.ts
@@ -26,15 +26,17 @@ export function parseBashEnvPrefix(prefix: string): Record<string, string> {
 /**
  * Build the shell-aware command prefix for git commands.
  * Uses the shared shell detection and env prefix builder to emit correct syntax
- * for PowerShell ($env:VAR='value';), cmd (set VAR="value" &&), or unix (VAR=value).
+ * for PowerShell ($env:VAR='value';), cmd (set VAR="value" &&),
+ * csh (setenv VAR value;), or unix (VAR=value).
  *
  * For unix shells, we use the inline VAR=value prefix style (not export) to match
  * the original behavior where the env var applies only to the immediately following command.
+ * For csh/tcsh, we use setenv syntax since csh does not support inline VAR=value.
  */
 export function buildShellAwareGitPrefix(bashPrefix: string, shellType?: ShellType): string {
 	if (!bashPrefix) return ""
 	const resolvedShellType = shellType ?? detectShellType()
-	if (resolvedShellType === "unix" || resolvedShellType === "csh") {
+	if (resolvedShellType === "unix") {
 		return bashPrefix
 	}
 	const envRecord = parseBashEnvPrefix(bashPrefix)
@@ -48,8 +50,8 @@ export function injectGitMasterConfig(template: string, config?: GitMasterConfig
 
 	const shellType = detectShellType()
 	const shellPrefix = gitEnvPrefix ? buildShellAwareGitPrefix(gitEnvPrefix, shellType) : ""
-	const codeBlockLang = shellType === "powershell" ? "pwsh" : "bash"
-	const skipBashBlockPrefixing = shellType === "powershell" || shellType === "cmd"
+	const codeBlockLang = shellType === "powershell" ? "pwsh" : shellType === "csh" ? "csh" : "bash"
+	const skipBashBlockPrefixing = shellType === "powershell" || shellType === "cmd" || shellType === "csh"
 
 	let result = gitEnvPrefix ? injectGitEnvPrefix(template, shellPrefix, codeBlockLang) : template
 

--- a/src/shared/shell-env.test.ts
+++ b/src/shared/shell-env.test.ts
@@ -120,6 +120,39 @@ describe("shell-env", () => {
 
       expect(result).toBe("unix")
     })
+
+    test("#given SHELL set to /bin/csh #when detectShellType is called #then returns csh", () => {
+      delete process.env.PSModulePath
+      delete process.env.MSYSTEM
+      process.env.SHELL = "/bin/csh"
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      const result = detectShellType()
+
+      expect(result).toBe("csh")
+    })
+
+    test("#given SHELL set to /bin/tcsh #when detectShellType is called #then returns csh", () => {
+      delete process.env.PSModulePath
+      delete process.env.MSYSTEM
+      process.env.SHELL = "/bin/tcsh"
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      const result = detectShellType()
+
+      expect(result).toBe("csh")
+    })
+
+    test("#given SHELL set to /usr/local/bin/tcsh #when detectShellType is called #then returns csh", () => {
+      delete process.env.PSModulePath
+      delete process.env.MSYSTEM
+      process.env.SHELL = "/usr/local/bin/tcsh"
+      Object.defineProperty(process, "platform", { value: "darwin" })
+
+      const result = detectShellType()
+
+      expect(result).toBe("csh")
+    })
   })
 
   describe("shellEscape", () => {
@@ -308,6 +341,28 @@ describe("shell-env", () => {
 
       test("#given empty env object #when buildEnvPrefix is called with cmd #then returns empty string", () => {
         const result = buildEnvPrefix({}, "cmd")
+        expect(result).toBe("")
+      })
+    })
+
+    describe("csh", () => {
+      test("#given single environment variable #when buildEnvPrefix is called with csh #then builds setenv command", () => {
+        const result = buildEnvPrefix({ VAR: "value" }, "csh")
+        expect(result).toBe("setenv VAR value;")
+      })
+
+      test("#given multiple environment variables #when buildEnvPrefix is called with csh #then builds separate setenv commands", () => {
+        const result = buildEnvPrefix({ VAR1: "val1", VAR2: "val2" }, "csh")
+        expect(result).toBe("setenv VAR1 val1; setenv VAR2 val2;")
+      })
+
+      test("#given env var with spaces #when buildEnvPrefix is called with csh #then escapes value with single quotes", () => {
+        const result = buildEnvPrefix({ MSG: "has spaces" }, "csh")
+        expect(result).toBe("setenv MSG 'has spaces';")
+      })
+
+      test("#given empty env object #when buildEnvPrefix is called with csh #then returns empty string", () => {
+        const result = buildEnvPrefix({}, "csh")
         expect(result).toBe("")
       })
     })


### PR DESCRIPTION
## Summary

Follow-up fix for PR #4138 (merged for #3207). Cubic flagged a P2 warning: `csh` was incorrectly handled as unix in `buildShellAwareGitPrefix()`, so csh/tcsh users still received bash-style `VAR=value git ...` prefixes instead of csh-compatible `setenv VAR value;` syntax.

## Changes

- **`git-master-template-injection.ts`**: Remove csh from the unix early-return path in `buildShellAwareGitPrefix()` so csh routes through `buildEnvPrefix()` which emits correct `setenv` syntax
- **`git-master-template-injection.ts`**: Set `codeBlockLang` to `"csh"` (not `"bash"`) when shell is csh
- **`git-master-template-injection.ts`**: Add csh to `skipBashBlockPrefixing` since csh env prefix syntax is incompatible with the bash inline `VAR=value` regex rewriting
- **`shell-env.test.ts`**: Add csh/tcsh detection tests and csh `buildEnvPrefix` tests
- **`git-master-template-injection.test.ts`**: Add csh `buildShellAwareGitPrefix` tests and full `injectGitMasterConfig` integration tests for csh/tcsh

## Testing

- `bun run typecheck` clean
- `bun test` 7118 pass (1 pre-existing flaky tmux test)
- `bun run build` clean
- 78 targeted tests across shell-env + git-master-template-injection: all pass

## Related Issues

Follow-up to PR #4138 (Cubic P2 finding)
Fixes #3207 (csh edge case)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds csh/tcsh support to shell detection and env prefixing so users get csh-compatible setenv syntax instead of bash-style VAR=value. Fixes #3207.

- **Bug Fixes**
  - Route csh/tcsh through `buildEnvPrefix()` to emit `setenv VAR value;` and remove csh from the unix path in `buildShellAwareGitPrefix()`.
  - Use `csh` code blocks when shell is csh/tcsh and skip bash block prefixing to avoid invalid inline env rewriting.
  - Add detection tests for csh/tcsh and coverage for `buildEnvPrefix()` and `injectGitMasterConfig()` with csh.

<sup>Written for commit 82b0672c05ece9fb0c8f48846cd8be331aaee145. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4143?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

