### PR TITLE
fix(shared,delegate-task,claude-code-agent-loader): guard model parsers against non-string input (fixes #4145)

### DIFF
--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -11,6 +11,7 @@ const CLAUDE_CODE_ALIAS_MAP = new Map<string, string>([
 
 function mapClaudeModelString(model: string | undefined): string | undefined {
   if (!model) return undefined
+  if (typeof model !== "string") return undefined
 
   const trimmed = model.trim()
   if (trimmed.length === 0) return undefined

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -395,3 +395,65 @@ describe("findMostSpecificFallbackEntry", () => {
     })
   })
 })
+
+// Regression: type-guard against non-string model field (issue #4145).
+// Crash signature was `model.trim is not a function` aborting session.processor
+// for every provider when a caller forwarded a FallbackModelObject where a
+// plain string was expected.
+describe("parseFallbackModelEntry: non-string input (issue #4145)", () => {
+  test("returns undefined when caller forwards an object instead of a string", () => {
+    //#given
+    const wrong = { model: "anthropic/claude-opus-4-7", variant: "high" } as unknown as string
+
+    //#when
+    const parsed = parseFallbackModelEntry(wrong, "anthropic")
+
+    //#then: must not throw, must reject the malformed entry
+    expect(parsed).toBeUndefined()
+  })
+
+  test("returns undefined for null and undefined", () => {
+    //#given
+    const nullInput = null as unknown as string
+    const undefinedInput = undefined as unknown as string
+
+    //#when / #then
+    expect(parseFallbackModelEntry(nullInput, "anthropic")).toBeUndefined()
+    expect(parseFallbackModelEntry(undefinedInput, "anthropic")).toBeUndefined()
+  })
+
+  test("parseFallbackModelObjectEntry returns undefined when nested model field is non-string", () => {
+    //#given: FallbackModelObject whose .model was somehow forwarded as a nested
+    //object instead of a flat string (issue #4145 reproduction).
+    const malformedObject = {
+      model: ({ model: "claude-opus-4-7" } as unknown) as string,
+      variant: "high",
+    }
+
+    //#when
+    const parsed = parseFallbackModelObjectEntry(malformedObject, "anthropic")
+
+    //#then: must not throw, must reject the malformed entry
+    expect(parsed).toBeUndefined()
+  })
+
+  test("buildFallbackChainFromModels skips entries whose model is a number", () => {
+    //#given
+    const fallbackModels = [
+      "openai/gpt-5.5",
+      (42 as unknown) as string,
+    ]
+
+    //#when
+    const chain = buildFallbackChainFromModels(fallbackModels, "openai")
+
+    //#then: only the valid string survives, the number is dropped without crashing
+    expect(chain).toEqual([
+      {
+        providers: ["openai"],
+        model: "gpt-5.5",
+        variant: undefined,
+      },
+    ])
+  })
+})

--- a/src/shared/fallback-chain-from-models.ts
+++ b/src/shared/fallback-chain-from-models.ts
@@ -4,6 +4,9 @@ import { normalizeFallbackModels } from "./model-resolver"
 import { KNOWN_VARIANTS } from "./known-variants"
 
 function parseVariantFromModel(rawModel: string): { modelID: string; variant?: string } {
+  if (typeof rawModel !== "string") {
+    return { modelID: "" }
+  }
   const trimmedModel = rawModel.trim()
   if (!trimmedModel) {
     return { modelID: "" }
@@ -33,6 +36,7 @@ export function parseFallbackModelEntry(
   contextProviderID: string | undefined,
   defaultProviderID = "opencode",
 ): FallbackEntry | undefined {
+  if (typeof model !== "string") return undefined
   const trimmed = model.trim()
   if (!trimmed) return undefined
 

--- a/src/shared/model-string-parser.ts
+++ b/src/shared/model-string-parser.ts
@@ -11,6 +11,9 @@ const KNOWN_VARIANTS = new Set([
 ])
 
 export function parseVariantFromModelID(rawModelID: string): { modelID: string; variant?: string } {
+  if (typeof rawModelID !== "string") {
+    return { modelID: "" }
+  }
   const trimmedModelID = rawModelID.trim()
   if (!trimmedModelID) {
     return { modelID: "" }
@@ -38,6 +41,7 @@ export function parseVariantFromModelID(rawModelID: string): { modelID: string; 
 export function parseModelString(
   model: string,
 ): { providerID: string; modelID: string; variant?: string } | undefined {
+  if (typeof model !== "string") return undefined
   const trimmedModel = model.trim()
   if (!trimmedModel) return undefined
 

--- a/src/tools/delegate-task/model-string-parser.ts
+++ b/src/tools/delegate-task/model-string-parser.ts
@@ -11,6 +11,9 @@ const KNOWN_VARIANTS = new Set([
 ])
 
 export function parseVariantFromModelID(rawModelID: string): { modelID: string; variant?: string } {
+  if (typeof rawModelID !== "string") {
+    return { modelID: "" }
+  }
   const trimmedModelID = rawModelID.trim()
   if (!trimmedModelID) {
     return { modelID: "" }
@@ -38,6 +41,7 @@ export function parseVariantFromModelID(rawModelID: string): { modelID: string; 
 export function parseModelString(
   model: string,
 ): { providerID: string; modelID: string; variant?: string } | undefined {
+  if (typeof model !== "string") return undefined
   const trimmedModel = model.trim()
   if (!trimmedModel) return undefined
 


### PR DESCRIPTION
## Summary
Issue #4145: roughly 90% of subagent dispatches abort with TypeError 'model.trim is not a function' on oh-my-openagent 4.2.0 + opencode 1.15.4, across every provider. The crash rejects the session.processor promise -> 'Aborted process' -> UI 'interrupted'.

This patch adds a runtime ``typeof model !== \"string\"`` guard at the four parser entrypoints called from the unified-dispatch path. Each parser now returns ``undefined`` / ``{ modelID: \"\" }`` for non-string input instead of throwing.

## Root Cause
After the 4.2.0 unified-dispatch refactor cycle (a42f894f / df198d8b / fee515c5 / 989ab717 / dd3fecaf / 1bbe065c / 12bd6580), at least one caller in the new prompt-async-gate path forwards a ``FallbackModelObject`` (``{ model, variant, ... }``) into parsers that statically claim ``model: string``. The downstream ``.trim()`` call then throws on the object.

The issue narrows the crash to four parser callsites that all do an unguarded ``rawModel.trim()`` / ``model.trim()``.

## Changes
| File | Change |
|------|--------|
| ``src/shared/fallback-chain-from-models.ts`` | Add ``typeof !== \"string\"`` guard to ``parseVariantFromModel`` and ``parseFallbackModelEntry`` before ``.trim()``. |
| ``src/tools/delegate-task/model-string-parser.ts`` | Add the same guard to ``parseVariantFromModelID`` and ``parseModelString``. |
| ``src/shared/model-string-parser.ts`` | Same guard on the duplicate-named module in ``shared/`` (both files are reachable from the dispatch path). |
| ``src/features/claude-code-agent-loader/claude-model-mapper.ts`` | Already had a truthy check; add an explicit type guard before ``.trim()`` so an object passing the truthy check no longer crashes. |
| ``src/shared/fallback-chain-from-models.test.ts`` | Add 3 regression tests pinning the non-string behavior (object input, null/undefined, number). |

Diff: **75 LOC, 5 files** (4 source + 1 test).

## Why this is the minimal fix
This patch deliberately masks the symptom at the parser boundary. It does NOT fix whichever caller forwards the wrong shape - that should be a follow-up. The reason for shipping the guard first:

- Issue #4145 is a P0: 90% of subagent dispatches fail across every provider.
- The parser contract (``model: string``) is documented; defending it is uncontroversial.
- Tracing the caller through the unified-dispatch refactor is a larger investigation that should not block the regression fix.

## Reproduction (before fix)
~~~ts
import { parseFallbackModelEntry } from \"./src/shared/fallback-chain-from-models\"
parseFallbackModelEntry({ model: \"anthropic/claude-opus-4-7\" } as unknown as string, \"anthropic\")
// TypeError: model.trim is not a function
~~~

## Verification (after fix)
~~~
$ bun test src/shared/fallback-chain-from-models.test.ts
 41 pass
 0 fail
 44 expect() calls
Ran 41 tests across 1 file. [134.00ms]

$ bun test src/features/claude-code-agent-loader/claude-model-mapper.test.ts
 22 pass
 0 fail
 22 expect() calls
Ran 22 tests across 1 file. [127.00ms]

$ bun run typecheck
$ tsgo --noEmit
# clean - no output
~~~

## Test
- New regression tests live in ``src/shared/fallback-chain-from-models.test.ts``:
  - ``parseFallbackModelEntry`` returns ``undefined`` when an object is forwarded as the model field
  - ``parseFallbackModelEntry`` returns ``undefined`` for ``null`` / ``undefined``
  - ``parseFallbackModelObjectEntry`` returns ``undefined`` when its nested ``.model`` field is itself a non-string
  - ``buildFallbackChainFromModels`` drops a numeric entry instead of crashing
- Existing 38 ``fallback-chain-from-models`` tests still pass.
- ``claude-model-mapper`` 22 tests still pass.
- ``bun run typecheck`` clean.

Fixes #4145

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded all model string parsers against non‑string input to stop “model.trim is not a function” crashes and unblock subagent dispatch across providers. Fixes #4145 by returning safe fallbacks instead of throwing.

- **Bug Fixes**
  - Added runtime type checks to parser entrypoints in `src/shared/fallback-chain-from-models.ts`, `src/shared/model-string-parser.ts`, `src/tools/delegate-task/model-string-parser.ts`, and the Claude mapper in `src/features/claude-code-agent-loader/claude-model-mapper.ts`.
  - Non-string inputs now return `undefined` or `{ modelID: "" }`, preventing aborted sessions.
  - Added regression tests for object, null/undefined, and numeric inputs; existing tests remain green.

<sup>Written for commit ae0c106ed40b87eecbc108dcee6a26dd61bc5cdf. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

