### PR TITLE
fix(plugin): wire tool.definition handler so todo-description-override actually fires (fixes #3705)

### DIFF
--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -8,6 +8,7 @@ import { createCommandExecuteBeforeHandler } from "./plugin/command-execute-befo
 import { createMessagesTransformHandler } from "./plugin/messages-transform"
 import { createSystemTransformHandler } from "./plugin/system-transform"
 import { createEventHandler } from "./plugin/event"
+import { createToolDefinitionHandler } from "./plugin/tool-definition"
 import { createToolExecuteAfterHandler } from "./plugin/tool-execute-after"
 import { createToolExecuteBeforeHandler } from "./plugin/tool-execute-before"
 
@@ -67,6 +68,10 @@ export function createPluginInterface(args: {
       pluginConfig,
       firstMessageVariantGate,
       managers,
+      hooks,
+    }),
+
+    "tool.definition": createToolDefinitionHandler({
       hooks,
     }),
 

--- a/src/plugin/tool-definition.test.ts
+++ b/src/plugin/tool-definition.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test"
+import { createToolDefinitionHandler } from "./tool-definition"
+import { createTodoDescriptionOverrideHook } from "../hooks/todo-description-override/hook"
+import { TODOWRITE_DESCRIPTION } from "../hooks/todo-description-override/description"
+import type { CreatedHooks } from "../create-hooks"
+
+function buildHooks(overrides: Partial<CreatedHooks> = {}): CreatedHooks {
+  return overrides as CreatedHooks
+}
+
+describe("createToolDefinitionHandler (regression for #3705)", () => {
+  describe("#given todoDescriptionOverride hook is registered", () => {
+    describe("#when the tool.definition handler runs for the todowrite tool", () => {
+      it("#then forwards to the hook and rewrites the description", async () => {
+        //#given
+        const handler = createToolDefinitionHandler({
+          hooks: buildHooks({ todoDescriptionOverride: createTodoDescriptionOverrideHook() }),
+        })
+        const output = { description: "opencode core default", parameters: {} }
+
+        //#when
+        await handler({ toolID: "todowrite" }, output)
+
+        //#then
+        expect(output.description).toBe(TODOWRITE_DESCRIPTION)
+      })
+    })
+
+    describe("#when the tool.definition handler runs for any other tool", () => {
+      it("#then leaves the description untouched", async () => {
+        //#given
+        const handler = createToolDefinitionHandler({
+          hooks: buildHooks({ todoDescriptionOverride: createTodoDescriptionOverrideHook() }),
+        })
+        const output = { description: "bash native description", parameters: {} }
+
+        //#when
+        await handler({ toolID: "bash" }, output)
+
+        //#then
+        expect(output.description).toBe("bash native description")
+      })
+    })
+  })
+
+  describe("#given todoDescriptionOverride hook is disabled (null)", () => {
+    describe("#when the tool.definition handler runs for todowrite", () => {
+      it("#then is a no-op", async () => {
+        //#given
+        const handler = createToolDefinitionHandler({
+          hooks: buildHooks({ todoDescriptionOverride: null }),
+        })
+        const output = { description: "opencode default kept", parameters: {} }
+
+        //#when
+        await handler({ toolID: "todowrite" }, output)
+
+        //#then
+        expect(output.description).toBe("opencode default kept")
+      })
+    })
+  })
+})

--- a/src/plugin/tool-definition.ts
+++ b/src/plugin/tool-definition.ts
@@ -1,0 +1,16 @@
+import type { CreatedHooks } from "../create-hooks"
+
+export function createToolDefinitionHandler(args: {
+  hooks: CreatedHooks
+}): (
+  input: { toolID: string },
+  output: { description: string; parameters: unknown },
+) => Promise<void> {
+  const { hooks } = args
+  return async (input, output) => {
+    const overrideHook = hooks.todoDescriptionOverride
+    if (overrideHook) {
+      await overrideHook["tool.definition"](input, output)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Issue #3705: the bundled ``todo-description-override`` hook is registered but never fires. The ``todowrite`` tool description in the live prompt stays at OpenCode core's ~7 KB instead of the ~1.4 KB ``TODOWRITE_DESCRIPTION`` defined in the hook. The reporter confirmed user-defined plugins under ``~/.config/opencode/plugin/*.js`` using the same ``tool.definition`` hook contract work correctly, so the OpenCode plugin API itself is functional - only the bundled wiring is broken.

## Root Cause
``src/plugin/hooks/create-tool-guard-hooks.ts`` constructs the hook (lines 132-134) and stores it on the ``CreatedHooks`` record as ``todoDescriptionOverride``. But ``src/plugin-interface.ts`` does not export a ``tool.definition`` key in its OpenCode hook interface, so OpenCode never invokes the hook function. The hook is constructed and discarded.

OpenCode's plugin API supports ``tool.definition`` per [``@opencode-ai/plugin``](https://www.npmjs.com/package/@opencode-ai/plugin)'s ``index.d.ts``:

~~~ts
""tool.definition""?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
~~~

## Changes
| File | Change |
|------|--------|
| ``src/plugin/tool-definition.ts`` | **New.** ``createToolDefinitionHandler`` forwards the OpenCode ``tool.definition`` input/output pair into ``hooks.todoDescriptionOverride``. No-op when the hook is disabled (null). |
| ``src/plugin-interface.ts`` | Add ``""tool.definition"": createToolDefinitionHandler({ hooks })`` alongside the existing ``tool.execute.before`` / ``tool.execute.after`` handlers. |
| ``src/plugin/tool-definition.test.ts`` | **New.** Regression tests covering: (a) ``todowrite`` description gets overridden, (b) other tools left untouched, (c) ``null`` hook is a no-op. |

Diff: **84 LOC, 3 files** (2 new + 1 wiring edit).

## Reproduction (before fix)
- ``opencode debug agent sisyphus`` would emit OpenCode core's 7 KB ``todowrite`` description starting with ``Use this tool to create and manage a structured task list for your current coding session...``
- After the fix, the same path will see MoerAI's 1.4 KB ``TODOWRITE_DESCRIPTION`` starting with ``Use this tool to create and manage a structured task list for tracking progress on multi-step work...``

I did not reproduce the full ``opencode debug`` flow locally (it would require a full OpenCode session). The root-cause analysis is structural: ``plugin-interface.ts`` exposes 10 hook handlers, none of which are ``tool.definition``, so OpenCode's plugin runner has no callback to invoke. Adding the handler is the minimal correct fix per OpenCode's plugin contract.

## Verification (after fix)
~~~
$ bun test src/plugin/tool-definition.test.ts src/hooks/todo-description-override/
 7 pass
 0 fail
 9 expect() calls
Ran 7 tests across 2 files. [112.00ms]

$ bun test src/plugin-interface.test.ts
 5 pass
 0 fail
 14 expect() calls

$ bun run typecheck
$ tsgo --noEmit
# clean - no output
~~~

## Test
- New regression test ``src/plugin/tool-definition.test.ts``:
  - ``todowrite`` is rewritten with ``TODOWRITE_DESCRIPTION``
  - ``bash`` (or any non-todowrite) is left untouched
  - ``null`` hook does not throw and does not mutate output
- Existing 3 tests in ``src/hooks/todo-description-override/index.test.ts`` still pass.
- ``bun run typecheck`` clean.

Fixes #3705

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire the missing `tool.definition` handler so the bundled `todo-description-override` hook runs and overrides the `todowrite` description as intended. Fixes #3705.

- **Bug Fixes**
  - Added `createToolDefinitionHandler` to forward `tool.definition` input/output to `hooks.todoDescriptionOverride` (no-op when disabled).
  - Registered `"tool.definition"` in `createPluginInterface` alongside existing handlers.
  - Added regression tests: `todowrite` overridden, other tools unchanged, null hook is a no-op.

<sup>Written for commit ed44466f331e465e21025dd6d97fcc47de98573e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

