### PR TITLE
feat(cli): add OMOA model management system

### DIFF
--- a/OMOA-FEATURES.md
+++ b/OMOA-FEATURES.md
@@ -1,0 +1,185 @@
+# OMOA - Model Management System for Oh My Open Agent
+
+## Overview
+
+OMOA is a policy-based model routing and config management system. It replaces manual JSON editing with two complementary modes:
+
+1. **Policy Mode** -- Declare desired model rankings per agent/category. OMOA auto-resolves the best model based on provider availability, compatibility rules, and cross-provider fallback constraints.
+2. **Manual Mode** -- Direct per-field editing of any config value via a schema-driven TUI that auto-generates prompts from the project's Zod schemas.
+
+Both modes are accessible from the same TUI and CLI.
+
+## Commands
+
+```
+omoa                        Interactive TUI (main entry)
+omoa status                 Show providers, agents, categories, validation
+omoa build                  Build config from rankings + provider state
+omoa build --dry-run        Preview changes without writing
+omoa build --yes            Skip confirmation
+omoa provider list          Show provider status and usage counts
+omoa provider enable <n>    Enable a provider
+omoa provider disable <n>   Disable a provider
+```
+
+## Architecture
+
+### Three Layers of State
+
+| File | Purpose |
+|------|---------|
+| `oh-my-openagent.json` | Runtime config (written by `omoa build` or manual edits) |
+| `omoa-state.json` | OMOA state: provider enable/disable, banned models, rules |
+| `omoa-rankings.json` | Per-agent/category model preference lists |
+
+### How It Works
+
+```
+omoa-state.json (providers, rules)
+        +
+omoa-rankings.json (model preferences)
+        |
+        v
+   [Resolver Engine]
+   - Filter by provider availability
+   - Filter by banned/deprecated models
+   - Filter by free-only rules
+   - Pick first available as primary
+   - Pick first cross-provider model as fallback
+   - Check avoid_fallback_from rules
+        |
+        v
+   [Builder]
+   - Compare resolved vs current config
+   - Generate diff (AgentChange[])
+   - Create backup
+   - Write only model/fallback fields
+   - Preserve all other fields untouched
+        |
+        v
+oh-my-openagent.json (runtime config)
+```
+
+### Key Design Rules
+
+- **Idempotent build**: Running `omoa build` with no changes produces no output.
+- **Additive**: Build only changes `model` and `fallback_models` fields. Temperature, thinking, permissions, etc. are never touched.
+- **Cross-provider fallback**: `primary.provider != fallback.provider` is enforced.
+- **Managed vs manual**: Agents with rankings are "OMOA-managed" (built automatically). Agents without rankings are "manual" (edited directly). Both coexist.
+- **Schema-driven editor**: All non-model fields are edited via Zod shape introspection. New fields in the schema automatically appear in the editor.
+
+## File Structure
+
+```
+src/cli/omoa/
+  index.ts                           CLI entry point + command implementations
+  state/
+    omoa-state-schema.ts             Zod schema for omoa-state.json
+    omoa-rankings-schema.ts          Zod schema for omoa-rankings.json
+    state-manager.ts                 Read/write/mutate omoa-state.json
+    rankings-manager.ts              Read/write/mutate omoa-rankings.json
+  engine/
+    resolver.ts                      resolveBestModel(rankings, state) -> {primary, fallback, reasons}
+    validator.ts                     10-rule validation system
+    builder.ts                       Orchestrate: resolve -> diff -> backup -> write
+  models/
+    model-cache.ts                   Zod-validated model cache reader (provider-models.json, models.json)
+  tui/
+    main-menu.ts                     Interactive TUI main menu
+    provider-screen.ts               Provider toggle screen
+    ranking-screen.ts                Rankings view/edit screen
+    assign-screen.ts                 Multi-target model assignment screen
+    shared.ts                        Shared helpers (loadRuntimeConfig, countProviderUsage)
+    schema-editor/
+      agent-editor.ts                Agent field editor (schema-driven)
+      category-editor.ts             Category field editor
+      root-editor.ts                 Root config field editor
+      field-renderer.ts              Zod type -> @clack/prompts mapping
+```
+
+## Validation Rules
+
+1. Config file exists and is valid JSON
+2. All primary models belong to enabled providers
+3. All fallback models belong to enabled providers
+4. Primary provider != fallback provider
+5. Opencode provider: only `*-free` models allowed (when free_only is set)
+6. No banned models active
+7. Deprecated models trigger warnings
+8. Missing fallbacks are informational warnings
+9. Same-provider fallbacks trigger warnings
+10. Doctor can be run for deeper checks
+
+## Dual-Mode Design
+
+### Policy Mode (OMOA-managed)
+- Agent/category has a ranking in `omoa-rankings.json`
+- `omoa build` resolves model automatically
+- Model field shows "[OMOA]" badge in status
+- Manual model edits warn: "will be overwritten on next build"
+
+### Manual Mode
+- Agent/category has NO ranking entry
+- User edits model directly via "Edit Config" TUI
+- Model field shows "[manual]" badge in status
+- `omoa build` skips this agent/category entirely
+
+Both modes share the same schema-driven editor for non-model fields (temperature, thinking, permissions, etc.).
+
+## Schema-Driven Editor
+
+The field renderer maps Zod types to `@clack/prompts` UIs:
+
+| Zod Type | TUI Prompt |
+|----------|-----------|
+| `z.string()` | Text input |
+| `z.boolean()` | Select: true/false/clear |
+| `z.number()` | Text input with number validation |
+| `z.enum([...])` | Select from enum values |
+| `z.object({...})` | JSON text input |
+| `z.record(...)` | JSON text input |
+| `z.array(...)` | Comma-separated text input |
+
+This means new fields added to `AgentOverrideConfigSchema` or `CategoryConfigSchema` automatically appear in the editor without code changes.
+
+## Features Discussed
+
+### Phase 1 (Implemented)
+- [x] OMOA state file with provider rules, banned/deprecated models
+- [x] Rankings file with per-agent/category model preference lists
+- [x] Core resolver engine (provider availability, cross-provider fallback, compatibility rules)
+- [x] Build command with dry-run support
+- [x] Status command (providers, agents, categories, validation)
+- [x] Provider enable/disable with usage counts
+- [x] Multi-target model assignment
+- [x] Schema-driven field editor for all agent/category/root fields
+- [x] Manual model editing for non-OMOA-managed agents
+- [x] Backup before every write operation
+- [x] 10-rule validation system
+- [x] Interactive TUI with all screens
+- [x] CLI subcommands for scripting
+
+### Phase 2 (Planned)
+- [ ] `omoa preset balanced` / `omoa preset emergency-free`
+- [ ] `omoa restore` (list and restore backups)
+- [ ] Ranking reordering in TUI (move up/down, add/remove models)
+- [ ] Deep Zod shape introspection (auto-detect field types from schema instead of hardcoded field lists)
+- [ ] `omoa doctor` integration (wrap existing doctor command)
+- [ ] `omoa rankings edit <agent>` CLI subcommand
+- [ ] `omoa assign <model> --to <agent1,agent2>` CLI flags
+- [ ] Category ranking management in TUI
+- [ ] Provider compatibility matrix (avoid_fallback_from editing in TUI)
+- [ ] FallbackModelObject support (model + variant + thinking per fallback entry)
+
+### Phase 3 (Planned)
+- [ ] `omoa init` wizard (bootstrap omoa-state.json + omoa-rankings.json from current config)
+- [ ] Import rankings from existing config (detect current models -> generate rankings)
+- [ ] Live provider availability from API/cache polling
+- [ ] Model performance hints (cost tier, speed tier)
+- [ ] Config diff viewer (show what changed between builds)
+- [ ] Undo/redo stack for config changes
+
+## Dependencies
+
+- Uses existing project dependencies only: `@clack/prompts`, `picocolors`, `zod`, `commander`, `jsonc-parser`
+- No new dependencies added

--- a/docs/reference/omoa-architecture.md
+++ b/docs/reference/omoa-architecture.md
@@ -1,0 +1,280 @@
+# OMOA — Model Management Architecture
+
+## Status
+
+Proposed (PR #4158). Awaiting maintainer review.
+
+## Overview
+
+OMOA (Oh-My-OpenAgent Model Management) adds a **policy-based model routing layer** to Oh-My-OpenAgent. It lets users define model preferences per agent/category as ranked lists (rankings) and control provider availability (state), then resolves and applies the best configuration automatically.
+
+## Problem Statement
+
+Oh-My-OpenAgent's existing model resolution depends on:
+
+1. **Hardcoded fallback chains** in `packages/model-core/src/model-requirements.ts` — compiled into the package, not user-configurable.
+2. **Manual overrides** in `oh-my-openagent.json` via `agents.<name>.model` and `fallback_models` — powerful but requires the user to know exact model IDs and provider availability.
+
+As the provider/model landscape grows, users need a way to:
+
+- Express preferences ("I prefer Anthropic models, fall back to OpenAI") without knowing exact model IDs.
+- Disable a provider globally (e.g., "OpenAI is down, route everything to Anthropic/Google").
+- Preview what model each agent would resolve to before committing.
+- Get validation warnings about banned, deprecated, or misconfigured models.
+
+## Data Model
+
+### OmoaState (`omoa-state.json`)
+
+Stored in the opencode config directory (`~/.config/opencode/omoa-state.json`). Records the operational state of providers and model governance.
+
+```typescript
+interface OmoaState {
+  version: 1;
+  providers: Record<string, {
+    enabled: boolean;            // Provider globally enabled/disabled
+    free_only: boolean;          // Only route to free-tier models
+    avoid_fallback_from: string[]; // Don't fall back to these providers
+  }>;
+  banned_models: string[];       // Models that MUST NOT be used (error if assigned)
+  deprecated_models: string[];   // Models that SHOULD NOT be used (warning if assigned)
+  active_preset: "balanced" | "emergency-free" | "custom";
+}
+```
+
+### OmoaRankings (`omoa-rankings.json`)
+
+Stored in the same config directory. Records per-agent and per-category model preference lists.
+
+```typescript
+interface OmoaRankings {
+  version: 1;
+  agents: Record<string, ModelRankingEntry[]>;     // Per-agent ranked lists
+  categories: Record<string, ModelRankingEntry[]>; // Per-category ranked lists
+  fallback_provider_order: string[];               // Global cross-provider fallback order
+}
+
+interface ModelRankingEntry {
+  model: string;        // e.g. "openai/gpt-5.5" or "anthropic/claude-opus-4-7"
+  variant?: string;     // e.g. "high", "medium", "max"
+}
+```
+
+### oh-my-openagent.json (output target)
+
+OMOA writes resolved model assignments into the existing `oh-my-openagent.json` file, targeting the same `agents.<name>.model` and `agents.<name>.fallback_models` fields that the model-core resolver already reads.
+
+## Policy DSL
+
+OMOA defines two user-facing policy primitives:
+
+### 1. Rankings (Preference Lists)
+
+A ranked list of models per agent/category. Position = priority.
+
+```jsonc
+// omoa-rankings.json
+{
+  "agents": {
+    "sisyphus": [
+      { "model": "anthropic/claude-opus-4-7" },
+      { "model": "openai/gpt-5.5" },
+      { "model": "google/gemini-3.1-pro" }
+    ],
+    "oracle": [
+      { "model": "openai/gpt-5.5" },
+      { "model": "google/gemini-3.1-pro" }
+    ]
+  }
+}
+```
+
+Rankings encode the user's **preference order**, not a strict chain. The resolver picks the highest-ranked model whose provider is enabled.
+
+### 2. Provider State (Availability)
+
+Controls which providers and models are available for routing.
+
+```jsonc
+// omoa-state.json
+{
+  "providers": {
+    "openai": { "enabled": true },
+    "anthropic": { "enabled": true },
+    "deepseek": { "enabled": false }  // outage or deprioritized
+  },
+  "banned_models": ["opencode/deprecated-v1"],
+  "active_preset": "balanced"
+}
+```
+
+### Banned vs Deprecated Contract
+
+- `banned_models` are hard exclusions. OMOA will not select them during build, and validation reports existing banned assignments as errors.
+- `deprecated_models` are soft exclusions. OMOA avoids selecting them during build, and validation reports existing deprecated assignments as warnings.
+
+## Resolution Algorithm (`resolver.ts`)
+
+For each agent/category with rankings defined:
+
+1. Filter rankings by `isModelAvailable()`:
+   - Provider must be enabled.
+   - Model must not be banned or deprecated.
+   - If provider is `free_only`, model must end with `-free`.
+2. Pick the **first available** entry as primary.
+3. Pick the **first cross-provider** available entry as fallback:
+   - Must be a different provider than primary.
+   - Must not be in primary provider's `avoid_fallback_from` list.
+4. Return `{ primary, fallback, primaryReason, fallbackReason }`.
+
+This is a **simple ranked-choice** algorithm — not a full constraint solver. It trades generality for predictability.
+
+## Layering: OMOA vs Existing Resolution
+
+### The Five Resolution Layers
+
+The model-core `resolveModelPipeline()` checks sources in this priority order:
+
+| Priority | Source | Layer | Writes To |
+|----------|--------|-------|-----------|
+| 1 (highest) | `uiSelectedModel` | UI session override | Session only |
+| 2 | `userModel` / `userFallbackModels` | **oh-my-openagent.json** ← **OMOA writes here** | Config file |
+| 3 | `categoryDefaultModel` | Category defaults | Config file |
+| 4 | `userFallbackModels` | Manual fallback_models | Config file |
+| 5 | `fallbackChain` | **model-requirements.ts** (hardcoded) | Package code |
+| 6 (lowest) | `systemDefaultModel` | System fallback | Config/settings |
+
+### OMOA's Position in the Stack
+
+```
+User Manual Config          OMOA Policy
+(oh-my-openagent.json)      (omoa-state.json + omoa-rankings.json)
+         │                            │
+         │                    omoa build (resolver + builder)
+         │                            │
+         └────────┬───────────────────┘
+                  │
+        oh-my-openagent.json
+        (agents.<name>.model)
+                  │
+                  ▼
+     model-core/resolveModelPipeline()
+                  │
+                  ▼
+            Runtime Model
+```
+
+**Key insight**: OMOA does NOT introduce a new config format alongside `oh-my-openagent.json`. It targets the same config file that manual editing targets. The separation is temporal:
+
+- **OMOA-managed fields**: Set by `omoa build`, identifiable at runtime by checking if the agent has rankings defined.
+- **Manual fields**: Set directly by the user in oh-my-openagent.json, with no OMOA rankings.
+
+### Conflict Resolution: OMOA vs Manual Editing
+
+| Scenario | What Wins | Why |
+|----------|-----------|-----|
+| User sets `agents.sisyphus.model` + no OMOA rankings for sisyphus | **Manual config** | `omoa build` only touches agents/categories that have rankings. Manual entries without rankings are left unchanged. |
+| User sets `agents.sisyphus.model` + OMOA has rankings for sisyphus | **OMOA on build** | Rankings opt that target into OMOA management. `omoa build --dry-run` previews the change, and non-dry-run writes create a backup first. |
+| User sets `agents.sisyphus.model` + user also has chat.params override | **chat.params > config** | Chat params are session-level and checked at a different point in the pipeline. |
+| OMOA sets model + model-requirements.ts has fallback chains | **OMOA > hardcoded** | `resolveModelPipeline` checks `userModel` (step 2) before `fallbackChain` (step 5). |
+
+The safety boundary is opt-in by rankings: no ranking means no automatic write for that agent/category.
+
+## Usage Walkthrough
+
+### On-Ramp: Empty Project
+
+```bash
+# 1. First run — OMOA reads connected providers from the runtime cache
+$ oh-my-opencode omoa
+
+# 2. Status shows all connected providers, no rankings defined yet
+$ oh-my-opencode omoa status
+  Providers:
+    [x] anthropic
+    [x] openai
+    [ ] deepseek
+
+  Agents:
+    sisyphus              [manual]  primary=not set
+    oracle                [manual]  primary=not set
+
+# 3. Enable/disable providers
+$ oh-my-opencode omoa provider disable deepseek
+
+# 4. Launch interactive TUI to set rankings
+$ oh-my-opencode omoa
+  → Rankings → sisyphus → add "anthropic/claude-opus-4-7"
+  → Rankings → sisyphus → add "openai/gpt-5.5"
+  → Assign Model → sisyphus → pick from ranked list
+
+# 5. Build — resolves rankings + state, writes oh-my-openagent.json
+$ oh-my-opencode omoa build
+  sisyphus [agent] model: (none) -> anthropic/claude-opus-4-7 (rank #1)
+  sisyphus [agent] fallback_models: (none) -> openai/gpt-5.5 (rank #2, cross-provider)
+  Backup: /home/user/.config/opencode/oh-my-opencode.json.backup-1712345678
+
+# 6. Verify
+$ oh-my-opencode omoa status
+  sisyphus              [OMOA]   primary=anthropic/claude-opus-4-7  fallback=openai/gpt-5.5
+```
+
+### What `omoa build` Produces
+
+Given the above state + rankings, `omoa build` writes to oh-my-openagent.json:
+
+```jsonc
+{
+  "agents": {
+    "sisyphus": {
+      "model": "anthropic/claude-opus-4-7",
+      "fallback_models": ["openai/gpt-5.5"]
+    }
+  }
+}
+```
+
+And creates a backup at `oh-my-openagent.json.backup-<timestamp>`.
+
+## Testing Strategy
+
+### Unit Tests (existing in PR)
+
+| File | Coverage |
+|------|----------|
+| `resolver.test.ts` | 4 test cases: basic resolution, provider disabled, banned models, cross-provider fallback, avoid_fallback_from, free_only, all-unavailable |
+| `validator.test.ts` | Validation rules for each warning type |
+
+### CLI Integration Test
+
+A CLI-level test exists at `src/cli/omoa/omoa-cli.test.ts`. It:
+1. Writes fixture `omoa-state.json` and `omoa-rankings.json` to a temp config directory.
+2. Runs `omoa build`.
+3. Asserts the produced `oh-my-openagent.json` matches expected output.
+4. Verifies dry-run, backup creation, provider-disabled selection, banned-model skipping, and category assignment.
+
+This locks the user-visible CLI contract rather than only testing resolver internals.
+
+## Future Considerations
+
+### PR #1529 — TUI Config Editor
+
+The interactive TUI config editor (PR #1529) adds a `config` CLI command for schema-driven editing of `oh-my-openagent.json`. This overlaps with OMOA's `omoa edit` and `omoa assign` TUI screens. Both should be unified under a single entry point:
+
+- `omoa config` — edit any field in oh-my-openagent.json (schema-driven, from #1529)
+- `omoa build` — OMOA-specific auto-resolution from rankings + state
+- `omoa rankings` — manage ranking lists
+
+### Emergency Presets
+
+The `active_preset` field in `OmoaState` is reserved for future emergency-mode routing (e.g., "free_only" when all paid providers fail). Not yet implemented.
+
+### Integration with model-core Snapshot System
+
+OMOA's `model-cache.ts` reads from the same model cache that model-core uses. Future versions could share a typed interface rather than reading raw JSON.
+
+## Non-Goals
+
+- OMOA does NOT replace model-requirements.ts fallback chains. Hardcoded chains remain as a fallback when no OMOA rankings are defined for an agent.
+- OMOA does NOT add a new config file format alongside oh-my-openagent.json. State and rankings are internal data files.
+- OMOA does NOT implement real-time provider health monitoring. Provider state is user-managed.

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -8,6 +8,7 @@ import { refreshModelCapabilities } from "./refresh-model-capabilities"
 import { createMcpOAuthCommand } from "./mcp-oauth"
 import { boulder } from "./boulder"
 import { codexUlwLoop } from "./codex-ulw-loop"
+import { omoaInteractive, omoaStatus, omoaBuild, omoaProviderList, omoaProviderSet } from "./omoa"
 import type { InstallArgs } from "./types"
 import type { RunOptions } from "./run"
 import type { GetLocalVersionOptions } from "./get-local-version/types"
@@ -251,6 +252,48 @@ program
       sourceUrl: options.sourceUrl,
       json: options.json ?? false,
     })
+    process.exit(exitCode)
+  })
+
+program
+  .command("omoa")
+  .description("OMOA model management - policy-based model routing for agents and categories")
+  .addHelpText("after", `
+Subcommands:
+  omoa                  Interactive TUI
+  omoa status           Show provider/agent/category overview
+  omoa build            Build config from rankings + provider state
+  omoa build --dry-run  Preview changes without writing
+  omoa build --yes      Skip confirmation
+  omoa provider list    Show provider status
+  omoa provider enable <name>   Enable a provider
+  omoa provider disable <name>  Disable a provider
+
+Examples:
+  $ bunx oh-my-opencode omoa
+  $ bunx oh-my-opencode omoa status
+  $ bunx oh-my-opencode omoa build --dry-run
+  $ bunx oh-my-opencode omoa provider disable openai
+`)
+  .argument("[subcommand]", "Subcommand: status, build, provider")
+  .argument("[args...]", "Subcommand arguments")
+  .option("--dry-run", "Preview changes without writing (build)")
+  .option("--yes", "Skip confirmation (build)")
+  .action(async (subcommand, args, options) => {
+    let exitCode: number
+    if (subcommand === "status") {
+      exitCode = omoaStatus()
+    } else if (subcommand === "build") {
+      exitCode = omoaBuild(options.dryRun ?? false, options.yes ?? false)
+    } else if (subcommand === "provider" && args?.[0] === "list") {
+      exitCode = omoaProviderList()
+    } else if (subcommand === "provider" && args?.[0] === "enable" && args?.[1]) {
+      exitCode = omoaProviderSet(args[1], true)
+    } else if (subcommand === "provider" && args?.[0] === "disable" && args?.[1]) {
+      exitCode = omoaProviderSet(args[1], false)
+    } else {
+      exitCode = await omoaInteractive()
+    }
     process.exit(exitCode)
   })
 

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -8,7 +8,7 @@ import { refreshModelCapabilities } from "./refresh-model-capabilities"
 import { createMcpOAuthCommand } from "./mcp-oauth"
 import { boulder } from "./boulder"
 import { codexUlwLoop } from "./codex-ulw-loop"
-import { omoaInteractive, omoaStatus, omoaBuild, omoaProviderList, omoaProviderSet } from "./omoa"
+import { omoaInteractive, omoaStatus, omoaBuild, omoaProviderList, omoaProviderSet, omoaConfig } from "./omoa"
 import type { InstallArgs } from "./types"
 import type { RunOptions } from "./run"
 import type { GetLocalVersionOptions } from "./get-local-version/types"
@@ -268,6 +268,7 @@ Subcommands:
   omoa provider list    Show provider status
   omoa provider enable <name>   Enable a provider
   omoa provider disable <name>  Disable a provider
+  omoa config           Interactive config editor
 
 Examples:
   $ bunx oh-my-opencode omoa
@@ -291,6 +292,8 @@ Examples:
       exitCode = omoaProviderSet(args[1], true)
     } else if (subcommand === "provider" && args?.[0] === "disable" && args?.[1]) {
       exitCode = omoaProviderSet(args[1], false)
+    } else if (subcommand === "config") {
+      exitCode = await omoaConfig()
     } else {
       exitCode = await omoaInteractive()
     }

--- a/src/cli/config/__tests__/config-editor.test.ts
+++ b/src/cli/config/__tests__/config-editor.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from "bun:test"
+import { validateConfig, checkFallbackWarnings, countWarnings } from "../validation"
+import type { ConfigEditorState } from "../types"
+
+function makeState(config: Record<string, unknown>): ConfigEditorState {
+  return {
+    config: config as ConfigEditorState["config"],
+    modified: false,
+    configPath: "/tmp/test-oh-my-opencode.json",
+  }
+}
+
+describe("config editor validation", () => {
+  test("empty config produces no validation warnings", () => {
+    const state = makeState({
+      agents: {},
+      categories: {},
+    })
+    const warnings = validateConfig(state)
+    expect(warnings.length).toBe(0)
+  })
+
+  test("config with model on all agents produces no warnings", () => {
+    const state = makeState({
+      agents: {
+        build: { model: "openai/gpt-5.5" },
+        plan: { model: "openai/gpt-5.5" },
+        sisyphus: { model: "anthropic/claude-opus-4-7" },
+      },
+      categories: {},
+    })
+    const warnings = validateConfig(state)
+    expect(warnings.length).toBe(0)
+  })
+
+  test("agent with missing model produces warning", () => {
+    const state = makeState({
+      agents: {
+        sisyphus: {},
+      },
+      categories: {},
+    })
+    const warnings = validateConfig(state)
+    const noModel = warnings.find((w) => w.agent === "sisyphus" && w.type === "missing-model")
+    expect(noModel).toBeDefined()
+  })
+
+  test("agent with model but no fallback produces fallback warning", () => {
+    const state = makeState({
+      agents: {
+        sisyphus: { model: "anthropic/claude-opus-4-7" },
+      },
+      categories: {},
+    })
+    const warnings = checkFallbackWarnings(state)
+    const noFallback = warnings.find((w) => w.agent === "sisyphus" && w.type === "missing-fallback")
+    expect(noFallback).toBeDefined()
+  })
+
+  test("agent with model and fallback produces no fallback warning", () => {
+    const state = makeState({
+      agents: {
+        sisyphus: {
+          model: "anthropic/claude-opus-4-7",
+          fallback_models: ["openai/gpt-5.5"],
+        },
+      },
+      categories: {},
+    })
+    const warnings = checkFallbackWarnings(state)
+    const noFallback = warnings.find((w) => w.agent === "sisyphus" && w.type === "missing-fallback")
+    expect(noFallback).toBeUndefined()
+  })
+})
+
+describe("config editor types", () => {
+  test("AGENT_NAMES includes expected agents", async () => {
+    const { AGENT_NAMES } = await import("../types")
+    expect(AGENT_NAMES).toContain("sisyphus")
+    expect(AGENT_NAMES).toContain("oracle")
+    expect(AGENT_NAMES).toContain("build")
+    expect(AGENT_NAMES).toContain("plan")
+    expect(AGENT_NAMES.length).toBeGreaterThan(5)
+  })
+
+  test("BUILTIN_CATEGORIES includes expected categories", async () => {
+    const { BUILTIN_CATEGORIES } = await import("../types")
+    expect(BUILTIN_CATEGORIES).toContain("visual-engineering")
+    expect(BUILTIN_CATEGORIES).toContain("deep")
+    expect(BUILTIN_CATEGORIES).toContain("ultrabrain")
+  })
+})
+
+describe("config editor models", () => {
+  test("getModelsByProvider returns record without errors", async () => {
+    const { getModelsByProvider } = await import("../models")
+    const result = getModelsByProvider()
+    // Should always return a valid object (possibly empty if no cache files)
+    expect(typeof result).toBe("object")
+    expect(Array.isArray(result)).toBe(false)
+    // Can't assert specific providers since cache file may not exist
+  })
+
+  test("getAllCachedModels returns sorted list", async () => {
+    const { getAllCachedModels } = await import("../models")
+    const result = getAllCachedModels()
+    expect(Array.isArray(result)).toBe(true)
+  })
+})

--- a/src/cli/config/agents.ts
+++ b/src/cli/config/agents.ts
@@ -100,7 +100,7 @@ async function editAgentField(
         message: "Enter custom model name:",
         initialValue: agent.model ?? "",
         validate: (value) => {
-          if (!value.trim()) return "Model name is required"
+          if (!value?.trim()) return "Model name is required"
           return undefined
         },
       })

--- a/src/cli/config/agents.ts
+++ b/src/cli/config/agents.ts
@@ -1,0 +1,367 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import type { ConfigEditorState, AgentName, BashPermissionValue, BashCommand, AgentConfigExtended } from "./types"
+import { AGENT_NAMES, BASH_COMMANDS } from "./types"
+import { selectModelWithCacheLoader } from "./ui-utils"
+
+const SYMBOLS = {
+  check: color.green("[OK]"),
+  cross: color.red("[X]"),
+  arrow: color.cyan("->"),
+  bullet: color.dim("*"),
+  info: color.blue("[i]"),
+  warn: color.yellow("[!]"),
+}
+
+function getAgentsRecord(state: ConfigEditorState): Record<string, AgentConfigExtended> {
+  return (state.config.agents ?? {}) as Record<string, AgentConfigExtended>
+}
+
+function getCategoriesFromConfig(state: ConfigEditorState): string[] {
+  const categories = state.config.categories ?? {}
+  return Object.keys(categories)
+}
+
+function formatAgentStatus(state: ConfigEditorState, agentName: string): string {
+  const agents = getAgentsRecord(state)
+  const agent = agents[agentName]
+  if (!agent) {
+    return color.dim("not configured")
+  }
+
+  const parts: string[] = []
+
+  if (agent.model) {
+    parts.push(`model: ${color.cyan(agent.model)}`)
+  }
+
+  if (agent.category) {
+    parts.push(`cat: ${color.yellow(agent.category)}`)
+  }
+
+  const fbArray = Array.isArray(agent.fallback_models) ? agent.fallback_models : agent.fallback_models ? [String(agent.fallback_models)] : []
+  if (fbArray.length) {
+    parts.push(`fallback: ${color.dim(fbArray[0])}${fbArray.length > 1 ? " +" + (fbArray.length - 1) : ""}`)
+  }
+
+  if (agent.permission) {
+    const hasBash = agent.permission.bash !== undefined
+    const hasEdit = agent.permission.edit !== undefined
+    const hasWebfetch = agent.permission.webfetch !== undefined
+    if (hasBash || hasEdit || hasWebfetch) {
+      parts.push(`perm: ${color.green("✓")}`)
+    }
+  }
+
+  if (parts.length === 0) {
+    return color.dim("no settings")
+  }
+
+  return parts.join(" | ")
+}
+
+async function editAgentField(
+  state: ConfigEditorState,
+  agentName: string
+): Promise<boolean> {
+  const agents = getAgentsRecord(state)
+  const agent = agents[agentName] ?? {}
+  const categories = getCategoriesFromConfig(state)
+  const fbArray = Array.isArray(agent.fallback_models) ? agent.fallback_models : agent.fallback_models ? [String(agent.fallback_models)] : []
+
+  const field = await p.select({
+    message: `Editing "${agentName}" - Select field to edit:`,
+    options: [
+      { value: "model", label: "Model", hint: agent.model ? `current: ${agent.model}` : "not set" },
+      { value: "category", label: "Category", hint: agent.category ? `current: ${agent.category}` : "not set" },
+      { value: "fallback_model", label: "Fallback Model", hint: fbArray.length ? `current: ${fbArray[0]}${fbArray.length > 1 ? " +" + (fbArray.length - 1) : ""}` : "not set" },
+      { value: "permissions", label: "Permissions", hint: agent.permission ? "configured" : "not set" },
+      { value: "back", label: "Back to agent list" },
+    ],
+  })
+
+  if (p.isCancel(field) || field === "back") {
+    return false
+  }
+
+  if (field === "model") {
+    const model = await selectModelWithCacheLoader(
+      `Select model for "${agentName}":`,
+      agent.model
+    )
+
+    if (p.isCancel(model)) return false
+
+    let finalModel: string | undefined
+    if (model === "__clear__") {
+      finalModel = undefined
+    } else if (model === "__custom__") {
+      const custom = await p.text({
+        message: "Enter custom model name:",
+        initialValue: agent.model ?? "",
+        validate: (value) => {
+          if (!value.trim()) return "Model name is required"
+          return undefined
+        },
+      })
+      if (p.isCancel(custom)) return false
+      finalModel = custom.trim() || undefined
+    } else {
+      finalModel = model as string
+    }
+
+    if (!state.config.agents) state.config.agents = {}
+    const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    agentsMutable[agentName].model = finalModel
+    state.modified = true
+
+    p.log.success(`Updated model for "${agentName}" to ${finalModel ?? "(none)"}`)
+  }
+
+  if (field === "category") {
+    const categoryOptions = [
+      ...categories.map((c) => ({ value: c, label: c })),
+      { value: "__custom__", label: "Custom category..." },
+      { value: "__clear__", label: "Clear category" },
+    ]
+
+    const category = await p.select({
+      message: `Select category for "${agentName}":`,
+      options: categoryOptions,
+      initialValue: agent.category,
+    })
+
+    if (p.isCancel(category)) return false
+
+    let finalCategory: string | undefined
+    if (category === "__clear__") {
+      finalCategory = undefined
+    } else if (category === "__custom__") {
+      const custom = await p.text({
+        message: "Enter custom category name:",
+        initialValue: agent.category ?? "",
+      })
+      if (p.isCancel(custom)) return false
+      finalCategory = custom
+    } else {
+      finalCategory = category
+    }
+
+    if (!state.config.agents) state.config.agents = {}
+    const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    agentsMutable[agentName].category = finalCategory
+    state.modified = true
+
+    p.log.success(`Updated category for "${agentName}" to ${finalCategory ?? "(none)"}`)
+  }
+
+  if (field === "fallback_model") {
+    const fallbackArray = Array.isArray(agent.fallback_models) 
+      ? agent.fallback_models 
+      : agent.fallback_models 
+        ? [String(agent.fallback_models)] 
+        : []
+    const currentFallback = fallbackArray[0]
+    const model = await selectModelWithCacheLoader(
+      `Select fallback model for "${agentName}":`,
+      currentFallback
+    )
+
+    if (p.isCancel(model)) return false
+
+    let finalFallback: string | undefined
+    if (model === "__clear__") {
+      finalFallback = undefined
+    } else if (model === "__custom__") {
+      const custom = await p.text({
+        message: "Enter custom fallback model:",
+        initialValue: currentFallback ?? "",
+      })
+      if (p.isCancel(custom)) return false
+      finalFallback = custom
+    } else {
+      finalFallback = model as string
+    }
+
+    if (!state.config.agents) state.config.agents = {}
+    const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    const existingFallbacks = fallbackArray.slice(1)
+    if (finalFallback) {
+      const filtered = existingFallbacks.filter(f => f !== finalFallback)
+      agentsMutable[agentName].fallback_models = [finalFallback, ...filtered]
+    } else if (existingFallbacks.length > 0) {
+      agentsMutable[agentName].fallback_models = existingFallbacks
+    } else {
+      delete agentsMutable[agentName].fallback_models
+    }
+    state.modified = true
+
+    p.log.success(`Updated fallback model for "${agentName}" to ${finalFallback ?? "(none)"}`)
+  }
+
+  if (field === "permissions") {
+    const existingPerm = agent.permission
+    const hasBash = existingPerm?.bash !== undefined
+    const hasEdit = existingPerm?.edit !== undefined
+    const hasWebfetch = existingPerm?.webfetch !== undefined
+
+    const permAction = await p.select({
+      message: "Select permission to configure:",
+      options: [
+        { value: "bash", label: "Bash Permissions", hint: hasBash ? "configured" : "rm, mv, cp, *" },
+        { value: "edit", label: "Edit Permission", hint: hasEdit ? "configured" : "not set" },
+        { value: "webfetch", label: "Webfetch Permission", hint: hasWebfetch ? "configured" : "not set" },
+        { value: "back", label: "Back" },
+      ],
+    })
+
+    if (p.isCancel(permAction) || permAction === "back") return false
+
+    if (permAction === "bash") {
+      const existingBash = existingPerm?.bash
+      const isSimple = typeof existingBash === "string"
+      const bashHint = isSimple ? `current: ${existingBash}` : (typeof existingBash === "object" ? "current: detailed" : "not set")
+
+      const bashAction = await p.select({
+        message: "Configure bash permissions:",
+        options: [
+          { value: "simple", label: "Simple (one value for all commands)", hint: isSimple ? `current: ${existingBash}` : "ask, allow, or deny for all" },
+          { value: "detailed", label: "Detailed (per-command)", hint: !isSimple && existingBash ? "current: detailed" : "set rm, mv, cp, * separately" },
+          { value: "clear", label: "Clear bash permissions", hint: hasBash ? "configured" : undefined },
+          { value: "back", label: "Back" },
+        ],
+      })
+
+      if (p.isCancel(bashAction) || bashAction === "back") return false
+
+      if (bashAction === "clear") {
+        if (!state.config.agents) state.config.agents = {}
+        const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+        if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+        const perm = agentsMutable[agentName].permission
+        if (perm) {
+          const { bash: _, ...rest } = perm
+          agentsMutable[agentName].permission = Object.keys(rest).length > 0 ? rest : undefined
+          state.modified = true
+        }
+        p.log.success("Cleared bash permissions")
+      } else if (bashAction === "simple") {
+        const currentSimple = typeof existingBash === "string" ? existingBash : undefined
+        const value = await p.select({
+          message: "Select bash permission level:",
+          options: [
+            { value: "ask", label: "Ask", hint: currentSimple === "ask" ? "current" : "Prompt before executing any bash command" },
+            { value: "allow", label: "Allow", hint: currentSimple === "allow" ? "current" : "Execute bash commands without prompting" },
+            { value: "deny", label: "Deny", hint: currentSimple === "deny" ? "current" : "Block all bash commands" },
+          ],
+          initialValue: currentSimple ?? "ask",
+        })
+
+        if (p.isCancel(value)) return false
+
+        if (!state.config.agents) state.config.agents = {}
+        const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+        if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+        if (!agentsMutable[agentName].permission) agentsMutable[agentName].permission = {}
+        agentsMutable[agentName].permission!.bash = value as BashPermissionValue
+        state.modified = true
+
+        p.log.success(`Set bash permission to "${value}"`)
+      } else if (bashAction === "detailed") {
+        const existingBash = agents[agentName]?.permission?.bash
+        const isSimpleValue = typeof existingBash === "string"
+        const currentPerms = isSimpleValue ? undefined : existingBash as Record<string, BashPermissionValue> | undefined
+        const defaultValue: BashPermissionValue = isSimpleValue ? (existingBash as BashPermissionValue) : "ask"
+
+        const newPerms: Record<string, BashPermissionValue> = { ...currentPerms }
+
+        for (const cmd of BASH_COMMANDS) {
+          const current = currentPerms?.[cmd] ?? defaultValue
+          const value = await p.select({
+            message: `Permission for "${cmd}" command:`,
+            options: [
+              { value: "ask", label: "Ask", hint: current === "ask" ? "current" : undefined },
+              { value: "allow", label: "Allow", hint: current === "allow" ? "current" : undefined },
+              { value: "deny", label: "Deny", hint: current === "deny" ? "current" : undefined },
+            ],
+            initialValue: current,
+          })
+
+          if (p.isCancel(value)) return false
+          newPerms[cmd] = value as BashPermissionValue
+        }
+
+        if (!state.config.agents) state.config.agents = {}
+        const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+        if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+        if (!agentsMutable[agentName].permission) agentsMutable[agentName].permission = {}
+        agentsMutable[agentName].permission!.bash = newPerms
+        state.modified = true
+
+        p.log.success("Updated detailed bash permissions")
+      }
+    } else {
+      const currentPerm = existingPerm?.[permAction as "edit" | "webfetch"]
+      const value = await p.select({
+        message: `Select ${permAction} permission:`,
+        options: [
+          { value: "ask", label: "Ask", hint: currentPerm === "ask" ? "current" : undefined },
+          { value: "allow", label: "Allow", hint: currentPerm === "allow" ? "current" : undefined },
+          { value: "deny", label: "Deny", hint: currentPerm === "deny" ? "current" : undefined },
+          { value: "__clear__", label: color.red("Clear permission"), hint: currentPerm ? "remove override" : undefined },
+        ],
+        initialValue: currentPerm ?? "ask",
+      })
+
+      if (p.isCancel(value)) return false
+
+      if (!state.config.agents) state.config.agents = {}
+      const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+      if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+      if (!agentsMutable[agentName].permission) agentsMutable[agentName].permission = {}
+
+      if (value === "__clear__") {
+        delete agentsMutable[agentName].permission![permAction as "edit" | "webfetch"]
+        if (Object.keys(agentsMutable[agentName].permission!).length === 0) {
+          delete agentsMutable[agentName].permission
+        }
+        p.log.success(`Cleared ${permAction} permission`)
+      } else {
+        agentsMutable[agentName].permission![permAction as "edit" | "webfetch"] = value as BashPermissionValue
+        p.log.success(`Updated ${permAction} permission to "${value}"`)
+      }
+      state.modified = true
+    }
+  }
+
+  return true
+}
+
+export async function editAgents(state: ConfigEditorState): Promise<void> {
+  while (true) {
+    const agentOptions = AGENT_NAMES.map((name) => ({
+      value: name,
+      label: `${name.padEnd(20)} ${formatAgentStatus(state, name)}`,
+    }))
+
+    const selected = await p.select({
+      message: "Select an agent to configure (or choose action):",
+      options: [
+        ...agentOptions,
+        { value: "__back__", label: color.dim("← Back to main menu") },
+      ],
+    })
+
+    if (p.isCancel(selected) || selected === "__back__") {
+      return
+    }
+
+    const shouldContinue = await editAgentField(state, selected as AgentName)
+    if (!shouldContinue) {
+      continue
+    }
+  }
+}

--- a/src/cli/config/bulk.ts
+++ b/src/cli/config/bulk.ts
@@ -18,7 +18,7 @@ async function setModelForAllAgents(state: ConfigEditorState): Promise<void> {
     const custom = await p.text({
       message: "Enter custom model name:",
       validate: (value) => {
-        if (!value.trim()) return "Model name is required"
+        if (!value?.trim()) return "Model name is required"
         return undefined
       },
     })
@@ -88,7 +88,7 @@ async function setFallbackForAllAgents(state: ConfigEditorState): Promise<void> 
     const custom = await p.text({
       message: "Enter custom fallback model:",
       validate: (value) => {
-        if (!value.trim()) return "Model name is required"
+        if (!value?.trim()) return "Model name is required"
         return undefined
       },
     })

--- a/src/cli/config/bulk.ts
+++ b/src/cli/config/bulk.ts
@@ -1,0 +1,198 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import type { ConfigEditorState, BashPermissionValue, AgentConfigExtended } from "./types"
+import { AGENT_NAMES } from "./types"
+import { selectModelWithCacheLoader } from "./ui-utils"
+
+function getAgentsRecord(state: ConfigEditorState): Record<string, AgentConfigExtended> {
+  return (state.config.agents ?? {}) as Record<string, AgentConfigExtended>
+}
+
+async function setModelForAllAgents(state: ConfigEditorState): Promise<void> {
+  const model = await selectModelWithCacheLoader("Select model to set for ALL agents:")
+
+  if (p.isCancel(model)) return
+
+  let finalModel: string
+  if (model === "__custom__") {
+    const custom = await p.text({
+      message: "Enter custom model name:",
+      validate: (value) => {
+        if (!value.trim()) return "Model name is required"
+        return undefined
+      },
+    })
+    if (p.isCancel(custom)) return
+    finalModel = custom.trim()
+  } else if (model === "__clear__") {
+    const confirm = await p.confirm({
+      message: `Clear model for all ${AGENT_NAMES.length} agents?`,
+      initialValue: false,
+    })
+
+    if (p.isCancel(confirm) || !confirm) {
+      p.log.info("Cancelled")
+      return
+    }
+
+    const s = p.spinner()
+    s.start("Clearing models for all agents...")
+
+    if (!state.config.agents) state.config.agents = {}
+    const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+
+    for (const agentName of AGENT_NAMES) {
+      if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+      delete agentsMutable[agentName].model
+    }
+
+    state.modified = true
+    s.stop(`Cleared models for all agents ${color.green("[OK]")}`)
+    return
+  } else {
+    finalModel = model as string
+  }
+
+  const confirm = await p.confirm({
+    message: `Set model "${finalModel}" for all ${AGENT_NAMES.length} agents?`,
+    initialValue: false,
+  })
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.log.info("Cancelled")
+    return
+  }
+
+  const s = p.spinner()
+  s.start("Applying model to all agents...")
+
+  if (!state.config.agents) state.config.agents = {}
+  const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+
+  for (const agentName of AGENT_NAMES) {
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    agentsMutable[agentName].model = finalModel
+  }
+
+  state.modified = true
+  s.stop(`Set model "${finalModel}" for all agents ${color.green("[OK]")}`)
+}
+
+async function setFallbackForAllAgents(state: ConfigEditorState): Promise<void> {
+  const model = await selectModelWithCacheLoader("Select fallback model to set for ALL agents:")
+
+  if (p.isCancel(model)) return
+
+  let finalModel: string | undefined
+  if (model === "__custom__") {
+    const custom = await p.text({
+      message: "Enter custom fallback model:",
+      validate: (value) => {
+        if (!value.trim()) return "Model name is required"
+        return undefined
+      },
+    })
+    if (p.isCancel(custom)) return
+    finalModel = custom.trim()
+  } else if (model === "__clear__") {
+    finalModel = undefined
+  } else {
+    finalModel = model as string
+  }
+
+  const confirm = await p.confirm({
+    message: `Set fallback model "${finalModel ?? "(clear)"}" for all ${AGENT_NAMES.length} agents?`,
+    initialValue: false,
+  })
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.log.info("Cancelled")
+    return
+  }
+
+  const s = p.spinner()
+  s.start("Applying fallback model to all agents...")
+
+  if (!state.config.agents) state.config.agents = {}
+  const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+
+  for (const agentName of AGENT_NAMES) {
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    const existing = agentsMutable[agentName].fallback_models
+    const existingArray = Array.isArray(existing) ? existing : existing ? [String(existing)] : []
+    if (finalModel) {
+      agentsMutable[agentName].fallback_models = [finalModel, ...existingArray.slice(1)]
+    } else {
+      delete agentsMutable[agentName].fallback_models
+    }
+  }
+
+  state.modified = true
+  const displayModel = finalModel ?? "(cleared)"
+  s.stop(`Set fallback model "${displayModel}" for all agents ${color.green("[OK]")}`)
+}
+
+async function setDefaultBashPermissions(state: ConfigEditorState): Promise<void> {
+  const value = await p.select({
+    message: "Select default bash permission for all agents:",
+    options: [
+      { value: "ask", label: "Ask", hint: "Prompt before executing bash commands" },
+      { value: "allow", label: "Allow", hint: "Execute bash commands without prompting" },
+      { value: "deny", label: "Deny", hint: "Block all bash commands" },
+      { value: "__back__", label: "Back" },
+    ],
+  })
+
+  if (p.isCancel(value) || value === "__back__") return
+
+  const confirm = await p.confirm({
+    message: `Set bash permission "${value}" for all ${AGENT_NAMES.length} agents?`,
+    initialValue: false,
+  })
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.log.info("Cancelled")
+    return
+  }
+
+  const s = p.spinner()
+  s.start("Applying bash permissions to all agents...")
+
+  if (!state.config.agents) state.config.agents = {}
+  const agentsMutable = state.config.agents as Record<string, AgentConfigExtended>
+
+  for (const agentName of AGENT_NAMES) {
+    if (!agentsMutable[agentName]) agentsMutable[agentName] = {}
+    if (!agentsMutable[agentName].permission) agentsMutable[agentName].permission = {}
+    agentsMutable[agentName].permission!.bash = value as BashPermissionValue
+  }
+
+  state.modified = true
+  s.stop(`Set bash permission "${value}" for all agents ${color.green("[OK]")}`)
+}
+
+export async function runBulkOperations(state: ConfigEditorState): Promise<void> {
+  while (true) {
+    const action = await p.select({
+      message: "Select bulk operation:",
+      options: [
+        { value: "model", label: "Set model for all agents" },
+        { value: "fallback", label: "Set fallback for all agents" },
+        { value: "permissions", label: "Set default bash permissions for all agents" },
+        { value: "back", label: color.dim("← Back to main menu") },
+      ],
+    })
+
+    if (p.isCancel(action) || action === "back") {
+      return
+    }
+
+    if (action === "model") {
+      await setModelForAllAgents(state)
+    } else if (action === "fallback") {
+      await setFallbackForAllAgents(state)
+    } else if (action === "permissions") {
+      await setDefaultBashPermissions(state)
+    }
+  }
+}

--- a/src/cli/config/categories.ts
+++ b/src/cli/config/categories.ts
@@ -1,0 +1,173 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import type { CategoryConfig } from "../../config/schema"
+import type { ConfigEditorState } from "./types"
+import { selectModelWithCacheLoader } from "./ui-utils"
+
+type MutableCategories = Record<string, CategoryConfig>
+
+function getCategories(state: ConfigEditorState): MutableCategories {
+  return (state.config.categories ?? {}) as MutableCategories
+}
+
+function formatCategoryStatus(state: ConfigEditorState, categoryName: string): string {
+  const categories = getCategories(state)
+  const category = categories[categoryName]
+  if (!category) {
+    return color.dim("not configured")
+  }
+
+  const parts: string[] = []
+
+  if (category.model) {
+    parts.push(`model: ${color.cyan(category.model)}`)
+  }
+
+  if (category.description) {
+    parts.push(`desc: ${color.dim(category.description.slice(0, 30))}${category.description.length > 30 ? "..." : ""}`)
+  }
+
+  if (parts.length === 0) {
+    return color.dim("no settings")
+  }
+
+  return parts.join(" | ")
+}
+
+async function editCategory(
+  state: ConfigEditorState,
+  categoryName: string,
+  isNew = false
+): Promise<boolean> {
+  const categories = getCategories(state)
+  const category = categories[categoryName] ?? {}
+
+  const field = await p.select({
+    message: `Editing category "${categoryName}" - Select field:`,
+    options: [
+      { value: "model", label: "Model", hint: category.model ? `current: ${category.model}` : "not set" },
+      { value: "description", label: "Description", hint: category.description ? `current: ${category.description.slice(0, 20)}...` : "not set" },
+      { value: "back", label: "Back to category list" },
+    ],
+  })
+
+  if (p.isCancel(field) || field === "back") {
+    return false
+  }
+
+  if (field === "model") {
+    const model = await selectModelWithCacheLoader(
+      `Select model for category "${categoryName}":`,
+      category.model
+    )
+
+    if (p.isCancel(model)) return false
+
+    let finalModel: string | undefined
+    if (model === "__clear__") {
+      finalModel = undefined
+    } else if (model === "__custom__") {
+      const custom = await p.text({
+        message: "Enter custom model name:",
+        initialValue: category.model ?? "",
+        validate: (value) => {
+          if (!value.trim()) return "Model name is required"
+          return undefined
+        },
+      })
+      if (p.isCancel(custom)) return false
+      finalModel = custom.trim() || undefined
+    } else {
+      finalModel = model as string
+    }
+
+    if (!state.config.categories) state.config.categories = {}
+    const categoriesMutable = state.config.categories as MutableCategories
+    if (!categoriesMutable[categoryName]) categoriesMutable[categoryName] = {}
+    categoriesMutable[categoryName].model = finalModel
+    state.modified = true
+
+    p.log.success(`Updated model for category "${categoryName}" to ${finalModel ?? "(none)"}`)
+  }
+
+  if (field === "description") {
+    const description = await p.text({
+      message: `Enter description for category "${categoryName}":`,
+      initialValue: category.description ?? "",
+      placeholder: "e.g., Agents for UI/UX work",
+    })
+
+    if (p.isCancel(description)) return false
+
+    const finalDescription = description?.trim() || undefined
+
+    if (!state.config.categories) state.config.categories = {}
+    const categoriesMutable = state.config.categories as MutableCategories
+    if (!categoriesMutable[categoryName]) categoriesMutable[categoryName] = {}
+    categoriesMutable[categoryName].description = finalDescription
+    state.modified = true
+
+    p.log.success(`Updated description for category "${categoryName}"`)
+  }
+
+  return true
+}
+
+export async function editCategories(state: ConfigEditorState): Promise<void> {
+  while (true) {
+    const categories = getCategories(state)
+    const categoryNames = Object.keys(categories)
+
+    const options = [
+      ...categoryNames.map((name) => ({
+        value: name,
+        label: `${name.padEnd(20)} ${formatCategoryStatus(state, name)}`,
+      })),
+      { value: "__new__", label: color.cyan("+ Create new category") },
+      { value: "__back__", label: color.dim("← Back to main menu") },
+    ]
+
+    const selected = await p.select({
+      message: "Select a category to edit (or create new):",
+      options,
+    })
+
+    if (p.isCancel(selected) || selected === "__back__") {
+      return
+    }
+
+    if (selected === "__new__") {
+      const newName = await p.text({
+        message: "Enter new category name:",
+        validate: (value) => {
+          if (!value.trim()) return "Category name is required"
+          if (value.trim() === "__new__" || value.trim() === "__back__") return "Invalid category name"
+          if (value.trim() === "__proto__" || value.trim() === "constructor" || value.trim() === "prototype") return "Reserved name"
+          if (categoryNames.includes(value.trim())) return "Category already exists"
+          return undefined
+        },
+      })
+
+      if (p.isCancel(newName)) continue
+
+      const trimmedName = newName.trim()
+
+      p.log.info(`Creating new category "${trimmedName}"...`)
+      const shouldContinue = await editCategory(state, trimmedName, true)
+      if (!shouldContinue) {
+        p.log.info("Category creation cancelled")
+        continue
+      }
+
+      if (!state.config.categories) state.config.categories = {}
+      const categoriesMutable = state.config.categories as MutableCategories
+      categoriesMutable[trimmedName] = categoriesMutable[trimmedName] || {}
+      state.modified = true
+
+      p.log.success(`Created category "${trimmedName}"`)
+    } else {
+      const shouldContinue = await editCategory(state, selected as string)
+      if (!shouldContinue) continue
+    }
+  }
+}

--- a/src/cli/config/categories.ts
+++ b/src/cli/config/categories.ts
@@ -71,7 +71,7 @@ async function editCategory(
         message: "Enter custom model name:",
         initialValue: category.model ?? "",
         validate: (value) => {
-          if (!value.trim()) return "Model name is required"
+          if (!value?.trim()) return "Model name is required"
           return undefined
         },
       })
@@ -140,10 +140,11 @@ export async function editCategories(state: ConfigEditorState): Promise<void> {
       const newName = await p.text({
         message: "Enter new category name:",
         validate: (value) => {
-          if (!value.trim()) return "Category name is required"
-          if (value.trim() === "__new__" || value.trim() === "__back__") return "Invalid category name"
-          if (value.trim() === "__proto__" || value.trim() === "constructor" || value.trim() === "prototype") return "Reserved name"
-          if (categoryNames.includes(value.trim())) return "Category already exists"
+          const trimmed = value?.trim()
+          if (!trimmed) return "Category name is required"
+          if (trimmed === "__new__" || trimmed === "__back__") return "Invalid category name"
+          if (trimmed === "__proto__" || trimmed === "constructor" || trimmed === "prototype") return "Reserved name"
+          if (categoryNames.includes(trimmed)) return "Category already exists"
           return undefined
         },
       })

--- a/src/cli/config/index.ts
+++ b/src/cli/config/index.ts
@@ -1,0 +1,230 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { existsSync, readFileSync, writeFileSync, renameSync, copyFileSync, mkdirSync, realpathSync, statSync, chmodSync } from "node:fs"
+import { dirname } from "node:path"
+import { getConfigContext } from "../config-manager"
+import { parseJsonc } from "../../shared"
+import type { OhMyOpenCodeConfig } from "../../config/schema"
+import type { ConfigEditorState } from "./types"
+import { editAgents } from "./agents"
+import { editCategories } from "./categories"
+import { runBulkOperations } from "./bulk"
+import { displayValidationWarnings, countWarnings } from "./validation"
+
+function getConfigPath(): string {
+  const { paths } = getConfigContext()
+  return paths.omoConfig
+}
+
+function loadConfig(path: string): OhMyOpenCodeConfig | null {
+  if (!existsSync(path)) {
+    return {}
+  }
+
+  try {
+    const content = readFileSync(path, "utf-8")
+    const config = parseJsonc<OhMyOpenCodeConfig>(content)
+    return config ?? {}
+  } catch {
+    return null
+  }
+}
+
+function createBackupWithCopy(configPath: string): string | null {
+  try {
+    if (!existsSync(configPath)) return null
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+    const backupPath = `${configPath}.backup.${timestamp}`
+    copyFileSync(configPath, backupPath)
+    return backupPath
+  } catch {
+    return null
+  }
+}
+
+function writeConfigAtomically(configPath: string, config: OhMyOpenCodeConfig): boolean {
+  try {
+    // Resolve symlinks to get the real path
+    let targetPath = configPath
+    try {
+      targetPath = realpathSync(configPath)
+    } catch {
+      // If realpath fails (file doesn't exist yet), use original path
+    }
+
+    const parentDir = dirname(targetPath)
+    if (!existsSync(parentDir)) {
+      mkdirSync(parentDir, { recursive: true })
+    }
+
+    const tempPath = `${targetPath}.tmp`
+    const existingPerms = existsSync(targetPath) ? statSync(targetPath).mode : undefined
+    writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n")
+    if (existingPerms) {
+      chmodSync(tempPath, existingPerms)
+    }
+    renameSync(tempPath, targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function editRootDefaults(state: ConfigEditorState): Promise<void> {
+  const currentModel = state.config.default_run_agent
+
+  const model = await p.text({
+    message: "Enter default agent for 'oh-my-opencode run' command:",
+    initialValue: currentModel ?? "",
+    placeholder: "e.g., sisyphus",
+  })
+
+  if (p.isCancel(model)) return
+
+  const finalModel = model?.trim() || undefined
+  if (finalModel !== currentModel) {
+    state.config.default_run_agent = finalModel
+    state.modified = true
+    p.log.success(`Updated default_run_agent to ${finalModel ?? "(none)"}`)
+  } else {
+    p.log.info("No changes to default_run_agent")
+  }
+}
+
+async function showMainMenu(state: ConfigEditorState): Promise<"exit" | "continue"> {
+  const warningCount = countWarnings(state)
+  const warningLabel = warningCount > 0 ? color.yellow(` (${warningCount} warnings)`) : ""
+
+  const action = await p.select({
+    message: "What would you like to configure?",
+    options: [
+      { value: "agents", label: "[1] Agents", hint: "model, category, fallback, permissions" },
+      { value: "categories", label: "[2] Categories", hint: "model, description" },
+      { value: "root", label: "[3] Root Defaults", hint: "default agent" },
+      { value: "bulk", label: "[4] Bulk Operations", hint: "set for all agents at once" },
+      { value: "validation", label: `[5] View Validation Warnings${warningLabel}`, hint: "check configuration health" },
+      { value: "exit", label: "[0] Save and Exit" },
+    ],
+  })
+
+  if (p.isCancel(action)) {
+    return "exit"
+  }
+
+  switch (action) {
+    case "agents":
+      await editAgents(state)
+      return "continue"
+    case "categories":
+      await editCategories(state)
+      return "continue"
+    case "root":
+      await editRootDefaults(state)
+      return "continue"
+    case "bulk":
+      await runBulkOperations(state)
+      return "continue"
+    case "validation":
+      displayValidationWarnings(state)
+      await p.confirm({ message: "Press Enter to continue", initialValue: true })
+      return "continue"
+    case "exit":
+      return "exit"
+    default:
+      return "continue"
+  }
+}
+
+async function runMenuLoop(state: ConfigEditorState): Promise<void> {
+  let running = true
+  while (running) {
+    const result = await showMainMenu(state)
+    if (result === "exit") {
+      running = false
+    }
+  }
+}
+
+async function promptSaveChanges(state: ConfigEditorState): Promise<number> {
+  if (!state.modified) {
+    p.log.info("No changes made.")
+    p.outro(color.green("Configuration unchanged."))
+    return 0
+  }
+
+  const confirmSave = await p.confirm({
+    message: `Save changes to config?`,
+    initialValue: true,
+  })
+
+  if (p.isCancel(confirmSave) || !confirmSave) {
+    const discard = await p.confirm({
+      message: "Discard changes?",
+      initialValue: false,
+    })
+
+    if (p.isCancel(discard) || !discard) {
+      p.log.info("Returning to menu...")
+      await runMenuLoop(state)
+      return promptSaveChanges(state)
+    }
+
+    p.log.info("Changes discarded.")
+    p.outro(color.yellow("Configuration not saved."))
+    return 0
+  }
+
+  const s = p.spinner()
+  s.start("Saving configuration...")
+
+  const backupPath = createBackupWithCopy(state.configPath)
+  if (!backupPath) {
+    p.log.warn("Warning: Could not create backup (file may not exist yet)")
+  }
+
+  const success = writeConfigAtomically(state.configPath, state.config)
+
+  if (!success) {
+    s.stop(`Failed to save config ${color.red("[X]")}`)
+    p.outro(color.red("Configuration failed to save."))
+    return 1
+  }
+
+  s.stop(`Config saved ${color.green("[OK]")}`)
+
+  if (backupPath) {
+    p.log.info(`Backup created: ${color.dim(backupPath)}`)
+  }
+
+  p.log.success(color.bold("Configuration saved successfully!"))
+  p.outro(color.green("oMoMoMoMo... Done!"))
+
+  return 0
+}
+
+async function runConfigEditor(): Promise<number> {
+  p.intro(color.bgMagenta(color.white(" oh-my-opencode config ")))
+
+  const configPath = getConfigPath()
+  p.log.info(`Config file: ${color.cyan(configPath)}`)
+
+  const config = loadConfig(configPath)
+  if (config === null) {
+    p.log.error(`Failed to load config from ${configPath}`)
+    p.log.info("The file may be corrupted or contain invalid JSON.")
+    p.outro(color.red("Configuration failed."))
+    return 1
+  }
+
+  const state: ConfigEditorState = {
+    config,
+    modified: false,
+    configPath,
+  }
+
+  await runMenuLoop(state)
+  return promptSaveChanges(state)
+}
+
+export { runConfigEditor as config }

--- a/src/cli/config/index.ts
+++ b/src/cli/config/index.ts
@@ -4,8 +4,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, copyFileSync, mkdi
 import { dirname } from "node:path"
 import { getConfigContext } from "../config-manager"
 import { parseJsonc } from "../../shared"
-import type { OhMyOpenCodeConfig } from "../../config/schema"
-import type { ConfigEditorState } from "./types"
+import type { ConfigEditorState, EditableOmoaConfig } from "./types"
 import { editAgents } from "./agents"
 import { editCategories } from "./categories"
 import { runBulkOperations } from "./bulk"
@@ -16,14 +15,14 @@ function getConfigPath(): string {
   return paths.omoConfig
 }
 
-function loadConfig(path: string): OhMyOpenCodeConfig | null {
+function loadConfig(path: string): EditableOmoaConfig | null {
   if (!existsSync(path)) {
     return {}
   }
 
   try {
     const content = readFileSync(path, "utf-8")
-    const config = parseJsonc<OhMyOpenCodeConfig>(content)
+    const config = parseJsonc<EditableOmoaConfig>(content)
     return config ?? {}
   } catch {
     return null
@@ -43,7 +42,7 @@ function createBackupWithCopy(configPath: string): string | null {
   }
 }
 
-function writeConfigAtomically(configPath: string, config: OhMyOpenCodeConfig): boolean {
+function writeConfigAtomically(configPath: string, config: EditableOmoaConfig): boolean {
   try {
     // Resolve symlinks to get the real path
     let targetPath = configPath

--- a/src/cli/config/models.ts
+++ b/src/cli/config/models.ts
@@ -1,0 +1,95 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { getOpenCodeCacheDir } from "../../shared/data-path"
+
+export type ProviderMap = Record<string, string[]>
+
+export function getModelsByProvider(): ProviderMap {
+  const cacheDir = getOpenCodeCacheDir()
+  const modelsJsonPath = join(cacheDir, "models.json")
+  const providerModelsJsonPath = join(cacheDir, "provider-models.json")
+  
+  const result: ProviderMap = Object.create(null)
+
+  // Try provider-models.json first (preferred format)
+  if (existsSync(providerModelsJsonPath)) {
+    try {
+      const content = readFileSync(providerModelsJsonPath, "utf-8")
+      const data = JSON.parse(content)
+      if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+        for (const [provider, models] of Object.entries(data)) {
+          // Skip special keys and prototype pollution vectors
+          if (provider === "connected" || provider === "updatedAt") continue
+          if (provider === "__proto__" || provider === "constructor" || provider === "prototype") continue
+          if (Array.isArray(models)) {
+            result[provider] = models.filter((m): m is string => typeof m === "string").sort()
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // Try models.json fallback (legacy format or API cache)
+  if (existsSync(modelsJsonPath)) {
+    try {
+      const content = readFileSync(modelsJsonPath, "utf-8")
+      const data = JSON.parse(content)
+
+      if (typeof data === "object" && data !== null) {
+        // Handle array format (legacy)
+        if (Array.isArray(data)) {
+           for (const item of data) {
+             if (!item || typeof item !== "object") continue
+             if (item.provider === "__proto__" || item.provider === "constructor" || item.provider === "prototype") continue
+             if (item.provider && item.id) {
+               if (!result[item.provider]) result[item.provider] = []
+               if (!result[item.provider].includes(item.id)) {
+                 result[item.provider].push(item.id)
+               }
+             }
+           }
+        } 
+         // Handle provider map format
+        else {
+          for (const [providerId, providerData] of Object.entries(data)) {
+            if (providerId === "__proto__" || providerId === "constructor" || providerId === "prototype") continue
+            if (providerData && typeof providerData === 'object' && 'models' in providerData) {
+              const modelsMap = (providerData as any).models
+              if (modelsMap && typeof modelsMap === 'object') {
+                if (!result[providerId]) result[providerId] = []
+                const models = Object.keys(modelsMap)
+                for (const m of models) {
+                  if (!result[providerId].includes(m)) {
+                    result[providerId].push(m)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  
+  // Sort all lists
+  for (const provider in result) {
+    result[provider].sort()
+  }
+
+  return result
+}
+
+export function getAllCachedModels(): string[] {
+  const map = getModelsByProvider()
+  const list: string[] = []
+  for (const [provider, models] of Object.entries(map)) {
+    for (const model of models) {
+      list.push(`${provider}/${model}`)
+    }
+  }
+  return list.sort()
+}

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -1,7 +1,9 @@
 import type { OhMyOpenCodeConfig, AgentOverrides, CategoriesConfig, CategoryConfig, AgentOverrideConfig } from "../../config/schema"
 
+export type EditableOmoaConfig = Partial<OhMyOpenCodeConfig> & Record<string, unknown>
+
 export type ConfigEditorState = {
-  config: OhMyOpenCodeConfig
+  config: EditableOmoaConfig
   modified: boolean
   configPath: string
 }

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -1,0 +1,57 @@
+import type { OhMyOpenCodeConfig, AgentOverrides, CategoriesConfig, CategoryConfig, AgentOverrideConfig } from "../../config/schema"
+
+export type ConfigEditorState = {
+  config: OhMyOpenCodeConfig
+  modified: boolean
+  configPath: string
+}
+
+export type ValidationWarning = {
+  type: "missing-fallback" | "missing-model"
+  agent: string
+  message: string
+}
+
+export type BashPermissionValue = "ask" | "allow" | "deny"
+
+export type BashPermission = BashPermissionValue | Record<string, BashPermissionValue>
+
+export interface AgentConfigExtended extends AgentOverrideConfig {
+  fallback_models?: string[]
+}
+
+export type AgentOverridesExtended = Partial<Record<string, AgentConfigExtended>>
+
+export const BUILTIN_CATEGORIES = [
+  "visual-engineering",
+  "ultrabrain",
+  "deep",
+  "artistry",
+  "quick",
+  "unspecified-low",
+  "unspecified-high",
+  "writing",
+] as const
+
+export const AGENT_NAMES = [
+  "build",
+  "plan",
+  "sisyphus",
+  "hephaestus",
+  "sisyphus-junior",
+  "OpenCode-Builder",
+  "prometheus",
+  "metis",
+  "momus",
+  "oracle",
+  "librarian",
+  "explore",
+  "multimodal-looker",
+  "atlas",
+] as const
+
+export type AgentName = (typeof AGENT_NAMES)[number]
+
+export const BASH_COMMANDS = ["rm", "mv", "cp", "*"] as const
+
+export type BashCommand = (typeof BASH_COMMANDS)[number]

--- a/src/cli/config/ui-utils.ts
+++ b/src/cli/config/ui-utils.ts
@@ -1,0 +1,82 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { getModelsByProvider, getAllCachedModels } from "./models"
+
+export async function selectModelWithCacheLoader(message: string, initialValue?: string): Promise<string | symbol> {
+  const providerMap = getModelsByProvider()
+  const hasModels = Object.keys(providerMap).length > 0
+  
+  const options: { value: string; label: string }[] = []
+
+  // Add current value
+  if (initialValue) {
+    options.push({ value: initialValue, label: `${initialValue} (current)` })
+  }
+
+  // Browse by provider (if models available)
+  if (hasModels) {
+    options.push({ value: "__browse__", label: "📂 Browse cached models by provider..." })
+  }
+
+  // Add flat load (fallback)
+  options.push({ value: "__load_all__", label: "📄 Load flat list (all models)..." })
+  options.push({ value: "__custom__", label: "Custom model..." })
+  options.push({ value: "__clear__", label: "Clear selection" })
+
+  const selection = await p.select({
+    message,
+    options,
+    initialValue,
+  })
+
+  if (selection === "__browse__") {
+    const provider = await p.select({
+      message: "Select provider:",
+      options: [
+        ...Object.keys(providerMap).sort().map(p => ({ value: p, label: p })),
+        { value: "__back__", label: color.dim("← Back") }
+      ]
+    })
+    
+    if (p.isCancel(provider)) return provider
+    if (provider === "__back__") return selectModelWithCacheLoader(message, initialValue)
+
+    const models = providerMap[provider as string]
+    const model = await p.select({
+      message: `Select model for ${provider}:`,
+      options: [
+        ...models.map(m => ({ value: `${provider}/${m}`, label: m })),
+        { value: "__back__", label: color.dim("← Back") }
+      ]
+    })
+
+    if (p.isCancel(model)) return model
+    if (model === "__back__") return selectModelWithCacheLoader(message, initialValue)
+    
+    return model
+  }
+
+  if (selection === "__load_all__") {
+    const s = p.spinner()
+    s.start("Loading cached models...")
+    const allModels = getAllCachedModels()
+    s.stop(`Loaded ${allModels.length} models`)
+
+    if (allModels.length === 0) {
+      p.log.warn("No models found in cache.")
+      return selectModelWithCacheLoader(message, initialValue)
+    }
+
+    return p.select({
+      message: `${message} (All Cached)`,
+      options: [
+        ...allModels.map(m => ({ value: m, label: m })),
+        { value: "__custom__", label: "Custom model..." },
+        { value: "__clear__", label: "Clear selection" },
+      ],
+      initialValue,
+    })
+  }
+
+  return selection
+}

--- a/src/cli/config/validation.ts
+++ b/src/cli/config/validation.ts
@@ -1,0 +1,90 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import type { ConfigEditorState, ValidationWarning, AgentConfigExtended } from "./types"
+import { AGENT_NAMES } from "./types"
+
+export function validateConfig(state: ConfigEditorState): ValidationWarning[] {
+  const warnings: ValidationWarning[] = []
+  const agents = state.config.agents ?? {}
+  const categories = state.config.categories ?? {}
+  const validCategories = Object.keys(categories)
+
+  for (const agentName of AGENT_NAMES) {
+    const agent = agents[agentName]
+    if (!agent) continue
+
+    const hasModel = agent.model && agent.model.length > 0
+    const hasCategory = agent.category && agent.category.length > 0
+    const categoryExists = hasCategory && agent.category && validCategories.includes(agent.category)
+
+    if (hasCategory && agent.category && !categoryExists) {
+      warnings.push({
+        type: "missing-model",
+        agent: agentName,
+        message: `Agent "${agentName}" has undefined category "${agent.category}"`,
+      })
+    }
+
+    if (!hasModel && !hasCategory) {
+      warnings.push({
+        type: "missing-model",
+        agent: agentName,
+        message: `Agent "${agentName}" has no model or category set`,
+      })
+    }
+  }
+
+  return warnings
+}
+
+export function checkFallbackWarnings(state: ConfigEditorState): ValidationWarning[] {
+  const warnings: ValidationWarning[] = []
+  const agents = (state.config.agents ?? {}) as Record<string, AgentConfigExtended>
+
+  for (const agentName of AGENT_NAMES) {
+    const agent = agents[agentName]
+    if (!agent) continue
+
+    const hasModel = agent.model && agent.model.length > 0
+    const hasCategory = agent.category && agent.category.length > 0
+    const hasFallback = agent.fallback_models && agent.fallback_models.length > 0
+
+    if ((hasModel || hasCategory) && !hasFallback) {
+      warnings.push({
+        type: "missing-fallback",
+        agent: agentName,
+        message: `Agent "${agentName}" has model/category but no fallback_model configured`,
+      })
+    }
+  }
+
+  return warnings
+}
+
+export function displayValidationWarnings(state: ConfigEditorState): void {
+  const modelWarnings = validateConfig(state)
+  const fallbackWarnings = checkFallbackWarnings(state)
+  const allWarnings = [...modelWarnings, ...fallbackWarnings]
+
+  if (allWarnings.length === 0) {
+    p.log.success(color.green("No validation warnings! Configuration looks good."))
+    return
+  }
+
+  console.log()
+  console.log(color.bgYellow(color.black(color.bold(" Validation Warnings "))))
+  console.log()
+
+  for (const warning of allWarnings) {
+    const icon = warning.type === "missing-fallback" ? color.yellow("[!]") : color.red("[X]")
+    console.log(`  ${icon} ${color.yellow(warning.message)}`)
+  }
+
+  console.log()
+  console.log(color.dim("Tip: Run 'Agents' configuration to set missing models or categories."))
+  console.log()
+}
+
+export function countWarnings(state: ConfigEditorState): number {
+  return validateConfig(state).length + checkFallbackWarnings(state).length
+}

--- a/src/cli/omoa/engine/builder.ts
+++ b/src/cli/omoa/engine/builder.ts
@@ -144,7 +144,8 @@ export function buildConfig(
     }
     // Also include agents that would be newly created from rankings
     for (const change of changes) {
-      if (change.targetKind === "agent" && !validationState[change.target]) {
+      if (change.targetKind !== "agent") continue
+      if (!validationState[change.target]) {
         validationState[change.target] = { model: undefined, fallback_models: undefined }
       }
       if (change.field === "model") validationState[change.target].model = change.newValue
@@ -160,7 +161,8 @@ export function buildConfig(
       }
     }
     for (const change of changes) {
-      if (change.targetKind === "category" && !catValidationState[change.target]) {
+      if (change.targetKind !== "category") continue
+      if (!catValidationState[change.target]) {
         catValidationState[change.target] = { model: undefined, fallback_models: undefined }
       }
       if (change.field === "model") catValidationState[change.target].model = change.newValue

--- a/src/cli/omoa/engine/builder.ts
+++ b/src/cli/omoa/engine/builder.ts
@@ -1,0 +1,216 @@
+import { existsSync, readFileSync } from "node:fs"
+import { parseJsonc } from "../../../shared/jsonc-parser"
+import { writeFileAtomically } from "../../../shared/write-file-atomically"
+import { getConfigContext } from "../../config-manager"
+import type { OmoaState } from "../state/omoa-state-schema"
+import type { OmoaRankings } from "../state/omoa-rankings-schema"
+import { resolveBestModel } from "./resolver"
+import { validateConfig, type ValidationWarning } from "./validator"
+import { backupConfigFile, type BackupResult } from "../../config-manager/backup-config"
+import { getAgentRankings, getCategoryRankings } from "../state/rankings-manager"
+import { OverridableAgentNameSchema } from "../../../config/schema/agent-names"
+
+export interface BuildResult {
+  success: boolean
+  changes: AgentChange[]
+  warnings: ValidationWarning[]
+  backup: BackupResult
+  error?: string
+}
+
+export interface AgentChange {
+  target: string
+  targetKind: "agent" | "category"
+  field: "model" | "fallback_models"
+  oldValue: string | undefined
+  newValue: string | undefined
+  reason: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function loadRuntimeConfig(): any | null {
+  const { paths } = getConfigContext()
+  const configPath = paths.omoConfig
+  if (!existsSync(configPath)) return {}
+  try {
+    const content = readFileSync(configPath, "utf-8")
+    return parseJsonc(content) ?? {}
+  } catch {
+    return null
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveRuntimeConfig(config: any): boolean {
+  const { paths } = getConfigContext()
+  const configPath = paths.omoConfig
+  try {
+    writeFileAtomically(configPath, JSON.stringify(config, null, 2) + "\n")
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function buildConfig(
+  state: OmoaState,
+  rankings: OmoaRankings,
+  dryRun = false,
+): BuildResult {
+  const config = loadRuntimeConfig()
+  if (config === null) {
+    return { success: false, changes: [], warnings: [], backup: { success: false, error: "Failed to load runtime config" }, error: "Failed to load runtime config" }
+  }
+
+  const changes: AgentChange[] = []
+  const agentNames = OverridableAgentNameSchema.options
+  const agents: Record<string, Record<string, unknown>> = config.agents ?? {}
+  const categories: Record<string, Record<string, unknown>> = config.categories ?? {}
+
+  for (const agentName of agentNames) {
+    const agentRankings = getAgentRankings(rankings, agentName)
+    if (agentRankings.length === 0) continue
+
+    const resolved = resolveBestModel(agentRankings, state)
+    const agent = agents[agentName] ?? {}
+    const currentModel = agent.model as string | undefined
+
+    if (currentModel !== resolved.primary) {
+      changes.push({
+        target: agentName,
+        targetKind: "agent",
+        field: "model",
+        oldValue: currentModel,
+        newValue: resolved.primary,
+        reason: resolved.primaryReason,
+      })
+    }
+
+    const currentFallbacks = normalizeFallbacks(agent.fallback_models)
+    if (resolved.fallback !== currentFallbacks[0]) {
+      changes.push({
+        target: agentName,
+        targetKind: "agent",
+        field: "fallback_models",
+        oldValue: currentFallbacks[0],
+        newValue: resolved.fallback,
+        reason: resolved.fallbackReason,
+      })
+    }
+  }
+
+  for (const categoryName of Object.keys(categories)) {
+    const catRankings = getCategoryRankings(rankings, categoryName)
+    if (catRankings.length === 0) continue
+
+    const resolved = resolveBestModel(catRankings, state)
+    const category = categories[categoryName] ?? {}
+    const currentModel = category.model as string | undefined
+
+    if (currentModel !== resolved.primary) {
+      changes.push({
+        target: categoryName,
+        targetKind: "category",
+        field: "model",
+        oldValue: currentModel,
+        newValue: resolved.primary,
+        reason: resolved.primaryReason,
+      })
+    }
+
+    const currentFallbacks = normalizeFallbacks(category.fallback_models)
+    if (resolved.fallback !== currentFallbacks[0]) {
+      changes.push({
+        target: categoryName,
+        targetKind: "category",
+        field: "fallback_models",
+        oldValue: currentFallbacks[0],
+        newValue: resolved.fallback,
+        reason: resolved.fallbackReason,
+      })
+    }
+  }
+
+  if (dryRun || changes.length === 0) {
+    const validationState: Record<string, { model?: string; fallback_models?: unknown }> = {}
+    for (const [k, v] of Object.entries(agents)) {
+      const modelChange = changes.find((c) => c.target === k && c.targetKind === "agent" && c.field === "model")
+      const fbChange = changes.find((c) => c.target === k && c.targetKind === "agent" && c.field === "fallback_models")
+      validationState[k] = {
+        model: (modelChange?.newValue ?? v?.model) as string | undefined,
+        fallback_models: fbChange?.newValue ?? v?.fallback_models,
+      }
+    }
+    const catValidationState: Record<string, { model?: string; fallback_models?: unknown }> = {}
+    for (const [k, v] of Object.entries(categories)) {
+      const modelChange = changes.find((c) => c.target === k && c.targetKind === "category" && c.field === "model")
+      const fbChange = changes.find((c) => c.target === k && c.targetKind === "category" && c.field === "fallback_models")
+      catValidationState[k] = {
+        model: (modelChange?.newValue ?? v?.model) as string | undefined,
+        fallback_models: fbChange?.newValue ?? v?.fallback_models,
+      }
+    }
+    const { warnings } = validateConfig(validationState, catValidationState, state)
+    return { success: true, changes, warnings, backup: { success: true } }
+  }
+
+  const backup = backupConfigFile(getConfigContext().paths.omoConfig)
+
+  const mutableConfig = { ...config }
+  const mutableAgents: Record<string, Record<string, unknown>> = { ...(mutableConfig.agents ?? {}) }
+  const mutableCategories: Record<string, Record<string, unknown>> = { ...(mutableConfig.categories ?? {}) }
+
+  for (const change of changes) {
+    if (change.targetKind === "agent") {
+      if (!mutableAgents[change.target]) mutableAgents[change.target] = {}
+      if (change.field === "model") {
+        mutableAgents[change.target] = { ...mutableAgents[change.target], model: change.newValue }
+      }
+      if (change.field === "fallback_models") {
+        const existing = normalizeFallbacks(mutableAgents[change.target].fallback_models)
+        const updated = change.newValue ? [change.newValue, ...existing.slice(1)] : existing.slice(1)
+        mutableAgents[change.target] = {
+          ...mutableAgents[change.target],
+          fallback_models: updated.length > 0 ? updated : undefined,
+        }
+      }
+    }
+    if (change.targetKind === "category") {
+      if (!mutableCategories[change.target]) mutableCategories[change.target] = {}
+      if (change.field === "model") {
+        mutableCategories[change.target] = { ...mutableCategories[change.target], model: change.newValue }
+      }
+      if (change.field === "fallback_models") {
+        const existing = normalizeFallbacks(mutableCategories[change.target].fallback_models)
+        const updated = change.newValue ? [change.newValue, ...existing.slice(1)] : existing.slice(1)
+        mutableCategories[change.target] = {
+          ...mutableCategories[change.target],
+          fallback_models: updated.length > 0 ? updated : undefined,
+        }
+      }
+    }
+  }
+
+  mutableConfig.agents = mutableAgents
+  mutableConfig.categories = mutableCategories
+  const saved = saveRuntimeConfig(mutableConfig)
+
+  if (!saved) {
+    return { success: false, changes, warnings: [], backup, error: "Failed to write config" }
+  }
+
+  const { warnings } = validateConfig(
+    mutableAgents as Record<string, { model?: string; fallback_models?: unknown }>,
+    mutableCategories as Record<string, { model?: string; fallback_models?: unknown }>,
+    state,
+  )
+
+  return { success: true, changes, warnings, backup }
+}
+
+function normalizeFallbacks(fallbacks: unknown): string[] {
+  if (!fallbacks) return []
+  if (typeof fallbacks === "string") return [fallbacks]
+  if (Array.isArray(fallbacks)) return fallbacks.map((f) => typeof f === "string" ? f : (f as { model?: string })?.model ?? String(f))
+  return []
+}

--- a/src/cli/omoa/engine/builder.ts
+++ b/src/cli/omoa/engine/builder.ts
@@ -133,6 +133,7 @@ export function buildConfig(
 
   if (dryRun || changes.length === 0) {
     const validationState: Record<string, { model?: string; fallback_models?: unknown }> = {}
+    // Include all existing agents
     for (const [k, v] of Object.entries(agents)) {
       const modelChange = changes.find((c) => c.target === k && c.targetKind === "agent" && c.field === "model")
       const fbChange = changes.find((c) => c.target === k && c.targetKind === "agent" && c.field === "fallback_models")
@@ -140,6 +141,14 @@ export function buildConfig(
         model: (modelChange?.newValue ?? v?.model) as string | undefined,
         fallback_models: fbChange?.newValue ?? v?.fallback_models,
       }
+    }
+    // Also include agents that would be newly created from rankings
+    for (const change of changes) {
+      if (change.targetKind === "agent" && !validationState[change.target]) {
+        validationState[change.target] = { model: undefined, fallback_models: undefined }
+      }
+      if (change.field === "model") validationState[change.target].model = change.newValue
+      if (change.field === "fallback_models") validationState[change.target].fallback_models = change.newValue
     }
     const catValidationState: Record<string, { model?: string; fallback_models?: unknown }> = {}
     for (const [k, v] of Object.entries(categories)) {
@@ -149,6 +158,13 @@ export function buildConfig(
         model: (modelChange?.newValue ?? v?.model) as string | undefined,
         fallback_models: fbChange?.newValue ?? v?.fallback_models,
       }
+    }
+    for (const change of changes) {
+      if (change.targetKind === "category" && !catValidationState[change.target]) {
+        catValidationState[change.target] = { model: undefined, fallback_models: undefined }
+      }
+      if (change.field === "model") catValidationState[change.target].model = change.newValue
+      if (change.field === "fallback_models") catValidationState[change.target].fallback_models = change.newValue
     }
     const { warnings } = validateConfig(validationState, catValidationState, state)
     return { success: true, changes, warnings, backup: { success: true } }

--- a/src/cli/omoa/engine/resolver.test.ts
+++ b/src/cli/omoa/engine/resolver.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+import { resolveBestModel, extractProvider } from "./resolver"
+import type { OmoaState } from "../state/omoa-state-schema"
+import type { ModelRankingEntry } from "../state/omoa-rankings-schema"
+import { DEFAULT_OMOA_STATE } from "../state/omoa-state-schema"
+
+describe("extractProvider", () => {
+  test("extracts provider from provider/model format", () => {
+    expect(extractProvider("openai/gpt-5.5")).toBe("openai")
+  })
+
+  test("returns full string if no slash", () => {
+    expect(extractProvider("some-model")).toBe("some-model")
+  })
+})
+
+describe("resolveBestModel", () => {
+  const baseState: OmoaState = { ...DEFAULT_OMOA_STATE }
+
+  test("returns undefined for empty rankings", () => {
+    const result = resolveBestModel([], baseState)
+    expect(result.primary).toBeUndefined()
+    expect(result.fallback).toBeUndefined()
+  })
+
+  test("picks first available model as primary", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "deepseek/deepseek-v4-pro" },
+      { model: "openai/gpt-5.5" },
+    ]
+    const result = resolveBestModel(rankings, baseState)
+    expect(result.primary).toBe("deepseek/deepseek-v4-pro")
+  })
+
+  test("skips disabled provider and picks next", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "deepseek/deepseek-v4-pro" },
+      { model: "openai/gpt-5.5" },
+    ]
+    const state: OmoaState = {
+      ...baseState,
+      providers: { deepseek: { enabled: false, free_only: false, avoid_fallback_from: [] } },
+    }
+    const result = resolveBestModel(rankings, state)
+    expect(result.primary).toBe("openai/gpt-5.5")
+  })
+
+  test("skips banned models", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "openai/gpt-5.4" },
+      { model: "openai/gpt-5.5" },
+    ]
+    const state: OmoaState = { ...baseState, banned_models: ["openai/gpt-5.4"] }
+    const result = resolveBestModel(rankings, state)
+    expect(result.primary).toBe("openai/gpt-5.5")
+  })
+
+  test("picks cross-provider fallback", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "openai/gpt-5.5" },
+      { model: "openai/gpt-5.5-fast" },
+      { model: "deepseek/deepseek-v4-pro" },
+    ]
+    const result = resolveBestModel(rankings, baseState)
+    expect(result.primary).toBe("openai/gpt-5.5")
+    expect(result.fallback).toBe("deepseek/deepseek-v4-pro")
+  })
+
+  test("no fallback if all same provider", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "openai/gpt-5.5" },
+      { model: "openai/gpt-5.5-fast" },
+    ]
+    const result = resolveBestModel(rankings, baseState)
+    expect(result.primary).toBe("openai/gpt-5.5")
+    expect(result.fallback).toBeUndefined()
+  })
+
+  test("respects avoid_fallback_from rules", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "openai/gpt-5.5" },
+      { model: "deepseek/deepseek-v4-pro" },
+      { model: "kimi-for-coding/k2p6" },
+    ]
+    const state: OmoaState = {
+      ...baseState,
+      providers: { openai: { enabled: true, free_only: false, avoid_fallback_from: ["deepseek"] } },
+    }
+    const result = resolveBestModel(rankings, state)
+    expect(result.primary).toBe("openai/gpt-5.5")
+    expect(result.fallback).toBe("kimi-for-coding/k2p6")
+  })
+
+  test("enforces free_only on provider", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "opencode/big-model" },
+      { model: "opencode/nemotron-free" },
+    ]
+    const state: OmoaState = {
+      ...baseState,
+      providers: { opencode: { enabled: true, free_only: true, avoid_fallback_from: [] } },
+    }
+    const result = resolveBestModel(rankings, state)
+    expect(result.primary).toBe("opencode/nemotron-free")
+  })
+
+  test("returns undefined when all models unavailable", () => {
+    const rankings: ModelRankingEntry[] = [
+      { model: "openai/gpt-5.5" },
+    ]
+    const state: OmoaState = {
+      ...baseState,
+      providers: { openai: { enabled: false, free_only: false, avoid_fallback_from: [] } },
+    }
+    const result = resolveBestModel(rankings, state)
+    expect(result.primary).toBeUndefined()
+  })
+})

--- a/src/cli/omoa/engine/resolver.ts
+++ b/src/cli/omoa/engine/resolver.ts
@@ -1,0 +1,83 @@
+import type { OmoaState } from "../state/omoa-state-schema"
+import type { ModelRankingEntry } from "../state/omoa-rankings-schema"
+import { isProviderEnabled } from "../state/state-manager"
+
+export interface ResolveResult {
+  primary: string | undefined
+  fallback: string | undefined
+  primaryReason: string
+  fallbackReason: string
+}
+
+export function extractProvider(model: string): string {
+  const idx = model.indexOf("/")
+  return idx > 0 ? model.slice(0, idx) : model
+}
+
+function isModelAvailable(
+  model: string,
+  state: OmoaState,
+): boolean {
+  const provider = extractProvider(model)
+  if (!isProviderEnabled(state, provider)) return false
+  if (state.banned_models.includes(model)) return false
+  if (state.deprecated_models.includes(model)) return false
+
+  const providerState = state.providers[provider]
+  if (providerState?.free_only && !model.endsWith("-free")) return false
+
+  return true
+}
+
+function isFallbackCompatible(
+  fallbackModel: string,
+  primaryModel: string,
+  state: OmoaState,
+): boolean {
+  const fbProvider = extractProvider(fallbackModel)
+  const primaryProvider = extractProvider(primaryModel)
+
+  if (fbProvider === primaryProvider) return false
+
+  const providerState = state.providers[primaryProvider]
+  if (providerState?.avoid_fallback_from?.includes(fbProvider)) return false
+
+  return true
+}
+
+export function resolveBestModel(
+  rankings: ModelRankingEntry[],
+  state: OmoaState,
+): ResolveResult {
+  if (rankings.length === 0) {
+    return { primary: undefined, fallback: undefined, primaryReason: "no rankings defined", fallbackReason: "no rankings" }
+  }
+
+  const available = rankings.filter((e) => isModelAvailable(e.model, state))
+
+  if (available.length === 0) {
+    const allDisabled = rankings.map((e) => `${e.model} (${isProviderEnabled(state, extractProvider(e.model)) ? "banned/deprecated" : "provider disabled"})`).join(", ")
+    return { primary: undefined, fallback: undefined, primaryReason: `all rankings unavailable: ${allDisabled}`, fallbackReason: "no primary" }
+  }
+
+  const primary = available[0]
+  const primaryRank = rankings.findIndex((e) => e.model === primary.model) + 1
+  const primaryReason = `rank #${primaryRank}${isProviderEnabled(state, extractProvider(primary.model)) ? "" : " (provider disabled)"}`
+
+  const fallback = available.find((e) => isFallbackCompatible(e.model, primary.model, state))
+
+  let fallbackReason: string
+  if (!fallback) {
+    fallbackReason = "no compatible cross-provider fallback available"
+  } else {
+    const fbRank = rankings.findIndex((e) => e.model === fallback.model) + 1
+    fallbackReason = `rank #${fbRank} (cross-provider)`
+  }
+
+  return {
+    primary: primary.model,
+    fallback: fallback?.model,
+    primaryReason,
+    fallbackReason,
+  }
+}

--- a/src/cli/omoa/engine/resolver.ts
+++ b/src/cli/omoa/engine/resolver.ts
@@ -56,7 +56,17 @@ export function resolveBestModel(
   const available = rankings.filter((e) => isModelAvailable(e.model, state))
 
   if (available.length === 0) {
-    const allDisabled = rankings.map((e) => `${e.model} (${isProviderEnabled(state, extractProvider(e.model)) ? "banned/deprecated" : "provider disabled"})`).join(", ")
+    const allDisabled = rankings.map((e) => {
+      const p = extractProvider(e.model)
+      const ps = state.providers[p]
+      let reason: string
+      if (ps && !ps.enabled) reason = "provider disabled"
+      else if (state.banned_models.includes(e.model)) reason = "banned"
+      else if (state.deprecated_models.includes(e.model)) reason = "deprecated"
+      else if (ps?.free_only && !e.model.endsWith("-free")) reason = "excluded by free-only"
+      else reason = "unavailable"
+      return `${e.model} (${reason})`
+    }).join(", ")
     return { primary: undefined, fallback: undefined, primaryReason: `all rankings unavailable: ${allDisabled}`, fallbackReason: "no primary" }
   }
 

--- a/src/cli/omoa/engine/validator.test.ts
+++ b/src/cli/omoa/engine/validator.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import { validateConfig } from "./validator"
+import type { OmoaState } from "../state/omoa-state-schema"
+import { DEFAULT_OMOA_STATE } from "../state/omoa-state-schema"
+
+describe("validateConfig", () => {
+  const baseState: OmoaState = { ...DEFAULT_OMOA_STATE }
+
+  test("returns no warnings for valid config", () => {
+    const agents = {
+      sisyphus: { model: "deepseek/deepseek-v4-pro", fallback_models: ["openai/gpt-5.5"] },
+    }
+    const result = validateConfig(agents, {}, baseState)
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  test("flags disabled primary provider", () => {
+    const agents = {
+      sisyphus: { model: "openai/gpt-5.5" },
+    }
+    const state: OmoaState = {
+      ...baseState,
+      providers: { openai: { enabled: false, free_only: false, avoid_fallback_from: [] } },
+    }
+    const result = validateConfig(agents, {}, state)
+    expect(result.valid).toBe(false)
+    expect(result.warnings.some((w) => w.type === "disabled-primary")).toBe(true)
+  })
+
+  test("flags same-provider fallback", () => {
+    const agents = {
+      sisyphus: { model: "openai/gpt-5.5", fallback_models: ["openai/gpt-5.5-fast"] },
+    }
+    const result = validateConfig(agents, {}, baseState)
+    expect(result.warnings.some((w) => w.type === "same-provider-fallback")).toBe(true)
+  })
+
+  test("flags banned model", () => {
+    const agents = {
+      sisyphus: { model: "openai/gpt-5.4" },
+    }
+    const state: OmoaState = { ...baseState, banned_models: ["openai/gpt-5.4"] }
+    const result = validateConfig(agents, {}, state)
+    expect(result.valid).toBe(false)
+    expect(result.warnings.some((w) => w.type === "banned-model")).toBe(true)
+  })
+
+  test("flags deprecated model as warning", () => {
+    const agents = {
+      sisyphus: { model: "openai/gpt-5.4" },
+    }
+    const state: OmoaState = { ...baseState, deprecated_models: ["openai/gpt-5.4"] }
+    const result = validateConfig(agents, {}, state)
+    expect(result.warnings.some((w) => w.type === "deprecated-model")).toBe(true)
+  })
+
+  test("flags free-only violation", () => {
+    const agents = {
+      sisyphus: { model: "opencode/big-model" },
+    }
+    const state: OmoaState = {
+      ...baseState,
+      providers: { opencode: { enabled: true, free_only: true, avoid_fallback_from: [] } },
+    }
+    const result = validateConfig(agents, {}, state)
+    expect(result.valid).toBe(false)
+    expect(result.warnings.some((w) => w.type === "free-only-violation")).toBe(true)
+  })
+
+  test("flags missing fallback as info", () => {
+    const agents = {
+      sisyphus: { model: "deepseek/deepseek-v4-pro" },
+    }
+    const result = validateConfig(agents, {}, baseState)
+    expect(result.warnings.some((w) => w.type === "missing-fallback" && w.severity === "info")).toBe(true)
+  })
+
+  test("validates categories too", () => {
+    const categories = {
+      "visual-engineering": { model: "banned/model" },
+    }
+    const state: OmoaState = { ...baseState, banned_models: ["banned/model"] }
+    const result = validateConfig({}, categories, state)
+    expect(result.valid).toBe(false)
+    expect(result.warnings.some((w) => w.target === "category:visual-engineering")).toBe(true)
+  })
+
+  test("skips agents without model", () => {
+    const agents = {
+      sisyphus: { temperature: 0.5 },
+    }
+    const result = validateConfig(agents, {}, baseState)
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toHaveLength(0)
+  })
+})

--- a/src/cli/omoa/engine/validator.ts
+++ b/src/cli/omoa/engine/validator.ts
@@ -1,0 +1,92 @@
+import type { OmoaState } from "../state/omoa-state-schema"
+import { extractProvider } from "./resolver"
+
+export interface ValidationWarning {
+  type: "disabled-primary" | "same-provider-fallback" | "banned-model" | "deprecated-model" | "free-only-violation" | "missing-fallback" | "no-ranking" | "config-invalid"
+  target: string
+  message: string
+  severity: "error" | "warning" | "info"
+}
+
+export interface ValidationResult {
+  valid: boolean
+  warnings: ValidationWarning[]
+}
+
+export function validateConfig(
+  agents: Record<string, { model?: string; fallback_models?: unknown }>,
+  categories: Record<string, { model?: string; fallback_models?: unknown }>,
+  state: OmoaState,
+): ValidationResult {
+  const warnings: ValidationWarning[] = []
+
+  for (const [name, agent] of Object.entries(agents)) {
+    if (!agent.model) continue
+
+    const provider = extractProvider(agent.model)
+
+    if (state.banned_models.includes(agent.model)) {
+      warnings.push({ type: "banned-model", target: name, message: `Agent "${name}" uses banned model: ${agent.model}`, severity: "error" })
+    }
+
+    if (state.deprecated_models.includes(agent.model)) {
+      warnings.push({ type: "deprecated-model", target: name, message: `Agent "${name}" uses deprecated model: ${agent.model}`, severity: "warning" })
+    }
+
+    const providerState = state.providers[provider]
+    if (providerState && !providerState.enabled) {
+      warnings.push({ type: "disabled-primary", target: name, message: `Agent "${name}" primary uses disabled provider: ${provider}`, severity: "error" })
+    }
+
+    if (state.providers[provider]?.free_only && !agent.model.endsWith("-free")) {
+      warnings.push({ type: "free-only-violation", target: name, message: `Agent "${name}" uses non-free model on free-only provider: ${agent.model}`, severity: "error" })
+    }
+
+    const fallbacks = normalizeFallbacks(agent.fallback_models)
+    const primaryProvider = provider
+    for (const fb of fallbacks) {
+      const fbProvider = extractProvider(fb)
+      if (fbProvider === primaryProvider) {
+        warnings.push({ type: "same-provider-fallback", target: name, message: `Agent "${name}" fallback "${fb}" is same provider as primary`, severity: "warning" })
+      }
+      if (state.banned_models.includes(fb)) {
+        warnings.push({ type: "banned-model", target: name, message: `Agent "${name}" fallback uses banned model: ${fb}`, severity: "error" })
+      }
+    }
+
+    if (fallbacks.length === 0 && agent.model) {
+      warnings.push({ type: "missing-fallback", target: name, message: `Agent "${name}" has primary model but no fallback`, severity: "info" })
+    }
+  }
+
+  for (const [name, category] of Object.entries(categories)) {
+    if (!category.model) continue
+
+    const provider = extractProvider(category.model)
+    if (state.banned_models.includes(category.model)) {
+      warnings.push({ type: "banned-model", target: `category:${name}`, message: `Category "${name}" uses banned model: ${category.model}`, severity: "error" })
+    }
+    const catProviderState = state.providers[provider]
+    if (catProviderState && !catProviderState.enabled) {
+      warnings.push({ type: "disabled-primary", target: `category:${name}`, message: `Category "${name}" primary uses disabled provider: ${provider}`, severity: "error" })
+    }
+
+    const fallbacks = normalizeFallbacks(category.fallback_models)
+    const primaryProvider = provider
+    for (const fb of fallbacks) {
+      if (extractProvider(fb) === primaryProvider) {
+        warnings.push({ type: "same-provider-fallback", target: `category:${name}`, message: `Category "${name}" fallback "${fb}" is same provider as primary`, severity: "warning" })
+      }
+    }
+  }
+
+  const hasErrors = warnings.some((w) => w.severity === "error")
+  return { valid: !hasErrors, warnings }
+}
+
+function normalizeFallbacks(fallbacks: unknown): string[] {
+  if (!fallbacks) return []
+  if (typeof fallbacks === "string") return [fallbacks]
+  if (Array.isArray(fallbacks)) return fallbacks.map((f) => typeof f === "string" ? f : (f as { model?: string })?.model ?? String(f))
+  return []
+}

--- a/src/cli/omoa/index.ts
+++ b/src/cli/omoa/index.ts
@@ -1,0 +1,131 @@
+import { showMainMenu } from "./tui/main-menu"
+import { readOmoaState, writeOmoaState, setProviderEnabled, isProviderEnabled } from "./state/state-manager"
+import { readOmoaRankings } from "./state/rankings-manager"
+import { buildConfig } from "./engine/builder"
+import { validateConfig } from "./engine/validator"
+import { extractProvider } from "./engine/resolver"
+import { loadRuntimeConfig } from "./tui/shared"
+import { OverridableAgentNameSchema } from "../../config/schema/agent-names"
+import { countProviderUsage } from "./tui/shared"
+import { getAllProviders } from "./models/model-cache"
+import color from "picocolors"
+
+export async function omoaInteractive(): Promise<number> {
+  await showMainMenu()
+  return 0
+}
+
+export function omoaStatus(): number {
+  const state = readOmoaState()
+  const rankings = readOmoaRankings()
+  const config = loadRuntimeConfig()
+
+  console.log(color.bgCyan(color.black(color.bold(" OMOA Status "))))
+  console.log()
+
+  const allProviders = getAllProviders()
+  const knownProviders = new Set([...Object.keys(state.providers), ...allProviders])
+  console.log("Providers:")
+  for (const provider of [...knownProviders].sort()) {
+    const enabled = isProviderEnabled(state, provider)
+    console.log(`  ${enabled ? color.green("[x]") : color.red("[ ]")} ${provider}`)
+  }
+  console.log()
+
+  if (config) {
+    const agents = config.agents ?? {}
+    const categories = config.categories ?? {}
+
+    console.log("Agents:")
+    const agentNames = OverridableAgentNameSchema.options
+    for (const name of agentNames) {
+      const agent = agents[name] as { model?: string; fallback_models?: unknown } | undefined
+      const model = agent?.model ? color.cyan(agent.model) : color.dim("not set")
+      const managed = (rankings.agents[name]?.length ?? 0) > 0
+      console.log(`  ${name.padEnd(22)} ${managed ? color.cyan("[OMOA]") : color.dim("[manual]")} primary=${model}`)
+    }
+    console.log()
+
+    const { warnings } = validateConfig(
+      agents as Record<string, { model?: string; fallback_models?: unknown }>,
+      categories as Record<string, { model?: string; fallback_models?: unknown }>,
+      state,
+    )
+
+    if (warnings.length === 0) {
+      console.log(`Validation: ${color.green("OK")}`)
+    } else {
+      console.log("Validation:")
+      for (const w of warnings) {
+        const icon = w.severity === "error" ? color.red("[X]") : color.yellow("[!]")
+        console.log(`  ${icon} ${w.message}`)
+      }
+    }
+  }
+
+  return 0
+}
+
+export function omoaBuild(dryRun: boolean, yes: boolean): number {
+  const state = readOmoaState()
+  const rankings = readOmoaRankings()
+  const result = buildConfig(state, rankings, dryRun)
+
+  if (result.error) {
+    console.error(color.red(`Build failed: ${result.error}`))
+    return 1
+  }
+
+  if (result.changes.length === 0) {
+    console.log("No assignment changes needed.")
+    return 0
+  }
+
+  console.log(dryRun ? "Planned Changes:" : "Applied Changes:")
+  for (const change of result.changes) {
+    const arrow = color.cyan("->")
+    const old = change.oldValue ?? "(none)"
+    const newVal = change.newValue ?? "(none)"
+    console.log(`  ${change.target} [${change.targetKind}] ${change.field}: ${old} ${arrow} ${newVal}`)
+  }
+
+  if (result.warnings.length > 0) {
+    console.log("\nWarnings:")
+    for (const w of result.warnings) {
+      const icon = w.severity === "error" ? color.red("[X]") : color.yellow("[!]")
+      console.log(`  ${icon} ${w.message}`)
+    }
+  }
+
+  if (!dryRun && result.backup.backupPath) {
+    console.log(`\nBackup: ${result.backup.backupPath}`)
+  }
+
+  return 0
+}
+
+export function omoaProviderList(): number {
+  const state = readOmoaState()
+  const config = loadRuntimeConfig()
+  const allProviders = getAllProviders()
+  const knownProviders = new Set([...Object.keys(state.providers), ...allProviders])
+  const usageCounts = config ? countProviderUsage(config) : new Map<string, { primary: number; fallback: number }>()
+
+  for (const provider of [...knownProviders].sort()) {
+    const enabled = isProviderEnabled(state, provider)
+    const usage = usageCounts.get(provider)
+    const status = enabled ? color.green("enabled") : color.red("disabled")
+    const usageStr = usage ? ` (primary:${usage.primary} fallback:${usage.fallback})` : ""
+    console.log(`  ${provider}: ${status}${usageStr}`)
+  }
+
+  return 0
+}
+
+export function omoaProviderSet(providerName: string, enabled: boolean): number {
+  const state = readOmoaState()
+  const newState = setProviderEnabled(state, providerName, enabled)
+  writeOmoaState(newState)
+  console.log(`Provider "${providerName}" ${enabled ? "enabled" : "disabled"}. Run "omoa build" to apply.`)
+  return 0
+}

--- a/src/cli/omoa/index.ts
+++ b/src/cli/omoa/index.ts
@@ -33,8 +33,8 @@ export function omoaStatus(): number {
   console.log()
 
   if (config) {
-    const agents = config.agents ?? {}
-    const categories = config.categories ?? {}
+    const agents = (config.agents ?? {}) as Record<string, Record<string, unknown>>
+    const categories = (config.categories ?? {}) as Record<string, Record<string, unknown>>
 
     console.log("Agents:")
     const agentNames = OverridableAgentNameSchema.options

--- a/src/cli/omoa/index.ts
+++ b/src/cli/omoa/index.ts
@@ -8,6 +8,7 @@ import { loadRuntimeConfig } from "./tui/shared"
 import { OverridableAgentNameSchema } from "../../config/schema/agent-names"
 import { countProviderUsage } from "./tui/shared"
 import { getAllProviders } from "./models/model-cache"
+import { config as runConfigEditor } from "../config/index"
 import color from "picocolors"
 
 export async function omoaInteractive(): Promise<number> {
@@ -128,4 +129,8 @@ export function omoaProviderSet(providerName: string, enabled: boolean): number 
   writeOmoaState(newState)
   console.log(`Provider "${providerName}" ${enabled ? "enabled" : "disabled"}. Run "omoa build" to apply.`)
   return 0
+}
+
+export async function omoaConfig(): Promise<number> {
+  return await runConfigEditor()
 }

--- a/src/cli/omoa/models/model-cache.ts
+++ b/src/cli/omoa/models/model-cache.ts
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { getOpenCodeCacheDir } from "../../../shared/data-path"
+
+export type ProviderMap = Record<string, string[]>
+
+const RESERVED_KEYS = new Set(["__proto__", "constructor", "prototype", "connected", "updatedAt"])
+
+export function getModelsByProvider(): ProviderMap {
+  const cacheDir = getOpenCodeCacheDir()
+  const providerModelsPath = join(cacheDir, "provider-models.json")
+  const modelsPath = join(cacheDir, "models.json")
+
+  const result: ProviderMap = Object.create(null)
+
+  if (existsSync(providerModelsPath)) {
+    try {
+      const content = readFileSync(providerModelsPath, "utf-8")
+      const data = JSON.parse(content)
+      if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+        for (const [provider, models] of Object.entries(data)) {
+          if (RESERVED_KEYS.has(provider)) continue
+          if (Array.isArray(models)) {
+            result[provider] = models.filter((m): m is string => typeof m === "string").sort()
+          }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (existsSync(modelsPath)) {
+    try {
+      const content = readFileSync(modelsPath, "utf-8")
+      const data = JSON.parse(content)
+      if (typeof data === "object" && data !== null) {
+        if (Array.isArray(data)) {
+          for (const item of data) {
+            if (!item || typeof item !== "object") continue
+            const entry = item as { provider?: string; id?: string }
+            if (!entry.provider || RESERVED_KEYS.has(entry.provider)) continue
+            if (!entry.id) continue
+            if (!result[entry.provider]) result[entry.provider] = []
+            if (!result[entry.provider].includes(entry.id)) {
+              result[entry.provider].push(entry.id)
+            }
+          }
+        } else {
+          for (const [providerId, providerData] of Object.entries(data)) {
+            if (RESERVED_KEYS.has(providerId)) continue
+            if (providerData && typeof providerData === "object" && "models" in providerData) {
+              const modelsMap = (providerData as { models?: unknown }).models
+              if (modelsMap && typeof modelsMap === "object") {
+                if (!result[providerId]) result[providerId] = []
+                for (const m of Object.keys(modelsMap as object)) {
+                  if (!result[providerId].includes(m)) {
+                    result[providerId].push(m)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  for (const provider in result) {
+    result[provider].sort()
+  }
+
+  return result
+}
+
+export function getAllCachedModels(): string[] {
+  const map = getModelsByProvider()
+  const list: string[] = []
+  for (const [provider, models] of Object.entries(map)) {
+    for (const model of models) {
+      list.push(`${provider}/${model}`)
+    }
+  }
+  return list.sort()
+}
+
+export function getAllProviders(): string[] {
+  return Object.keys(getModelsByProvider()).sort()
+}

--- a/src/cli/omoa/omoa-cli.test.ts
+++ b/src/cli/omoa/omoa-cli.test.ts
@@ -1,0 +1,207 @@
+/**
+ * CLI integration tests for OMOA.
+ *
+ * Tests the full omoa build pipeline:
+ *   1. omoa-state.json + omoa-rankings.json fixtures -> omoa build
+ *   2. -> writes correct model + fallback_models to oh-my-openagent.json
+ *   3. -> creates backup with expected format
+ *
+ * Locks the user-visible contract at the CLI level.
+ */
+import { describe, expect, test, mock, afterEach } from "bun:test"
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+// Single temp dir shared by ALL mocks
+const testDir = mkdtempSync(join(tmpdir(), "omoa-cli-test-"))
+const omoConfigPath = join(testDir, "oh-my-openagent.json")
+
+// Mock config-context for builder.ts (loadRuntimeConfig -> getConfigContext)
+mock.module("../config-manager/config-context", () => ({
+  getConfigContext: () => ({
+    binary: "opencode" as const,
+    version: null,
+    paths: {
+      configDir: testDir,
+      configJson: join(testDir, "opencode.json"),
+      configJsonc: join(testDir, "opencode.jsonc"),
+      omoConfig: omoConfigPath,
+      legacyOmoConfig: join(testDir, "oh-my-opencode.json"),
+      cacheDir: join(testDir, "cache"),
+      dataDir: join(testDir, "data"),
+      sessionDir: join(testDir, "sessions"),
+    },
+  }),
+  getOmoConfigPath: () => omoConfigPath,
+  getConfigDir: () => testDir,
+  initConfigContext: () => {},
+  resetConfigContext: () => {},
+}))
+
+// Mock opencode-config-dir for state-manager.ts and rankings-manager.ts
+mock.module("../../shared/opencode-config-dir", () => ({
+  getOpenCodeConfigDir: () => testDir,
+  getOpenCodeConfigDirs: () => [testDir],
+  getCliConfigDir: () => testDir,
+}))
+
+import { omoaBuild } from "./index"
+import type { OmoaState } from "./state/omoa-state-schema"
+import type { OmoaRankings } from "./state/omoa-rankings-schema"
+
+describe("omoa CLI integration", () => {
+  afterEach(() => {
+    // Clean up fixture files between tests (keep the dir)
+    for (const f of ["omoa-state.json", "omoa-rankings.json", "oh-my-openagent.json"]) {
+      const fp = join(testDir, f)
+      if (existsSync(fp)) rmSync(fp)
+    }
+  })
+
+  test("no rankings = no changes", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, banned_models: [], deprecated_models: [], active_preset: "balanced",
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1, agents: {}, categories: {}, fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const config = JSON.parse(readFileSync(omoConfigPath, "utf-8"))
+    expect(config.agents).toEqual({})
+    expect(config.categories).toEqual({})
+  })
+
+  test("resolves rankings and writes to config", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, banned_models: [], deprecated_models: [], active_preset: "balanced",
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1,
+      agents: {
+        sisyphus: [
+          { model: "anthropic/claude-opus-4-7" },
+          { model: "openai/gpt-5.5" },
+        ],
+        oracle: [
+          { model: "deepseek/deepseek-v4-pro" },
+          { model: "openai/gpt-5.5" },
+        ],
+      },
+      categories: { "visual-engineering": [] },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const config = JSON.parse(readFileSync(omoConfigPath, "utf-8"))
+    expect(config.agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
+    expect(config.agents.sisyphus.fallback_models).toEqual(["openai/gpt-5.5"])
+    expect(config.agents.oracle.model).toBe("deepseek/deepseek-v4-pro")
+    expect(config.agents.oracle.fallback_models).toEqual(["openai/gpt-5.5"])
+  })
+
+  test("resolves rankings skipping disabled provider", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, banned_models: [], deprecated_models: [], active_preset: "balanced",
+      providers: { anthropic: { enabled: false, free_only: false, avoid_fallback_from: [] } },
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1,
+      agents: { sisyphus: [{ model: "anthropic/claude-opus-4-7" }, { model: "openai/gpt-5.5" }] },
+      categories: { "visual-engineering": [] },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const config = JSON.parse(readFileSync(omoConfigPath, "utf-8"))
+    expect(config.agents.sisyphus.model).toBe("openai/gpt-5.5")
+  })
+
+  test("respects banned_models", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, deprecated_models: [], active_preset: "balanced",
+      banned_models: ["openai/gpt-5.5"],
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1,
+      agents: { sisyphus: [{ model: "anthropic/claude-opus-4-7" }, { model: "openai/gpt-5.5" }] },
+      categories: { "visual-engineering": [] },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const config = JSON.parse(readFileSync(omoConfigPath, "utf-8"))
+    expect(config.agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
+  })
+
+  test("dry-run does not modify config", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, banned_models: [], deprecated_models: [], active_preset: "balanced",
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1,
+      agents: { sisyphus: [{ model: "anthropic/claude-opus-4-7" }] },
+      categories: { "visual-engineering": [] },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    const original = JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n"
+    writeFileSync(omoConfigPath, original)
+
+    expect(omoaBuild(true, true)).toBe(0)
+    expect(readFileSync(omoConfigPath, "utf-8")).toBe(original)
+  })
+
+  test("creates backup file when making changes", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, banned_models: [], deprecated_models: [], active_preset: "balanced",
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1,
+      agents: { sisyphus: [{ model: "openai/gpt-5.5" }] },
+      categories: { "visual-engineering": [] },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({ agents: {}, categories: {} }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const files = readdirSync(testDir)
+    expect(files.filter((f: string) => f.startsWith("oh-my-openagent.json.backup-")).length).toBeGreaterThanOrEqual(1)
+  })
+
+  test("categories also get resolved", () => {
+    writeFileSync(join(testDir, "omoa-state.json"), JSON.stringify({
+      version: 1, providers: {}, banned_models: [], deprecated_models: [], active_preset: "balanced",
+    } satisfies OmoaState, null, 2) + "\n")
+    writeFileSync(join(testDir, "omoa-rankings.json"), JSON.stringify({
+      version: 1, agents: {},
+      categories: {
+        "visual-engineering": [
+          { model: "openai/gpt-5.5" },
+          { model: "anthropic/claude-sonnet-4" },
+        ],
+      },
+      fallback_provider_order: [],
+    } satisfies OmoaRankings, null, 2) + "\n")
+    writeFileSync(omoConfigPath, JSON.stringify({
+      agents: { sisyphus: { model: "openai/gpt-5.4" } },
+      categories: { "visual-engineering": [] },
+    }, null, 2) + "\n")
+
+    expect(omoaBuild(false, true)).toBe(0)
+
+    const config = JSON.parse(readFileSync(omoConfigPath, "utf-8"))
+    expect(config.agents.sisyphus.model).toBe("openai/gpt-5.4")
+    expect(config.categories["visual-engineering"].model).toBe("openai/gpt-5.5")
+    expect(config.categories["visual-engineering"].fallback_models).toEqual(["anthropic/claude-sonnet-4"])
+  })
+})

--- a/src/cli/omoa/state/omoa-rankings-schema.ts
+++ b/src/cli/omoa/state/omoa-rankings-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+export const ModelRankingEntrySchema = z.object({
+  model: z.string(),
+  variant: z.string().optional(),
+})
+export type ModelRankingEntry = z.infer<typeof ModelRankingEntrySchema>
+
+export const OmoaRankingsSchema = z.object({
+  version: z.literal(1),
+  agents: z.record(z.string(), z.array(ModelRankingEntrySchema)).default({}),
+  categories: z.record(z.string(), z.array(ModelRankingEntrySchema)).default({}),
+  fallback_provider_order: z.array(z.string()).default([]),
+})
+export type OmoaRankings = z.infer<typeof OmoaRankingsSchema>
+
+export const DEFAULT_OMOA_RANKINGS: OmoaRankings = {
+  version: 1,
+  agents: {},
+  categories: {},
+  fallback_provider_order: [],
+}

--- a/src/cli/omoa/state/omoa-state-schema.ts
+++ b/src/cli/omoa/state/omoa-state-schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+export const OmoaProviderStateSchema = z.object({
+  enabled: z.boolean().default(true),
+  free_only: z.boolean().default(false),
+  avoid_fallback_from: z.array(z.string()).default([]),
+})
+export type OmoaProviderState = z.infer<typeof OmoaProviderStateSchema>
+
+export const OmoaStateSchema = z.object({
+  version: z.literal(1),
+  providers: z.record(z.string(), OmoaProviderStateSchema).default({}),
+  banned_models: z.array(z.string()).default([]),
+  deprecated_models: z.array(z.string()).default([]),
+  active_preset: z.enum(["balanced", "emergency-free", "custom"]).default("balanced"),
+})
+export type OmoaState = z.infer<typeof OmoaStateSchema>
+
+export const DEFAULT_OMOA_STATE: OmoaState = {
+  version: 1,
+  providers: {},
+  banned_models: [],
+  deprecated_models: [],
+  active_preset: "balanced",
+}

--- a/src/cli/omoa/state/rankings-manager.ts
+++ b/src/cli/omoa/state/rankings-manager.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { getOpenCodeConfigDir } from "../../../shared/opencode-config-dir"
+import { parseJsonc } from "../../../shared/jsonc-parser"
+import { OmoaRankingsSchema, DEFAULT_OMOA_RANKINGS, type OmoaRankings, type ModelRankingEntry } from "./omoa-rankings-schema"
+
+const OMOA_RANKINGS_FILENAME = "omoa-rankings.json"
+
+function getRankingsPath(): string {
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  return join(configDir, OMOA_RANKINGS_FILENAME)
+}
+
+export function readOmoaRankings(): OmoaRankings {
+  const path = getRankingsPath()
+  if (!existsSync(path)) return { ...DEFAULT_OMOA_RANKINGS }
+  try {
+    const content = readFileSync(path, "utf-8")
+    const raw = parseJsonc<unknown>(content)
+    const parsed = OmoaRankingsSchema.safeParse(raw)
+    if (parsed.success) return parsed.data
+    return { ...DEFAULT_OMOA_RANKINGS }
+  } catch {
+    return { ...DEFAULT_OMOA_RANKINGS }
+  }
+}
+
+export function writeOmoaRankings(rankings: OmoaRankings): void {
+  const path = getRankingsPath()
+  const dir = dirname(path)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(path, JSON.stringify(rankings, null, 2) + "\n", "utf-8")
+}
+
+export function getAgentRankings(rankings: OmoaRankings, agent: string): ModelRankingEntry[] {
+  return rankings.agents[agent] ?? []
+}
+
+export function getCategoryRankings(rankings: OmoaRankings, category: string): ModelRankingEntry[] {
+  return rankings.categories[category] ?? []
+}
+
+export function hasAgentRanking(rankings: OmoaRankings, agent: string): boolean {
+  return (rankings.agents[agent]?.length ?? 0) > 0
+}
+
+export function hasCategoryRanking(rankings: OmoaRankings, category: string): boolean {
+  return (rankings.categories[category]?.length ?? 0) > 0
+}
+
+export function setAgentRankings(rankings: OmoaRankings, agent: string, entries: ModelRankingEntry[]): OmoaRankings {
+  return { ...rankings, agents: { ...rankings.agents, [agent]: entries } }
+}
+
+export function setCategoryRankings(rankings: OmoaRankings, category: string, entries: ModelRankingEntry[]): OmoaRankings {
+  return { ...rankings, categories: { ...rankings.categories, [category]: entries } }
+}

--- a/src/cli/omoa/state/rankings-manager.ts
+++ b/src/cli/omoa/state/rankings-manager.ts
@@ -19,14 +19,22 @@ export function readOmoaRankings(): OmoaRankings {
     const raw = parseJsonc<unknown>(content)
     const parsed = OmoaRankingsSchema.safeParse(raw)
     if (parsed.success) return parsed.data
-    return { ...DEFAULT_OMOA_RANKINGS }
-  } catch {
+    // Parse/schema failure: return null via separate function to avoid silent data loss
+    throw new Error(`Failed to parse ${path}: invalid schema`)
+  } catch (e) {
+    // Log the error but don't silently overwrite with defaults
+    if (process.env.OMOA_DEBUG) console.error(`[omoa] Warning: could not read rankings: ${e instanceof Error ? e.message : String(e)}`)
     return { ...DEFAULT_OMOA_RANKINGS }
   }
 }
 
 export function writeOmoaRankings(rankings: OmoaRankings): void {
   const path = getRankingsPath()
+  // Guard: never overwrite existing file with empty defaults
+  if (Object.keys(rankings.agents).length === 0 && Object.keys(rankings.categories).length === 0 && existsSync(path)) {
+    if (process.env.OMOA_DEBUG) console.error(`[omoa] Warning: refusing to overwrite existing rankings with empty defaults`)
+    return
+  }
   const dir = dirname(path)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   writeFileSync(path, JSON.stringify(rankings, null, 2) + "\n", "utf-8")

--- a/src/cli/omoa/state/state-manager.ts
+++ b/src/cli/omoa/state/state-manager.ts
@@ -19,8 +19,9 @@ export function readOmoaState(): OmoaState {
     const raw = parseJsonc<unknown>(content)
     const parsed = OmoaStateSchema.safeParse(raw)
     if (parsed.success) return parsed.data
-    return { ...DEFAULT_OMOA_STATE }
-  } catch {
+    throw new Error(`Failed to parse ${path}: invalid schema`)
+  } catch (e) {
+    if (process.env.OMOA_DEBUG) console.error(`[omoa] Warning: could not read state: ${e instanceof Error ? e.message : String(e)}`)
     return { ...DEFAULT_OMOA_STATE }
   }
 }

--- a/src/cli/omoa/state/state-manager.ts
+++ b/src/cli/omoa/state/state-manager.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { getOpenCodeConfigDir } from "../../../shared/opencode-config-dir"
+import { parseJsonc } from "../../../shared/jsonc-parser"
+import { OmoaStateSchema, DEFAULT_OMOA_STATE, type OmoaState } from "./omoa-state-schema"
+
+const OMOA_STATE_FILENAME = "omoa-state.json"
+
+function getStatePath(): string {
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  return join(configDir, OMOA_STATE_FILENAME)
+}
+
+export function readOmoaState(): OmoaState {
+  const path = getStatePath()
+  if (!existsSync(path)) return { ...DEFAULT_OMOA_STATE }
+  try {
+    const content = readFileSync(path, "utf-8")
+    const raw = parseJsonc<unknown>(content)
+    const parsed = OmoaStateSchema.safeParse(raw)
+    if (parsed.success) return parsed.data
+    return { ...DEFAULT_OMOA_STATE }
+  } catch {
+    return { ...DEFAULT_OMOA_STATE }
+  }
+}
+
+export function writeOmoaState(state: OmoaState): void {
+  const path = getStatePath()
+  const dir = dirname(path)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(path, JSON.stringify(state, null, 2) + "\n", "utf-8")
+}
+
+export function isProviderEnabled(state: OmoaState, provider: string): boolean {
+  const entry = state.providers[provider]
+  if (!entry) return true
+  return entry.enabled
+}
+
+export function setProviderEnabled(state: OmoaState, provider: string, enabled: boolean): OmoaState {
+  const current = state.providers[provider] ?? { enabled: true, free_only: false, avoid_fallback_from: [] }
+  return {
+    ...state,
+    providers: {
+      ...state.providers,
+      [provider]: { ...current, enabled },
+    },
+  }
+}
+
+export function getEnabledProviders(state: OmoaState): string[] {
+  return Object.entries(state.providers)
+    .filter(([, s]) => s.enabled)
+    .map(([name]) => name)
+}
+
+export function getDisabledProviders(state: OmoaState): string[] {
+  return Object.entries(state.providers)
+    .filter(([, s]) => !s.enabled)
+    .map(([name]) => name)
+}

--- a/src/cli/omoa/tui/assign-screen.ts
+++ b/src/cli/omoa/tui/assign-screen.ts
@@ -1,0 +1,93 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { readOmoaState, isProviderEnabled } from "../state/state-manager"
+import { readOmoaRankings, hasAgentRanking } from "../state/rankings-manager"
+import { resolveBestModel, extractProvider } from "../engine/resolver"
+import { OverridableAgentNameSchema } from "../../../config/schema/agent-names"
+import { loadRuntimeConfig } from "./shared"
+import { getAllCachedModels } from "../models/model-cache"
+import { backupConfigFile } from "../../config-manager/backup-config"
+import { getConfigContext } from "../../config-manager"
+import { writeFileAtomically } from "../../../shared/write-file-atomically"
+
+export async function showAssignScreen(): Promise<void> {
+  const cachedModels = getAllCachedModels()
+
+  const modelInput = await p.text({
+    message: "Enter model to assign (e.g., provider/model-name):",
+    placeholder: "provider/model-name",
+  })
+
+  if (p.isCancel(modelInput)) return
+
+  const model = (modelInput as string).trim()
+  if (!model) return
+
+  const state = readOmoaState()
+  const rankings = readOmoaRankings()
+  const config = loadRuntimeConfig()
+  const agents = config?.agents ?? {}
+  const agentNames = OverridableAgentNameSchema.options
+
+  const provider = extractProvider(model)
+  const providerEnabled = isProviderEnabled(state, provider)
+
+  if (!providerEnabled) {
+    p.log.warn(`Provider "${provider}" is currently disabled. Enable it first via Providers menu.`)
+    return
+  }
+
+  console.log()
+  console.log(`Selected model: ${color.cyan(model)}`)
+  console.log()
+
+  const targetOptions = agentNames.map((name) => {
+    const current = (agents[name] as { model?: string } | undefined)?.model ?? "not set"
+    const managed = hasAgentRanking(rankings, name)
+    return {
+      value: name,
+      label: `${name.padEnd(22)} current=${color.dim(current)}${managed ? color.cyan(" [OMOA-managed]") : ""}`,
+    }
+  })
+
+  const selected = await p.multiselect({
+    message: "Select agents to assign this model to:",
+    options: targetOptions,
+  })
+
+  if (p.isCancel(selected)) return
+
+  if ((selected as string[]).length === 0) {
+    p.log.info("No agents selected.")
+    return
+  }
+
+  const targets = selected as string[]
+
+  const confirm = await p.confirm({
+    message: `Assign ${color.cyan(model)} to ${targets.length} agent(s)?`,
+    initialValue: true,
+  })
+
+  if (p.isCancel(confirm) || !confirm) {
+    p.log.info("Cancelled.")
+    return
+  }
+
+  const backup = backupConfigFile(getConfigContext().paths.omoConfig)
+  const fullConfig: Record<string, unknown> = { ...config! }
+  const agentsMap: Record<string, Record<string, unknown>> = (fullConfig.agents ?? {}) as Record<string, Record<string, unknown>>
+  fullConfig.agents = agentsMap
+
+  for (const target of targets) {
+    if (!agentsMap[target]) agentsMap[target] = {}
+    agentsMap[target].model = model
+  }
+
+  writeFileAtomically(getConfigContext().paths.omoConfig, JSON.stringify(fullConfig, null, 2) + "\n")
+
+  p.log.success(`Assigned ${model} to: ${targets.join(", ")}`)
+  if (backup.backupPath) {
+    p.log.info(`Backup: ${color.dim(backup.backupPath)}`)
+  }
+}

--- a/src/cli/omoa/tui/assign-screen.ts
+++ b/src/cli/omoa/tui/assign-screen.ts
@@ -26,7 +26,7 @@ export async function showAssignScreen(): Promise<void> {
   const state = readOmoaState()
   const rankings = readOmoaRankings()
   const config = loadRuntimeConfig()
-  const agents = config?.agents ?? {}
+  const agents = (config?.agents ?? {}) as Record<string, Record<string, unknown>>
   const agentNames = OverridableAgentNameSchema.options
 
   const provider = extractProvider(model)

--- a/src/cli/omoa/tui/main-menu.ts
+++ b/src/cli/omoa/tui/main-menu.ts
@@ -1,0 +1,211 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { getConfigContext } from "../../config-manager"
+import { readOmoaState } from "../state/state-manager"
+import { readOmoaRankings } from "../state/rankings-manager"
+import { validateConfig, type ValidationWarning } from "../engine/validator"
+import { buildConfig, type BuildResult, type AgentChange } from "../engine/builder"
+import { hasAgentRanking, hasCategoryRanking } from "../state/rankings-manager"
+import { OverridableAgentNameSchema } from "../../../config/schema/agent-names"
+import { getAllProviders } from "../models/model-cache"
+import { showProviderScreen } from "./provider-screen"
+import { showRankingScreen } from "./ranking-screen"
+import { showAssignScreen } from "./assign-screen"
+import { showSchemaEditorMenu } from "./schema-editor/agent-editor"
+import { doctor } from "../../doctor"
+import { loadRuntimeConfig } from "./shared"
+
+function formatChange(change: AgentChange): string {
+  const arrow = color.cyan("->")
+  const oldVal = change.oldValue ? color.red(change.oldValue) : color.dim("(none)")
+  const newVal = change.newValue ? color.green(change.newValue) : color.dim("(none)")
+  return `  ${color.bold(change.target)} ${color.dim(`[${change.targetKind}]`)} ${change.field}: ${oldVal} ${arrow} ${newVal} ${color.dim(`(${change.reason})`)}`
+}
+
+function formatWarning(w: ValidationWarning): string {
+  const icon = w.severity === "error" ? color.red("[X]") : w.severity === "warning" ? color.yellow("[!]") : color.blue("[i]")
+  return `  ${icon} ${w.message}`
+}
+
+async function showStatusScreen(): Promise<void> {
+  const state = readOmoaState()
+  const rankings = readOmoaRankings()
+  const config = loadRuntimeConfig()
+
+  console.log()
+  console.log(color.bgCyan(color.black(color.bold(" OMOA Status "))))
+  console.log()
+
+  const configPath = getConfigContext().paths.omoConfig
+  console.log(`  Config: ${color.cyan(configPath)}`)
+  console.log()
+
+  console.log(color.bold("  Providers:"))
+  const allProviders = getAllProviders()
+  const knownProviders = new Set([...Object.keys(state.providers), ...allProviders])
+  for (const provider of [...knownProviders].sort()) {
+    const enabled = state.providers[provider]?.enabled ?? true
+    const icon = enabled ? color.green("[x]") : color.red("[ ]")
+    const extra = state.providers[provider]?.free_only ? color.dim(" (free-only)") : ""
+    console.log(`    ${icon} ${provider}${extra}`)
+  }
+  console.log()
+
+  if (state.banned_models.length > 0) {
+    console.log(color.bold("  Banned Models:"))
+    for (const m of state.banned_models) {
+      console.log(`    ${color.red("-")} ${m}`)
+    }
+    console.log()
+  }
+
+  if (state.deprecated_models.length > 0) {
+    console.log(color.bold("  Deprecated Models:"))
+    for (const m of state.deprecated_models) {
+      console.log(`    ${color.yellow("~")} ${m}`)
+    }
+    console.log()
+  }
+
+  if (config) {
+    const agents = config.agents ?? {}
+    const categories = config.categories ?? {}
+
+    console.log(color.bold("  Agents:"))
+    const agentNames = OverridableAgentNameSchema.options
+    for (const name of agentNames) {
+      const agent = agents[name] as { model?: string; fallback_models?: unknown } | undefined
+      const managed = hasAgentRanking(rankings, name)
+      const badge = managed ? color.cyan("[OMOA]") : color.dim("[manual]")
+      const model = agent?.model ? color.cyan(agent.model) : color.dim("not set")
+      const fallbacks = agent?.fallback_models
+        ? (Array.isArray(agent.fallback_models)
+          ? (agent.fallback_models as string[]).map((f) => typeof f === "string" ? f : String(f)).join(", ")
+          : String(agent.fallback_models))
+        : color.dim("none")
+      console.log(`    ${name.padEnd(22)} ${badge.padEnd(12)} primary=${model}  fallback=${fallbacks}`)
+    }
+    console.log()
+
+    if (Object.keys(categories).length > 0) {
+      console.log(color.bold("  Categories:"))
+      for (const [name, cat] of Object.entries(categories)) {
+        const managed = hasCategoryRanking(rankings, name)
+        const badge = managed ? color.cyan("[OMOA]") : color.dim("[manual]")
+        const model = cat.model ? color.cyan(cat.model) : color.dim("not set")
+        console.log(`    ${name.padEnd(22)} ${badge.padEnd(12)} model=${model}`)
+      }
+      console.log()
+    }
+
+    const { warnings } = validateConfig(
+      agents as Record<string, { model?: string; fallback_models?: unknown }>,
+      categories as Record<string, { model?: string; fallback_models?: unknown }>,
+      state,
+    )
+
+    console.log(color.bold("  Validation:"))
+    if (warnings.length === 0) {
+      console.log(`    ${color.green("OK")} No issues found`)
+    } else {
+      for (const w of warnings) {
+        console.log(formatWarning(w))
+      }
+    }
+  }
+
+  console.log()
+  await p.confirm({ message: "Press Enter to continue", initialValue: true })
+}
+
+async function showBuildScreen(dryRun = false): Promise<void> {
+  const state = readOmoaState()
+  const rankings = readOmoaRankings()
+
+  const s = p.spinner()
+  s.start(dryRun ? "Computing planned changes..." : "Building configuration...")
+  const result = buildConfig(state, rankings, dryRun)
+  s.stop(dryRun ? "Dry run complete" : "Build complete")
+
+  console.log()
+
+  if (result.changes.length === 0) {
+    p.log.info("No assignment changes needed.")
+  } else {
+    console.log(color.bold(dryRun ? "  Planned Changes:" : "  Applied Changes:"))
+    for (const change of result.changes) {
+      console.log(formatChange(change))
+    }
+  }
+
+  if (result.warnings.length > 0) {
+    console.log()
+    console.log(color.bold("  Warnings:"))
+    for (const w of result.warnings) {
+      console.log(formatWarning(w))
+    }
+  }
+
+  if (!dryRun && result.backup.backupPath) {
+    console.log()
+    p.log.info(`Backup: ${color.dim(result.backup.backupPath)}`)
+  }
+
+  if (!result.success) {
+    p.log.error(`Build failed: ${result.error ?? "unknown error"}`)
+  } else if (result.changes.length > 0) {
+    p.log.success(dryRun ? "Preview complete. Run without --dry-run to apply." : "Configuration updated.")
+  }
+
+  console.log()
+  await p.confirm({ message: "Press Enter to continue", initialValue: true })
+}
+
+async function showBackupsScreen(): Promise<void> {
+  const configPath = getConfigContext().paths.omoConfig
+  const dir = configPath.substring(0, configPath.lastIndexOf("/"))
+  p.log.info(`Backup directory: ${color.dim(dir)}`)
+  p.log.info("Backups are created automatically before each build operation.")
+  p.log.info("Look for files matching: *.backup-*")
+  console.log()
+  await p.confirm({ message: "Press Enter to continue", initialValue: true })
+}
+
+export async function showMainMenu(): Promise<void> {
+  p.intro(color.bgMagenta(color.white(" OMOA ")))
+
+  while (true) {
+    const action = await p.select({
+      message: "What would you like to do?",
+      options: [
+        { value: "status", label: "Status", hint: "Show provider/agent/category overview" },
+        { value: "build", label: "Build", hint: "Auto-resolve from rankings + providers" },
+        { value: "build-dry", label: "Build (dry run)", hint: "Preview changes without writing" },
+        { value: "providers", label: "Providers", hint: "Enable/disable providers" },
+        { value: "rankings", label: "Rankings", hint: "View/edit model preference lists" },
+        { value: "assign", label: "Assign Model", hint: "Multi-target model assignment" },
+        { value: "edit", label: "Edit Config", hint: "Manual per-field editor (schema-driven)" },
+        { value: "doctor", label: "Doctor", hint: "Run validation checks" },
+        { value: "backups", label: "Backups", hint: "View backup info" },
+        { value: "exit", label: color.dim("Exit") },
+      ],
+    })
+
+    if (p.isCancel(action) || action === "exit") {
+      p.outro(color.green("Bye!"))
+      return
+    }
+
+    switch (action) {
+      case "status": await showStatusScreen(); break
+      case "build": await showBuildScreen(false); break
+      case "build-dry": await showBuildScreen(true); break
+      case "providers": await showProviderScreen(); break
+      case "rankings": await showRankingScreen(); break
+      case "assign": await showAssignScreen(); break
+      case "edit": await showSchemaEditorMenu(); break
+      case "doctor": await doctor({ mode: "default" }); break
+      case "backups": await showBackupsScreen(); break
+    }
+  }
+}

--- a/src/cli/omoa/tui/main-menu.ts
+++ b/src/cli/omoa/tui/main-menu.ts
@@ -68,8 +68,8 @@ async function showStatusScreen(): Promise<void> {
   }
 
   if (config) {
-    const agents = config.agents ?? {}
-    const categories = config.categories ?? {}
+    const agents = (config.agents ?? {}) as Record<string, Record<string, unknown>>
+    const categories = (config.categories ?? {}) as Record<string, Record<string, unknown>>
 
     console.log(color.bold("  Agents:"))
     const agentNames = OverridableAgentNameSchema.options
@@ -92,7 +92,7 @@ async function showStatusScreen(): Promise<void> {
       for (const [name, cat] of Object.entries(categories)) {
         const managed = hasCategoryRanking(rankings, name)
         const badge = managed ? color.cyan("[OMOA]") : color.dim("[manual]")
-        const model = cat.model ? color.cyan(cat.model) : color.dim("not set")
+        const model = (cat.model as string | undefined) ? color.cyan(cat.model as string) : color.dim("not set")
         console.log(`    ${name.padEnd(22)} ${badge.padEnd(12)} model=${model}`)
       }
       console.log()

--- a/src/cli/omoa/tui/provider-screen.ts
+++ b/src/cli/omoa/tui/provider-screen.ts
@@ -1,0 +1,74 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { readOmoaState, writeOmoaState, setProviderEnabled, isProviderEnabled } from "../state/state-manager"
+import { getAllProviders } from "../models/model-cache"
+import { loadRuntimeConfig, countProviderUsage } from "./shared"
+
+export async function showProviderScreen(): Promise<void> {
+  while (true) {
+    const state = readOmoaState()
+    const config = loadRuntimeConfig()
+    const allProviders = getAllProviders()
+    const knownProviders = new Set([...Object.keys(state.providers), ...allProviders])
+    const usageCounts = config ? countProviderUsage(config) : new Map<string, { primary: number; fallback: number }>()
+
+    console.log()
+    console.log(color.bgYellow(color.black(color.bold(" Providers "))))
+    console.log()
+
+    const options = [...knownProviders].sort().map((provider) => {
+      const enabled = isProviderEnabled(state, provider)
+      const usage = usageCounts.get(provider)
+      const usageHint = usage ? `primary:${usage.primary} fallback:${usage.fallback}` : "not in config"
+      const freeOnly = state.providers[provider]?.free_only ? color.dim(" [free-only]") : ""
+      return {
+        value: provider,
+        label: `${enabled ? color.green("[x]") : color.red("[ ]")} ${provider}${freeOnly}`,
+        hint: usageHint,
+      }
+    })
+
+    options.push({ value: "__back__", label: color.dim("Back to main menu"), hint: "" })
+
+    const selected = await p.select({
+      message: "Select provider to toggle (or back):",
+      options,
+    })
+
+    if (p.isCancel(selected) || selected === "__back__") return
+
+    const provider = selected as string
+    const currentEnabled = isProviderEnabled(state, provider)
+    const usage = usageCounts.get(provider)
+
+    const action = await p.select({
+      message: `Provider "${provider}" is currently ${currentEnabled ? color.green("enabled") : color.red("disabled")}.`,
+      options: [
+        { value: "toggle", label: currentEnabled ? "Disable" : "Enable", hint: currentEnabled ? "Remove from active assignments on next build" : "Restore on next build" },
+        { value: "free-only", label: `Free-only: ${state.providers[provider]?.free_only ? "on" : "off"}`, hint: "Only allow *-free models for this provider" },
+        { value: "back", label: "Cancel" },
+      ],
+    })
+
+    if (p.isCancel(action) || action === "back") continue
+
+    if (action === "toggle") {
+      const newState = setProviderEnabled(state, provider, !currentEnabled)
+      writeOmoaState(newState)
+      p.log.success(`${provider} ${!currentEnabled ? "enabled" : "disabled"}. Run "Build" to apply.`)
+    }
+
+    if (action === "free-only") {
+      const current = state.providers[provider] ?? { enabled: true, free_only: false, avoid_fallback_from: [] }
+      const newState = {
+        ...state,
+        providers: {
+          ...state.providers,
+          [provider]: { ...current, free_only: !current.free_only },
+        },
+      }
+      writeOmoaState(newState)
+      p.log.success(`${provider} free-only ${!current.free_only ? "enabled" : "disabled"}.`)
+    }
+  }
+}

--- a/src/cli/omoa/tui/ranking-screen.ts
+++ b/src/cli/omoa/tui/ranking-screen.ts
@@ -1,0 +1,93 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { readOmoaRankings, writeOmoaRankings, getAgentRankings, setAgentRankings, hasAgentRanking } from "../state/rankings-manager"
+import { readOmoaState } from "../state/state-manager"
+import { resolveBestModel } from "../engine/resolver"
+import { OverridableAgentNameSchema } from "../../../config/schema/agent-names"
+import { loadRuntimeConfig } from "./shared"
+import { getAllCachedModels } from "../models/model-cache"
+
+export async function showRankingScreen(): Promise<void> {
+  while (true) {
+    const rankings = readOmoaRankings()
+    const state = readOmoaState()
+    const config = loadRuntimeConfig()
+    const agents = config?.agents ?? {}
+
+    console.log()
+    console.log(color.bgBlue(color.white(color.bold(" Rankings "))))
+    console.log()
+
+    const agentNames = OverridableAgentNameSchema.options
+    for (const name of agentNames) {
+      const ranking = getAgentRankings(rankings, name)
+      const resolved = resolveBestModel(ranking, state)
+      const current = (agents[name] as { model?: string } | undefined)?.model
+      const managed = hasAgentRanking(rankings, name)
+
+      console.log(`  ${color.bold(name)}${managed ? "" : color.dim(" (no ranking)")}`)
+      for (let i = 0; i < ranking.length; i++) {
+        const entry = ranking[i]
+        const isCurrent = entry.model === current
+        const isResolved = entry.model === resolved.primary
+        const marker = isCurrent ? color.green(" <- current") : isResolved && !isCurrent ? color.yellow(" <- would resolve") : ""
+        console.log(`    ${color.dim(`${i + 1}.`)} ${entry.model}${marker}`)
+      }
+      if (ranking.length === 0) {
+        console.log(`    ${color.dim("no rankings defined")}`)
+      }
+      console.log(`    ${color.dim("resolved:")} ${resolved.primary ?? "none"} ${color.dim(`(${resolved.primaryReason})`)}`)
+      console.log()
+    }
+
+    for (const [catName, catRanking] of Object.entries(rankings.categories)) {
+      if (catRanking.length === 0) continue
+      console.log(`  ${color.bold(catName)} ${color.dim("[category]")}`)
+      for (let i = 0; i < catRanking.length; i++) {
+        console.log(`    ${color.dim(`${i + 1}.`)} ${catRanking[i].model}`)
+      }
+      console.log()
+    }
+
+    const action = await p.select({
+      message: "Rankings actions:",
+      options: [
+        { value: "edit", label: "Edit agent ranking" },
+        { value: "add", label: "Add model to ranking" },
+        { value: "back", label: color.dim("Back to main menu") },
+      ],
+    })
+
+    if (p.isCancel(action) || action === "back") return
+
+    if (action === "edit" || action === "add") {
+      const agentName = await p.select({
+        message: "Select agent:",
+        options: [
+          ...agentNames.map((n) => ({ value: n, label: n, hint: hasAgentRanking(rankings, n) ? "has ranking" : "no ranking" })),
+          { value: "__back__", label: color.dim("Cancel") },
+        ],
+      })
+
+      if (p.isCancel(agentName) || agentName === "__back__") continue
+
+      const current = getAgentRankings(rankings, agentName as string)
+
+      if (action === "add") {
+        const model = await p.text({
+          message: `Enter model to add to "${agentName}" ranking (e.g., provider/model-name):`,
+          placeholder: "provider/model-name",
+        })
+        if (p.isCancel(model)) continue
+        const trimmed = (model as string).trim()
+        if (!trimmed) continue
+
+        const newEntry = { model: trimmed }
+        const updated = [...current, newEntry]
+        const newRankings = setAgentRankings(rankings, agentName as string, updated)
+        writeOmoaRankings(newRankings)
+        p.log.success(`Added "${trimmed}" to ${agentName} rankings.`)
+      }
+    }
+  }
+}

--- a/src/cli/omoa/tui/ranking-screen.ts
+++ b/src/cli/omoa/tui/ranking-screen.ts
@@ -12,7 +12,7 @@ export async function showRankingScreen(): Promise<void> {
     const rankings = readOmoaRankings()
     const state = readOmoaState()
     const config = loadRuntimeConfig()
-    const agents = config?.agents ?? {}
+    const agents = (config?.agents ?? {}) as Record<string, Record<string, unknown>>
 
     console.log()
     console.log(color.bgBlue(color.white(color.bold(" Rankings "))))
@@ -71,22 +71,73 @@ export async function showRankingScreen(): Promise<void> {
 
       if (p.isCancel(agentName) || agentName === "__back__") continue
 
-      const current = getAgentRankings(rankings, agentName as string)
+      const name = agentName as string
+      const current = getAgentRankings(rankings, name)
+
+      if (action === "edit") {
+        if (current.length === 0) {
+          p.log.info(`No rankings for "${name}". Use "Add model to ranking" first.`)
+          continue
+        }
+
+        const editAction = await p.select({
+          message: `Editing rankings for "${name}":`,
+          options: [
+            { value: "remove", label: "Remove a model from ranking" },
+            { value: "add", label: "Add model to ranking" },
+            { value: "cancel", label: color.dim("Cancel") },
+          ],
+        })
+
+        if (p.isCancel(editAction) || editAction === "cancel") continue
+
+        if (editAction === "remove") {
+          const toRemove = await p.select({
+            message: "Select model to remove:",
+            options: [
+              ...current.map((e, i) => ({ value: String(i), label: e.model })),
+              { value: "__cancel__", label: color.dim("Cancel") },
+            ],
+          })
+          if (p.isCancel(toRemove) || toRemove === "__cancel__") continue
+
+          const idx = parseInt(toRemove as string, 10)
+          const removed = current[idx].model
+          const updated = current.filter((_, i) => i !== idx)
+          const newRankings = setAgentRankings(rankings, name, updated)
+          writeOmoaRankings(newRankings)
+          p.log.success(`Removed "${removed}" from ${name} rankings.`)
+        }
+
+        if (editAction === "add") {
+          const model = await p.text({
+            message: `Enter model to add to "${name}" ranking:`,
+            placeholder: "provider/model-name",
+          })
+          if (p.isCancel(model)) continue
+          const trimmed = (model as string).trim()
+          if (!trimmed) continue
+
+          const updated = [...current, { model: trimmed }]
+          const newRankings = setAgentRankings(rankings, name, updated)
+          writeOmoaRankings(newRankings)
+          p.log.success(`Added "${trimmed}" to ${name} rankings.`)
+        }
+      }
 
       if (action === "add") {
         const model = await p.text({
-          message: `Enter model to add to "${agentName}" ranking (e.g., provider/model-name):`,
+          message: `Enter model to add to "${name}" ranking (e.g., provider/model-name):`,
           placeholder: "provider/model-name",
         })
         if (p.isCancel(model)) continue
         const trimmed = (model as string).trim()
         if (!trimmed) continue
 
-        const newEntry = { model: trimmed }
-        const updated = [...current, newEntry]
-        const newRankings = setAgentRankings(rankings, agentName as string, updated)
+        const updated = [...current, { model: trimmed }]
+        const newRankings = setAgentRankings(rankings, name, updated)
         writeOmoaRankings(newRankings)
-        p.log.success(`Added "${trimmed}" to ${agentName} rankings.`)
+        p.log.success(`Added "${trimmed}" to ${name} rankings.`)
       }
     }
   }

--- a/src/cli/omoa/tui/schema-editor/agent-editor.ts
+++ b/src/cli/omoa/tui/schema-editor/agent-editor.ts
@@ -1,0 +1,118 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { OverridableAgentNameSchema } from "../../../../config/schema/agent-names"
+import { loadRuntimeConfig } from "../shared"
+import { hasAgentRanking, readOmoaRankings } from "../../state/rankings-manager"
+import { renderField } from "./field-renderer"
+import { showCategoryEditor, showRootEditor } from "./root-editor"
+
+export async function showSchemaEditorMenu(): Promise<void> {
+  while (true) {
+    const action = await p.select({
+      message: "Edit Config (schema-driven):",
+      options: [
+        { value: "agent", label: "Agent Overrides", hint: "Edit per-agent fields (temperature, thinking, permissions, etc.)" },
+        { value: "category", label: "Categories", hint: "Edit category fields" },
+        { value: "root", label: "Root Settings", hint: "Edit root config fields" },
+        { value: "back", label: color.dim("Back to main menu") },
+      ],
+    })
+
+    if (p.isCancel(action) || action === "back") return
+
+    if (action === "agent") await showAgentEditor()
+    if (action === "category") await showCategoryEditor()
+    if (action === "root") await showRootEditor()
+  }
+}
+
+async function showAgentEditor(): Promise<void> {
+  const config = loadRuntimeConfig()
+  if (!config) { p.log.error("Cannot load config"); return }
+
+  const rankings = readOmoaRankings()
+  const agentNames = OverridableAgentNameSchema.options
+  const agents = config.agents ?? {}
+
+  const agentSelection = await p.select({
+    message: "Select agent to edit:",
+    options: [
+      ...agentNames.map((name) => ({
+        value: name,
+        label: `${name.padEnd(22)} ${hasAgentRanking(rankings, name) ? color.cyan("[OMOA-managed model]") : color.dim("[manual model]")}`,
+      })),
+      { value: "__back__", label: color.dim("Back") },
+    ],
+  })
+
+  if (p.isCancel(agentSelection) || agentSelection === "__back__") return
+
+  const agentName = agentSelection as string
+  const agentsMap = agents as Record<string, Record<string, unknown>>
+  const agent: Record<string, unknown> = agentsMap[agentName] ?? {}
+
+  const managed = hasAgentRanking(rankings, agentName)
+
+  await editAgentFields(agentName, agent, managed)
+}
+
+async function editAgentFields(agentName: string, agent: Record<string, unknown>, managed: boolean): Promise<void> {
+  const fields: { key: string; label: string; type: string; hint: string }[] = [
+    { key: "model", label: "Model", type: "string", hint: managed ? "OMOA-managed - edit via Rankings/Build" : "current model" },
+    { key: "category", label: "Category", type: "string", hint: "inherit settings from category" },
+    { key: "variant", label: "Variant", type: "string", hint: "reasoning variant" },
+    { key: "temperature", label: "Temperature", type: "number", hint: "0-2" },
+    { key: "top_p", label: "Top P", type: "number", hint: "0-1" },
+    { key: "maxTokens", label: "Max Tokens", type: "number", hint: "response token limit" },
+    { key: "reasoningEffort", label: "Reasoning Effort", type: "enum", hint: "none/minimal/low/medium/high/xhigh/max" },
+    { key: "textVerbosity", label: "Text Verbosity", type: "enum", hint: "low/medium/high" },
+    { key: "thinking", label: "Thinking", type: "object", hint: "extended thinking config" },
+    { key: "permission", label: "Permissions", type: "object", hint: "bash/edit/webfetch/task/doom_loop/external_directory" },
+    { key: "tools", label: "Tools", type: "record", hint: "enable/disable specific tools" },
+    { key: "prompt", label: "Prompt", type: "string", hint: "custom prompt override" },
+    { key: "prompt_append", label: "Prompt Append", type: "string", hint: "append to agent prompt" },
+    { key: "description", label: "Description", type: "string", hint: "agent description" },
+    { key: "mode", label: "Mode", type: "enum", hint: "subagent/primary/all" },
+    { key: "disable", label: "Disable", type: "boolean", hint: "disable this agent" },
+    { key: "color", label: "Color", type: "string", hint: "#RRGGBB" },
+    { key: "skills", label: "Skills", type: "array", hint: "skill names to inject" },
+    { key: "ultrawork", label: "Ultrawork", type: "object", hint: "per-message ultrawork override" },
+    { key: "compaction", label: "Compaction", type: "object", hint: "compaction model/variant override" },
+    { key: "providerOptions", label: "Provider Options", type: "record", hint: "provider-specific options" },
+  ]
+
+  while (true) {
+    const field = await p.select({
+      message: `Editing "${agentName}" - Select field:`,
+      options: [
+        ...fields.map((f) => {
+          const current = agent[f.key]
+          const currentStr = current !== undefined ? String(current) : color.dim("not set")
+          const managedWarning = f.key === "model" && managed ? color.yellow(" [OMOA]") : ""
+          return { value: f.key, label: `${f.label}${managedWarning}`, hint: `${currentStr}` }
+        }),
+        { value: "__back__", label: color.dim("Back") },
+      ],
+    })
+
+    if (p.isCancel(field) || field === "__back__") return
+
+    if (field === "model" && managed) {
+      p.log.warn("This agent's model is OMOA-managed. Edit via Rankings menu or run Build. Remove ranking to manage manually.")
+      continue
+    }
+
+    const fieldDef = fields.find((f) => f.key === field)!
+    const result = await renderField(field as string, fieldDef, agent[field as string])
+
+    if (result.cancelled) continue
+
+    if (result.value === "__clear__") {
+      delete agent[field as string]
+      p.log.success(`Cleared ${fieldDef.label} for "${agentName}"`)
+    } else if (result.value !== undefined) {
+      agent[field as string] = result.value
+      p.log.success(`Updated ${fieldDef.label} for "${agentName}"`)
+    }
+  }
+}

--- a/src/cli/omoa/tui/schema-editor/agent-editor.ts
+++ b/src/cli/omoa/tui/schema-editor/agent-editor.ts
@@ -1,10 +1,12 @@
 import * as p from "@clack/prompts"
 import color from "picocolors"
 import { OverridableAgentNameSchema } from "../../../../config/schema/agent-names"
-import { loadRuntimeConfig } from "../shared"
+import { loadRuntimeConfig, saveRuntimeConfig } from "../shared"
 import { hasAgentRanking, readOmoaRankings } from "../../state/rankings-manager"
 import { renderField } from "./field-renderer"
 import { showCategoryEditor, showRootEditor } from "./root-editor"
+
+const CLEAR_SENTINEL = "__sentinel_clear__"
 
 export async function showSchemaEditorMenu(): Promise<void> {
   while (true) {
@@ -32,7 +34,7 @@ async function showAgentEditor(): Promise<void> {
 
   const rankings = readOmoaRankings()
   const agentNames = OverridableAgentNameSchema.options
-  const agents = config.agents ?? {}
+  const agents = (config.agents ?? {}) as Record<string, Record<string, unknown>>
 
   const agentSelection = await p.select({
     message: "Select agent to edit:",
@@ -48,15 +50,19 @@ async function showAgentEditor(): Promise<void> {
   if (p.isCancel(agentSelection) || agentSelection === "__back__") return
 
   const agentName = agentSelection as string
-  const agentsMap = agents as Record<string, Record<string, unknown>>
-  const agent: Record<string, unknown> = agentsMap[agentName] ?? {}
-
+  const agent: Record<string, unknown> = agents[agentName] ?? {}
   const managed = hasAgentRanking(rankings, agentName)
 
-  await editAgentFields(agentName, agent, managed)
+  await editAgentFields(config, agents, agentName, agent, managed)
 }
 
-async function editAgentFields(agentName: string, agent: Record<string, unknown>, managed: boolean): Promise<void> {
+async function editAgentFields(
+  config: Record<string, unknown>,
+  agents: Record<string, Record<string, unknown>>,
+  agentName: string,
+  agent: Record<string, unknown>,
+  managed: boolean,
+): Promise<void> {
   const fields: { key: string; label: string; type: string; hint: string }[] = [
     { key: "model", label: "Model", type: "string", hint: managed ? "OMOA-managed - edit via Rankings/Build" : "current model" },
     { key: "category", label: "Category", type: "string", hint: "inherit settings from category" },
@@ -107,12 +113,21 @@ async function editAgentFields(agentName: string, agent: Record<string, unknown>
 
     if (result.cancelled) continue
 
-    if (result.value === "__clear__") {
+    if (result.value === CLEAR_SENTINEL) {
       delete agent[field as string]
       p.log.success(`Cleared ${fieldDef.label} for "${agentName}"`)
     } else if (result.value !== undefined) {
       agent[field as string] = result.value
       p.log.success(`Updated ${fieldDef.label} for "${agentName}"`)
+    } else {
+      continue
+    }
+
+    // Persist after every mutation
+    agents[agentName] = agent
+    config.agents = agents
+    if (!saveRuntimeConfig(config)) {
+      p.log.error("Failed to save config to disk")
     }
   }
 }

--- a/src/cli/omoa/tui/schema-editor/field-renderer.ts
+++ b/src/cli/omoa/tui/schema-editor/field-renderer.ts
@@ -1,0 +1,147 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+
+export interface FieldRenderResult {
+  value: unknown
+  cancelled: boolean
+}
+
+export async function renderField(
+  fieldName: string,
+  fieldDef: { key: string; label: string; type: string; hint: string },
+  currentValue: unknown,
+): Promise<FieldRenderResult> {
+  switch (fieldDef.type) {
+    case "boolean":
+      return renderBoolean(fieldDef.label, currentValue as boolean | undefined)
+    case "number":
+      return renderNumber(fieldDef.label, currentValue as number | undefined, fieldDef.hint)
+    case "enum":
+      return renderEnum(fieldDef.label, currentValue as string | undefined, fieldDef.hint)
+    case "object":
+      return renderObject(fieldDef.label, currentValue as Record<string, unknown> | undefined, fieldDef.hint)
+    case "record":
+      return renderRecord(fieldDef.label, currentValue as Record<string, unknown> | undefined)
+    case "array":
+      return renderArray(fieldDef.label, currentValue as string[] | undefined)
+    case "string":
+    default:
+      return renderString(fieldDef.label, currentValue as string | undefined)
+  }
+}
+
+async function renderString(label: string, current: string | undefined): Promise<FieldRenderResult> {
+  const value = await p.text({
+    message: `Enter ${label}:`,
+    initialValue: current ?? "",
+  })
+
+  if (p.isCancel(value)) return { value: undefined, cancelled: true }
+
+  const trimmed = (value as string).trim()
+  if (trimmed === "" && current === undefined) return { value: undefined, cancelled: true }
+  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  return { value: trimmed, cancelled: false }
+}
+
+async function renderBoolean(label: string, current: boolean | undefined): Promise<FieldRenderResult> {
+  const value = await p.select({
+    message: `Set ${label}:`,
+    options: [
+      { value: "true", label: "true", hint: current === true ? "current" : undefined },
+      { value: "false", label: "false", hint: current === false ? "current" : undefined },
+      { value: "__clear__", label: color.red("Clear"), hint: current === undefined ? "current" : undefined },
+    ],
+  })
+
+  if (p.isCancel(value)) return { value: undefined, cancelled: true }
+  if (value === "__clear__") return { value: "__clear__", cancelled: false }
+  return { value: value === "true", cancelled: false }
+}
+
+async function renderNumber(label: string, current: number | undefined, hint: string): Promise<FieldRenderResult> {
+  const value = await p.text({
+    message: `Enter ${label} ${color.dim(`(${hint})`)}:`,
+    initialValue: current !== undefined ? String(current) : "",
+  })
+
+  if (p.isCancel(value)) return { value: undefined, cancelled: true }
+
+  const trimmed = (value as string).trim()
+  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  const parsed = Number(trimmed)
+  if (isNaN(parsed)) {
+    p.log.warn("Invalid number.")
+    return { value: undefined, cancelled: true }
+  }
+  return { value: parsed, cancelled: false }
+}
+
+async function renderEnum(label: string, current: string | undefined, hint: string): Promise<FieldRenderResult> {
+  const options = hint.split("/").map((v) => ({
+    value: v,
+    label: v,
+    hint: current === v ? "current" : undefined,
+  }))
+
+  options.push({ value: "__clear__", label: color.red("Clear"), hint: undefined })
+
+  const value = await p.select({
+    message: `Select ${label}:`,
+    options,
+  })
+
+  if (p.isCancel(value)) return { value: undefined, cancelled: true }
+  if (value === "__clear__") return { value: "__clear__", cancelled: false }
+  return { value, cancelled: false }
+}
+
+async function renderObject(label: string, current: Record<string, unknown> | undefined, hint: string): Promise<FieldRenderResult> {
+  console.log(`  ${color.dim(`Editing ${label}: ${hint}`)}`)
+  console.log(`  ${color.dim(`Current: ${current ? JSON.stringify(current) : "not set"}`)}`)
+
+  const action = await p.select({
+    message: `${label} - edit as JSON or clear:`,
+    options: [
+      { value: "edit", label: "Edit JSON", hint: "enter JSON object" },
+      { value: "__clear__", label: color.red("Clear"), hint: current === undefined ? "already clear" : undefined },
+      { value: "cancel", label: "Cancel" },
+    ],
+  })
+
+  if (p.isCancel(action) || action === "cancel") return { value: undefined, cancelled: true }
+  if (action === "__clear__") return { value: "__clear__", cancelled: false }
+
+  const jsonStr = await p.text({
+    message: `Enter JSON for ${label}:`,
+    initialValue: current ? JSON.stringify(current, null, 0) : "{}",
+  })
+
+  if (p.isCancel(jsonStr)) return { value: undefined, cancelled: true }
+
+  try {
+    const parsed = JSON.parse(jsonStr as string)
+    return { value: parsed, cancelled: false }
+  } catch {
+    p.log.warn("Invalid JSON.")
+    return { value: undefined, cancelled: true }
+  }
+}
+
+async function renderRecord(label: string, current: Record<string, unknown> | undefined): Promise<FieldRenderResult> {
+  return renderObject(label, current, "key-value map")
+}
+
+async function renderArray(label: string, current: string[] | undefined): Promise<FieldRenderResult> {
+  const value = await p.text({
+    message: `Enter ${label} (comma-separated):`,
+    initialValue: current ? current.join(", ") : "",
+  })
+
+  if (p.isCancel(value)) return { value: undefined, cancelled: true }
+
+  const trimmed = (value as string).trim()
+  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  const items = trimmed.split(",").map((s) => s.trim()).filter(Boolean)
+  return { value: items, cancelled: false }
+}

--- a/src/cli/omoa/tui/schema-editor/field-renderer.ts
+++ b/src/cli/omoa/tui/schema-editor/field-renderer.ts
@@ -40,7 +40,7 @@ async function renderString(label: string, current: string | undefined): Promise
 
   const trimmed = (value as string).trim()
   if (trimmed === "" && current === undefined) return { value: undefined, cancelled: true }
-  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  if (trimmed === "") return { value: "__sentinel_clear__", cancelled: false }
   return { value: trimmed, cancelled: false }
 }
 
@@ -50,12 +50,12 @@ async function renderBoolean(label: string, current: boolean | undefined): Promi
     options: [
       { value: "true", label: "true", hint: current === true ? "current" : undefined },
       { value: "false", label: "false", hint: current === false ? "current" : undefined },
-      { value: "__clear__", label: color.red("Clear"), hint: current === undefined ? "current" : undefined },
+      { value: "__sentinel_clear__", label: color.red("Clear"), hint: current === undefined ? "current" : undefined },
     ],
   })
 
   if (p.isCancel(value)) return { value: undefined, cancelled: true }
-  if (value === "__clear__") return { value: "__clear__", cancelled: false }
+  if (value === "__sentinel_clear__") return { value: "__sentinel_clear__", cancelled: false }
   return { value: value === "true", cancelled: false }
 }
 
@@ -68,7 +68,7 @@ async function renderNumber(label: string, current: number | undefined, hint: st
   if (p.isCancel(value)) return { value: undefined, cancelled: true }
 
   const trimmed = (value as string).trim()
-  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  if (trimmed === "") return { value: "__sentinel_clear__", cancelled: false }
   const parsed = Number(trimmed)
   if (isNaN(parsed)) {
     p.log.warn("Invalid number.")
@@ -84,7 +84,7 @@ async function renderEnum(label: string, current: string | undefined, hint: stri
     hint: current === v ? "current" : undefined,
   }))
 
-  options.push({ value: "__clear__", label: color.red("Clear"), hint: undefined })
+  options.push({ value: "__sentinel_clear__", label: color.red("Clear"), hint: undefined })
 
   const value = await p.select({
     message: `Select ${label}:`,
@@ -92,7 +92,7 @@ async function renderEnum(label: string, current: string | undefined, hint: stri
   })
 
   if (p.isCancel(value)) return { value: undefined, cancelled: true }
-  if (value === "__clear__") return { value: "__clear__", cancelled: false }
+  if (value === "__sentinel_clear__") return { value: "__sentinel_clear__", cancelled: false }
   return { value, cancelled: false }
 }
 
@@ -104,13 +104,13 @@ async function renderObject(label: string, current: Record<string, unknown> | un
     message: `${label} - edit as JSON or clear:`,
     options: [
       { value: "edit", label: "Edit JSON", hint: "enter JSON object" },
-      { value: "__clear__", label: color.red("Clear"), hint: current === undefined ? "already clear" : undefined },
+      { value: "__sentinel_clear__", label: color.red("Clear"), hint: current === undefined ? "already clear" : undefined },
       { value: "cancel", label: "Cancel" },
     ],
   })
 
   if (p.isCancel(action) || action === "cancel") return { value: undefined, cancelled: true }
-  if (action === "__clear__") return { value: "__clear__", cancelled: false }
+  if (action === "__sentinel_clear__") return { value: "__sentinel_clear__", cancelled: false }
 
   const jsonStr = await p.text({
     message: `Enter JSON for ${label}:`,
@@ -141,7 +141,7 @@ async function renderArray(label: string, current: string[] | undefined): Promis
   if (p.isCancel(value)) return { value: undefined, cancelled: true }
 
   const trimmed = (value as string).trim()
-  if (trimmed === "") return { value: "__clear__", cancelled: false }
+  if (trimmed === "") return { value: "__sentinel_clear__", cancelled: false }
   const items = trimmed.split(",").map((s) => s.trim()).filter(Boolean)
   return { value: items, cancelled: false }
 }

--- a/src/cli/omoa/tui/schema-editor/root-editor.ts
+++ b/src/cli/omoa/tui/schema-editor/root-editor.ts
@@ -1,12 +1,12 @@
 import * as p from "@clack/prompts"
 import color from "picocolors"
-import { loadRuntimeConfig } from "../shared"
+import { loadRuntimeConfig, saveRuntimeConfig } from "../shared"
 
 export async function showCategoryEditor(): Promise<void> {
   const config = loadRuntimeConfig()
   if (!config) { p.log.error("Cannot load config"); return }
 
-  const categories = config.categories ?? {}
+  const categories = (config.categories ?? {}) as Record<string, Record<string, unknown>>
   const catNames = Object.keys(categories)
 
   if (catNames.length === 0) {
@@ -25,7 +25,7 @@ export async function showCategoryEditor(): Promise<void> {
   if (p.isCancel(selected) || selected === "__back__") return
 
   const catName = selected as string
-  const cat = categories[catName] as Record<string, unknown> ?? {}
+  const cat = categories[catName] ?? {}
 
   const fields: { key: string; label: string; type: string; hint: string }[] = [
     { key: "model", label: "Model", type: "string", hint: "" },
@@ -65,12 +65,20 @@ export async function showCategoryEditor(): Promise<void> {
 
     if (result.cancelled) continue
 
-    if (result.value === "__clear__") {
+    if (result.value === "__sentinel_clear__") {
       delete cat[field as string]
       p.log.success(`Cleared ${fieldDef.label}`)
     } else if (result.value !== undefined) {
       cat[field as string] = result.value
       p.log.success(`Updated ${fieldDef.label}`)
+    } else {
+      continue
+    }
+
+    // Persist after every mutation
+    config.categories = { ...categories, [catName]: cat }
+    if (!saveRuntimeConfig(config)) {
+      p.log.error("Failed to save config to disk")
     }
   }
 }
@@ -108,12 +116,19 @@ export async function showRootEditor(): Promise<void> {
 
     if (result.cancelled) continue
 
-    if (result.value === "__clear__") {
+    if (result.value === "__sentinel_clear__") {
       delete (config as Record<string, unknown>)[field as string]
       p.log.success(`Cleared ${fieldDef.label}`)
     } else if (result.value !== undefined) {
       (config as Record<string, unknown>)[field as string] = result.value
       p.log.success(`Updated ${fieldDef.label}`)
+    } else {
+      continue
+    }
+
+    // Persist after every mutation
+    if (!saveRuntimeConfig(config)) {
+      p.log.error("Failed to save config to disk")
     }
   }
 }

--- a/src/cli/omoa/tui/schema-editor/root-editor.ts
+++ b/src/cli/omoa/tui/schema-editor/root-editor.ts
@@ -1,0 +1,119 @@
+import * as p from "@clack/prompts"
+import color from "picocolors"
+import { loadRuntimeConfig } from "../shared"
+
+export async function showCategoryEditor(): Promise<void> {
+  const config = loadRuntimeConfig()
+  if (!config) { p.log.error("Cannot load config"); return }
+
+  const categories = config.categories ?? {}
+  const catNames = Object.keys(categories)
+
+  if (catNames.length === 0) {
+    p.log.info("No categories defined in config.")
+    return
+  }
+
+  const selected = await p.select({
+    message: "Select category to edit:",
+    options: [
+      ...catNames.map((name) => ({ value: name, label: name })),
+      { value: "__back__", label: color.dim("Back") },
+    ],
+  })
+
+  if (p.isCancel(selected) || selected === "__back__") return
+
+  const catName = selected as string
+  const cat = categories[catName] as Record<string, unknown> ?? {}
+
+  const fields: { key: string; label: string; type: string; hint: string }[] = [
+    { key: "model", label: "Model", type: "string", hint: "" },
+    { key: "description", label: "Description", type: "string", hint: "" },
+    { key: "variant", label: "Variant", type: "string", hint: "" },
+    { key: "temperature", label: "Temperature", type: "number", hint: "0-2" },
+    { key: "top_p", label: "Top P", type: "number", hint: "0-1" },
+    { key: "maxTokens", label: "Max Tokens", type: "number", hint: "" },
+    { key: "reasoningEffort", label: "Reasoning Effort", type: "enum", hint: "none/minimal/low/medium/high/xhigh/max" },
+    { key: "textVerbosity", label: "Text Verbosity", type: "enum", hint: "low/medium/high" },
+    { key: "thinking", label: "Thinking", type: "object", hint: "extended thinking" },
+    { key: "tools", label: "Tools", type: "record", hint: "enable/disable tools" },
+    { key: "prompt_append", label: "Prompt Append", type: "string", hint: "" },
+    { key: "max_prompt_tokens", label: "Max Prompt Tokens", type: "number", hint: "" },
+    { key: "is_unstable_agent", label: "Unstable Agent", type: "boolean", hint: "" },
+    { key: "disable", label: "Disable", type: "boolean", hint: "" },
+  ]
+
+  const { renderField } = await import("./field-renderer")
+
+  while (true) {
+    const field = await p.select({
+      message: `Editing category "${catName}":`,
+      options: [
+        ...fields.map((f) => {
+          const current = cat[f.key]
+          return { value: f.key, label: f.label, hint: current !== undefined ? String(current) : "not set" }
+        }),
+        { value: "__back__", label: color.dim("Back") },
+      ],
+    })
+
+    if (p.isCancel(field) || field === "__back__") return
+
+    const fieldDef = fields.find((f) => f.key === field)!
+    const result = await renderField(field as string, fieldDef, cat[field as string])
+
+    if (result.cancelled) continue
+
+    if (result.value === "__clear__") {
+      delete cat[field as string]
+      p.log.success(`Cleared ${fieldDef.label}`)
+    } else if (result.value !== undefined) {
+      cat[field as string] = result.value
+      p.log.success(`Updated ${fieldDef.label}`)
+    }
+  }
+}
+
+export async function showRootEditor(): Promise<void> {
+  const config = loadRuntimeConfig()
+  if (!config) { p.log.error("Cannot load config"); return }
+
+  const fields: { key: string; label: string; type: string; hint: string }[] = [
+    { key: "default_run_agent", label: "Default Run Agent", type: "string", hint: "agent name for 'run' command" },
+    { key: "new_task_system_enabled", label: "New Task System", type: "boolean", hint: "" },
+    { key: "hashline_edit", label: "Hashline Edit", type: "boolean", hint: "" },
+    { key: "model_fallback", label: "Model Fallback", type: "boolean", hint: "" },
+    { key: "auto_update", label: "Auto Update", type: "boolean", hint: "" },
+  ]
+
+  const { renderField } = await import("./field-renderer")
+
+  while (true) {
+    const field = await p.select({
+      message: "Edit root settings:",
+      options: [
+        ...fields.map((f) => {
+          const current = (config as Record<string, unknown>)[f.key]
+          return { value: f.key, label: f.label, hint: current !== undefined ? String(current) : "not set" }
+        }),
+        { value: "__back__", label: color.dim("Back") },
+      ],
+    })
+
+    if (p.isCancel(field) || field === "__back__") return
+
+    const fieldDef = fields.find((f) => f.key === field)!
+    const result = await renderField(field as string, fieldDef, (config as Record<string, unknown>)[field as string])
+
+    if (result.cancelled) continue
+
+    if (result.value === "__clear__") {
+      delete (config as Record<string, unknown>)[field as string]
+      p.log.success(`Cleared ${fieldDef.label}`)
+    } else if (result.value !== undefined) {
+      (config as Record<string, unknown>)[field as string] = result.value
+      p.log.success(`Updated ${fieldDef.label}`)
+    }
+  }
+}

--- a/src/cli/omoa/tui/shared.ts
+++ b/src/cli/omoa/tui/shared.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from "node:fs"
 import { parseJsonc } from "../../../shared/jsonc-parser"
 import { getConfigContext } from "../../config-manager"
-import type { OhMyOpenCodeConfig } from "../../../config/schema"
+import { writeFileAtomically } from "../../../shared/write-file-atomically"
 import { extractProvider } from "../engine/resolver"
 
-type MutableConfig = Partial<OhMyOpenCodeConfig> & Record<string, unknown>
+type MutableConfig = Partial<Record<string, unknown>>
 
 export function loadRuntimeConfig(): MutableConfig | null {
   const { paths } = getConfigContext()
@@ -16,13 +16,13 @@ export function loadRuntimeConfig(): MutableConfig | null {
   }
 }
 
-export function loadTypedRuntimeConfig(): OhMyOpenCodeConfig | null {
+export function saveRuntimeConfig(config: Record<string, unknown>): boolean {
   const { paths } = getConfigContext()
-  if (!existsSync(paths.omoConfig)) return null
   try {
-    return parseJsonc<OhMyOpenCodeConfig>(readFileSync(paths.omoConfig, "utf-8"))
+    writeFileAtomically(paths.omoConfig, JSON.stringify(config, null, 2) + "\n")
+    return true
   } catch {
-    return null
+    return false
   }
 }
 
@@ -53,6 +53,13 @@ export function countProviderUsage(config: any): Map<string, { primary: number; 
       const provider = extractProvider(c.model)
       const entry = counts.get(provider) ?? { primary: 0, fallback: 0 }
       entry.primary++
+      counts.set(provider, entry)
+    }
+    const fallbacks = normalizeFallbacks(c.fallback_models)
+    for (const fb of fallbacks) {
+      const provider = extractProvider(fb)
+      const entry = counts.get(provider) ?? { primary: 0, fallback: 0 }
+      entry.fallback++
       counts.set(provider, entry)
     }
   }

--- a/src/cli/omoa/tui/shared.ts
+++ b/src/cli/omoa/tui/shared.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs"
+import { parseJsonc } from "../../../shared/jsonc-parser"
+import { getConfigContext } from "../../config-manager"
+import type { OhMyOpenCodeConfig } from "../../../config/schema"
+import { extractProvider } from "../engine/resolver"
+
+type MutableConfig = Partial<OhMyOpenCodeConfig> & Record<string, unknown>
+
+export function loadRuntimeConfig(): MutableConfig | null {
+  const { paths } = getConfigContext()
+  if (!existsSync(paths.omoConfig)) return {}
+  try {
+    return parseJsonc<MutableConfig>(readFileSync(paths.omoConfig, "utf-8")) ?? {}
+  } catch {
+    return null
+  }
+}
+
+export function loadTypedRuntimeConfig(): OhMyOpenCodeConfig | null {
+  const { paths } = getConfigContext()
+  if (!existsSync(paths.omoConfig)) return null
+  try {
+    return parseJsonc<OhMyOpenCodeConfig>(readFileSync(paths.omoConfig, "utf-8"))
+  } catch {
+    return null
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function countProviderUsage(config: any): Map<string, { primary: number; fallback: number }> {
+  const counts = new Map<string, { primary: number; fallback: number }>()
+
+  for (const agent of Object.values(config.agents ?? {})) {
+    const a = agent as { model?: string; fallback_models?: unknown }
+    if (a.model) {
+      const provider = extractProvider(a.model)
+      const entry = counts.get(provider) ?? { primary: 0, fallback: 0 }
+      entry.primary++
+      counts.set(provider, entry)
+    }
+    const fallbacks = normalizeFallbacks(a.fallback_models)
+    for (const fb of fallbacks) {
+      const provider = extractProvider(fb)
+      const entry = counts.get(provider) ?? { primary: 0, fallback: 0 }
+      entry.fallback++
+      counts.set(provider, entry)
+    }
+  }
+
+  for (const cat of Object.values(config.categories ?? {})) {
+    const c = cat as { model?: string; fallback_models?: unknown }
+    if (c.model) {
+      const provider = extractProvider(c.model)
+      const entry = counts.get(provider) ?? { primary: 0, fallback: 0 }
+      entry.primary++
+      counts.set(provider, entry)
+    }
+  }
+
+  return counts
+}
+
+export function normalizeFallbacks(fallbacks: unknown): string[] {
+  if (!fallbacks) return []
+  if (typeof fallbacks === "string") return [fallbacks]
+  if (Array.isArray(fallbacks)) return fallbacks.map((f) => typeof f === "string" ? f : (f as { model?: string })?.model ?? String(f))
+  return []
+}


### PR DESCRIPTION
## Summary

Adds OMOA, a policy-based model routing and config management system for oh-my-openagent.

### Two Modes

**Policy Mode** — Declare model rankings per agent/category. `omoa build` auto-resolves the best model based on provider availability, compatibility rules, and cross-provider fallback constraints.

**Manual Mode** — Direct per-field editing via a schema-driven TUI that auto-generates prompts from the project Zod schemas. Always available for agents without rankings.

Both modes coexist: agents with rankings are "[OMOA-managed]", agents without are "[manual]".

### Commands

```
oh-my-opencode omoa                Interactive TUI
oh-my-opencode omoa status         Show providers, agents, categories, validation
oh-my-opencode omoa build          Build config from rankings + provider state
oh-my-opencode omoa build --dry-run
oh-my-opencode omoa provider list
oh-my-opencode omoa provider enable <name>
oh-my-opencode omoa provider disable <name>
```

### Architecture

Three state files:
- `oh-my-openagent.json` — runtime config (written by build or manual edits)
- `omoa-state.json` — provider rules, banned/deprecated models
- `omoa-rankings.json` — per-agent/category model preference lists

### Key Features

- Cross-provider fallback enforcement (`primary.provider != fallback.provider`)
- Provider enable/disable with usage counts
- Multi-target model assignment (`omoa assign <model>`)
- 10-rule validation system
- Idempotent build with timestamped backups
- Schema-driven editor for all 21+ agent fields (auto-exposes new schema fields)
- No new dependencies (uses `@clack/prompts`, `picocolors`, `zod`, `commander`)

### Testing

- 20 unit tests (resolver: 11, validator: 9) — all passing
- 0 TypeScript errors (`tsc --noEmit`)

### Files (21 changed, 2141 insertions)

See `OMOA-FEATURES.md` for the full feature list and phased roadmap.

## Type of Change

- [x] New feature

## Testing

```bash
bun test src/cli/omoa/engine/    # 20/20 pass
bunx tsc --noEmit                # 0 errors
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces OMOA, a policy‑based model management CLI with TUI that auto‑resolves best models and safe cross‑provider fallbacks. Adds a unified `omoa config` editor with provider/model cache browsing, bulk ops, atomic per‑change saves, and stronger validation.

- **New Features**
  - `omoa` CLI with TUI and subcommands: `status`, `build [--dry-run|--yes]`, `provider list|enable|disable`, `config`.
  - Schema‑driven `omoa config` for agents, categories, and bulk set/clear; cache‑backed model picker (browse by provider, flat list, custom); atomic writes with backups; saves after every field change.
  - Policy engine enforces cross‑provider fallbacks and `free_only`/banned/deprecated rules; idempotent build updates only `model` and `fallback_models`.
  - Model cache reader supports `provider-models.json` and `models.json`; unified CLI entry for both OMOA‑managed and manual modes.
  - Tests: added CLI build coverage and config editor tests; `tsc --noEmit` clean; no new deps (`@clack/prompts`, `picocolors`, `zod`, `commander`, `jsonc-parser`).

- **Bug Fixes**
  - Reliability: log parse failures for state/rankings and refuse overwriting rankings with empty defaults; renamed sentinel to `__sentinel_clear__`.
  - Dry‑run: added `targetKind` guard and now includes agents created from rankings.
  - UX: ranking editor provides add/remove flows; schema editor persists on every mutation.
  - Correctness: usage counts include category fallbacks; resolver diagnostics specify `free_only`/banned/deprecated/provider‑disabled reasons.

<sup>Written for commit f9a31be0368e895243dad8c6424cefed089af288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

