### PR TITLE
fix(agents): declare multimodal-looker tool allowlist in prompt to prevent death loop on small VL models (fixes #4116)

### DIFF
--- a/src/agents/multimodal-looker.test.ts
+++ b/src/agents/multimodal-looker.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "bun:test"
+import { createMultimodalLookerAgent } from "./multimodal-looker"
+
+describe("createMultimodalLookerAgent", () => {
+  test("prompt explicitly enumerates the agent's available tools to prevent death loop on small VL models", () => {
+    // given
+    const agent = createMultimodalLookerAgent("openai/gpt-5-nano")
+
+    // when
+    const prompt = typeof agent.prompt === "string" ? agent.prompt : ""
+
+    // then
+    expect(prompt).toMatch(/available tools/i)
+    expect(prompt).toContain("read")
+  })
+
+  test("prompt instructs the agent never to call other tools", () => {
+    // given
+    const agent = createMultimodalLookerAgent("openai/gpt-5-nano")
+
+    // when
+    const prompt = typeof agent.prompt === "string" ? agent.prompt : ""
+
+    // then
+    expect(prompt.toLowerCase()).toContain("never")
+  })
+})

--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -23,6 +23,8 @@ export function createMultimodalLookerAgent(model: string): AgentConfig {
     ...restrictions,
     prompt: `You interpret media files that cannot be read as plain text.
 
+Your only available tools are 'read' and 'call_omo_agent'. Always use 'read' to load the file first, then analyze the returned content. Never attempt to call any other tool.
+
 Your job: examine the attached file and extract ONLY what was requested.
 
 When to use you:


### PR DESCRIPTION
## Summary

The `multimodal-looker` prompt described **what to do** but never told the model **which tools are available**. Smaller VL models (Qwen3-VL-8B was the reported case) repeatedly tried to call non-existent tools and entered an infinite loop with the error message:

```
Model tried to call unavailable tool 'invalid'. Available tools: call_omo_agent, read.
```

Add a single sentence at the top of the prompt that explicitly enumerates the only allowed tools (`read` and `call_omo_agent`) and forbids calling any other tool. This matches the runtime allowlist enforced by `createAgentToolAllowlist(["read"])` and the suggested fix from the issue reporter.

## Root Cause

`src/agents/multimodal-looker.ts` builds the agent with `createAgentToolAllowlist(["read"])` (line 15), so at runtime only `read` and `call_omo_agent` are exposed. The prompt, however, only mentions `Read tool` in passing — nothing tells the model that no other tool is callable. Frontier VL models infer the tool list from context, but smaller VL models do not — they hallucinate tools and the harness then re-prompts them with `Model tried to call unavailable tool ...`, which the model treats as a new task and loops.

## Changes

| File | Change |
|------|--------|
| `src/agents/multimodal-looker.ts` | Insert a single sentence at the top of the prompt declaring the available tools and forbidding any other tool call. |
| `src/agents/multimodal-looker.test.ts` | New co-located regression test (given/when/then) asserting the prompt enumerates the allowed tools and contains an explicit `never` instruction. |

## Reproduction (before fix)

```
$ bun test src/agents/multimodal-looker.test.ts
...
error: expect(received).toMatch(expected)
Expected substring or pattern: /available tools/i
Received: "You interpret media files that cannot be read as plain text....
...(fail) createMultimodalLookerAgent > prompt explicitly enumerates the agent's available tools to prevent death loop on small VL models
 1 pass
 1 fail
```

## Verification (after fix)

```
$ bun test src/agents/multimodal-looker.test.ts
bun test v1.3.11 (af24e281)
 2 pass
 0 fail
 3 expect() calls
Ran 2 tests across 1 file. [103.00ms]
```

```
$ bun test src/agents/
 385 pass
 0 fail
 1193 expect() calls
Ran 385 tests across 28 files. [1.67s]
```

## Test

- Regression test: `src/agents/multimodal-looker.test.ts` (newly added; no previous test file existed for this agent)
- Related suite: `bun test src/agents/` — 385/385 pass, no regressions
- Typecheck: `bun run typecheck` — clean

Fixes #4116

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly declare the only tools in the `multimodal-looker` prompt (`read`, `call_omo_agent`) to stop small VL models from calling invalid tools and looping. Aligns the prompt with the runtime allowlist and fixes #4116.

- **Bug Fixes**
  - Added a sentence at the top of the agent prompt listing allowed tools and forbidding any others; use `read` first, then analyze.
  - Added a regression test to ensure the prompt enumerates the tools and includes the “never” instruction.

<sup>Written for commit 81ce512705ef27f9b54840e9c175dbf8fffe16c0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

