### PR TITLE
fix(cli): add 'setup' as an alias for the install command (fixes #4112)

### DIFF
--- a/src/cli/cli-program.test.ts
+++ b/src/cli/cli-program.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
+describe("cli-program", () => {
+  test("install command exposes 'setup' as an alias so the historical install path keeps working", async () => {
+    // given
+    const cliProgramSource = await readFile(
+      path.resolve(import.meta.dir, "cli-program.ts"),
+      "utf-8",
+    )
+
+    // when
+    const installBlock = cliProgramSource.match(
+      /program\s*\n\s*\.command\("install"\)([\s\S]*?)\.action\(/,
+    )
+
+    // then
+    expect(installBlock).not.toBeNull()
+    expect(installBlock?.[1]).toContain('.alias("setup")')
+  })
+})

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -24,6 +24,7 @@ program
 
 program
   .command("install")
+  .alias("setup")
   .description("Install and configure oh-my-opencode with interactive setup")
   .option("--no-tui", "Run in non-interactive mode (requires all options)")
   .option("--claude <value>", "Claude subscription: no, yes, max20")


### PR DESCRIPTION
## Summary

Discord support and other public guidance still tell users to run \`bunx oh-my-opencode setup\` when skills like \`hyperplan\` are missing from the slash menu, but the CLI only registers \`install\`. The recommended command currently dead-ends:

\`\`\`
$ bunx oh-my-opencode setup
error: unknown command 'setup'
\`\`\`

This 1-line fix registers \`setup\` as a Commander.js alias for the existing \`install\` command, so both commands resolve to the same action without any code duplication. Help output now reads:

\`\`\`
Usage: oh-my-opencode install|setup [options]
\`\`\`

Newcomers and users following older docs both land at the right wizard.

## Root Cause

\`src/cli/cli-program.ts\` declared the install command without an alias, so Commander.js had no way to route \`setup\` to it. The user-facing message and the registered command had drifted.

## Changes

| File | Change |
|------|--------|
| \`src/cli/cli-program.ts\` | Add \`.alias(\"setup\")\` immediately after \`.command(\"install\")\`. |
| \`src/cli/cli-program.test.ts\` | New regression test asserting the install command block contains \`.alias(\"setup\")\` before its \`.action(\` so a future refactor cannot silently drop it. |

## Reproduction (before fix)

\`\`\`
$ bun run build
$ bun ./dist/cli/index.js setup
error: unknown command 'setup'
\`\`\`

## Verification (after fix)

\`\`\`
$ bun run build
$ bun ./dist/cli/index.js setup --help
Usage: oh-my-opencode install|setup [options]

Install and configure oh-my-opencode with interactive setup

Options:
  --no-tui                     Run in non-interactive mode (requires all
                               options)
...
\`\`\`

\`\`\`
$ bun test src/cli/cli-program.test.ts
 1 pass
 0 fail
 2 expect() calls
\`\`\`

I also confirmed the existing \`install\` command still resolves identically — \`bun ./dist/cli/index.js install --help\` produces the same usage banner.

## Test

- Regression test: \`src/cli/cli-program.test.ts\` (new file). Reads \`cli-program.ts\` source and asserts \`.alias(\"setup\")\` is present inside the install command declaration. Removing the alias makes the test fail (verified with \`git stash\`).
- Related suite: \`bun test src/cli/\` — +1 test added, no regressions. The 25 pre-existing fails are Windows-platform issues unrelated to this change (PowerShell detection, run-command spawn, bun install spawn, OPENCODE_CONFIG_DIR caching); the same set fails on \`git stash\` baseline.
- Typecheck: \`bun run typecheck\` — clean.

Fixes #4112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `setup` as an alias for the `install` CLI command so `bunx oh-my-opencode setup` works again and routes to the same install wizard.

- **Bug Fixes**
  - Map `setup` to the existing `install` command via `.alias("setup")`; help now shows `install|setup`.
  - Add a regression test to ensure the alias stays in place.

<sup>Written for commit 554a6aabd17ad6f27b20df7f717685efd11979d9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

