### PR TITLE
fix(plugin): guard Anthropic assistant prefill tails

### DIFF
--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -328,6 +328,47 @@ describe("createMessagesTransformHandler", () => {
     })
   })
 
+  it("#given an Anthropic-family provider history ends with a rejecting assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_vertex_anthropic",
+          role: "user",
+          sessionID: "ses_vertex_anthropic",
+          agent: "sisyphus",
+          model: { providerID: "google-vertex-anthropic", modelID: "claude-opus-4-7" },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_vertex_anthropic",
+          role: "assistant",
+          sessionID: "ses_vertex_anthropic",
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_vertex_anthropic",
+      agent: "sisyphus",
+      model: { providerID: "google-vertex-anthropic", modelID: "claude-opus-4-7" },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
   it("#given rejecting model metadata uses direct provider and model fields #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
     //#given
     const messages: TestMessage[] = [

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -286,6 +286,48 @@ describe("createMessagesTransformHandler", () => {
     })
   })
 
+  it("#given the assistant tail identifies a rejecting Anthropic model after an allowed user model #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_allowed_then_rejecting_assistant",
+          role: "user",
+          sessionID: "ses_allowed_then_rejecting_assistant",
+          agent: "sisyphus",
+          model: { providerID: "openai", modelID: "gpt-5.4" },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_rejecting_metadata",
+          role: "assistant",
+          sessionID: "ses_allowed_then_rejecting_assistant",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_allowed_then_rejecting_assistant",
+      agent: "sisyphus",
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
   it("#given rejecting model metadata uses direct provider and model fields #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
     //#given
     const messages: TestMessage[] = [
@@ -352,6 +394,13 @@ describe("createMessagesTransformHandler", () => {
       {
         name: "missing model",
         userInfo: { role: "user" },
+      },
+      {
+        name: "non-anthropic provider",
+        userInfo: {
+          role: "user",
+          model: { providerID: "opencode", modelID: "claude-opus-4-7" },
+        },
       },
     ]
 

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -19,7 +19,17 @@ type TestPart = {
 }
 
 type TestMessage = {
-  info: { role: "assistant" | "user" }
+  info: {
+    role: "assistant" | "user"
+    id?: string
+    sessionID?: string
+    agent?: string
+    model?: { providerID: string; modelID: string }
+    system?: string
+    tools?: Record<string, boolean>
+    providerID?: string
+    modelID?: string
+  }
   parts: TestPart[]
 }
 
@@ -186,12 +196,216 @@ describe("createMessagesTransformHandler", () => {
     expect(messages.at(-1)?.info.role).toBe("assistant")
   })
 
+  it("#given an Anthropic Opus 4.7 history ends with an ordinary assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user",
+          role: "user",
+          sessionID: "ses_opus47_prefill",
+          agent: "sisyphus",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+          system: "system-prompt",
+          tools: { bash: true },
+        },
+        parts: [{ type: "text", text: "finish the debugging report" }],
+      },
+      {
+        info: {
+          id: "msg_assistant",
+          role: "assistant",
+          sessionID: "ses_opus47_prefill",
+        },
+        parts: [{ type: "text", text: "## 정리 — 완료" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_opus47_prefill",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      system: "system-prompt",
+      tools: { bash: true },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given rejecting model metadata is only on the assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_assistant_model_fallback",
+          role: "user",
+          sessionID: "ses_assistant_model_fallback",
+          agent: "sisyphus",
+          system: "system-prompt",
+          tools: { bash: true },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_model_fallback",
+          role: "assistant",
+          sessionID: "ses_assistant_model_fallback",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_assistant_model_fallback",
+      agent: "sisyphus",
+      model: { providerID: "internal", modelID: "assistant-prefill-guard" },
+      system: "system-prompt",
+      tools: { bash: true },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given rejecting model metadata uses direct provider and model fields #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_direct_model",
+          role: "user",
+          sessionID: "ses_direct_model",
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4.6",
+          system: "system-prompt",
+          tools: { bash: true },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_direct_model",
+          role: "assistant",
+          sessionID: "ses_direct_model",
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_direct_model",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4.6" },
+      system: "system-prompt",
+      tools: { bash: true },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given models that still allow assistant prefill or missing model metadata #when messages transform runs #then it keeps the assistant tail unchanged", async () => {
+    //#given
+    const scenarios: Array<{ name: string; userInfo: TestMessage["info"] }> = [
+      {
+        name: "openai",
+        userInfo: {
+          role: "user",
+          model: { providerID: "openai", modelID: "gpt-5.4" },
+        },
+      },
+      {
+        name: "anthropic allowed",
+        userInfo: {
+          role: "user",
+          model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+        },
+      },
+      {
+        name: "missing model",
+        userInfo: { role: "user" },
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const messages: TestMessage[] = [
+        { info: scenario.userInfo, parts: [{ type: "text", text: scenario.name }] },
+        { info: { role: "assistant" }, parts: [{ type: "text", text: "completed assistant answer" }] },
+      ]
+
+      //#when
+      await runHandler(makeHooks({}), messages)
+
+      //#then
+      expect(messages, scenario.name).toHaveLength(2)
+      expect(messages.at(-1)?.info.role, scenario.name).toBe("assistant")
+    }
+  })
+
   it("#given an internal compaction continuation reaches an assistant prefill tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
     //#given
     const messages: TestMessage[] = [
       { info: { role: "user" }, parts: [{ type: "text", text: "work on this" }] },
       {
         info: { role: "user" },
+        parts: [{
+          type: "text",
+          text: `[session recovered - continuing previous task]\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+          synthetic: true,
+          metadata: { compaction_continue: true },
+        }],
+      },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "partial assistant tail" }] },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages.at(-1)?.info).toMatchObject({ role: "user" })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given an allowed model compaction continuation reaches an assistant tail #when messages transform runs #then it still appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          role: "user",
+          model: { providerID: "openai", modelID: "gpt-5.4" },
+        },
         parts: [{
           type: "text",
           text: `[session recovered - continuing previous task]\n${OMO_INTERNAL_INITIATOR_MARKER}`,

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -5,11 +5,7 @@ import { normalizeModelID } from "../shared/model-normalization"
 import type { CreatedHooks } from "../create-hooks"
 
 const ASSISTANT_PREFILL_RECOVERY_TEXT = "[internal] Continue from the previous assistant state."
-const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS = new Set([
-  "anthropic",
-  "google-vertex-anthropic",
-  "opencode",
-])
+const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDER = "anthropic"
 const ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES = [
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -98,7 +94,7 @@ function shouldRepairAssistantPrefillForModel(model: ModelIdentifier | undefined
   }
 
   const providerID = model.providerID.toLowerCase()
-  if (!ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS.has(providerID)) {
+  if (providerID !== ASSISTANT_PREFILL_UNSUPPORTED_PROVIDER) {
     return false
   }
 
@@ -162,7 +158,8 @@ function ensureUserTurnAfterAssistantTail(output: MessagesTransformOutput): void
   }
 
   const shouldRepairAssistantTail = hasInternalContinuationTrigger(output.messages) ||
-    shouldRepairAssistantPrefillForModel(findLastUserModel(output.messages) ?? readModelIdentifier(lastMessage.info))
+    shouldRepairAssistantPrefillForModel(findLastUserModel(output.messages)) ||
+    shouldRepairAssistantPrefillForModel(readModelIdentifier(lastMessage.info))
   if (!shouldRepairAssistantTail) {
     return
   }

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -5,7 +5,10 @@ import { normalizeModelID } from "../shared/model-normalization"
 import type { CreatedHooks } from "../create-hooks"
 
 const ASSISTANT_PREFILL_RECOVERY_TEXT = "[internal] Continue from the previous assistant state."
-const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDER = "anthropic"
+const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS = new Set([
+  "anthropic",
+  "google-vertex-anthropic",
+])
 const ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES = [
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -94,7 +97,7 @@ function shouldRepairAssistantPrefillForModel(model: ModelIdentifier | undefined
   }
 
   const providerID = model.providerID.toLowerCase()
-  if (providerID !== ASSISTANT_PREFILL_UNSUPPORTED_PROVIDER) {
+  if (!ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS.has(providerID)) {
     return false
   }
 

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -1,9 +1,21 @@
 import type { Message, Part } from "@opencode-ai/sdk"
 
 import { log } from "../shared/logger"
+import { normalizeModelID } from "../shared/model-normalization"
 import type { CreatedHooks } from "../create-hooks"
 
 const ASSISTANT_PREFILL_RECOVERY_TEXT = "[internal] Continue from the previous assistant state."
+const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS = new Set([
+  "anthropic",
+  "google-vertex-anthropic",
+  "opencode",
+])
+const ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES = [
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-mythos",
+]
 
 type MessageWithParts = {
   info: Message
@@ -12,6 +24,10 @@ type MessageWithParts = {
 
 type MessagesTransformOutput = { messages: MessageWithParts[] }
 type UserMessageInfo = Extract<Message, { role: "user" }>
+type ModelIdentifier = {
+  providerID: string
+  modelID: string
+}
 
 function getSessionID(message: MessageWithParts): string | undefined {
   return message.info.sessionID
@@ -43,6 +59,53 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function readStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function readModelIdentifier(info: unknown): ModelIdentifier | undefined {
+  if (!isRecord(info)) {
+    return undefined
+  }
+
+  const model = info["model"]
+  const nestedModel = isRecord(model) ? model : undefined
+  const providerID = nestedModel
+    ? readStringField(nestedModel, "providerID") ?? readStringField(info, "providerID")
+    : readStringField(info, "providerID")
+  const modelID = nestedModel
+    ? readStringField(nestedModel, "modelID") ?? readStringField(info, "modelID")
+    : readStringField(info, "modelID")
+
+  return providerID && modelID ? { providerID, modelID } : undefined
+}
+
+function findLastUserModel(messages: MessageWithParts[]): ModelIdentifier | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.info.role === "user") {
+      return readModelIdentifier(message.info)
+    }
+  }
+
+  return undefined
+}
+
+function shouldRepairAssistantPrefillForModel(model: ModelIdentifier | undefined): boolean {
+  if (!model) {
+    return false
+  }
+
+  const providerID = model.providerID.toLowerCase()
+  if (!ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS.has(providerID)) {
+    return false
+  }
+
+  const modelID = normalizeModelID(model.modelID.toLowerCase())
+  return ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES.some((prefix) => modelID.startsWith(prefix))
+}
+
 function isCompactionContinuationPart(part: unknown): boolean {
   if (!isRecord(part)) {
     return false
@@ -63,7 +126,7 @@ function createAssistantPrefillRecoveryMessage(
   const lastUserMessage = findLastUserMessage(messages)
   const sessionID = getSessionID(lastAssistantMessage) ?? lastUserMessage?.sessionID ?? ""
   const messageID = `${lastAssistantMessage.info.id}_prefill_recovery`
-  const model = lastUserMessage?.model ?? {
+  const model = readModelIdentifier(lastUserMessage) ?? {
     providerID: "internal",
     modelID: "assistant-prefill-guard",
   }
@@ -98,7 +161,9 @@ function ensureUserTurnAfterAssistantTail(output: MessagesTransformOutput): void
     return
   }
 
-  if (!hasInternalContinuationTrigger(output.messages)) {
+  const shouldRepairAssistantTail = hasInternalContinuationTrigger(output.messages) ||
+    shouldRepairAssistantPrefillForModel(findLastUserModel(output.messages) ?? readModelIdentifier(lastMessage.info))
+  if (!shouldRepairAssistantTail) {
     return
   }
 


### PR DESCRIPTION
## Summary
Fixes Claude Opus 4.7 assistant-prefill failures when an outgoing OpenCode history ends with a completed assistant message.

The message transform now appends the existing synthetic user recovery turn only for Anthropic models that reject assistant prefill, while preserving assistant-tail behavior for supported or unknown models.

## Changes
- Detect nested and direct provider/model metadata on the last user message, with assistant-tail metadata as fallback.
- Guard Opus 4.7, Opus 4.6, Sonnet 4.6, and Mythos-style Anthropic model IDs.
- Add regression tests for rejecting models, allowed models, unknown metadata, and compaction continuation compatibility.

## Testing
- `bun test src/plugin/messages-transform.test.ts --bail`
- `bun run typecheck`
- `bun run build`
- Library smoke via `bun --eval` importing `createMessagesTransformHandler`

## Notes
Scenario notes: `/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/ulw-scenarios.XXXXXX.md.dZWsV5yljC`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic-family assistant-prefill failures by adding a synthetic user recovery turn only when the last message is an assistant tail for rejecting models. Keeps tails unchanged for allowed or non-Anthropic models.

- **Bug Fixes**
  - Read provider/model from nested `model` or direct fields on the last user message, and also check the assistant tail.
  - Guard only Anthropic-family providers (`anthropic`, `google-vertex-anthropic`) with normalized model ID prefixes: `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-mythos`.
  - Preserve compaction continuation by still adding the recovery turn when continuation markers are present, including for allowed models.
  - Add tests for assistant-tail-only metadata, allowed user model followed by rejecting Anthropic tail, Vertex Anthropic, non-Anthropic Claude-like IDs, allowed models, missing metadata, and continuation paths.

<sup>Written for commit 5f0e037dae6714295befaccb9811138e2bda1719. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4175?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

