### PR TITLE
fix(skill-mcp-manager): trust explicit skill MCP env vars (#3995)

### DIFF
--- a/src/features/skill-mcp-manager/env-cleaner.test.ts
+++ b/src/features/skill-mcp-manager/env-cleaner.test.ts
@@ -142,23 +142,55 @@ describe("createCleanMcpEnvironment", () => {
       expect(cleanEnv.NODE_ENV).toBe("production")
     })
 
-    it("filters secret keys from customEnv that would bypass process.env filtering", () => {
-      // given - customEnv tries to inject secrets that should be filtered
+    it("passes through secret-named keys from customEnv without filtering", () => {
+      // given - custom env values are explicitly declared in skill config
       process.env.PATH = "/usr/bin"
+      process.env.MCP_API_KEY = "ambient-secret-from-process-env"
       const customEnv = {
-        MCP_API_KEY: "secret-key-that-should-be-filtered",
-        CUSTOM_SECRET: "another-secret",
+        MCP_API_KEY: "skill-declared-api-key",
+        TELEGRAM_BOT_TOKEN: "skill-configured-bot-token",
         SAFE_VAR: "safe-value",
       }
 
       // when
       const cleanEnv = createCleanMcpEnvironment(customEnv)
 
-      // then - secret keys from customEnv are filtered despite not being in process.env
-      expect(cleanEnv.MCP_API_KEY).toBeUndefined()
-      expect(cleanEnv.CUSTOM_SECRET).toBeUndefined()
+      // then - custom env overrides ambient values and is not filtered
+      expect(cleanEnv.MCP_API_KEY).toBe("skill-declared-api-key")
+      expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBe("skill-configured-bot-token")
       expect(cleanEnv.SAFE_VAR).toBe("safe-value")
       expect(cleanEnv.PATH).toBe("/usr/bin")
+    })
+
+    it("passes TELEGRAM_BOT_TOKEN through when declared in skill env (issue #3995)", () => {
+      // given - TELEGRAM_BOT_TOKEN matches /_TOKEN$/i but is explicitly declared
+      process.env.TELEGRAM_BOT_TOKEN = "ambient-bot-token"
+      const customEnv = {
+        TELEGRAM_BOT_TOKEN: "skill-bot-token",
+      }
+
+      // when
+      const cleanEnv = createCleanMcpEnvironment(customEnv)
+
+      // then
+      expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBe("skill-bot-token")
+    })
+
+    it("still filters secret-named vars from process.env when customEnv is provided", () => {
+      // given
+      process.env.AMBIENT_API_KEY = "ambient-secret"
+      process.env.PATH = "/usr/bin"
+      const customEnv = {
+        SAFE_CUSTOM_VAR: "custom-value",
+      }
+
+      // when
+      const cleanEnv = createCleanMcpEnvironment(customEnv)
+
+      // then
+      expect(cleanEnv.AMBIENT_API_KEY).toBeUndefined()
+      expect(cleanEnv.PATH).toBe("/usr/bin")
+      expect(cleanEnv.SAFE_CUSTOM_VAR).toBe("custom-value")
     })
   })
 

--- a/src/features/skill-mcp-manager/env-cleaner.ts
+++ b/src/features/skill-mcp-manager/env-cleaner.ts
@@ -35,25 +35,25 @@ export const EXCLUDED_ENV_PATTERNS: RegExp[] = [
   /_API_KEY$/i,
 ]
 
+function isExcludedEnvKey(key: string): boolean {
+  return EXCLUDED_ENV_PATTERNS.some((pattern) => pattern.test(key))
+}
+
 export function createCleanMcpEnvironment(
   customEnv: Record<string, string> = {}
 ): Record<string, string> {
-  const mergedEnv: Record<string, string> = {}
+  const cleanEnv: Record<string, string> = {}
 
+  // Apply the blacklist only to inherited ambient environment variables.
+  // Skill-configured env entries are explicitly declared and must be passed
+  // through as-is so stdio MCP servers can receive required credentials.
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue
-    mergedEnv[key] = value
+    if (isExcludedEnvKey(key)) continue
+    cleanEnv[key] = value
   }
 
-  Object.assign(mergedEnv, customEnv)
-
-  const cleanEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(mergedEnv)) {
-    const shouldExclude = EXCLUDED_ENV_PATTERNS.some((pattern) => pattern.test(key))
-    if (!shouldExclude) {
-      cleanEnv[key] = value
-    }
-  }
+  Object.assign(cleanEnv, customEnv)
 
   return cleanEnv
 }


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

## Summary

- Fix `createCleanMcpEnvironment()` silently dropping secret-named env vars declared in skill MCP config
- Apply `EXCLUDED_ENV_PATTERNS` blacklist only to ambient `process.env`, not to explicitly declared `customEnv`
- `TELEGRAM_BOT_TOKEN` and similar vars configured in a skill's `env` field now reach the stdio MCP server as intended

## Changes

- `src/features/skill-mcp-manager/env-cleaner.ts`
  - Extract `isExcludedEnvKey()` helper for clarity
  - Change execution order: filter `process.env` first, then overlay `customEnv` — replacing the previous merge-then-filter-all approach
- `src/features/skill-mcp-manager/env-cleaner.test.ts`
  - Remove incorrect assertion that secret-named keys in `customEnv` should be filtered
  - Add regression test: `TELEGRAM_BOT_TOKEN` declared in skill env passes through (issue #3995)
  - Add test: ambient `process.env` secrets remain blocked even when `customEnv` is provided

## Testing

```bash
bun run typecheck
bun test src/features/skill-mcp-manager
```

## Related Issues

Closes #3995 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes env cleaning for skill MCP so explicit skill env vars (e.g., TELEGRAM_BOT_TOKEN) pass through to the MCP server, while secret-like vars from ambient `process.env` stay blocked. Resolves #3995.

- **Bug Fixes**
  - Apply exclusion patterns only to inherited `process.env`; do not filter explicit `customEnv`.
  - Change order: filter `process.env` first, then overlay `customEnv`.
  - Add regression tests for TELEGRAM_BOT_TOKEN pass-through and ambient secret blocking.

<sup>Written for commit 22aadd686340e9e7ea2dee2629c75d20c2cbfebb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4176?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

