### PR TITLE
docs(readme): add docs site badge linking to omo.vibetip.help/docs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-openagent?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/issues)
 [![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/LICENSE.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-openagent)
+[![Docs](https://img.shields.io/badge/docs-omo.vibetip.help-369eff?labelColor=black&logo=readthedocs&logoColor=white&style=flat-square)](https://omo.vibetip.help/docs)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,6 +54,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-openagent?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/issues)
 [![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/LICENSE.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-openagent)
+[![Docs](https://img.shields.io/badge/docs-omo.vibetip.help-369eff?labelColor=black&logo=readthedocs&logoColor=white&style=flat-square)](https://omo.vibetip.help/docs)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-openagent?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/issues)
 [![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/LICENSE.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-openagent)
+[![Docs](https://img.shields.io/badge/docs-omo.vibetip.help-369eff?labelColor=black&logo=readthedocs&logoColor=white&style=flat-square)](https://omo.vibetip.help/docs)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -55,6 +55,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-openagent?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/issues)
 [![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/LICENSE.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-openagent)
+[![Docs](https://img.shields.io/badge/docs-omo.vibetip.help-369eff?labelColor=black&logo=readthedocs&logoColor=white&style=flat-square)](https://omo.vibetip.help/docs)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
 


### PR DESCRIPTION
## Summary

- Add a `Docs` badge next to `Ask DeepWiki` in all four READMEs so the hosted documentation site at https://omo.vibetip.help/docs is discoverable from the project front page.
- Minimal, single-line addition per file — no other content touched.

## Changes

- `README.md` — append `Docs` shields.io badge after `Ask DeepWiki`.
- `README.ko.md` — same line, kept identical for visual parity across languages.
- `README.ja.md` — same line.
- `README.zh-cn.md` — same line.

Badge color `369eff` matches the existing `GitHub Release` badge; `readthedocs` logo signals "documentation site" without inventing a new icon.

## Screenshots

| Before | After |
|:---:|:---:|
| existing badge block ends at `Ask DeepWiki` | `Ask DeepWiki` + new `docs / omo.vibetip.help` badge |

## Testing

No code paths changed. Verified the destination URL responds with `HTTP/2 200` and renders the hosted Fumadocs site.

## Related Issues

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Docs badge next to Ask DeepWiki in all README variants, linking to https://omo.vibetip.help/docs to make the hosted docs easy to find.
One-line addition per file; no other content changed.

<sup>Written for commit c5cc720dee26ed52f47b4d70ca9865281647c89c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4181?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

