### PR TITLE
fix(model-heuristics): register Grok family so reasoningEffort survives on @ai-sdk/openai

### DIFF
--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -46,6 +46,12 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     variants: ["low", "medium", "high"],
   },
   {
+    family: "grok",
+    includes: ["grok"],
+    variants: ["low", "medium", "high"],
+    reasoningEfforts: ["low", "medium", "high"],
+  },
+  {
     family: "kimi-thinking",
     includes: ["kimi-thinking", "k2-thinking", "k2-think"],
     pattern: /(?:kimi|k2).*-(?:thinking|think)/,

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -253,6 +253,7 @@ describe("resolveCompatibleModelSettings", () => {
       hasReasoningEffort: boolean
     }> = [
       { name: "Gemini", modelID: "gemini-3.1-pro", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Grok", modelID: "grok-4.3", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
       { name: "Kimi (kimi)", modelID: "kimi-k2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },


### PR DESCRIPTION
## Summary

- Add a `grok` family entry to `HEURISTIC_MODEL_FAMILY_REGISTRY` so Grok models served via `@ai-sdk/openai` / `@ai-sdk/openai-compatible` retain their configured `reasoningEffort`.
- Mirrors PR #3084 (Claude) — same one-line registry fix, same pattern as the Minimax (#2118) and DeepSeek (#3922) requests.

Closes #4185.

## Changes

- `src/shared/model-capability-heuristics.ts` — Register a `grok` family with `includes: ["grok"]`, `variants: ["low", "medium", "high"]`, and `reasoningEfforts: ["low", "medium", "high"]`. xAI's Grok reasoning models accept `reasoning_effort` ∈ `{low, medium, high}`, matching the variant list exactly.
- `src/shared/model-settings-compatibility.test.ts` — Extend the family table-driven test to assert that `grok-4.3` resolves to `expectedVariants: ["low", "medium", "high"]` with `hasReasoningEffort: true`.

## Why

Without a Grok family in the registry, `resolveCompatibleModelSettings("grok-4.3")` returns the "unknown family" result. The `chat.params` hook reads `hasReasoningEffort: false` and deletes `output.options.reasoningEffort` before the request leaves the plugin — so users routing Grok through CLIProxyAPI, LiteLLM, or any other OpenAI-compatible gateway never see their `reasoningEffort` forwarded, even with `forceReasoning: true` set on the provider. See #4185 for the full root-cause walkthrough.

## Testing

```bash
bun run typecheck   # passes
bun test src/shared/model-settings-compatibility.test.ts   # 64 pass, 0 fail
```

Pre-existing failures in `scheduleDeferredModelOverride` are unrelated to this change (they fail identically on `upstream/dev` before this PR) and only touch files outside `src/shared/model-capability-heuristics.ts` / `src/shared/model-settings-compatibility.test.ts`.

Manually verified end-to-end against a Grok-backed CLIProxyAPI gateway: with this fix, `reasoningEffort: "high"` reaches the upstream xAI endpoint as `reasoning_effort: "high"` and Grok returns reasoning tokens.

## Related Issues

Closes #4185


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the Grok model family so `reasoningEffort` (low/medium/high) is preserved when using Grok via `@ai-sdk/openai` or `@ai-sdk/openai-compatible`. Prevents the plugin from stripping `reasoningEffort` for models like `grok-4.3`.

- **Bug Fixes**
  - Add `grok` to `HEURISTIC_MODEL_FAMILY_REGISTRY` (includes: "grok"; variants and reasoningEfforts: low, medium, high).
  - Extend `resolveCompatibleModelSettings` test to validate `grok-4.3` has reasoning effort support.

<sup>Written for commit 8b097f2c3b50b265da20f2b122cf8d789ab6ea6c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

