### PR TITLE
fix(rules-core): fall back to workspace directory when no project root marker is found

### DIFF
--- a/packages/rules-core/src/finder.ts
+++ b/packages/rules-core/src/finder.ts
@@ -15,19 +15,35 @@ export function findRuleFiles(
 ): RuleFileCandidate[] {
   const startDir = dirname(resolve(currentFile));
   const skipClaudeUserRules = options?.skipClaudeUserRules ?? false;
-  const cacheKey = [projectRoot ?? "", startDir, skipClaudeUserRules ? "1" : "0"].join("\0");
+  const effectiveProjectRoot = resolveEffectiveProjectRoot(
+    projectRoot,
+    options?.workspaceDirectory,
+    startDir,
+  );
+  const cacheKey = [projectRoot ?? "", effectiveProjectRoot, startDir, skipClaudeUserRules ? "1" : "0"].join(
+    "\0",
+  );
   const cached = cache?.get(cacheKey);
   if (cached) return [...cached];
   const candidates: RuleFileCandidate[] = [];
   const seenRealPaths = new Set<string>();
-  if (projectRoot) {
-    addProjectRuleCandidates(projectRoot, startDir, candidates, seenRealPaths, cache);
-    addProjectSingleFileCandidates(projectRoot, candidates, seenRealPaths);
-  }
+  addProjectRuleCandidates(effectiveProjectRoot, startDir, candidates, seenRealPaths, cache);
+  addProjectSingleFileCandidates(effectiveProjectRoot, candidates, seenRealPaths);
   addUserRuleCandidates(homeDir || homedir(), skipClaudeUserRules, candidates, seenRealPaths, cache);
   const sorted = sortCandidates(candidates);
   cache?.set(cacheKey, sorted);
   return sorted;
+}
+
+function resolveEffectiveProjectRoot(
+  projectRoot: string | null,
+  workspaceDirectory: string | undefined,
+  startDir: string,
+): string {
+  if (projectRoot) return projectRoot;
+  if (!workspaceDirectory) return startDir;
+  const workspaceRoot = resolve(workspaceDirectory);
+  return isSameOrChildPath(startDir, workspaceRoot) ? workspaceRoot : startDir;
 }
 
 function addProjectRuleCandidates(

--- a/packages/rules-core/src/index.test.ts
+++ b/packages/rules-core/src/index.test.ts
@@ -62,6 +62,29 @@ describe("rules-core", () => {
     expect(found.map((rule) => rule.relativePath)).not.toContain(".sisyphus/rules/sisyphus.md");
   });
 
+  it("#given a workspace directory has no project marker (no .git, no package.json, etc.) AND contains .omo/rules/ #when findRuleFiles is called #then the .omo/rules/ files are still discovered", () => {
+    // given
+    const root = createTestRoot("rules-core-markerless-workspace");
+    const homeDir = join(root, "home");
+    const sourceDir = join(root, "src");
+    const ruleFile = join(root, ".omo", "rules", "test-rule.md");
+    const currentFile = join(sourceDir, "index.ts");
+    mkdirSync(join(root, ".omo", "rules"), { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(ruleFile, "markerless workspace rule");
+    writeFileSync(currentFile, "export {};");
+    const projectRoot = findProjectRoot(currentFile);
+    const options = { skipClaudeUserRules: false, workspaceDirectory: root };
+
+    // when
+    const found = findRuleFiles(projectRoot, homeDir, currentFile, options);
+
+    // then
+    expect(projectRoot).toBeNull();
+    expect(found.map((rule) => rule.path)).toContain(ruleFile);
+  });
+
   it("#given frontmatter aliases and negative glob #when matching #then honors applyTo paths and exclusions", () => {
     // given
     const { metadata } = parseRuleFrontmatter(`---\npaths: ["src/**/*.ts"]\napplyTo:\n  - "!src/**/*.test.ts"\n---\nRule\n`);

--- a/packages/rules-core/src/types.ts
+++ b/packages/rules-core/src/types.ts
@@ -58,6 +58,7 @@ export interface RuleScanCache {
 
 export interface FindRuleFilesOptions {
   readonly skipClaudeUserRules?: boolean;
+  readonly workspaceDirectory?: string;
 }
 
 export interface AgentsMdCache {

--- a/src/hooks/rules-injector/injector.test.ts
+++ b/src/hooks/rules-injector/injector.test.ts
@@ -339,6 +339,7 @@ describe("createRuleInjectionProcessor", () => {
 				contentHashes: new Set<string>(),
 				realPaths: new Set<string>([ruleRealPath]),
 			}),
+			homedir: () => homeRoot,
 		});
 
 		// when

--- a/src/hooks/rules-injector/injector.ts
+++ b/src/hooks/rules-injector/injector.ts
@@ -137,6 +137,9 @@ export function createRuleInjectionProcessor(deps: {
 	} = deps;
 
 	const matchDecisionCache: MatchDecisionCache = new Map();
+	const finderOptions: FindRuleFilesOptions = ruleFinderOptions
+		? { ...ruleFinderOptions, workspaceDirectory }
+		: { workspaceDirectory };
 
 	function getParsedRule(filePath: string, realPath: string): ParsedRule {
 		try {
@@ -189,7 +192,7 @@ export function createRuleInjectionProcessor(deps: {
 			projectRoot,
 			home,
 			resolved,
-			ruleFinderOptions,
+			finderOptions,
 			ruleScanCache,
 		);
 		const toInject: RuleToInject[] = [];


### PR DESCRIPTION
## Summary
Fixes BUG-F in `rules-core/finder`: markerless workspaces with project rules no longer lose `.omo/rules`, `.claude/rules`, `.cursor/rules`, `.github/instructions`, or `.github/copilot-instructions.md` candidates.

## Evidence
L1 G8 ultrabrain confirmed: "a workspace without .git, package.json, etc. can have .omo/rules, .claude/rules, .cursor/rules, but they will not be discovered".

The regression came from the extracted `packages/rules-core/src/finder.ts` gating all project rule scans on a non-null `projectRoot`, while the pre-v4.2.2 inline parser walked upward from the working directory and discovered project rule directories even without project markers.

## Changes
- Add a RED regression test for markerless workspace project rule discovery.
- Add `workspaceDirectory` to `FindRuleFilesOptions` and use it as the effective project root when marker discovery returns null.
- Pass the hook `workspaceDirectory` through the rules-injector caller.
- Keep the duplicate-cache injector test isolated from user-level rules.

## Testing
- `bun test packages/rules-core/src/index.test.ts` failed before the fix, then passed after the fix
- `bun test packages/rules-core/`
- `bun test src/hooks/rules-injector/`
- `bun test src/hooks/directory-agents-injector/`
- `bun run typecheck`
- `bun test`
- `bun run build`

## Merge
HALT-BEFORE-MERGE: ready for manual approval after CI, review-work, and Cubic pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rule discovery in markerless workspaces by falling back to the workspace directory when no project root marker is found. Restores detection of project rules in `.omo/rules`, `.claude/rules`, `.cursor/rules`, `.github/instructions`, and `.github/copilot-instructions.md`.

- **Bug Fixes**
  - `rules-core` finder now computes an effective project root and scans project rules using it, even without markers.
  - Added `workspaceDirectory` to `FindRuleFilesOptions` and threaded it through the `rules-injector`.
  - Updated the cache key to include the effective project root.
  - Added a regression test for markerless workspaces and isolated homedir in injector tests.

<sup>Written for commit 1f9a581e703d0416e4bf42846baeb12d58164efc. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

