### PR TITLE
fix(ast-grep-mcp): allow absolute paths whose realpath is inside the workspace

### DIFF
--- a/packages/ast-grep-mcp/src/mcp.test.ts
+++ b/packages/ast-grep-mcp/src/mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleAstGrepMcpRequest } from "./mcp";
@@ -158,6 +158,98 @@ describe("ast-grep MCP", () => {
     }
 
     expect(didRun).toBe(false);
+  });
+
+  it("#given paths contains an absolute path inside the workspace #when search and replace are called #then it is normalized to relative and processed normally", async () => {
+    const captured: RunOptions[] = [];
+    const workspaceDirectory = createTemporaryDirectory("omo-ast-grep-absolute-inside-");
+    const sourcePath = join(workspaceDirectory, "foo.ts");
+    writeFileSync(sourcePath, "console.log('hello')\n");
+
+    const runSg = async (options: RunOptions): Promise<SgResult> => {
+      captured.push(options);
+      return emptyResult;
+    };
+
+    const searchResponse = await handleAstGrepMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: "search-absolute-inside",
+        method: "tools/call",
+        params: { name: "search", arguments: { pattern: "console.log($$$)", lang: "typescript", paths: [sourcePath] } },
+      },
+      { workspaceDirectory, runSg },
+    );
+    const replaceResponse = await handleAstGrepMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: "replace-absolute-inside",
+        method: "tools/call",
+        params: { name: "replace", arguments: { pattern: "console.log($MSG)", rewrite: "logger.info($MSG)", lang: "typescript", paths: [sourcePath] } },
+      },
+      { workspaceDirectory, runSg },
+    );
+
+    expect(searchResponse?.result?.isError).toBe(false);
+    expect(replaceResponse?.result?.isError).toBe(false);
+    expect(captured.map((options) => options.paths)).toEqual([["foo.ts"], ["foo.ts"]]);
+  });
+
+  it("#given paths contains an absolute path outside the workspace #when search is called #then it is rejected", async () => {
+    const workspaceDirectory = createTemporaryDirectory("omo-ast-grep-absolute-outside-workspace-");
+    const outsideDirectory = createTemporaryDirectory("omo-ast-grep-absolute-outside-");
+    const outsidePath = join(outsideDirectory, "foo.ts");
+    writeFileSync(outsidePath, "console.log('outside')\n");
+    let didRun = false;
+
+    const response = await handleAstGrepMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: "absolute-outside",
+        method: "tools/call",
+        params: { name: "search", arguments: { pattern: "console.log($$$)", lang: "typescript", paths: [outsidePath] } },
+      },
+      {
+        workspaceDirectory,
+        runSg: async () => {
+          didRun = true;
+          return emptyResult;
+        },
+      },
+    );
+
+    expect(response?.result?.isError).toBe(true);
+    expect(response?.result?.content?.[0]?.text).toContain("stay inside the workspace");
+    expect(didRun).toBe(false);
+  });
+
+  it("#given paths contains an absolute path whose realpath resolves inside workspace through a symlink #when search is called #then it is allowed", async () => {
+    const captured: { value?: RunOptions } = {};
+    const workspaceDirectory = createTemporaryDirectory("omo-ast-grep-symlink-target-");
+    const symlinkParent = createTemporaryDirectory("omo-ast-grep-symlink-parent-");
+    const sourcePath = join(workspaceDirectory, "foo.ts");
+    const symlinkPath = join(symlinkParent, "workspace-link");
+    writeFileSync(sourcePath, "console.log('via symlink')\n");
+    symlinkSync(workspaceDirectory, symlinkPath);
+
+    const response = await handleAstGrepMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: "absolute-symlink-inside",
+        method: "tools/call",
+        params: { name: "search", arguments: { pattern: "console.log($$$)", lang: "typescript", paths: [join(symlinkPath, "foo.ts")] } },
+      },
+      {
+        workspaceDirectory,
+        runSg: async (options) => {
+          captured.value = options;
+          return emptyResult;
+        },
+      },
+    );
+
+    expect(response?.result?.isError).toBe(false);
+    expect(captured.value?.paths).toEqual(["foo.ts"]);
   });
 
   it("#given tools list request #when handled #then preserves detailed ast-grep guidance", async () => {

--- a/packages/ast-grep-mcp/src/workspace-paths.ts
+++ b/packages/ast-grep-mcp/src/workspace-paths.ts
@@ -15,7 +15,7 @@ function resolveWorkspacePath(rawPath: string, workspaceDirectory: string): stri
   if (rawPath.length === 0) throw new Error("paths entries must be non-empty strings");
   if (rawPath.startsWith("-")) throw new Error(`paths entries must not start with '-': ${rawPath}`);
   if (rawPath.includes("\0")) throw new Error("paths entries must not contain null bytes");
-  if (isAbsolute(rawPath)) throw new Error(`paths entries must be relative to the workspace: ${rawPath}`);
+  if (isAbsolute(rawPath)) return resolveAbsoluteWorkspacePath(rawPath, workspaceDirectory);
 
   const absolutePath = resolve(workspaceDirectory, rawPath);
   assertInsideWorkspace(absolutePath, workspaceDirectory, rawPath);
@@ -26,6 +26,20 @@ function resolveWorkspacePath(rawPath: string, workspaceDirectory: string): stri
   }
 
   const normalizedPath = relative(workspaceDirectory, absolutePath);
+  return normalizedPath === "" ? "." : normalizedPath;
+}
+
+function resolveAbsoluteWorkspacePath(rawPath: string, workspaceDirectory: string): string {
+  let realPath: string;
+  try {
+    realPath = realpathSync(rawPath);
+  } catch {
+    throw new Error(`absolute path entry does not exist: ${rawPath}`);
+  }
+
+  assertInsideWorkspace(realPath, workspaceDirectory, rawPath);
+
+  const normalizedPath = relative(workspaceDirectory, realPath);
   return normalizedPath === "" ? "." : normalizedPath;
 }
 


### PR DESCRIPTION
## Summary
Fixes BUG-I: package-backed ast-grep MCP regressed from the native tool by rejecting every absolute `paths` entry, including paths copied from Read output that resolve inside the workspace. Absolute paths now realpath through the workspace sandbox and normalize to relative paths before reaching the ast-grep CLI.

## Changes
- Added red coverage for absolute paths inside the workspace, outside the workspace, and symlinked absolute paths whose realpath resolves inside the workspace.
- Preserved the sandbox guarantee by rejecting absolute paths outside the workspace.
- Rejects absolute path entries whose realpath cannot be resolved with a clear missing-path error.

## Testing
- `bun test packages/ast-grep-mcp/` ✅
- `bun test src/mcp/` ✅
- `bun run typecheck` ✅
- `HOME=$(mktemp -d) bun test` ✅
- `bun install` postinstall `bun run build` ✅

## Regression context
The old native ast-grep tool defaulted paths to absolute `ctx.directory` and tolerated absolute path inputs. L1 G7 evidence: existing skills or agents may pass paths copied from Read output or project prompts, causing `paths entries must be relative to the workspace`. This PR restores that real-world usage while keeping outside-workspace paths rejected.

## Merge status
HALT-BEFORE-MERGE: ready for manual merge after CI/review approval.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ast-grep-mcp` rejecting absolute paths by resolving them within the workspace and converting them to relative before invoking `ast-grep`. Preserves the sandbox by blocking outside-workspace paths and giving clear errors for missing targets.

- **Bug Fixes**
  - Allow absolute paths whose realpath is inside the workspace (including via symlinks) and normalize them to relative before calling `ast-grep`.
  - Reject absolute paths outside the workspace; return “absolute path entry does not exist” when realpath fails.

<sup>Written for commit 2ea2159d80ccb26b4fcde194a6d6837ba15ebb33. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

