### PR TITLE
fix(background-agent): re-enqueue parent wake on same-source reservation instead of dropping

### DIFF
--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -224,9 +224,9 @@ export class ParentWakeNotifier {
         throw promptResult.error
       }
       if (promptResult.status === "reserved" && promptResult.reservedBy === "background-agent-parent-wake") {
-        log("[background-agent] Ignored duplicate parent wake flush already reserved by promptAsync gate:", {
-          sessionID,
-        })
+        this.requeueWake(sessionID, latestWake)
+        this.schedulePendingParentWakeFlush(sessionID, 2_000)
+        log("[background-agent] Requeued parent wake flush reserved by promptAsync gate hold:", { sessionID })
         return
       }
       if (!isInternalPromptDispatchAccepted(promptResult)) {

--- a/src/features/background-agent/parent-wake-same-source-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-same-source-requeue.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    agent?: string
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type SessionMessageStub = {
+  info?: {
+    role?: string
+    finish?: string
+    time?: { created?: number }
+  }
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; content?: unknown }>
+}
+
+function createNotifier(args: {
+  sessionMessages?: SessionMessageStub[]
+  promptAsyncImpl?: (call: PromptAsyncCall, attempt: number) => Promise<unknown>
+} = {}): {
+  notifier: ParentWakeNotifier
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const sessionMessages = args.sessionMessages ?? [
+    {
+      info: {
+        role: "assistant",
+        finish: "stop",
+        time: { created: Date.now() - 10_000 },
+      },
+    },
+  ]
+  const client = {
+    session: {
+      messages: async () => ({ data: sessionMessages }),
+      status: async () => ({ data: {} }),
+      promptAsync: async (call: PromptAsyncCall) => {
+        promptAsyncCalls.push(call)
+        const attempt = promptAsyncCalls.length
+        return args.promptAsyncImpl?.(call, attempt) ?? { data: {} }
+      },
+      abort: async () => ({ data: {} }),
+    },
+  } as unknown as ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 100,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: 5_000,
+      userMessageInProgressWindowMs: 0,
+    },
+  )
+
+  return { notifier, promptAsyncCalls }
+}
+
+function releaseParentWakeHold(sessionID: string): void {
+  const released = releasePromptAsyncReservation(sessionID, "test:simulate-expired-parent-wake-hold", {
+    reservedBy: "background-agent-parent-wake",
+  })
+  expect(released).toBe(true)
+}
+
+describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () => {
+  test("#given a parent wake is in post-dispatch hold #when a new pending wake fires within the hold window #then the new wake is re-enqueued and dispatched after the hold expires", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-hold-new-wake"
+    notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+
+      // when
+      notifier.queuePendingParentWake(sessionID, "wake B", { agent: "sisyphus" }, true)
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual(["wake B"])
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a parent wake failed dispatch and is queued for retry #when the retry fires within the hold window of the failed dispatch #then the retry is preserved", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier({
+      promptAsyncImpl: async (_call, attempt) => {
+        if (attempt === 1) {
+          throw new Error("JSON Parse error: Unexpected EOF")
+        }
+        return { data: {} }
+      },
+    })
+    const sessionID = "parent-failed-retry-during-hold"
+    notifier.queuePendingParentWake(sessionID, "retry wake", { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(true)
+
+      // when
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual(["retry wake"])
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Fixes BUG-E where `ParentWakeNotifier.flushPendingParentWake()` could silently drop a pending parent wake when `dispatchInternalPrompt()` returned `reserved` from the same `background-agent-parent-wake` source during the prompt gate post-dispatch hold.

## Changes
- Added failing-first coverage for a later wake arriving during an existing parent-wake hold.
- Added failing-first coverage for a failed parent wake retry firing while the failed dispatch hold is still active.
- Re-enqueues the pending wake and schedules the next flush after the prompt gate hold instead of treating same-source reservation as a duplicate.

## Evidence chain
- `parent-wake-notifier.ts` deletes `pendingParentWakes` before dispatch.
- The prompt gate keeps same-source reservations during its post-dispatch hold.
- A same-source `reserved` result can mean an earlier wake is still holding the gate, not that the current pending wake is duplicate content.
- This complements Wave 2 prompt-gate work without modifying `prompt-async-gate.ts`.

## Testing
- `bun test src/features/background-agent/` ✅
- `bun test src/hooks/shared/prompt-async-gate.test.ts` ✅
- `bun test src/shared/prompt-async-route-audit.test.ts` ✅
- `bun run typecheck` ✅
- `HOME=/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/opencode/omo-empty-home bun test` ✅
- `bun run build` ✅

Note: plain local `bun test` with my normal HOME fails on existing `src/hooks/rules-injector/injector.test.ts` because local user rule files are discovered by that test. The same test also fails on local `dev`; isolated HOME matches CI-style clean home and passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a pending parent wake could be dropped if the prompt gate returned a same-source reservation during its post-dispatch hold. We now re-enqueue the wake and schedule a flush after the hold to prevent lost wakes.

- **Bug Fixes**
  - When `reserved` by `background-agent-parent-wake`, re-enqueue the wake and schedule the next flush after the gate hold instead of treating it as a duplicate.
  - Added tests for: a new wake arriving during an active hold, and a retry firing while the failed-dispatch hold is still active.

<sup>Written for commit 11d2cfb8a8ed3f83eb99fec5606974e822c77ce5. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

