### PR TITLE
fix(plugin): dispatch synthetic idle hooks

### DIFF
--- a/src/hooks/rules-injector/storage.ts
+++ b/src/hooks/rules-injector/storage.ts
@@ -37,10 +37,6 @@ export function saveInjectedRules(
   sessionID: string,
   data: { contentHashes: Set<string>; realPaths: Set<string> }
 ): void {
-  if (!existsSync(RULES_INJECTOR_STORAGE)) {
-    mkdirSync(RULES_INJECTOR_STORAGE, { recursive: true });
-  }
-
   const storageData: InjectedRulesData = {
     sessionID,
     injectedHashes: [...data.contentHashes],
@@ -48,7 +44,16 @@ export function saveInjectedRules(
     updatedAt: Date.now(),
   };
 
-  writeFileSync(getStoragePath(sessionID), JSON.stringify(storageData, null, 2));
+  mkdirSync(RULES_INJECTOR_STORAGE, { recursive: true });
+  try {
+    writeFileSync(getStoragePath(sessionID), JSON.stringify(storageData, null, 2));
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+    mkdirSync(RULES_INJECTOR_STORAGE, { recursive: true });
+    writeFileSync(getStoragePath(sessionID), JSON.stringify(storageData, null, 2));
+  }
 }
 
 export function clearInjectedRules(sessionID: string): void {

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -208,6 +208,55 @@ describe("createEventHandler - idle deduplication", () => {
 		expect(onEvent.mock.calls[0]?.[0]).toEqual(idleEvent.event)
 	})
 
+	it("#given tmux integration enabled #when session.status reports idle #then synthetic idle forwards to tmuxSessionManager.onEvent", async () => {
+		//#given
+		const onEvent = mock<(event: EventInput["event"]) => void>(() => {})
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({
+				directory: "/tmp",
+				client: {
+					session: {},
+				},
+			}),
+			pluginConfig: asPluginConfig({
+				tmux: { enabled: true },
+			}),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers({
+				tmuxSessionManager: {
+					onEvent,
+					onSessionCreated: async () => {},
+					onSessionDeleted: async () => {},
+				},
+			}),
+			hooks: createEventHandlerHooks({}),
+		})
+
+		//#when
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.status",
+				properties: {
+					sessionID: "ses_tmux_synthetic_idle",
+					status: { type: "idle" },
+				},
+			},
+		}))
+
+		//#then
+		expect(onEvent).toHaveBeenCalledTimes(1)
+		expect(onEvent.mock.calls[0]?.[0]).toEqual({
+			type: "session.idle",
+			properties: {
+				sessionID: "ses_tmux_synthetic_idle",
+				synthetic: true,
+			},
+		})
+	})
+
 	it("#given a readiness retry is pending #when session.idle arrives through the plugin handler #then tmux retry spawns the pane", async () => {
 		//#given
 		const sessionStatusData: Record<string, { type: string }> = {}

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -394,6 +394,12 @@ export function createEventHandler(args: {
     return hooks.sessionRecovery.handleInterruptedToolResultsOnIdle(sessionID);
   };
 
+  const dispatchIdleOnlyHooks = async (input: EventInput): Promise<void> => {
+    managers.tmuxSessionManager?.onEvent?.(input.event);
+    await runEventHookSafely("teamIdleWakeHint", teamIdleWakeHint, input);
+    await runEventHookSafely("teamMemberStatusHandler", teamMemberStatusHandler, input);
+  };
+
   const getFallbackContinuationKeys = (fallbackContext?: FallbackContinuationContext): FallbackContinuationDedupeKeys => {
     const agentKey = fallbackContext?.agentName
       ? getAgentConfigKey(fallbackContext.agentName).trim().toLowerCase()
@@ -628,7 +634,8 @@ export function createEventHandler(args: {
       if (!shouldDispatchIdleEvent(sessionID, now)) {
         return;
       }
-      await dispatchToHooks(syntheticIdle as EventInput);
+      const syntheticIdleInput = syntheticIdle as EventInput;
+      await dispatchToHooks(syntheticIdleInput);
       if (pluginConfig.openclaw) {
         await dispatchOpenClawEvent({
           config: pluginConfig.openclaw,
@@ -640,6 +647,7 @@ export function createEventHandler(args: {
           },
         });
       }
+      await dispatchIdleOnlyHooks(syntheticIdleInput);
     }
 
     const { event } = input;
@@ -761,9 +769,7 @@ export function createEventHandler(args: {
     }
 
     if (event.type === "session.idle") {
-      managers.tmuxSessionManager?.onEvent?.(event);
-      await runEventHookSafely("teamIdleWakeHint", teamIdleWakeHint, input);
-      await runEventHookSafely("teamMemberStatusHandler", teamMemberStatusHandler, input);
+      await dispatchIdleOnlyHooks(input);
     }
 
     if (event.type === "message.updated") {


### PR DESCRIPTION
## Summary

- Normalize `session.status` idle events all the way through the idle-only continuation/team/tmux hooks, matching current OpenCode completion semantics.
- Fix a rules-injector storage cleanup race that surfaced under the full Bun suite.

## Changes

- Extracted `dispatchIdleOnlyHooks()` in `src/plugin/event.ts` and invoked it for both real `session.idle` and synthetic idle derived from `session.status`.
- Added a regression test proving synthetic idle reaches `tmuxSessionManager.onEvent`, covering the stuck continuation/team wake surface.
- Retried rules-injector storage writes after recreating the storage directory when cleanup removes it between mkdir and write.

## Screenshots

Not applicable.

## Testing

```bash
bun run typecheck
bun test
bun run build
```

Local results:

- `bun run typecheck` passed.
- `bun test` passed: 7258 pass, 1 skip, 0 fail; 7259 tests across 736 files.
- `bun run build` passed and regenerated the schema without a diff.

## Related Issues

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispatch synthetic idle (from session.status) through the same idle-only hooks as real session.idle to fix missed tmux forwarding and stuck continuations. Also harden rules-injector storage writes to handle a cleanup race.

- **Bug Fixes**
  - Synthetic idle now triggers idle-only hooks: tmux forwarding and team idle wake/member status handling.
  - Rules-injector storage: mkdir before write and retry once on ENOENT to avoid directory deletion races.

<sup>Written for commit 0ebba9eba10c78f4c14e104d92e9ba97c10da7eb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

