### PR TITLE
fix(notification): suppress ready alerts during background tasks

### DIFF
--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -1,6 +1,11 @@
+/// <reference types="bun-types" />
 import { afterEach, beforeEach, describe, expect, jest, spyOn, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { createSessionNotification } from "./session-notification"
 import { setMainSession, subagentSessions, _resetForTesting } from "../features/claude-code-session-state"
+import { setContinuationMarkerSource } from "../features/run-continuation-state"
 import * as utils from "./session-notification-utils"
 import * as sender from "./session-notification-sender"
 
@@ -57,7 +62,7 @@ function createShellMock(options: {
   }
 }
 
-function createMockInput(shell: ReturnType<typeof createShellMock>): MockPluginInput {
+function createMockInput(shell: ReturnType<typeof createShellMock>, directory = "/tmp/test"): MockPluginInput {
   const input = {} as MockPluginInput
   return Object.assign(input, {
     $: shell,
@@ -66,17 +71,24 @@ function createMockInput(shell: ReturnType<typeof createShellMock>): MockPluginI
         todo: async () => ({ data: [] }),
       },
     },
-    directory: "/tmp/test",
-    project: "/tmp/test",
-    worktree: "/tmp/test",
+    directory,
+    project: directory,
+    worktree: directory,
     serverUrl: "http://localhost",
   })
 }
 
 describe("session-notification", () => {
   let notificationCalls: string[]
+  const tempDirs: string[] = []
 
-  function createMockPluginInput(): MockPluginInput {
+  function createTempDir(): string {
+    const directory = mkdtempSync(join(tmpdir(), "omo-session-notification-"))
+    tempDirs.push(directory)
+    return directory
+  }
+
+  function createMockPluginInput(directory = "/tmp/test"): MockPluginInput {
     return createMockInput(
       createShellMock({
         capture: (cmdStr) => {
@@ -85,7 +97,8 @@ describe("session-notification", () => {
             notificationCalls.push(cmdStr)
           }
         }
-      })
+      }),
+      directory,
     )
   }
 
@@ -126,6 +139,12 @@ describe("session-notification", () => {
     Date.now = originalDateNow
     subagentSessions.clear()
     _resetForTesting()
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop()
+      if (directory) {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    }
   })
 
   test("should not trigger notification for subagent session", async () => {
@@ -200,6 +219,58 @@ describe("session-notification", () => {
     await new Promise((resolve) => setTimeout(resolve, 100))
 
     // then - notification should be sent
+    expect(notificationCalls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test("should not trigger ready notification while background tasks are active", async () => {
+    // given - a main session has active background work marker
+    const mainSessionID = "main-bg-active"
+    const directory = createTempDir()
+    setMainSession(mainSessionID)
+    setContinuationMarkerSource(directory, mainSessionID, "background-task", "active", "1 background task active")
+
+    const hook = createSessionNotification(createMockPluginInput(directory), {
+      idleConfirmationDelay: 10,
+      enforceMainSessionFilter: false,
+    })
+
+    // when - main session goes idle before background work completes
+    await hook({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // then - ready notification should not be sent
+    expect(notificationCalls).toHaveLength(0)
+  })
+
+  test("should trigger ready notification when background task marker is idle", async () => {
+    // given - a main session has no active background work marker
+    const mainSessionID = "main-bg-idle"
+    const directory = createTempDir()
+    setMainSession(mainSessionID)
+    setContinuationMarkerSource(directory, mainSessionID, "background-task", "idle")
+
+    const hook = createSessionNotification(createMockPluginInput(directory), {
+      idleConfirmationDelay: 10,
+      enforceMainSessionFilter: false,
+    })
+
+    // when - main session goes idle after background work completes
+    await hook({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // then - ready notification should be sent
     expect(notificationCalls.length).toBeGreaterThanOrEqual(1)
   })
 

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -4,7 +4,7 @@ import { buildReadyNotificationContent } from "./session-notification-content"
 import { type Platform } from "./session-notification-sender"
 import * as sessionNotificationSender from "./session-notification-sender"
 import { getEventToolName, getQuestionText, getSessionID } from "./session-notification-event-properties"
-import { hasIncompleteTodos } from "./session-todo-status"
+import { hasPendingSessionWork } from "./session-todo-status"
 import { createIdleNotificationScheduler } from "./session-notification-scheduler"
 import { createSessionNotificationInit } from "./session-notification-init"
 import { resolveSessionEventID } from "../shared/event-session-id"
@@ -49,7 +49,7 @@ export function createSessionNotification(ctx: PluginInput, config: SessionNotif
   const scheduler = createIdleNotificationScheduler({
     ctx,
     config: mergedConfig,
-    hasIncompleteTodos,
+    hasIncompleteTodos: hasPendingSessionWork,
     send: async (hookCtx, sessionID) => {
       const platform = ensureNotificationPlatform()
       if (typeof hookCtx.client.session.get !== "function" && typeof hookCtx.client.session.messages !== "function") {

--- a/src/hooks/session-todo-status.ts
+++ b/src/hooks/session-todo-status.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import { readContinuationMarker } from "../features/run-continuation-state"
 import { normalizeSDKResponse } from "../shared"
 
 interface Todo {
@@ -17,4 +18,13 @@ export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): P
   } catch {
     return false
   }
+}
+
+export async function hasPendingSessionWork(ctx: PluginInput, sessionID: string): Promise<boolean> {
+  const marker = readContinuationMarker(ctx.directory, sessionID)
+  if (marker?.sources["background-task"]?.state === "active") {
+    return true
+  }
+
+  return hasIncompleteTodos(ctx, sessionID)
 }


### PR DESCRIPTION
## Summary

- Suppress idle ready notifications while a `background-task` continuation marker is active.
- Reuse the existing pending-work notification gate instead of coupling session notifications directly to `BackgroundManager`.
- Preserve existing incomplete todo suppression by falling back to the original todo check when no active background task marker exists.

## Changes

- Add `hasPendingSessionWork()` to check active background-task continuation markers before incomplete todos.
- Wire session ready notifications to use the pending-session-work check.
- Add regression coverage for active and idle background-task marker behavior.

## Screenshots

Not applicable. This is notification timing behavior.

## Testing

```bash
bun test src/hooks/session-notification.test.ts src/features/run-continuation-state/storage.test.ts --bail
bun run typecheck
bun run build
git diff --check
```

Manual QA: drove the `session.idle` notification hook path with an active background marker and confirmed ready notification suppression, then switched the marker to idle and confirmed ready notification delivery.

## Related Issues

Related context: #1249, #3452, #3708, #3711, #4163, #4164.

This is a narrower, marker-based alternative to the stale/conflicting #1249. It follows the `background-task` continuation marker direction introduced by #3455.

## Scope note

This PR only suppresses premature idle ready notifications while active background work is marked. It does not change background completion wake delivery, parent-turn wake timing, or descendant task quiescence behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress ready notifications when a session has active background tasks, preventing premature alerts during idle. The idle-ready gate now uses the background-task continuation marker and falls back to the existing todo check.

- **Bug Fixes**
  - Added `hasPendingSessionWork()` to prefer the background-task marker before checking incomplete todos.
  - Wired the idle notification scheduler to use `hasPendingSessionWork`.
  - Added tests for active vs. idle background-task marker behavior.

<sup>Written for commit 60a23a557e14ca9b370e9a9a7ac3b06801bd5a8c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

