### PR TITLE
fix(background-agent): skip disconnected explicit-provider fallbacks

### DIFF
--- a/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/src/features/background-agent/fallback-retry-handler.test.ts
@@ -431,26 +431,26 @@ describe("tryFallbackRetry", () => {
   })
 
   describe("#given disconnected fallback providers with connected preferred provider", () => {
-    test("keeps fallback entry and selects connected preferred provider", async () => {
+    test("skips explicit-provider fallback entries when none of their providers are connected", async () => {
       readProviderModelsCacheMock.mockReturnValueOnce({
         connected: ["provider-a"],
         models: {},
         updatedAt: new Date("2026-05-16T00:00:00.000Z").toISOString(),
       })
-      selectFallbackProviderMock.mockImplementationOnce(
-        (_providers: string[], preferredProviderID?: string) => preferredProviderID ?? "provider-b",
-      )
 
       const args = createDefaultArgs({
         fallbackChain: [{ model: "fallback-model-1", providers: ["provider-b"], variant: undefined }],
         model: { providerID: "provider-a", modelID: "original-model" },
       })
 
+      const providerCallsBefore = selectFallbackProviderMock.mock.calls.length
+
       const result = await tryFallbackRetry(args)
 
-      expect(result).toBe(true)
+      expect(result).toBe(false)
       expect(args.task.model?.providerID).toBe("provider-a")
-      expect(args.task.model?.modelID).toBe("fallback-model-1")
+      expect(args.task.model?.modelID).toBe("original-model")
+      expect(selectFallbackProviderMock.mock.calls.length).toBe(providerCallsBefore)
     })
   })
 })

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -73,14 +73,10 @@ export async function tryFallbackRetry(args: {
   const providerModelsCache = deps.readProviderModelsCache()
   const connectedProviders = providerModelsCache?.connected ?? deps.readConnectedProvidersCache()
   const connectedSet = connectedProviders ? new Set(connectedProviders.map(p => p.toLowerCase())) : null
-  const preferredProvider = task.model?.providerID?.toLowerCase()
 
   const isReachable = (entry: FallbackEntry): boolean => {
     if (!connectedSet) return true
-    if (entry.providers.some((provider) => connectedSet.has(provider.toLowerCase()))) {
-      return true
-    }
-    return preferredProvider ? connectedSet.has(preferredProvider) : false
+    return entry.providers.some((provider) => connectedSet.has(provider.toLowerCase()))
   }
 
   let selectedAttemptCount = attemptCount


### PR DESCRIPTION
## Summary

Fixes background-agent fallback selection when a fallback entry explicitly targets a provider that is not connected in the current runtime.

The bad path was silently rewriting an explicit provider/model fallback onto another connected provider instead of skipping it. For example, a fallback entry that explicitly names another provider could still be retried through the current provider even though that provider was never registered for that fallback target.

## Changes

- keep explicit `provider/model` fallback entries pinned to their declared provider
- skip explicit fallback entries whose declared provider is not connected in the current runtime
- preserve the existing fallback behavior for entries that do not explicitly pin a provider
- add regression coverage for disconnected explicit-provider fallback entries

## Testing

- `bun test src/features/background-agent/fallback-retry-handler.test.ts`
- `bun run build`

## Related Issues

- Related to #3400
- Related to #3191


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background-agent fallback selection so explicit-provider fallbacks are not rerouted to another provider. If the declared provider isn’t connected, we skip that entry and keep the current provider/model.

- **Bug Fixes**
  - Keep explicit `provider/model` fallbacks pinned to their provider.
  - Skip explicit-provider entries when their provider isn’t connected (no provider selection call).
  - Preserve existing behavior for non-explicit fallbacks.
  - Add regression test for disconnected explicit-provider fallbacks.

<sup>Written for commit 5a965fb44f1e92aa3219f98b6396a76f6baa620e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4222?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

