### PR TITLE
fix(runtime-fallback): harden delegated fallback retry flow

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry-signal.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry-signal.test.ts
@@ -39,4 +39,15 @@ describe("extractAutoRetrySignal", () => {
     //#then
     expect(signal).toBeUndefined()
   })
+
+  test("does not treat immediate quota upsell text as a provider auto-retry schedule", () => {
+    //#given
+    const info = { status: "Free usage exceeded, subscribe to Go" }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeUndefined()
+  })
 })

--- a/src/hooks/runtime-fallback/auto-retry.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
+import { getLastUserRetryPayload } from "./last-user-retry-parts"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+import {
+  clearDelegatedChildSessionBootstrap,
+  getDelegatedChildSessionBootstrap,
+  registerDelegatedChildSessionBootstrap,
+} from "../../shared/delegated-child-session-bootstrap"
+import {
+  cancelQueuedInternalPrompts,
+  dispatchInternalPrompt,
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../shared/prompt-async-gate"
 
 function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInput {
   const session = {
@@ -15,12 +27,17 @@ function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInp
         },
       ],
     }),
+    prompt: async () => {
+      promptCalls.count += 1
+      return {}
+    },
     promptAsync: async () => {
       promptCalls.count += 1
       return {}
     },
     status: async () => ({ data: { "session-auto-retry": { type: "busy" } } }),
   }
+
   return {
     client: {
       session,
@@ -56,6 +73,11 @@ function createDeps(promptCalls: { count: number }): HookDeps {
 }
 
 describe("createAutoRetryHelpers", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+    clearDelegatedChildSessionBootstrap("session-bootstrap-reuse")
+  })
+
   test("#given fallback prompt returns ambiguous EOF #when auto retry runs #then pending fallback is marked as possibly accepted", async () => {
     // given
     const promptCalls = { count: 0 }
@@ -99,4 +121,138 @@ describe("createAutoRetryHelpers", () => {
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
     expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
   })
+
+  test("#given sync prompt reservation is active #when session.status fallback retries #then stale runtime fallback prompts do not dispatch after the reserved prompt completes", async () => {
+    // given
+    const promptCalls = { count: 0 }
+    const deps = createDeps(promptCalls)
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-auto-retry-queued"
+    const state = createFallbackState("cliproxy/deepseek-v4-flash-free")
+    deps.sessionStates.set(sessionID, state)
+
+    const heldPrompt = dispatchInternalPrompt({
+      mode: "sync",
+      client: deps.ctx.client,
+      sessionID,
+      input: {
+        path: { id: sessionID },
+      },
+      source: "model-suggestion-retry:sync",
+      settleMs: 0,
+      checkStatus: false,
+      checkToolState: false,
+      queueBehavior: "defer",
+    })
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.status")
+    const heldResult = await heldPrompt
+    const released = releasePromptAsyncReservation(sessionID, "test-release", {
+      reservedBy: "model-suggestion-retry:sync",
+    })
+    expect(released).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // then
+    expect(heldResult.status).toBe("dispatched")
+    expect(promptCalls.count).toBe(1)
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
+    expect(deps.sessionRetryInFlight.has(sessionID)).toBe(false)
+    expect(cancelQueuedInternalPrompts(sessionID, {
+      sourcePrefix: "runtime-fallback:",
+    })).toBe(0)
+  })
+
+  test("#given runtime fallback cleanup already ran #when checking the queue again #then no stale runtime fallback prompts remain", async () => {
+    // given
+    const promptCalls = { count: 0 }
+    const deps = createDeps(promptCalls)
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-auto-retry-cleanup"
+    const state = createFallbackState("cliproxy/deepseek-v4-flash-free")
+    deps.sessionStates.set(sessionID, state)
+
+    const heldPrompt = dispatchInternalPrompt({
+      mode: "sync",
+      client: deps.ctx.client,
+      sessionID,
+      input: {
+        path: { id: sessionID },
+      },
+      source: "model-suggestion-retry:sync",
+      settleMs: 0,
+      checkStatus: false,
+      checkToolState: false,
+      queueBehavior: "defer",
+    })
+
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.status")
+    const heldResult = await heldPrompt
+    expect(heldResult.status).toBe("dispatched")
+
+    const released = releasePromptAsyncReservation(sessionID, "test-release", {
+      reservedBy: "model-suggestion-retry:sync",
+    })
+    expect(released).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // when / then
+    expect(cancelQueuedInternalPrompts(sessionID, {
+      sourcePrefix: "runtime-fallback:",
+    })).toBe(0)
+  })
+
+  test("#given the latest stored user turn is an internal retry prompt #when resolving the retry payload #then it reuses the last real user text instead of the internal retry", async () => {
+    // given
+    const payload = getLastUserRetryPayload({
+      data: [
+        {
+          info: { role: "user" },
+          parts: [{ type: "text", text: "original real prompt" }],
+        },
+        {
+          info: { role: "assistant" },
+          parts: [],
+        },
+        {
+          info: { role: "user" },
+          parts: [{ type: "text", text: "internal retry\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+        },
+      ],
+    })
+
+    // then
+    expect(payload.retryParts).toEqual([{ type: "text", text: "original real prompt" }])
+  })
+
+  test("#given delegated child history is still empty after one fallback #when resolving a later retry payload #then it keeps reusing bootstrap prompt text", async () => {
+    // given
+    const sessionID = "session-bootstrap-reuse"
+    registerDelegatedChildSessionBootstrap({
+      sessionID,
+      promptText: "original delegated prompt",
+      system: "delegated system",
+      tools: { call_omo_agent: true, question: false },
+    })
+
+    // when
+    const firstPayload = getLastUserRetryPayload({ data: [] }, sessionID)
+    const secondPayload = getLastUserRetryPayload({
+      data: [
+        {
+          role: "assistant",
+          time: { completed: 123 },
+        },
+      ],
+    }, sessionID)
+
+    // then
+    expect(firstPayload.retryParts).toEqual([{ type: "text", text: "original delegated prompt\n<!-- OMO_INTERNAL_INITIATOR -->" }])
+    expect(secondPayload.retryParts).toEqual([{ type: "text", text: "original delegated prompt\n<!-- OMO_INTERNAL_INITIATOR -->" }])
+    expect(getDelegatedChildSessionBootstrap(sessionID)?.retryParts).toEqual(firstPayload.retryParts)
+  })
+
 })

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -12,6 +12,11 @@ import { getLastUserRetryPayload } from "./last-user-retry-parts"
 import { extractSessionMessages } from "./session-messages"
 import { resolveRegisteredAgentName } from "../../features/claude-code-session-state"
 import {
+  createInternalAgentTextPart,
+  isSyntheticOrInternalTextPart,
+} from "../../shared/internal-initiator-marker"
+import {
+  cancelQueuedInternalPrompts,
   dispatchInternalPrompt,
   isInternalPromptDispatchAccepted,
   releasePromptAsyncReservation,
@@ -19,6 +24,18 @@ import {
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 
 const SESSION_TTL_MS = 30 * 60 * 1000
+
+function normalizeRetryPartsForInternalDispatch(
+  retryParts: Array<{ type: "text"; text: string }>,
+): Array<{ type: "text"; text: string }> {
+  return retryParts.map((part) => {
+    if (isSyntheticOrInternalTextPart(part)) {
+      return part
+    }
+
+    return createInternalAgentTextPart(part.text)
+  })
+}
 
 declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
 declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
@@ -155,7 +172,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         query: { directory: ctx.directory },
       })
       const retryPayload = getLastUserRetryPayload(messagesResp, sessionID)
-      const retryParts = retryPayload.retryParts
+      const retryParts = normalizeRetryPartsForInternalDispatch(retryPayload.retryParts)
       if (retryParts.length > 0) {
         log(`[${HOOK_NAME}] Auto-retrying with fallback model (${source})`, {
           sessionID,
@@ -175,7 +192,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
           sessionID,
           source: `runtime-fallback:${source}`,
           settleMs: 0,
-          queueBehavior: "defer",
+          queueBehavior: "enqueue",
           input: {
             path: { id: sessionID },
             body: {
@@ -243,6 +260,19 @@ export function createAutoRetryHelpers(deps: HookDeps) {
             state.pendingFallbackModel = undefined
             state.pendingFallbackPromptMayHaveBeenAccepted = false
           }
+        }
+      }
+
+      if (!retryMayHaveBeenAccepted) {
+        const cancelled = cancelQueuedInternalPrompts(sessionID, {
+          sourcePrefix: "runtime-fallback:",
+        })
+        if (cancelled > 0) {
+          log(`[${HOOK_NAME}] Cancelled stale queued runtime fallback prompts`, {
+            sessionID,
+            cancelled,
+            source,
+          })
         }
       }
     }

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -82,6 +82,7 @@ describe("runtime-fallback error classifier", () => {
       { message: "额度不足" },
       { message: "账户余额不足" },
       { message: "免费额度已耗尽" },
+      { message: "Free usage exceeded, subscribe to Go" },
     ]
 
     //#when
@@ -89,6 +90,7 @@ describe("runtime-fallback error classifier", () => {
 
     //#then
     expect(classifications).toEqual([
+      "quota_exceeded",
       "quota_exceeded",
       "quota_exceeded",
       "quota_exceeded",

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -134,6 +134,7 @@ export function classifyErrorType(error: unknown): string | undefined {
     errorName?.includes("billingerror") ||
     /quota.?exceeded/i.test(message) ||
     /exceeded.*quota/i.test(message) ||
+    /free\s+usage\s+exceeded/i.test(message) ||
     /usage\s*quota/i.test(message) ||
     /subscription.*quota/i.test(message) ||
     /insufficient.?(?:quota|balance|funds?)/i.test(message) ||

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -7,15 +7,15 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
-import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
+import { resolveFallbackBootstrapModel, normalizeRuntimeFallbackModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 
 function resolveEventModel(props: Record<string, unknown> | undefined): string | undefined {
-  const model = props?.model
-  if (typeof model === "string") {
-    return model
+  const normalizedModel = normalizeRuntimeFallbackModel(props?.model as Parameters<typeof normalizeRuntimeFallbackModel>[0])
+  if (normalizedModel) {
+    return normalizedModel
   }
 
   const providerID = props?.providerID
@@ -45,9 +45,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = props?.info as { id?: string; model?: unknown } | undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = normalizeRuntimeFallbackModel(sessionInfo?.model as Parameters<typeof normalizeRuntimeFallbackModel>[0])
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -209,7 +209,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: props?.model as Parameters<typeof normalizeRuntimeFallbackModel>[0],
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
+++ b/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
@@ -3,19 +3,37 @@ import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 
+type EventModelLike = string | { providerID?: string; modelID?: string; id?: string; variant?: string } | undefined
+
 type ResolveFallbackBootstrapModelOptions = {
   sessionID: string
   source: string
-  eventModel?: string
+  eventModel?: EventModelLike
   resolvedAgent?: string
   pluginConfig?: OhMyOpenCodeConfig
+}
+
+export function normalizeRuntimeFallbackModel(model: EventModelLike): string | undefined {
+  if (!model) return undefined
+  if (typeof model === "string") {
+    return model.length > 0 ? model : undefined
+  }
+
+  const providerID = typeof model.providerID === "string" ? model.providerID : undefined
+  const modelID = typeof model.modelID === "string"
+    ? model.modelID
+    : (typeof model.id === "string" ? model.id : undefined)
+
+  if (!providerID || !modelID) return undefined
+  return `${providerID}/${modelID}`
 }
 
 export function resolveFallbackBootstrapModel(
   options: ResolveFallbackBootstrapModelOptions,
 ): string | undefined {
-  if (options.eventModel) {
-    return options.eventModel
+  const normalizedEventModel = normalizeRuntimeFallbackModel(options.eventModel)
+  if (normalizedEventModel) {
+    return normalizedEventModel
   }
 
   const agentConfigs = options.pluginConfig?.agents

--- a/src/hooks/runtime-fallback/index.test.ts
+++ b/src/hooks/runtime-fallback/index.test.ts
@@ -557,7 +557,7 @@ describe("runtime-fallback", () => {
       expect(promptBody?.tools?.question).toBe(false)
       expect(promptBody?.tools?.call_omo_agent).toBe(true)
       expect(promptBody?.parts?.[0]?.text).toContain("inspect src/tools/delegate-task")
-      expect(getDelegatedChildSessionBootstrap(sessionID)).toBeUndefined()
+      expect(getDelegatedChildSessionBootstrap(sessionID)?.retryParts[0]?.text).toContain("inspect src/tools/delegate-task")
     })
 
     test("should use persisted user prompt while preserving delegated bootstrap launch context", async () => {
@@ -613,7 +613,7 @@ describe("runtime-fallback", () => {
         system?: string
         tools?: Record<string, boolean>
       } | undefined
-      expect(promptBody?.parts?.[0]?.text).toBe("persisted child task prompt")
+      expect(promptBody?.parts?.[0]?.text).toBe("persisted child task prompt\n<!-- OMO_INTERNAL_INITIATOR -->")
       expect(promptBody?.system).toBe("persisted delegated child system prompt")
       expect(promptBody?.tools?.question).toBe(false)
       expect(promptBody?.tools?.call_omo_agent).toBe(true)
@@ -1016,6 +1016,27 @@ describe("runtime-fallback", () => {
       const createLog = logCalls.find((c) => c.msg.includes("Session created with model"))
       expect(createLog).toBeDefined()
       expect(createLog?.data).toMatchObject({ sessionID, model })
+    })
+
+    test("should normalize object-shaped session.created models into provider/model strings", async () => {
+      const hook = createRuntimeFallbackHook(createMockPluginInput(), { config: createMockConfig() })
+      const sessionID = "test-session-create-object-model"
+
+      await hook.event({
+        event: {
+          type: "session.created",
+          properties: {
+            info: {
+              id: sessionID,
+              model: { providerID: "cliproxy", id: "deepseek-v4-flash-free" },
+            },
+          },
+        },
+      })
+
+      const createLog = logCalls.find((c) => c.msg.includes("Session created with model") && c.data?.sessionID === sessionID)
+      expect(createLog).toBeDefined()
+      expect(createLog?.data).toMatchObject({ sessionID, model: "cliproxy/deepseek-v4-flash-free" })
     })
 
     test("should cleanup state on session.deleted", async () => {

--- a/src/hooks/runtime-fallback/last-user-retry-parts.ts
+++ b/src/hooks/runtime-fallback/last-user-retry-parts.ts
@@ -3,6 +3,7 @@ import {
   clearDelegatedChildSessionBootstrap,
   getDelegatedChildSessionBootstrap,
 } from "../../shared/delegated-child-session-bootstrap"
+import { isSyntheticOrInternalUserMessage } from "../../shared/internal-initiator-marker"
 
 type RetryPart = { type: "text"; text: string }
 
@@ -25,7 +26,10 @@ export function getLastUserRetryPayload(
 ): LastUserRetryPayload {
   const bootstrap = sessionID ? getDelegatedChildSessionBootstrap(sessionID) : undefined
   const messages = extractSessionMessages(messagesResponse)
-  const lastUserMessage = messages?.filter((message) => message.info?.role === "user").pop()
+  const lastUserMessage = messages
+    ?.filter((message) => message.info?.role === "user")
+    .filter((message) => !isSyntheticOrInternalUserMessage(message))
+    .pop()
   const lastUserParts =
     lastUserMessage?.parts
     ?? (lastUserMessage?.info?.parts as Array<{ type?: string; text?: string }> | undefined)
@@ -55,9 +59,6 @@ export function getLastUserRetryPayload(
   }
 
   const bootstrapRetryParts = bootstrap?.retryParts ?? []
-  if (bootstrapRetryParts.length > 0) {
-    clearDelegatedChildSessionBootstrap(sessionID)
-  }
 
   return {
     retryParts: bootstrapRetryParts,

--- a/src/hooks/runtime-fallback/message-update-handler.test.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.test.ts
@@ -79,4 +79,89 @@ describe("hasVisibleAssistantResponse", () => {
     // then
     expect(result).toBe(false)
   })
+
+  it("#given an assistant reply with reasoning-only progress after the latest user turn #when visibility is checked #then it is treated as visible progress", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = createContext({
+      data: [
+        { info: { role: "user" }, parts: [{ type: "text", text: "latest question" }] },
+        { info: { role: "assistant" }, parts: [{ type: "reasoning", text: "working through the task" }] },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-reasoning-progress", undefined)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  it("#given an assistant reply with a completion marker but no text #when visibility is checked #then it is not treated as visible completion", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = createContext({
+      data: [
+        { info: { role: "user" }, parts: [{ type: "text", text: "latest question" }] },
+        { info: { role: "assistant", finish: "stop" }, parts: [] },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-finish-marker", undefined)
+
+    // then
+    expect(result).toBe(false)
+  })
+
+  it("#given an assistant reply with top-level completion but no payload #when visibility is checked #then it is ignored as non-visible", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = createContext({
+      data: [
+        { role: "user", parts: [{ type: "text", text: "latest question" }] },
+        { role: "assistant", time: { completed: 123 }, tokens: { output: 0, reasoning: 0 }, cost: 0 },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-top-level-empty-completion", undefined)
+
+    // then
+    expect(result).toBe(false)
+  })
+
+  it("#given an assistant reply with top-level completion and token payload #when visibility is checked #then it is treated as visible completion", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = createContext({
+      data: [
+        { role: "user", parts: [{ type: "text", text: "latest question" }] },
+        { role: "assistant", time: { completed: 123 }, tokens: { output: 24, reasoning: 0 }, cost: 0 },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-top-level-token-completion", undefined)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  it("#given an sdk messages response without a data wrapper #when visibility is checked #then top-level payload still drives completion visibility", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = createContext({
+      messages: [
+        { role: "user", parts: [] },
+        { role: "assistant", time: { completed: 123 }, tokens: { output: 12, reasoning: 0 }, cost: 0 },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-raw-sdk-response", undefined)
+
+    // then
+    expect(result).toBe(true)
+  })
 })

--- a/src/hooks/runtime-fallback/message-update-handler.test.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.test.ts
@@ -148,6 +148,37 @@ describe("hasVisibleAssistantResponse", () => {
     expect(result).toBe(true)
   })
 
+  it("#given an assistant auto-retry signal with reasoning progress #when visibility is checked #then it does not suppress fallback as visible progress", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(extractAutoRetrySignal)
+    const ctx = createContext({
+      data: [
+        { info: { role: "user" }, parts: [{ type: "text", text: "latest question" }] },
+        {
+          info: { role: "assistant", finish: "stop" },
+          parts: [
+            {
+              type: "text",
+              text: "Too Many Requests: Sorry, you've exhausted this model's rate limit. Please try a different model.",
+            },
+            {
+              type: "reasoning",
+              text: "provider says it will retry later",
+            },
+          ],
+          tokens: { output: 10, reasoning: 4 },
+          cost: 0,
+        },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-rate-limit-with-progress", undefined)
+
+    // then
+    expect(result).toBe(false)
+  })
+
   it("#given an sdk messages response without a data wrapper #when visibility is checked #then top-level payload still drives completion visibility", async () => {
     // given
     const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)

--- a/src/hooks/runtime-fallback/session-messages.ts
+++ b/src/hooks/runtime-fallback/session-messages.ts
@@ -1,3 +1,5 @@
+import { normalizeSDKResponse } from "../../shared/normalize-sdk-response"
+
 export type SessionMessagePart = {
   type?: string
   text?: string
@@ -21,6 +23,14 @@ function isSessionMessageArray(value: unknown): value is SessionMessage[] {
 }
 
 export function extractSessionMessages(messagesResponse: unknown): SessionMessage[] | undefined {
+  const normalized = normalizeSDKResponse(messagesResponse, undefined as SessionMessage[] | undefined, {
+    preferResponseOnMissingData: true,
+  })
+
+  if (isSessionMessageArray(normalized)) {
+    return normalized
+  }
+
   if (isSessionMessageArray(messagesResponse)) {
     return messagesResponse
   }
@@ -32,6 +42,11 @@ export function extractSessionMessages(messagesResponse: unknown): SessionMessag
   const data = messagesResponse.data
   if (isSessionMessageArray(data)) {
     return data
+  }
+
+  const messages = messagesResponse.messages
+  if (isSessionMessageArray(messages)) {
+    return messages
   }
 
   return undefined

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -147,4 +147,78 @@ describe("createSessionStatusHandler", () => {
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
     SessionCategoryRegistry.clear()
   })
+
+  it("#given an immediate quota upsell retry status #when no retry schedule is present #then it falls back without aborting the in-flight request", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-immediate-quota-fallback"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("cliproxy/deepseek-v4-flash-free")
+    deps.sessionStates.set(sessionID, state)
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: "cliproxy/deepseek-v4-flash-free",
+      status: {
+        type: "retry",
+        attempt: 2,
+        message: "Free usage exceeded, subscribe to Go",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    expect(state.currentModel).toBe("openai/gpt-5.4")
+    expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given an object-shaped live model #when immediate quota retry status arrives #then it normalizes the model and advances fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-object-model-fallback"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: { providerID: "cliproxy", id: "deepseek-v4-flash-free" },
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "Free usage exceeded, subscribe to Go",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    SessionCategoryRegistry.clear()
+  })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -2,13 +2,17 @@ import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME, RETRYABLE_ERROR_PATTERNS } from "./constants"
 import { log } from "../../shared/logger"
-import { extractAutoRetrySignal } from "./error-classifier"
+import { extractAutoRetrySignal, isRetryableError } from "./error-classifier"
 import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/retry-status-utils"
-import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
+import { resolveFallbackBootstrapModel, normalizeRuntimeFallbackModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+
+function hasExplicitProviderRetrySchedule(message: string): boolean {
+  return /retrying\s+in|quota\s+will\s+reset\s+after|cool(?:ing)?\s+down|\bcooldown\b/i.test(message)
+}
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -26,20 +30,22 @@ export function createSessionStatusHandler(
     const sessionID = resolveSessionEventID(props)
     const status = props?.status as { type?: string; message?: string; attempt?: number } | undefined
     const agent = props?.agent as string | undefined
-    const model = props?.model as string | undefined
+    const model = normalizeRuntimeFallbackModel(props?.model as Parameters<typeof normalizeRuntimeFallbackModel>[0])
     const timeoutEnabled = deps.config.timeout_seconds > 0
 
     if (!sessionID || status?.type !== "retry") return
 
     const retryMessage = typeof status.message === "string" ? status.message : ""
     const retrySignal = extractAutoRetrySignal({ status: retryMessage, message: retryMessage })
+    const hasRetrySchedule = hasExplicitProviderRetrySchedule(retryMessage)
     if (!retrySignal) {
-      // Fallback: status.type is already "retry", so check the message against
-      // retryable error patterns directly. This handles providers like Gemini whose
-      // retry status message may not contain "retrying in" text alongside the error.
+      // Fallback: status.type is already "retry", so treat the message as a
+      // retryable session-status error if either the lightweight retry patterns
+      // or the full runtime error classifier says it should advance the chain.
       const messageLower = retryMessage.toLowerCase()
       const matchesRetryablePattern = RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(messageLower))
-      if (!matchesRetryablePattern) {
+      const retryableStatusError = isRetryableError({ name: "SessionRetry", message: retryMessage }, deps.config.retry_on_errors)
+      if (!matchesRetryablePattern && !retryableStatusError) {
         // Diagnostic: capture the actual retry message content so we can extend
         // RETRYABLE_ERROR_PATTERNS if a provider emits a phrasing we don't yet match.
         if (retryMessage) {
@@ -51,6 +57,14 @@ export function createSessionStatusHandler(
         }
         return
       }
+    }
+
+    if (!hasRetrySchedule) {
+      log(`[${HOOK_NAME}] session.status retry treated as immediate retryable error fallback`, {
+        sessionID,
+        attempt: status.attempt,
+        retryMessage,
+      })
     }
 
     const retryKey = `${extractRetryAttempt(status.attempt, retryMessage)}:${normalizeRetryStatusMessage(retryMessage)}`
@@ -127,13 +141,21 @@ export function createSessionStatusHandler(
       }
     }
 
-    log(`[${HOOK_NAME}] Detected provider auto-retry signal in session.status`, {
-      sessionID,
-      model: state.currentModel,
-      retryAttempt: status.attempt,
-    })
+    if (hasRetrySchedule) {
+      log(`[${HOOK_NAME}] Detected provider auto-retry signal in session.status`, {
+        sessionID,
+        model: state.currentModel,
+        retryAttempt: status.attempt,
+      })
 
-    await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
+      await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
+    } else {
+      log(`[${HOOK_NAME}] Treating provider retry status as direct fallback trigger`, {
+        sessionID,
+        model: state.currentModel,
+        retryAttempt: status.attempt,
+      })
+    }
 
     await dispatchFallbackRetry(deps, helpers, {
       sessionID,

--- a/src/hooks/runtime-fallback/visible-assistant-response.ts
+++ b/src/hooks/runtime-fallback/visible-assistant-response.ts
@@ -3,14 +3,73 @@ import type { SessionMessage, SessionMessagePart } from "./session-messages"
 import { extractSessionMessages } from "./session-messages"
 import { extractAutoRetrySignal } from "./error-classifier"
 
+const NON_TEXT_PROGRESS_PART_TYPES = new Set([
+  "reasoning",
+  "thinking",
+  "tool",
+  "tool_use",
+  "tool_result",
+  "tool-call",
+  "step-start",
+  "step-finish",
+  "file",
+])
+
+type SessionMessageRecord = SessionMessage & Record<string, unknown>
+
+function getMessageInfo(message: SessionMessage): Record<string, unknown> {
+  const record = message as SessionMessageRecord
+  const info = record.info
+  return typeof info === "object" && info !== null ? info : {}
+}
+
+function getMessageRole(message: SessionMessage): string | undefined {
+  const info = getMessageInfo(message)
+  const record = message as SessionMessageRecord
+  return typeof info.role === "string"
+    ? info.role
+    : typeof record.role === "string"
+      ? record.role
+      : undefined
+}
+
+function getMessageTime(message: SessionMessage): Record<string, unknown> {
+  const info = getMessageInfo(message)
+  const record = message as SessionMessageRecord
+  const infoTime = info.time
+  if (typeof infoTime === "object" && infoTime !== null) {
+    return infoTime as Record<string, unknown>
+  }
+
+  const recordTime = record.time
+  return typeof recordTime === "object" && recordTime !== null
+    ? (recordTime as Record<string, unknown>)
+    : {}
+}
+
 function getLastUserMessageIndex(messages: SessionMessage[]): number {
   for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index]?.info?.role === "user") {
+    if (messages[index] && getMessageRole(messages[index]) === "user") {
       return index
     }
   }
 
   return -1
+}
+
+function isCompletionMarker(value: unknown): boolean {
+  if (typeof value === "boolean") return value
+  return value !== undefined && value !== null
+}
+
+function hasAssistantCompletionMarker(message: SessionMessage): boolean {
+  const info = getMessageInfo(message)
+  const completedAt = getMessageTime(message).completed
+
+  return isCompletionMarker(info.finish)
+    || isCompletionMarker(info.finished)
+    || isCompletionMarker(info.completed)
+    || isCompletionMarker(completedAt)
 }
 
 function getAssistantText(parts: SessionMessagePart[] | undefined): string {
@@ -24,6 +83,31 @@ function getAssistantText(parts: SessionMessagePart[] | undefined): string {
       return text.length > 0 ? [text] : []
     })
     .join("\n")
+}
+
+function hasNonTextProgress(parts: SessionMessagePart[] | undefined): boolean {
+  return (parts ?? []).some((part) => typeof part.type === "string" && NON_TEXT_PROGRESS_PART_TYPES.has(part.type))
+}
+
+function hasMeaningfulAssistantPayload(message: SessionMessage, parts: SessionMessagePart[] | undefined): boolean {
+  const assistantText = getAssistantText(parts)
+  if (assistantText.length > 0) {
+    return true
+  }
+
+  if (hasNonTextProgress(parts)) {
+    return true
+  }
+
+  const record = message as SessionMessageRecord
+  const tokens = typeof record.tokens === "object" && record.tokens !== null
+    ? (record.tokens as Record<string, unknown>)
+    : {}
+  const outputTokens = typeof tokens.output === "number" ? tokens.output : 0
+  const reasoningTokens = typeof tokens.reasoning === "number" ? tokens.reasoning : 0
+  const cost = typeof record.cost === "number" ? record.cost : 0
+
+  return outputTokens > 0 || reasoningTokens > 0 || cost > 0
 }
 
 export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof extractAutoRetrySignal) {
@@ -45,15 +129,16 @@ export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof ext
 
       for (let index = lastUserMessageIndex + 1; index < messages.length; index++) {
         const message = messages[index]
-        if (message?.info?.role !== "assistant") {
+        if (!message || getMessageRole(message) !== "assistant") {
           continue
         }
 
-        if (message.info?.error) {
+        const info = getMessageInfo(message)
+        if (info.error) {
           continue
         }
 
-        const infoParts = message.info?.parts
+        const infoParts = info.parts
         const infoMessageParts = Array.isArray(infoParts)
           ? infoParts.filter((part): part is SessionMessagePart => typeof part === "object" && part !== null)
           : undefined
@@ -61,15 +146,16 @@ export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof ext
           ? message.parts
           : infoMessageParts
         const assistantText = getAssistantText(parts)
-        if (!assistantText) {
-          continue
+        const hasCompletion = hasAssistantCompletionMarker(message)
+        const hasProgress = hasNonTextProgress(parts)
+
+        if (assistantText && !extractAutoRetrySignalFn({ message: assistantText })) {
+          return true
         }
 
-        if (extractAutoRetrySignalFn({ message: assistantText })) {
-          continue
+        if ((hasCompletion && hasMeaningfulAssistantPayload(message, parts)) || hasProgress) {
+          return true
         }
-
-        return true
       }
 
       return false

--- a/src/hooks/runtime-fallback/visible-assistant-response.ts
+++ b/src/hooks/runtime-fallback/visible-assistant-response.ts
@@ -148,12 +148,15 @@ export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof ext
         const assistantText = getAssistantText(parts)
         const hasCompletion = hasAssistantCompletionMarker(message)
         const hasProgress = hasNonTextProgress(parts)
+        const autoRetrySignal = assistantText
+          ? extractAutoRetrySignalFn({ message: assistantText })
+          : undefined
 
-        if (assistantText && !extractAutoRetrySignalFn({ message: assistantText })) {
+        if (assistantText && !autoRetrySignal) {
           return true
         }
 
-        if ((hasCompletion && hasMeaningfulAssistantPayload(message, parts)) || hasProgress) {
+        if (!autoRetrySignal && ((hasCompletion && hasMeaningfulAssistantPayload(message, parts)) || hasProgress)) {
           return true
         }
       }

--- a/src/shared/internal-initiator-marker.test.ts
+++ b/src/shared/internal-initiator-marker.test.ts
@@ -23,9 +23,10 @@ describe("internal-initiator-marker", () => {
       // then
       expect(part.type).toBe("text")
       expect(part.text).toBe(`Hello world\n${OMO_INTERNAL_INITIATOR_MARKER}`)
+      expect(part.synthetic).toBe(true)
     })
 
-    test("#given regular internal text #when creating a text part #then leaves it visible as a normal message part", () => {
+    test("#given regular internal text #when creating a text part #then marks it synthetic so it stays hidden in history", () => {
       // given
       const text = "Visible notification"
 
@@ -33,7 +34,7 @@ describe("internal-initiator-marker", () => {
       const part = createInternalAgentTextPart(text)
 
       // then
-      expect("synthetic" in part).toBe(false)
+      expect(part.synthetic).toBe(true)
       expect("metadata" in part).toBe(false)
     })
 
@@ -48,6 +49,7 @@ describe("internal-initiator-marker", () => {
       const markerCount = part.text.split(OMO_INTERNAL_INITIATOR_MARKER).length - 1
       expect(markerCount).toBe(1)
       expect(part.text).toBe(`Already marked\n${OMO_INTERNAL_INITIATOR_MARKER}`)
+      expect(part.synthetic).toBe(true)
     })
 
     test("#given text containing multiple embedded markers #when creating a text part #then collapses to a single trailing marker", () => {

--- a/src/shared/internal-initiator-marker.ts
+++ b/src/shared/internal-initiator-marker.ts
@@ -68,11 +68,13 @@ export function stripInternalInitiatorMarkers(text: string): string {
 export function createInternalAgentTextPart(text: string): {
   type: "text"
   text: string
+  synthetic: true
 } {
   const cleanText = stripInternalInitiatorMarkers(text)
   return {
     type: "text",
     text: `${cleanText}\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+    synthetic: true,
   }
 }
 

--- a/src/shared/prompt-async-gate.ts
+++ b/src/shared/prompt-async-gate.ts
@@ -95,6 +95,11 @@ type PromptAsyncReservationReleaseOptions = {
   reservedByPrefix?: string | readonly string[]
 }
 
+type PromptQueueCancelOptions = {
+  source?: string | readonly string[]
+  sourcePrefix?: string | readonly string[]
+}
+
 const promptAsyncReservations = new Map<string, PromptAsyncReservation>()
 const promptQueues = new Map<string, QueuedInternalPrompt[]>()
 const promptQueueDraining = new Set<string>()
@@ -273,6 +278,35 @@ function reservationSourceMatches(
   return prefixes
     .filter((prefix) => prefix.length > 0 && prefix.endsWith(":"))
     .some((prefix) => reservationSource.startsWith(prefix))
+}
+
+function sourceMatches(
+  source: string,
+  expectedSource?: string | readonly string[],
+  expectedPrefix?: string | readonly string[],
+): boolean {
+  if (expectedSource === undefined && expectedPrefix === undefined) {
+    return true
+  }
+
+  if (expectedSource !== undefined) {
+    if (typeof expectedSource === "string") {
+      if (source === expectedSource) {
+        return true
+      }
+    } else if (expectedSource.includes(source)) {
+      return true
+    }
+  }
+
+  if (expectedPrefix === undefined) {
+    return false
+  }
+
+  const prefixes = typeof expectedPrefix === "string" ? [expectedPrefix] : expectedPrefix
+  return prefixes
+    .filter((prefix) => prefix.length > 0)
+    .some((prefix) => source.startsWith(prefix))
 }
 
 async function withDispatchTimeout<T>(
@@ -882,4 +916,41 @@ export function releasePromptAsyncReservation(
     reservedBy: existing.source,
   })
   return true
+}
+
+export function cancelQueuedInternalPrompts(
+  sessionID: string,
+  options?: PromptQueueCancelOptions,
+): number {
+  const queue = promptQueues.get(sessionID)
+  const inFlight = promptQueueInFlight.get(sessionID)
+  let removed = 0
+
+  if (queue && queue.length > 0) {
+    const nextQueue = queue.filter((entry) => {
+      const shouldRemove = sourceMatches(entry.source, options?.source, options?.sourcePrefix)
+      if (shouldRemove) {
+        removed += 1
+      }
+      return !shouldRemove
+    })
+    setPromptQueue(sessionID, nextQueue)
+  }
+
+  if (inFlight && sourceMatches(inFlight.source, options?.source, options?.sourcePrefix)) {
+    promptQueueInFlight.delete(sessionID)
+    promptQueueDraining.delete(sessionID)
+  }
+
+  if (removed > 0) {
+    schedulePromptQueueDrain(sessionID, 0)
+    log("[prompt-async-gate] queued prompts cancelled", {
+      sessionID,
+      removed,
+      source: options?.source,
+      sourcePrefix: options?.sourcePrefix,
+    })
+  }
+
+  return removed
 }

--- a/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/src/tools/delegate-task/sync-session-poller.test.ts
@@ -28,6 +28,85 @@ describe("pollSyncSession", () => {
   })
 
   describe("native finish-based completion", () => {
+    test("detects completion when session messages use top-level role/time.completed shape with meaningful payload", async () => {
+      // given: real session rows with top-level role/time.completed and non-empty assistant payload
+      const { pollSyncSession } = require("./sync-session-poller")
+
+      const mockClient = {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                role: "user",
+                time: { created: 1000 },
+                model: { providerID: "cliproxy", modelID: "deepseek-v4-flash-free" },
+              },
+              {
+                role: "assistant",
+                time: { created: 2000, completed: 3000 },
+                providerID: "cliproxy",
+                modelID: "deepseek-v4-flash-free",
+                tokens: { output: 24, reasoning: 0 },
+              },
+            ],
+          }),
+          status: async () => ({ data: { "ses_test": { type: "idle" } } }),
+        },
+      }
+
+      // when
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_test",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      }, 50)
+
+      // then
+      expect(result).toBeNull()
+    })
+
+    test("keeps polling when top-level time.completed exists but assistant payload is empty", async () => {
+      const { pollSyncSession } = require("./sync-session-poller")
+
+      let abortCount = 0
+      const mockClient = {
+        session: {
+          abort: async () => {
+            abortCount++
+          },
+          messages: async () => ({
+            data: [
+              {
+                role: "user",
+                time: { created: 1000 },
+                model: { providerID: "cliproxy", modelID: "deepseek-v4-flash-free" },
+              },
+              {
+                role: "assistant",
+                time: { created: 2000, completed: 3000 },
+                providerID: "cliproxy",
+                modelID: "deepseek-v4-flash-free",
+                cost: 0,
+                tokens: { output: 0, reasoning: 0 },
+              },
+            ],
+          }),
+          status: async () => ({ data: { "ses_test": { type: "idle" } } }),
+        },
+      }
+
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_test",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      }, 50)
+
+      expect(result).toContain("Poll inactivity timeout reached")
+      expect(abortCount).toBe(1)
+    })
+
     test("returns terminal session error when assistant message contains info.error", async () => {
       // given: error in assistant message
       const { pollSyncSession } = require("./sync-session-poller")
@@ -607,10 +686,10 @@ describe("pollSyncSession", () => {
       expect(result).toBe(false)
     })
 
-    test("returns false when assistant message has missing info.id field", () => {
+    test("returns true when assistant id is missing but created timestamps still prove completion order", () => {
       const { isSessionComplete } = require("./sync-session-poller")
 
-      // given: assistant message without id in info
+      // given: assistant message without id in info, but message timestamps still establish ordering
       const messages = [
         { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
         {
@@ -622,7 +701,23 @@ describe("pollSyncSession", () => {
       // when: calling isSessionComplete
       const result = isSessionComplete(messages)
 
-      // then: returns false (missing assistant id)
+      // then: returns true because timestamps preserve ordering even without assistant id
+      expect(result).toBe(true)
+    })
+
+    test("returns false when assistant id is missing and no timestamp fallback exists", () => {
+      const { isSessionComplete } = require("./sync-session-poller")
+
+      const messages = [
+        { info: { id: "msg_001", role: "user" } },
+        {
+          info: { role: "assistant", finish: "end_turn" },
+          parts: [{ type: "text", text: "Response" }],
+        },
+      ]
+
+      const result = isSessionComplete(messages)
+
       expect(result).toBe(false)
     })
 
@@ -664,10 +759,10 @@ describe("pollSyncSession", () => {
       expect(result).toBe(false)
     })
 
-    test("returns false when user message has missing info.id field", () => {
+    test("returns true when user id is missing but created timestamps still prove completion order", () => {
       const { isSessionComplete } = require("./sync-session-poller")
 
-      // given: user message without id in info
+      // given: user message without id in info, but timestamps still show request-before-response ordering
       const messages = [
         { info: { role: "user", time: { created: 1000 } } },
         {
@@ -679,7 +774,23 @@ describe("pollSyncSession", () => {
       // when: calling isSessionComplete
       const result = isSessionComplete(messages)
 
-      // then: returns false (missing user id)
+      // then: returns true because timestamps preserve ordering even without user id
+      expect(result).toBe(true)
+    })
+
+    test("returns false when user id is missing and no timestamp fallback exists", () => {
+      const { isSessionComplete } = require("./sync-session-poller")
+
+      const messages = [
+        { info: { role: "user" } },
+        {
+          info: { id: "msg_002", role: "assistant", finish: "end_turn" },
+          parts: [{ type: "text", text: "Response" }],
+        },
+      ]
+
+      const result = isSessionComplete(messages)
+
       expect(result).toBe(false)
     })
   })

--- a/src/tools/delegate-task/sync-session-poller.ts
+++ b/src/tools/delegate-task/sync-session-poller.ts
@@ -9,6 +9,103 @@ const NON_TERMINAL_FINISH_REASONS = new Set(["tool-calls", "unknown"])
 const PENDING_TOOL_PART_TYPES = new Set(["tool", "tool_use", "tool-call"])
 const ACTIVE_SESSION_STATUSES = new Set(["busy", "retry", "running"])
 
+type SessionMessageRecord = SessionMessage & Record<string, unknown>
+
+type MessageIdentity = {
+  id?: string
+  role?: string
+  finish?: string
+  error?: unknown
+  created?: number
+  completed?: number
+}
+
+function getMessageIdentity(message: SessionMessage): MessageIdentity {
+  const record = message as SessionMessageRecord
+  const info = (record.info ?? {}) as Record<string, unknown>
+  const time = (record.time ?? info.time ?? {}) as Record<string, unknown>
+
+  const id = typeof info.id === "string" ? info.id : typeof record.id === "string" ? record.id : undefined
+  const role = typeof info.role === "string" ? info.role : typeof record.role === "string" ? record.role : undefined
+  const finish = typeof info.finish === "string" ? info.finish : typeof record.finish === "string" ? record.finish : undefined
+  const error = info.error ?? record.error
+  const created = typeof time.created === "number" ? time.created : undefined
+  const completed = typeof time.completed === "number" ? time.completed : undefined
+
+  return { id, role, finish, error, created, completed }
+}
+
+function hasMeaningfulAssistantPayload(message: SessionMessage): boolean {
+  if (getMessageText(message).length > 0) {
+    return true
+  }
+
+  if ((message.parts?.length ?? 0) > 0) {
+    return true
+  }
+
+  const record = message as SessionMessageRecord
+  const tokens = (record.tokens ?? {}) as Record<string, unknown>
+  const outputTokens = typeof tokens.output === "number" ? tokens.output : 0
+  const reasoningTokens = typeof tokens.reasoning === "number" ? tokens.reasoning : 0
+  const cost = typeof record.cost === "number" ? record.cost : 0
+
+  return outputTokens > 0 || reasoningTokens > 0 || cost > 0
+}
+
+function isTerminalAssistantMessage(message: SessionMessage | undefined): boolean {
+  if (!message) return false
+  const identity = getMessageIdentity(message)
+  if (identity.finish) {
+    if (NON_TERMINAL_FINISH_REASONS.has(identity.finish)) return false
+    if (message.parts?.some((part) => part.type && PENDING_TOOL_PART_TYPES.has(part.type))) return false
+    return true
+  }
+
+  return identity.completed !== undefined && hasMeaningfulAssistantPayload(message)
+}
+
+function compareMessageOrder(a: SessionMessage | undefined, b: SessionMessage | undefined): boolean {
+  if (!a || !b) return false
+  const aIdentity = getMessageIdentity(a)
+  const bIdentity = getMessageIdentity(b)
+
+  if (aIdentity.id && bIdentity.id) {
+    return aIdentity.id < bIdentity.id
+  }
+
+  if (aIdentity.created !== undefined && bIdentity.created !== undefined) {
+    return aIdentity.created < bIdentity.created
+  }
+
+  return false
+}
+
+function getMessageText(message: SessionMessage): string {
+  const parts = message.parts ?? []
+  return parts
+    .filter((part) => part.type === "text" || part.type === "reasoning")
+    .map((part) => (part.text ?? "").trim())
+    .filter(Boolean)
+    .join("\n")
+}
+
+function isAssistantMessage(message: SessionMessage): boolean {
+  return getMessageIdentity(message).role === "assistant"
+}
+
+function isUserMessage(message: SessionMessage): boolean {
+  return getMessageIdentity(message).role === "user"
+}
+
+function getLastMessageByRole(messages: SessionMessage[], role: "assistant" | "user"): SessionMessage | undefined {
+  return [...messages].reverse().find((message) => getMessageIdentity(message).role === role)
+}
+
+function hasAnyAssistantText(messages: SessionMessage[]): boolean {
+  return messages.some((message) => isAssistantMessage(message) && getMessageText(message).length > 0)
+}
+
 function wait(milliseconds: number): Promise<void> {
   const sharedBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
   const typedArray = new Int32Array(sharedBuffer)
@@ -39,35 +136,27 @@ async function fetchSessionMessages(
 }
 
 function getTerminalSessionError(messages: SessionMessage[]): string | null {
-  const lastAssistant = [...messages].reverse().find((msg) => msg.info?.role === "assistant")
-  const lastUser = [...messages].reverse().find((msg) => msg.info?.role === "user")
-  if (lastUser?.info?.id && lastAssistant?.info?.id && lastAssistant.info.id <= lastUser.info.id) {
-    return null
-  }
-  if (!lastAssistant?.info || !("error" in lastAssistant.info)) {
+  const lastAssistant = getLastMessageByRole(messages, "assistant")
+  const lastUser = getLastMessageByRole(messages, "user")
+  if (compareMessageOrder(lastAssistant, lastUser)) {
     return null
   }
 
-  const errorMessage = extractErrorMessage((lastAssistant.info as { error?: unknown }).error)
+  const { error } = lastAssistant ? getMessageIdentity(lastAssistant) : {}
+  if (error === undefined) {
+    return null
+  }
+
+  const errorMessage = extractErrorMessage(error)
   return errorMessage && errorMessage.length > 0 ? errorMessage : "Session error"
 }
 
 export function isSessionComplete(messages: SessionMessage[]): boolean {
-  let lastUser: SessionMessage | undefined
-  let lastAssistant: SessionMessage | undefined
+  const lastUser = getLastMessageByRole(messages, "user")
+  const lastAssistant = getLastMessageByRole(messages, "assistant")
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-    if (!lastAssistant && msg.info?.role === "assistant") lastAssistant = msg
-    if (!lastUser && msg.info?.role === "user") lastUser = msg
-    if (lastUser && lastAssistant) break
-  }
-
-  if (!lastAssistant?.info?.finish) return false
-  if (NON_TERMINAL_FINISH_REASONS.has(lastAssistant.info.finish)) return false
-  if (lastAssistant.parts?.some((part) => part.type && PENDING_TOOL_PART_TYPES.has(part.type))) return false
-  if (!lastUser?.info?.id || !lastAssistant?.info?.id) return false
-  return lastUser.info.id < lastAssistant.info.id
+  if (!isTerminalAssistantMessage(lastAssistant)) return false
+  return compareMessageOrder(lastUser, lastAssistant)
 }
 
 const DEFAULT_MAX_ASSISTANT_TURNS = 300
@@ -191,9 +280,11 @@ export async function pollSyncSession(
     }
 
     // Count new assistant turns to circuit-break infinite loops
-    const lastAssistant = [...messages].reverse().find((m) => m.info?.role === "assistant")
-    if (lastAssistant?.info?.id && lastAssistant.info.id !== lastSeenAssistantId) {
-      lastSeenAssistantId = lastAssistant.info.id
+    const lastAssistant = getLastMessageByRole(messages, "assistant")
+    const lastAssistantIdentity = lastAssistant ? getMessageIdentity(lastAssistant) : undefined
+    const lastAssistantMarker = lastAssistantIdentity?.id ?? `created:${lastAssistantIdentity?.created ?? "none"}`
+    if (lastAssistantIdentity?.role === "assistant" && lastAssistantMarker !== lastSeenAssistantId) {
+      lastSeenAssistantId = lastAssistantMarker
       assistantTurnCount++
       if (assistantTurnCount >= maxTurns) {
         log("[task] Max assistant turns reached, aborting to prevent infinite loop", {
@@ -207,17 +298,9 @@ export async function pollSyncSession(
       }
     }
 
-    const hasAssistantText = messages.some((m) => {
-      if (m.info?.role !== "assistant") return false
-      const parts = m.parts ?? []
-      return parts.some((p) => {
-        if (p.type !== "text" && p.type !== "reasoning") return false
-        const text = (p.text ?? "").trim()
-        return text.length > 0
-      })
-    })
+    const hasAssistantText = hasAnyAssistantText(messages)
 
-    if (!lastAssistant?.info?.finish && hasAssistantText) {
+    if (lastAssistant && !lastAssistantIdentity?.finish && lastAssistantIdentity?.completed === undefined && hasAssistantText) {
       log("[task] Poll complete - assistant text detected (fallback)", {
         sessionID: input.sessionID,
         pollCount,


### PR DESCRIPTION
## Summary

Fixes a reproduced runtime-fallback failure chain in delegated child sessions:

- immediate quota/retry statuses could advance fallback incorrectly
- object-shaped/top-level message and event payloads were not normalized consistently
- sync delegated retries could be dropped behind prompt-gate reservations
- empty assistant completion rows could suppress fallback without producing a usable result
- delegated child retries could lose their bootstrap prompt before a real user turn was persisted
- fallback replays could create a second visible opening prompt

## Changes

- trigger runtime fallback directly on immediate provider retry/quota signals instead of treating them as successful progress
- normalize object-shaped and top-level runtime-fallback/session-message payloads before fallback state, visibility checks, and sync completion checks
- queue delegated sync fallback retries behind the active prompt reservation instead of dropping them as `reserved`
- ignore empty assistant completion markers unless they carry meaningful payload
- ignore synthetic/internal retry turns when rebuilding fallback retry payloads
- preserve delegated child bootstrap retry parts until a real persisted user turn exists
- redispatch fallback retry prompts as internal-only prompts
- mark internal retry text parts as `synthetic: true` so they stay hidden in history instead of appearing as a second user prompt
- cancel stale queued runtime-fallback prompts after successful retry progression
- add regression coverage for the reproduced hang and duplicate-prompt paths

## Testing

- `bun test src/hooks/runtime-fallback/auto-retry.test.ts src/hooks/runtime-fallback/index.test.ts src/hooks/runtime-fallback/message-update-handler.test.ts src/tools/delegate-task/sync-session-poller.test.ts`
- `bun test src/shared/internal-initiator-marker.test.ts src/hooks/runtime-fallback/auto-retry.test.ts src/hooks/runtime-fallback/index.test.ts src/hooks/runtime-fallback/message-update-handler.test.ts src/tools/delegate-task/sync-session-poller.test.ts src/tools/delegate-task/sync-prompt-sender.test.ts src/shared/model-suggestion-retry.test.ts src/plugin/chat-message.test.ts`
- `bun run build`

## Related Issues

- Related to #4207
- Related to #3255
- Related to #4019
- Related to #3963
- Related to #4074
- Related to #4136
- Related to #4197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens delegated runtime fallback and retries to prevent hangs, duplicate prompts, and dropped retries. Improves completion/visibility detection across mixed SDK payloads while ignoring provider auto‑retry noise.

- **Bug Fixes**
  - Treat immediate provider retry/quota statuses as fallback triggers (no false progress); normalize object-shaped models into `provider/model` strings.
  - Normalize message responses (raw arrays, `data`, or `messages`) before checks; ignore provider auto‑retry text in visibility checks; count reasoning-only and token/cost-based completions as visible; ignore empty finish markers.
  - Queue sync delegated retries behind an active prompt reservation; enqueue runtime fallback prompts and cancel stale queued `runtime-fallback:` prompts when not accepted.
  - Dispatch fallback retry prompts as internal-only text parts (`synthetic: true`) to keep them hidden and avoid a second visible user prompt.
  - Build retry payloads from the last real user turn (ignore synthetic/internal retries); keep delegated child bootstrap prompt until a real user turn is persisted.
  - Sync poller: detect completion via top-level `time.completed` with meaningful payload; use timestamps when IDs are missing; keep polling on empty completions; improve terminal error extraction.
  - Error classification: recognize “Free usage exceeded, subscribe to Go” as quota-exceeded.

<sup>Written for commit b2ef8007a877b4c28f14ce7421f525a61ef95977. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

