### PR TITLE
fix(background-agent): defer parent wakes during active turns

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -142,6 +142,7 @@ const PARENT_WAKE_TOOL_CALL_DEFER_MAX_MS = 5_000
  * env. See issue #4120.
  */
 const PARENT_WAKE_USER_MESSAGE_IN_PROGRESS_WINDOW_MS = 2_000
+const PARENT_WAKE_SESSION_ACTIVITY_IN_PROGRESS_WINDOW_MS = 2_000
 
 interface MessagePartInfo {
   id?: string
@@ -309,6 +310,7 @@ export class BackgroundManager {
         toolCallDeferMaxMs: PARENT_WAKE_TOOL_CALL_DEFER_MAX_MS,
         failureRequeueWindowMs: PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS,
         userMessageInProgressWindowMs: PARENT_WAKE_USER_MESSAGE_IN_PROGRESS_WINDOW_MS,
+        parentSessionActivityInProgressWindowMs: PARENT_WAKE_SESSION_ACTIVITY_IN_PROGRESS_WINDOW_MS,
       },
     )
     this.registerProcessCleanup()
@@ -1479,6 +1481,7 @@ The fallback retry session is now created and can be inspected directly.
       const role = (info as Record<string, unknown>)["role"]
       if (!sessionID) return
       this.clearDispatchedParentWake(sessionID)
+      this.parentWakeNotifier.recordParentSessionActivity(sessionID)
 
       if (role === "tool") {
         this.markSessionOutputObserved(sessionID)
@@ -1513,6 +1516,7 @@ The fallback retry session is now created and can be inspected directly.
       const sessionID = resolveMessageEventSessionID(props)
       if (!sessionID) return
       this.clearDispatchedParentWake(sessionID)
+      this.parentWakeNotifier.recordParentSessionActivity(sessionID)
 
       const resolved = this.resolveTaskAttemptBySession(sessionID)
       if (!resolved?.isCurrent) return
@@ -1621,6 +1625,7 @@ The fallback retry session is now created and can be inspected directly.
       if (!props || typeof props !== "object") return
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
+        this.parentWakeNotifier.clearParentSessionActivity(sessionID)
         void this.enqueueNotificationForParent(sessionID, () => this.flushPendingParentWake(sessionID)).catch((error) => {
           log("[background-agent] Failed to flush pending parent wake:", { sessionID, error })
         })

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1625,7 +1625,6 @@ The fallback retry session is now created and can be inspected directly.
       if (!props || typeof props !== "object") return
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
-        this.parentWakeNotifier.clearParentSessionActivity(sessionID)
         void this.enqueueNotificationForParent(sessionID, () => this.flushPendingParentWake(sessionID)).catch((error) => {
           log("[background-agent] Failed to flush pending parent wake:", { sessionID, error })
         })

--- a/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -141,4 +141,39 @@ describe("BackgroundManager parent wake active turn events", () => {
     expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
   })
+
+  test("#when parent idle event follows fresh reasoning delta #then background completion still does not fork a reply", async () => {
+    // given
+    const sessionStatuses: Record<string, { type: string }> = {
+      "parent-1": { type: "idle" },
+    }
+    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
+    managerUnderTest = manager
+    manager.handleEvent({
+      type: "message.part.delta",
+      properties: {
+        sessionID: "parent-1",
+        field: "reasoning",
+        delta: "still thinking",
+      },
+    })
+    const task = createTask({
+      id: "task-a",
+      parentSessionId: "parent-1",
+      description: "task A",
+      status: "completed",
+      completedAt: new Date("2026-05-20T14:19:14.625Z"),
+    })
+    getTasks(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+    // when
+    await notifyParentSessionForTest(manager, task)
+    manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(0)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+  })
 })

--- a/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -1,0 +1,144 @@
+import { tmpdir } from "node:os"
+import { afterEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type PendingParentWakeForTest = {
+  notifications: string[]
+  shouldReply: boolean
+}
+
+let managerUnderTest: BackgroundManager | undefined
+
+afterEach(() => {
+  managerUnderTest?.shutdown()
+  releaseAllPromptAsyncReservationsForTesting()
+  managerUnderTest = undefined
+})
+
+function createTask(overrides: Partial<BackgroundTask> & { id: string; parentSessionId: string }): BackgroundTask {
+  const id = overrides.id
+  const parentSessionID = overrides.parentSessionId
+  const { id: _ignoredID, parentSessionId: _ignoredParentSessionID, ...rest } = overrides
+
+  return {
+    parentMessageId: overrides.parentMessageId ?? "parent-message-id",
+    description: overrides.description ?? overrides.id,
+    prompt: overrides.prompt ?? `Prompt for ${overrides.id}`,
+    agent: overrides.agent ?? "test-agent",
+    status: overrides.status ?? "running",
+    startedAt: overrides.startedAt ?? new Date("2026-05-20T14:19:10.000Z"),
+    ...rest,
+    id,
+    parentSessionId: parentSessionID,
+  }
+}
+
+function createManager(sessionStatuses: Record<string, { type: string }>): {
+  manager: BackgroundManager
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client = {
+    session: {
+      messages: async () => [],
+      status: async () => ({ data: sessionStatuses }),
+      prompt: async () => ({}),
+      promptAsync: async (call: PromptAsyncCall) => {
+        promptAsyncCalls.push(call)
+        return {}
+      },
+      abort: async () => ({}),
+    },
+  }
+  const ctx: PluginInput = {
+    client: client as PluginInput["client"],
+    project: {} as PluginInput["project"],
+    directory: tmpdir(),
+    worktree: tmpdir(),
+    serverUrl: new URL("http://localhost"),
+    $: {} as PluginInput["$"],
+  }
+
+  const manager = new BackgroundManager({
+    pluginContext: ctx,
+    config: undefined,
+    enableParentSessionNotifications: true,
+  })
+
+  return { manager, promptAsyncCalls }
+}
+
+function getTasks(manager: BackgroundManager): Map<string, BackgroundTask> {
+  return Reflect.get(manager, "tasks") as Map<string, BackgroundTask>
+}
+
+function getPendingByParent(manager: BackgroundManager): Map<string, Set<string>> {
+  return Reflect.get(manager, "pendingByParent") as Map<string, Set<string>>
+}
+
+function getPendingParentWakes(manager: BackgroundManager): Map<string, PendingParentWakeForTest> {
+  const parentWakeNotifier = Reflect.get(manager, "parentWakeNotifier") as {
+    getPendingParentWakes: () => Map<string, PendingParentWakeForTest>
+  }
+  return parentWakeNotifier.getPendingParentWakes()
+}
+
+async function notifyParentSessionForTest(manager: BackgroundManager, task: BackgroundTask): Promise<void> {
+  const notifyParentSession = Reflect.get(manager, "notifyParentSession") as (task: BackgroundTask) => Promise<void>
+  return notifyParentSession.call(manager, task)
+}
+
+async function flushPendingParentWakeForTest(manager: BackgroundManager, sessionID: string): Promise<void> {
+  const flushPendingParentWake = Reflect.get(manager, "flushPendingParentWake") as (sessionID: string) => Promise<void>
+  return flushPendingParentWake.call(manager, sessionID)
+}
+
+describe("BackgroundManager parent wake active turn events", () => {
+  test("#when parent reasoning delta is newer than stale idle state #then background completion does not fork a reply", async () => {
+    // given
+    const sessionStatuses: Record<string, { type: string }> = {
+      "parent-1": { type: "idle" },
+    }
+    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
+    managerUnderTest = manager
+    manager.handleEvent({
+      type: "message.part.delta",
+      properties: {
+        sessionID: "parent-1",
+        field: "reasoning",
+        delta: "still thinking",
+      },
+    })
+    const task = createTask({
+      id: "task-a",
+      parentSessionId: "parent-1",
+      description: "task A",
+      status: "completed",
+      completedAt: new Date("2026-05-20T14:19:14.625Z"),
+    })
+    getTasks(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+    // when
+    await notifyParentSessionForTest(manager, task)
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(0)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+  })
+})

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -122,10 +122,6 @@ export class ParentWakeNotifier {
     this.recentParentSessionActivity.set(sessionID, Date.now())
   }
 
-  clearParentSessionActivity(sessionID: string): void {
-    this.recentParentSessionActivity.delete(sessionID)
-  }
-
   queuePendingParentWake(
     sessionID: string,
     notification: string,

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -67,6 +67,7 @@ type ParentWakeNotifierOptions = {
    * inside OpenCode's `@parcel/watcher` TSFN callback path. See issue #4120.
    */
   userMessageInProgressWindowMs: number
+  parentSessionActivityInProgressWindowMs?: number
 }
 
 type ToolWaitDeferralDecision = {
@@ -94,6 +95,7 @@ export class ParentWakeNotifier {
   private pendingParentWakeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   private dispatchedParentWakes: Map<string, PendingParentWake> = new Map()
   private dispatchedParentWakeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+  private recentParentSessionActivity: Map<string, number> = new Map()
 
   constructor(
     private readonly deps: ParentWakeNotifierDeps,
@@ -114,6 +116,14 @@ export class ParentWakeNotifier {
 
   getDispatchedParentWakeTimers(): Map<string, ReturnType<typeof setTimeout>> {
     return this.dispatchedParentWakeTimers
+  }
+
+  recordParentSessionActivity(sessionID: string): void {
+    this.recentParentSessionActivity.set(sessionID, Date.now())
+  }
+
+  clearParentSessionActivity(sessionID: string): void {
+    this.recentParentSessionActivity.delete(sessionID)
   }
 
   queuePendingParentWake(
@@ -160,6 +170,14 @@ export class ParentWakeNotifier {
 
     const latestWake = this.pendingParentWakes.get(sessionID)
     if (!latestWake) {
+      return
+    }
+
+    if (this.hasRecentParentSessionActivity(sessionID)) {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake because parent session activity is still fresh:", {
+        sessionID,
+      })
       return
     }
 
@@ -324,10 +342,27 @@ export class ParentWakeNotifier {
     this.dispatchedParentWakeTimers.clear()
     this.pendingParentWakes.clear()
     this.dispatchedParentWakes.clear()
+    this.recentParentSessionActivity.clear()
   }
 
   private async isSessionActive(sessionID: string): Promise<boolean> {
     return isOpenCodeSessionActive(this.deps.client, sessionID)
+  }
+
+  private hasRecentParentSessionActivity(sessionID: string): boolean {
+    const windowMs = this.options.parentSessionActivityInProgressWindowMs ?? 0
+    if (windowMs <= 0) {
+      return false
+    }
+    const lastActivityAt = this.recentParentSessionActivity.get(sessionID)
+    if (lastActivityAt === undefined) {
+      return false
+    }
+    if (Date.now() - lastActivityAt <= windowMs) {
+      return true
+    }
+    this.recentParentSessionActivity.delete(sessionID)
+    return false
   }
 
   private resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {


### PR DESCRIPTION
## Summary

Fixes the background parent-wake race where OpenCode can report a parent session as idle while it is still streaming reasoning/message-part activity. Background completion notifications now stay queued during fresh parent session activity instead of dispatching a `promptAsync` wake into the active turn and creating a parallel response branch.

## Changes

- Record fresh parent session `message.updated`, `message.part.updated`, and `message.part.delta` activity in `BackgroundManager`.
- Defer `ParentWakeNotifier` flushes while that activity is inside the active-turn freshness window.
- Clear the freshness marker on real `session.idle` events so queued wakes can flush promptly after the parent turn settles.
- Add a regression test for the Discord 4.2.3 / OpenCode 1.15.5 repro shape: a parent reasoning delta followed by a stale-idle background completion wake.

## Testing

- `bun test src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/task-completion-cleanup.test.ts src/shared/prompt-async-route-audit.test.ts --bail` - pass, 47 tests
- `bun run typecheck` - pass
- `bun run build` - pass
- `bun test` - fails on unrelated existing timeout in `src/tools/look-at/tools.test.ts` (`createLookAt sync prompt (race condition fix)`); the same timeout reproduces with `bun test src/tools/look-at/tools.test.ts --bail`

## Related Issues

- Fixes #4212
- Refs #4019
- Refs #3774

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers background parent-wake notifications during active parent turns so background completions don’t create parallel reply branches. Fixes #4212 by holding wakes during fresh parent message activity, even if the session reports idle.

- **Bug Fixes**
  - Record fresh parent session activity (`message.updated`, `message.part.updated`, `message.part.delta`) in `BackgroundManager`, and timestamp it in `ParentWakeNotifier`.
  - Defer wake flushes within a 2s window via `parentSessionActivityInProgressWindowMs`; preserve the activity marker across `session.idle` until it expires to avoid the stale-idle race.
  - Add regression tests for the Discord 4.2.3 / OpenCode 1.15.5 repro, including the idle-after-reasoning-delta case, to ensure no forked replies during active reasoning.

<sup>Written for commit 0ad4d974f1a6aa9dc07f88dd7270aa21125878df. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

