### PR TITLE
fix(keyword-detector): stop hyperplan firing on '.hpp' C++ header paths (fixes #4215)

### DIFF
--- a/src/hooks/keyword-detector/hyperplan.test.ts
+++ b/src/hooks/keyword-detector/hyperplan.test.ts
@@ -122,6 +122,46 @@ describe("keyword-detector hyperplan keyword", () => {
     expect(textPart!.text).not.toContain("<hyperplan-mode>")
   })
 
+  test("should NOT trigger hyperplan when 'hpp' is the extension of a C++ header path", async () => {
+    // given - text references a .hpp file, which is extremely common in C++ codebases
+    const sessionID = "hyperplan-hpp-extension-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "please help to check interface.hpp" }],
+    }
+
+    // when - keyword detection runs on a message that only contains 'hpp' as a file extension
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - hyperplan must NOT fire just because '.hpp' appears as a file extension
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toBe("please help to check interface.hpp")
+    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+  })
+
+  test("should NOT trigger hyperplan when path-like '.hpp' appears in a deeper file path", async () => {
+    // given - text contains a longer path ending in .hpp (free of other trigger words like 'review')
+    const sessionID = "hyperplan-hpp-path-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "open src/include/audio/buffer.hpp and fix the leak" }],
+    }
+
+    // when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - hyperplan must not fire (the trailing '.hpp' is a header extension, not the trigger)
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    expect(textPart!.text).not.toContain('skill(name="hyperplan")')
+  })
+
   test("should fire 'Hyperplan Mode Activated' toast when keyword detected", async () => {
     // given - main session and toast tracking
     const sessionID = "hyperplan-toast-session"

--- a/src/hooks/keyword-detector/hyperplan/default.ts
+++ b/src/hooks/keyword-detector/hyperplan/default.ts
@@ -8,9 +8,14 @@
  *
  * The detector injects a thin wrapper that loads the `hyperplan` skill, which
  * carries the full orchestration instructions for the 5-member adversarial team.
+ *
+ * The `hpp` shorthand uses an extra negative-lookbehind so that the very common
+ * C++ header-file extension `.hpp` (e.g. `interface.hpp`, `src/buffer.hpp`)
+ * does NOT falsely trigger hyperplan mode. A leading `.` would otherwise
+ * satisfy `\b` because the dot is a non-word character. See issue #4215.
  */
 
-export const HYPERPLAN_PATTERN = /\b(hyperplan|hpp)\b/i
+export const HYPERPLAN_PATTERN = /\bhyperplan\b|(?<![\w.])hpp\b/i
 
 export const HYPERPLAN_MESSAGE = `<hyperplan-mode>
 **MANDATORY**: Say "HYPERPLAN MODE ENABLED!" as your first response, exactly once.


### PR DESCRIPTION
## Summary

The hyperplan keyword detector falsely triggers on routine C++ header references like `check interface.hpp` or `open buffer.hpp`. The current regex `\b(hyperplan|hpp)\b/i` treats `.` as a word boundary, so `.hpp` satisfies `\bhpp\b`. Split the alternation so `hpp` additionally rejects a preceding word character or `.`, eliminating the false positive on file extensions while preserving every intended trigger.

## Root Cause

`src/hooks/keyword-detector/hyperplan/default.ts:13` defines:

```ts
export const HYPERPLAN_PATTERN = /\b(hyperplan|hpp)\b/i
```

`\b` is satisfied at any non-word/word transition. For `interface.hpp`, the `.` is a non-word character and `h` is a word character, so `\b` matches between them and the regex fires on the `hpp` extension. The reporter (`@troyliu0105`) hit this every time they typed something like _"check the interface.hpp"_; even disabling the hyperplan skill did not help because the keyword-detector hook runs before skill resolution.

## Fix

Replace the single alternation with two anchored branches:

```ts
export const HYPERPLAN_PATTERN = /\bhyperplan\b|(?<![\w.])hpp\b/i
```

- `\bhyperplan\b` is unchanged — the full word `hyperplan` still triggers under the original word-boundary semantics.
- `(?<![\w.])hpp\b` requires that the character preceding `hpp` is **neither** a word character **nor** a `.`. This rejects file-extension uses like `interface.hpp`, `buffer.hpp`, `path/foo.hpp` without affecting standalone `hpp`, `hpp:` mid-sentence, or the `/hpp` slash-command path (the slash-command guard runs separately and still wins).

## Changes

| File | Change |
|------|--------|
| `src/hooks/keyword-detector/hyperplan/default.ts` | Tighten `HYPERPLAN_PATTERN` so `hpp` no longer matches `.hpp` file extensions. |
| `src/hooks/keyword-detector/hyperplan.test.ts` | Add 2 regression tests for `interface.hpp` and `src/include/audio/buffer.hpp`. |

Net diff: **+46/-1 across 2 files** (≤50 LOC budget). No public API surface change.

## Reproduction (before fix)

Adding the new tests to `hyperplan.test.ts` and running `bun test src/hooks/keyword-detector/hyperplan.test.ts` on `dev`:

~~~
- "please help to check interface.hpp"
+ "<hyperplan-mode>
+ **MANDATORY**: Say "HYPERPLAN MODE ENABLED!" as your first response, exactly once.
+ ...
+ please help to check interface.hpp"

(fail) keyword-detector hyperplan keyword > should NOT trigger hyperplan when 'hpp' is the extension of a C++ header path
(fail) keyword-detector hyperplan keyword > should NOT trigger hyperplan when path-like '.hpp' appears in a deeper file path

 12 pass
 2 fail
~~~

## Verification (after fix)

~~~
bun test src/hooks/keyword-detector/hyperplan.test.ts

 14 pass
 0 fail
 52 expect() calls
Ran 14 tests across 1 file. [338.00ms]
~~~

Broader regression (entire keyword-detector module):

~~~
bun test src/hooks/keyword-detector/

 92 pass
 0 fail
 280 expect() calls
Ran 92 tests across 6 files. [450.00ms]
~~~

Typecheck:

~~~
bun run typecheck
... (no errors)
EXIT=0
~~~

## Test

- Regression tests: 2 new cases added to `src/hooks/keyword-detector/hyperplan.test.ts` (`should NOT trigger hyperplan when 'hpp' is the extension of a C++ header path` and `should NOT trigger hyperplan when path-like '.hpp' appears in a deeper file path`).
- Existing positive triggers still pass: bare `hyperplan`, bare `hpp`, mixed case `HyperPlan`, `hyperplan:` mid-sentence, etc.
- Existing negative tests still pass: `myhppvar = 1`, `/hyperplan ...` slash command, `/hpp ...` slash command, planner-agent filter.
- Related suite: `bun test src/hooks/keyword-detector/` — 92 pass.
- Typecheck: `bun run typecheck` — clean.

Fixes #4215

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4215 by stopping the hyperplan keyword detector from firing on C++ `.hpp` file paths. Tightens the regex so `.hpp` extensions are ignored while valid triggers still work.

- **Bug Fixes**
  - Replace pattern with `\bhyperplan\b|(?<![\w.])hpp\b` (case-insensitive) to block `.hpp` file extensions without affecting real triggers.
  - Add regression tests for `interface.hpp` and `src/include/audio/buffer.hpp`; existing positive and negative cases still pass.

<sup>Written for commit 61b812ffa92bf70849e1e8b62da2f5622e7cbda5. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4232?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

