### PR TITLE
Add Grok Sisyphus harness overlay

### DIFF
--- a/src/agents/grok-harness.test.ts
+++ b/src/agents/grok-harness.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import { createSisyphusAgent } from "./sisyphus"
+
+const GROK_4_3_MODEL = "xai/grok-4.3"
+const GROK_BUILD_MODEL = "xai/grok-build-0.1"
+
+const SISYPHUS_OPERATION_CRITERIA = [
+  "Powerful AI Agent with orchestration capabilities",
+  "Default Bias: DELEGATE",
+  "task(category=",
+  "lsp_diagnostics",
+  "run_in_background=true",
+  "Evidence Requirements",
+]
+
+const GROK_OPERATION_CRITERIA = [
+  "Sisyphus baseline preservation",
+  "Hook-triggered workflow modes are execution triggers",
+  "include at least one real tool call in the same assistant response",
+  "OMO features are first-class tools",
+  "Codebase mapping before edits",
+]
+
+function expectPromptIncludes(prompt: string, criteria: readonly string[]): void {
+  expect(criteria.filter((criterion) => !prompt.includes(criterion))).toEqual([])
+}
+
+describe("Grok Sisyphus harness", () => {
+  test("#given supported Grok models #when Sisyphus is created #then core agent settings are usable", () => {
+    for (const model of [GROK_4_3_MODEL, GROK_BUILD_MODEL]) {
+      const agent = createSisyphusAgent(model)
+
+      expect(agent.mode).toBe("primary")
+      expect(agent.model).toBe(model)
+      expect(agent.maxTokens).toBe(64000)
+      expect(agent.reasoningEffort).toBe("medium")
+      expect(agent.permission).toHaveProperty("question", "allow")
+      expect(agent.permission).toHaveProperty("call_omo_agent", "deny")
+      expect(agent.permission).toHaveProperty("apply_patch", "deny")
+    }
+  })
+
+  test("#given supported Grok model #when Sisyphus prompt is built #then baseline orchestration behavior remains available", () => {
+    const agent = createSisyphusAgent(GROK_4_3_MODEL)
+
+    expectPromptIncludes(agent.prompt, SISYPHUS_OPERATION_CRITERIA)
+  })
+
+  test("#given supported Grok model #when Sisyphus prompt is built #then Grok execution guardrails are applied", () => {
+    const agent = createSisyphusAgent(GROK_BUILD_MODEL)
+
+    expect(agent.prompt).toContain("based on Grok")
+    expect(agent.prompt).not.toContain("based on GPT-5.5")
+    expectPromptIncludes(agent.prompt, GROK_OPERATION_CRITERIA)
+  })
+
+  test("#given Grok model strings with supported variants #when Sisyphus is created #then they use the Grok harness", () => {
+    for (const model of [
+      "xai/grok-4.3 high",
+      "xai/grok-4.3(high)",
+      "xai/grok-build-0.1 high",
+      "xai/grok-build-0.1(high)",
+    ]) {
+      const agent = createSisyphusAgent(model)
+
+      expect(agent.prompt).toContain("Grok Harness Overlay")
+      expect(agent.prompt).not.toContain("based on GPT-5.5")
+      expect(agent.reasoningEffort).toBe("medium")
+    }
+  })
+
+  test("#given adjacent Grok versions #when Sisyphus is created #then only supported Grok variants use the harness", () => {
+    const grok43Variant = createSisyphusAgent("xai/grok-4.3-fast")
+    const grokBuild = createSisyphusAgent(GROK_BUILD_MODEL)
+    const grokBuildDot = createSisyphusAgent("xai/grok-build.0.1")
+    const grok430 = createSisyphusAgent("xai/grok-4.30")
+    const grok42 = createSisyphusAgent("xai/grok-4.2")
+    const grokBuild010 = createSisyphusAgent("xai/grok-build-0.10")
+
+    expect(grok43Variant.prompt).toContain("Grok Harness Overlay")
+    expect(grokBuild.prompt).toContain("Grok Harness Overlay")
+    expect(grokBuildDot.prompt).toContain("Grok Harness Overlay")
+    expect(grok430.prompt).not.toContain("Grok Harness Overlay")
+    expect(grok42.prompt).not.toContain("Grok Harness Overlay")
+    expect(grokBuild010.prompt).not.toContain("Grok Harness Overlay")
+  })
+})

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -19,10 +19,12 @@ import {
 import { buildClaudeOpus47SisyphusPrompt } from "./sisyphus/claude-opus-4-7";
 import { buildGpt54SisyphusPrompt } from "./sisyphus/gpt-5-4";
 import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
+import { buildGrokSisyphusPrompt } from "./sisyphus/grok";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import { buildTaskManagementSection } from "./sisyphus/default";
 import { getGptApplyPatchPermission } from "./gpt-apply-patch-guard";
 import { getFrontierToolSchemaPermission } from "./frontier-tool-schema-guard";
+import { parseModelString } from "../shared";
 
 const MODE: AgentMode = "primary";
 export const SISYPHUS_PROMPT_METADATA: AgentPromptMetadata = {
@@ -53,6 +55,14 @@ import {
   buildAntiDuplicationSection,
   categorizeTools,
 } from "./dynamic-agent-prompt-builder";
+
+function isGrokSisyphusModel(model: string): boolean {
+  const parsedModel = parseModelString(model);
+  const modelName = parsedModel?.modelID ?? (model.includes("/") ? (model.split("/").pop() ?? model) : model);
+  const normalized = modelName.toLowerCase();
+  return /^grok[-.]4[-.]3(?:$|[-_+.:])/.test(normalized)
+    || /^grok[-.]build[-.]0[-.]1(?:$|[-_+.:])/.test(normalized);
+}
 
 function buildDynamicSisyphusPrompt(
   model: string,
@@ -516,6 +526,34 @@ export function createSisyphusAgent(
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
         ...getGptApplyPatchPermission(model),
+      } as AgentConfig["permission"],
+      reasoningEffort: "medium",
+    };
+  }
+
+  if (isGrokSisyphusModel(model)) {
+    const baseline = buildDynamicSisyphusPrompt(
+      model,
+      agents,
+      tools,
+      skills,
+      categories,
+      useTaskSystem,
+    );
+    const prompt = buildGrokSisyphusPrompt(baseline);
+    return {
+      description:
+        "Powerful AI orchestrator. Plans obsessively with todos, assesses search complexity before exploration, delegates strategically via category+skills combinations. Uses explore for internal code (parallel-friendly), librarian for external docs. (Sisyphus - OhMyOpenCode)",
+      mode: MODE,
+      model,
+      maxTokens: 64000,
+      prompt,
+      color: "#00CED1",
+      permission: {
+        question: "allow",
+        call_omo_agent: "deny",
+        ...getFrontierToolSchemaPermission(model),
+        apply_patch: "deny",
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
     };

--- a/src/agents/sisyphus/grok.ts
+++ b/src/agents/sisyphus/grok.ts
@@ -1,0 +1,66 @@
+/**
+ * Grok Sisyphus prompt overlay.
+ *
+ * The base behavior stays aligned with Sisyphus orchestration while this file
+ * adds only Grok-specific execution guardrails.
+ */
+
+const GROK_EXECUTION_OVERLAY = `
+
+# Grok Harness Overlay
+
+You are Sisyphus, an orchestration agent based on Grok.
+
+## Sisyphus baseline preservation
+
+Preserve the Sisyphus delegation discipline, context gathering, task tracking, and manual QA gates already defined above. These Grok-specific rules only tighten execution around observed Grok stall modes; they do not reduce any baseline obligations.
+
+- If a rule feels optional, follow the stricter interpretation that produces earlier tool-grounded evidence.
+- Prefer observable tool activity over status prose. A status-only turn is weaker than a tool-grounded turn unless the user explicitly asked for prose only.
+- When uncertain whether to delegate, map context first, then delegate the smallest well-scoped lane with concrete files, acceptance criteria, and forbidden actions.
+
+## Hook-triggered execution
+
+Hook-triggered workflow modes are execution triggers. When the current user message contains \`<ultrawork-mode>\`, \`ulw\`, \`ulw ulw\`, \`ultrawork\`, or \`$oh-my-codex:ultrawork\`, you must not answer with only a banner. Say the required activation banner and include at least one real tool call in the same assistant response. If you say "calling the plan agent" or similar narration, the matching \`task(...)\` call must appear in that same response.
+
+## Action-by-default gate
+
+Act without asking when the next useful step is reasonably inferable. Do not ask permission questions like "Should I create it?", "Would you like me to do that?", "Do you want me to proceed?", "Should I proceed?", or "Do you want this?".
+
+You may ask the user a question only when all three conditions hold:
+
+1. The missing detail creates materially different valid outcomes or real risk.
+2. The answer cannot be discovered from the repo, docs, config, session history, or a safe local inspection.
+3. A reasonable default would likely waste work, damage state, or violate the user's intent.
+
+If those conditions do not all hold, choose the safest useful default and execute. For example, if you just proposed creating \`docs/docs-index.json\` and the user has not objected, create it with a minimal useful schema, validate it, and report what you did. Do not end with options unless the user explicitly asked for options.
+
+Never ask a permission question when a safe next action exists.
+
+## OMO feature gate
+
+OMO features are first-class tools, not optional extras. On every action request, run this gate before deciding to answer in prose: choose any applicable \`skill\`, \`task\`, \`skill_mcp\`, \`lsp_*\`, \`session_search\`, \`session_read\`, \`background_*\`, \`interactive_bash\`, or \`look_at\` capability. If a skill or MCP could improve correctness, use it before relying on internal reasoning.
+
+If you skip an obvious OMO feature, have a concrete reason. Default to using the feature.
+
+## Codebase mapping before edits
+
+Before non-trivial implementation work, map the affected code before editing. This applies when a change spans multiple files, touches an unfamiliar area, affects shared behavior, public APIs, state, persistence, CLI/TUI flow, tests, build wiring, or risks breaking callers.
+
+Your map should identify:
+- Files likely to be edited.
+- Direct callers, importers, dependents, or call chains.
+- Related tests and validation commands.
+- Existing local patterns or helpers to follow.
+- User or uncommitted changes that must be preserved.
+
+Preferred mapping tools: \`rg\`, \`rg --files\`, \`lsp_symbols\`, \`lsp_goto_definition\`, \`lsp_find_references\`, and \`ast_grep_search\` when text search is too loose.
+
+Skip the mapping pass for typos, documentation-only edits, isolated single-file fixes, and simple test additions. Do not use mapping as a reason to delay obvious work after the relevant context is already known.
+`
+
+export function buildGrokSisyphusPrompt(
+  baseline: string,
+): string {
+  return `${baseline}${GROK_EXECUTION_OVERLAY}`
+}

--- a/src/agents/sisyphus/index.ts
+++ b/src/agents/sisyphus/index.ts
@@ -7,6 +7,7 @@
  * - gemini.ts: Corrective overlays for Gemini's aggressive tendencies
  * - gpt-5-4.ts: Native GPT-5.4 prompt with block-structured guidance
  * - gpt-5-5.ts: Native GPT-5.5 prompt with Codex-style sections
+ * - grok.ts: Grok overlay on the Sisyphus harness
  */
 
 export { buildDefaultSisyphusPrompt, buildTaskManagementSection } from "./default";
@@ -21,4 +22,5 @@ export {
 } from "./gemini";
 export { buildGpt54SisyphusPrompt } from "./gpt-5-4";
 export { buildGpt55SisyphusPrompt } from "./gpt-5-5";
+export { buildGrokSisyphusPrompt } from "./grok";
 export { buildKimiK26SisyphusPrompt } from "./kimi-k2-6";


### PR DESCRIPTION
## Summary
Split from #4229. Adds a Grok-specific Sisyphus harness overlay for supported Grok 4.3/build variants without changing other model behavior.

## Changes
- Adds `src/agents/sisyphus/grok.ts` with Grok harness prompt overlay and model detection.
- Wires the overlay into Sisyphus creation for `grok-4.3` and `grok-build-0.1` model forms.
- Adds regression tests for supported variants and adjacent-version non-matches.

## Testing
- `bun test src/agents/grok-harness.test.ts` ✅

## Split from
- #4229


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Grok-specific Sisyphus harness overlay for `xai/grok-4.3` and `xai/grok-build-0.1` variants, preserving baseline orchestration while tightening execution guardrails. Non-Grok models are unchanged.

- **New Features**
  - Detects Grok models (including decorated strings) and appends a Grok overlay to the dynamic Sisyphus prompt.
  - Overlay enforces: tool call on ultrawork trigger, action-by-default (no permission questions), OMO tools gate, and codebase mapping before edits.
  - Integrated into `createSisyphusAgent` with 64k tokens and medium reasoning; adds tests for supported variants and adjacent non-matches.

<sup>Written for commit 0fd3f9e6e25cb16830517d277974ddfe46471524. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

