### PR TITLE
Continue todos on terminal assistant updates

### DIFF
--- a/src/hooks/todo-continuation-enforcer/assistant-response-completion.ts
+++ b/src/hooks/todo-continuation-enforcer/assistant-response-completion.ts
@@ -1,0 +1,86 @@
+import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined
+}
+
+function getStringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function hasCompletedTimeMarker(info: Record<string, unknown> | undefined): boolean {
+  const time = asRecord(info?.time)
+  const completed = time?.completed ?? info?.completed ?? info?.finished
+  if (typeof completed === "number") {
+    return Number.isFinite(completed)
+  }
+  if (typeof completed === "string") {
+    return completed.length > 0
+  }
+  return completed === true
+}
+
+function getDedupeTimeMarker(info: Record<string, unknown> | undefined): string | undefined {
+  const time = asRecord(info?.time)
+  const completed = time?.completed ?? info?.completed ?? info?.finished
+  if (typeof completed === "number" && Number.isFinite(completed)) {
+    return String(completed)
+  }
+  if (typeof completed === "string" && completed.length > 0) {
+    return completed
+  }
+  if (completed === true) {
+    return "true"
+  }
+  return undefined
+}
+
+export function resolveResponseCompleteSessionID(properties: Record<string, unknown> | undefined): string | undefined {
+  const info = asRecord(properties?.info)
+  return resolveMessageEventSessionID(properties)
+    ?? getStringField(properties, "sessionId")
+    ?? getStringField(info, "sessionId")
+}
+
+export function resolveResponseMessageID(properties: Record<string, unknown> | undefined): string | undefined {
+  return getStringField(asRecord(properties?.info), "id")
+}
+
+export function resolveResponseCompletionDedupeKey(properties: Record<string, unknown> | undefined): string {
+  const info = asRecord(properties?.info)
+  const messageID = resolveResponseMessageID(properties)
+  if (messageID) {
+    return `id:${messageID}`
+  }
+
+  const finish = typeof info?.finish === "string" && info.finish.length > 0 ? info.finish : "complete"
+  const timeMarker = getDedupeTimeMarker(info) ?? "no-time"
+  return `no-id:${finish}:${timeMarker}`
+}
+
+export function isAssistantResponseComplete(properties: Record<string, unknown> | undefined): boolean {
+  const info = asRecord(properties?.info)
+  if (getStringField(info, "role") !== "assistant") {
+    return false
+  }
+  if (info && Object.hasOwn(info, "error")) {
+    return false
+  }
+  if (hasCompletedTimeMarker(info)) {
+    return true
+  }
+
+  const finish = info?.finish
+  if (finish === true) {
+    return true
+  }
+  if (typeof finish !== "string" || finish.length === 0) {
+    return false
+  }
+
+  const normalizedFinish = finish.toLowerCase()
+  return normalizedFinish !== "tool-calls"
+    && normalizedFinish !== "tool_calls"
+    && normalizedFinish !== "unknown"
+}

--- a/src/hooks/todo-continuation-enforcer/handler.test.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.test.ts
@@ -44,7 +44,210 @@ function createRecordingStateStore(): {
   }
 }
 
+function createCompletedTodoHandler() {
+  const { store } = createRecordingStateStore()
+  const resetCalls: string[] = []
+  let pruneCalls = 0
+  let todoCalls = 0
+  const handler = createTodoContinuationHandler({
+    ctx: {
+      directory: "/tmp/test",
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              { info: { id: "msg-user", role: "user" } },
+              { info: { id: "msg-assistant", role: "assistant", finish: "stop" } },
+            ],
+          }),
+          todo: async () => {
+            todoCalls += 1
+            return { data: [{ id: "todo-1", content: "Verify", status: "completed", priority: "high" }] }
+          },
+        },
+      },
+    } as never,
+    sessionStateStore: {
+      ...store,
+      startPruneInterval: () => {
+        pruneCalls += 1
+      },
+      resetContinuationProgress: (sessionID: string) => {
+        resetCalls.push(sessionID)
+      },
+    },
+  })
+
+  return {
+    handler,
+    getStats: () => ({ pruneCalls, resetCalls, todoCalls }),
+  }
+}
+
 describe("createTodoContinuationHandler", () => {
+  test("#given assistant response completion with camelCase session id #when message update arrives #then continuation state is checked after response", async () => {
+    // given
+    const sessionID = "ses_assistant_finish_checks_todos"
+    const { handler, getStats } = createCompletedTodoHandler()
+
+    // when
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant", sessionId: sessionID, role: "assistant", finish: "stop" } },
+      },
+    })
+
+    // then
+    expect(getStats()).toEqual({ pruneCalls: 1, resetCalls: [sessionID], todoCalls: 1 })
+  })
+
+  test("#given duplicate assistant completion update #when message id repeats #then continuation state is checked once", async () => {
+    // given
+    const sessionID = "ses_assistant_finish_dedupe"
+    const { handler, getStats } = createCompletedTodoHandler()
+    const event = {
+      type: "message.updated",
+      properties: { info: { id: "msg-assistant", sessionID, role: "assistant", finish: "stop" } },
+    }
+
+    // when
+    await handler({ event })
+    await handler({ event })
+
+    // then
+    expect(getStats()).toEqual({ pruneCalls: 1, resetCalls: [sessionID], todoCalls: 1 })
+  })
+
+  test("#given duplicate assistant completion update without message id #when event repeats #then continuation state is checked once", async () => {
+    // given
+    const sessionID = "ses_assistant_finish_no_id_dedupe"
+    const { handler, getStats } = createCompletedTodoHandler()
+    const event = {
+      type: "message.updated",
+      properties: { info: { sessionID, role: "assistant", finish: "stop" } },
+    }
+
+    // when
+    await handler({ event })
+    await handler({ event })
+
+    // then
+    expect(getStats()).toEqual({ pruneCalls: 1, resetCalls: [sessionID], todoCalls: 1 })
+  })
+
+  test("#given active countdown and terminal assistant update #when completion is handled #then existing countdown is cancelled before todo check", async () => {
+    // given
+    const sessionID = "ses_assistant_finish_cancels_existing_countdown"
+    const { cancelCalls, state, store } = createRecordingStateStore()
+    let todoCalls = 0
+    const handler = createTodoContinuationHandler({
+      ctx: {
+        directory: "/tmp/test",
+        client: {
+          session: {
+            messages: async () => ({
+              data: [
+                { info: { id: "msg-user", role: "user" } },
+                { info: { id: "msg-assistant", role: "assistant", finish: "stop" } },
+              ],
+            }),
+            todo: async () => {
+              todoCalls += 1
+              return { data: [{ id: "todo-1", content: "Verify", status: "completed", priority: "high" }] }
+            },
+          },
+        },
+      } as never,
+      sessionStateStore: store,
+    })
+
+    // when
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant", sessionId: sessionID, role: "assistant", finish: "stop" } },
+      },
+    })
+
+    // then
+    expect(cancelCalls).toEqual([sessionID])
+    expect(todoCalls).toBe(1)
+    expect(state.wasCancelled).toBeUndefined()
+    expect(state.abortDetectedAt).toBeUndefined()
+  })
+
+  test("#given an abort is draining #when terminal assistant update follows #then abort markers prevent continuation", async () => {
+    // given
+    const sessionID = "ses_abort_then_terminal_assistant_update"
+    const { cancelCalls, state, store } = createRecordingStateStore()
+    let todoCalls = 0
+    const handler = createTodoContinuationHandler({
+      ctx: {
+        directory: "/tmp/test",
+        client: {
+          session: {
+            messages: async () => ({
+              data: [
+                { info: { id: "msg-user", role: "user" } },
+                { info: { id: "msg-assistant", role: "assistant", finish: "stop" } },
+              ],
+            }),
+            todo: async () => {
+              todoCalls += 1
+              return { data: [{ id: "todo-1", content: "Verify", status: "pending", priority: "high" }] }
+            },
+          },
+        },
+      } as never,
+      sessionStateStore: store,
+    })
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: { sessionID, error: { name: "MessageAbortedError" } },
+      },
+    })
+    const abortDetectedAt = state.abortDetectedAt
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant", sessionId: sessionID, role: "assistant", finish: "stop" } },
+      },
+    })
+
+    // then
+    expect(cancelCalls).toEqual([sessionID, sessionID])
+    expect(todoCalls).toBe(0)
+    expect(state.wasCancelled).toBe(true)
+    expect(state.abortDetectedAt).toBe(abortDetectedAt)
+  })
+
+  test("#given assistant response is not terminal #when message update arrives #then todo continuation is not checked yet", async () => {
+    // given
+    const sessionID = "ses_assistant_not_terminal"
+    const { handler, getStats } = createCompletedTodoHandler()
+
+    // when
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant-streaming", sessionID, role: "assistant" } },
+      },
+    })
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant-tool-calls", sessionID, role: "assistant", finish: "tool-calls" } },
+      },
+    })
+
+    // then
+    expect(getStats()).toEqual({ pruneCalls: 0, resetCalls: [], todoCalls: 0 })
+  })
+
   test("#given an active continuation countdown #when the session compacts #then it arms the compaction guard without cancelling the countdown", async () => {
     // given
     const sessionID = "ses_compaction_keeps_countdown"

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -9,6 +9,11 @@ import { resolveSessionEventID } from "../../shared/event-session-id"
 
 import { DEFAULT_SKIP_AGENTS, HOOK_NAME } from "./constants"
 import { armCompactionGuard } from "./compaction-guard"
+import {
+  isAssistantResponseComplete,
+  resolveResponseCompletionDedupeKey,
+  resolveResponseCompleteSessionID,
+} from "./assistant-response-completion"
 import type { SessionStateStore } from "./session-state"
 import { handleSessionIdle } from "./idle-event"
 import { handleNonIdleEvent } from "./non-idle-events"
@@ -67,9 +72,36 @@ export function createTodoContinuationHandler(args: {
     skipAgents = DEFAULT_SKIP_AGENTS,
     isContinuationStopped,
   } = args
+  const handledResponseMessagesBySession = new Map<string, Set<string>>()
+
+  function markResponseMessageHandled(sessionID: string, dedupeKey: string): boolean {
+    const existing = handledResponseMessagesBySession.get(sessionID) ?? new Set<string>()
+    handledResponseMessagesBySession.set(sessionID, existing)
+    if (existing.has(dedupeKey)) {
+      return false
+    }
+    existing.add(dedupeKey)
+    return true
+  }
+
+  function clearResponseMessageDedupeOnUserActivity(properties: Record<string, unknown> | undefined): void {
+    const info = asRecord(properties?.info)
+    if (getStringField(info, "role") !== "user") {
+      return
+    }
+    const sessionID = resolveResponseCompleteSessionID(properties)
+    if (sessionID) {
+      handledResponseMessagesBySession.delete(sessionID)
+    }
+  }
+
+  function cancelExistingAssistantCountdown(sessionID: string): void {
+    sessionStateStore.cancelCountdown(sessionID)
+  }
 
   return async ({ event }: { event: { type: string; properties?: unknown } }): Promise<void> => {
     const props = event.properties as Record<string, unknown> | undefined
+    const assistantResponseComplete = event.type === "message.updated" && isAssistantResponseComplete(props)
 
     if (event.type === "session.error") {
       const sessionID = resolveSessionEventID(props)
@@ -132,13 +164,39 @@ export function createTodoContinuationHandler(args: {
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
         clearContinuationMarker(ctx.directory, sessionID)
+        handledResponseMessagesBySession.delete(sessionID)
       }
     }
 
-    handleNonIdleEvent({
-      eventType: event.type,
-      properties: props,
-      sessionStateStore,
-    })
+    if (!assistantResponseComplete) {
+      if (event.type === "message.updated") {
+        clearResponseMessageDedupeOnUserActivity(props)
+      }
+      handleNonIdleEvent({
+        eventType: event.type,
+        properties: props,
+        sessionStateStore,
+      })
+    }
+
+    if (assistantResponseComplete) {
+      const sessionID = resolveResponseCompleteSessionID(props)
+      if (!sessionID) return
+
+      const dedupeKey = resolveResponseCompletionDedupeKey(props)
+      if (!markResponseMessageHandled(sessionID, dedupeKey)) return
+
+      cancelExistingAssistantCountdown(sessionID)
+      log(`[${HOOK_NAME}] assistant response complete`, { sessionID })
+      sessionStateStore.startPruneInterval()
+      await handleSessionIdle({
+        ctx,
+        sessionID,
+        sessionStateStore,
+        backgroundManager,
+        skipAgents,
+        isContinuationStopped,
+      })
+    }
   }
 }

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -17,6 +17,7 @@ import {
 import type { SessionStateStore } from "./session-state"
 import { handleSessionIdle } from "./idle-event"
 import { handleNonIdleEvent } from "./non-idle-events"
+import { createResponseCompletionDedupeStore } from "./response-completion-dedupe-store"
 import { isTokenLimitError } from "./token-limit-detection"
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -72,16 +73,10 @@ export function createTodoContinuationHandler(args: {
     skipAgents = DEFAULT_SKIP_AGENTS,
     isContinuationStopped,
   } = args
-  const handledResponseMessagesBySession = new Map<string, Set<string>>()
+  const responseCompletionDedupe = createResponseCompletionDedupeStore()
 
   function markResponseMessageHandled(sessionID: string, dedupeKey: string): boolean {
-    const existing = handledResponseMessagesBySession.get(sessionID) ?? new Set<string>()
-    handledResponseMessagesBySession.set(sessionID, existing)
-    if (existing.has(dedupeKey)) {
-      return false
-    }
-    existing.add(dedupeKey)
-    return true
+    return responseCompletionDedupe.markHandled(sessionID, dedupeKey)
   }
 
   function clearResponseMessageDedupeOnUserActivity(properties: Record<string, unknown> | undefined): void {
@@ -91,7 +86,7 @@ export function createTodoContinuationHandler(args: {
     }
     const sessionID = resolveResponseCompleteSessionID(properties)
     if (sessionID) {
-      handledResponseMessagesBySession.delete(sessionID)
+      responseCompletionDedupe.clearSession(sessionID)
     }
   }
 
@@ -164,7 +159,7 @@ export function createTodoContinuationHandler(args: {
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
         clearContinuationMarker(ctx.directory, sessionID)
-        handledResponseMessagesBySession.delete(sessionID)
+        responseCompletionDedupe.clearSession(sessionID)
       }
     }
 

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -113,8 +113,8 @@ export async function handleSessionIdle(args: {
 
   const incompleteCount = getIncompleteCount(todos)
   if (incompleteCount === 0) {
-    state.allTodosCompletedAt = Date.now()
     sessionStateStore.resetContinuationProgress(sessionID)
+    state.allTodosCompletedAt = Date.now()
     log(`[${HOOK_NAME}] All todos complete`, { sessionID, total: todos.length })
     return
   }

--- a/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
+++ b/src/hooks/todo-continuation-enforcer/non-idle-events.test.ts
@@ -98,4 +98,29 @@ describe("handleNonIdleEvent", () => {
     expect(state.wasCancelled).toBe(true)
     expect(state.tokenLimitDetected).toBe(true)
   })
+
+  test("given abort markers and assistant message update, cancels countdown without clearing abort state", () => {
+    // given
+    const sessionID = "ses_assistant_update_after_abort"
+    const state = sessionStateStore.getState(sessionID)
+    const abortDetectedAt = Date.now()
+    state.countdownStartedAt = abortDetectedAt - 10_000
+    state.abortDetectedAt = abortDetectedAt
+    state.wasCancelled = true
+
+    // when
+    handleNonIdleEvent({
+      eventType: "message.updated",
+      properties: {
+        sessionID,
+        info: { role: "assistant" },
+      },
+      sessionStateStore,
+    })
+
+    // then
+    expect(state.countdownStartedAt).toBeUndefined()
+    expect(state.wasCancelled).toBe(true)
+    expect(state.abortDetectedAt).toBe(abortDetectedAt)
+  })
 })

--- a/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -85,11 +85,6 @@ export function handleNonIdleEvent(args: {
     }
 
     if (role === "assistant") {
-      const state = sessionStateStore.getExistingState(sessionID)
-      if (state) {
-        state.abortDetectedAt = undefined
-        state.wasCancelled = false
-      }
       sessionStateStore.cancelCountdown(sessionID)
       return
     }

--- a/src/hooks/todo-continuation-enforcer/response-completion-dedupe-store.test.ts
+++ b/src/hooks/todo-continuation-enforcer/response-completion-dedupe-store.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { createResponseCompletionDedupeStore } from "./response-completion-dedupe-store"
+
+describe("createResponseCompletionDedupeStore", () => {
+  test("#given a repeated response key #when it is marked twice #then the second mark is rejected", () => {
+    // given
+    const store = createResponseCompletionDedupeStore()
+
+    // when
+    const first = store.markHandled("ses-1", "id:msg-1")
+    const second = store.markHandled("ses-1", "id:msg-1")
+
+    // then
+    expect(first).toBe(true)
+    expect(second).toBe(false)
+    expect(store.size).toBe(1)
+  })
+
+  test("#given a cleared session #when the same key is marked again #then it is accepted", () => {
+    // given
+    const store = createResponseCompletionDedupeStore()
+    store.markHandled("ses-1", "id:msg-1")
+
+    // when
+    store.clearSession("ses-1")
+    const accepted = store.markHandled("ses-1", "id:msg-1")
+
+    // then
+    expect(accepted).toBe(true)
+    expect(store.size).toBe(1)
+  })
+
+  test("#given stale sessions #when a new response is marked #then expired sessions are pruned", () => {
+    // given
+    let currentTime = 0
+    const store = createResponseCompletionDedupeStore({
+      ttlMs: 100,
+      now: () => currentTime,
+    })
+    store.markHandled("old-1", "id:msg-1")
+    store.markHandled("old-2", "id:msg-2")
+    currentTime = 101
+
+    // when
+    store.markHandled("new-1", "id:msg-3")
+
+    // then
+    expect(store.size).toBe(1)
+    expect(store.markHandled("old-1", "id:msg-1")).toBe(true)
+  })
+
+  test("#given more sessions than the cap #when responses are marked #then the oldest sessions are pruned", () => {
+    // given
+    let currentTime = 0
+    const store = createResponseCompletionDedupeStore({
+      maxSessions: 2,
+      now: () => currentTime,
+    })
+    store.markHandled("old-1", "id:msg-1")
+    currentTime = 1
+    store.markHandled("old-2", "id:msg-2")
+    currentTime = 2
+
+    // when
+    store.markHandled("new-1", "id:msg-3")
+
+    // then
+    expect(store.size).toBe(2)
+    expect(store.markHandled("old-1", "id:msg-1")).toBe(true)
+    expect(store.size).toBe(2)
+  })
+})

--- a/src/hooks/todo-continuation-enforcer/response-completion-dedupe-store.ts
+++ b/src/hooks/todo-continuation-enforcer/response-completion-dedupe-store.ts
@@ -1,0 +1,87 @@
+interface ResponseCompletionDedupeEntry {
+  readonly keys: Set<string>
+  lastTouchedAt: number
+}
+
+export interface ResponseCompletionDedupeStore {
+  readonly size: number
+  markHandled: (sessionID: string, dedupeKey: string) => boolean
+  clearSession: (sessionID: string) => void
+  prune: () => void
+}
+
+export interface ResponseCompletionDedupeStoreOptions {
+  ttlMs?: number
+  maxSessions?: number
+  now?: () => number
+}
+
+const DEFAULT_DEDUPE_TTL_MS = 10 * 60 * 1000
+const DEFAULT_MAX_DEDUPE_SESSIONS = 256
+
+export function createResponseCompletionDedupeStore(
+  options: ResponseCompletionDedupeStoreOptions = {},
+): ResponseCompletionDedupeStore {
+  const entries = new Map<string, ResponseCompletionDedupeEntry>()
+  const ttlMs = options.ttlMs ?? DEFAULT_DEDUPE_TTL_MS
+  const maxSessions = Math.max(1, options.maxSessions ?? DEFAULT_MAX_DEDUPE_SESSIONS)
+  const now = options.now ?? Date.now
+
+  function pruneExpired(currentTime: number): void {
+    for (const [sessionID, entry] of entries.entries()) {
+      if (currentTime - entry.lastTouchedAt > ttlMs) {
+        entries.delete(sessionID)
+      }
+    }
+  }
+
+  function pruneOverflow(): void {
+    while (entries.size > maxSessions) {
+      let oldestSessionID: string | undefined
+      let oldestTouchedAt = Number.POSITIVE_INFINITY
+      for (const [sessionID, entry] of entries.entries()) {
+        if (entry.lastTouchedAt < oldestTouchedAt) {
+          oldestTouchedAt = entry.lastTouchedAt
+          oldestSessionID = sessionID
+        }
+      }
+      if (!oldestSessionID) return
+      entries.delete(oldestSessionID)
+    }
+  }
+
+  function prune(): void {
+    pruneExpired(now())
+    pruneOverflow()
+  }
+
+  function markHandled(sessionID: string, dedupeKey: string): boolean {
+    const currentTime = now()
+    pruneExpired(currentTime)
+    let entry = entries.get(sessionID)
+    if (!entry) {
+      entry = { keys: new Set<string>(), lastTouchedAt: currentTime }
+      entries.set(sessionID, entry)
+    }
+    entry.lastTouchedAt = currentTime
+    pruneOverflow()
+    if (entry.keys.has(dedupeKey)) {
+      return false
+    }
+    entry.keys.add(dedupeKey)
+    return true
+  }
+
+  function clearSession(sessionID: string): void {
+    entries.delete(sessionID)
+  }
+
+  return {
+    get size() {
+      return entries.size
+    },
+    markHandled,
+    clearSession,
+    prune,
+  }
+}

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -325,6 +325,93 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls[0].text).toContain("TODO CONTINUATION")
   }, { timeout: 15000 })
 
+  test("should inject once when assistant completion arrives before idle", async () => {
+    // given
+    const sessionID = "main-assistant-complete-before-idle"
+    setMainSession(sessionID)
+    mockMessages = [
+      { info: { id: "msg-1", role: "user" } },
+      { info: { id: "msg-2", role: "assistant", finish: "stop" } },
+    ]
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+    const completionEvent = {
+      type: "message.updated",
+      properties: { info: { id: "msg-2", sessionId: sessionID, role: "assistant", finish: "stop" } },
+    }
+
+    // when
+    await hook.handler({ event: completionEvent })
+    await hook.handler({ event: completionEvent })
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    await fakeTimers.advanceBy(2500)
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0].sessionID).toBe(sessionID)
+    expect(promptCalls[0].text).toContain("TODO CONTINUATION")
+  })
+
+  test("should inject from assistant completion without a later idle event", async () => {
+    // given
+    const sessionID = "main-assistant-complete-no-idle"
+    setMainSession(sessionID)
+    mockMessages = [
+      { info: { id: "msg-1", role: "user" } },
+      { info: { id: "msg-2", role: "assistant", finish: "stop" } },
+    ]
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    // when
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-2", sessionId: sessionID, role: "assistant", finish: "stop" } },
+      },
+    })
+    await fakeTimers.advanceBy(2500)
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0].sessionID).toBe(sessionID)
+    expect(promptCalls[0].text).toContain("TODO CONTINUATION")
+  })
+
+  test("should cancel stale countdown when assistant completion finds all todos complete", async () => {
+    // given
+    const sessionID = "main-assistant-complete-cancels-stale-countdown"
+    setMainSession(sessionID)
+    mockMessages = [
+      { info: { id: "msg-1", role: "user" } },
+      { info: { id: "msg-2", role: "assistant", finish: "stop" } },
+    ]
+    const pendingTodos = [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+      { id: "2", content: "Task 2", status: "completed", priority: "medium" },
+    ]
+    const completedTodos = [
+      { id: "1", content: "Task 1", status: "completed", priority: "high" },
+      { id: "2", content: "Task 2", status: "completed", priority: "medium" },
+    ]
+    let todos = pendingTodos
+    const mockInput = createMockPluginInput()
+    mockInput.client.session.todo = async () => ({ data: todos })
+    const hook = createTodoContinuationEnforcer(mockInput, {})
+
+    // when
+    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+    todos = completedTodos
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { id: "msg-2", sessionId: sessionID, role: "assistant", finish: "stop" } },
+      },
+    })
+    await fakeTimers.advanceBy(2500)
+
+    // then
+    expect(promptCalls).toHaveLength(0)
+  })
+
   test("should not inject when all todos are complete", async () => {
     // given - session with all todos complete
     const sessionID = "main-456"
@@ -342,6 +429,10 @@ describe("todo-continuation-enforcer", () => {
       event: { type: "session.idle", properties: { sessionID } },
     })
 
+    await fakeTimers.advanceBy(3000)
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
     await fakeTimers.advanceBy(3000)
 
     // then - no continuation injected
@@ -1458,7 +1549,7 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls).toHaveLength(0)
   }, { timeout: 15000 })
 
-  test("should clear abort flag on assistant message activity", async () => {
+  test("should preserve abort flag on assistant message activity", async () => {
     fakeTimers.restore()
     // given - session with abort detected
     const sessionID = "main-clear-on-assistant"
@@ -1478,7 +1569,7 @@ describe("todo-continuation-enforcer", () => {
       },
     })
 
-    // when - assistant starts responding (clears abort flag)
+    // when - assistant activity arrives while the abort is still draining
     await hook.handler({
       event: {
         type: "message.updated",
@@ -1493,8 +1584,8 @@ describe("todo-continuation-enforcer", () => {
 
     await wait(2500)
 
-    // then - continuation injected (abort flag was cleared by assistant activity)
-    expect(promptCalls.length).toBeGreaterThan(0)
+    // then - continuation is skipped until user activity clears the abort flag
+    expect(promptCalls).toHaveLength(0)
   }, { timeout: 15000 })
 
   test("should clear abort flag on tool execution", async () => {


### PR DESCRIPTION
## Summary
Split from #4229. Starts todo-continuation checks when a terminal assistant `message.updated` event arrives, so continuation can proceed even if a later `session.idle` event is missing or delayed.

## Changes
- Adds a dependency-free assistant completion predicate and dedupe key helper.
- Routes terminal assistant completion through the existing idle continuation path.
- Cancels stale countdowns without clearing abort markers when assistant completion/activity arrives during an abort drain.
- Preserves `allTodosCompletedAt` after resetting continuation progress.
- Adds regression coverage for duplicate completion events, missing idle events, stale countdown cancellation, and abort-marker preservation.

## Testing
- `bun test src/hooks/todo-continuation-enforcer/handler.test.ts src/hooks/todo-continuation-enforcer/non-idle-events.test.ts src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts` ✅

## Split from
- #4229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start todo continuation when a terminal assistant message update arrives, so continuation proceeds even if `session.idle` is missing or delayed. Adds dedupe, pruning, and state handling to prevent duplicate injections and preserve abort behavior.

- **New Features**
  - Trigger continuation on terminal assistant `message.updated` without waiting for `session.idle`.
  - Route through the existing idle continuation path for consistent logic.

- **Bug Fixes**
  - Deduplicate completion events (by message ID or finish/time markers), prune stale dedupe state with a TTL and session cap, and reset dedupe on user activity or session clears.
  - Cancel stale countdowns on assistant completion while preserving abort markers during abort drain.
  - Preserve `allTodosCompletedAt` after `resetContinuationProgress`.

<sup>Written for commit b11f551e3b967b64266e883f2a4a8dd8b834345c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4237?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

