### PR TITLE
Avoid look_at status map wait hang

### DIFF
--- a/src/tools/look-at/look-at-session-runner.ts
+++ b/src/tools/look-at/look-at-session-runner.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
-import { log, promptSyncWithModelSuggestionRetry } from "../../shared"
+import { isAmbiguousPromptDispatchFailure, log, promptSyncWithModelSuggestionRetry } from "../../shared"
 import { extractLatestAssistantText } from "./assistant-message-extractor"
 import { MULTIMODAL_LOOKER_AGENT } from "./constants"
 import { READ_ENABLED, buildLookAtPrompt } from "./look-at-prompt"
@@ -61,7 +61,7 @@ Original error: ${createResult.error}`
   log(`[look_at] Created session: ${sessionID}`)
 
   log(`[look_at] Sending prompt with ${isBase64Input ? "base64 image" : "file"} to session ${sessionID}`)
-  let promptFailed = false
+  let shouldWaitForStatus = true
   try {
     await promptSyncWithModelSuggestionRetry(ctx.client, {
       path: { id: sessionID },
@@ -84,16 +84,15 @@ Original error: ${createResult.error}`
       queueBehavior: "defer",
     })
   } catch (promptError) {
-    promptFailed = true
-    log("[look_at] Prompt error (ignored, will still fetch messages):", promptError)
+    log("[look_at] Prompt dispatch failed; checking child session evidence:", promptError)
+    shouldWaitForStatus = isAmbiguousPromptDispatchFailure(promptError)
   }
 
   let observedMessages: unknown[] | undefined
   let observedText: string | undefined
-  if (typeof ctx.client.session.status === "function") {
+  if (shouldWaitForStatus && typeof ctx.client.session.status === "function") {
     const waitResult = await waitForLookAtSessionResult(ctx.client, sessionID, {
       allowStableIdleWithoutActivity: true,
-      allowEmptyStableIdleWithoutActivity: promptFailed,
     })
     observedText = waitResult.outcome.text ?? undefined
     if (observedText) {

--- a/src/tools/look-at/session-poller.test.ts
+++ b/src/tools/look-at/session-poller.test.ts
@@ -90,6 +90,36 @@ describe("waitForLookAtSessionResult", () => {
     ).rejects.toThrow("timed out")
   })
 
+  test("#given status omits session before it starts #when later idle has response #then waits instead of treating empty status as done", async () => {
+    const assistantMessages: RawMessage[] = [
+      { info: { role: "user" }, parts: [{ type: "text", text: "analyze this" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "late result" }] },
+    ]
+    let statusCalls = 0
+    const client = {
+      session: {
+        status: mock(async () => {
+          statusCalls += 1
+          if (statusCalls <= 3) return { data: {} }
+          if (statusCalls === 4) return { data: { ses_test: { type: "busy" } } }
+          return { data: { ses_test: { type: "idle" } } }
+        }),
+        messages: mock(async () => ({
+          data: statusCalls >= 5 ? assistantMessages : [],
+          error: null,
+        })),
+      },
+    }
+
+    const result = await waitForLookAtSessionResult(unsafeTestValue(client), "ses_test", {
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    })
+
+    expect(result.outcome.text).toBe("late result")
+    expect(statusCalls).toBe(5)
+  })
+
   test("#given session never becomes idle #when polling exceeds timeout #then rejects", async () => {
     const client = createMockClient(
       [{ data: { ses_test: { type: "busy" } } }],

--- a/src/tools/look-at/session-poller.test.ts
+++ b/src/tools/look-at/session-poller.test.ts
@@ -90,6 +90,22 @@ describe("waitForLookAtSessionResult", () => {
     ).rejects.toThrow("timed out")
   })
 
+  test("#given supported status never lists the session but assistant output exists #when polling #then resolves with observed output", async () => {
+    const assistantMessages: RawMessage[] = [
+      { info: { role: "user" }, parts: [{ type: "text", text: "inspect this" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "observed result" }] },
+    ]
+    const client = createMockClient([{ data: {} }], assistantMessages)
+
+    const result = await waitForLookAtSessionResult(unsafeTestValue(client), "ses_test", {
+      pollIntervalMs: 10,
+      timeoutMs: 5000,
+    })
+
+    expect(result.outcome.text).toBe("observed result")
+    expect(client.session.status).toHaveBeenCalledTimes(1)
+  })
+
   test("#given status omits session before it starts #when later idle has response #then waits instead of treating empty status as done", async () => {
     const assistantMessages: RawMessage[] = [
       { info: { role: "user" }, parts: [{ type: "text", text: "analyze this" }] },

--- a/src/tools/look-at/session-poller.ts
+++ b/src/tools/look-at/session-poller.ts
@@ -109,11 +109,11 @@ export async function waitForLookAtSessionResult(
     const { messages, error: messagesError } = await getSessionMessages(client, sessionID)
     const outcome = extractLatestAssistantOutcome(messages)
 
-    if (outcome.text && !isActive) {
+    if (outcome.text && (!isActive || supportedButNeverSeen)) {
       return { messages, outcome, statusType }
     }
 
-    if (outcome.errorName && !isActive) {
+    if (outcome.errorName && (!isActive || supportedButNeverSeen)) {
       return { messages, outcome, statusType }
     }
 


### PR DESCRIPTION
## Summary
Split from #4229. Fixes a `look_at` hang where the child session can produce assistant output but never appears in the status map.

## Changes
- Narrows ambiguous prompt-dispatch failure detection to the genuine "session never appeared" case.
- Lets the poller return observed assistant text for supported-but-never-seen sessions.
- Adds poller regression coverage for absent status entries with and without observed output.

## Testing
- `bun test src/tools/look-at/session-poller.test.ts` ✅

## Split from
- #4229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a look_at hang when a child session produces assistant output but never appears in the status map. Results are now returned when output is observed, and we only wait on status when it’s actually useful.

- Bug Fixes
  - Only wait for status when prompt dispatch failure is ambiguous and the session may have never appeared.
  - Poller returns assistant text/error as soon as observed, even if the session never shows up in the status map.
  - Added regression coverage for permanently absent status with observed output, and for empty status followed by late output.

<sup>Written for commit c4a51bee238ca18c7fc4e9daadab36c76f79d950. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

