### PR TITLE
fix: deny bash/interactive_bash for Prometheus agent (#2273)

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/tool-config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/tool-config-handler.test.ts
@@ -387,4 +387,59 @@ describe("applyToolConfig", () => {
       )
     })
   })
+
+  describe("#given prometheus agent", () => {
+    describe("#when applying tool config", () => {
+      it("#then should deny bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.bash).toBe("deny")
+      })
+
+      it("#then should deny interactive_bash for prometheus", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.interactive_bash).toBe("deny")
+      })
+
+      it("#then should preserve other prometheus permissions", () => {
+        const params = createParams({ agents: ["prometheus"] })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult.prometheus as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.call_omo_agent).toBe("deny")
+        expect(agent.permission.task).toBe("allow")
+        expect(agent.permission["task_*"]).toBe("allow")
+        expect(agent.permission.teammate).toBe("allow")
+      })
+
+      it("#then should NOT deny bash for other agents", () => {
+        const otherAgents = ["atlas", "sisyphus", "hephaestus", "sisyphus-junior"]
+        const params = createParams({ agents: otherAgents })
+
+        applyToolConfig(params)
+
+        for (const agentName of otherAgents) {
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.bash).toBeUndefined()
+          expect(agent.permission.interactive_bash).toBeUndefined()
+        }
+      })
+    })
+  })
 })

--- a/packages/omo-opencode/src/plugin-handlers/tool-config-handler.ts
+++ b/packages/omo-opencode/src/plugin-handlers/tool-config-handler.ts
@@ -131,6 +131,8 @@ export function applyToolConfig(params: {
       "task_*": "allow",
       teammate: "allow",
       ...denyTodoTools,
+      bash: "deny",
+      interactive_bash: "deny",
     };
   }
   const junior = agentByKey(params.agentResult, "sisyphus-junior");


### PR DESCRIPTION
> **Reopened from #2414** — branch was recreated during rebase, GitHub would not allow reopening the old PR.

## Summary

Closes #2273 — Prometheus agent can bypass file write restrictions via bash/interactive_bash tools.

## Context

The `prometheus-md-only` hook blocks `Write` and `Edit` tools, but Prometheus can still modify files via bash commands (`cp`, `rm`, `python3 -c`, etc.).

Three approaches were considered:

| Option | Approach | Status |
|--------|----------|--------|
| **A** | Enhance hook to parse/intercept bash commands | Implemented in #2403 — 424-line tokenizer still has 8 security bypasses after 2 review rounds. Bash syntax is too complex for static analysis. |
| **B** | Strengthen agent prompt to not work around restrictions | Unreliable — the original issue shows the model explicitly reasoning around the hook |
| **C (this PR)** | Deny bash tools, rely on existing read-only tools | Minimal, zero attack surface |

## Why Option C works

Prometheus needs bash for one thing: inspecting the codebase. But we already have purpose-built read-only tools:

| Bash command | Existing tool | Advantage |
|---|---|---|
| `cat`, `head`, `tail` | `Read` (with offset/limit) | Line numbers, pagination |
| `grep`, `rg` | `Grep` | Regex, output modes, file filtering |
| `find`, `ls` | `Glob` | Pattern matching, sorted by mtime |
| — | `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols` | Semantic code understanding |

Oracle, Librarian, and Explore are all read-only agents that operate without bash — and they work well. Prometheus follows the same proven pattern.

## Changes

- `src/plugin-handlers/tool-config-handler.ts` — Added bash and interactive_bash deny rules to Prometheus agent permissions
- `src/plugin-handlers/tool-config-handler.test.ts` — Added 4 new tests verifying the deny behavior for both tools

## Testing

- 4 new tests, all passing
- Existing tests unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `bash` and `interactive_bash` for the Prometheus agent to prevent bypassing the `prometheus-md-only` read-only policy. Closes #2273.

- **Bug Fixes**
  - Added deny rules in `packages/omo-opencode/src/plugin-handlers/tool-config-handler.ts`.
  - Added 4 tests in `packages/omo-opencode/src/plugin-handlers/tool-config-handler.test.ts` to verify denial and preserve other Prometheus permissions.
  - Other agents remain unchanged.

<sup>Written for commit 624bed21cdb96882acdedd1812f61dd13a5b7b22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

