### PR TITLE
feat(glm): add provider-safe thinking config

### DIFF
--- a/packages/model-core/src/model-requirements.test.ts
+++ b/packages/model-core/src/model-requirements.test.ts
@@ -28,10 +28,10 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const sisyphus = AGENT_MODEL_REQUIREMENTS["sisyphus"]
 
     // #when - accessing Sisyphus requirement
-    // #then - fallbackChain has 7 entries with correct ordering
+    // #then - fallbackChain has GLM 5.1, GLM 5, and GLM 5 Turbo before big-pickle
     expect(sisyphus).toBeDefined()
     expect(sisyphus.fallbackChain).toBeArray()
-    expect(sisyphus.fallbackChain).toHaveLength(7)
+    expect(sisyphus.fallbackChain).toHaveLength(9)
     expect(sisyphus.requiresAnyModel).toBe(true)
 
     const primary = sisyphus.fallbackChain[0]
@@ -56,10 +56,18 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
 	expect(fifth.variant).toBe("medium")
 
     const sixth = sisyphus.fallbackChain[5]
-    expect(sixth.providers[0]).toBe("zai-coding-plan")
-    expect(sixth.model).toBe("glm-5")
+    expect(sixth.providers).toEqual(["zai-coding-plan", "opencode", "vercel"])
+    expect(sixth.model).toBe("glm-5.1")
 
-    const last = sisyphus.fallbackChain[6]
+    const seventh = sisyphus.fallbackChain[6]
+    expect(seventh.providers).toEqual(["zai-coding-plan", "opencode", "vercel"])
+    expect(seventh.model).toBe("glm-5")
+
+    const eighth = sisyphus.fallbackChain[7]
+    expect(eighth.providers).toEqual(["zai-coding-plan", "opencode"])
+    expect(eighth.model).toBe("glm-5-turbo")
+
+    const last = sisyphus.fallbackChain[8]
     expect(last.providers[0]).toBe("opencode")
     expect(last.model).toBe("big-pickle")
   })
@@ -357,10 +365,10 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const visualEngineering = CATEGORY_MODEL_REQUIREMENTS["visual-engineering"]
 
     // when - accessing visual-engineering requirement
-    // then - fallbackChain: gemini-3.1-pro(high) → glm-5 → opus-4-6(max) → opencode-go/glm-5.1 → k2p5
+    // then - fallbackChain includes GLM 5 and GLM 5 Turbo before Opus
     expect(visualEngineering).toBeDefined()
     expect(visualEngineering.fallbackChain).toBeArray()
-    expect(visualEngineering.fallbackChain).toHaveLength(5)
+    expect(visualEngineering.fallbackChain).toHaveLength(6)
 
     const primary = visualEngineering.fallbackChain[0]
     expect(primary.providers[0]).toBe("google")
@@ -372,16 +380,20 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(second.model).toBe("glm-5")
 
     const third = visualEngineering.fallbackChain[2]
-    expect(third.model).toBe("claude-opus-4-7")
-    expect(third.variant).toBe("max")
+    expect(third.providers).toEqual(["zai-coding-plan", "opencode"])
+    expect(third.model).toBe("glm-5-turbo")
 
     const fourth = visualEngineering.fallbackChain[3]
-    expect(fourth.providers[0]).toBe("opencode-go")
-    expect(fourth.model).toBe("glm-5.1")
+    expect(fourth.model).toBe("claude-opus-4-7")
+    expect(fourth.variant).toBe("max")
 
     const fifth = visualEngineering.fallbackChain[4]
-    expect(fifth.providers[0]).toBe("kimi-for-coding")
-    expect(fifth.model).toBe("k2p5")
+    expect(fifth.providers[0]).toBe("opencode-go")
+    expect(fifth.model).toBe("glm-5.1")
+
+    const sixth = visualEngineering.fallbackChain[5]
+    expect(sixth.providers[0]).toBe("kimi-for-coding")
+    expect(sixth.model).toBe("k2p5")
   })
 
   test("quick has valid fallbackChain with gpt-5.4-mini as primary and claude-haiku-4-5 as secondary", () => {

--- a/packages/model-core/src/model-requirements.ts
+++ b/packages/model-core/src/model-requirements.ts
@@ -40,7 +40,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "kimi-k2.5",
       },
       { providers: ["openai", "github-copilot", "opencode", "vercel"], model: "gpt-5.5", variant: "medium" },
+      { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5.1" },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
+      { providers: ["zai-coding-plan", "opencode"], model: "glm-5-turbo" },
       { providers: ["opencode"], model: "big-pickle" },
     ],
     requiresAnyModel: true,
@@ -198,6 +200,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
+      { providers: ["zai-coding-plan", "opencode"], model: "glm-5-turbo" },
       {
         providers: ["anthropic", "github-copilot", "opencode", "vercel"],
         model: "claude-opus-4-7",

--- a/src/agents/glm-thinking-config.test.ts
+++ b/src/agents/glm-thinking-config.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { createMetisAgent } from "./metis"
+import { createMomusAgent } from "./momus"
+import { createOracleAgent } from "./oracle"
+import { createSisyphusAgent } from "./sisyphus"
+import { createSisyphusJuniorAgentWithOverrides as createSisyphusJuniorAgent } from "./sisyphus-junior/agent"
+
+const GLM_TEXT_MODELS = [
+  "z-ai/glm-5",
+  "opencode/glm-5",
+  "opencode-go/glm-5",
+  "zai-coding-plan/glm-5",
+  "z-ai/glm-5.1",
+  "z-ai/glm-5-turbo",
+  "vercel/zai/glm-5",
+] as const
+
+const GLM_VISION_MODELS = [
+  "opencode/glm-4.6v",
+  "zai-coding-plan/glm-4.6v",
+  "opencode/glm-5v-turbo",
+  "opencode-go/glm5v-turbo",
+] as const
+
+const CLAUDE_MODELS = [
+  "anthropic/claude-opus-4-7",
+  "anthropic/claude-sonnet-4-6",
+] as const
+
+function hasBudgetTokens(thinking: unknown): boolean {
+  return typeof thinking === "object"
+    && thinking !== null
+    && "budgetTokens" in thinking
+}
+
+const factories = [
+  { name: "Sisyphus", create: (model: string) => createSisyphusAgent(model) },
+  { name: "Sisyphus-Junior", create: (model: string) => createSisyphusJuniorAgent({ model }) },
+  { name: "Oracle", create: (model: string) => createOracleAgent(model) },
+  { name: "Metis", create: (model: string) => createMetisAgent(model) },
+  { name: "Momus", create: (model: string) => createMomusAgent(model) },
+]
+
+describe("GLM thinking config", () => {
+  for (const factory of factories) {
+    for (const model of GLM_TEXT_MODELS) {
+      test(`#given ${factory.name} with ${model} #when creating agent #then enables thinking without budgetTokens`, () => {
+        const config = factory.create(model)
+
+        expect(config.thinking).toEqual({ type: "enabled" })
+        expect(hasBudgetTokens(config.thinking)).toBe(false)
+      })
+    }
+  }
+
+  for (const factory of factories) {
+    for (const model of GLM_VISION_MODELS) {
+      test(`#given ${factory.name} with vision model ${model} #when creating agent #then does not use GLM text thinking path`, () => {
+        const config = factory.create(model)
+
+        expect(config.thinking).not.toEqual({ type: "enabled" })
+      })
+    }
+  }
+
+  for (const factory of factories) {
+    for (const model of CLAUDE_MODELS) {
+      test(`#given ${factory.name} with ${model} #when creating agent #then keeps budgetTokens thinking`, () => {
+        const config = factory.create(model)
+
+        expect(hasBudgetTokens(config.thinking)).toBe(true)
+      })
+    }
+  }
+})

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
+import { isGlmThinkingModel } from "./types"
 import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
@@ -299,7 +300,7 @@ const metisRestrictions = createAgentToolRestrictions([
 ])
 
 export function createMetisAgent(model: string): AgentConfig {
-  return {
+  const base = {
     description:
       "Pre-planning consultant that analyzes requests to identify hidden intentions, ambiguities, and AI failure points. (Metis - OhMyOpenCode)",
     mode: MODE,
@@ -307,8 +308,13 @@ export function createMetisAgent(model: string): AgentConfig {
     temperature: 0.3,
     ...metisRestrictions,
     prompt: METIS_SYSTEM_PROMPT,
-    thinking: { type: "enabled", budgetTokens: 32000 },
   } as AgentConfig
+
+  if (isGlmThinkingModel(model)) {
+    return { ...base, thinking: { type: "enabled" } } as AgentConfig
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } } as AgentConfig
 }
 createMetisAgent.mode = MODE
 

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { isGpt5_2Model, isGptModel } from "./types";
+import { isGlmThinkingModel, isGpt5_2Model, isGptModel } from "./types";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -408,6 +408,10 @@ export function createMomusAgent(model: string): AgentConfig {
       reasoningEffort: "medium",
       textVerbosity: "high",
     } as AgentConfig;
+  }
+
+  if (isGlmThinkingModel(model)) {
+    return { ...base, thinking: { type: "enabled" } } as AgentConfig;
   }
 
   return {

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { isGpt5_2Model, isGpt5_5Model, isGptModel } from "./types";
+import { isGlmThinkingModel, isGpt5_2Model, isGpt5_5Model, isGptModel } from "./types";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -581,6 +581,10 @@ export function createOracleAgent(model: string): AgentConfig {
       reasoningEffort: "medium",
       textVerbosity: "high",
     } as AgentConfig;
+  }
+
+  if (isGlmThinkingModel(model)) {
+    return { ...base, thinking: { type: "enabled" } } as AgentConfig;
   }
 
   return {

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -12,7 +12,7 @@
 
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode } from "../types"
-import { isGlmModel, isGpt5_5Model, isGptModel, isGeminiModel, isKimiK2Model } from "../types"
+import { isGlmModel, isGlmThinkingModel, isGpt5_5Model, isGptModel, isGeminiModel, isKimiK2Model } from "../types"
 import type { AgentOverrideConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
@@ -143,6 +143,10 @@ export function createSisyphusJuniorAgentWithOverrides(
 
   if (isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" } as AgentConfig
+  }
+
+  if (isGlmThinkingModel(model)) {
+    return { ...base, thinking: { type: "enabled" } } as AgentConfig
   }
 
   if (isGlmModel(model)) {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -7,6 +7,7 @@ import {
   isGptNativeSisyphusModel,
   isClaudeOpus47Model,
   isKimiK2Model,
+  isGlmThinkingModel,
 } from "./types";
 import {
   buildGeminiToolMandate,
@@ -652,6 +653,10 @@ export function createSisyphusAgent(
 
   if (isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" };
+  }
+
+  if (isGlmThinkingModel(model)) {
+    return { ...base, thinking: { type: "enabled" } };
   }
 
   return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } };

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -3,6 +3,8 @@ import {
   isGptModel,
   isGeminiModel,
   isGlmModel,
+  isGlmThinkingModel,
+  isGlmVisionModel,
   isGptNativeSisyphusModel,
   isMiniMaxModel,
 } from "./types";
@@ -138,6 +140,49 @@ describe("isGlmModel", () => {
     expect(isGlmModel("openai/gpt-5.4")).toBe(false);
     expect(isGlmModel("anthropic/claude-opus-4-7")).toBe(false);
     expect(isGlmModel("google/gemini-3.1-pro")).toBe(false);
+  });
+});
+
+describe("isGlmVisionModel", () => {
+  test("#given GLM vision variants #then returns true", () => {
+    expect(isGlmVisionModel("opencode/glm-4.6v")).toBe(true);
+    expect(isGlmVisionModel("opencode/glm-5v")).toBe(true);
+    expect(isGlmVisionModel("opencode/glm-5v-turbo")).toBe(true);
+    expect(isGlmVisionModel("opencode-go/glm5v-turbo")).toBe(true);
+  });
+
+  test("#given GLM text models #then returns false", () => {
+    expect(isGlmVisionModel("opencode/glm-5")).toBe(false);
+    expect(isGlmVisionModel("z-ai/glm-5.1")).toBe(false);
+    expect(isGlmVisionModel("opencode/glm-5-turbo")).toBe(false);
+    expect(isGlmVisionModel("opencode-go/glm5-turbo")).toBe(false);
+  });
+
+  test("#given non GLM models #then returns false", () => {
+    expect(isGlmVisionModel("openai/gpt-5.5")).toBe(false);
+    expect(isGlmVisionModel("anthropic/claude-opus-4-7")).toBe(false);
+  });
+});
+
+describe("isGlmThinkingModel", () => {
+  test("#given GLM 5 text models #then returns true", () => {
+    expect(isGlmThinkingModel("opencode/glm-5")).toBe(true);
+    expect(isGlmThinkingModel("z-ai/glm-5.1")).toBe(true);
+    expect(isGlmThinkingModel("opencode/glm-5-turbo")).toBe(true);
+    expect(isGlmThinkingModel("opencode-go/glm5-turbo")).toBe(true);
+    expect(isGlmThinkingModel("zai-coding-plan/glm-5")).toBe(true);
+  });
+
+  test("#given GLM vision models #then returns false", () => {
+    expect(isGlmThinkingModel("opencode/glm-4.6v")).toBe(false);
+    expect(isGlmThinkingModel("opencode/glm-5v")).toBe(false);
+    expect(isGlmThinkingModel("opencode/glm-5v-turbo")).toBe(false);
+  });
+
+  test("#given non GLM models #then returns false", () => {
+    expect(isGlmThinkingModel("openai/gpt-5.5")).toBe(false);
+    expect(isGlmThinkingModel("anthropic/claude-opus-4-7")).toBe(false);
+    expect(isGlmThinkingModel("google/gemini-3.1-pro")).toBe(false);
   });
 });
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -135,6 +135,18 @@ export function isGlmModel(model: string): boolean {
   return modelName.includes("glm");
 }
 
+const GLM_VISION_MODEL_RE = /glm[\d.-]+v/;
+
+export function isGlmVisionModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return modelName.includes("glm") && GLM_VISION_MODEL_RE.test(modelName);
+}
+
+export function isGlmThinkingModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return isGlmModel(model) && !isGlmVisionModel(model) && /^glm[-]?5/.test(modelName);
+}
+
 export function isGeminiModel(model: string): boolean {
   if (GEMINI_PROVIDERS.some((prefix) => model.startsWith(prefix))) return true;
 

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -1057,7 +1057,13 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
           "variant": "medium",
         },
         {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -1163,6 +1169,9 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
       "fallback_models": [
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -1282,7 +1291,13 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
           "variant": "medium",
         },
         {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -1392,6 +1407,9 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
       "fallback_models": [
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -1812,7 +1830,15 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
       "model": "opencode/gpt-5-nano",
     },
     "sisyphus": {
-      "model": "zai-coding-plan/glm-5",
+      "fallback_models": [
+        {
+          "model": "zai-coding-plan/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+      ],
+      "model": "zai-coding-plan/glm-5.1",
     },
     "sisyphus-junior": {
       "model": "opencode/gpt-5-nano",
@@ -1838,6 +1864,11 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
       "model": "opencode/gpt-5-nano",
     },
     "visual-engineering": {
+      "fallback_models": [
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+      ],
       "model": "zai-coding-plan/glm-5",
     },
     "writing": {
@@ -1876,7 +1907,15 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/gpt-5-nano",
     },
     "sisyphus": {
-      "model": "zai-coding-plan/glm-5",
+      "fallback_models": [
+        {
+          "model": "zai-coding-plan/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+      ],
+      "model": "zai-coding-plan/glm-5.1",
     },
     "sisyphus-junior": {
       "model": "opencode/gpt-5-nano",
@@ -1902,6 +1941,11 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/gpt-5-nano",
     },
     "visual-engineering": {
+      "fallback_models": [
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+      ],
       "model": "zai-coding-plan/glm-5",
     },
     "writing": {
@@ -2038,7 +2082,13 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
           "variant": "medium",
         },
         {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -2168,6 +2218,9 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
       "fallback_models": [
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "anthropic/claude-opus-4-7",
@@ -2503,7 +2556,13 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + ZAI combinat
     "sisyphus": {
       "fallback_models": [
         {
+          "model": "zai-coding-plan/glm-5.1",
+        },
+        {
           "model": "zai-coding-plan/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
         },
       ],
       "model": "anthropic/claude-opus-4-7",
@@ -2537,6 +2596,9 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + ZAI combinat
     },
     "visual-engineering": {
       "fallback_models": [
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
         {
           "model": "anthropic/claude-opus-4-7",
           "variant": "max",
@@ -2869,10 +2931,22 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
           "variant": "medium",
         },
         {
+          "model": "zai-coding-plan/glm-5.1",
+        },
+        {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "zai-coding-plan/glm-5",
         },
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -3044,6 +3118,12 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "github-copilot/claude-opus-4.7",
@@ -3344,10 +3424,22 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
           "variant": "medium",
         },
         {
+          "model": "zai-coding-plan/glm-5.1",
+        },
+        {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "zai-coding-plan/glm-5",
         },
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -3594,6 +3686,12 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "anthropic/claude-opus-4-7",
@@ -3904,10 +4002,22 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
           "variant": "medium",
         },
         {
+          "model": "zai-coding-plan/glm-5.1",
+        },
+        {
+          "model": "opencode/glm-5.1",
+        },
+        {
           "model": "zai-coding-plan/glm-5",
         },
         {
           "model": "opencode/glm-5",
+        },
+        {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
         },
         {
           "model": "opencode/big-pickle",
@@ -4163,6 +4273,12 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
           "model": "opencode/glm-5",
         },
         {
+          "model": "zai-coding-plan/glm-5-turbo",
+        },
+        {
+          "model": "opencode/glm-5-turbo",
+        },
+        {
           "model": "anthropic/claude-opus-4-7",
           "variant": "max",
         },
@@ -4345,6 +4461,9 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/openai/gpt-5.5",
           "variant": "medium",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
         },
         {
           "model": "vercel/zai/glm-5",
@@ -4656,6 +4775,9 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/openai/gpt-5.5",
           "variant": "medium",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
         },
         {
           "model": "vercel/zai/glm-5",


### PR DESCRIPTION
## Summary

First split from #4243. This keeps the GLM work limited to provider/model support and thinking config.

It does not add prompt overlays or look_at routing changes.

## Changes

- classify GLM text and GLM VLM model variants
- avoid Anthropic-style budget tokens for GLM 5 text models
- add GLM 5.1 and GLM 5 Turbo fallback entries where GLM already participates
- update model fallback snapshots and focused regression tests

## Testing

- `bun test src/agents/types.test.ts src/agents/glm-thinking-config.test.ts packages/model-core/src/model-requirements.test.ts`
- `bun test src/cli/model-fallback.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun test`

## Related

Refs #4243
Supersedes part of #3843


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add provider‑safe thinking config for GLM 5 text models and expand GLM fallbacks. GLM text models now use thinking without budget tokens, and GLM 5.1/GLM 5 Turbo are added to relevant fallback chains.

- **New Features**
  - Added `isGlmVisionModel` and `isGlmThinkingModel` to separate GLM text vs vision.
  - Updated Sisyphus, Sisyphus‑Junior, Oracle, Metis, and Momus to use `thinking: { type: "enabled" }` for GLM 5 text models; Claude keeps budget tokens.
  - Inserted GLM 5.1 and GLM 5 Turbo into `AGENT_MODEL_REQUIREMENTS` and `CATEGORY_MODEL_REQUIREMENTS` where GLM already participates; updated CLI snapshots accordingly.

<sup>Written for commit 76dd746f584ff89258efbab52d85e97f0b663176. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4244?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

