### PR TITLE
fix(runtime-fallback): match ZAI 'Limit Exhausted' quota errors (fixes #4207)

### DIFF
--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -30,6 +30,7 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /exceeded.*quota/i,
   /usage\s*quota/i,
   /exhausted\s+your\s+capacity/i,
+  /limit\s+exhausted/i,
   /all\s+credentials\s+for\s+model/i,
   /cool(?:ing)?\s+down/i,
   /model.{0,20}?not.{0,10}?supported/i,

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -148,6 +148,7 @@ export function classifyErrorType(error: unknown): string | undefined {
     /payment.?required/i.test(message) ||
     /usage\s+limit/i.test(message) ||
     /credit\s+balance.*too\s+low/i.test(message) ||
+    /limit\s+exhausted/i.test(message) ||
     /使用上限/.test(message) ||
     /达到.*限制/.test(message) ||
     /额度.*不足/.test(message) ||

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -143,4 +143,43 @@ describe("runtime-fallback quota error regressions", () => {
     expect(errorType).toBe("quota_exceeded")
     expect(retryable).toBe(true)
   })
+
+  test("classifies ZAI weekly/monthly Limit Exhausted as quota_exceeded and triggers fallback", () => {
+    //#given
+    // ZAI (Zhipu) emits this exact message for both weekly and monthly quota
+    // exhaustion on the coding-plan subscription. The capitalization, the
+    // 'Limit Exhausted' phrasing, and the 'limit will reset at' suffix do not
+    // match any of the existing quota regex patterns, so the runtime-fallback
+    // never fires and the user is stuck on the dead model.
+    const error = {
+      message:
+        "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-20 15:43:27",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies ZAI weekly-only Limit Exhausted variant as quota_exceeded", () => {
+    //#given
+    // Weekly-only variant uses the same phrasing minus the slash; the regex
+    // must not require the literal `Weekly/Monthly` prefix.
+    const error = {
+      message:
+        "Weekly Limit Exhausted. Your limit will reset at 2026-05-28 10:30:00",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

The ZAI (Zhipu) provider emits `Weekly/Monthly Limit Exhausted. Your limit will reset at YYYY-MM-DD HH:MM:SS` when the coding-plan subscription quota is hit. None of the existing quota regex patterns matched the `Limit Exhausted` phrasing, so `runtime-fallback` never fired and the user was stuck on the dead model even with `fallback_models` configured.

Add `/limit\s+exhausted/i` to both pattern lists that gate fallback dispatch.

## Root Cause

The ZAI message uses the bare phrase `Limit Exhausted`, not `Limit Reached`, `Quota Exceeded`, or any other already-covered variant:

```
Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-20 15:43:27
```

Two parallel pattern lists in `src/hooks/runtime-fallback/` decide whether a fallback fires:

1. `RETRYABLE_ERROR_PATTERNS` in [`constants.ts`](src/hooks/runtime-fallback/constants.ts) — used by the text-pattern scan in `extractStatusCode`/retryable detection.
2. The `quota_exceeded` branch of `classifyErrorType` in [`error-classifier.ts`](src/hooks/runtime-fallback/error-classifier.ts) — used by `isRetryableError` for typed classification.

Both lists already have `/usage\s+limit/`, `/exhausted\s+your\s+capacity/`, `/quota.?exceeded/`, `/credit\s+balance.*too\s+low/`, etc. — but none of them match `Limit Exhausted`. Direct verification on `dev`:

```js
const msg = "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-20 15:43:27"
/quota.?exceeded/i.test(msg)            // false
/usage\s+limit/i.test(msg)              // false
/exhausted\s+your\s+capacity/i.test(msg)// false
/credit\s+balance.*too\s+low/i.test(msg)// false
```

Result: `classifyErrorType()` returns `undefined`, `isRetryableError()` returns `false`, no fallback ever fires.

## Fix

Add the same regex to both lists:

```ts
/limit\s+exhausted/i
```

The pattern is intentionally narrow: it requires the literal token \"Limit\" followed by whitespace then \"Exhausted\". It matches the ZAI weekly, monthly, and combined `Weekly/Monthly` variants but does not collide with phrases like `context limit` or `rate limit` which already have their own dedicated patterns and live elsewhere in the lists.

## Changes

| File | Change |
|------|--------|
| `src/hooks/runtime-fallback/constants.ts` | Add `/limit\s+exhausted/i` to `RETRYABLE_ERROR_PATTERNS` |
| `src/hooks/runtime-fallback/error-classifier.ts` | Add `/limit\s+exhausted/i.test(message)` to the `quota_exceeded` branch of `classifyErrorType` |
| `src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` | Add 2 regression tests covering `Weekly/Monthly Limit Exhausted` and `Weekly Limit Exhausted` variants |

Net diff: **+41/-0 across 3 files** (well under the ≤50 LOC ideal).

## Reproduction (before fix)

```
$ bun test src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts

(fail) runtime-fallback quota error regressions > classifies ZAI weekly/monthly Limit Exhausted as quota_exceeded and triggers fallback
error: expect(received).toBe(expected)

Expected: \"quota_exceeded\"
Received: undefined

(fail) runtime-fallback quota error regressions > classifies ZAI weekly-only Limit Exhausted variant as quota_exceeded

 9 pass
 2 fail
 18 expect() calls
Ran 11 tests across 1 file.
```

## Verification (after fix)

```
$ bun test src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts

 11 pass
 0 fail
 20 expect() calls
Ran 11 tests across 1 file. [319.00ms]
```

## Test

- Regression tests: 2 new cases added to `src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` covering the exact ZAI message and a weekly-only variant.
- Related suite: \`bun test src/hooks/runtime-fallback/\` goes from 135/196 pass on clean `upstream/dev` to 137/198 pass with this PR. **The 61 pre-existing failures (verified by stashing this change and re-running the same command) are unrelated to this fix** — they live in `index.test.ts`, `event-handler.test.ts`, `subagent-quota-abort.test.ts`, etc. and reproduce on a clean checkout.
- Typecheck: \`bun run typecheck\` — exit 0, clean.

Fixes #4207

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `runtime-fallback` trigger on ZAI quota errors by matching “Limit Exhausted” messages, so requests fail over instead of sticking on an exhausted model. Fixes #4207.

- **Bug Fixes**
  - Add `/limit\s+exhausted/i` to `RETRYABLE_ERROR_PATTERNS` and the `quota_exceeded` branch in `classifyErrorType`.
  - Add two regression tests for `Weekly/Monthly Limit Exhausted` and `Weekly Limit Exhausted` variants.

<sup>Written for commit 3513c45a025b2b84c0783392ea9c782c4ca75000. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4245?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

