### PR TITLE
fix(glm): deny look_at for text-only GLM models

### DIFF
--- a/src/agents/atlas/agent.ts
+++ b/src/agents/atlas/agent.ts
@@ -24,7 +24,7 @@ import { getGptAtlasPrompt } from "./gpt"
 import { getGeminiAtlasPrompt } from "./gemini"
 import { getKimiAtlasPrompt } from "./kimi"
 import { getOpus47AtlasPrompt } from "./opus-4-7"
-import { getGlmVisionToolDeny } from "../frontier-tool-schema-guard"
+import { getTextOnlyGlmVisionToolDeny } from "../frontier-tool-schema-guard"
 import {
   getCategoryDescription,
   buildAgentSelectionSection,
@@ -111,7 +111,7 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
 }
 
 export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
-  const visionDeny = ctx.model ? getGlmVisionToolDeny(ctx.model) : {}
+  const textOnlyVisionDeny = ctx.model ? getTextOnlyGlmVisionToolDeny(ctx.model) : {}
   const baseConfig = {
     description:
       "Orchestrates work via task() to complete ALL tasks in a todo list until fully done. (Atlas - OhMyOpenCode)",
@@ -122,8 +122,8 @@ export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
     color: "#10B981",
   }
 
-  if (Object.keys(visionDeny).length > 0) {
-    return { ...baseConfig, permission: visionDeny } as AgentConfig
+  if (Object.keys(textOnlyVisionDeny).length > 0) {
+    return { ...baseConfig, permission: textOnlyVisionDeny } as AgentConfig
   }
 
   return baseConfig as AgentConfig

--- a/src/agents/atlas/agent.ts
+++ b/src/agents/atlas/agent.ts
@@ -24,6 +24,7 @@ import { getGptAtlasPrompt } from "./gpt"
 import { getGeminiAtlasPrompt } from "./gemini"
 import { getKimiAtlasPrompt } from "./kimi"
 import { getOpus47AtlasPrompt } from "./opus-4-7"
+import { getGlmVisionToolDeny } from "../frontier-tool-schema-guard"
 import {
   getCategoryDescription,
   buildAgentSelectionSection,
@@ -110,6 +111,7 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
 }
 
 export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
+  const visionDeny = ctx.model ? getGlmVisionToolDeny(ctx.model) : {}
   const baseConfig = {
     description:
       "Orchestrates work via task() to complete ALL tasks in a todo list until fully done. (Atlas - OhMyOpenCode)",
@@ -118,6 +120,10 @@ export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
     temperature: 0.1,
     prompt: buildDynamicOrchestratorPrompt(ctx),
     color: "#10B981",
+  }
+
+  if (Object.keys(visionDeny).length > 0) {
+    return { ...baseConfig, permission: visionDeny } as AgentConfig
   }
 
   return baseConfig as AgentConfig

--- a/src/agents/frontier-tool-schema-guard.ts
+++ b/src/agents/frontier-tool-schema-guard.ts
@@ -1,5 +1,5 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
-import { isGpt5_5Model } from "./types"
+import { isGlmModel, isGlmVisionModel, isGpt5_5Model } from "./types"
 import type { PermissionValue } from "../shared/permission-compat"
 
 const FRONTIER_TOOL_SCHEMA_NAMES = ["grep", "glob"] as const
@@ -15,6 +15,11 @@ export function getFrontierToolSchemaPermission(model: string): Record<string, "
   return isOpus47Model(model) || isGpt5_5Model(model)
     ? { grep: "deny" as const, glob: "deny" as const }
     : {}
+}
+
+export function getGlmVisionToolDeny(model: string): Record<string, "deny"> {
+  if (!isGlmModel(model) || isGlmVisionModel(model)) return {}
+  return { look_at: "deny" as const }
 }
 
 export function applyFrontierToolSchemaPermission(

--- a/src/agents/frontier-tool-schema-guard.ts
+++ b/src/agents/frontier-tool-schema-guard.ts
@@ -17,7 +17,7 @@ export function getFrontierToolSchemaPermission(model: string): Record<string, "
     : {}
 }
 
-export function getGlmVisionToolDeny(model: string): Record<string, "deny"> {
+export function getTextOnlyGlmVisionToolDeny(model: string): Record<string, "deny"> {
   if (!isGlmModel(model) || isGlmVisionModel(model)) return {}
   return { look_at: "deny" as const }
 }

--- a/src/agents/glm-vision-tool-deny.test.ts
+++ b/src/agents/glm-vision-tool-deny.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import type { AgentConfig } from "@opencode-ai/sdk"
+import { createAtlasAgent } from "./atlas/agent"
+import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard"
+import { createMetisAgent } from "./metis"
+import { createMomusAgent } from "./momus"
+import { createOracleAgent } from "./oracle"
+import { createSisyphusAgent } from "./sisyphus"
+import { createSisyphusJuniorAgentWithOverrides } from "./sisyphus-junior"
+import { isGlmVisionModel } from "./types"
+
+const GLM_TEXT_MODEL = "zai-coding-plan/glm-5-turbo"
+const GLM_VISION_MODEL = "zai-coding-plan/glm-5v-turbo"
+const NON_GLM_MODEL = "anthropic/claude-opus-4-7"
+
+function permission(agent: AgentConfig): Record<string, unknown> {
+  return (agent.permission ?? {}) as Record<string, unknown>
+}
+
+const factories = [
+  { name: "Atlas", create: (model: string) => createAtlasAgent({ model }) },
+  { name: "Metis", create: createMetisAgent },
+  { name: "Momus", create: createMomusAgent },
+  { name: "Oracle", create: createOracleAgent },
+  { name: "Sisyphus", create: createSisyphusAgent },
+  {
+    name: "Sisyphus-Junior",
+    create: (model: string) => createSisyphusJuniorAgentWithOverrides({ model }),
+  },
+]
+
+describe("GLM vision tool denial", () => {
+  describe("#given GLM model names", () => {
+    it("#then separates VLM variants from text-only variants", () => {
+      expect(isGlmVisionModel("zai/glm-4.6v")).toBe(true)
+      expect(isGlmVisionModel("zai/glm-5v-turbo")).toBe(true)
+      expect(isGlmVisionModel("zai/glm-5-turbo")).toBe(false)
+      expect(isGlmVisionModel("zai/glm-5.1")).toBe(false)
+    })
+  })
+
+  describe("#given direct look_at guard resolution", () => {
+    it("#then denies only text-only GLM models", () => {
+      expect(getGlmVisionToolDeny(GLM_TEXT_MODEL)).toEqual({ look_at: "deny" })
+      expect(getGlmVisionToolDeny(GLM_VISION_MODEL)).toEqual({})
+      expect(getGlmVisionToolDeny(NON_GLM_MODEL)).toEqual({})
+    })
+  })
+
+  describe("#given agent factories with a text-only GLM model", () => {
+    it("#then every returned config denies direct look_at access", () => {
+      for (const factory of factories) {
+        const agent = factory.create(GLM_TEXT_MODEL)
+
+        expect(permission(agent).look_at, factory.name).toBe("deny")
+      }
+    })
+  })
+
+  describe("#given agent factories with non-text-only GLM models", () => {
+    it("#then returned configs do not deny direct look_at access", () => {
+      for (const factory of factories) {
+        expect(permission(factory.create(GLM_VISION_MODEL)).look_at, factory.name).toBeUndefined()
+        expect(permission(factory.create(NON_GLM_MODEL)).look_at, factory.name).toBeUndefined()
+      }
+    })
+  })
+})

--- a/src/agents/glm-vision-tool-deny.test.ts
+++ b/src/agents/glm-vision-tool-deny.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "bun:test"
 import type { AgentConfig } from "@opencode-ai/sdk"
 import { createAtlasAgent } from "./atlas/agent"
-import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard"
+import { getTextOnlyGlmVisionToolDeny } from "./frontier-tool-schema-guard"
 import { createMetisAgent } from "./metis"
 import { createMomusAgent } from "./momus"
 import { createOracleAgent } from "./oracle"
@@ -43,9 +43,9 @@ describe("GLM vision tool denial", () => {
 
   describe("#given direct look_at guard resolution", () => {
     it("#then denies only text-only GLM models", () => {
-      expect(getGlmVisionToolDeny(GLM_TEXT_MODEL)).toEqual({ look_at: "deny" })
-      expect(getGlmVisionToolDeny(GLM_VISION_MODEL)).toEqual({})
-      expect(getGlmVisionToolDeny(NON_GLM_MODEL)).toEqual({})
+      expect(getTextOnlyGlmVisionToolDeny(GLM_TEXT_MODEL)).toEqual({ look_at: "deny" })
+      expect(getTextOnlyGlmVisionToolDeny(GLM_VISION_MODEL)).toEqual({})
+      expect(getTextOnlyGlmVisionToolDeny(NON_GLM_MODEL)).toEqual({})
     })
   })
 

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
 import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
+import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
@@ -299,6 +300,11 @@ const metisRestrictions = createAgentToolRestrictions([
 ])
 
 export function createMetisAgent(model: string): AgentConfig {
+  const permission = {
+    ...metisRestrictions.permission,
+    ...getGlmVisionToolDeny(model),
+  } as AgentConfig["permission"]
+
   return {
     description:
       "Pre-planning consultant that analyzes requests to identify hidden intentions, ambiguities, and AI failure points. (Metis - OhMyOpenCode)",
@@ -306,6 +312,7 @@ export function createMetisAgent(model: string): AgentConfig {
     model,
     temperature: 0.3,
     ...metisRestrictions,
+    permission,
     prompt: METIS_SYSTEM_PROMPT,
     thinking: { type: "enabled", budgetTokens: 32000 },
   } as AgentConfig

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
 import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
-import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard"
+import { getTextOnlyGlmVisionToolDeny } from "./frontier-tool-schema-guard"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
@@ -302,7 +302,7 @@ const metisRestrictions = createAgentToolRestrictions([
 export function createMetisAgent(model: string): AgentConfig {
   const permission = {
     ...metisRestrictions.permission,
-    ...getGlmVisionToolDeny(model),
+    ...getTextOnlyGlmVisionToolDeny(model),
   } as AgentConfig["permission"]
 
   return {

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { isGpt5_2Model, isGptModel } from "./types";
-import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
+import { getTextOnlyGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -392,7 +392,7 @@ export function createMomusAgent(model: string): AgentConfig {
     ...restrictions,
     permission: {
       ...restrictions.permission,
-      ...getGlmVisionToolDeny(model),
+      ...getTextOnlyGlmVisionToolDeny(model),
     },
     prompt: MOMUS_DEFAULT_PROMPT,
   } as AgentConfig;

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { isGpt5_2Model, isGptModel } from "./types";
+import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -389,6 +390,10 @@ export function createMomusAgent(model: string): AgentConfig {
     model,
     temperature: 0.1,
     ...restrictions,
+    permission: {
+      ...restrictions.permission,
+      ...getGlmVisionToolDeny(model),
+    },
     prompt: MOMUS_DEFAULT_PROMPT,
   } as AgentConfig;
 

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { isGpt5_2Model, isGpt5_5Model, isGptModel } from "./types";
+import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -553,6 +554,10 @@ export function createOracleAgent(model: string): AgentConfig {
     model,
     temperature: 0.1,
     ...restrictions,
+    permission: {
+      ...restrictions.permission,
+      ...getGlmVisionToolDeny(model),
+    },
     prompt: ORACLE_DEFAULT_PROMPT,
   } as AgentConfig;
 

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
 import { isGpt5_2Model, isGpt5_5Model, isGptModel } from "./types";
-import { getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
+import { getTextOnlyGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -556,7 +556,7 @@ export function createOracleAgent(model: string): AgentConfig {
     ...restrictions,
     permission: {
       ...restrictions.permission,
-      ...getGlmVisionToolDeny(model),
+      ...getTextOnlyGlmVisionToolDeny(model),
     },
     prompt: ORACLE_DEFAULT_PROMPT,
   } as AgentConfig;

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -19,6 +19,7 @@ import {
   type PermissionValue,
 } from "../../shared/permission-compat"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
+import { getGlmVisionToolDeny } from "../frontier-tool-schema-guard"
 
 import { buildDefaultSisyphusJuniorPrompt } from "./default"
 import { buildKimiK26SisyphusJuniorPrompt } from "./kimi-k2-6"
@@ -123,6 +124,7 @@ export function createSisyphusJuniorAgentWithOverrides(
   const permission: Record<string, PermissionValue> = {
     ...toolsConfig.permission,
     ...getGptApplyPatchPermission(model),
+    ...getGlmVisionToolDeny(model),
   }
 
   const base: AgentConfig = {

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -19,7 +19,7 @@ import {
   type PermissionValue,
 } from "../../shared/permission-compat"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
-import { getGlmVisionToolDeny } from "../frontier-tool-schema-guard"
+import { getTextOnlyGlmVisionToolDeny } from "../frontier-tool-schema-guard"
 
 import { buildDefaultSisyphusJuniorPrompt } from "./default"
 import { buildKimiK26SisyphusJuniorPrompt } from "./kimi-k2-6"
@@ -124,7 +124,7 @@ export function createSisyphusJuniorAgentWithOverrides(
   const permission: Record<string, PermissionValue> = {
     ...toolsConfig.permission,
     ...getGptApplyPatchPermission(model),
-    ...getGlmVisionToolDeny(model),
+    ...getTextOnlyGlmVisionToolDeny(model),
   }
 
   const base: AgentConfig = {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -22,7 +22,7 @@ import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import { buildTaskManagementSection } from "./sisyphus/default";
 import { getGptApplyPatchPermission } from "./gpt-apply-patch-guard";
-import { getFrontierToolSchemaPermission } from "./frontier-tool-schema-guard";
+import { getFrontierToolSchemaPermission, getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 
 const MODE: AgentMode = "primary";
 export const SISYPHUS_PROMPT_METADATA: AgentPromptMetadata = {
@@ -515,6 +515,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
+        ...getGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -542,6 +543,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
+        ...getGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -569,6 +571,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
+        ...getGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -596,6 +599,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
+        ...getGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       thinking: { type: "enabled", budgetTokens: 32000 },
@@ -637,6 +641,7 @@ export function createSisyphusAgent(
     question: "allow",
     call_omo_agent: "deny",
     ...getFrontierToolSchemaPermission(model),
+    ...getGlmVisionToolDeny(model),
     ...getGptApplyPatchPermission(model),
   } as AgentConfig["permission"];
   const base = {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -22,7 +22,7 @@ import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import { buildTaskManagementSection } from "./sisyphus/default";
 import { getGptApplyPatchPermission } from "./gpt-apply-patch-guard";
-import { getFrontierToolSchemaPermission, getGlmVisionToolDeny } from "./frontier-tool-schema-guard";
+import { getFrontierToolSchemaPermission, getTextOnlyGlmVisionToolDeny } from "./frontier-tool-schema-guard";
 
 const MODE: AgentMode = "primary";
 export const SISYPHUS_PROMPT_METADATA: AgentPromptMetadata = {
@@ -515,7 +515,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
-        ...getGlmVisionToolDeny(model),
+        ...getTextOnlyGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -543,7 +543,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
-        ...getGlmVisionToolDeny(model),
+        ...getTextOnlyGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -571,7 +571,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
-        ...getGlmVisionToolDeny(model),
+        ...getTextOnlyGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       reasoningEffort: "medium",
@@ -599,7 +599,7 @@ export function createSisyphusAgent(
         question: "allow",
         call_omo_agent: "deny",
         ...getFrontierToolSchemaPermission(model),
-        ...getGlmVisionToolDeny(model),
+        ...getTextOnlyGlmVisionToolDeny(model),
         ...getGptApplyPatchPermission(model),
       } as AgentConfig["permission"],
       thinking: { type: "enabled", budgetTokens: 32000 },
@@ -641,7 +641,7 @@ export function createSisyphusAgent(
     question: "allow",
     call_omo_agent: "deny",
     ...getFrontierToolSchemaPermission(model),
-    ...getGlmVisionToolDeny(model),
+    ...getTextOnlyGlmVisionToolDeny(model),
     ...getGptApplyPatchPermission(model),
   } as AgentConfig["permission"];
   const base = {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -135,6 +135,13 @@ export function isGlmModel(model: string): boolean {
   return modelName.includes("glm");
 }
 
+const GLM_VISION_MODEL_RE = /glm[\d.-]+v/;
+
+export function isGlmVisionModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return modelName.includes("glm") && GLM_VISION_MODEL_RE.test(modelName);
+}
+
 export function isGeminiModel(model: string): boolean {
   if (GEMINI_PROVIDERS.some((prefix) => model.startsWith(prefix))) return true;
 


### PR DESCRIPTION
## Summary

Second split from #4243. This PR only blocks direct `look_at` access for text-only GLM models.

It does not add GLM prompt overlays, fallback model changes, or generated capability data.

## Changes

- detect GLM VLM model IDs separately from text-only GLM IDs
- add a reusable `look_at` deny helper for GLM text models
- apply the deny helper to Sisyphus, Atlas, Sisyphus-Junior, Oracle, Metis, and Momus
- keep GLM VLM and non-GLM models unblocked

## Testing

- `bun test src/agents/glm-vision-tool-deny.test.ts src/agents/tool-restrictions.test.ts`
- `bun run typecheck`
- `bun run build`

## Related

Refs #4243
Supersedes part of #3843
Follows #4244

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks direct `look_at` access for text‑only GLM models so they don’t use local vision. GLM VLM and non‑GLM models keep current behavior.

- **Bug Fixes**
  - Added `isGlmVisionModel` and `getTextOnlyGlmVisionToolDeny` to deny `look_at` only for text‑only GLMs.
  - Applied the deny to Atlas, Sisyphus, Sisyphus‑Junior, Oracle, Metis, and Momus.
  - Added tests to validate model separation and per‑agent permissions.

<sup>Written for commit 645ab89caf454fe0089c79f55047f34e2f655025. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4246?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

