### PR TITLE
fix(skill-loader): support short skill names in sync resolvers, getSkillByName, and slash commands

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5096,7 +5096,362 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "fallback_models": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "variant": {
+                      "type": "string"
+                    },
+                    "reasoningEffort": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                      ]
+                    },
+                    "temperature": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 2
+                    },
+                    "top_p": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "maxTokens": {
+                      "type": "number"
+                    },
+                    "thinking": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "enabled",
+                            "disabled"
+                          ]
+                        },
+                        "budgetTokens": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "model"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "variant": {
+                          "type": "string"
+                        },
+                        "reasoningEffort": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh",
+                            "max"
+                          ]
+                        },
+                        "temperature": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 2
+                        },
+                        "top_p": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "maxTokens": {
+                          "type": "number"
+                        },
+                        "thinking": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "enabled",
+                                "disabled"
+                              ]
+                            },
+                            "budgetTokens": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "model"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "variant": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "prompt_append": {
+            "type": "string"
+          },
+          "tools": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "disable": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "subagent",
+              "primary",
+              "all"
+            ]
+          },
+          "color": {
+            "type": "string",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "permission": {
+            "type": "object",
+            "properties": {
+              "edit": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "bash": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "webfetch": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "task": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "doom_loop": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "external_directory": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "maxTokens": {
+            "type": "number"
+          },
+          "thinking": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "enabled",
+                  "disabled"
+                ]
+              },
+              "budgetTokens": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "reasoningEffort": {
+            "type": "string",
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "textVerbosity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "providerOptions": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          },
+          "ultrawork": {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "compaction": {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "categories": {
       "type": "object",

--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -703,4 +703,126 @@ Skill body.
       }
     })
   })
+
+  describe("getSkillByName short name matching", () => {
+    it("resolves skill by exact full name", async () => {
+      // given
+      const skillContent = `---
+name: systematic-debugging
+description: A namespaced skill
+---
+Skill body.
+`
+      const skillsDir = join(TEST_DIR, ".opencode", "skills", "superpowers", "systematic-debugging")
+      mkdirSync(skillsDir, { recursive: true })
+      writeFileSync(join(skillsDir, "SKILL.md"), skillContent)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("superpowers/systematic-debugging", { includeClaudeCodePaths: false })
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.name).toBe("superpowers/systematic-debugging")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("resolves skill by unique short name", async () => {
+      // given
+      const skillContent = `---
+name: systematic-debugging
+description: A namespaced skill
+---
+Skill body.
+`
+      const skillsDir = join(TEST_DIR, ".opencode", "skills", "superpowers", "systematic-debugging")
+      mkdirSync(skillsDir, { recursive: true })
+      writeFileSync(join(skillsDir, "SKILL.md"), skillContent)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("systematic-debugging", { includeClaudeCodePaths: false })
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.name).toBe("superpowers/systematic-debugging")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("returns undefined for ambiguous short name", async () => {
+      // given: two skills with same short name
+      const skillContent1 = `---
+name: debugging
+description: First debugging skill
+---
+Skill body 1.
+`
+      const skillContent2 = `---
+name: debugging
+description: Second debugging skill
+---
+Skill body 2.
+`
+      const dir1 = join(TEST_DIR, ".opencode", "skills", "superpowers", "debugging")
+      const dir2 = join(TEST_DIR, ".opencode", "skills", "utils", "debugging")
+      mkdirSync(dir1, { recursive: true })
+      mkdirSync(dir2, { recursive: true })
+      writeFileSync(join(dir1, "SKILL.md"), skillContent1)
+      writeFileSync(join(dir2, "SKILL.md"), skillContent2)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("debugging", { includeClaudeCodePaths: false })
+
+        // then: ambiguous => undefined
+        expect(skill).toBeUndefined()
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("is case-insensitive for short name matching", async () => {
+      // given
+      const skillContent = `---
+name: systematic-debugging
+description: A namespaced skill
+---
+Skill body.
+`
+      const skillsDir = join(TEST_DIR, ".opencode", "skills", "superpowers", "systematic-debugging")
+      mkdirSync(skillsDir, { recursive: true })
+      writeFileSync(join(skillsDir, "SKILL.md"), skillContent)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("Systematic-Debugging", { includeClaudeCodePaths: false })
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.name).toBe("superpowers/systematic-debugging")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+  })
 })

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -13,6 +13,7 @@ import type { LoadedSkill } from "./types"
 import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
 import { deduplicateSkillsByName } from "./skill-deduplication"
 import { loadSkillsFromDir } from "./skill-directory-loader"
+import { matchSkillByName } from "../../tools/skill/skill-matcher"
 
 export async function loadUserSkills(): Promise<Record<string, CommandDefinition>> {
   const userSkillsDir = join(getClaudeConfigDir(), "skills")
@@ -122,7 +123,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {
   const skills = await discoverSkills(options)
-  return skills.find(s => s.name === name)
+  return matchSkillByName(skills, name)
 }
 
 export async function discoverUserClaudeSkills(): Promise<LoadedSkill[]> {

--- a/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/src/features/opencode-skill-loader/skill-content.test.ts
@@ -87,6 +87,17 @@ describe("resolveSkillContent", () => {
 		// then: returns null
 		expect(result).toBeNull()
 	})
+
+	it("is case-insensitive for builtin skill matching", () => {
+		// given: builtin skill 'frontend-ui-ux'
+		// when: resolving with different casing
+		const result = resolveSkillContent("Frontend-Ui-Ux")
+
+		// then: finds it case-insensitively
+		expect(result).not.toBeNull()
+		expect(typeof result).toBe("string")
+		expect(result).toContain("Designer-Turned-Developer")
+	})
 })
 
 describe("resolveMultipleSkills", () => {
@@ -167,6 +178,21 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.has("playwright")).toBe(true)
 		expect(result.resolved.has("frontend-ui-ux")).toBe(true)
 		expect(result.resolved.size).toBe(2)
+	})
+
+	it("is case-insensitive when resolving multiple builtin skills", () => {
+		// given: mixed-case builtin skill names
+		const skillNames = ["Git-Master", "Playwright", "FRONTEND-UI-UX"]
+
+		// when: resolving multiple skills with varying case
+		const result = resolveMultipleSkills(skillNames)
+
+		// then: all resolved case-insensitively
+		expect(result.resolved.size).toBe(3)
+		expect(result.notFound).toEqual([])
+		expect(result.resolved.get("Git-Master")).toContain("Git Master Agent")
+		expect(result.resolved.get("Playwright")).toContain("Playwright Browser Automation")
+		expect(result.resolved.get("FRONTEND-UI-UX")).toContain("Designer-Turned-Developer")
 	})
 })
 

--- a/src/features/opencode-skill-loader/skill-template-resolver.ts
+++ b/src/features/opencode-skill-loader/skill-template-resolver.ts
@@ -11,7 +11,7 @@ export function resolveSkillContent(skillName: string, options?: SkillResolution
 		disabledSkills: options?.disabledSkills,
 		teamModeEnabled: options?.teamModeEnabled,
 	})
-	const skill = skills.find((builtinSkill) => builtinSkill.name === skillName)
+	const skill = matchSkillByName(skills, skillName)
 	if (!skill) return null
 
 	if (skill.name === "git-master") {
@@ -30,13 +30,12 @@ export function resolveMultipleSkills(
 		disabledSkills: options?.disabledSkills,
 		teamModeEnabled: options?.teamModeEnabled,
 	})
-	const skillMap = new Map(skills.map((skill) => [skill.name, skill]))
 
 	const resolved = new Map<string, string>()
 	const notFound: string[] = []
 
 	for (const name of skillNames) {
-		const match = skillMap.get(name)
+		const match = matchSkillByName(skills, name)
 		if (match) {
 			if (match.name === "git-master") {
 				resolved.set(name, injectGitMasterConfig(match.template, options?.gitMasterConfig))

--- a/src/hooks/auto-slash-command/executor.test.ts
+++ b/src/hooks/auto-slash-command/executor.test.ts
@@ -215,4 +215,77 @@ describe("auto-slash command executor plugin dispatch", () => {
     expect(result.success).toBe(true)
     expect(result.replacementText).toContain("**Agent**: atlas")
   })
+
+  it("resolves slash command by unique short name for namespaced skills", async () => {
+    // given: a namespaced skill
+    const skill = {
+      name: "code-review-graph/Debug Issue",
+      path: "/fake/path",
+      definition: {
+        name: "code-review-graph/Debug Issue",
+        description: "Debug an issue",
+        template: "Debug template content",
+      },
+      scope: "skill" as const,
+      lazyContent: undefined,
+    }
+
+    // when: invoking by short name
+    const result = await executeSlashCommand(
+      {
+        command: "Debug Issue",
+        args: "test args",
+        raw: "/Debug Issue test args",
+      },
+      {
+        skills: [skill],
+      },
+    )
+
+    // then: resolved via short name
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain("Debug template content")
+  })
+
+  it("does not resolve ambiguous short name for slash commands", async () => {
+    // given: two skills with same short name
+    const skill1 = {
+      name: "team-a/debug",
+      path: "/fake/path1",
+      definition: {
+        name: "team-a/debug",
+        description: "Debug team A",
+        template: "Team A debug",
+      },
+      scope: "skill" as const,
+      lazyContent: undefined,
+    }
+    const skill2 = {
+      name: "team-b/debug",
+      path: "/fake/path2",
+      definition: {
+        name: "team-b/debug",
+        description: "Debug team B",
+        template: "Team B debug",
+      },
+      scope: "skill" as const,
+      lazyContent: undefined,
+    }
+
+    // when: invoking ambiguous short name
+    const result = await executeSlashCommand(
+      {
+        command: "debug",
+        args: "",
+        raw: "/debug",
+      },
+      {
+        skills: [skill1, skill2],
+      },
+    )
+
+    // then: not found because ambiguous
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Command "/debug" not found')
+  })
 })

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -70,9 +70,23 @@ async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandIn
 
 async function findCommand(commandName: string, options?: ExecutorOptions): Promise<CommandInfo | null> {
   const allCommands = await discoverAllCommands(options)
-  return allCommands.find(
-    (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase()
-  ) ?? null
+  const normalizedName = commandName.toLowerCase()
+
+  // Step 1: exact match (case-insensitive)
+  const exactMatch = allCommands.find(
+    (cmd) => cmd.name.toLowerCase() === normalizedName
+  )
+  if (exactMatch) return exactMatch
+
+  // Step 2: short name match for namespaced commands (unambiguous only)
+  const shortNameMatches = allCommands.filter((cmd) => {
+    const parts = cmd.name.split("/")
+    const shortName = parts[parts.length - 1]
+    return parts.length > 1 && shortName?.toLowerCase() === normalizedName
+  })
+  if (shortNameMatches.length === 1) return shortNameMatches[0]
+
+  return null
 }
 
 async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<string> {

--- a/src/tools/skill/skill-matcher.ts
+++ b/src/tools/skill/skill-matcher.ts
@@ -2,7 +2,7 @@ import { sortByScopePriority } from "./scope-priority"
 import type { CommandInfo } from "../slashcommand/types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 
-export function matchSkillByName(skills: LoadedSkill[], requestedName: string): LoadedSkill | undefined {
+export function matchSkillByName<T extends { name: string }>(skills: T[], requestedName: string): T | undefined {
   const normalizedName = requestedName.toLowerCase()
   const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
   if (exactMatch) {


### PR DESCRIPTION
## Summary

PR #4146 fixed short-name matching for async skill resolvers (esolveSkillContentAsync / esolveMultipleSkillsAsync). This PR applies the same matchSkillByName logic to the remaining paths that still used exact full-name matching, closing the gap reported in #4183.

## Affected paths

| Function | File | Before | After |
|---|---|---|---|
| esolveSkillContent() | skill-template-resolver.ts | skills.find(s => s.name === skillName) | matchSkillByName(skills, skillName) |
| esolveMultipleSkills() | skill-template-resolver.ts | skillMap.get(name) | matchSkillByName(skills, name) |
| getSkillByName() | loader.ts | skills.find(s => s.name === name) | matchSkillByName(skills, name) |
| indCommand() | executor.ts | exact match only | exact + short name (unambiguous) |

## Changes

- **Generic matchSkillByName**: changed parameter type from LoadedSkill[] to Array<{ name: string }> so it can be reused with BuiltinSkill[] in sync resolvers without casting.
- **Sync resolvers**: replaced exact matching with matchSkillByName, bringing case-insensitive and short-name support to the builtin-only sync path.
- **getSkillByName**: now uses matchSkillByName instead of exact equality, fixing the broken public API for short names.
- **Slash commands**: indCommand() now tries exact match first, then falls back to unambiguous short name matching for namespaced skills/commands.
- **Tests**: added regression tests for all four functions covering exact match, unique short name, ambiguous short name rejection, case-insensitivity, and mixed batch.

## Verification

- un run typecheck passes
- un run build succeeds
- un test src/features/opencode-skill-loader/skill-content.test.ts 39 pass
- un test src/features/opencode-skill-loader/loader.test.ts 23 pass
- un test src/hooks/auto-slash-command/executor.test.ts 7 pass

Closes #4183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable short-name and case-insensitive matching in sync skill resolvers, getSkillByName, and slash commands for consistent skill lookup. Closes #4183.

- **Bug Fixes**
  - Use `matchSkillByName` in `resolveSkillContent()`, `resolveMultipleSkills()`, and `getSkillByName()` to support short names and case-insensitive matches.
  - Slash commands: try exact match first, then unambiguous short-name match for namespaced commands.
  - Add regression tests for exact, unique short, ambiguous short, case-insensitivity, and mixed batches.

- **Refactors**
  - Make `matchSkillByName` generic so it works with any `{ name: string }` items (builtin and loaded skills).

<sup>Written for commit 85987ea438f4a6e15bbb5ff4610d83b2ee40e6c4. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4247?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

