### PR TITLE
fix(opencode-skill-loader): align getSkillByName with short-name matching (fixes #4183)

### DIFF
--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -703,4 +703,90 @@ Skill body.
       }
     })
   })
+
+  describe("getSkillByName", () => {
+    it("#given a discoverable skill #when getSkillByName is called with the exact full name #then it returns the skill", async () => {
+      // given - a skill with a plain (non-namespaced) name
+      const skillContent = `---
+name: my-exact-skill
+description: A skill resolvable by exact name
+---
+Body.
+`
+      createTestSkill("my-exact-skill", skillContent)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("my-exact-skill", { includeClaudeCodePaths: false })
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.name).toBe("my-exact-skill")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("#given a namespaced skill #when getSkillByName is called with its unique short name #then it returns the skill", async () => {
+      // given - a namespaced skill that is the unique short-name match
+      const skillContent = `---
+name: superpowers/systematic-debugging
+description: Namespaced skill the agent should be able to load by short name
+---
+Body.
+`
+      createTestSkill("systematic-debugging", skillContent)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("systematic-debugging", { includeClaudeCodePaths: false })
+
+        // then - the short-name lookup must succeed, mirroring matchSkillByName semantics
+        expect(skill).toBeDefined()
+        expect(skill?.name).toBe("superpowers/systematic-debugging")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("#given two namespaced skills sharing a short name #when getSkillByName is called with that short name #then it returns undefined (ambiguous)", async () => {
+      // given - two skills under different namespaces with the same short name
+      const skillA = `---
+name: alpha/duplicated
+description: Skill A
+---
+Body A.
+`
+      const skillB = `---
+name: beta/duplicated
+description: Skill B
+---
+Body B.
+`
+      createTestSkill("alpha-duplicated", skillA)
+      createTestSkill("beta-duplicated", skillB)
+
+      // when
+      const { getSkillByName } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skill = await getSkillByName("duplicated", { includeClaudeCodePaths: false })
+
+        // then - ambiguous short-name match must NOT resolve, matching matchSkillByName behavior
+        expect(skill).toBeUndefined()
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+  })
 })

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -8,6 +8,7 @@ import {
   findProjectClaudeSkillDirs,
   findProjectOpencodeSkillDirs,
 } from "../../shared/project-discovery-dirs"
+import { matchSkillByName } from "../../tools/skill/skill-matcher"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { LoadedSkill } from "./types"
 import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
@@ -122,7 +123,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {
   const skills = await discoverSkills(options)
-  return skills.find(s => s.name === name)
+  return matchSkillByName(skills, name)
 }
 
 export async function discoverUserClaudeSkills(): Promise<LoadedSkill[]> {


### PR DESCRIPTION
## Summary

PR #4146 fixed the async resolvers (`resolveSkillContentAsync`, `resolveMultipleSkillsAsync`) to support unambiguous short-name skill lookups by routing through `matchSkillByName`. But the public `getSkillByName` API in [`src/features/opencode-skill-loader/loader.ts`](src/features/opencode-skill-loader/loader.ts) was left on the old `skills.find(s => s.name === name)` lookup, so an external caller asking for `\"systematic-debugging\"` against a `\"superpowers/systematic-debugging\"` skill silently gets `undefined`.

Wire `getSkillByName` through the same `matchSkillByName` helper so the public API matches the async resolver semantics.

## Root Cause

[`src/features/opencode-skill-loader/loader.ts:123-126`](src/features/opencode-skill-loader/loader.ts):

```ts
export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {
  const skills = await discoverSkills(options)
  return skills.find(s => s.name === name)  //  exact, case-sensitive, no short-name fallback
}
```

Meanwhile [`src/tools/skill/skill-matcher.ts:5-23`](src/tools/skill/skill-matcher.ts) already provides the canonical lookup helper used everywhere else after PR #4146:

```ts
export function matchSkillByName(skills: LoadedSkill[], requestedName: string): LoadedSkill | undefined {
  // case-insensitive exact, then unique short-name fallback, then undefined (ambiguous)
}
```

So calling `getSkillByName(\"systematic-debugging\")` returns `undefined` even when a single `superpowers/systematic-debugging` skill is the obvious unambiguous match.

## Fix

Route `getSkillByName` through `matchSkillByName` so the public API now:
1. Prefers an exact (case-insensitive) full-name hit.
2. Falls back to a unique namespaced short-name hit.
3. Returns `undefined` for ambiguous short-name lookups (≥2 namespaces share the same short tail).

This mirrors the async resolver behavior introduced by #4146 and the `skill` tool's existing lookup semantics, so all three entry points behave identically.

## Changes

| File | Change |
|------|--------|
| `src/features/opencode-skill-loader/loader.ts` | Import `matchSkillByName` and use it inside `getSkillByName` instead of the raw `skills.find` lookup. |
| `src/features/opencode-skill-loader/loader.test.ts` | Add `getSkillByName` describe block with 3 regression tests covering exact match, unique short-name resolution, and ambiguous short-name rejection. |

Net diff: **+88/-1 across 2 files** (production change is 2 lines; the rest is test coverage).

## Reproduction (before fix)

```
$ bun test src/features/opencode-skill-loader/loader.test.ts -t \"getSkillByName\"

(fail) skill loader MCP parsing > getSkillByName > #given a namespaced skill #when getSkillByName is called with its unique short name #then it returns the skill
error: expect(received).toBeDefined()
Received: undefined

 2 pass
 1 fail
 4 expect() calls
Ran 3 tests across 1 file.
```

## Verification (after fix)

```
$ bun test src/features/opencode-skill-loader/loader.test.ts -t \"getSkillByName\"

 3 pass
 19 filtered out
 0 fail
 5 expect() calls
Ran 3 tests across 1 file.
```

## Test

- Regression tests: 3 new cases added to `src/features/opencode-skill-loader/loader.test.ts` under a `getSkillByName` describe block.
- Related suite: `bun test src/features/opencode-skill-loader/` — **129 / 129 pass** (was 126/126 before the new tests).
- Typecheck: `bun run typecheck` — exit 0, clean.

Fixes #4183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the public `getSkillByName` API with short-name matching so lookups like `systematic-debugging` resolve to `superpowers/systematic-debugging`. Fixes #4183.

- **Bug Fixes**
  - Route `getSkillByName` through `matchSkillByName` instead of a strict `skills.find`.
  - Behavior: case-insensitive exact match, then unique short-name fallback; ambiguous short names return `undefined`.
  - Added tests for exact, unique short-name, and ambiguous cases.

<sup>Written for commit bac9a6057a9c2bc24e872382214c2d302cf0b7f4. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4248?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

