### PR TITLE
feat: add OpenCode Zen Go subscription mode

### DIFF
--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -35,6 +35,7 @@ program
   .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
   .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
   .option("--opencode-go <value>", "OpenCode Go subscription: no, yes (default: no)")
+  .option("--opencode-zen-go <value>", "OpenCode Zen Go subscription ($10/mo curated set): no, yes (default: no)")
   .option("--vercel-ai-gateway <value>", "Vercel AI Gateway: no, yes (default: no)")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
@@ -64,6 +65,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Verce
       zaiCodingPlan: options.zaiCodingPlan,
       kimiForCoding: options.kimiForCoding,
       opencodeGo: options.opencodeGo,
+      opencodeZenGo: options.opencodeZenGo,
       vercelAiGateway: options.vercelAiGateway,
       skipAuth: options.skipAuth ?? false,
     }

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -61,6 +61,7 @@ function detectProvidersFromOmoConfig(): {
   }
 }
 
+
 function isOurPlugin(plugin: string): boolean {
   return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
          plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
@@ -83,6 +84,7 @@ export function detectCurrentConfig(): DetectedConfig {
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
     hasOpencodeGo: false,
+    hasOpencodeZenGo: false,
     hasVercelAiGateway: false,
   }
 
@@ -118,6 +120,7 @@ export function detectCurrentConfig(): DetectedConfig {
   result.hasZaiCodingPlan = hasZaiCodingPlan
   result.hasKimiForCoding = hasKimiForCoding
   result.hasOpencodeGo = hasOpencodeGo
+  result.hasOpencodeZenGo = false
   result.hasVercelAiGateway = hasVercelAiGateway
 
   return result

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -40,6 +40,7 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))
   lines.push(formatProvider("Z.ai Coding Plan", config.hasZaiCodingPlan, "Librarian/Multimodal"))
   lines.push(formatProvider("Kimi For Coding", config.hasKimiForCoding, "Sisyphus/Prometheus fallback"))
+  lines.push(formatProvider("OpenCode Zen Go", config.hasOpencodeZenGo, "GLM-5.1/MiniMax M2.7/Kimi K2.6 curated set"))
   lines.push(formatProvider("Vercel AI Gateway", config.hasVercelAiGateway, "universal proxy"))
 
   lines.push("")
@@ -154,6 +155,10 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --kimi-for-coding value: ${args.kimiForCoding} (expected: no, yes)`)
   }
 
+  if (args.opencodeZenGo !== undefined && !["no", "yes"].includes(args.opencodeZenGo)) {
+    errors.push(`Invalid --opencode-zen-go value: ${args.opencodeZenGo} (expected: no, yes)`)
+  }
+
   if (args.vercelAiGateway !== undefined && !["no", "yes"].includes(args.vercelAiGateway)) {
     errors.push(`Invalid --vercel-ai-gateway value: ${args.vercelAiGateway} (expected: no, yes)`)
   }
@@ -172,6 +177,7 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasZaiCodingPlan: args.zaiCodingPlan === "yes",
 hasKimiForCoding: args.kimiForCoding === "yes",
     hasOpencodeGo: args.opencodeGo === "yes",
+    hasOpencodeZenGo: args.opencodeZenGo === "yes",
     hasVercelAiGateway: args.vercelAiGateway === "yes",
   }
 }
@@ -185,6 +191,7 @@ export function detectedToInitialValues(detected: DetectedConfig): {
   zaiCodingPlan: BooleanArg
 kimiForCoding: BooleanArg
   opencodeGo: BooleanArg
+  opencodeZenGo: BooleanArg
   vercelAiGateway: BooleanArg
 } {
   let claude: ClaudeSubscription = "no"
@@ -201,6 +208,7 @@ kimiForCoding: BooleanArg
     zaiCodingPlan: detected.hasZaiCodingPlan ? "yes" : "no",
 kimiForCoding: detected.hasKimiForCoding ? "yes" : "no",
     opencodeGo: detected.hasOpencodeGo ? "yes" : "no",
+    opencodeZenGo: detected.hasOpencodeZenGo ? "yes" : "no",
     vercelAiGateway: detected.hasVercelAiGateway ? "yes" : "no",
   }
 }

--- a/src/cli/model-fallback-types.ts
+++ b/src/cli/model-fallback-types.ts
@@ -11,6 +11,7 @@ export interface ProviderAvailability {
 	zai: boolean
 kimiForCoding: boolean
 	opencodeGo: boolean
+	opencodeZenGo: boolean
 	vercelAiGateway: boolean
 	isMaxPlan: boolean
 }

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -25,6 +25,25 @@ const ZAI_MODEL = "zai-coding-plan/glm-4.7"
 const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 
+const OPENCODE_ZEN_GO_AGENT_MODELS: Record<string, string> = {
+  sisyphus: "opencode-go/glm-5.1",
+  oracle: "opencode-go/glm-5.1",
+  prometheus: "opencode-go/glm-5.1",
+  metis: "opencode-go/glm-5.1",
+  momus: "opencode-go/glm-5.1",
+  hephaestus: "opencode-go/minimax-m2.7",
+  librarian: "opencode-go/minimax-m2.7",
+  explore: "opencode-go/minimax-m2.7",
+  atlas: "opencode-go/kimi-k2.6",
+  "sisyphus-junior": "opencode-go/kimi-k2.6",
+  "multimodal-looker": "opencode-go/kimi-k2.6",
+}
+
+const OPENCODE_ZEN_GO_CATEGORY_MODELS: Record<string, string> = {
+  "visual-engineering": "opencode-go/kimi-k2.6",
+  writing: "opencode-go/kimi-k2.6",
+}
+
 function toFallbackModelObject(entry: FallbackEntry, provider: string): FallbackModelObject {
   return {
     model: `${provider}/${transformModelForProvider(provider, entry.model)}`,
@@ -97,6 +116,17 @@ function attachAllFallbackModels<T extends AgentConfig | CategoryConfig>(
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
   const avail = toProviderAvailability(config)
+
+  if (avail.opencodeZenGo) {
+    const agents: Record<string, AgentConfig> = Object.fromEntries(
+      Object.entries(OPENCODE_ZEN_GO_AGENT_MODELS).map(([role, model]) => [role, { model }])
+    )
+    const categories: Record<string, CategoryConfig> = Object.fromEntries(
+      Object.entries(OPENCODE_ZEN_GO_CATEGORY_MODELS).map(([name, model]) => [name, { model }])
+    )
+    return { $schema: SCHEMA_URL, agents, categories }
+  }
+
   const hasAnyProvider =
     avail.native.claude ||
     avail.native.openai ||
@@ -106,6 +136,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     avail.zai ||
     avail.kimiForCoding ||
     avail.opencodeGo ||
+    avail.opencodeZenGo ||
     avail.vercelAiGateway
   if (!hasAnyProvider) {
     return {

--- a/src/cli/provider-availability.ts
+++ b/src/cli/provider-availability.ts
@@ -13,6 +13,7 @@ export function toProviderAvailability(config: InstallConfig): ProviderAvailabil
 		zai: config.hasZaiCodingPlan,
 kimiForCoding: config.hasKimiForCoding,
 		opencodeGo: config.hasOpencodeGo,
+		opencodeZenGo: config.hasOpencodeZenGo,
 		vercelAiGateway: config.hasVercelAiGateway,
 		isMaxPlan: config.isMax20,
 	}

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -110,6 +110,16 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
   })
   if (!opencodeGo) return null
 
+  const opencodeZenGo = await selectOrCancel({
+    message: "Do you have an OpenCode Zen Go subscription ($10/month)?",
+    options: [
+      { value: "no", label: "No", hint: "Will use other configured providers" },
+      { value: "yes", label: "Yes", hint: "Curated GLM-5.1/MiniMax M2.7/Kimi K2.6 via opencode-go/" },
+    ],
+    initialValue: initial.opencodeZenGo,
+  })
+  if (!opencodeZenGo) return null
+
   const vercelAiGateway = await selectOrCancel({
     message: "Do you have a Vercel AI Gateway API key?",
     options: [
@@ -130,6 +140,7 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     hasZaiCodingPlan: zaiCodingPlan === "yes",
     hasKimiForCoding: kimiForCoding === "yes",
     hasOpencodeGo: opencodeGo === "yes",
+    hasOpencodeZenGo: opencodeZenGo === "yes",
     hasVercelAiGateway: vercelAiGateway === "yes",
   }
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -11,6 +11,7 @@ export interface InstallArgs {
   zaiCodingPlan?: BooleanArg
 kimiForCoding?: BooleanArg
   opencodeGo?: BooleanArg
+  opencodeZenGo?: BooleanArg
   vercelAiGateway?: BooleanArg
   skipAuth?: boolean
 }
@@ -25,6 +26,7 @@ export interface InstallConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasOpencodeZenGo: boolean
   hasVercelAiGateway: boolean
 }
 
@@ -46,5 +48,6 @@ export interface DetectedConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasOpencodeZenGo: boolean
   hasVercelAiGateway: boolean
 }


### PR DESCRIPTION
## Summary

Adds support for **OpenCode Zen Go** (`opencode-go/` provider) as a first-class subscription tier in the installer and model fallback logic. When a user has an OpenCode Zen Go subscription (\$10/month), all agents are configured using its curated model set, bypassing the normal provider fallback chain entirely.

## Why

The existing fallback chain requires users to hold subscriptions to Claude, OpenAI, Gemini, GitHub Copilot, Z.ai, or Kimi individually — which can be expensive. OpenCode Zen Go bundles access to GLM-5.1, MiniMax M2.7, and Kimi K2.6 under a single affordable subscription, giving users a complete, well-matched set of models without needing any native API keys.

## Model Assignment

| Agent(s) | Model | Reasoning |
|---|---|---|
| `sisyphus`, `oracle`, `prometheus`, `metis`, `momus` | `opencode-go/glm-5.1` | Strong reasoning/coding for orchestration and high-IQ agents |
| `hephaestus`, `librarian`, `explore` | `opencode-go/minimax-m2.7` | Broad capability at moderate cost for implementation and retrieval |
| `atlas`, `sisyphus-junior`, `multimodal-looker` | `opencode-go/kimi-k2.6` | Multimodal and structured-output capabilities |
| `visual-engineering`, `writing` (categories) | `opencode-go/kimi-k2.6` | Strong multilingual and structured output |

## Changes

- **`src/cli/model-fallback.ts`** — `OPENCODE_ZEN_GO_AGENT_MODELS` / `OPENCODE_ZEN_GO_CATEGORY_MODELS` constants; early-return branch in `generateModelConfig` when `avail.opencodeZenGo` is true
- **`src/cli/model-fallback-types.ts`** — `opencodeZenGo: boolean` added to `ProviderAvailability`
- **`src/cli/provider-availability.ts`** — `opencodeZenGo` wired through
- **`src/cli/types.ts`** — `opencodeZenGo` added to `InstallArgs`, `InstallConfig`, `DetectedConfig`
- **`src/cli/cli-program.ts`** — `--opencode-zen-go` flag
- **`src/cli/install-validators.ts`** — validation, config summary, `argsToConfig`, `detectedToInitialValues`
- **`src/cli/tui-install-prompts.ts`** — TUI prompt step
- **`src/cli/config-manager/detect-current-config.ts`** — `hasOpencodeZenGo: false` default (can't auto-detect from config; user must select explicitly)

## Notes

- Rebased clean onto current `dev` (which already added `opencodeGo` / `vercelAiGateway` providers — `opencodeZenGo` is a separate subscription-tier concept that sits alongside those)
- Model versions use the latest available on `opencode-go/`: `glm-5.1`, `minimax-m2.7`, `kimi-k2.6`
- All 11 defined agents covered — no agent left without a model when Zen Go mode is active

---

I agree to the terms of the Contributor License Agreement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenCode Zen Go (`opencode-go/`) subscription mode. When enabled, all agents use a curated model set and the normal provider fallback is skipped.

- **New Features**
  - Early-return in model config when `opencodeZenGo` is true; agents map to `opencode-go/glm-5.1`, `opencode-go/minimax-m2.7`, and `opencode-go/kimi-k2.6`; categories `visual-engineering` and `writing` use `opencode-go/kimi-k2.6`.
  - Installer support: `--opencode-zen-go` flag, TUI prompt, validation, and config/types/provider availability wiring; detection defaults to false.

- **Migration**
  - Opt in via the TUI or run the installer with `--opencode-zen-go yes`.
  - Auto-detect is not supported; users must choose this explicitly.

<sup>Written for commit 587667ee1383ee7b06115e8f87f035af9c178bd7. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4257?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

