### PR TITLE
omits plugin command user-request tags when arguments are empty

### DIFF
--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { clearCommandLoaderCache } from "../../features/claude-code-command-loader"
+import type { LoadedSkill } from "../../features/opencode-skill-loader"
 import { executeSlashCommand } from "./executor"
 
 const ENV_KEYS = [
@@ -194,6 +195,90 @@ describe("auto-slash command executor plugin dispatch", () => {
     expect(result.replacementText).toContain("Echo ship it and ship it.")
     expect(result.replacementText).not.toContain("$ARGUMENTS")
     expect(result.replacementText).not.toContain("${user_message}")
+  })
+
+  it("omits plugin command user-request tags when arguments are empty", async () => {
+    // given
+
+    // when
+    const result = await executeSlashCommand(
+      {
+        command: "daplug:templated",
+        args: "",
+        raw: "/daplug:templated",
+      },
+      {
+        skills: [],
+        pluginsEnabled: true,
+      },
+    )
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).not.toContain("<user-request>")
+    expect(result.replacementText).not.toContain("</user-request>")
+  })
+
+  it("omits skill user-request tags when arguments are empty", async () => {
+    // given
+    const skill: LoadedSkill = {
+      name: "humanizer",
+      definition: {
+        name: "humanizer",
+        description: "Humanize text",
+        template: "<skill-instruction>Rewrite naturally.</skill-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>",
+      },
+      scope: "user",
+    }
+
+    // when
+    const result = await executeSlashCommand(
+      {
+        command: "humanizer",
+        args: "",
+        raw: "/humanizer",
+      },
+      {
+        skills: [skill],
+        pluginsEnabled: false,
+      },
+    )
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).not.toContain("<user-request>")
+    expect(result.replacementText).not.toContain("</user-request>")
+  })
+
+  it("keeps skill user-request tags when arguments are present", async () => {
+    // given
+    const skill: LoadedSkill = {
+      name: "humanizer",
+      definition: {
+        name: "humanizer",
+        description: "Humanize text",
+        template: "<skill-instruction>Rewrite naturally.</skill-instruction>\n\n<user-request>\n$ARGUMENTS\n</user-request>",
+      },
+      scope: "user",
+    }
+
+    // when
+    const result = await executeSlashCommand(
+      {
+        command: "humanizer",
+        args: "make this sound human",
+        raw: "/humanizer make this sound human",
+      },
+      {
+        skills: [skill],
+        pluginsEnabled: false,
+      },
+    )
+
+    // then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain("<user-request>")
+    expect(result.replacementText).toContain("make this sound human")
   })
 
   it("renders Atlas as the builtin start-work agent during slash-command execution", async () => {

--- a/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/executor.ts
@@ -17,6 +17,25 @@ interface SkillCommandInfo {
 
 type CommandInfo = DiscoveredCommandInfo | SkillCommandInfo
 
+const EMPTY_USER_REQUEST_PLACEHOLDER_PATTERN = /\n*<user-request>\s*(?:\$ARGUMENTS|\$\{user_message\})\s*<\/user-request>\n*/g
+const EMPTY_USER_REQUEST_BLOCK_PATTERN = /\n*<user-request>\s*<\/user-request>\n*/g
+
+function removeEmptyUserRequestPlaceholders(content: string, args: string): string {
+  if (args.trim()) {
+    return content
+  }
+
+  return content.replace(EMPTY_USER_REQUEST_PLACEHOLDER_PATTERN, "\n")
+}
+
+function removeEmptyUserRequestBlocks(content: string, args: string): string {
+  if (args.trim()) {
+    return content
+  }
+
+  return content.replace(EMPTY_USER_REQUEST_BLOCK_PATTERN, "\n")
+}
+
 function skillToCommandInfo(skill: LoadedSkill): SkillCommandInfo {
   return {
     name: skill.name,
@@ -84,7 +103,7 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
     sections.push(`**Description**: ${cmd.metadata.description}\n`)
   }
 
-  if (args) {
+  if (args.trim()) {
     sections.push(`**User Arguments**: ${args}\n`)
   }
 
@@ -109,12 +128,14 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
   const withFileRefs = await resolveFileReferencesInText(content, commandDir)
   const resolvedContent = await resolveCommandsInText(withFileRefs)
   const resolvedArguments = args
-  const substitutedContent = resolvedContent
+  const contentWithoutEmptyUserRequest = removeEmptyUserRequestPlaceholders(resolvedContent, resolvedArguments)
+  const substitutedContent = contentWithoutEmptyUserRequest
     .replace(/\$\{user_message\}/g, resolvedArguments)
     .replace(/\$ARGUMENTS/g, resolvedArguments)
-  sections.push(substitutedContent.trim())
+  const finalContent = removeEmptyUserRequestBlocks(substitutedContent, resolvedArguments)
+  sections.push(finalContent.trim())
 
-  if (args) {
+  if (args.trim()) {
     sections.push("\n\n---\n")
     sections.push("## User Request\n")
     sections.push(args)

--- a/packages/omo-opencode/src/hooks/auto-slash-command/hook.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/hook.ts
@@ -20,6 +20,15 @@ import type {
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 
 const COMMAND_EXECUTE_FALLBACK_DEDUP_TTL_MS = 100
+const EMPTY_USER_REQUEST_BLOCK_PATTERN = /\n*<user-request>\s*<\/user-request>\n*/g
+
+function removeEmptyUserRequestBlocksFromParts(parts: Array<{ type: string; text?: string; [key: string]: unknown }>): void {
+  for (const part of parts) {
+    if (typeof part.text === "string") {
+      part.text = part.text.replace(EMPTY_USER_REQUEST_BLOCK_PATTERN, "\n")
+    }
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -107,6 +116,7 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
         promptText.includes(AUTO_SLASH_COMMAND_TAG_OPEN) ||
         promptText.includes(AUTO_SLASH_COMMAND_TAG_CLOSE)
       ) {
+        removeEmptyUserRequestBlocksFromParts(output.parts)
         return
       }
 
@@ -164,6 +174,7 @@ export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions
       output: CommandExecuteBeforeOutput
     ): Promise<void> => {
       if (partsContainAutoSlashCommandTags(output.parts)) {
+        removeEmptyUserRequestBlocksFromParts(output.parts)
         return
       }
 

--- a/packages/omo-opencode/src/hooks/auto-slash-command/index.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-slash-command/index.test.ts
@@ -457,6 +457,41 @@ describe("createAutoSlashCommandHook", () => {
       expect(output.parts[0].text).toContain("This is the skill template content")
     })
 
+    it("removes empty user-request tags from already-rendered auto slash command prompts", async () => {
+      // given
+      const hook = createAutoSlashCommandHook()
+      const sessionID = `test-session-empty-user-request-${Date.now()}`
+      const input = createMockInput(sessionID)
+      const output = createMockOutput(
+        "<auto-slash-command>\n# /humanizer Command\n\n<user-request>\n\n</user-request>\n</auto-slash-command>"
+      )
+
+      // when
+      await hook["chat.message"](input, output)
+
+      // then
+      expect(output.parts[0].text).toContain("<auto-slash-command>")
+      expect(output.parts[0].text).not.toContain("<user-request>")
+      expect(output.parts[0].text).not.toContain("</user-request>")
+    })
+
+    it("keeps populated user-request tags in already-rendered auto slash command prompts", async () => {
+      // given
+      const hook = createAutoSlashCommandHook()
+      const sessionID = `test-session-populated-user-request-${Date.now()}`
+      const input = createMockInput(sessionID)
+      const output = createMockOutput(
+        "<auto-slash-command>\n# /humanizer Command\n\n<user-request>\nmake this human\n</user-request>\n</auto-slash-command>"
+      )
+
+      // when
+      await hook["chat.message"](input, output)
+
+      // then
+      expect(output.parts[0].text).toContain("<user-request>")
+      expect(output.parts[0].text).toContain("make this human")
+    })
+
     it("does not replace synthetic slash text with a skill template", async () => {
       // given
       const skill = createTestSkill("my-test-skill", "This is the skill template content")
@@ -497,6 +532,32 @@ describe("createAutoSlashCommandHook", () => {
       expect(output.parts[0].text).toContain("/my-test-skill Command")
       expect(output.parts[0].text).toContain("Skill template for command execute")
       expect(output.parts[0].text).toContain("extra args")
+    })
+
+    it("removes empty user-request tags from command.execute.before output that is already tagged", async () => {
+      // given
+      const hook = createAutoSlashCommandHook()
+      const input: CommandExecuteBeforeInput = {
+        command: "humanizer",
+        sessionID: `test-session-empty-user-request-cmd-${Date.now()}`,
+        arguments: "",
+      }
+      const output: CommandExecuteBeforeOutput = {
+        parts: [
+          {
+            type: "text",
+            text: "<auto-slash-command>\n# /humanizer Command\n\n<user-request>\n\n</user-request>\n</auto-slash-command>",
+          },
+        ],
+      }
+
+      // when
+      await hook["command.execute.before"](input, output)
+
+      // then
+      expect(output.parts[0].text).toContain("<auto-slash-command>")
+      expect(output.parts[0].text).not.toContain("<user-request>")
+      expect(output.parts[0].text).not.toContain("</user-request>")
     })
 
     it("should handle skill with lazy content loader", async () => {


### PR DESCRIPTION
## Summary
- Prevent plugin command user-request tags from being included when slash command arguments are empty.
- Adds regression coverage for auto slash command execution and hook behavior.

## Changes
- Updated auto slash command execution to omit user-request tag injection when no command arguments are present.
- Adjusted auto slash command hook behavior to preserve expected command handling for empty arguments.
- Added unit tests covering empty-argument plugin command execution paths.

## Testing
```bash
bun test src/hooks/auto-slash-command/executor.test.ts src/hooks/auto-slash-command/index.test.ts
```

## Result

Before:

<img width="1078" height="969" alt="Screenshot 2026-05-22 at 07 39 30" src="https://github.com/user-attachments/assets/b33ef1ee-8eb2-4c00-aa5d-b856995dce97" />

After:

<img width="1040" height="1006" alt="Screenshot 2026-05-22 at 07 42 51" src="https://github.com/user-attachments/assets/56835882-d451-4dea-aeb2-70303a2fa71b" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit `<user-request>` tags when slash command arguments are empty for both plugins and skills, reducing noise in auto slash command prompts and keeping behavior consistent.

- **Bug Fixes**
  - Executor removes empty `<user-request>` placeholder blocks and `${user_message}`/`$ARGUMENTS` placeholders; shows “User Arguments” only when `args.trim()` has content.
  - Hook strips empty `<user-request>` tags from already-rendered auto slash prompts in both `chat.message` and `command.execute.before`.
  - Keeps tags when arguments are present.
  - Added unit tests for plugin and skill execution paths and hook behavior.

<sup>Written for commit 39147e49a51d1ec6d3dd57612f6a4636fb8eda5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

