### PR TITLE
fix: avoid duplicate keyword mode injection

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -29,6 +29,13 @@ function suppressComboStandalones(detected: DetectedKeyword[]): DetectedKeyword[
   return detected.filter((k) => k.type !== "ultrawork" && k.type !== "hyperplan")
 }
 
+function filterAlreadyInjectedKeywords(
+  detected: DetectedKeyword[],
+  text: string,
+): DetectedKeyword[] {
+  return detected.filter((keyword) => !text.includes(keyword.message))
+}
+
 export function createKeywordDetectorHook(
   ctx: PluginInput,
   _collector?: ContextCollector,
@@ -146,6 +153,12 @@ export function createKeywordDetectorHook(
           })
           return
         }
+      }
+
+      detectedKeywords = filterAlreadyInjectedKeywords(detectedKeywords, cleanText)
+      if (detectedKeywords.length === 0) {
+        log(`[keyword-detector] Skipping already injected keyword messages`, { sessionID: input.sessionID })
+        return
       }
 
       const hasUltrawork = detectedKeywords.some((k) => k.type === "ultrawork")

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -96,6 +96,41 @@ describe("keyword-detector message transform", () => {
     expect(textPart!.text).toContain("[search-mode]")
   })
 
+  test("should not prepend mode messages twice when an injected message is processed again", async () => {
+    const cases = [
+      { prompt: "search for the bug", marker: "[search-mode]" },
+      { prompt: "analyze the failing test", marker: "[analyze-mode]" },
+      { prompt: "team mode for this refactor", marker: "[team-mode]" },
+      { prompt: "hyperplan the migration", marker: "<hyperplan-mode>" },
+      { prompt: "ultrawork fix the flaky suite", marker: "<ultrawork-mode>" },
+    ]
+
+    for (const testCase of cases) {
+      // given - OpenCode can re-submit an already-mutated message after undo/resend
+      const collector = new ContextCollector()
+      const sessionID = `idempotent-${testCase.marker}`
+      getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+      const output = {
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: testCase.prompt }],
+      }
+
+      // when - keyword detection sees the same output twice
+      await hook["chat.message"]({ sessionID }, output)
+      await hook["chat.message"]({ sessionID }, output)
+
+      // then - the mode prompt remains idempotent
+      const textPart = output.parts.find(p => p.type === "text")
+      expect(textPart).toBeDefined()
+      const markerMatches = textPart!.text!.split(testCase.marker).length - 1
+      expect(markerMatches).toBe(1)
+      expect(textPart!.text).toContain(testCase.prompt)
+
+      getMainSessionSpy?.mockRestore()
+    }
+  })
+
   test("should tell analyze-mode agents to evaluate skills before delegating", async () => {
     // given - analyze mode keyword detection runs on a user investigation request
     const collector = new ContextCollector()


### PR DESCRIPTION
## Summary

- Makes keyword mode prompt injection idempotent when OpenCode re-processes an already-mutated message after undo/resend.
- Prevents duplicate mode banners for search, analyze, team, hyperplan, and ultrawork prompts.

## Changes

- Filters detected keyword prompts that are already present in the current user text before injection/toast handling.
- Adds regression coverage that runs the same `chat.message` output through the keyword detector twice and asserts each mode marker appears only once.

## Testing

```bash
bun test src/hooks/keyword-detector/index.test.ts --bail
bun test src/hooks/keyword-detector --bail
bun run typecheck
bun run build
```

## Related Issues

Closes #4251


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make keyword mode injection idempotent so reprocessed messages don’t show duplicate mode banners after undo/resend. Covers search, analyze, team, hyperplan, and ultrawork; closes #4251.

- **Bug Fixes**
  - Filter out detected keywords already present in the user text before injecting, preventing duplicates.
  - Add regression tests that process the same message twice and assert each mode marker appears only once.

<sup>Written for commit 8a828181e55e0c28889e12332989c9d8c6f8acb5. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

