### PR TITLE
fix(migration): stop rewriting explicit gpt-5.3-codex to gpt-5.4 (#3777)

### DIFF
--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -578,10 +578,18 @@ describe("MODEL_VERSION_MAP", () => {
     expect(MODEL_VERSION_MAP["anthropic/claude-opus-4-5"]).toBe("anthropic/claude-opus-4-7")
   })
 
-  test("maps openai/gpt-5.3-codex to openai/gpt-5.4 for deep category migration", () => {
+  test("does not migrate openai/gpt-5.3-codex (still a supported codex variant, #3777)", () => {
     // given/when: Check MODEL_VERSION_MAP
-    // then: gpt-5.3-codex should migrate to gpt-5.4
-    expect(MODEL_VERSION_MAP["openai/gpt-5.3-codex"]).toBe("openai/gpt-5.4")
+    // then: gpt-5.3-codex must remain user-selectable — it is the codex
+    //       powerhouse documented in agent-model-matching.md, not a
+    //       deprecated alias for gpt-5.4
+    expect(MODEL_VERSION_MAP["openai/gpt-5.3-codex"]).toBeUndefined()
+  })
+
+  test("maps openai/gpt-5.4 to openai/gpt-5.5", () => {
+    // given/when: Check MODEL_VERSION_MAP
+    // then: gpt-5.4 should migrate to gpt-5.5
+    expect(MODEL_VERSION_MAP["openai/gpt-5.4"]).toBe("openai/gpt-5.5")
   })
 })
 
@@ -600,6 +608,26 @@ describe("migrateModelVersions", () => {
     const sisyphus = migrated["sisyphus"] as Record<string, unknown>
     expect(sisyphus.model).toBe("openai/gpt-5.4-codex")
     expect(sisyphus.temperature).toBe(0.1)
+  })
+
+  test("#given a config with explicit gpt-5.3-codex (#3777) #when migrating #then preserves the codex variant", () => {
+    // given: User explicitly picked the codex powerhouse for token efficiency
+    const agents = {
+      sisyphus: { model: "openai/gpt-5.3-codex", variant: "medium" },
+      hephaestus: {
+        model: "openai/gpt-5.3-codex",
+        fallback_models: [{ model: "openai/gpt-5.3-codex" }],
+      },
+    }
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+
+    // then: gpt-5.3-codex must remain — auto-rewriting silently broke configs
+    expect(changed).toBe(false)
+    expect(newMigrations).toEqual([])
+    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.3-codex")
+    expect((migrated["hephaestus"] as Record<string, unknown>).model).toBe("openai/gpt-5.3-codex")
   })
 
   test("replaces anthropic model version", () => {

--- a/src/shared/migration/model-versions.ts
+++ b/src/shared/migration/model-versions.ts
@@ -4,12 +4,17 @@
  * bumps to newer model versions.
  *
  * Keys are full "provider/model" strings. Only openai and anthropic entries needed.
+ *
+ * Only include genuinely retired/superseded models here. Do NOT add mappings
+ * for current, user-selectable variants — `gpt-5.3-codex` is the canonical
+ * codex powerhouse referenced in docs/guide/agent-model-matching.md and is
+ * NOT a deprecated alias for `gpt-5.4`. Auto-rewriting an explicit user
+ * choice silently broke configurations (#3777).
  */
 export const MODEL_VERSION_MAP: Record<string, string> = {
   "anthropic/claude-opus-4-5": "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6": "anthropic/claude-opus-4-7",
   "anthropic/claude-sonnet-4-5": "anthropic/claude-sonnet-4-6",
-  "openai/gpt-5.3-codex": "openai/gpt-5.4",
   "openai/gpt-5.4": "openai/gpt-5.5",
 }
 


### PR DESCRIPTION
## Summary

Closes #3777.

`openai/gpt-5.3-codex` is the codex-series model still recommended in [`docs/guide/agent-model-matching.md`](docs/guide/agent-model-matching.md) ("Still the deep-coding powerhouse. Kept as an explicit override option.") and listed in the default fallback chain in [`docs/reference/configuration.md`](docs/reference/configuration.md). It is **not** a deprecated alias for `gpt-5.4` — the two are different products (one is codex-tuned, the other is the newer general model).

`MODEL_VERSION_MAP` in [`src/shared/migration/model-versions.ts`](src/shared/migration/model-versions.ts) carried `"openai/gpt-5.3-codex": "openai/gpt-5.4"`, so `migrateConfigFile()` silently rewrote any user that picked `gpt-5.3-codex` for its token efficiency on every config load. The owner's confirmation comment on #3777 already noted "the bug is in config migration rather than runtime model resolution" — runtime can still accept `gpt-5.3-codex` when passed through directly, the migration was rewriting it before runtime ever saw it.

### Changes

- Drop the bogus `gpt-5.3-codex → gpt-5.4` entry from `MODEL_VERSION_MAP`.
- Add a comment at the top of the map explaining the rule: only retired/superseded model IDs go here, current user-selectable variants do not.
- Flip the existing assertion `MAP["openai/gpt-5.3-codex"] === "openai/gpt-5.4"` into a `.toBeUndefined()` regression guard, plus a positive assertion that `gpt-5.4 → gpt-5.5` still maps.
- Add a `migrateModelVersions` test that explicit `gpt-5.3-codex` selections (including in nested `fallback_models`) survive migration.

### Compatibility

- Users that were never migrated keep their explicit `gpt-5.3-codex`.
- Users that were already auto-migrated and reverted by hand keep their revert — sidecar/legacy `_migrations` entries still match by string and the existing #3263 sidecar tests (`migration.test.ts` 1374–1499) cover this path without change. I re-ran them: all green.

## Test plan

- [x] `bun test src/shared/migration.test.ts` — 86 pass / 0 fail
- [x] `bun test src/shared/migration/config-migration.test.ts src/shared/migration/migrations-sidecar.test.ts src/shared/migration/agent-names.test.ts` — 24 pass / 0 fail
- [x] `bun test src/plugin-config.test.ts` — 40 pass / 0 fail
- [x] Manually verified compiled `migrateModelVersions` behaviour:
  - `MODEL_VERSION_MAP["openai/gpt-5.3-codex"]` is `undefined`
  - explicit `openai/gpt-5.3-codex` configs pass through unchanged
  - `anthropic/claude-opus-4-5` still migrates to `anthropic/claude-opus-4-7`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop rewriting explicit `openai/gpt-5.3-codex` selections to `openai/gpt-5.4` during config migration so users keep the codex variant they chose. Fixes #3777.

- **Bug Fixes**
  - Removed the `openai/gpt-5.3-codex` → `openai/gpt-5.4` entry from `MODEL_VERSION_MAP`.
  - Added a comment clarifying that only retired/superseded models should be mapped.
  - Added tests to ensure `gpt-5.3-codex` is preserved (including in nested `fallback_models`) and that `openai/gpt-5.4` still migrates to `openai/gpt-5.5`.

<sup>Written for commit d788c3d1a976b78eceb7a88de73dac61e92253d8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4263?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

