### PR TITLE
fix(tasks-todowrite-disabler): stop blocking TodoWrite to keep todo panel live (#3764)

### DIFF
--- a/src/hooks/tasks-todowrite-disabler/constants.ts
+++ b/src/hooks/tasks-todowrite-disabler/constants.ts
@@ -1,14 +1,19 @@
 export const HOOK_NAME = "tasks-todowrite-disabler"
-export const BLOCKED_TOOLS = ["TodoWrite", "TodoRead"]
-export const REPLACEMENT_MESSAGE = `TodoRead/TodoWrite are DISABLED because experimental.task_system is enabled.
+// TodoWrite is intentionally NOT blocked — it is the only path that keeps
+// the live todo panel UI in sync during execution. Blocking it froze the
+// panel on stale state under experimental.task_system (#3764). TodoRead is
+// still routed through Task tools because TaskList/TaskGet are the
+// canonical readers when the task system is on.
+export const BLOCKED_TOOLS = ["TodoRead"]
+export const REPLACEMENT_MESSAGE = `TodoRead is DISABLED because experimental.task_system is enabled.
 
-**ACTION REQUIRED**: RE-REGISTER what you were about to write as Todo using Task tools NOW. Then ASSIGN yourself and START WORKING immediately.
+**ACTION REQUIRED**: Use Task tools to inspect work state. TodoWrite is still allowed so the live todo panel keeps updating, but reads belong to the task system.
 
-**Use these tools instead:**
-- TaskCreate: Create new task with auto-generated ID
-- TaskUpdate: Update status, assign owner, add dependencies
+**Use these tools instead of TodoRead:**
 - TaskList: List active tasks with dependency info
 - TaskGet: Get full task details
+- TaskCreate: Create new task with auto-generated ID
+- TaskUpdate: Update status, assign owner, add dependencies
 
 **Workflow:**
 1. TaskCreate({ subject: "your task description" })
@@ -27,4 +32,4 @@ Even if the task seems trivial (1 line fix, simple edit, quick change), you MUST
 
 **WHY?** Task tracking = visibility = accountability. Skipping registration = invisible work = chaos.
 
-DO NOT retry TodoWrite. Convert to TaskCreate NOW.`
+DO NOT retry TodoRead. Use TaskList or TaskGet NOW.`

--- a/src/hooks/tasks-todowrite-disabler/hook.test.ts
+++ b/src/hooks/tasks-todowrite-disabler/hook.test.ts
@@ -21,7 +21,7 @@ describe("createTasksTodowriteDisablerHook", () => {
   })
 
   describe("#given experimental.task_system is enabled", () => {
-    test("#when TodoWrite runs #then it is blocked", async () => {
+    test("#when TodoWrite runs #then it is allowed so the live todo panel stays in sync (#3764)", async () => {
       // given
       const hook = createTasksTodowriteDisablerHook({
         experimental: { task_system: true },
@@ -30,6 +30,22 @@ describe("createTasksTodowriteDisablerHook", () => {
       // when
       const result = hook["tool.execute.before"](
         { tool: "TodoWrite", sessionID: "ses_123", callID: "call_123" },
+        { args: {} },
+      )
+
+      // then: TodoWrite must pass through — blocking it froze the panel
+      await expect(result).resolves.toBeUndefined()
+    })
+
+    test("#when TodoRead runs #then it is blocked because TaskList/TaskGet replace reads", async () => {
+      // given
+      const hook = createTasksTodowriteDisablerHook({
+        experimental: { task_system: true },
+      })
+
+      // when
+      const result = hook["tool.execute.before"](
+        { tool: "TodoRead", sessionID: "ses_123", callID: "call_123" },
         { args: {} },
       )
 

--- a/src/hooks/tasks-todowrite-disabler/index.test.ts
+++ b/src/hooks/tasks-todowrite-disabler/index.test.ts
@@ -4,7 +4,7 @@ const { createTasksTodowriteDisablerHook } = await import("./index")
 
 describe("tasks-todowrite-disabler", () => {
   describe("when experimental.task_system is enabled", () => {
-    test("should block TodoWrite tool", async () => {
+    test("should NOT block TodoWrite so the live todo panel keeps updating (#3764)", async () => {
       // given
       const hook = createTasksTodowriteDisablerHook({ experimental: { task_system: true } })
       const input = {
@@ -19,7 +19,7 @@ describe("tasks-todowrite-disabler", () => {
       // when / then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("TodoRead/TodoWrite are DISABLED")
+      ).resolves.toBeUndefined()
     })
 
     test("should block TodoRead tool", async () => {
@@ -37,7 +37,7 @@ describe("tasks-todowrite-disabler", () => {
       // when / then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("TodoRead/TodoWrite are DISABLED")
+      ).rejects.toThrow("TodoRead is DISABLED")
     })
 
     test("should not block other tools", async () => {
@@ -120,7 +120,7 @@ describe("tasks-todowrite-disabler", () => {
       // given
       const hook = createTasksTodowriteDisablerHook({ experimental: { task_system: true } })
       const input = {
-        tool: "TodoWrite",
+        tool: "TodoRead",
         sessionID: "test-session",
         callID: "call-1",
       }


### PR DESCRIPTION
## Summary

Closes #3764.

When `experimental.task_system` is enabled the `tasks-todowrite-disabler` hook blocks `TodoWrite` along with `TodoRead`, but `TodoWrite` is the only path that drives the live todo panel UI. Blocking it freezes the panel on stale state for the rest of the session — the task tools (`TaskCreate` / `TaskUpdate`) update task records but do **not** propagate back into the OpenCode todo panel.

The original reporter recommended the minimal fix (block read only). The owner-decision comment on the issue calls out "make blocking behavior configurable" as a possible longer-term option, but blocking `TodoWrite` is incorrect in every configuration — the live UI sync is not a thing users would want to opt out of — so the minimal fix is also the right default.

### Changes

- [`src/hooks/tasks-todowrite-disabler/constants.ts`](src/hooks/tasks-todowrite-disabler/constants.ts): drop `TodoWrite` from `BLOCKED_TOOLS`; rewrite `REPLACEMENT_MESSAGE` so it only talks about `TodoRead` and points users at `TaskList` / `TaskGet`. Inline comment explains the live-panel constraint so the next reader does not "fix" it back.
- [`src/hooks/tasks-todowrite-disabler/hook.test.ts`](src/hooks/tasks-todowrite-disabler/hook.test.ts): flip the `TodoWrite is blocked` assertion to `TodoWrite is allowed (#3764)`, add a `TodoRead is blocked` assertion to cover the remaining tool.
- [`src/hooks/tasks-todowrite-disabler/index.test.ts`](src/hooks/tasks-todowrite-disabler/index.test.ts): same flip on the integration test; switch the error-message-content check from `TodoWrite` to `TodoRead` so it actually triggers the hook.

### Surface impact

- Hook config schema unchanged (`tasks-todowrite-disabler` still listed in [`src/config/schema/hooks.ts`](src/config/schema/hooks.ts) and wired in [`src/plugin/hooks/create-tool-guard-hooks.ts`](src/plugin/hooks/create-tool-guard-hooks.ts)). No new config flags.
- Task system behaviour unchanged for `TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet`.

## Test plan

- [x] `bun test src/hooks/tasks-todowrite-disabler/` — 10 pass / 0 fail
- [x] `bun test src/plugin/hooks/` — 4 pass / 0 fail (hook wiring untouched)
- [x] Manual: grep for `"TodoRead/TodoWrite are DISABLED"` to confirm no stale references remain anywhere in `src/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop blocking `TodoWrite` in `tasks-todowrite-disabler` when `experimental.task_system` is on so the live todo panel stays up to date; keep `TodoRead` blocked and steer reads to `TaskList`/`TaskGet`. Fixes #3764.

- **Bug Fixes**
  - Removed `TodoWrite` from `BLOCKED_TOOLS`; `TodoRead` remains blocked to use `TaskList`/`TaskGet`.
  - Updated replacement message to mention only `TodoRead` and explain the live panel sync constraint.
  - Adjusted tests to expect `TodoWrite` allowed and `TodoRead` blocked.
  - No config changes; `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet` behavior unchanged.

<sup>Written for commit 3b4c93b880c9c7b2689876610438428141599165. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4264?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

