### PR TITLE
fix(build): include i18n locale data in npm dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "./schema.json": "./dist/oh-my-opencode.schema.json"
   },
   "scripts": {
-    "build": "bun run build:ast-grep-mcp && bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi --external zod && bun run build:node-require-shim && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi && bun run build:schema",
+    "build": "bun run build:ast-grep-mcp && bun run build:locales && bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi --external zod && bun run build:node-require-shim && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi && bun run build:schema",
+    "build:locales": "bun build src/locales/index.ts --outdir dist/locales --target bun --format esm",
     "build:lsp-tools-mcp": "npm --prefix packages/lsp-tools-mcp ci && npm --prefix packages/lsp-tools-mcp run build",
     "build:node-require-shim": "bun run script/patch-node-require-shim.ts",
     "build:all": "bun run build && bun run build:binaries",


### PR DESCRIPTION
## Description

Fixes #4259

The i18n locale data under src/locales was not being transpiled into dist/locales during the build process. As a result, only TypeScript declaration files (.d.ts) were present in the npm distribution, and the actual JavaScript locale modules were missing. This caused runtime errors when the plugin tried to load translations.

## Changes

- Added a uild:locales script to package.json that bundles src/locales/index.ts into dist/locales/index.js using un build.
- Integrated un run build:locales into the main uild script so locale data is included in every build.

## Verification

1. Ran un run build:locales locally.
2. Confirmed dist/locales/index.js is generated alongside existing .d.ts files.
3. Ran the full un run build pipeline successfully.

## Checklist

- [x] PR targets dev branch
- [x] un run build passes
- [x] un run typecheck passes (existing pre-existing errors unrelated to this change)
- [x] un test passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include i18n locale JavaScript modules in the npm dist to stop runtime translation errors. Fixes #4259.

- **Bug Fixes**
  - Added `build:locales` to bundle `src/locales/index.ts` into `dist/locales/index.js` via `bun build`.
  - Integrated `build:locales` into the main `build` so locale data ships in every build.

<sup>Written for commit 4dc59c86164ff1b7192a7ff3a38e82e264c11673. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4265?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

