### PR TITLE
fix(keyword-detector): guard against duplicate keyword injection on undo+resend

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -225,6 +225,13 @@ export function createKeywordDetectorHook(
       const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
+      // Guard against duplicate injection when the same message is re-processed (e.g., undo + resend)
+      const alreadyInjected = detectedKeywords.every((k) => originalText.includes(k.message))
+      if (alreadyInjected) {
+        log(`[keyword-detector] Keywords already injected, skipping`, { sessionID: input.sessionID })
+        return
+      }
+
       output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {


### PR DESCRIPTION
## Description

Fixes #4251

When a user types "search", sends the message, then uses `/undo` and resends, the `[search-mode]` system banner is injected twice into the assistant context. This happens because `chat.message` fires again on resend, and the keyword detector prepends the keyword messages without checking if they were already present in the text.

## Root Cause

The regex `/\b(search|...)\b/i` matches "search" even inside the already-injected `[search-mode]` marker (because `\b` matches between `[` and `s`). Since there is no re-entry guard, the injection logic runs again on undo+resend, producing duplicate blocks.

## Changes

- Added a re-entry guard in `src/hooks/keyword-detector/hook.ts` that checks if all detected keyword messages are already present in the original text before injecting.
- If already injected, the hook logs a skip message and returns early.

## Verification

1. Ran `bun test src/hooks/keyword-detector` ? all 92 tests pass.

## Checklist

- [x] PR targets `dev` branch
- [x] `bun test` passes
- [x] `bun run build` passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate keyword banners (e.g., `[search-mode]`) when a user undoes and resends a message. Fixes #4251.

- **Bug Fixes**
  - Added a guard in `src/hooks/keyword-detector/hook.ts` to skip injection if all detected keyword messages are already in the text.
  - Logs a skip message when a re-processed message is detected (undo + resend).

<sup>Written for commit 7102a90f4cebfb1b5121b84720fd01a86ad7d8d3. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4268?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

