### PR TITLE
fix(skill-resolver): support short-name matching in sync resolvers (#4183)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -528,3 +528,4 @@
     "@oh-my-opencode/ast-grep-mcp/@ast-grep/cli/@ast-grep/cli-win32-x64-msvc": ["@ast-grep/cli-win32-x64-msvc@0.41.1", "", { "os": "win32", "cpu": "x64" }, "sha512-AUbR67UKWsfgyy3SWQq258ZB0xSlaAe15Gl5hPu5tbUu4HTt6rKrUCTEEubYgbNdPPZWtxjobjFjMsDTWfnrug=="],
   }
 }
+

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -12,6 +12,7 @@ import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { LoadedSkill } from "./types"
 import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
 import { deduplicateSkillsByName } from "./skill-deduplication"
+import { matchSkillByName } from "../../tools/skill/skill-matcher"
 import { loadSkillsFromDir } from "./skill-directory-loader"
 
 export async function loadUserSkills(): Promise<Record<string, CommandDefinition>> {
@@ -122,7 +123,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {
   const skills = await discoverSkills(options)
-  return skills.find(s => s.name === name)
+  return matchSkillByName(skills, name)
 }
 
 export async function discoverUserClaudeSkills(): Promise<LoadedSkill[]> {

--- a/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/src/features/opencode-skill-loader/skill-content.test.ts
@@ -195,6 +195,39 @@ describe("resolveSkillContent (case-insensitive parity)", () => {
 	})
 })
 
+// cubic-dev-ai review on #4269 asked for explicit short-name fallback and
+// ambiguity coverage on the sync resolvers. The real `createBuiltinSkills`
+// fixture has no namespaced (`ns/name`) entries, so the short-name fallback
+// path can't be exercised against the real builtins. Sync resolvers delegate
+// to `matchSkillByName` (the shared matcher) — its contract is locked in
+// `src/tools/skill/skill-matcher.test.ts` with 15 cases (exact match,
+// short-name fallback, ambiguity protection, exact-match precedence,
+// multi-slash names). The asserts below pin the parts of that contract the
+// sync resolvers exercise against builtins.
+describe("sync resolver — short-name & ambiguity contract (issue #4269)", () => {
+	it("non-existent name returns null (cannot short-name-match without a namespace)", () => {
+		// builtins are all non-namespaced, so a name with no exact builtin match
+		// has no fallback to try — verifies the matcher path returns null cleanly
+		expect(resolveSkillContent("systematic-debugging")).toBeNull()
+	})
+
+	it("resolveMultipleSkills reports unresolvable short names in notFound (matches matchSkillByName contract)", () => {
+		// `debugging` is not a builtin and there is no namespaced builtin whose
+		// basename is `debugging`, so the matcher's short-name fallback can't fire
+		const result = resolveMultipleSkills(["debugging"])
+		expect(result.notFound).toEqual(["debugging"])
+		expect(result.resolved.size).toBe(0)
+	})
+
+	it("ambiguity protection — when no exact match exists, sync resolver returns null (does not guess)", () => {
+		// The matcher's ambiguity-protection contract: if there's no exact match
+		// and no unique short-name, return undefined. Builtins are non-namespaced
+		// so the practical demonstration here is "ambiguous-looking input → null,
+		// not silent pick of an unrelated builtin".
+		expect(resolveSkillContent("nonexistent-skill")).toBeNull()
+	})
+})
+
 describe("resolveSkillContentAsync", () => {
 	it("should return template for builtin skill async", async () => {
 		// given: builtin skill 'frontend-ui-ux'

--- a/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/src/features/opencode-skill-loader/skill-content.test.ts
@@ -11,6 +11,7 @@ import {
 	resolveSkillContentAsync,
 	resolveMultipleSkillsAsync,
 } from "./skill-content"
+import { getSkillByName } from "./loader"
 
 function createNestedSkill(baseDir: string, namespace: string, name: string, content: string): void {
 	const dir = join(baseDir, "skills", namespace, name)
@@ -167,6 +168,30 @@ describe("resolveMultipleSkills", () => {
 		expect(result.resolved.has("playwright")).toBe(true)
 		expect(result.resolved.has("frontend-ui-ux")).toBe(true)
 		expect(result.resolved.size).toBe(2)
+	})
+
+	// regression: issue #4183 — sync resolver should align with async (case-insensitive)
+	it("should resolve builtin skill case-insensitively (parity with async)", () => {
+		// given: builtin skill 'frontend-ui-ux' exists; requested name uses different casing
+		// when: resolving with mixed-case name
+		const result = resolveMultipleSkills(["Frontend-UI-UX"])
+
+		// then: matches case-insensitively, not in notFound
+		expect(result.notFound).toEqual([])
+		expect(result.resolved.size).toBe(1)
+		expect(result.resolved.get("Frontend-UI-UX")).toContain("Designer-Turned-Developer")
+	})
+})
+
+describe("resolveSkillContent (case-insensitive parity)", () => {
+	// regression: issue #4183
+	it("should resolve a builtin skill case-insensitively", () => {
+		// given: builtin 'playwright' exists; request uses upper case
+		const result = resolveSkillContent("PLAYWRIGHT")
+
+		// then: matched
+		expect(result).not.toBeNull()
+		expect(result).toContain("Playwright Browser Automation")
 	})
 })
 
@@ -573,5 +598,59 @@ describe("resolveMultipleSkillsAsync with browserProvider filtering", () => {
 		expect(result.resolved.has("agent-browser")).toBe(true)
 		expect(result.resolved.has("git-master")).toBe(true)
 		expect(result.notFound).not.toContain("agent-browser")
+	})
+})
+
+// regression: issue #4183 — getSkillByName should support short-name & case-insensitive
+describe("getSkillByName short-name matching (issue #4183)", () => {
+	it("resolves a namespaced skill by its short name", async () => {
+		// given: namespaced skill superpowers/systematic-debugging on disk
+		createNestedSkill(testConfigDir, "superpowers", "systematic-debugging", "Resolved via short name")
+
+		// when: caller passes only the short name
+		const result = await getSkillByName("systematic-debugging")
+
+		// then: returns the namespaced skill
+		expect(result).toBeDefined()
+		expect(result?.name).toBe("superpowers/systematic-debugging")
+	})
+
+	it("returns undefined for ambiguous short names", async () => {
+		// given: two skills sharing a short name in different namespaces
+		createNestedSkill(testConfigDir, "ns-a", "shared", "from ns-a")
+		createNestedSkill(testConfigDir, "ns-b", "shared", "from ns-b")
+
+		// when: caller passes the ambiguous short name
+		const result = await getSkillByName("shared")
+
+		// then: refuses to guess (matches async matchSkillByName semantics)
+		expect(result).toBeUndefined()
+	})
+
+	it("prefers exact match over short-name match", async () => {
+		// given: both an exact-name skill and a namespaced skill sharing the basename
+		createNestedSkill(testConfigDir, "superpowers", "debug", "namespaced content")
+		const exactDir = join(testConfigDir, "skills", "debug")
+		mkdirSync(exactDir, { recursive: true })
+		writeFileSync(join(exactDir, "SKILL.md"), "---\nname: debug\ndescription: exact debug\n---\nexact content")
+
+		// when: caller passes the exact name
+		const result = await getSkillByName("debug")
+
+		// then: exact match wins
+		expect(result).toBeDefined()
+		expect(result?.name).toBe("debug")
+	})
+
+	it("matches case-insensitively", async () => {
+		// given: a discoverable namespaced skill
+		createNestedSkill(testConfigDir, "superpowers", "case-test", "case insensitive")
+
+		// when: caller varies casing
+		const result = await getSkillByName("Case-Test")
+
+		// then: still matches
+		expect(result).toBeDefined()
+		expect(result?.name).toBe("superpowers/case-test")
 	})
 })

--- a/src/features/opencode-skill-loader/skill-template-resolver.ts
+++ b/src/features/opencode-skill-loader/skill-template-resolver.ts
@@ -11,7 +11,7 @@ export function resolveSkillContent(skillName: string, options?: SkillResolution
 		disabledSkills: options?.disabledSkills,
 		teamModeEnabled: options?.teamModeEnabled,
 	})
-	const skill = skills.find((builtinSkill) => builtinSkill.name === skillName)
+	const skill = matchSkillByName(skills, skillName)
 	if (!skill) return null
 
 	if (skill.name === "git-master") {
@@ -30,13 +30,12 @@ export function resolveMultipleSkills(
 		disabledSkills: options?.disabledSkills,
 		teamModeEnabled: options?.teamModeEnabled,
 	})
-	const skillMap = new Map(skills.map((skill) => [skill.name, skill]))
 
 	const resolved = new Map<string, string>()
 	const notFound: string[] = []
 
 	for (const name of skillNames) {
-		const match = skillMap.get(name)
+		const match = matchSkillByName(skills, name)
 		if (match) {
 			if (match.name === "git-master") {
 				resolved.set(name, injectGitMasterConfig(match.template, options?.gitMasterConfig))

--- a/src/hooks/auto-slash-command/executor-resolution.test.ts
+++ b/src/hooks/auto-slash-command/executor-resolution.test.ts
@@ -115,4 +115,79 @@ describe("executeSlashCommand resolution semantics", () => {
     expect(result.success).toBe(true)
     expect(result.replacementText).toContain("restricted template")
   })
+
+  // regression: issue #4183 — short-name resolution for namespaced skills
+  it("resolves a namespaced skill via its short name", async () => {
+    //#given
+    setupExecutorSpies()
+    const namespacedSkill: LoadedSkill = {
+      name: "superpowers/systematic-debugging",
+      definition: {
+        name: "superpowers/systematic-debugging",
+        description: "debug skill",
+        template: "debug template body",
+      },
+      scope: "user",
+    }
+    const parsed = {
+      command: "systematic-debugging",
+      args: "",
+      raw: "/systematic-debugging",
+    }
+
+    //#when: caller invokes the short name
+    const result = await executeSlashCommand(parsed, { skills: [namespacedSkill] })
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain("debug template body")
+    expect(result.replacementText).toContain("**Scope**: skill")
+  })
+
+  it("does not resolve an ambiguous short name across namespaces", async () => {
+    //#given
+    setupExecutorSpies()
+    const skillA: LoadedSkill = {
+      name: "ns-a/shared",
+      definition: { name: "ns-a/shared", description: "a", template: "A" },
+      scope: "user",
+    }
+    const skillB: LoadedSkill = {
+      name: "ns-b/shared",
+      definition: { name: "ns-b/shared", description: "b", template: "B" },
+      scope: "user",
+    }
+    const parsed = { command: "shared", args: "", raw: "/shared" }
+
+    //#when: caller invokes the ambiguous short name
+    const result = await executeSlashCommand(parsed, { skills: [skillA, skillB] })
+
+    //#then: refuses to pick — better than guessing wrong
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Command "/shared" not found')
+  })
+
+  it("prefers exact full-name match over short-name match", async () => {
+    //#given
+    setupExecutorSpies()
+    const exactSkill: LoadedSkill = {
+      name: "debug",
+      definition: { name: "debug", description: "exact", template: "EXACT template" },
+      scope: "user",
+    }
+    const namespacedSkill: LoadedSkill = {
+      name: "superpowers/debug",
+      definition: { name: "superpowers/debug", description: "ns", template: "NS template" },
+      scope: "user",
+    }
+    const parsed = { command: "debug", args: "", raw: "/debug" }
+
+    //#when
+    const result = await executeSlashCommand(parsed, { skills: [namespacedSkill, exactSkill] })
+
+    //#then: exact wins
+    expect(result.success).toBe(true)
+    expect(result.replacementText).toContain("EXACT template")
+    expect(result.replacementText).not.toContain("NS template")
+  })
 })

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -3,6 +3,7 @@ import { resolveCommandsInText } from "../../shared/command-executor/resolve-com
 import { resolveFileReferencesInText } from "../../shared/file-reference-resolver"
 import { discoverAllSkills, type LoadedSkill, type LazyContentLoader } from "../../features/opencode-skill-loader"
 import * as commandDiscovery from "../../tools/slashcommand/command-discovery"
+import { matchSkillByName } from "../../tools/skill/skill-matcher"
 import type { CommandInfo as DiscoveredCommandInfo, CommandMetadata } from "../../tools/slashcommand/types"
 import type { ParsedSlashCommand } from "./types"
 
@@ -70,9 +71,7 @@ async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandIn
 
 async function findCommand(commandName: string, options?: ExecutorOptions): Promise<CommandInfo | null> {
   const allCommands = await discoverAllCommands(options)
-  return allCommands.find(
-    (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase()
-  ) ?? null
+  return matchSkillByName(allCommands, commandName) ?? null
 }
 
 async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<string> {

--- a/src/tools/skill/skill-matcher.test.ts
+++ b/src/tools/skill/skill-matcher.test.ts
@@ -1,0 +1,134 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { matchSkillByName } from "./skill-matcher"
+
+// `matchSkillByName` is the shared matcher that every skill-resolving entry
+// point in this codebase delegates to (sync `resolveSkillContent` /
+// `resolveMultipleSkills`, async equivalents, `getSkillByName`, and the
+// auto-slash-command `findCommand`). Its contract drives all of them, so this
+// file pins the contract directly — independent of which caller is exercising
+// it. Issue #4183 + cubic-dev-ai review on #4269.
+
+type NameOnly = { readonly name: string }
+
+const skills = <T extends NameOnly>(arr: readonly T[]): T[] => [...arr]
+
+describe("matchSkillByName — contract for every skill resolver in the codebase", () => {
+  describe("exact match (case-insensitive)", () => {
+    test("matches identical name", () => {
+      const fixture = skills([{ name: "frontend-ui-ux" }, { name: "playwright" }])
+      expect(matchSkillByName(fixture, "playwright")).toEqual({ name: "playwright" })
+    })
+
+    test("matches case-insensitively against the stored name", () => {
+      const fixture = skills([{ name: "frontend-ui-ux" }])
+      expect(matchSkillByName(fixture, "Frontend-UI-UX")?.name).toBe("frontend-ui-ux")
+      expect(matchSkillByName(fixture, "FRONTEND-UI-UX")?.name).toBe("frontend-ui-ux")
+    })
+
+    test("matches case-insensitively when stored name has mixed case", () => {
+      const fixture = skills([{ name: "Frontend-UI-UX" }])
+      expect(matchSkillByName(fixture, "frontend-ui-ux")?.name).toBe("Frontend-UI-UX")
+    })
+  })
+
+  describe("short-name fallback for namespaced skills", () => {
+    test("matches a namespaced skill via its basename", () => {
+      const fixture = skills([{ name: "superpowers/systematic-debugging" }])
+      expect(matchSkillByName(fixture, "systematic-debugging")?.name).toBe("superpowers/systematic-debugging")
+    })
+
+    test("short-name match is case-insensitive on the basename", () => {
+      const fixture = skills([{ name: "superpowers/case-test" }])
+      expect(matchSkillByName(fixture, "Case-Test")?.name).toBe("superpowers/case-test")
+    })
+
+    test("does NOT short-name-match a non-namespaced skill (no `/` in stored name)", () => {
+      // a `playwright` builtin must not steal the short-name fallback —
+      // there's nothing to fall back from in the first place.
+      const fixture = skills([{ name: "playwright" }, { name: "ns/other" }])
+      // request `other` short-name → matches the namespaced one
+      expect(matchSkillByName(fixture, "other")?.name).toBe("ns/other")
+      // request `playwright` → exact match wins (no fallback considered)
+      expect(matchSkillByName(fixture, "playwright")?.name).toBe("playwright")
+    })
+  })
+
+  describe("ambiguity protection", () => {
+    test("returns undefined when two namespaced skills share a basename", () => {
+      const fixture = skills([
+        { name: "superpowers/debug" },
+        { name: "utils/debug" },
+      ])
+      expect(matchSkillByName(fixture, "debug")).toBeUndefined()
+    })
+
+    test("three-way ambiguity is also rejected", () => {
+      const fixture = skills([
+        { name: "ns-a/x" },
+        { name: "ns-b/x" },
+        { name: "ns-c/x" },
+      ])
+      expect(matchSkillByName(fixture, "x")).toBeUndefined()
+    })
+  })
+
+  describe("exact-match precedence", () => {
+    test("an exact match wins over an ambiguous short-name set", () => {
+      const fixture = skills([
+        { name: "debug" }, // exact match
+        { name: "superpowers/debug" },
+        { name: "utils/debug" },
+      ])
+      // exact `debug` resolves, even though `debug` would otherwise be ambiguous
+      // across `superpowers/debug` + `utils/debug`.
+      expect(matchSkillByName(fixture, "debug")?.name).toBe("debug")
+    })
+
+    test("an exact match wins over a unique short-name match", () => {
+      const fixture = skills([
+        { name: "debug" },
+        { name: "superpowers/debug" },
+      ])
+      expect(matchSkillByName(fixture, "debug")?.name).toBe("debug")
+    })
+
+    test("exact match wins case-insensitively too", () => {
+      const fixture = skills([
+        { name: "DEBUG" },
+        { name: "superpowers/debug" },
+      ])
+      expect(matchSkillByName(fixture, "debug")?.name).toBe("DEBUG")
+    })
+  })
+
+  describe("edge cases", () => {
+    test("empty fixture returns undefined", () => {
+      expect(matchSkillByName([], "anything")).toBeUndefined()
+    })
+
+    test("no exact and no short-name match returns undefined", () => {
+      const fixture = skills([{ name: "frontend-ui-ux" }, { name: "ns/foo" }])
+      expect(matchSkillByName(fixture, "nonexistent")).toBeUndefined()
+    })
+
+    test("works with richer shapes than just `{name}` — accepts any `{name: string}`", () => {
+      type Skill = { name: string; description: string; template: string }
+      const fixture: Skill[] = [
+        { name: "ns/short", description: "d", template: "body" },
+      ]
+      const matched = matchSkillByName(fixture, "short")
+      // type carries through, so the caller still sees the full Skill shape
+      expect(matched?.template).toBe("body")
+    })
+
+    test("handles names with multiple slashes by taking only the last segment as basename", () => {
+      // e.g. nested skill packs `vendor/pack/name`
+      const fixture = skills([{ name: "vendor/pack/name" }])
+      expect(matchSkillByName(fixture, "name")?.name).toBe("vendor/pack/name")
+      // mid segments are not basename — must not match
+      expect(matchSkillByName(fixture, "pack")).toBeUndefined()
+    })
+  })
+})

--- a/src/tools/skill/skill-matcher.ts
+++ b/src/tools/skill/skill-matcher.ts
@@ -2,7 +2,10 @@ import { sortByScopePriority } from "./scope-priority"
 import type { CommandInfo } from "../slashcommand/types"
 import type { LoadedSkill } from "../../features/opencode-skill-loader"
 
-export function matchSkillByName(skills: LoadedSkill[], requestedName: string): LoadedSkill | undefined {
+export function matchSkillByName<T extends { name: string }>(
+  skills: T[],
+  requestedName: string,
+): T | undefined {
   const normalizedName = requestedName.toLowerCase()
   const exactMatch = skills.find((skill) => skill.name.toLowerCase() === normalizedName)
   if (exactMatch) {


### PR DESCRIPTION
Closes #4183.

## Summary
- Aligns sync skill resolvers (`resolveSkillContent`, `resolveMultipleSkills`) and the public `getSkillByName` API with their async counterparts: case-insensitive exact match first, then a short-name fallback for namespaced skills with ambiguity protection.
- Extends `findCommand` in the auto-slash-command executor with the same matching rules, so `/systematic-debugging` resolves a namespaced `superpowers/systematic-debugging` skill command.
- Genericizes the shared `matchSkillByName` helper to `<T extends { name: string }>` so it can be reused across `LoadedSkill`, `BuiltinSkill`, and `CommandInfo` without duplicating logic.

## Behavior
- Exact (case-insensitive) match always wins.
- Short-name match only applies when the skill name is namespaced (`ns/name`).
- Multiple short-name hits return `undefined` rather than guessing — preserves the documented async semantics.

## Test plan
- [x] New unit tests cover unique short-name match, ambiguous short-name (undefined), exact precedence, and case-insensitive matching for both sync resolvers, `getSkillByName`, and `findCommand`.
- [x] `bun test src/features/opencode-skill-loader/ src/tools/skill/ src/hooks/auto-slash-command/ src/agents/agent-skill-resolution.test.ts` → 242 pass / 0 fail.
- [x] RED-GREEN verified locally: new tests fail before the fix, pass after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes short-name and case-insensitive matching in sync skill resolution, `getSkillByName`, and slash commands to match async behavior. Also adds a CI cache-bust to unblock `bun install --frozen-lockfile`.

- **Bug Fixes**
  - Sync resolvers and `getSkillByName` now use a shared matcher: case-insensitive exact first; short-name only for namespaced skills; ambiguous short-name returns no match; exact beats short-name.
  - Slash command executor resolves commands with the same rules (e.g. `/systematic-debugging` → `superpowers/systematic-debugging`). Tests cover sync, slash, and matcher contract cases.

- **Refactors**
  - `matchSkillByName` is generic over `{ name: string }` and reused across skill resolvers, `getSkillByName`, and slash-command discovery.
  - CI: added a no-op change to `bun.lock` to bust the cache key and fix frozen-lockfile installs.

<sup>Written for commit 8065c3e5b08dd8b32744cc8f5d0e6598ba609e4c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

