### PR TITLE
test(ast-grep): lock Windows path matching against #4220 regression

### DIFF
--- a/src/mcp/cli-suffix.test.ts
+++ b/src/mcp/cli-suffix.test.ts
@@ -29,4 +29,21 @@ describe("hasCliSuffix", () => {
     // then
     expect(result).toBe(false)
   })
+
+  // regression: issue #4220 — ast_grep MCP failed on Windows because the older
+  // dist used `path.endsWith("dist/cli.js")`. `hasCliSuffix` must match Windows
+  // backslash paths against the POSIX-shaped `dist/cli.js` suffix.
+  it("matches the ast_grep dist cli suffix on Windows path separators", () => {
+    // given
+    const windowsPath = "C:\\Users\\test\\AppData\\Local\\cache\\oh-my-opencode\\dist\\packages\\ast-grep-mcp\\dist\\cli.js"
+
+    // when: matched against just the trailing `dist/cli.js` segment
+    const matchesShortSuffix = hasCliSuffix(windowsPath, "dist/cli.js")
+    // and the fully-qualified package suffix
+    const matchesPackageSuffix = hasCliSuffix(windowsPath, "packages/ast-grep-mcp/dist/cli.js")
+
+    // then: both must succeed despite the backslashes
+    expect(matchesShortSuffix).toBe(true)
+    expect(matchesPackageSuffix).toBe(true)
+  })
 })


### PR DESCRIPTION
Refs #4220.

## Context
The dist-side bug reported in #4220 (`path.endsWith(\"dist/cli.js\")` failing on Windows backslash paths) **has already been fixed in source**:

- `src/mcp/ast-grep.ts:100-105` and `src/mcp/lsp.ts` route suffix matching through `hasCliSuffix` in `src/mcp/cli-suffix.ts`.
- `hasCliSuffix` normalizes both sides (`replaceAll(\"\\\\\", \"/\")`) before comparing.

Users on 4.3.0+ should already be unaffected. This PR adds the missing regression test so the fix can't quietly drift back.

## What's new
`cli-suffix.test.ts` previously covered the `lsp-tools-mcp` shape (mixed separators, UNC, POSIX). This adds an explicit ast_grep variant:

```ts
const windowsPath = \"C:\\\\Users\\\\test\\\\AppData\\\\Local\\\\cache\\\\oh-my-opencode\\\\dist\\\\packages\\\\ast-grep-mcp\\\\dist\\\\cli.js\"
// must match both forms:
hasCliSuffix(windowsPath, \"dist/cli.js\")                     // true
hasCliSuffix(windowsPath, \"packages/ast-grep-mcp/dist/cli.js\") // true
```

## Test plan
- [x] `bun test src/mcp/cli-suffix.test.ts src/mcp/ast-grep.test.ts` → 9 pass / 0 fail.
- [x] No source/runtime changes — pure regression protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to lock Windows backslash path matching for the `ast-grep-mcp` dist CLI suffix, preventing the #4220 regression from returning. The test confirms a Windows-style absolute path matches both `dist/cli.js` and `packages/ast-grep-mcp/dist/cli.js` via hasCliSuffix.

<sup>Written for commit ccaf61e09b30282d2de6939a340d22d9ed518c88. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4272?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

