### PR TITLE
test(doctor,schema): lock reasoningEffort 'max' against #4165 regression

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -188,7 +188,7 @@ Agent tab cycling defaults to Sisyphus, Hephaestus, Prometheus, Atlas. Override 
 | `variant`         | string        | Model variant: `max`, `high`, `medium`, `low`, `xhigh`. Normalized to supported values |
 | `maxTokens`       | number        | Max response tokens                                    |
 | `thinking`        | object        | Anthropic extended thinking                            |
-| `reasoningEffort` | string        | OpenAI reasoning: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. Normalized to supported values |
+| `reasoningEffort` | string        | OpenAI reasoning: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Normalized to supported values |
 | `textVerbosity`   | string        | Text verbosity: `low`, `medium`, `high`                |
 | `providerOptions` | object        | Provider-specific options                              |
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -164,7 +164,7 @@ You can define custom categories in your plugin config file. During the rename t
 | `top_p`             | number  | Nucleus sampling parameter (0.0 ~ 1.0)                                      |
 | `prompt_append`     | string  | Content to append to system prompt when this category is selected           |
 | `thinking`          | object  | Thinking model configuration (`{ type: "enabled", budgetTokens: 16000 }`)   |
-| `reasoningEffort`   | string  | Reasoning effort level (`low`, `medium`, `high`)                            |
+| `reasoningEffort`   | string  | Reasoning effort level (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) |
 | `textVerbosity`     | string  | Text verbosity level (`low`, `medium`, `high`)                              |
 | `tools`             | object  | Tool usage control (disable with `{ "tool_name": false }`)                  |
 | `maxTokens`         | number  | Maximum response token count                                                |

--- a/src/cli/doctor/checks/config.test.ts
+++ b/src/cli/doctor/checks/config.test.ts
@@ -125,5 +125,41 @@ describe("config check", () => {
         }
       }
     })
+
+    // regression: issue #4165 — doctor used to falsely flag reasoningEffort: "max"
+    // as an "Invalid configuration" error even though the schema and runtime accept it.
+    it("does not flag reasoningEffort: 'max' as an invalid configuration", async () => {
+      const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+      const testConfigDir = join(
+        tmpdir(),
+        `omo-doctor-reasoning-effort-max-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      )
+
+      try {
+        mkdirSync(testConfigDir, { recursive: true })
+        process.env.OPENCODE_CONFIG_DIR = testConfigDir
+        writeFileSync(
+          join(testConfigDir, "oh-my-openagent.json"),
+          JSON.stringify({
+            agents: {
+              sisyphus: { reasoningEffort: "max" },
+            },
+          }, null, 2) + "\n",
+          "utf-8",
+        )
+
+        const result = await config.checkConfig()
+        const invalidConfig = result.issues.find((issue) => issue.title === "Invalid configuration")
+
+        expect(invalidConfig).toBeUndefined()
+      } finally {
+        rmSync(testConfigDir, { recursive: true, force: true })
+        if (originalConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+        }
+      }
+    })
   })
 })

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -8,6 +8,7 @@ import {
   BuiltinCategoryNameSchema,
   CategoryConfigSchema,
   ExperimentalConfigSchema,
+  FallbackModelObjectSchema,
   GitMasterConfigSchema,
   HookNameSchema,
   OhMyOpenCodeConfigSchema,
@@ -419,6 +420,68 @@ describe("CategoryConfigSchema", () => {
     }
     if (minimalResult.success) {
       expect(minimalResult.data.reasoningEffort).toBe("minimal")
+    }
+  })
+
+  // regression: issue #4165 — doctor used to falsely report "max" invalid; lock
+  // the full enum and assert all three reasoningEffort schemas agree.
+  test("accepts reasoningEffort 'max' on CategoryConfigSchema", () => {
+    // given
+    const config = { reasoningEffort: "max" }
+
+    // when
+    const result = CategoryConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reasoningEffort).toBe("max")
+    }
+  })
+
+  test("accepts reasoningEffort 'max' on AgentOverrideConfigSchema", () => {
+    // given
+    const config = { reasoningEffort: "max" }
+
+    // when
+    const result = AgentOverrideConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reasoningEffort).toBe("max")
+    }
+  })
+
+  test("accepts reasoningEffort 'max' on FallbackModelObjectSchema", () => {
+    // given
+    const config = { model: "openai/gpt-5", reasoningEffort: "max" }
+
+    // when
+    const result = FallbackModelObjectSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reasoningEffort).toBe("max")
+    }
+  })
+
+  test("all three reasoningEffort enums share the same accepted values", () => {
+    // given: the full list of values declared in src/config/schema/*.ts
+    const validValues = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const
+    const schemas = [
+      { name: "Category", schema: CategoryConfigSchema, build: (v: string) => ({ reasoningEffort: v }) },
+      { name: "AgentOverride", schema: AgentOverrideConfigSchema, build: (v: string) => ({ reasoningEffort: v }) },
+      { name: "FallbackModel", schema: FallbackModelObjectSchema, build: (v: string) => ({ model: "openai/gpt-5", reasoningEffort: v }) },
+    ]
+
+    // when / then: every schema accepts every value — guards against drift
+    for (const { name, schema, build } of schemas) {
+      for (const value of validValues) {
+        const result = schema.safeParse(build(value))
+        expect(result.success, `${name}Schema should accept reasoningEffort '${value}'`).toBe(true)
+      }
     }
   })
 


### PR DESCRIPTION
Refs #4165.

## Context
The user-facing symptom (\`bunx oh-my-openagent doctor\` flagging \`reasoningEffort: \"max\"\` as an invalid configuration that would prevent opencode from starting) is **already resolved** in source — all three Zod schemas accept \`\"max\"\`:

- \`src/config/schema/agent-overrides.ts:40\`
- \`src/config/schema/categories.ts:19\`
- \`src/config/schema/fallback-models.ts:6\`

Users on 4.3.0+ shouldn't reproduce the bug. But the previous schema tests only covered \`xhigh\`, \`none\`, \`minimal\`, leaving the three enums free to drift apart and silently bring the false positive back.

## What's added
1. **Per-schema acceptance tests** for \`reasoningEffort: \"max\"\` on \`CategoryConfigSchema\`, \`AgentOverrideConfigSchema\`, and \`FallbackModelObjectSchema\`.
2. **Cross-schema parity test** — iterates the full enum (\`none, minimal, low, medium, high, xhigh, max\`) against all three schemas so any drift fails loudly with the schema name in the assertion message.
3. **Doctor end-to-end regression** in \`config.test.ts\` — writes an \`oh-my-openagent.json\` with \`agents.sisyphus.reasoningEffort = \"max\"\` and asserts \`checkConfig()\` does **not** surface an \"Invalid configuration\" issue.

## Test plan
- [x] \`bun test src/config/schema.test.ts src/cli/doctor/checks/config.test.ts\` → 76 pass / 0 fail.
- [x] No production code changes — pure regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests to ensure `reasoningEffort: "max"` is accepted across all schemas and that `bunx oh-my-openagent doctor` does not flag it. Updates docs to list `xhigh` and `max` to prevent #4165 regression. No production code changes.

- **Bug Fixes**
  - Per-schema tests for `CategoryConfigSchema`, `AgentOverrideConfigSchema`, `FallbackModelObjectSchema` accepting `"max"`.
  - Cross-schema parity test over `none|minimal|low|medium|high|xhigh|max`.
  - Doctor E2E test asserting `checkConfig()` does not surface an "Invalid configuration" issue for `"max"`.
  - Docs: update `features.md` and `configuration.md` tables to include `xhigh` and `max`.

<sup>Written for commit 1c16bb65ba280db353ad3737ce438b0dbf42a390. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

