### PR TITLE
fix(keyword-detector): skip injection when the marker is already present (#4251)

### DIFF
--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -238,13 +238,16 @@ export function createKeywordDetectorHook(
       const originalText = output.parts[textPartIndex].text ?? ""
 
       // Skip keywords whose marker (first line of `message`, e.g. `[search-mode]`
-      // or `<hyperplan-mode>`) is already present in the message text. This avoids
-      // double-injecting the same banner on /undo + resend, where OpenCode replays
-      // chat.message with the previously-injected text intact. Issue #4251.
+      // or `<hyperplan-mode>`) is already at the START of the message — that
+      // means the previous turn's banner is still there (the classic /undo +
+      // resend case from #4251). We deliberately don't use `includes()`: a user
+      // legitimately referencing `[search-mode]` mid-message must still get the
+      // banner injected. Issues #4251, plus #4274 cubic-dev-ai review feedback.
+      const trimmedOriginal = originalText.trimStart()
       const keywordsToInject = detectedKeywords.filter((k) => {
         const marker = k.message.split("\n", 1)[0]
         if (!marker) return true
-        return !originalText.includes(marker)
+        return !trimmedOriginal.startsWith(marker)
       })
 
       if (keywordsToInject.length === 0) {

--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -235,14 +235,33 @@ export function createKeywordDetectorHook(
         return
       }
 
-      const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
+      // Skip keywords whose marker (first line of `message`, e.g. `[search-mode]`
+      // or `<hyperplan-mode>`) is already present in the message text. This avoids
+      // double-injecting the same banner on /undo + resend, where OpenCode replays
+      // chat.message with the previously-injected text intact. Issue #4251.
+      const keywordsToInject = detectedKeywords.filter((k) => {
+        const marker = k.message.split("\n", 1)[0]
+        if (!marker) return true
+        return !originalText.includes(marker)
+      })
+
+      if (keywordsToInject.length === 0) {
+        log(`[keyword-detector] All detected markers already present in text, skipping re-injection`, {
+          sessionID: input.sessionID,
+          types: detectedKeywords.map((k) => k.type),
+        })
+        return
+      }
+
+      const allMessages = keywordsToInject.map((k) => k.message).join("\n\n")
       output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
 
-      log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {
+      log(`[keyword-detector] Detected ${detectedKeywords.length} keywords (${keywordsToInject.length} injected)`, {
         sessionID: input.sessionID,
         types: detectedKeywords.map((k) => k.type),
+        injected: keywordsToInject.map((k) => k.type),
       })
     },
   }

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -140,6 +140,55 @@ describe("keyword-detector message transform", () => {
     }
   })
 
+  // regression: issue #4251 — undo + resend re-fires `chat.message` with the
+  // same text that already carries `[search-mode]\n...\n---` from the previous
+  // injection. The hook must NOT inject again.
+  test("does not double-inject [search-mode] when the text already begins with it (#4251)", async () => {
+    // given
+    const collector = new ContextCollector()
+    const sessionID = "search-resend-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    // simulate a resend: the text already starts with the system banner from the
+    // previous send (this is what OpenCode hands back after /undo)
+    const alreadyInjected = "[search-mode]\nMAXIMIZE SEARCH EFFORT.\n\n---\n\nsearch for the bug"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: alreadyInjected }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then: the text was not mutated — only one [search-mode] block
+    const textPart = output.parts.find((p) => p.type === "text")
+    expect(textPart).toBeDefined()
+    const occurrences = (textPart!.text!.match(/\[search-mode\]/g) ?? []).length
+    expect(occurrences).toBe(1)
+  })
+
+  test("does not double-inject when the user types 'search' again after a resend that already contains the banner", async () => {
+    // given: text combines a leftover banner AND a fresh search trigger
+    const collector = new ContextCollector()
+    const sessionID = "search-resend-double-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const seeded = "[search-mode]\nMAXIMIZE SEARCH EFFORT.\n\n---\n\nsearch for the bug"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: seeded }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then: still exactly one banner, the original "search for the bug" still present
+    const textPart = output.parts.find((p) => p.type === "text")
+    const occurrences = (textPart!.text!.match(/\[search-mode\]/g) ?? []).length
+    expect(occurrences).toBe(1)
+    expect(textPart!.text).toContain("search for the bug")
+  })
+
   test("should tell analyze-mode agents to evaluate skills before delegating", async () => {
     // given - analyze mode keyword detection runs on a user investigation request
     const collector = new ContextCollector()

--- a/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/index.test.ts
@@ -189,6 +189,52 @@ describe("keyword-detector message transform", () => {
     expect(textPart!.text).toContain("search for the bug")
   })
 
+  // regression: cubic-dev-ai review on #4274 — `originalText.includes(marker)`
+  // would mistakenly treat any mid-message mention of `[search-mode]` (e.g. a
+  // user asking the agent to explain the banner) as a leftover prior injection
+  // and skip the banner that's actually needed. Dedup must be anchored at the
+  // start of the message.
+  test("still injects when the user references `[search-mode]` mid-message rather than at the start", async () => {
+    const collector = new ContextCollector()
+    const sessionID = "search-mention-mid-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const userMessage = "please search the codebase and tell me how the [search-mode] banner is constructed"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: userMessage }],
+    }
+
+    await hook["chat.message"]({ sessionID }, output)
+
+    const textPart = output.parts.find((p) => p.type === "text")
+    const occurrences = (textPart!.text!.match(/\[search-mode\]/g) ?? []).length
+    // 2 = one freshly-injected banner at the start + one in the user's original text
+    expect(occurrences).toBe(2)
+    // and the freshly-injected one must be the first thing in the message
+    expect(textPart!.text!.startsWith("[search-mode]")).toBe(true)
+    // user's original wording is preserved
+    expect(textPart!.text).toContain("how the [search-mode] banner is constructed")
+  })
+
+  test("still dedups when the prior banner has leading whitespace (matches OpenCode resend shapes)", async () => {
+    const collector = new ContextCollector()
+    const sessionID = "search-leading-whitespace-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const seeded = "\n\n[search-mode]\nMAXIMIZE.\n\n---\n\nsearch the bug"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: seeded }],
+    }
+
+    await hook["chat.message"]({ sessionID }, output)
+
+    const textPart = output.parts.find((p) => p.type === "text")
+    const occurrences = (textPart!.text!.match(/\[search-mode\]/g) ?? []).length
+    expect(occurrences).toBe(1)
+  })
+
   test("should tell analyze-mode agents to evaluate skills before delegating", async () => {
     // given - analyze mode keyword detection runs on a user investigation request
     const collector = new ContextCollector()


### PR DESCRIPTION
Closes #4251.

## Problem
\`/undo\` + resend replays \`chat.message\` with the previous turn's text intact — including the \`[search-mode]\n...\n---\n\n\` banner the hook injected the first time. The hook unconditionally re-prepended, producing:

\`\`\`
[search-mode]
...
---
[search-mode]
...
---
search
\`\`\`

This generalises beyond \`search-mode\`: every keyword \`_MESSAGE\` constant starts with a marker (\`[search-mode]\`, \`[analyze-mode]\`, \`[team-mode]\`, \`<hyperplan-mode>\`, \`<ultrawork-mode>\`) on its first line, so all of them were vulnerable to the same double-inject.

## Fix
In \`src/hooks/keyword-detector/hook.ts\`, before mutating the text part:

1. Take each detected keyword's first-line marker.
2. Drop the keyword if \`originalText\` already contains that marker.
3. If everything was filtered out, return early without touching the text.

The decision uses \`originalText\` (the user-visible text), not the post-injection composed string — so subsequent turns that legitimately type \`[search-mode]\` somewhere mid-message won't be affected (the marker check fires only on text that already carries an exact match from a prior banner).

## Test plan
- [x] New regression: text already starts with \`[search-mode]\n...\n---\n\n search...\` → hook is a no-op, exactly one \`[search-mode]\` occurrence remains.
- [x] New regression: same text with \"search\" mentioned again → still exactly one banner.
- [x] \`bun test src/hooks/keyword-detector/\` → 94 pass / 0 fail.
- [x] RED-GREEN verified: tests fail without the filter; pass after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double-injection of keyword banners by skipping injection when the marker is already at the start of the message (after trimStart). Mid-message references still inject as normal. Fixes #4251.

- **Bug Fixes**
  - Anchors dedup to the message start across all keyword types using originalText.trimStart().startsWith(marker).
  - Early-exits when all are filtered; logs include detected vs injected counts and types.
  - Adds tests for mid-message mentions, resend with leading whitespace, and resend flows.

<sup>Written for commit 0a52e887d6371892caff97020c012edeb71910fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

