### PR TITLE
test(cli-suffix): pin lsp-tools-mcp Windows path matching against #4193

### DIFF
--- a/packages/omo-opencode/src/mcp/cli-suffix.test.ts
+++ b/packages/omo-opencode/src/mcp/cli-suffix.test.ts
@@ -46,4 +46,38 @@ describe("hasCliSuffix", () => {
     expect(matchesShortSuffix).toBe(true)
     expect(matchesPackageSuffix).toBe(true)
   })
+
+  // regression: issue #4193 — mirrors the candidate paths `resolveLspCommand`'s
+  // ancestor walk produces on Windows. Pins the matcher so future churn can't
+  // re-introduce the "MCP error -32000: Connection closed" failure caused by
+  // `path.endsWith("dist/cli.js")` missing on backslash paths.
+  it("matches the lsp-tools-mcp dist cli candidate reported in issue #4193", () => {
+    // given: the EXISTS candidate from the issue's resolution simulation
+    const realCandidate = "C:\\Users\\user\\.cache\\opencode\\packages\\oh-my-openagent@latest\\node_modules\\oh-my-openagent\\packages\\lsp-tools-mcp\\dist\\cli.js"
+
+    // when: matched against the fully-qualified package suffix and the short form
+    const matchesPackage = hasCliSuffix(realCandidate, "packages/lsp-tools-mcp/dist/cli.js")
+    const matchesShort = hasCliSuffix(realCandidate, "dist/cli.js")
+
+    // then: both must succeed despite the backslashes — this was the missing
+    // hit that pushed the resolver into its non-existent fallback path
+    expect(matchesPackage).toBe(true)
+    expect(matchesShort).toBe(true)
+  })
+
+  it("does not confuse a sibling 'dist/packages/lsp-tools-mcp/dist/cli.js' fallback for the real one", () => {
+    // given: the buggy fallback path the original resolver landed on (still
+    // contains `packages/lsp-tools-mcp/dist/cli.js` as a substring, but the
+    // suffix actually starts later — its containing dir is `dist/packages`, not
+    // the package root)
+    const fallback = "C:\\Users\\user\\.cache\\opencode\\packages\\oh-my-openagent@latest\\node_modules\\oh-my-openagent\\dist\\packages\\lsp-tools-mcp\\dist\\cli.js"
+
+    // when
+    const matchesPackage = hasCliSuffix(fallback, "packages/lsp-tools-mcp/dist/cli.js")
+
+    // then: still matches as a suffix — disambiguation between the real cli and
+    // this stale fallback is the resolver's job (via `exists` checks), not the
+    // matcher's. This test pins that contract so callers don't assume otherwise.
+    expect(matchesPackage).toBe(true)
+  })
 })


### PR DESCRIPTION
Refs #4193.

## Context
The dist-side bug reported in #4193 — \`path.endsWith(\"dist/cli.js\")\` failing on Windows backslash paths and falling back to a non-existent path → \`MCP error -32000: Connection closed\` — was already fixed in source:

- \`src/mcp/lsp.ts:141,147\` route suffix matching through \`hasCliSuffix\` from \`src/mcp/cli-suffix.ts\`.
- \`hasCliSuffix\` normalizes both sides (\`replaceAll(\"\\\\\", \"/\")\`) before comparing.
- This is the same abstraction that \`src/mcp/ast-grep.ts\` uses for #4220.

Existing \`cli-suffix.test.ts\` covered mixed-separator and UNC cases but never reproduced the **exact** candidate paths from the issue's resolution simulation. This PR pins them so a future change can't quietly bring the bug back.

## What's added
1. The \"real\" Windows candidate from the bug report — must match the full \`packages/lsp-tools-mcp/dist/cli.js\` suffix and the short \`dist/cli.js\` form.
2. The wrong sibling fallback the buggy resolver picked (\`...\\\\dist\\\\packages\\\\lsp-tools-mcp\\\\dist\\\\cli.js\`) — still matches as a suffix by design. Disambiguation between the real cli and this stale fallback is the resolver's job via \`exists\` checks; this test documents that contract.

## Test plan
- [x] \`bun test src/mcp/cli-suffix.test.ts src/mcp/lsp.test.ts\` → 9 pass / 0 fail.
- [x] No source/runtime changes — pure regression protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to lock Windows backslash path handling in `hasCliSuffix` for the `lsp-tools-mcp` CLI, preventing a return of #4193. Tests mirror the real Windows candidate for `packages/lsp-tools-mcp/dist/cli.js` and the short `dist/cli.js`, plus the `dist/packages/...` fallback; the matcher accepts both, and the resolver disambiguates via exists checks.

<sup>Written for commit 839009043ec5e1f71bdec04f324bd9803571ed65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

