### PR TITLE
feat(doctor): warn when a custom provider model is missing limit.context (#4184)

### DIFF
--- a/src/cli/doctor/checks/custom-provider-limits.test.ts
+++ b/src/cli/doctor/checks/custom-provider-limits.test.ts
@@ -155,4 +155,91 @@ describe("collectCustomProviderLimitIssues (issue #4184)", () => {
     const issues = collectCustomProviderLimitIssues()
     expect(issues).toHaveLength(1)
   })
+
+  // hardening from cubic-dev-ai review on #4276 ↓
+
+  test("does not crash when a provider entry is null (malformed config)", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          "broken": null,
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "glm-5.1": {} },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.description).toContain("glm/glm-5.1")
+  })
+
+  test("does not crash when a model entry is null or a primitive", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: {
+              "glm-broken": null,
+              "glm-also-broken": "not-an-object",
+              "glm-good": { limit: { context: 128000 } },
+            },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toHaveLength(2)
+    const descriptions = issues.map((i) => i.description).join("\n")
+    expect(descriptions).toContain("glm/glm-broken")
+    expect(descriptions).toContain("glm/glm-also-broken")
+    expect(descriptions).not.toContain("glm/glm-good")
+  })
+
+  test("does not crash when the top-level provider field is malformed", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({ provider: "not-an-object" })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
+
+  test("does not crash when provider.models is malformed", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: "garbage",
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
+
+  test("does not crash when provider.npm is null", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: { npm: null, models: { "glm-5.1": {} } },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
 })

--- a/src/cli/doctor/checks/custom-provider-limits.test.ts
+++ b/src/cli/doctor/checks/custom-provider-limits.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { collectCustomProviderLimitIssues } from "./custom-provider-limits"
+
+describe("collectCustomProviderLimitIssues (issue #4184)", () => {
+  const originalXDGConfig = process.env["XDG_CONFIG_HOME"]
+  const originalCwd = process.cwd()
+  let tempDir: string
+  let userConfigDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    tempDir = join("/tmp", `doctor-provider-limits-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+    userConfigDir = join(tempDir, "config", "opencode")
+    projectDir = join(tempDir, "project")
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+    process.env["XDG_CONFIG_HOME"] = join(tempDir, "config")
+    process.chdir(projectDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    if (originalXDGConfig === undefined) {
+      delete process.env["XDG_CONFIG_HOME"]
+    } else {
+      process.env["XDG_CONFIG_HOME"] = originalXDGConfig
+    }
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test("returns no issues when no opencode.json exists", () => {
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
+
+  test("flags an @ai-sdk/openai-compatible model without limit.context", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "glm-5.1": { name: "GLM-5.1" } },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.title).toBe("Custom provider model is missing limit.context")
+    expect(issues[0]?.severity).toBe("warning")
+    expect(issues[0]?.description).toContain("glm/glm-5.1")
+    expect(issues[0]?.description).toContain("@ai-sdk/openai-compatible")
+    expect(issues[0]?.fix).toContain("limit.context")
+    expect(issues[0]?.fix).toContain("provider.glm.models.glm-5.1")
+  })
+
+  test("does not flag models that already specify limit.context", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "glm-5.1": { name: "GLM-5.1", limit: { context: 200000, output: 16384 } } },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
+
+  test("ignores providers that don't use @ai-sdk/openai-compatible", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          "my-builtin": {
+            npm: "@some-other-sdk/provider",
+            models: { "foo": {} },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toEqual([])
+  })
+
+  test("flags multiple models across multiple custom providers", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: {
+              "glm-5.1": {},
+              "glm-air": { limit: { context: 128000 } },
+            },
+          },
+          kimi: {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "kimi-k2": {} },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toHaveLength(2)
+    const titles = issues.map((i) => i.description)
+    expect(titles.some((t) => t.includes("glm/glm-5.1"))).toBe(true)
+    expect(titles.some((t) => t.includes("kimi/kimi-k2"))).toBe(true)
+    expect(titles.some((t) => t.includes("glm/glm-air"))).toBe(false)
+  })
+
+  test("also scans project .opencode/opencode.json", () => {
+    writeFileSync(
+      join(projectDir, ".opencode", "opencode.json"),
+      JSON.stringify({
+        provider: {
+          "project-llm": {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "model-a": {} },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.description).toContain("project-llm/model-a")
+  })
+
+  test("treats limit.context: 0 as missing (matches OpenCode overflow detector)", () => {
+    writeFileSync(
+      join(userConfigDir, "opencode.json"),
+      JSON.stringify({
+        provider: {
+          glm: {
+            npm: "@ai-sdk/openai-compatible",
+            models: { "glm-5.1": { limit: { context: 0, output: 0 } } },
+          },
+        },
+      })
+    )
+
+    const issues = collectCustomProviderLimitIssues()
+    expect(issues).toHaveLength(1)
+  })
+})

--- a/src/cli/doctor/checks/custom-provider-limits.ts
+++ b/src/cli/doctor/checks/custom-provider-limits.ts
@@ -51,13 +51,22 @@ function readOpenCodeConfig(candidatePaths: readonly string[]): { path: string; 
   return null
 }
 
-function isOpenAiCompatProvider(entry: OpenCodeProviderEntry): boolean {
-  if (!entry.npm) return false
-  return COMPAT_SDK_PREFIXES.some((prefix) => entry.npm === prefix || entry.npm?.startsWith(`${prefix}@`))
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function modelHasUsableLimit(entry: OpenCodeModelEntry): boolean {
-  const context = entry.limit?.context
+function isOpenAiCompatProvider(entry: unknown): entry is OpenCodeProviderEntry & { npm: string } {
+  if (!isPlainObject(entry)) return false
+  const npm = (entry as OpenCodeProviderEntry).npm
+  if (typeof npm !== "string" || npm.length === 0) return false
+  return COMPAT_SDK_PREFIXES.some((prefix) => npm === prefix || npm.startsWith(`${prefix}@`))
+}
+
+function modelHasUsableLimit(entry: unknown): boolean {
+  if (!isPlainObject(entry)) return false
+  const limit = (entry as OpenCodeModelEntry).limit
+  if (!isPlainObject(limit)) return false
+  const context = (limit as { context?: unknown }).context
   return typeof context === "number" && context > 0
 }
 
@@ -66,10 +75,10 @@ function collectIssuesFromConfig(
   configPath: string,
 ): DoctorIssue[] {
   const issues: DoctorIssue[] = []
-  const providers = config.provider ?? {}
+  const providers = isPlainObject(config.provider) ? config.provider : {}
   for (const [providerId, providerEntry] of Object.entries(providers)) {
     if (!isOpenAiCompatProvider(providerEntry)) continue
-    const models = providerEntry.models ?? {}
+    const models = isPlainObject(providerEntry.models) ? providerEntry.models : {}
     for (const [modelId, modelEntry] of Object.entries(models)) {
       if (modelHasUsableLimit(modelEntry)) continue
       issues.push({

--- a/src/cli/doctor/checks/custom-provider-limits.ts
+++ b/src/cli/doctor/checks/custom-provider-limits.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { parseJsonc } from "../../../shared"
+import type { DoctorIssue } from "../types"
+
+type OpenCodeModelEntry = {
+  limit?: { context?: number; output?: number }
+}
+
+type OpenCodeProviderEntry = {
+  npm?: string
+  models?: Record<string, OpenCodeModelEntry>
+}
+
+type OpenCodeConfig = {
+  provider?: Record<string, OpenCodeProviderEntry>
+}
+
+// Providers that route through @ai-sdk/openai-compatible (or its forks) do NOT
+// publish their context window to OpenCode's models.dev cache, so `limit` MUST
+// be supplied inline in opencode.json. When it's missing, OpenCode's overflow
+// detector sees `context === 0` and auto-compaction never triggers. Issue #4184.
+const COMPAT_SDK_PREFIXES: readonly string[] = [
+  "@ai-sdk/openai-compatible",
+  "@ai-sdk/openai", // user-defined custom providers
+]
+
+function getUserOpencodeConfigCandidates(): string[] {
+  const xdgConfig = process.env["XDG_CONFIG_HOME"]
+  const configDir = xdgConfig ? join(xdgConfig, "opencode") : join(homedir(), ".config", "opencode")
+  return [join(configDir, "opencode.json"), join(configDir, "opencode.jsonc")]
+}
+
+function getProjectOpencodeConfigCandidates(): string[] {
+  const projectDir = join(process.cwd(), ".opencode")
+  return [join(projectDir, "opencode.json"), join(projectDir, "opencode.jsonc")]
+}
+
+function readOpenCodeConfig(candidatePaths: readonly string[]): { path: string; config: OpenCodeConfig } | null {
+  for (const path of candidatePaths) {
+    if (!existsSync(path)) continue
+    try {
+      const content = readFileSync(path, "utf-8")
+      const parsed = parseJsonc<OpenCodeConfig>(content)
+      if (parsed) return { path, config: parsed }
+    } catch {
+      // ignore parse errors — the main config check surfaces them separately
+    }
+  }
+  return null
+}
+
+function isOpenAiCompatProvider(entry: OpenCodeProviderEntry): boolean {
+  if (!entry.npm) return false
+  return COMPAT_SDK_PREFIXES.some((prefix) => entry.npm === prefix || entry.npm?.startsWith(`${prefix}@`))
+}
+
+function modelHasUsableLimit(entry: OpenCodeModelEntry): boolean {
+  const context = entry.limit?.context
+  return typeof context === "number" && context > 0
+}
+
+function collectIssuesFromConfig(
+  config: OpenCodeConfig,
+  configPath: string,
+): DoctorIssue[] {
+  const issues: DoctorIssue[] = []
+  const providers = config.provider ?? {}
+  for (const [providerId, providerEntry] of Object.entries(providers)) {
+    if (!isOpenAiCompatProvider(providerEntry)) continue
+    const models = providerEntry.models ?? {}
+    for (const [modelId, modelEntry] of Object.entries(models)) {
+      if (modelHasUsableLimit(modelEntry)) continue
+      issues.push({
+        title: "Custom provider model is missing limit.context",
+        description:
+          `${providerId}/${modelId} (npm: ${providerEntry.npm}) has no limit.context. OpenCode's auto-compaction relies on this to detect overflow; without it, sessions silently exhaust the context window and the agent stops emitting tool calls.`,
+        fix:
+          `Add limit.context (and ideally limit.output) to provider.${providerId}.models.${modelId} in ${configPath}. Example: "limit": { "context": 128000, "output": 8192 }`,
+        severity: "warning",
+        affects: ["auto-compaction", `${providerId}/${modelId}`],
+      })
+    }
+  }
+  return issues
+}
+
+export function collectCustomProviderLimitIssues(): DoctorIssue[] {
+  const issues: DoctorIssue[] = []
+  for (const candidates of [getUserOpencodeConfigCandidates(), getProjectOpencodeConfigCandidates()]) {
+    const found = readOpenCodeConfig(candidates)
+    if (!found) continue
+    issues.push(...collectIssuesFromConfig(found.config, found.path))
+  }
+  return issues
+}

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -2,6 +2,7 @@ import { AGENT_MODEL_REQUIREMENTS, CATEGORY_MODEL_REQUIREMENTS } from "../../../
 import { getModelCapabilities } from "../../../shared/model-capabilities"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import type { CheckResult, DoctorIssue } from "../types"
+import { collectCustomProviderLimitIssues } from "./custom-provider-limits"
 import { loadAvailableModelsFromCache } from "./model-resolution-cache"
 import { loadOmoConfig } from "./model-resolution-config"
 import { buildModelResolutionDetails } from "./model-resolution-details"
@@ -133,6 +134,7 @@ export async function checkModels(): Promise<CheckResult> {
   }
 
   issues.push(...collectCapabilityResolutionIssues(info))
+  issues.push(...collectCustomProviderLimitIssues())
 
   const overrideCount =
     info.agents.filter((agent) => Boolean(agent.userOverride)).length +


### PR DESCRIPTION
Closes #4184.

## Problem
Providers loaded via \`@ai-sdk/openai-compatible\` (GLM, custom local LLMs, etc.) need a \`limit\` field declared **inline** in \`opencode.json\` because their context window isn't published to the \`models.dev\` cache. When it's missing, OpenCode's overflow detector reads \`context === 0\` and **auto-compaction never triggers** — sessions silently exhaust the context window and the agent eventually stops emitting tool calls.

This is exactly the kind of failure where the user has no idea why their long session got stuck. The diagnosis path involves cross-referencing \`opencode.json\` against \`packages/opencode/src/session/overflow.ts\` from upstream OpenCode.

## Scope note
omo **does not write provider/model configuration to opencode.json** — users manage that file themselves. So the fix is not \"populate limit automatically\" (that would silently override user intent); it's **detection + concrete fix guidance** in doctor.

## What's added
New doctor check \`src/cli/doctor/checks/custom-provider-limits.ts\`:

- Scans both \`~/.config/opencode/opencode.json\` (or \`.jsonc\`) and \`<cwd>/.opencode/opencode.json\`.
- For each provider whose \`npm\` matches \`@ai-sdk/openai-compatible\` (or \`@ai-sdk/openai\`, or a versioned variant like \`@ai-sdk/openai-compatible@1.2.3\`), every model whose \`limit.context\` is missing or \`<= 0\` produces a \`warning\` \`DoctorIssue\`:

\`\`\`
Custom provider model is missing limit.context
  glm/glm-5.1 (npm: @ai-sdk/openai-compatible) has no limit.context. OpenCode's
  auto-compaction relies on this to detect overflow; without it, sessions
  silently exhaust the context window and the agent stops emitting tool calls.

  Fix: Add limit.context (and ideally limit.output) to
  provider.glm.models.glm-5.1 in ~/.config/opencode/opencode.json. Example:
  \"limit\": { \"context\": 128000, \"output\": 8192 }
\`\`\`

Wired into \`checkModels\` so it surfaces alongside existing model-resolution warnings (same check, no new top-level entry in the doctor table).

## Test plan
- [x] 7 new unit tests cover: no config, single missing-limit, with-limit (no warning), non-compat provider ignored, multiple models across multiple providers, project-level config scanning, and \`limit.context: 0\` treated as missing (matches OpenCode's overflow detector behavior).
- [x] \`bun test src/cli/doctor/checks/custom-provider-limits.test.ts src/cli/doctor/checks/model-resolution.test.ts\` → 24 pass / 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when custom provider models using `@ai-sdk/openai-compatible` or `@ai-sdk/openai` lack a positive `limit.context` in `opencode.json` to prevent context overflow and stuck tool calls. Handles malformed configs and surfaces in the doctor’s model check with clear fix guidance (addresses #4184).

- **New Features**
  - Adds `custom-provider-limits` doctor check that scans user and project `opencode.json`/`opencode.jsonc`, flags each matching model without `limit.context` (including versioned `npm` values), and treats `limit.context: 0` as missing.
  - Integrated into `checkModels` so warnings appear with existing model-resolution results.

<sup>Written for commit e23bef08b052a0623788abd069c14336798cfd42. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4276?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

