### PR TITLE
test(mcp-config-handler): lock disabled_mcps idempotency against #4178 regression

### DIFF
--- a/packages/omo-opencode/src/plugin-handlers/mcp-config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/mcp-config-handler.test.ts
@@ -183,4 +183,79 @@ describe("applyMcpConfig", () => {
     expect(createBuiltinMcpsSpy).toHaveBeenCalledWith([], pluginConfig, { cwd: TEST_CTX.directory })
   })
 
+  // regression: issue #4178 — `/new` triggers OpenCode to re-evaluate `config`,
+  // which re-invokes this handler. When that happens, `params.config.mcp` may have
+  // been reset to the raw merged set (re-introducing disabled entries). The
+  // handler must still produce a filtered `config.mcp` regardless of input shape.
+  test("re-applying after the session config gets reset still filters disabled_mcps", async () => {
+    //#given: first invocation — plugin init
+    createBuiltinMcpsSpy.mockReturnValue({
+      websearch: { type: "remote", url: "https://mcp.exa.ai/mcp", enabled: true },
+    })
+    loadMcpConfigsSpy.mockResolvedValue({
+      servers: {
+        firecrawl: { type: "remote", url: "https://firecrawl.example.com", enabled: true },
+        exa: { type: "remote", url: "https://exa.example.com", enabled: true },
+      },
+    })
+    const userMcpRaw = {
+      "user-disabled-server": { type: "local", command: ["foo"], enabled: true },
+      "user-keep-me": { type: "local", command: ["bar"], enabled: true },
+    }
+    const config: Record<string, unknown> = { mcp: { ...userMcpRaw } }
+    const pluginConfig = createPluginConfig({
+      disabled_mcps: unsafeTestValue(["firecrawl", "user-disabled-server"]),
+    })
+
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({ config, ctx: TEST_CTX, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+
+    //#then: first pass — disabled entries are gone
+    let merged = config.mcp as Record<string, Record<string, unknown>>
+    expect(merged).not.toHaveProperty("firecrawl")
+    expect(merged).not.toHaveProperty("user-disabled-server")
+    expect(merged).toHaveProperty("websearch")
+    expect(merged).toHaveProperty("exa")
+    expect(merged).toHaveProperty("user-keep-me")
+
+    //#when: simulate `/new` — the runtime resets config.mcp back to the raw user
+    // map (re-introducing the disabled entries) and re-invokes the config handler
+    config.mcp = { ...userMcpRaw }
+    await applyMcpConfig({ config, ctx: TEST_CTX, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+
+    //#then: second pass must produce the same filtered set
+    merged = config.mcp as Record<string, Record<string, unknown>>
+    expect(merged).not.toHaveProperty("firecrawl")
+    expect(merged).not.toHaveProperty("user-disabled-server")
+    expect(merged).toHaveProperty("websearch")
+    expect(merged).toHaveProperty("exa")
+    expect(merged).toHaveProperty("user-keep-me")
+  })
+
+  // Additional regression: ensure disabled filter survives when the same disabled
+  // entry was previously stripped — i.e. there is no path where the handler
+  // assumes the previous filtered set is the baseline.
+  test("idempotent across N invocations with disabled_mcps", async () => {
+    //#given
+    createBuiltinMcpsSpy.mockReturnValue({})
+    loadMcpConfigsSpy.mockResolvedValue({
+      servers: {
+        auggie: { type: "local", command: ["x"], enabled: true },
+      },
+    })
+    const config: Record<string, unknown> = {
+      mcp: { auggie: { type: "local", command: ["x"], enabled: true } },
+    }
+    const pluginConfig = createPluginConfig({ disabled_mcps: unsafeTestValue(["auggie"]) })
+
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+
+    //#when: 3 invocations in a row, each time the runtime hands us raw mcp again
+    for (let i = 0; i < 3; i++) {
+      config.mcp = { auggie: { type: "local", command: ["x"], enabled: true } }
+      await applyMcpConfig({ config, ctx: TEST_CTX, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+      //#then
+      expect(config.mcp).not.toHaveProperty("auggie")
+    }
+  })
 })


### PR DESCRIPTION
Refs #4178.

## Context
#4178 reports that \`disabled_mcps\` stops filtering after \`/new\` — disabled servers reappear and start timing out.

After tracing the code, omo's \`applyMcpConfig\` is **already idempotent**:
- Each invocation re-reads \`pluginConfig.disabled_mcps\`.
- \`createBuiltinMcps\` and \`loadMcpConfigs\` are passed \`disabledMcps\` and self-filter (defense in depth).
- The merged map gets a final \`delete merged[name]\` for every disabled entry.

So as long as the \`config\` hook gets re-invoked on \`/new\`, the omo side will produce a filtered set every time. **Whether OpenCode re-invokes the hook on \`/new\` is an upstream OpenCode behavior** — omo can't force it from a plugin event handler (the event API doesn't give us a writable \`config\` reference).

What omo **can** do is harden the contract so a future refactor of \`applyMcpConfig\` can't quietly introduce state that depends on prior invocations.

## What's added
Two regression tests in \`mcp-config-handler.test.ts\`:

1. **\`re-applying after the session config gets reset still filters disabled_mcps\`** — simulates OpenCode handing the same \`config\` back with \`config.mcp\` reset to the raw user map (re-introducing the disabled entries). After two back-to-back invocations, both passes must produce the filtered set.

2. **\`idempotent across N invocations with disabled_mcps\`** — three invocations in a row, each time the runtime hands us \`{ auggie: {...enabled: true...} }\` again. Each pass must end with \`auggie\` gone.

## Test plan
- [x] \`bun test src/plugin-handlers/mcp-config-handler.test.ts\` → 8 pass / 0 fail.
- [x] No production code changes — pure regression coverage for the existing idempotent behavior.

## Caveat
If the real bug is OpenCode not re-invoking the \`config\` hook on \`/new\`, this PR alone won't change user-visible behavior. The fix for that side belongs upstream in OpenCode. But this PR ensures the omo side is bulletproof against the regression mode it could theoretically cause.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two regression tests for `applyMcpConfig` ensuring `disabled_mcps` are always filtered, even after `/new` session resets (#4178). No production code changes.

<sup>Written for commit 25c58a1c8fae83376a05511d19de7136cd55c9d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

