### PR TITLE
fix(background-agent): reuse manager across duplicate plugin initialization

### DIFF
--- a/src/create-managers.test.ts
+++ b/src/create-managers.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import type { PluginInput } from "@opencode-ai/plugin"
 
 import { OhMyOpenCodeConfigSchema } from "./config/schema/oh-my-opencode-config"
-import { createManagers } from "./create-managers"
+import { createManagers, resetBackgroundManagerSingletonsForTesting } from "./create-managers"
 import * as openclawRuntimeDispatch from "./openclaw/runtime-dispatch"
 import { createModelCacheState } from "./plugin-state"
 
@@ -18,6 +18,7 @@ const markServerRunningInProcess = mock(() => {})
 let backgroundManagerOptions: {
   onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
 } | null = null
+let backgroundManagerConstructorCalls = 0
 const trackedPaneBySession = new Map<string, string>()
 const registeredCleanupManagers: CleanupRegistration[] = []
 const cleanupSessionTeamRunsMock = mock(async () => ({
@@ -30,6 +31,7 @@ class MockBackgroundManager {
   constructor(config: {
     onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   }) {
+    backgroundManagerConstructorCalls += 1
     backgroundManagerOptions = config
   }
 }
@@ -136,9 +138,11 @@ describe("createManagers", () => {
     markServerRunningInProcess.mockClear()
     dispatchOpenClawEvent.mockReset()
     backgroundManagerOptions = null
+    backgroundManagerConstructorCalls = 0
     trackedPaneBySession.clear()
     registeredCleanupManagers.length = 0
     cleanupSessionTeamRunsMock.mockClear()
+    resetBackgroundManagerSingletonsForTesting()
   })
 
   afterEach(() => {
@@ -195,6 +199,23 @@ describe("createManagers", () => {
     createManagers(args)
 
     expect(markServerRunningInProcess).not.toHaveBeenCalled()
+  })
+
+  it("#given the plugin initializes twice for the same project #when managers are created #then the background manager is reused", () => {
+    const args = {
+      ctx: createContext("/tmp/project"),
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(false),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+
+    const firstManagers = createManagers(args)
+    const secondManagers = createManagers(args)
+
+    expect(secondManagers.backgroundManager).toBe(firstManagers.backgroundManager)
+    expect(backgroundManagerConstructorCalls).toBe(1)
   })
 
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {

--- a/src/create-managers.test.ts
+++ b/src/create-managers.test.ts
@@ -19,6 +19,7 @@ let backgroundManagerOptions: {
   onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
 } | null = null
 let backgroundManagerConstructorCalls = 0
+let backgroundManagerUpdateCalls = 0
 const trackedPaneBySession = new Map<string, string>()
 const registeredCleanupManagers: CleanupRegistration[] = []
 const cleanupSessionTeamRunsMock = mock(async () => ({
@@ -32,6 +33,13 @@ class MockBackgroundManager {
     onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   }) {
     backgroundManagerConstructorCalls += 1
+    backgroundManagerOptions = config
+  }
+
+  updateRuntimeBindings(config: {
+    onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
+  }): void {
+    backgroundManagerUpdateCalls += 1
     backgroundManagerOptions = config
   }
 }
@@ -139,6 +147,7 @@ describe("createManagers", () => {
     dispatchOpenClawEvent.mockReset()
     backgroundManagerOptions = null
     backgroundManagerConstructorCalls = 0
+    backgroundManagerUpdateCalls = 0
     trackedPaneBySession.clear()
     registeredCleanupManagers.length = 0
     cleanupSessionTeamRunsMock.mockClear()
@@ -216,6 +225,36 @@ describe("createManagers", () => {
 
     expect(secondManagers.backgroundManager).toBe(firstManagers.backgroundManager)
     expect(backgroundManagerConstructorCalls).toBe(1)
+    expect(backgroundManagerUpdateCalls).toBe(1)
+  })
+
+  it("#given the plugin initializes twice for the same project #when the background session callback runs #then it uses the latest tmux manager", async () => {
+    const firstArgs = {
+      ctx: createContext("/tmp/project"),
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(false),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+    const secondArgs = {
+      ...firstArgs,
+      tmuxConfig: createTmuxConfig(true),
+    }
+
+    createManagers(firstArgs)
+    trackedPaneBySession.clear()
+    createManagers(secondArgs)
+
+    await backgroundManagerOptions?.onSubagentSessionCreated?.({
+      sessionID: "ses-bg-latest",
+      parentID: "ses-parent",
+      title: "child task",
+    })
+
+    expect(trackedPaneBySession.get("ses-bg-latest")).toBe("%pane-ses-bg-latest")
+    expect(backgroundManagerConstructorCalls).toBe(1)
+    expect(backgroundManagerUpdateCalls).toBe(1)
   })
 
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -38,6 +38,12 @@ const defaultCreateManagersDeps: CreateManagersDeps = {
   markServerRunningInProcessFn: markServerRunningInProcess,
 }
 
+const backgroundManagersByDirectory = new Map<string, BackgroundManager>()
+
+export function resetBackgroundManagerSingletonsForTesting(): void {
+  backgroundManagersByDirectory.clear()
+}
+
 export type Managers = {
   tmuxSessionManager: TmuxSessionManager
   backgroundManager: BackgroundManager
@@ -95,11 +101,18 @@ export function createManagers(args: {
     },
   })
 
-  backgroundManager = new deps.BackgroundManagerClass({
-    pluginContext: ctx,
-    config: pluginConfig.background_task,
-    tmuxConfig,
-    onSubagentSessionCreated: async (event: SubagentSessionCreatedEvent) => {
+  const backgroundManagerKey = ctx.directory
+  backgroundManager = backgroundManagersByDirectory.get(backgroundManagerKey)
+  if (backgroundManager) {
+    log("[create-managers] reusing BackgroundManager singleton", {
+      directory: backgroundManagerKey,
+    })
+  } else {
+    backgroundManager = new deps.BackgroundManagerClass({
+      pluginContext: ctx,
+      config: pluginConfig.background_task,
+      tmuxConfig,
+      onSubagentSessionCreated: async (event: SubagentSessionCreatedEvent) => {
         log("[create-managers] onSubagentSessionCreated callback received", {
           sessionID: event.sessionID,
           parentID: event.parentID,
@@ -130,18 +143,20 @@ export function createManagers(args: {
         }
 
         log("[create-managers] onSubagentSessionCreated callback completed")
-    },
-    onShutdown: async () => {
-      await cleanupTeamModeRuns().catch((error) => {
-        log("[create-managers] team-mode cleanup error during shutdown:", error)
-      })
-      await tmuxSessionManager.cleanup().catch((error) => {
-        log("[create-managers] tmux cleanup error during shutdown:", error)
-      })
-    },
-    enableParentSessionNotifications: backgroundNotificationHookEnabled,
-    modelFallbackControllerAccessor,
-  })
+      },
+      onShutdown: async () => {
+        await cleanupTeamModeRuns().catch((error) => {
+          log("[create-managers] team-mode cleanup error during shutdown:", error)
+        })
+        await tmuxSessionManager.cleanup().catch((error) => {
+          log("[create-managers] tmux cleanup error during shutdown:", error)
+        })
+      },
+      enableParentSessionNotifications: backgroundNotificationHookEnabled,
+      modelFallbackControllerAccessor,
+    })
+    backgroundManagersByDirectory.set(backgroundManagerKey, backgroundManager)
+  }
 
   deps.initTaskToastManagerFn(ctx.client)
 

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -101,18 +101,11 @@ export function createManagers(args: {
     },
   })
 
-  const backgroundManagerKey = ctx.directory
-  backgroundManager = backgroundManagersByDirectory.get(backgroundManagerKey)
-  if (backgroundManager) {
-    log("[create-managers] reusing BackgroundManager singleton", {
-      directory: backgroundManagerKey,
-    })
-  } else {
-    backgroundManager = new deps.BackgroundManagerClass({
-      pluginContext: ctx,
-      config: pluginConfig.background_task,
-      tmuxConfig,
-      onSubagentSessionCreated: async (event: SubagentSessionCreatedEvent) => {
+  const backgroundManagerConfig = {
+    pluginContext: ctx,
+    config: pluginConfig.background_task,
+    tmuxConfig,
+    onSubagentSessionCreated: async (event: SubagentSessionCreatedEvent) => {
         log("[create-managers] onSubagentSessionCreated callback received", {
           sessionID: event.sessionID,
           parentID: event.parentID,
@@ -143,18 +136,28 @@ export function createManagers(args: {
         }
 
         log("[create-managers] onSubagentSessionCreated callback completed")
-      },
-      onShutdown: async () => {
-        await cleanupTeamModeRuns().catch((error) => {
-          log("[create-managers] team-mode cleanup error during shutdown:", error)
-        })
-        await tmuxSessionManager.cleanup().catch((error) => {
-          log("[create-managers] tmux cleanup error during shutdown:", error)
-        })
-      },
-      enableParentSessionNotifications: backgroundNotificationHookEnabled,
-      modelFallbackControllerAccessor,
+    },
+    onShutdown: async () => {
+      await cleanupTeamModeRuns().catch((error) => {
+        log("[create-managers] team-mode cleanup error during shutdown:", error)
+      })
+      await tmuxSessionManager.cleanup().catch((error) => {
+        log("[create-managers] tmux cleanup error during shutdown:", error)
+      })
+    },
+    enableParentSessionNotifications: backgroundNotificationHookEnabled,
+    modelFallbackControllerAccessor,
+  }
+
+  const backgroundManagerKey = ctx.directory
+  backgroundManager = backgroundManagersByDirectory.get(backgroundManagerKey)
+  if (backgroundManager) {
+    log("[create-managers] reusing BackgroundManager singleton", {
+      directory: backgroundManagerKey,
     })
+    backgroundManager.updateRuntimeBindings(backgroundManagerConfig)
+  } else {
+    backgroundManager = new deps.BackgroundManagerClass(backgroundManagerConfig)
     backgroundManagersByDirectory.set(backgroundManagerKey, backgroundManager)
   }
 

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -301,6 +301,22 @@ export class BackgroundManager {
     this.registerProcessCleanup()
   }
 
+  updateRuntimeBindings(config: BackgroundManagerConfig): void {
+    const { pluginContext, ...options } = config
+    this.client = pluginContext.client
+    this.directory = pluginContext.directory
+    this.config = options.config
+    this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false
+    this.onSubagentSessionCreated = options?.onSubagentSessionCreated
+    this.onShutdown = options?.onShutdown
+    this.enableParentSessionNotifications = options?.enableParentSessionNotifications ?? true
+    this.modelFallbackControllerAccessor = options?.modelFallbackControllerAccessor
+    this.parentWakeNotifier.updateRuntimeDeps({
+      client: this.client,
+      directory: this.directory,
+    })
+  }
+
   private async abortSessionWithLogging(sessionID: string, reason: string): Promise<boolean> {
     try {
       const aborted = await abortWithTimeout(this.client, sessionID)

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -102,6 +102,11 @@ export class ParentWakeNotifier {
     private readonly options: ParentWakeNotifierOptions,
   ) {}
 
+  updateRuntimeDeps(input: Pick<ParentWakeNotifierDeps, "client" | "directory">): void {
+    this.deps.client = input.client
+    this.deps.directory = input.directory
+  }
+
   getPendingParentWakes(): Map<string, PendingParentWake> {
     return this.pendingParentWakes
   }


### PR DESCRIPTION
## Summary

Fixes #4095.

OpenCode Desktop can initialize the OMO plugin more than once for the same project. Before this change, each initialization created a separate BackgroundManager instance, so a task launched through one instance could be invisible to background_output routed through another instance.

This PR keeps one BackgroundManager singleton per project directory from createManagers(), so duplicate plugin initialization for the same project shares the same task store, polling state, and background_output lookup path.

## What changed

- Add a project-directory keyed BackgroundManager singleton in src/create-managers.ts.
- Reuse the existing manager when createManagers() is called again for the same directory.
- Add a regression test that initializes managers twice for one project and asserts the BackgroundManager constructor runs once and both results share the same instance.

## Test plan

- [x] LSP diagnostics on src/create-managers.ts and src/create-managers.test.ts: 0 errors.
- [x] bun test src/create-managers.test.ts: 6 pass / 0 fail.
- [x] bun run typecheck: pass.
- [x] bun run build: pass.
- [x] git diff --check: pass.

## PR Checklist

- [x] Code follows project conventions
- [x] bun run typecheck passes
- [x] bun run build succeeds
- [x] Tested locally through focused regression coverage
- [x] No version changes in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `BackgroundManager` a per-project singleton and refresh its runtime bindings on reuse. This prevents invisible tasks and keeps callbacks, tmux routing, and polling in sync.

- **Bug Fixes**
  - Reuse existing manager in `createManagers()` via a directory-keyed map; on reuse call `updateRuntimeBindings()` (client, tmux, callbacks) and log reuse.
  - Added `BackgroundManager.updateRuntimeBindings()` and `ParentWakeNotifier.updateRuntimeDeps()` to safely swap runtime deps.
  - Tests use `resetBackgroundManagerSingletonsForTesting()` and verify reuse, single constructor call, and that the latest tmux manager/callbacks are applied.

<sup>Written for commit 0b971f715bd5a795952c5854c1e41ca9cab03a9e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4280?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

