### PR TITLE
fix(todo-continuation): preserve completed-todos terminal guard

### DIFF
--- a/src/hooks/todo-continuation-enforcer/idle-event.test.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "bun:test"
 
 import { handleSessionIdle } from "./idle-event"
-import type { SessionStateStore } from "./session-state"
+import { createSessionStateStore, type SessionStateStore } from "./session-state"
 import type { ContinuationProgressUpdate, SessionState } from "./types"
 
 function createStateStore(): {
@@ -135,5 +135,44 @@ describe("handleSessionIdle", () => {
     expect(trackCalls).toHaveLength(0)
     // reset is still called only once (from the first idle)
     expect(resetCalls).toHaveLength(1)
+  })
+
+  it("keeps the completed-todos terminal guard after resetting continuation progress", async () => {
+    // given
+    const sessionID = "ses_real_store_completed_todos"
+    const store = createSessionStateStore()
+    let messageFetches = 0
+    let todoFetches = 0
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => {
+            messageFetches += 1
+            return { data: [] }
+          },
+          todo: async () => {
+            todoFetches += 1
+            return {
+              data: [
+                { id: "todo-1", content: "Ship", status: "completed", priority: "high" },
+                { id: "todo-2", content: "Verify", status: "completed", priority: "medium" },
+              ],
+            }
+          },
+        },
+      },
+      directory: "/tmp/test",
+    }
+
+    // when
+    await handleSessionIdle({ ctx: ctx as never, sessionID, sessionStateStore: store })
+    await handleSessionIdle({ ctx: ctx as never, sessionID, sessionStateStore: store })
+
+    // then
+    expect(store.getExistingState(sessionID)?.allTodosCompletedAt).toBeGreaterThan(0)
+    expect(messageFetches).toBe(1)
+    expect(todoFetches).toBe(1)
+
+    store.shutdown()
   })
 })

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -113,8 +113,8 @@ export async function handleSessionIdle(args: {
 
   const incompleteCount = getIncompleteCount(todos)
   if (incompleteCount === 0) {
-    state.allTodosCompletedAt = Date.now()
     sessionStateStore.resetContinuationProgress(sessionID)
+    state.allTodosCompletedAt = Date.now()
     log(`[${HOOK_NAME}] All todos complete`, { sessionID, total: todos.length })
     return
   }


### PR DESCRIPTION
## Summary

Fixes #4111.

When every todo was completed, handleSessionIdle set allTodosCompletedAt and then immediately called resetContinuationProgress(). The real SessionStateStore reset clears allTodosCompletedAt, so the terminal guard did not survive. Later session.idle events could re-enter the expensive todo-continuation path instead of treating the session as terminally complete.

This PR keeps the terminal completed-todos guard after resetting continuation progress, so repeated idle events do not refetch messages/todos or inject the full continuation prompt once all todos are done.

## What changed

- Reset continuation progress before setting allTodosCompletedAt.
- Add a regression test using the real SessionStateStore.
- Assert the second idle event exits through the completed-todos guard without fetching messages or todos again.

## Test plan

- [x] LSP diagnostics on idle-event.ts and idle-event.test.ts: 0 errors.
- [x] bun test src/hooks/todo-continuation-enforcer/idle-event.test.ts: 4 pass / 0 fail.
- [x] bun run typecheck: pass.
- [x] bun run build: pass.
- [x] git diff --check: pass.

## PR Checklist

- [x] Code follows project conventions
- [x] bun run typecheck passes
- [x] bun run build succeeds
- [x] Tested locally through focused regression coverage
- [x] No version changes in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the completed‑todos terminal guard so sessions don’t re-enter the continuation flow after all todos are done. Fixes #4111 and avoids extra message/todo fetches on repeated idle events.

- **Bug Fixes**
  - Reset continuation progress before setting `allTodosCompletedAt`.
  - Added a regression test with the real `createSessionStateStore` to ensure the guard persists.
  - Verified the second idle exits via the guard (no refetches, no continuation prompt).

<sup>Written for commit 6f883d6cef9779ae1183438b1772397d7acf55db. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

