### PR TITLE
fix(atlas): honor stopped continuation after boulder completion

### DIFF
--- a/src/hooks/atlas/idle-event.test.ts
+++ b/src/hooks/atlas/idle-event.test.ts
@@ -210,4 +210,55 @@ describe("handleAtlasSessionIdle completion nudge", () => {
     expect(promptAsyncMock).toHaveBeenCalledTimes(1)
     expect(getState(SESSION_ID).boulderCompletionNudgedAt?.[workId]).toBeNumber()
   })
+
+  it("does not send a completion nudge after continuation was explicitly stopped", async () => {
+    // given
+    const planPath = join(testDirectory, "plan.md")
+    writeFileSync(planPath, "## TODOs\n- [x] 1. Parse input\n")
+
+    const boulder = createBoulderState(planPath, SESSION_ID, "atlas")
+    const workId = boulder.active_work_id
+    if (!workId) {
+      throw new Error("Expected active_work_id")
+    }
+    writeBoulderState(testDirectory, boulder)
+
+    const promptAsyncMock = mock(async () => ({ data: {} }))
+    const ctx = unsafeTestValue<PluginInput>({
+      directory: testDirectory,
+      client: {
+        session: {
+          promptAsync: promptAsyncMock,
+        },
+      },
+    })
+    const retryTimer = setTimeout(() => {}, 60_000)
+    const sessionStateById = new Map<string, SessionState>([
+      [SESSION_ID, { promptFailureCount: 0, pendingRetryTimer: retryTimer }],
+    ])
+    const getState = (sessionId: string): SessionState => {
+      let state = sessionStateById.get(sessionId)
+      if (!state) {
+        state = { promptFailureCount: 0 }
+        sessionStateById.set(sessionId, state)
+      }
+      return state
+    }
+
+    // when
+    await handleAtlasSessionIdle({
+      ctx,
+      sessionID: SESSION_ID,
+      getState,
+      options: {
+        isContinuationStopped: (sessionId) => sessionId === SESSION_ID,
+      },
+    })
+
+    // then
+    expect(promptAsyncMock).not.toHaveBeenCalled()
+    expect(getState(SESSION_ID).pendingRetryTimer).toBeUndefined()
+    expect(getState(SESSION_ID).boulderCompletionNudgedAt?.[workId]).toBeUndefined()
+    expect(readBoulderState(testDirectory)?.works?.[workId]?.status).toBe("completed")
+  })
 })

--- a/src/hooks/atlas/idle-event.ts
+++ b/src/hooks/atlas/idle-event.ts
@@ -246,6 +246,11 @@ export async function handleAtlasSessionIdle(input: {
 
   const { boulderState, progress, appendedSession } = activeBoulderSession
   if (progress.isComplete) {
+    if (sessionState.pendingRetryTimer) {
+      clearTimeout(sessionState.pendingRetryTimer)
+      sessionState.pendingRetryTimer = undefined
+    }
+
     const work = getWorkForSession(ctx.directory, sessionID)
     if (work) {
       completeBoulder(ctx.directory, work.work_id)
@@ -255,6 +260,11 @@ export async function handleAtlasSessionIdle(input: {
 
     if (!work || work.status === "abandoned") {
       log(`[${HOOK_NAME}] Boulder complete`, { sessionID, plan: boulderState.plan_name })
+      return
+    }
+
+    if (options?.isContinuationStopped?.(sessionID)) {
+      log(`[${HOOK_NAME}] Boulder completion nudge skipped because continuation stopped`, { sessionID, plan: boulderState.plan_name })
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes #4149.

When a Boulder plan is already complete, stale retry timers and operator stop state should not produce another finalization turn. The existing completion nudge was idempotent per work, but the completion path did not cancel pending retry timers and did not honor /stop-continuation before sending the final BOULDER COMPLETE nudge.

This PR makes the completed-plan path terminal by clearing pending retry timers and skipping the final-summary nudge when continuation has been explicitly stopped for that session.

## What changed

- Clear pendingRetryTimer immediately when Atlas observes a complete Boulder plan.
- Check isContinuationStopped before dispatching the BOULDER COMPLETE final-summary nudge.
- Add a regression test proving stopped completion does not call promptAsync, clears the retry timer, and still persists the work as completed.

## Test plan

- [x] LSP diagnostics on src/hooks/atlas/idle-event.ts and idle-event.test.ts: 0 errors.
- [x] bun test src/hooks/atlas/idle-event.test.ts: 3 pass / 0 fail.
- [x] bun run typecheck: pass.
- [x] bun run build: pass.
- [x] git diff --check: pass.

## PR Checklist

- [x] Code follows project conventions
- [x] bun run typecheck passes
- [x] bun run build succeeds
- [x] Tested locally through focused regression coverage
- [x] No version changes in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a second finalization turn when a Boulder plan is already complete by making the completion path terminal and respecting stop-continuation. Fixes #4149.

- **Bug Fixes**
  - Clear any `pendingRetryTimer` when a plan completes.
  - Skip the final completion nudge when continuation is stopped for the session.
  - Add a regression test covering timer cleanup, no prompt dispatch, and persisted completed work.

<sup>Written for commit 7dae2711fc801de80ec5e2dba7fddd7098e7c507. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

