### PR TITLE
feat(config): excluded_agents — opt custom agents out of omo injections (#3735)

### DIFF
--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -40,6 +40,14 @@ export const OhMyOpenCodeConfigSchema = z.object({
   agent_definitions: AgentDefinitionsConfigSchema,
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),
   disabled_agents: z.array(z.string()).optional(),
+  /**
+   * Agents listed here keep working but receive NO omo runtime injections
+   * (no ultrawork system tag, no keyword-mode banners, no AGENTS.md /
+   * README / rules injection into tool output). Use for lightweight custom
+   * agents that have their own prompts and don't need omo's orchestration.
+   * Issue #3735.
+   */
+  excluded_agents: z.array(z.string()).optional(),
   disabled_skills: z.array(BuiltinSkillNameSchema).optional(),
   disabled_hooks: z.array(z.string()).optional(),
   disabled_commands: z.array(BuiltinCommandNameSchema).optional(),

--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -16,6 +16,7 @@ import {
   isSystemDirective,
   removeSystemReminders,
 } from "../../shared/system-directive"
+import { isAgentExcludedFromOmoInjection } from "../../shared/excluded-agents"
 import type { RalphLoopHook } from "../ralph-loop"
 import { isNonOmoAgent, isPlannerAgent } from "./constants"
 import type { DetectedKeyword } from "./detector"
@@ -35,6 +36,7 @@ export function createKeywordDetectorHook(
   _ralphLoop?: Pick<RalphLoopHook, "startLoop">,
   config?: KeywordDetectorConfig,
   defaultMode?: DefaultModeConfig,
+  excludedAgents?: readonly string[],
 ) {
   const disabledKeywords = config?.disabled_keywords
   const enabledExpansions = config?.enabled_expansions
@@ -81,6 +83,13 @@ export function createKeywordDetectorHook(
 
       if (isNonOmoAgent(currentAgent)) {
         log(`[keyword-detector] Skipping keyword injection for non-OMO agent`, { sessionID: input.sessionID, agent: currentAgent })
+        return
+      }
+
+      // Issue #3735 — respect `excluded_agents`: custom lightweight agents
+      // (e.g. cybersec) opted out of omo injections.
+      if (isAgentExcludedFromOmoInjection(currentAgent, excludedAgents)) {
+        log(`[keyword-detector] Skipping keyword injection for excluded agent`, { sessionID: input.sessionID, agent: currentAgent })
         return
       }
 

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -117,6 +117,63 @@ describe("keyword-detector message transform", () => {
     expect(textPart!.text).not.toContain("ALWAYS include load_skills=[]")
   })
 
+  // regression: issue #3735 — `excluded_agents` lets a custom lightweight agent
+  // opt out of keyword injection without disabling the whole hook.
+  test("should NOT inject keyword banner when the current agent is in excluded_agents", async () => {
+    // given
+    const collector = new ContextCollector()
+    const sessionID = "excluded-cybersec-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    updateSessionAgent(sessionID, "cybersec")
+    const hook = createKeywordDetectorHook(
+      createMockPluginInput(),
+      collector,
+      undefined,
+      undefined,
+      undefined,
+      ["cybersec"],
+    )
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "search for the bug" }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID, agent: "cybersec" }, output)
+
+    // then: text is unchanged — no [search-mode] banner
+    const textPart = output.parts.find((p) => p.type === "text")
+    expect(textPart!.text).toBe("search for the bug")
+    expect(textPart!.text).not.toContain("[search-mode]")
+  })
+
+  test("should still inject for non-excluded agents when excluded_agents is set", async () => {
+    // given: cybersec is excluded but the session is sisyphus
+    const collector = new ContextCollector()
+    const sessionID = "sisyphus-non-excluded-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    updateSessionAgent(sessionID, "sisyphus")
+    const hook = createKeywordDetectorHook(
+      createMockPluginInput(),
+      collector,
+      undefined,
+      undefined,
+      undefined,
+      ["cybersec"],
+    )
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "search for the bug" }],
+    }
+
+    // when
+    await hook["chat.message"]({ sessionID, agent: "sisyphus" }, output)
+
+    // then
+    const textPart = output.parts.find((p) => p.type === "text")
+    expect(textPart!.text).toContain("[search-mode]")
+  })
+
   test("should NOT transform when no keywords detected", async () => {
     // given - no keywords in message
     const collector = new ContextCollector()

--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -63,6 +63,7 @@ export function createPluginInterface(args: {
     "experimental.chat.system.transform": createSystemTransformHandler(
       pluginConfig.default_mode,
       getUltraworkMessage,
+      pluginConfig.excluded_agents,
     ),
 
     config: managers.configHandler,
@@ -87,6 +88,7 @@ export function createPluginInterface(args: {
     "tool.execute.after": createToolExecuteAfterHandler({
       ctx,
       hooks,
+      excludedAgents: pluginConfig.excluded_agents,
     }),
   }
 }

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -62,6 +62,7 @@ export function createTransformHooks(args: {
             ralphLoop ?? undefined,
             pluginConfig.keyword_detector,
             pluginConfig.default_mode,
+            pluginConfig.excluded_agents,
           ),
         { enabled: safeHookEnabled },
       )

--- a/src/plugin/system-transform.test.ts
+++ b/src/plugin/system-transform.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { _resetForTesting, setSessionAgent } from "../features/claude-code-session-state"
+import { createSystemTransformHandler } from "./system-transform"
+
+const ULTRAWORK_PAYLOAD = "<ultrawork-mode> heavy ultrawork instructions"
+
+describe("createSystemTransformHandler excluded_agents guard (#3735)", () => {
+  beforeEach(() => {
+    _resetForTesting()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+  })
+
+  test("skips ultrawork injection when current agent is in excluded_agents", async () => {
+    // given
+    setSessionAgent("s1", "cybersec")
+    const handler = createSystemTransformHandler(
+      { ultrawork: true },
+      () => ULTRAWORK_PAYLOAD,
+      ["cybersec"],
+    )
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler({ sessionID: "s1", model: { id: "claude", providerID: "anthropic" } }, output)
+
+    // then: system prompt is untouched
+    expect(output.system).toEqual(["base system prompt"])
+  })
+
+  test("still injects ultrawork for non-excluded agents", async () => {
+    // given
+    setSessionAgent("s2", "sisyphus")
+    const handler = createSystemTransformHandler(
+      { ultrawork: true },
+      () => ULTRAWORK_PAYLOAD,
+      ["cybersec"],
+    )
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler({ sessionID: "s2", model: { id: "claude", providerID: "anthropic" } }, output)
+
+    // then: sisyphus still gets the ultrawork tag
+    expect(output.system).toEqual(["base system prompt", ULTRAWORK_PAYLOAD])
+  })
+
+  test("matches excluded names case-insensitively", async () => {
+    // given: session agent is "CyberSec" (mixed case), config has "cybersec"
+    setSessionAgent("s3", "CyberSec")
+    const handler = createSystemTransformHandler(
+      { ultrawork: true },
+      () => ULTRAWORK_PAYLOAD,
+      ["cybersec"],
+    )
+    const output = { system: ["base"] }
+
+    // when
+    await handler({ sessionID: "s3", model: { id: "claude", providerID: "anthropic" } }, output)
+
+    // then
+    expect(output.system).toEqual(["base"])
+  })
+
+  test("injects normally when excluded_agents is undefined (backwards compatibility)", async () => {
+    // given
+    setSessionAgent("s4", "cybersec")
+    const handler = createSystemTransformHandler(
+      { ultrawork: true },
+      () => ULTRAWORK_PAYLOAD,
+    )
+    const output = { system: ["base"] }
+
+    // when
+    await handler({ sessionID: "s4", model: { id: "claude", providerID: "anthropic" } }, output)
+
+    // then: no excluded list means everyone gets the tag
+    expect(output.system).toEqual(["base", ULTRAWORK_PAYLOAD])
+  })
+
+  test("does not block when session agent is unknown (no setSessionAgent)", async () => {
+    // given: no session agent set for s5
+    const handler = createSystemTransformHandler(
+      { ultrawork: true },
+      () => ULTRAWORK_PAYLOAD,
+      ["cybersec"],
+    )
+    const output = { system: ["base"] }
+
+    // when
+    await handler({ sessionID: "s5", model: { id: "claude", providerID: "anthropic" } }, output)
+
+    // then: with no known agent, we can't tell — default behavior wins (inject)
+    expect(output.system).toEqual(["base", ULTRAWORK_PAYLOAD])
+  })
+})

--- a/src/plugin/system-transform.ts
+++ b/src/plugin/system-transform.ts
@@ -1,16 +1,24 @@
 import type { DefaultModeConfig } from "../config/schema/default-mode"
+import { getSessionAgent } from "../features/claude-code-session-state"
+import { isAgentExcludedFromOmoInjection } from "../shared/excluded-agents"
 
 const ULTRAWORK_MODE_TAG = "<ultrawork-mode>"
 
 export function createSystemTransformHandler(
   defaultMode?: DefaultModeConfig,
   getUltraworkMessage?: (agentName?: string, modelID?: string) => string,
+  excludedAgents?: readonly string[],
 ): (
   input: { sessionID?: string; model: { id: string; providerID: string; [key: string]: unknown } },
   output: { system: string[] },
 ) => Promise<void> {
   return async (input, output): Promise<void> => {
     if (!defaultMode?.ultrawork || !getUltraworkMessage) return
+
+    // Issue #3735 — respect `excluded_agents`: skip omo's ultrawork tag injection
+    // for agents the user opted out of.
+    const sessionAgent = input.sessionID ? getSessionAgent(input.sessionID) : undefined
+    if (isAgentExcludedFromOmoInjection(sessionAgent, excludedAgents)) return
 
     // Avoid re-injecting if the ultrawork prompt is already in the system prompt
     // (e.g. after compaction the system prompt is rebuilt and this hook fires again)

--- a/src/plugin/tool-execute-after.test.ts
+++ b/src/plugin/tool-execute-after.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 
+import { _resetForTesting, setSessionAgent } from "../features/claude-code-session-state"
 import { clearPendingStore, storeToolMetadata } from "../features/tool-metadata-store"
 import { createToolExecuteAfterHandler } from "./tool-execute-after"
 
@@ -171,5 +172,114 @@ describe("createToolExecuteAfterHandler", () => {
 
     // then
     expect(seenArgs).toBe(args)
+  })
+
+  // regression: issue #3735 — for `excluded_agents`, omo's three tool-output
+  // injectors (rules / AGENTS.md / README) must be silenced so a custom
+  // lightweight agent (e.g. cybersec) doesn't accumulate omo banner content
+  // in tool output context.
+  describe("excluded_agents guard (#3735)", () => {
+    beforeEach(() => {
+      _resetForTesting()
+    })
+    afterEach(() => {
+      _resetForTesting()
+    })
+
+    it("skips rules/agents-md/readme injectors when the session agent is excluded", async () => {
+      // given
+      setSessionAgent("ses_excluded", "cybersec")
+      const callOrder: string[] = []
+      const handler = createToolExecuteAfterHandler({
+        ctx: { directory: "/repo" } as never,
+        hooks: {
+          toolOutputTruncator: {
+            "tool.execute.after": async () => { callOrder.push("truncator") },
+          },
+          rulesInjector: {
+            "tool.execute.after": async () => { callOrder.push("rules") },
+          },
+          directoryAgentsInjector: {
+            "tool.execute.after": async () => { callOrder.push("agents-md") },
+          },
+          directoryReadmeInjector: {
+            "tool.execute.after": async () => { callOrder.push("readme") },
+          },
+        } as never,
+        excludedAgents: ["cybersec"],
+      })
+
+      // when
+      await handler(
+        { tool: "hashline_edit", sessionID: "ses_excluded", callID: "c1" },
+        { title: "result", output: "out", metadata: {} },
+      )
+
+      // then: safety hooks ran; omo-specific injectors did NOT
+      expect(callOrder).toContain("truncator")
+      expect(callOrder).not.toContain("rules")
+      expect(callOrder).not.toContain("agents-md")
+      expect(callOrder).not.toContain("readme")
+    })
+
+    it("still runs all injectors for non-excluded agents", async () => {
+      // given
+      setSessionAgent("ses_sisyphus", "sisyphus")
+      const callOrder: string[] = []
+      const handler = createToolExecuteAfterHandler({
+        ctx: { directory: "/repo" } as never,
+        hooks: {
+          toolOutputTruncator: {
+            "tool.execute.after": async () => { callOrder.push("truncator") },
+          },
+          rulesInjector: {
+            "tool.execute.after": async () => { callOrder.push("rules") },
+          },
+          directoryAgentsInjector: {
+            "tool.execute.after": async () => { callOrder.push("agents-md") },
+          },
+          directoryReadmeInjector: {
+            "tool.execute.after": async () => { callOrder.push("readme") },
+          },
+        } as never,
+        excludedAgents: ["cybersec"],
+      })
+
+      // when
+      await handler(
+        { tool: "hashline_edit", sessionID: "ses_sisyphus", callID: "c2" },
+        { title: "result", output: "out", metadata: {} },
+      )
+
+      // then: order matches tool-execute-after.ts hook sequence
+      expect(callOrder).toEqual(["truncator", "agents-md", "readme", "rules"])
+    })
+
+    it("runs all injectors when excluded_agents is undefined (backwards compatibility)", async () => {
+      // given
+      setSessionAgent("ses_default", "cybersec")
+      const callOrder: string[] = []
+      const handler = createToolExecuteAfterHandler({
+        ctx: { directory: "/repo" } as never,
+        hooks: {
+          rulesInjector: {
+            "tool.execute.after": async () => { callOrder.push("rules") },
+          },
+          directoryAgentsInjector: {
+            "tool.execute.after": async () => { callOrder.push("agents-md") },
+          },
+        } as never,
+        // no excludedAgents
+      })
+
+      // when
+      await handler(
+        { tool: "hashline_edit", sessionID: "ses_default", callID: "c3" },
+        { title: "result", output: "out", metadata: {} },
+      )
+
+      // then
+      expect(callOrder).toEqual(["agents-md", "rules"])
+    })
   })
 })

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -1,7 +1,9 @@
 import { recoverToolMetadata } from "../features/tool-metadata-store"
 import type { CreatedHooks } from "../create-hooks"
+import { getSessionAgent } from "../features/claude-code-session-state"
 import { log } from "../shared/logger"
 import { stripInvisibleAgentCharacters } from "../shared/agent-display-names"
+import { isAgentExcludedFromOmoInjection } from "../shared/excluded-agents"
 import type { PluginContext } from "./types"
 
 const VERIFICATION_ATTEMPT_PATTERN = /<ulw_verification_attempt_id>(.*?)<\/ulw_verification_attempt_id>/i
@@ -43,11 +45,12 @@ function getPluginDirectory(ctx: PluginContext): string | null {
 export function createToolExecuteAfterHandler(args: {
   ctx: PluginContext
   hooks: CreatedHooks
+  excludedAgents?: readonly string[]
 }): (
   input: ToolExecuteAfterInput,
   output: ToolExecuteAfterOutput | undefined,
 ) => Promise<void> {
-  const { ctx, hooks } = args
+  const { ctx, hooks, excludedAgents } = args
 
   // OpenCode injects tool call ids into execute() context and after-hook input via undocumented runtime fields.
   // We must treat their identity as a best-effort correlation key, not a guaranteed public contract.
@@ -149,14 +152,23 @@ export function createToolExecuteAfterHandler(args: {
     }
 
     const runToolExecuteAfterHooks = async (): Promise<void> => {
+      // Issue #3735 — for `excluded_agents`, skip the three omo-specific injectors
+      // that prepend AGENTS.md / README / rules content to every tool output. The
+      // other hooks (truncation, compaction, monitoring, validation, recovery) are
+      // safety/UX nets that must always run regardless of agent.
+      const sessionAgent = getSessionAgent(hookInput.sessionID)
+      const skipOmoInjectors = isAgentExcludedFromOmoInjection(sessionAgent, excludedAgents)
+
       await hooks.toolOutputTruncator?.["tool.execute.after"]?.(hookInput, output)
       await hooks.claudeCodeHooks?.["tool.execute.after"]?.(hookInput, output)
       await hooks.preemptiveCompaction?.["tool.execute.after"]?.(hookInput, output)
       await hooks.contextWindowMonitor?.["tool.execute.after"]?.(hookInput, output)
       await hooks.commentChecker?.["tool.execute.after"]?.(hookInput, output)
-      await hooks.directoryAgentsInjector?.["tool.execute.after"]?.(hookInput, output)
-      await hooks.directoryReadmeInjector?.["tool.execute.after"]?.(hookInput, output)
-      await hooks.rulesInjector?.["tool.execute.after"]?.(hookInput, output)
+      if (!skipOmoInjectors) {
+        await hooks.directoryAgentsInjector?.["tool.execute.after"]?.(hookInput, output)
+        await hooks.directoryReadmeInjector?.["tool.execute.after"]?.(hookInput, output)
+        await hooks.rulesInjector?.["tool.execute.after"]?.(hookInput, output)
+      }
       await hooks.emptyTaskResponseDetector?.["tool.execute.after"]?.(hookInput, output)
       await hooks.agentUsageReminder?.["tool.execute.after"]?.(hookInput, output)
       await hooks.categorySkillReminder?.["tool.execute.after"]?.(hookInput, output)

--- a/src/shared/excluded-agents.test.ts
+++ b/src/shared/excluded-agents.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { isAgentExcludedFromOmoInjection } from "./excluded-agents"
+
+describe("isAgentExcludedFromOmoInjection (issue #3735)", () => {
+  test("returns false when excluded_agents is undefined", () => {
+    expect(isAgentExcludedFromOmoInjection("cybersec", undefined)).toBe(false)
+  })
+
+  test("returns false when excluded_agents is empty", () => {
+    expect(isAgentExcludedFromOmoInjection("cybersec", [])).toBe(false)
+  })
+
+  test("returns false when agent name is undefined", () => {
+    expect(isAgentExcludedFromOmoInjection(undefined, ["cybersec"])).toBe(false)
+  })
+
+  test("returns false when agent name is empty / whitespace only", () => {
+    expect(isAgentExcludedFromOmoInjection("", ["cybersec"])).toBe(false)
+    expect(isAgentExcludedFromOmoInjection("   ", ["cybersec"])).toBe(false)
+  })
+
+  test("matches exact lowercase agent name", () => {
+    expect(isAgentExcludedFromOmoInjection("cybersec", ["cybersec"])).toBe(true)
+  })
+
+  test("matches case-insensitively", () => {
+    expect(isAgentExcludedFromOmoInjection("CyberSec", ["cybersec"])).toBe(true)
+    expect(isAgentExcludedFromOmoInjection("cybersec", ["CyberSec"])).toBe(true)
+    expect(isAgentExcludedFromOmoInjection("CYBERSEC", ["CyberSec"])).toBe(true)
+  })
+
+  test("treats underscores, spaces, and hyphens interchangeably", () => {
+    expect(isAgentExcludedFromOmoInjection("cyber-sec", ["cyber_sec"])).toBe(true)
+    expect(isAgentExcludedFromOmoInjection("cyber sec", ["cyber-sec"])).toBe(true)
+    expect(isAgentExcludedFromOmoInjection("cyber_sec", ["cyber sec"])).toBe(true)
+  })
+
+  test("returns false for non-matching names", () => {
+    expect(isAgentExcludedFromOmoInjection("sisyphus", ["cybersec"])).toBe(false)
+  })
+
+  test("matches any agent in the list, not just the first", () => {
+    expect(isAgentExcludedFromOmoInjection("audit", ["cybersec", "audit", "review"])).toBe(true)
+  })
+
+  test("does not partial-match (cyber should not match cybersec)", () => {
+    expect(isAgentExcludedFromOmoInjection("cyber", ["cybersec"])).toBe(false)
+    expect(isAgentExcludedFromOmoInjection("cybersec", ["cyber"])).toBe(false)
+  })
+})

--- a/src/shared/excluded-agents.ts
+++ b/src/shared/excluded-agents.ts
@@ -1,0 +1,34 @@
+// Helper for issue #3735 — `excluded_agents` config lets custom lightweight
+// agents opt out of omo's runtime prompt injections (ultrawork tag, keyword
+// banners, rules/AGENTS.md/README tool-output injection) while keeping the
+// rest of the plugin (model resolution, tools, etc.) intact.
+
+/**
+ * Normalizes an agent name for case- and separator-insensitive comparison.
+ * Mirrors how `disabled_agents` is matched in `cli/run/agent-resolver.ts`.
+ */
+function normalizeAgentName(name: string): string {
+  return name.trim().toLowerCase().replace(/[_\s]+/g, "-")
+}
+
+/**
+ * Returns true when the given agent should be excluded from omo's runtime
+ * prompt injections. Matching is case-insensitive and treats `_`, ` ` and
+ * `-` interchangeably, matching the casing tolerance users expect from
+ * existing `disabled_agents` behavior.
+ *
+ * @param agentName The agent name reported by the current session (may be
+ *   undefined when OpenCode hasn't routed the message to a named agent yet —
+ *   in that case nothing is excluded, since we can't tell).
+ * @param excludedAgents The `excluded_agents` array from plugin config.
+ */
+export function isAgentExcludedFromOmoInjection(
+  agentName: string | undefined,
+  excludedAgents: readonly string[] | undefined,
+): boolean {
+  if (!agentName) return false
+  if (!excludedAgents || excludedAgents.length === 0) return false
+  const target = normalizeAgentName(agentName)
+  if (target.length === 0) return false
+  return excludedAgents.some((excluded) => normalizeAgentName(excluded) === target)
+}


### PR DESCRIPTION
Closes #3735.

## Problem
omo's runtime hooks inject content into every agent session:
- The \`<ultrawork-mode>\` system-prompt tag.
- Keyword-mode banners (\`[search-mode]\`, \`[analyze-mode]\`, etc.) prepended to user messages.
- AGENTS.md / README / rules content appended to every tool output.

For users who keep omo around mainly for Sisyphus but also run a lightweight custom agent (the issue's example is a cybersec pentesting agent with a ~1.7K-token prompt), this adds tens of thousands of input tokens to every turn — even on \"hi\".

## What's added
A new config field:

\`\`\`jsonc
{
  \"excluded_agents\": [\"cybersec\"],
  \"agents\": { \"sisyphus\": { \"model\": \"...\" } }
}
\`\`\`

Agents listed here continue to work, but omo skips three runtime hooks for them:

| Guard point | What's skipped |
|---|---|
| \`src/plugin/system-transform.ts\` | \`<ultrawork-mode>\` tag injection into \`output.system\` |
| \`src/hooks/keyword-detector/hook.ts\` | All keyword-mode banner prepends |
| \`src/plugin/tool-execute-after.ts\` | \`directoryAgentsInjector\` + \`directoryReadmeInjector\` + \`rulesInjector\` |

Safety/recovery hooks (output truncation, preemptive compaction, format validators, edit-error recovery, etc.) still run because they're correctness nets, not opinionated content injection.

A shared helper \`src/shared/excluded-agents.ts\` implements the matching logic — case-insensitive, treats \`_\`, \` \`, \`-\` interchangeably (same tolerance as existing \`disabled_agents\`).

## Test plan
- [x] \`isAgentExcludedFromOmoInjection\` helper: 10 unit tests (undefined/empty/case/separator/partial-match).
- [x] \`system-transform\` guard: 5 tests (skip excluded, allow non-excluded, case-insensitive, backwards-compat when undefined, no-op when no agent set).
- [x] \`keyword-detector\` guard: 2 new regression tests (excluded agent gets no banner; non-excluded still does).
- [x] \`tool-execute-after\` guard: 3 new tests (excluded skips 3 omo injectors; non-excluded runs all in order; undefined config keeps prior behavior).
- [x] Full sweep \`bun test src/shared/excluded-agents.test.ts src/plugin/system-transform.test.ts src/plugin/tool-execute-after.test.ts src/hooks/keyword-detector/\` → 118 pass / 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `excluded_agents` config to let specific agents skip omo runtime injections, reducing token bloat for lightweight custom agents. Addresses #3735 and keeps default behavior unchanged.

- **New Features**
  - Added `excluded_agents: string[]` to config.
  - Case-insensitive matching; `_`, `-`, and spaces are equivalent.
  - Guards added in `system-transform`, `keyword-detector`, and `tool-execute-after` to skip the ultrawork tag, keyword banners, and AGENTS.md/README/rules injectors.
  - Safety and recovery hooks still run.

- **Migration**
  - No changes needed by default.
  - To opt out for an agent, set `excluded_agents: ["cybersec"]` in your config.

<sup>Written for commit 079a5f9df127d6c79f10fc949aeb78d7f66ed686. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4283?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

