### PR TITLE
fix(look-at): send json files as text parts

### DIFF
--- a/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { basename } from "node:path"
 import { pathToFileURL } from "node:url"
 import type { LookAtArgs } from "./types"
@@ -21,8 +22,15 @@ export interface LookAtFilePart {
   filename: string
 }
 
+export interface LookAtTextPart {
+  type: "text"
+  text: string
+}
+
+export type LookAtInputPart = LookAtFilePart | LookAtTextPart
+
 export interface PreparedLookAtInput {
-  readonly filePart: LookAtFilePart
+  readonly inputPart: LookAtInputPart
   readonly isBase64Input: boolean
   readonly sourceDescription: string
   cleanup(): void
@@ -48,6 +56,14 @@ function getTemporaryConversionPath(error: unknown): string | null {
   }
 
   return null
+}
+
+function createJsonTextPart(filePath: string): LookAtTextPart {
+  const fileContent = readFileSync(filePath, "utf-8")
+  return {
+    type: "text",
+    text: `Attached JSON file (${basename(filePath)}):\n\n${fileContent}`,
+  }
 }
 
 export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
@@ -83,7 +99,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       value: {
         isBase64Input: true,
         sourceDescription: "clipboard/pasted image",
-        filePart: {
+        inputPart: {
           type: "file",
           mime: finalMimeType,
           url: `data:${finalMimeType};base64,${finalBase64Data}`,
@@ -102,6 +118,18 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
     let mimeType = inferMimeTypeFromFilePath(filePath)
     let actualFilePath = filePath
     let tempConversionPath: string | null = null
+
+    if (mimeType === "application/json") {
+      return {
+        ok: true,
+        value: {
+          isBase64Input: false,
+          sourceDescription: filePath,
+          inputPart: createJsonTextPart(filePath),
+          cleanup() {},
+        },
+      }
+    }
 
     if (needsConversion(mimeType)) {
       log(`[look_at] Detected unsupported format: ${mimeType}, converting to JPEG...`)
@@ -129,7 +157,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       value: {
         isBase64Input: false,
         sourceDescription: filePath,
-        filePart: {
+        inputPart: {
           type: "file",
           mime: mimeType,
           url: pathToFileURL(actualFilePath).href,

--- a/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
@@ -4,7 +4,7 @@ import { isAmbiguousPromptDispatchFailure, log, promptSyncWithModelSuggestionRet
 import { extractLatestAssistantText } from "./assistant-message-extractor"
 import { MULTIMODAL_LOOKER_AGENT } from "./constants"
 import { READ_ENABLED, buildLookAtPrompt } from "./look-at-prompt"
-import type { LookAtFilePart } from "./look-at-input-preparer"
+import type { LookAtInputPart } from "./look-at-input-preparer"
 import { resolveMultimodalLookerAgentMetadata } from "./multimodal-agent-metadata"
 import { waitForLookAtSessionResult } from "./session-poller"
 
@@ -12,7 +12,7 @@ interface RunLookAtSessionInput {
   ctx: PluginInput
   toolContext: ToolContext
   goal: string
-  filePart: LookAtFilePart
+  inputPart: LookAtInputPart
   isBase64Input: boolean
 }
 
@@ -20,7 +20,7 @@ export async function runLookAtSession({
   ctx,
   toolContext,
   goal,
-  filePart,
+  inputPart,
   isBase64Input,
 }: RunLookAtSessionInput): Promise<string> {
   const prompt = buildLookAtPrompt(goal, isBase64Input)
@@ -75,7 +75,7 @@ Original error: ${createResult.error}`
         },
         parts: [
           { type: "text", text: prompt },
-          filePart,
+          inputPart,
         ],
         ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
         ...(agentVariant ? { variant: agentVariant } : {}),

--- a/packages/omo-opencode/src/tools/look-at/tools.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test, mock } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { clearVisionCapableModelsCache, setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
@@ -566,6 +569,51 @@ describe("look-at tool", () => {
       )
       expect(result).toContain("Error")
       expect(result).toContain("string error thrown")
+    })
+
+    test("sends JSON files as text instead of unsupported application/json file parts", async () => {
+      const temporaryDirectory = mkdtempSync(join(tmpdir(), "omo-look-at-json-"))
+      const jsonPath = join(temporaryDirectory, "sample.json")
+      writeFileSync(jsonPath, JSON.stringify({ hello: "world" }), "utf-8")
+
+      let promptBody: { parts: Array<{ type: string; text?: string; mime?: string }> } | undefined
+      const mockClient = {
+        app: {
+          agents: async () => ({ data: [] }),
+        },
+        session: {
+          get: async () => ({ data: { directory: temporaryDirectory } }),
+          create: async () => ({ data: { id: "ses_json_text" } }),
+          prompt: async (input: { body: { parts: Array<{ type: string; text?: string; mime?: string }> } }) => {
+            promptBody = input.body
+            return { data: {} }
+          },
+          messages: async () => ({
+            data: [
+              { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "ok" }] },
+            ],
+          }),
+        },
+      }
+
+      try {
+        const tool = createLookAt(unsafeTestValue({
+          client: mockClient,
+          directory: temporaryDirectory,
+        }))
+
+        const result = await tool.execute(
+          { file_path: jsonPath, goal: "summarize json" },
+          createToolContext(),
+        )
+
+        expect(result).toBe("ok")
+        expect(promptBody).toBeDefined()
+        expect(promptBody?.parts.some((part) => part.type === "file" && part.mime === "application/json")).toBe(false)
+        expect(promptBody?.parts.some((part) => part.type === "text" && part.text?.includes('{"hello":"world"}'))).toBe(true)
+      } finally {
+        rmSync(temporaryDirectory, { recursive: true, force: true })
+      }
     })
   })
 

--- a/packages/omo-opencode/src/tools/look-at/tools.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.ts
@@ -40,7 +40,7 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
           ctx,
           toolContext,
           goal: args.goal,
-          filePart: preparedInput.filePart,
+          inputPart: preparedInput.inputPart,
           isBase64Input,
         })
       } catch (error) {


### PR DESCRIPTION
## Summary

- Prevent `look_at` from sending JSON files as `application/json` file parts.
- Inline JSON file contents as a text part so providers using the AI SDK do not reject the prompt.

## Changes

- Add a text-part path for `.json` inputs in the look_at input preparer.
- Generalize the look_at session runner input from file-only to file-or-text parts.
- Add regression coverage proving JSON does not produce an `application/json` file part.

## Testing

```bash
bun test src/tools/look-at/tools.test.ts --bail
bun run typecheck
bun run build
```

## Related Issues

Closes #4249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `look-at` tool to send `.json` files as text parts with inlined content (not `application/json` file parts), preventing provider rejections and fixing prompt failures. Also broadens input handling and adds regression coverage.

- **Bug Fixes**
  - Generalizes input from `filePart` to `inputPart` (file or text) across the preparer, session runner, and tool wiring.
  - For `.json` inputs, reads file content and emits a single text part prefixed with the filename; adds a test verifying no `application/json` file parts are sent.

<sup>Written for commit 0a96925683c22c1ec099eaf31a1c2f1d243c6f0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

