### PR TITLE
fix(tool-pair-validator): continue after synthetic repairs

### DIFF
--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -9,6 +9,7 @@ import { createToolPairValidatorHook } from "./hook"
 import { _resetForTesting, subagentSessions } from "../../features/claude-code-session-state/state"
 
 const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)"
+const TOOL_RESULT_RECOVERY_CONTINUATION = "Recovered missing tool results. Continue from the repaired tool output."
 
 type TestPart = {
   type: string
@@ -19,6 +20,7 @@ type TestPart = {
   isError?: boolean
   content?: string | Array<{ type: "text"; text: string }>
   text?: string
+  synthetic?: boolean
 }
 
 type TestMessage = {
@@ -121,6 +123,11 @@ describe("createToolPairValidatorHook", () => {
             isError: true,
             content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
           },
+          {
+            type: "text",
+            text: TOOL_RESULT_RECOVERY_CONTINUATION,
+            synthetic: true,
+          },
         ],
       },
     ])
@@ -148,6 +155,10 @@ describe("createToolPairValidatorHook", () => {
           tool_use_id: "toolu_1",
           isError: true,
           content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+        }, {
+          type: "text",
+          text: TOOL_RESULT_RECOVERY_CONTINUATION,
+          synthetic: true,
         }],
       },
       { info: { role: "assistant" }, parts: [{ type: "text", text: "follow-up" }] },

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -4,6 +4,7 @@ import { subagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared/logger"
 
 const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)"
+const TOOL_RESULT_RECOVERY_CONTINUATION = "Recovered missing tool results. Continue from the repaired tool output."
 
 type ToolUsePart = {
   type: "tool_use"
@@ -20,7 +21,13 @@ type ToolResultPart = {
   [key: string]: unknown
 }
 
-type TransformPart = Part | ToolUsePart | ToolResultPart
+type TextPart = {
+  type: "text"
+  text: string
+  synthetic: true
+}
+
+type TransformPart = Part | ToolUsePart | ToolResultPart | TextPart
 
 type TransformMessageInfo = Message | {
   role: "user"
@@ -138,7 +145,14 @@ function createSyntheticUserMessage(assistantMessage: MessageWithParts, missingT
       role: "user",
       ...(sessionID ? { sessionID } : {}),
     },
-    parts: missingToolUseIDs.map((toolUseID) => createToolResultPart(toolUseID)),
+    parts: [
+      ...missingToolUseIDs.map((toolUseID) => createToolResultPart(toolUseID)),
+      {
+        type: "text",
+        text: TOOL_RESULT_RECOVERY_CONTINUATION,
+        synthetic: true,
+      },
+    ],
   }
 }
 

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -157,6 +157,10 @@ describe("createMessagesTransformHandler", () => {
         tool_use_id: "toolu_01SRMQs3DUtVKWoSxC8bxxVA",
         isError: true,
         content: [{ type: "text", text: "Tool output unavailable (context compacted)" }],
+      }, {
+        type: "text",
+        text: "Recovered missing tool results. Continue from the repaired tool output.",
+        synthetic: true,
       }],
     })
     expect(messages[4]?.parts[0]).toEqual({


### PR DESCRIPTION
## Summary

Fixes #4123.

When tool-pair-validator has to synthesize a missing user turn for orphaned tool calls, the repaired message only contained tool_result blocks. That restores API structure but gives the repaired turn no explicit continuation signal. This PR adds a synthetic text continuation part after the recovered tool_result blocks so the repaired transform output drives the next assistant turn instead of leaving the session inert.

## What changed

- Add a synthetic continuation text part to synthetic repair user messages.
- Preserve existing behavior for repairs inserted into an existing user message.
- Update direct tool-pair-validator and messages-transform regression tests.

## Test plan

- [x] LSP diagnostics on changed files: 0 errors.
- [x] bun test src/hooks/tool-pair-validator/hook.test.ts src/plugin/messages-transform.test.ts: 21 pass / 0 fail.
- [x] bun run typecheck: pass.
- [x] bun run build: pass.
- [x] git diff --check: pass.

## PR Checklist

- [x] Code follows project conventions
- [x] bun run typecheck passes
- [x] bun run build succeeds
- [x] Tested locally through focused regression coverage
- [x] No version changes in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linear #4123 by appending a synthetic text continuation after recovered tool_result blocks when `tool-pair-validator` synthesizes a user turn for orphaned tool calls. This ensures the repaired turn triggers the next assistant message; repairs inside existing user messages remain unchanged.

<sup>Written for commit 28569307ebbb04902b08eb7a228ac64244bd70a9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

