### PR TITLE
feat(mcp): add @modelcontextprotocol/server-memory as a builtin MCP

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,6 +3,7 @@ import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
 import { createAstGrepMcpConfig } from "./ast-grep"
 import { createLspMcpConfig, type LocalMcpConfig } from "./lsp"
+import { createServerMemoryConfig } from "./server-memory"
 import type { RuntimeExecutableResolver } from "./runtime-executable"
 import type { OhMyOpenCodeConfig } from "../config/schema"
 
@@ -51,6 +52,10 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: OhMyOpen
       disabledTools: config?.disabled_tools,
       resolveExecutable: options.resolveExecutable,
     })
+  }
+
+  if (!disabledMcps.includes("memory")) {
+    mcps.memory = createServerMemoryConfig()
   }
 
   return mcps

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -55,7 +55,7 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: OhMyOpen
   }
 
   if (!disabledMcps.includes("memory")) {
-    mcps.memory = createServerMemoryConfig()
+    mcps.memory = createServerMemoryConfig({ resolveExecutable: options.resolveExecutable })
   }
 
   return mcps

--- a/src/mcp/server-memory.test.ts
+++ b/src/mcp/server-memory.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import * as logger from "../shared/logger"
 import { createServerMemoryConfig } from "./server-memory"
 import type { RuntimeExecutableResolver } from "./runtime-executable"
 
@@ -106,5 +107,35 @@ describe("createServerMemoryConfig", () => {
     expect(existsSync(dirname(filePath))).toBe(false)
     createServerMemoryConfig({ resolveExecutable: npxAvailable })
     expect(existsSync(dirname(filePath))).toBe(true)
+  })
+
+  // cubic-dev-ai follow-up: don't swallow mkdir errors silently
+  test("logs (but does not throw) when the memory file parent directory cannot be created", () => {
+    // given: a path whose parent would be a child of an existing FILE — mkdirSync
+    // with recursive:true fails ENOTDIR in this case on every platform.
+    const tmp = mkdtempSync(join(tmpdir(), "omo-mem-mkdir-fail-"))
+    tempDirs.push(tmp)
+    const blockingFile = join(tmp, "im-a-file-not-a-dir")
+    writeFileSync(blockingFile, "x")
+    // child path under a file → mkdirSync(parent) throws
+    process.env["OMO_MEMORY_FILE_PATH"] = join(blockingFile, "nested", "memory.json")
+
+    const logSpy = spyOn(logger, "log").mockImplementation(() => {})
+    try {
+      // when
+      const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
+
+      // then: didn't throw, still produced a usable config
+      expect(config.enabled).toBe(true)
+      expect(config.environment?.MEMORY_FILE_PATH).toContain("memory.json")
+
+      // and: log captured a breadcrumb the user can find
+      const memoryLogs = logSpy.mock.calls.filter(
+        (call) => typeof call[0] === "string" && (call[0] as string).includes("[mcp/memory]"),
+      )
+      expect(memoryLogs.length).toBeGreaterThan(0)
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 })

--- a/src/mcp/server-memory.test.ts
+++ b/src/mcp/server-memory.test.ts
@@ -1,13 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, join } from "node:path"
 import { createServerMemoryConfig } from "./server-memory"
+import type { RuntimeExecutableResolver } from "./runtime-executable"
+
+const npxAvailable: RuntimeExecutableResolver = (name) => ({
+  command: name === "npx" ? "/usr/local/bin/npx" : name,
+  available: name === "npx",
+})
+const npxMissing: RuntimeExecutableResolver = (name) => ({
+  command: name,
+  available: false,
+})
 
 describe("createServerMemoryConfig", () => {
   const originalEnv = {
     OMO_MEMORY_FILE_PATH: process.env["OMO_MEMORY_FILE_PATH"],
     XDG_CACHE_HOME: process.env["XDG_CACHE_HOME"],
   }
+  const tempDirs: string[] = []
 
   beforeEach(() => {
     delete process.env["OMO_MEMORY_FILE_PATH"]
@@ -22,40 +34,77 @@ describe("createServerMemoryConfig", () => {
         process.env[key] = value
       }
     }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   test("returns a LocalMcpConfig that launches the official server-memory package", () => {
-    const config = createServerMemoryConfig()
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
     expect(config.type).toBe("local")
     expect(config.enabled).toBe(true)
-    expect(config.command).toEqual(["npx", "-y", "@modelcontextprotocol/server-memory"])
+    expect(config.command).toEqual(["/usr/local/bin/npx", "-y", "@modelcontextprotocol/server-memory"])
   })
 
   test("uses ~/.cache/opencode/oh-my-openagent-memory.json by default", () => {
-    const config = createServerMemoryConfig()
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
     expect(config.environment?.MEMORY_FILE_PATH).toBe(
       join(homedir(), ".cache", "opencode", "oh-my-openagent-memory.json"),
     )
   })
 
   test("respects XDG_CACHE_HOME when set", () => {
-    process.env["XDG_CACHE_HOME"] = "/tmp/cache"
-    const config = createServerMemoryConfig()
+    const tmp = mkdtempSync(join(tmpdir(), "omo-mem-xdg-"))
+    tempDirs.push(tmp)
+    process.env["XDG_CACHE_HOME"] = tmp
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
     expect(config.environment?.MEMORY_FILE_PATH).toBe(
-      "/tmp/cache/opencode/oh-my-openagent-memory.json",
+      join(tmp, "opencode", "oh-my-openagent-memory.json"),
     )
   })
 
   test("OMO_MEMORY_FILE_PATH overrides the default location entirely", () => {
-    process.env["OMO_MEMORY_FILE_PATH"] = "/custom/path/memory.json"
-    const config = createServerMemoryConfig()
-    expect(config.environment?.MEMORY_FILE_PATH).toBe("/custom/path/memory.json")
+    const tmp = mkdtempSync(join(tmpdir(), "omo-mem-env-"))
+    tempDirs.push(tmp)
+    process.env["OMO_MEMORY_FILE_PATH"] = join(tmp, "memory.json")
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
+    expect(config.environment?.MEMORY_FILE_PATH).toBe(join(tmp, "memory.json"))
   })
 
   test("OMO_MEMORY_FILE_PATH wins over XDG_CACHE_HOME", () => {
-    process.env["OMO_MEMORY_FILE_PATH"] = "/custom/memory.json"
-    process.env["XDG_CACHE_HOME"] = "/tmp/cache"
-    const config = createServerMemoryConfig()
-    expect(config.environment?.MEMORY_FILE_PATH).toBe("/custom/memory.json")
+    const tmpEnv = mkdtempSync(join(tmpdir(), "omo-mem-env-precedence-"))
+    const tmpXdg = mkdtempSync(join(tmpdir(), "omo-mem-xdg-precedence-"))
+    tempDirs.push(tmpEnv, tmpXdg)
+    process.env["OMO_MEMORY_FILE_PATH"] = join(tmpEnv, "memory.json")
+    process.env["XDG_CACHE_HOME"] = tmpXdg
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
+    expect(config.environment?.MEMORY_FILE_PATH).toBe(join(tmpEnv, "memory.json"))
+  })
+
+  // hardening from cubic-dev-ai review on #4286 ↓
+
+  test("disables itself when npx is not on PATH (instead of failing at runtime)", () => {
+    const config = createServerMemoryConfig({ resolveExecutable: npxMissing })
+    expect(config.enabled).toBe(false)
+    expect(config.command[0]).toBe("npx")
+  })
+
+  test("ignores OMO_MEMORY_FILE_PATH set to an empty / whitespace string", () => {
+    process.env["OMO_MEMORY_FILE_PATH"] = "   "
+    const config = createServerMemoryConfig({ resolveExecutable: npxAvailable })
+    expect(config.environment?.MEMORY_FILE_PATH).toBe(
+      join(homedir(), ".cache", "opencode", "oh-my-openagent-memory.json"),
+    )
+  })
+
+  test("creates the parent directory of the memory file so the first write does not ENOENT", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "omo-mem-mkdir-"))
+    tempDirs.push(tmp)
+    const filePath = join(tmp, "nested", "deeper", "memory.json")
+    process.env["OMO_MEMORY_FILE_PATH"] = filePath
+
+    expect(existsSync(dirname(filePath))).toBe(false)
+    createServerMemoryConfig({ resolveExecutable: npxAvailable })
+    expect(existsSync(dirname(filePath))).toBe(true)
   })
 })

--- a/src/mcp/server-memory.test.ts
+++ b/src/mcp/server-memory.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { createServerMemoryConfig } from "./server-memory"
+
+describe("createServerMemoryConfig", () => {
+  const originalEnv = {
+    OMO_MEMORY_FILE_PATH: process.env["OMO_MEMORY_FILE_PATH"],
+    XDG_CACHE_HOME: process.env["XDG_CACHE_HOME"],
+  }
+
+  beforeEach(() => {
+    delete process.env["OMO_MEMORY_FILE_PATH"]
+    delete process.env["XDG_CACHE_HOME"]
+  })
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  test("returns a LocalMcpConfig that launches the official server-memory package", () => {
+    const config = createServerMemoryConfig()
+    expect(config.type).toBe("local")
+    expect(config.enabled).toBe(true)
+    expect(config.command).toEqual(["npx", "-y", "@modelcontextprotocol/server-memory"])
+  })
+
+  test("uses ~/.cache/opencode/oh-my-openagent-memory.json by default", () => {
+    const config = createServerMemoryConfig()
+    expect(config.environment?.MEMORY_FILE_PATH).toBe(
+      join(homedir(), ".cache", "opencode", "oh-my-openagent-memory.json"),
+    )
+  })
+
+  test("respects XDG_CACHE_HOME when set", () => {
+    process.env["XDG_CACHE_HOME"] = "/tmp/cache"
+    const config = createServerMemoryConfig()
+    expect(config.environment?.MEMORY_FILE_PATH).toBe(
+      "/tmp/cache/opencode/oh-my-openagent-memory.json",
+    )
+  })
+
+  test("OMO_MEMORY_FILE_PATH overrides the default location entirely", () => {
+    process.env["OMO_MEMORY_FILE_PATH"] = "/custom/path/memory.json"
+    const config = createServerMemoryConfig()
+    expect(config.environment?.MEMORY_FILE_PATH).toBe("/custom/path/memory.json")
+  })
+
+  test("OMO_MEMORY_FILE_PATH wins over XDG_CACHE_HOME", () => {
+    process.env["OMO_MEMORY_FILE_PATH"] = "/custom/memory.json"
+    process.env["XDG_CACHE_HOME"] = "/tmp/cache"
+    const config = createServerMemoryConfig()
+    expect(config.environment?.MEMORY_FILE_PATH).toBe("/custom/memory.json")
+  })
+})

--- a/src/mcp/server-memory.ts
+++ b/src/mcp/server-memory.ts
@@ -1,0 +1,25 @@
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { LocalMcpConfig } from "./lsp"
+
+// Default storage location for the persistent knowledge-graph memory. We pin
+// this to the user's OpenCode cache directory rather than `process.cwd()` so
+// memories survive switching projects. Users can override with the
+// `OMO_MEMORY_FILE_PATH` env var or by disabling this MCP entirely and adding
+// their own server-memory config to opencode.json.
+function getDefaultMemoryFilePath(): string {
+  const xdgCache = process.env["XDG_CACHE_HOME"]
+  const base = xdgCache ? join(xdgCache, "opencode") : join(homedir(), ".cache", "opencode")
+  return join(base, "oh-my-openagent-memory.json")
+}
+
+export function createServerMemoryConfig(): LocalMcpConfig {
+  return {
+    type: "local",
+    command: ["npx", "-y", "@modelcontextprotocol/server-memory"],
+    enabled: true,
+    environment: {
+      MEMORY_FILE_PATH: process.env["OMO_MEMORY_FILE_PATH"] ?? getDefaultMemoryFilePath(),
+    },
+  }
+}

--- a/src/mcp/server-memory.ts
+++ b/src/mcp/server-memory.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
+import { log } from "../shared/logger"
 import type { LocalMcpConfig } from "./lsp"
 import { resolveRuntimeExecutable, type RuntimeExecutableResolver } from "./runtime-executable"
 
@@ -25,10 +26,14 @@ function readEnvMemoryFilePath(): string | undefined {
 function ensureParentDirectory(filePath: string): void {
   try {
     mkdirSync(dirname(filePath), { recursive: true })
-  } catch {
-    // Best-effort: if the parent can't be created (read-only volume, missing
-    // permission), the user will see a clear ENOENT at first write and can
-    // override OMO_MEMORY_FILE_PATH. Don't fail plugin startup over it.
+  } catch (error) {
+    // Best-effort: a read-only volume / EACCES shouldn't fail plugin startup.
+    // Log so the user has a breadcrumb when the memory server later trips on
+    // ENOENT — they can either grant permission or override OMO_MEMORY_FILE_PATH.
+    log("[mcp/memory] Failed to ensure memory file parent directory", {
+      directory: dirname(filePath),
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
 }
 

--- a/src/mcp/server-memory.ts
+++ b/src/mcp/server-memory.ts
@@ -1,6 +1,8 @@
+import { mkdirSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import type { LocalMcpConfig } from "./lsp"
+import { resolveRuntimeExecutable, type RuntimeExecutableResolver } from "./runtime-executable"
 
 // Default storage location for the persistent knowledge-graph memory. We pin
 // this to the user's OpenCode cache directory rather than `process.cwd()` so
@@ -13,13 +15,38 @@ function getDefaultMemoryFilePath(): string {
   return join(base, "oh-my-openagent-memory.json")
 }
 
-export function createServerMemoryConfig(): LocalMcpConfig {
+function readEnvMemoryFilePath(): string | undefined {
+  const raw = process.env["OMO_MEMORY_FILE_PATH"]
+  if (typeof raw !== "string") return undefined
+  const trimmed = raw.trim()
+  return trimmed.length === 0 ? undefined : trimmed
+}
+
+function ensureParentDirectory(filePath: string): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true })
+  } catch {
+    // Best-effort: if the parent can't be created (read-only volume, missing
+    // permission), the user will see a clear ENOENT at first write and can
+    // override OMO_MEMORY_FILE_PATH. Don't fail plugin startup over it.
+  }
+}
+
+type ServerMemoryOptions = {
+  readonly resolveExecutable?: RuntimeExecutableResolver
+}
+
+export function createServerMemoryConfig(options: ServerMemoryOptions = {}): LocalMcpConfig {
+  const resolveExecutable = options.resolveExecutable ?? resolveRuntimeExecutable
+  const npx = resolveExecutable("npx")
+  const filePath = readEnvMemoryFilePath() ?? getDefaultMemoryFilePath()
+  ensureParentDirectory(filePath)
   return {
     type: "local",
-    command: ["npx", "-y", "@modelcontextprotocol/server-memory"],
-    enabled: true,
+    command: [npx.command, "-y", "@modelcontextprotocol/server-memory"],
+    enabled: npx.available,
     environment: {
-      MEMORY_FILE_PATH: process.env["OMO_MEMORY_FILE_PATH"] ?? getDefaultMemoryFilePath(),
+      MEMORY_FILE_PATH: filePath,
     },
   }
 }

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "lsp", "ast_grep"])
+export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "lsp", "ast_grep", "memory"])
 
 export type McpName = z.infer<typeof McpNameSchema>
 

--- a/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -75,15 +75,17 @@ describe("createBuiltinMcps", () => {
     // when
     const result = createBuiltinMcps([])
 
-    // then
-    expect(result.memory).toEqual(
-      expect.objectContaining({
-        type: "local",
-        command: ["npx", "-y", "@modelcontextprotocol/server-memory"],
-        enabled: true,
-      }),
-    )
-    const memoryConfig = result.memory as { environment?: Record<string, string> }
+    // then: command[0] is whatever npx the runtime resolver picked (resolved or
+    // literal "npx" if not on PATH); the remainder is fixed
+    const memoryConfig = result.memory as {
+      type: string
+      command: readonly string[]
+      enabled: boolean
+      environment?: Record<string, string>
+    }
+    expect(memoryConfig.type).toBe("local")
+    expect(memoryConfig.command[0]).toMatch(/npx(\.exe)?$/)
+    expect(memoryConfig.command.slice(1)).toEqual(["-y", "@modelcontextprotocol/server-memory"])
     expect(memoryConfig.environment?.MEMORY_FILE_PATH).toBeDefined()
   })
 

--- a/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -84,7 +84,9 @@ describe("createBuiltinMcps", () => {
       environment?: Record<string, string>
     }
     expect(memoryConfig.type).toBe("local")
-    expect(memoryConfig.command[0]).toMatch(/npx(\.exe)?$/)
+    // Accept any npx shim shape — POSIX `npx`, Windows `npx.cmd` / `npx.exe` /
+    // `npx.ps1`, or any future extension a package manager might introduce.
+    expect(memoryConfig.command[0]).toMatch(/(?:^|[\\/])npx(?:\.[a-z0-9]+)?$/i)
     expect(memoryConfig.command.slice(1)).toEqual(["-y", "@modelcontextprotocol/server-memory"])
     expect(memoryConfig.environment?.MEMORY_FILE_PATH).toBeDefined()
   })

--- a/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -30,6 +30,7 @@ describe("createBuiltinMcps", () => {
     expect(result.grep_app).toBeDefined()
     expect(result.lsp).toBeDefined()
     expect(result.ast_grep).toBeDefined()
+    expect(result.memory).toBeDefined()
   })
 
   test("should filter out disabled MCPs", () => {
@@ -47,6 +48,43 @@ describe("createBuiltinMcps", () => {
     expect(result.grep_app).toBeDefined()
     expect(result.lsp).toBeDefined()
     expect(result.ast_grep).toBeDefined()
+    expect(result.memory).toBeDefined()
+  })
+
+  test("should filter out the new memory MCP when listed in disabled_mcps", () => {
+    // given
+    mockLocalMcps()
+    const { createBuiltinMcps } = require("../index") as typeof import("../index")
+    const disabledMcps = ["memory"]
+
+    // when
+    const result = createBuiltinMcps(disabledMcps)
+
+    // then
+    expect(result.memory).toBeUndefined()
+    expect(result.websearch).toBeDefined()
+    expect(result.context7).toBeDefined()
+    expect(result.grep_app).toBeDefined()
+  })
+
+  test("memory MCP is a LocalMcpConfig that launches @modelcontextprotocol/server-memory via npx", () => {
+    // given
+    mockLocalMcps()
+    const { createBuiltinMcps } = require("../index") as typeof import("../index")
+
+    // when
+    const result = createBuiltinMcps([])
+
+    // then
+    expect(result.memory).toEqual(
+      expect.objectContaining({
+        type: "local",
+        command: ["npx", "-y", "@modelcontextprotocol/server-memory"],
+        enabled: true,
+      }),
+    )
+    const memoryConfig = result.memory as { environment?: Record<string, string> }
+    expect(memoryConfig.environment?.MEMORY_FILE_PATH).toBeDefined()
   })
 
   test("should keep lsp when it uses a bootstrap command", () => {
@@ -67,7 +105,7 @@ describe("createBuiltinMcps", () => {
     // given
     mockLocalMcps()
     const { createBuiltinMcps } = require("../index") as typeof import("../index")
-    const disabledMcps = ["websearch", "context7", "grep_app", "lsp", "ast_grep"]
+    const disabledMcps = ["websearch", "context7", "grep_app", "lsp", "ast_grep", "memory"]
 
     // when
     const result = createBuiltinMcps(disabledMcps)
@@ -79,6 +117,7 @@ describe("createBuiltinMcps", () => {
     expect(remainingMcpNames).not.toContain("grep_app")
     expect(remainingMcpNames).not.toContain("lsp")
     expect(remainingMcpNames).not.toContain("ast_grep")
+    expect(remainingMcpNames).not.toContain("memory")
     expect(remainingMcpNames).toEqual([])
   })
 


### PR DESCRIPTION
Closes #3775 (\"OMO needs MEMORYS\").

## Why
Persistent knowledge-graph memory has been a long-standing community ask — agents lose every cross-session insight when the conversation ends. Anthropic's official \`@modelcontextprotocol/server-memory\` package provides a battle-tested knowledge graph (entities, relations, observations) that's exactly the right primitive for tasks spanning days.

omo already ships five builtin MCPs (websearch, context7, grep_app, lsp, ast_grep). Adding \`memory\` as a sixth gives every user persistent agent memory out of the box with zero config.

## What's added

| File | Change |
|---|---|
| \`src/mcp/server-memory.ts\` (new) | \`createServerMemoryConfig()\` returns a \`LocalMcpConfig\` running \`npx -y @modelcontextprotocol/server-memory\`. |
| \`src/mcp/index.ts\` | Registers \`memory\` in \`createBuiltinMcps\` alongside the other five. |
| \`src/mcp/types.ts\` | Adds \`\"memory\"\` to \`McpNameSchema\`. |
| \`src/mcp/server-memory.test.ts\` (new) | 5 unit tests. |
| \`src/mcp/zauc-mocks-mcp-index/index.test.ts\` | Extended to cover \`memory\` in the aggregation. |

## Path resolution
The official package defaults to \`process.cwd()/memory.json\` — which would make the knowledge graph per-project, defeating the point. omo pins the default to a stable location:

1. \`$OMO_MEMORY_FILE_PATH\` if set (user-overridable).
2. \`$XDG_CACHE_HOME/opencode/oh-my-openagent-memory.json\` if XDG is set.
3. \`~/.cache/opencode/oh-my-openagent-memory.json\` otherwise.

Users wanting a different shape can \`\"disabled_mcps\": [\"memory\"]\` and add their own server-memory entry in \`opencode.json\`.

## Test plan
- [x] \`bun test src/mcp/\` → 33 pass / 0 fail (5 new server-memory tests + 2 new aggregation cases).
- [x] Config schema unchanged at the JSON-schema level (no new top-level field; \`memory\` is reachable via existing \`disabled_mcps\` array).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@modelcontextprotocol/server-memory` as a built-in MCP to give agents persistent, cross-session knowledge-graph memory by default. Memory is stored in a stable user cache path so it survives switching projects.

- New Features
  - Adds `memory` to builtin MCPs via a `LocalMcpConfig` that runs `npx -y @modelcontextprotocol/server-memory`.
  - Sets `MEMORY_FILE_PATH` to `$OMO_MEMORY_FILE_PATH`, or `$XDG_CACHE_HOME/opencode/oh-my-openagent-memory.json`, or `~/.cache/opencode/oh-my-openagent-memory.json`.
  - Supports opt-out with `"disabled_mcps": ["memory"]`; `McpNameSchema` now includes `"memory"`.

- Bug Fixes
  - Disables `memory` when `npx` isn’t on PATH instead of failing at runtime.
  - Trims `OMO_MEMORY_FILE_PATH`; falls back to the default when empty/whitespace.
  - Creates the parent directory for `MEMORY_FILE_PATH` and logs failures (non-blocking) to avoid first-write ENOENT.

<sup>Written for commit baf14f9e52882812e4f8b34e8d26762f53685bed. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4286?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

