### PR TITLE
fix(ast-grep-mcp): resolve Windows executable shims

### DIFF
--- a/packages/ast-grep-mcp/src/sg-cli-path.test.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { executableCandidates, isValidBinary } from "./sg-cli-path"
+
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix))
+	temporaryDirectories.push(directory)
+	return directory
+}
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true })
+	}
+})
+
+describe("executableCandidates", () => {
+	it("adds Windows launcher extensions for extensionless ast-grep paths", () => {
+		expect(executableCandidates("C:\\omo\\node_modules\\@ast-grep\\cli\\sg", "win32")).toEqual([
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.cmd",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.bat",
+		])
+	})
+
+	it("does not duplicate an existing Windows executable extension", () => {
+		expect(executableCandidates("C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe", "win32")).toEqual([
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe",
+		])
+	})
+
+	it("keeps non-Windows executable paths unchanged", () => {
+		expect(executableCandidates("/workspace/node_modules/@ast-grep/cli/sg", "linux")).toEqual([
+			"/workspace/node_modules/@ast-grep/cli/sg",
+		])
+	})
+
+	it("accepts small Windows command shims as valid executables", () => {
+		const directory = createTemporaryDirectory("omo-sg-cli-shim-")
+		const shimPath = join(directory, "sg.cmd")
+		writeFileSync(shimPath, "@echo off\r\nnode sg.js %*\r\n", "utf8")
+
+		expect(isValidBinary(shimPath)).toBe(true)
+	})
+
+	it("rejects tiny native executable candidates", () => {
+		const directory = createTemporaryDirectory("omo-sg-cli-native-")
+		const exePath = join(directory, "sg.exe")
+		writeFileSync(exePath, "not a binary", "utf8")
+
+		expect(isValidBinary(exePath)).toBe(false)
+	})
+})

--- a/packages/ast-grep-mcp/src/sg-cli-path.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.ts
@@ -4,12 +4,42 @@ import { existsSync, statSync } from "fs"
 
 type Platform = "darwin" | "linux" | "win32" | "unsupported"
 
-function isValidBinary(filePath: string): boolean {
+const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const
+
+export function isValidBinary(filePath: string): boolean {
 	try {
-		return statSync(filePath).size > 10000
+		const size = statSync(filePath).size
+		const lowerPath = filePath.toLowerCase()
+		if (lowerPath.endsWith(".cmd") || lowerPath.endsWith(".bat")) {
+			return size > 0
+		}
+		return size > 10000
 	} catch {
 		return false
 	}
+}
+
+export function executableCandidates(filePath: string, platform: NodeJS.Platform = process.platform): string[] {
+	if (platform !== "win32") return [filePath]
+
+	const candidates = [filePath]
+	const lowerPath = filePath.toLowerCase()
+	if (WINDOWS_EXECUTABLE_EXTENSIONS.some((extension) => lowerPath.endsWith(extension))) {
+		return candidates
+	}
+	for (const extension of WINDOWS_EXECUTABLE_EXTENSIONS) {
+		candidates.push(`${filePath}${extension}`)
+	}
+	return candidates
+}
+
+function findValidExecutable(filePath: string): string | null {
+	for (const candidate of executableCandidates(filePath)) {
+		if (existsSync(candidate) && isValidBinary(candidate)) {
+			return candidate
+		}
+	}
+	return null
 }
 
 function getPlatformPackageName(): string | null {
@@ -30,16 +60,17 @@ function getPlatformPackageName(): string | null {
 }
 
 export function findSgCliPathSync(): string | null {
-	const binaryName = process.platform === "win32" ? "sg.exe" : "sg"
+	const binaryName = "sg"
 
 	try {
 		const require = createRequire(import.meta.url)
 		const cliPackageJsonPath = require.resolve("@ast-grep/cli/package.json")
 		const cliDirectory = dirname(cliPackageJsonPath)
 		const sgPath = join(cliDirectory, binaryName)
+		const validSgPath = findValidExecutable(sgPath)
 
-		if (existsSync(sgPath) && isValidBinary(sgPath)) {
-			return sgPath
+		if (validSgPath) {
+			return validSgPath
 		}
 	} catch {
 		// @ast-grep/cli not installed
@@ -51,11 +82,12 @@ export function findSgCliPathSync(): string | null {
 			const require = createRequire(import.meta.url)
 			const packageJsonPath = require.resolve(`${platformPackage}/package.json`)
 			const packageDirectory = dirname(packageJsonPath)
-			const astGrepBinaryName = process.platform === "win32" ? "ast-grep.exe" : "ast-grep"
+			const astGrepBinaryName = "ast-grep"
 			const binaryPath = join(packageDirectory, astGrepBinaryName)
+			const validBinaryPath = findValidExecutable(binaryPath)
 
-			if (existsSync(binaryPath) && isValidBinary(binaryPath)) {
-				return binaryPath
+			if (validBinaryPath) {
+				return validBinaryPath
 			}
 		} catch {
 			// Platform-specific package not installed


### PR DESCRIPTION
## Summary
- Fix Windows ast-grep MCP binary resolution to try extensionless `sg`/`ast-grep` plus `.exe`, `.cmd`, and `.bat` launcher variants.
- Treat small `.cmd`/`.bat` shims as valid launchers while keeping native executable size validation.
- Add regression coverage for Windows executable candidate generation and shim validation.

## Changes
- `packages/ast-grep-mcp/src/sg-cli-path.ts` now resolves Windows launcher candidates from extensionless base names.
- `packages/ast-grep-mcp/src/sg-cli-path.test.ts` covers `.exe`/`.cmd`/`.bat` candidates and shim validation.

## Testing
```bash
bun test packages/ast-grep-mcp/src/sg-cli-path.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts src/cli/run/output-renderer.test.ts src/shared/agent-display-names.test.ts
bun run typecheck
bun run build
```

## Related Issues
Closes #4188

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows detection of the `ast-grep` MCP binary by resolving `.exe`, `.cmd`, and `.bat` launchers from extensionless `sg`/`ast-grep` paths. Accepts small `.cmd`/`.bat` shims and returns the first valid candidate to stop Windows launch failures (fixes #4188).

- **Bug Fixes**
  - Generate Windows candidates for `sg`/`ast-grep` and avoid duplicates; no change on non-Windows.
  - Validate `.cmd`/`.bat` by size > 0; keep native `.exe` size check to filter bogus binaries.
  - Check both `@ast-grep/cli` (`sg`) and platform packages (`ast-grep`) and use the first valid path.
  - Add regression tests for candidate generation and shim validation.

<sup>Written for commit 77e8663950aeebdf21e17f3a420ec8311e9aabe7. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

