### PR TITLE
fix(parent-wake): reuse prompt gate assistant blocking

### DIFF
--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -9,6 +9,7 @@ import {
 } from "../../shared"
 import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
+import { latestAssistantTurnBlocksInternalPrompt } from "../../shared/prompt-async-gate/pending-tool-turn"
 import type { PluginInput } from "@opencode-ai/plugin"
 
 type OpencodeClient = PluginInput["client"]
@@ -557,8 +558,9 @@ export class ParentWakeNotifier {
     wake: PendingParentWake,
   ): Promise<ToolWaitDeferralDecision> {
     const messages = await this.loadParentWakeSessionMessages(sessionID)
+    const latestAssistantBlocksPrompt = latestAssistantTurnBlocksInternalPrompt(messages)
     const toolWaitState = this.latestAssistantToolWaitState(messages)
-    if (!toolWaitState.waiting) {
+    if (!latestAssistantBlocksPrompt) {
       delete wake.toolCallDeferralStartedAt
       return { defer: false, skipPromptGateToolStateCheck: false }
     }
@@ -577,7 +579,7 @@ export class ParentWakeNotifier {
       })
       return { defer: false, skipPromptGateToolStateCheck: true }
     }
-    log("[background-agent] Deferred parent wake because latest assistant turn is waiting on tool results:", {
+    log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
       sessionID,
     })
     return { defer: true, skipPromptGateToolStateCheck: false }

--- a/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -267,6 +267,39 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
+  test("#given latest assistant turn has unknown finish #when flushing pending wake #then the wake stays pending", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-unknown-finish": { type: "idle" } },
+      sessionMessages: [
+        {
+          info: {
+            role: "assistant",
+            finish: "unknown",
+            time: { created: Date.now() - 1_000 },
+          },
+          parts: [{ type: "reasoning", text: "still streaming" }],
+        },
+      ],
+    })
+    notifier.queuePendingParentWake(
+      "parent-unknown-finish",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+
+    // when
+    await notifier.flushPendingParentWake("parent-unknown-finish")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(0)
+    expect(notifier.getPendingParentWakes().has("parent-unknown-finish")).toBe(true)
+
+    notifier.shutdown()
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
   test("#given latest message is a user message just added #when flushing pending wake #then dispatch is deferred (no promptAsync)", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({

--- a/src/shared/prompt-async-gate/pending-tool-turn.ts
+++ b/src/shared/prompt-async-gate/pending-tool-turn.ts
@@ -141,7 +141,7 @@ function partIsWaitingOnTool(part: unknown): boolean {
   return state.status === "pending" || state.status === "running"
 }
 
-function latestAssistantTurnBlocksInternalPrompt(messages: unknown[]): boolean {
+export function latestAssistantTurnBlocksInternalPrompt(messages: unknown[]): boolean {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index]
     const role = messageRole(message)


### PR DESCRIPTION
## Summary
- Reuse the shared prompt-async-gate assistant-turn predicate before dispatching parent wake prompts.
- Prevent parent wakes from injecting while the latest assistant response is still streaming or has `finish: unknown`.
- Add regression coverage for stale-idle parent wake dispatch with an unknown/streaming assistant turn.

## Changes
- Export `latestAssistantTurnBlocksInternalPrompt` from the shared prompt gate.
- Use it in `ParentWakeNotifier` instead of the narrower tool-wait-only check.
- Extend parent-wake race tests for non-tool incomplete assistant turns.

## Testing
```bash
bun test packages/ast-grep-mcp/src/sg-cli-path.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts src/cli/run/output-renderer.test.ts src/shared/agent-display-names.test.ts
bun run typecheck
bun run build
```

## Related Issues
Refs #4164
Refs #4167
Refs #4169

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks parent wake prompts when the latest assistant turn is incomplete (tool wait, streaming, or finish: unknown) by reusing the shared prompt gate predicate. Fixes a race that injected parent wakes while an assistant response was still in progress (refs #4164, #4167, #4169).

- **Bug Fixes**
  - Exported and reused `latestAssistantTurnBlocksInternalPrompt` in `ParentWakeNotifier` (replaces tool-wait-only check).
  - Updated log message to reflect generic “blocks internal prompts” state.
  - Added tests for unknown/streaming assistant finishes and extended parent-wake race coverage.

<sup>Written for commit f21760377ccc4ff6d0c69b06028c42ac7d4725f8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4288?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

