### PR TITLE
fix(todo-continuation): wait for descendant background work

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1069,6 +1069,14 @@ The fallback retry session is now created and can be inspected directly.
     return result
   }
 
+  hasPendingParentWakeForSession(sessionID: string): boolean {
+    return this.parentWakeNotifier.getPendingParentWakes().has(sessionID)
+  }
+
+  hasDispatchedParentWakeForSession(sessionID: string): boolean {
+    return this.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)
+  }
+
   findBySession(sessionID: string): BackgroundTask | undefined {
     for (const task of this.tasks.values()) {
       if (task.sessionId === sessionID) {

--- a/src/hooks/todo-continuation-enforcer/active-background-work.ts
+++ b/src/hooks/todo-continuation-enforcer/active-background-work.ts
@@ -1,0 +1,26 @@
+import type { BackgroundManager } from "../../features/background-agent"
+
+function taskIsActive(task: { status: string }): boolean {
+  return task.status === "running" || task.status === "pending"
+}
+
+export function hasActiveBackgroundWork(
+  backgroundManager: BackgroundManager | undefined,
+  sessionID: string,
+): boolean {
+  if (!backgroundManager) {
+    return false
+  }
+
+  return backgroundManager.getAllDescendantTasks(sessionID).some(taskIsActive)
+    || backgroundManager.hasPendingParentWakeForSession(sessionID)
+    || backgroundManager.hasDispatchedParentWakeForSession(sessionID)
+}
+
+export function hasSettlingParentWake(
+  backgroundManager: BackgroundManager | undefined,
+  sessionID: string,
+): boolean {
+  return backgroundManager?.hasPendingParentWakeForSession(sessionID) === true
+    || backgroundManager?.hasDispatchedParentWakeForSession(sessionID) === true
+}

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -25,6 +25,7 @@ import {
 } from "../../shared/agent-display-names"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../shared/prompt-async-gate"
 
+import { hasActiveBackgroundWork } from "./active-background-work"
 import {
   CONTINUATION_PROMPT,
   DEFAULT_SKIP_AGENTS,
@@ -81,12 +82,8 @@ export async function injectContinuation(args: {
     return
   }
 
-  const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running" || task.status === "pending")
-    : false
-
-  if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped injection: background tasks running`, { sessionID })
+  if (hasActiveBackgroundWork(backgroundManager, sessionID)) {
+    log(`[${HOOK_NAME}] Skipped injection: background work still active`, { sessionID })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -6,6 +6,7 @@ import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { log } from "../../shared/logger"
 
 import { isLastAssistantMessageAborted } from "./abort-detection"
+import { hasActiveBackgroundWork, hasSettlingParentWake } from "./active-background-work"
 import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compaction-guard"
 import { ABORT_WINDOW_MS, CONTINUATION_COOLDOWN_MS, DEFAULT_SKIP_AGENTS, FAILURE_RESET_WINDOW_MS, HOOK_NAME, MAX_CONSECUTIVE_FAILURES } from "./constants"
 import { startCountdown } from "./countdown"
@@ -15,6 +16,22 @@ import type { SessionStateStore } from "./session-state"
 import { shouldStopForStagnation } from "./stagnation-detection"
 import { getIncompleteCount } from "./todo"
 import type { MessageWithInfo, ResolvedMessageInfo, Todo } from "./types"
+
+const BACKGROUND_WAKE_RECHECK_MS = 1_000
+
+type Unrefable = ReturnType<typeof setTimeout> & { unref?: () => unknown }
+
+function scheduleBackgroundWakeRecheck(args: Parameters<typeof handleSessionIdle>[0]): void {
+  const timer = setTimeout(() => {
+    void handleSessionIdle(args).catch((error) => {
+      log(`[${HOOK_NAME}] Background wake recheck failed`, { sessionID: args.sessionID, error: String(error) })
+    })
+  }, BACKGROUND_WAKE_RECHECK_MS)
+  const maybeUnref = (timer as Unrefable).unref
+  if (typeof maybeUnref === "function") {
+    maybeUnref.call(timer)
+  }
+}
 
 export async function handleSessionIdle(args: {
   ctx: PluginInput
@@ -68,12 +85,11 @@ export async function handleSessionIdle(args: {
     state.abortDetectedAt = undefined
   }
 
-  const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running" || task.status === "pending")
-    : false
-
-  if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
+  if (hasActiveBackgroundWork(backgroundManager, sessionID)) {
+    log(`[${HOOK_NAME}] Skipped: background work still active`, { sessionID })
+    if (hasSettlingParentWake(backgroundManager, sessionID)) {
+      scheduleBackgroundWakeRecheck(args)
+    }
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -232,10 +232,12 @@ describe("todo-continuation-enforcer", () => {
   }
 
   function createMockBackgroundManager(runningTasks: boolean = false): BackgroundManager {
+    const tasks = runningTasks ? [{ status: "running" }] : []
     return {
-      getTasksByParentSession: () => runningTasks
-        ? [{ status: "running" }]
-        : [],
+      getTasksByParentSession: () => tasks,
+      getAllDescendantTasks: () => tasks,
+      hasPendingParentWakeForSession: () => false,
+      hasDispatchedParentWakeForSession: () => false,
     } as BackgroundManager
   }
 
@@ -391,6 +393,82 @@ describe("todo-continuation-enforcer", () => {
 
     // then - no continuation injected
     expect(promptCalls).toHaveLength(0)
+  })
+
+  test("should not inject when descendant background tasks are running", async () => {
+    // given - session with a nested child background task still running
+    const sessionID = "main-descendant-running"
+    setMainSession(sessionID)
+
+    const backgroundManager = {
+      getTasksByParentSession: () => [],
+      getAllDescendantTasks: () => [{ status: "running" }],
+      hasPendingParentWakeForSession: () => false,
+      hasDispatchedParentWakeForSession: () => false,
+    } as BackgroundManager
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), { backgroundManager })
+
+    // when - session goes idle
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    await fakeTimers.advanceBy(3000)
+
+    // then - no continuation injected
+    expect(promptCalls).toHaveLength(0)
+  })
+
+  test("should not inject while a parent wake delivery is still settling", async () => {
+    // given - session with a parent wake already dispatched but not accepted/cleared
+    const sessionID = "main-parent-wake-settling"
+    setMainSession(sessionID)
+
+    const backgroundManager = {
+      getTasksByParentSession: () => [],
+      getAllDescendantTasks: () => [],
+      hasPendingParentWakeForSession: () => false,
+      hasDispatchedParentWakeForSession: () => true,
+    } as BackgroundManager
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), { backgroundManager })
+
+    // when - session goes idle
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    await fakeTimers.advanceBy(3000)
+
+    // then - no continuation injected
+    expect(promptCalls).toHaveLength(0)
+  })
+
+  test("should recheck after a settling parent wake clears", async () => {
+    // given - parent wake is settling on first idle, then clears before recheck
+    const sessionID = "main-parent-wake-recheck"
+    setMainSession(sessionID)
+    let wakeSettling = true
+
+    const backgroundManager = {
+      getTasksByParentSession: () => [],
+      getAllDescendantTasks: () => [],
+      hasPendingParentWakeForSession: () => false,
+      hasDispatchedParentWakeForSession: () => wakeSettling,
+    } as BackgroundManager
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), { backgroundManager })
+
+    // when - session goes idle while wake is settling
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+    expect(promptCalls).toHaveLength(0)
+
+    wakeSettling = false
+    await fakeTimers.advanceBy(1000)
+    await fakeTimers.advanceBy(3000)
+
+    // then - recheck starts the normal continuation countdown after wake clears
+    expect(promptCalls).toHaveLength(1)
   })
 
   test("should inject for any session with incomplete todos", async () => {


### PR DESCRIPTION
## Summary
- Block parent todo-continuation while descendant background work is still active, not only direct child tasks.
- Treat pending/dispatched parent wake delivery as active background work so parent continuation does not race completion notifications.
- Recheck after a settling parent wake clears, then continue through the normal countdown path.

## Changes
- Add `hasActiveBackgroundWork` / `hasSettlingParentWake` helper for todo-continuation gates.
- Add `BackgroundManager` accessors for pending/dispatched parent wake state.
- Apply the shared predicate in both idle handling and pre-injection checks.
- Add regression coverage for descendant tasks, wake-settlement blocking, and wake-clear recheck behavior.

## Testing
```bash
bun test packages/ast-grep-mcp/src/sg-cli-path.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts src/cli/run/output-renderer.test.ts src/shared/agent-display-names.test.ts
bun run typecheck
bun run build
```

## Related Issues
Closes #4163

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents todo continuation from firing while any descendant background work is active—including pending/dispatched parent wakes—to avoid races with completion notifications. Closes #4163; once a wake settles, we recheck and resume the normal countdown.

- **Bug Fixes**
  - Gate continuation with a shared `hasActiveBackgroundWork(...)` check in idle and pre-injection paths.
  - Treat pending/dispatched parent wakes as active; add `BackgroundManager` accessors: `hasPendingParentWakeForSession` and `hasDispatchedParentWakeForSession`.
  - Schedule a 1s recheck when a parent wake is settling, then continue via the normal countdown.
  - Add regression tests for descendant tasks, wake-settlement blocking, and recheck behavior.

<sup>Written for commit 67381c780c04670466febee8edc5a46fb672b13b. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

