### PR TITLE
fix(cli): preserve CJK agent header text

### DIFF
--- a/src/cli/run/output-renderer.test.ts
+++ b/src/cli/run/output-renderer.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "bun:test"
+
+import { renderAgentHeader } from "./output-renderer"
+
+const originalWrite = process.stdout.write.bind(process.stdout)
+
+function captureStdout(run: () => void): string {
+  const chunks: string[] = []
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"))
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    run()
+  } finally {
+    process.stdout.write = originalWrite as typeof process.stdout.write
+  }
+
+  return chunks.join("")
+}
+
+afterEach(() => {
+  process.stdout.write = originalWrite as typeof process.stdout.write
+})
+
+describe("renderAgentHeader", () => {
+  it("preserves CJK agent display names in stdout output", () => {
+    const output = captureStdout(() => {
+      renderAgentHeader("Sisyphus - 主脑", "zhipu/glm-5.1", "xhigh", {})
+    })
+
+    expect(output).toContain("Sisyphus - 主脑")
+    expect(output).toContain("zhipu/glm-5.1")
+  })
+
+  it("normalizes decomposed Unicode before rendering", () => {
+    const output = captureStdout(() => {
+      renderAgentHeader("헤파", null, null, {})
+    })
+
+    expect(output).toContain("헤파")
+  })
+})

--- a/src/cli/run/output-renderer.ts
+++ b/src/cli/run/output-renderer.ts
@@ -8,10 +8,12 @@ export function renderAgentHeader(
 ): void {
   if (!agent && !model) return
 
+  const normalizedAgent = agent?.normalize("NFC") ?? null
+  const normalizedModel = model?.normalize("NFC") ?? null
   const agentLabel = agent
-    ? pc.bold(colorizeWithProfileColor(agent, agentColorsByName[agent]))
+    ? pc.bold(colorizeWithProfileColor(normalizedAgent ?? agent, agentColorsByName[agent]))
     : ""
-  const modelBase = model ?? ""
+  const modelBase = normalizedModel ?? ""
   const variantSuffix = variant ? ` (${variant})` : ""
   const modelLabel = model ? pc.dim(`${modelBase}${variantSuffix}`) : ""
 

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -133,6 +133,12 @@ describe("getAgentDisplayName", () => {
     // then returns "multimodal-looker"
     expect(result).toBe("multimodal-looker")
   })
+
+  it("preserves CJK display-name overrides verbatim", () => {
+    expect(getAgentDisplayName("sisyphus", { sisyphus: { displayName: "Sisyphus - 主脑" } })).toBe("Sisyphus - 主脑")
+    expect(getAgentDisplayName("hephaestus", { hephaestus: { displayName: "헤파이스토스" } })).toBe("헤파이스토스")
+    expect(getAgentDisplayName("atlas", { atlas: { displayName: "アトラス" } })).toBe("アトラス")
+  })
 })
 
 describe("getAgentConfigKey", () => {


### PR DESCRIPTION
## Summary
- Normalize agent/model header text to NFC before CLI rendering so decomposed Unicode does not display as split glyphs.
- Add regression coverage that CJK display-name overrides are preserved verbatim.
- Add stdout rendering tests for CJK and decomposed Korean agent names.

## Changes
- `renderAgentHeader` normalizes rendered agent/model labels with `String.prototype.normalize(NFC)`.
- `agent-display-names.test.ts` covers Chinese/Korean/Japanese display-name overrides.
- `output-renderer.test.ts` captures stdout and verifies CJK text survives rendering.

## Testing
```bash
bun test packages/ast-grep-mcp/src/sg-cli-path.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts src/cli/run/output-renderer.test.ts src/shared/agent-display-names.test.ts
bun run typecheck
bun run build
```

## Related Issues
Refs #4170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize CLI agent/model header text to NFC so decomposed CJK characters don’t render as split glyphs; preserve CJK display-name overrides verbatim. Addresses #4170 and adds stdout tests to prevent regressions.

<sup>Written for commit ed4c04e57573bfede73c0838d11b821fbb05a65f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

