### PR TITLE
fix(gpt-5.5): block synthetic background reminders

### DIFF
--- a/src/agents/sisyphus-id-contract.test.ts
+++ b/src/agents/sisyphus-id-contract.test.ts
@@ -29,4 +29,15 @@ describe("Sisyphus background task ID guidance", () => {
       expect(prompt).not.toContain("receive task_ids")
     })
   }
+
+  test("#given gpt-5.5 prompt #when waiting on background tasks #then system reminders are input-only", () => {
+    // given, when
+    const prompt = buildGpt55SisyphusPrompt("gpt-5.5", [])
+
+    // then
+    expect(prompt).toContain("System reminders are input-only signals")
+    expect(prompt).toContain("Never write, quote, simulate, or pre-emptively emit `<system-reminder>`")
+    expect(prompt).toContain("never call `background_output` merely because you imagined such a reminder")
+    expect(prompt).toContain("actual harness-provided completion notification")
+  })
 })

--- a/src/agents/sisyphus/gpt-5-5.ts
+++ b/src/agents/sisyphus/gpt-5-5.ts
@@ -239,6 +239,8 @@ Each exploration prompt should include four fields: **CONTEXT** (what task, whic
 
 After firing exploration agents, keep the returned background task IDs (\`bg_...\`) for result collection and continuation session IDs (\`ses_...\`) for follow-ups. Continue only with non-overlapping preparation: setting up files, reading known-path files, drafting questions. If no non-overlapping work exists, end your response and wait for the completion notification; then use \`background_output(task_id="bg_...")\`, not \`task(task_id="ses_...")\`, to collect results.
 
+System reminders are input-only signals from the harness. Never write, quote, simulate, or pre-emptively emit \`<system-reminder>\` blocks yourself, and never call \`background_output\` merely because you imagined such a reminder. Only collect a background task after an actual harness-provided completion notification arrives.
+
 Stop searching when you have enough context to proceed confidently, when the same information keeps appearing across sources, when two iterations yield no new useful data, or when you found a direct answer.
 
 ### Tool persistence


### PR DESCRIPTION
## Summary
- Prevent the GPT-5.5 Sisyphus prompt from treating fabricated `<system-reminder>` text as a valid background task completion signal.
- Pin the background task contract with a focused regression test for the GPT-5.5 prompt.

Fixes #4144

## Verification
- `lsp_diagnostics` on `src/agents/sisyphus/gpt-5-5.ts`
- `lsp_diagnostics` on `src/agents/sisyphus-id-contract.test.ts`
- `bun test src/agents/sisyphus-id-contract.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `gpt-5.5` Sisyphus prompt to ignore fabricated `<system-reminder>` text and only collect background results after real harness notifications. Adds a regression test to lock the background-task contract and prevent premature `background_output` calls. Fixes #4144.

- **Bug Fixes**
  - Updated `src/agents/sisyphus/gpt-5-5.ts` to state system reminders are input-only, forbid emitting `<system-reminder>`, and block imagined reminders from triggering `background_output`.
  - Added `src/agents/sisyphus-id-contract.test.ts` to assert the new guidance strings and pin the `gpt-5.5` contract.

<sup>Written for commit 2feef132db657916a6cb9847ff1a52aa85d7f9ba. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

