### PR TITLE
fix(agent-config): refresh agent registry on config apply

### DIFF
--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -9,6 +9,7 @@ import {
   setMainSession,
   getMainSessionID,
   registerAgentName,
+  clearRegisteredAgentNames,
   isAgentRegistered,
   resolveRegisteredAgentName,
   _resetForTesting,
@@ -170,6 +171,21 @@ describe("claude-code-session-state", () => {
 
       // then
       expect(resolved).toBe("Prometheus - Plan Builder")
+    })
+
+    test("should clear registered agent names without clearing session ownership", () => {
+      // given
+      const sessionID = "test-session-preserved"
+      registerAgentName("Prometheus - Plan Builder")
+      setSessionAgent(sessionID, "Prometheus - Plan Builder")
+
+      // when
+      clearRegisteredAgentNames()
+
+      // then
+      expect(isAgentRegistered("prometheus")).toBe(false)
+      expect(resolveRegisteredAgentName("prometheus")).toBe("prometheus")
+      expect(getSessionAgent(sessionID)).toBe("Prometheus - Plan Builder")
     })
 
     describe("#given atlas display name with zero-width prefix", () => {

--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -42,6 +42,11 @@ export function registerAgentName(name: string): void {
   }
 }
 
+export function clearRegisteredAgentNames(): void {
+  registeredAgentNames.clear()
+  registeredAgentAliases.clear()
+}
+
 export function isAgentRegistered(name: string): boolean {
   return registeredAgentNames.has(normalizeRegisteredAgentName(name))
 }

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -10,6 +10,11 @@ import * as agentLoader from "../features/claude-code-agent-loader"
 import * as skillLoader from "../features/opencode-skill-loader"
 import type { LoadedSkill } from "../features/opencode-skill-loader"
 import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names"
+import {
+  isAgentRegistered,
+  registerAgentName,
+  _resetForTesting as resetSessionStateForTesting,
+} from "../features/claude-code-session-state"
 import { applyAgentConfig } from "./agent-config-handler"
 import type { PluginComponents } from "./plugin-components-loader"
 
@@ -99,6 +104,8 @@ describe("applyAgentConfig builtin override protection", () => {
   }
 
   beforeEach(() => {
+    resetSessionStateForTesting()
+
     createBuiltinAgentsSpy = spyOn(agents, "createBuiltinAgents").mockResolvedValue({
       sisyphus: builtinSisyphusConfig,
       oracle: builtinOracleConfig,
@@ -155,6 +162,8 @@ describe("applyAgentConfig builtin override protection", () => {
   })
 
   afterEach(() => {
+    resetSessionStateForTesting()
+
     createBuiltinAgentsSpy.mockRestore()
     createSisyphusJuniorAgentSpy.mockRestore()
     discoverConfigSourceSkillsSpy.mockRestore()
@@ -476,6 +485,25 @@ describe("applyAgentConfig builtin override protection", () => {
     const pluginAgent = result["plugin-worker"] as Record<string, unknown>
     expect(pluginAgent).toBeDefined()
     expect(pluginAgent.mode).toBe("subagent")
+  })
+
+  test("replaces registered agent names when config is re-applied", async () => {
+    // given - a stale agent name from the previous OpenCode instance/config pass
+    registerAgentName("stale-connect-agent")
+    expect(isAgentRegistered("stale-connect-agent")).toBe(true)
+
+    // when - /connect causes OpenCode to re-enter the config hook
+    await applyAgentConfig({
+      config: createBaseConfig(),
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then - the lookup mirrors the freshly rebuilt agent config only
+    expect(isAgentRegistered("stale-connect-agent")).toBe(false)
+    expect(isAgentRegistered(BUILTIN_SISYPHUS_DISPLAY_NAME)).toBe(true)
+    expect(isAgentRegistered("sisyphus")).toBe(true)
   })
 
   test("includes project and global .agents skills in builtin agent awareness", async () => {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -9,7 +9,10 @@ import {
 } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
-import { registerAgentName } from "../features/claude-code-session-state";
+import {
+  clearRegisteredAgentNames,
+  registerAgentName,
+} from "../features/claude-code-session-state";
 import {
   discoverConfigSourceSkills,
   discoverGlobalAgentsSkills,
@@ -416,6 +419,7 @@ export async function applyAgentConfig(params: {
   }
 
   const agentResult = params.config.agent as Record<string, unknown>;
+  clearRegisteredAgentNames();
   for (const name of Object.keys(agentResult)) {
     registerAgentName(name);
   }


### PR DESCRIPTION
## Summary
- Reset the registered agent-name lookup before each config-agent registration pass.
- Re-register the freshly rebuilt agent config so `/connect` config re-entry cannot leave stale selector aliases behind.
- Add regression coverage for clearing aliases and for config re-application keeping OMO agents registered.

Fixes #4130

## Verification
- `lsp_diagnostics` on `src/features/claude-code-session-state/state.ts`
- `lsp_diagnostics` on `src/plugin-handlers/agent-config-handler.ts`
- `lsp_diagnostics` on `src/features/claude-code-session-state/state.test.ts`
- `lsp_diagnostics` on `src/plugin-handlers/agent-config-handler.test.ts`
- `bun test src/features/claude-code-session-state/state.test.ts src/plugin-handlers/agent-config-handler.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the agent registry on each config apply so `/connect` can’t leave stale agent aliases behind. Keeps the registry aligned with the freshly rebuilt config and adds regression tests.

- **Bug Fixes**
  - Clear registered agent names and aliases before re-registering from the current config.
  - Ensure current/builtin agents are re-registered; stale names are removed.
  - Add tests that verify alias clearing without losing session ownership and that re-applying config replaces stale registrations.

<sup>Written for commit 66fefc3b90f0e2bc0d98be52e2134cec08b1a6ad. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

