### PR TITLE
fix(command-executor): settle timed-out hook commands

### DIFF
--- a/src/shared/command-executor/execute-hook-command.test.ts
+++ b/src/shared/command-executor/execute-hook-command.test.ts
@@ -5,6 +5,10 @@ import { mkdtempSync, rmSync } from "node:fs"
 
 const { executeHookCommand } = await import("./execute-hook-command")
 
+function nodeCommand(script: string): string {
+  return `"${process.execPath}" -e ${JSON.stringify(script)}`
+}
+
 describe("executeHookCommand", () => {
   let tempDirectory = ""
 
@@ -23,7 +27,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      "echo $__OMO_TEST_ALLOWED_VAR $__OMO_TEST_SECRET_VAR",
+      nodeCommand("console.log(process.env.__OMO_TEST_ALLOWED_VAR || '', process.env.__OMO_TEST_SECRET_VAR || '')"),
       "",
       tempDirectory,
       { allowedEnvVars: ["__OMO_TEST_ALLOWED_VAR"] },
@@ -45,7 +49,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      "echo $__OMO_TEST_FULL_ENV_VAR",
+      nodeCommand("console.log(process.env.__OMO_TEST_FULL_ENV_VAR || '')"),
       "",
       tempDirectory,
     )
@@ -56,6 +60,23 @@ describe("executeHookCommand", () => {
 
     // cleanup
     delete process.env.__OMO_TEST_FULL_ENV_VAR
+  })
+
+  test("#given command ignores normal completion #when timeout expires #then returns timeout instead of hanging", async () => {
+    // given
+    const command = nodeCommand("setTimeout(() => {}, 1000)")
+
+    // when
+    const startedAt = Date.now()
+    const result = await executeHookCommand(command, "", tempDirectory, {
+      timeoutMs: 20,
+      killGraceMs: 20,
+    })
+
+    // then
+    expect(result.exitCode).toBe(124)
+    expect(result.stderr).toContain("Hook command timed out after 20ms")
+    expect(Date.now() - startedAt).toBeLessThan(1000)
   })
 })
 

--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -16,6 +16,8 @@ export interface ExecuteHookOptions {
   zshPath?: string;
   /** Timeout in milliseconds. Process is killed after this. Default: 30000 */
   timeoutMs?: number;
+  /** Grace period before force-killing and resolving timed-out commands. Default: 5000 */
+  killGraceMs?: number;
   /** When provided, scrub process.env to only include these vars plus HOME/PATH/etc. Used for plugin-sourced hooks. */
   allowedEnvVars?: string[];
 }
@@ -28,6 +30,7 @@ export async function executeHookCommand(
 ): Promise<CommandResult> {
   const home = getHomeDirectory();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
+  const killGraceMs = options?.killGraceMs ?? SIGKILL_GRACE_MS;
 
   const expandedCommand = command
     .replace(/^~(?=\/|$)/g, home)
@@ -52,6 +55,7 @@ export async function executeHookCommand(
 
   return new Promise(resolve => {
     let settled = false;
+    let timedOut = false;
     let killTimer: ReturnType<typeof setTimeout> | null = null;
 
     const isWin32 = process.platform === "win32";
@@ -108,6 +112,15 @@ export async function executeHookCommand(
     };
 
     proc.on("close", code => {
+      if (timedOut) {
+        appendTimeoutNotice();
+        settle({
+          exitCode: 124,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        });
+        return;
+      }
       settle({
         exitCode: code ?? 1,
         stdout: stdout.trim(),
@@ -119,6 +132,20 @@ export async function executeHookCommand(
       settle({ exitCode: 1, stderr: err.message });
     });
 
+    const killWindowsProcessTree = (onComplete?: () => void) => {
+      if (!proc.pid) {
+        onComplete?.();
+        return;
+      }
+      const killer = spawn("taskkill", ["/PID", String(proc.pid), "/T", "/F"], {
+        windowsHide: true,
+        stdio: "ignore",
+      });
+      const finish = () => onComplete?.();
+      killer.on("error", finish);
+      killer.on("close", finish);
+    };
+
     const killProcessGroup = (signal: NodeJS.Signals) => {
       try {
         if (!isWin32 && proc.pid) {
@@ -129,20 +156,57 @@ export async function executeHookCommand(
           }
         } else {
           proc.kill(signal);
+          if (signal === "SIGKILL") {
+            killWindowsProcessTree();
+          }
         }
       } catch {}
     };
 
+    const appendTimeoutNotice = () => {
+      if (!stderr.includes("Hook command timed out after")) {
+        stderr += `\nHook command timed out after ${timeoutMs}ms`;
+      }
+    };
+
     const timeoutTimer = setTimeout(() => {
       if (settled) return;
+      timedOut = true;
+      appendTimeoutNotice();
+      if (isWin32) {
+        killWindowsProcessTree(() => {
+          settle({
+            exitCode: 124,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+          });
+        });
+        return;
+      }
       // Kill entire process group to avoid orphaned children
       killProcessGroup("SIGTERM");
       killTimer = setTimeout(() => {
         if (settled) return;
+        if (isWin32) {
+          killWindowsProcessTree(() => {
+            settle({
+              exitCode: 124,
+              stdout: stdout.trim(),
+              stderr: stderr.trim(),
+            });
+          });
+          return;
+        }
         killProcessGroup("SIGKILL");
-      }, SIGKILL_GRACE_MS);
-      // Append timeout notice to stderr
-      stderr += `\nHook command timed out after ${timeoutMs}ms`;
+        settle({
+          exitCode: 124,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        });
+      }, killGraceMs);
+      if (killTimer && typeof killTimer === "object" && "unref" in killTimer) {
+        killTimer.unref();
+      }
     }, timeoutMs);
 
     // Don't let the timeout timer keep the process alive


### PR DESCRIPTION
## Summary
- Make timed-out hook commands settle deterministically with exit code 124 instead of waiting forever for `close`.
- On Windows, terminate the full process tree with `taskkill /T /F` so Gradle-like child processes do not keep running or lock the working directory.
- Add a regression test for a command that would otherwise keep the process alive past timeout.

Fixes #4105

## Verification
- `lsp_diagnostics` on `src/shared/command-executor/execute-hook-command.ts`
- `lsp_diagnostics` on `src/shared/command-executor/execute-hook-command.test.ts`
- `bun test src/shared/command-executor/execute-hook-command.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hook commands from hanging on timeout by resolving with exit code 124 and a clear timeout message. On Windows, kill the entire process tree to prevent lingering child processes and directory locks.

- **Bug Fixes**
  - Timed-out commands now resolve with exit code 124 without waiting for "close", and stderr includes "Hook command timed out after {ms}".
  - Windows: terminate the full process tree using `taskkill /T /F` to clean up child processes.
  - Added `killGraceMs` option (default 5000ms) to control the grace period before force-kill and resolve.
  - Added a regression test for timeout behavior and switched tests to a `node -e` helper for cross-platform env var checks.

<sup>Written for commit 02096c0abad2ffcaeb73713c98f7b7ce0ce11b08. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

