### PR TITLE
fix(background-agent): keep cleanup error listener active

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -435,6 +435,34 @@ describe("#given process cleanup registration", () => {
       }
     })
 
+    test("#given repeated uncaughtException events #when manager is registered #then listener stays installed and host is not forced to exit", async () => {
+      const uncaughtExceptionListenersBefore = process.listeners("uncaughtException")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      const shutdown = mock(() => {})
+      const manager = { shutdown }
+      registeredManagers.push(manager)
+      __enableScheduledForcedExitForTesting()
+
+      try {
+        registerManagerForCleanup(manager)
+
+        process.emit("uncaughtException", new Error("first transient MCP failure"))
+        process.emit("uncaughtException", new Error("second transient MCP failure"))
+        await flushMicrotasks()
+
+        expect(process.listeners("uncaughtException")).toHaveLength(
+          uncaughtExceptionListenersBefore.length + 1,
+        )
+        expect(shutdown).not.toHaveBeenCalled()
+        expect(exitSpy).not.toHaveBeenCalled()
+        expect(process.exitCode).toBe(0)
+      } finally {
+        exitSpy.mockRestore()
+        __disableScheduledForcedExitForTesting()
+        process.exitCode = 0
+      }
+    })
+
     test("#given a manager registered AND process emits 'exit' #then cleanup still runs (signal path remains the real shutdown gate)", () => {
       const exitListenersBefore = process.listeners("exit")
       const shutdown = mock(() => {})

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -115,16 +115,22 @@ function registerErrorEvent(
   // regardless of cause, so cleanup is not skipped when the host genuinely
   // dies.
   //
-  // We still detach the listener before logging so a re-emit from inside
-  // `log()` (e.g. EPIPE while writing to a broken pipe during shutdown)
-  // cannot recurse and produce the 100+ GB log explosion that #3856-era
-  // regressions caused.
+  // Keep the listener installed after logging. Desktop sidecars can emit more
+  // than one transient error during MCP startup or provider reconnects; if we
+  // detach after the first event, the second uncaught exception falls through
+  // to Node's default process termination path and reproduces the exit-code-1
+  // crash from #4128. A local re-entry guard still prevents `log()` failures
+  // (for example EPIPE while writing during shutdown) from recursing into the
+  // 100+ GB log explosion that #3856-era regressions caused.
+  let logging = false
   const listener = (error: unknown) => {
-    process.off(signal, listener)
+    if (logging) return
+    logging = true
     log(
       `[background-agent] ${signal} observed; keeping host alive and skipping cleanup (signal handlers run on real shutdown)`,
       describeProcessCleanupError(error),
     )
+    logging = false
   }
   process.on(signal, listener)
   return listener


### PR DESCRIPTION
## Summary
- Keep the background-agent cleanup error listener installed after transient `uncaughtException` events.
- Preserve the existing log-only behavior so MCP/Desktop sidecar errors do not run cleanup or force `process.exit(1)`.
- Add regression coverage for repeated transient exceptions, matching the Windows Desktop crash pattern after multiple exchanges.

Fixes #4128

## Verification
- `lsp_diagnostics` on `src/features/background-agent/process-cleanup.ts`
- `lsp_diagnostics` on `src/features/background-agent/process-cleanup.test.ts`
- `bun test src/features/background-agent/process-cleanup.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the background-agent cleanup error listener active after transient `uncaughtException` events to prevent Desktop sidecar exit(1) crashes. Maintains log-only handling and adds tests for repeated exceptions, resolving #4128.

- **Bug Fixes**
  - Keep the listener installed and use a small re-entry guard in `log()` to avoid recursion and huge logs.
  - Repeated `uncaughtException` events no longer fall through to Node’s default handler; no cleanup or forced `process.exit(1)`.
  - Added a regression test that mirrors the Windows Desktop pattern of multiple transient errors.

<sup>Written for commit ec9997b7a6d47ef0c7d7c09d6b9172c5c597a954. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

