### PR TITLE
fix(tools/grep, tools/glob): Node-safe subprocess streaming for Desktop utility-process compatibility (#3919)

### DIFF
--- a/src/shared/binary-downloader.ts
+++ b/src/shared/binary-downloader.ts
@@ -4,6 +4,7 @@ import { spawn } from "./bun-spawn-shim";
 import { bunWrite } from "./bun-file-shim";
 import { validateArchiveEntries, type ArchiveEntry } from "./archive-entry-validator";
 import { extractZip } from "./zip-extractor";
+import { readProcessStream } from "./process-stream-reader";
 
 function isTarTraversalErrorOutput(output: string): boolean {
   return /path contains '\.\.'|member name contains '\.\.'|removing leading [`'\"]?\.\.\//i.test(output)
@@ -47,7 +48,8 @@ export async function extractTarGz(
 
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
-    const stderr = await new Response(proc.stderr).text();
+    // #3919: Avoid Response(stream).text() in Windows Desktop utility processes.
+    const stderr = await readProcessStream(proc.stderr);
 
     if (isTarTraversalErrorOutput(stderr)) {
       throw new Error(`Unsafe archive entry: path contains path traversal (${archivePath})`)
@@ -107,8 +109,9 @@ async function listTarEntries(archivePath: string, cwd?: string): Promise<Archiv
 
   const [exitCode, stdout, stderr] = await Promise.all([
     proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    // #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+    readProcessStream(proc.stdout),
+    readProcessStream(proc.stderr),
   ])
 
   if (isTarTraversalErrorOutput(stderr)) {

--- a/src/shared/bun-spawn-shim.test.ts
+++ b/src/shared/bun-spawn-shim.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { Readable } from "node:stream"
 
-import { spawn, spawnSync } from "./bun-spawn-shim"
+import { createNodeSpawnOptions, createNodeSpawnSyncOptions, spawn, spawnSync } from "./bun-spawn-shim"
+import { readProcessStream } from "./process-stream-reader"
 
 describe("bun-spawn-shim", () => {
   test("#given array command #when spawn exits successfully #then exited resolves to zero", async () => {
@@ -17,7 +19,7 @@ describe("bun-spawn-shim", () => {
 
     const [exitCode, stdout] = await Promise.all([
       proc.exited,
-      new Response(proc.stdout).text(),
+      readProcessStream(proc.stdout),
     ])
 
     expect(exitCode).toBe(0)
@@ -48,7 +50,7 @@ describe("bun-spawn-shim", () => {
     })
 
     const exitCode = await proc.exited
-    const stdout = await new Response(proc.stdout).text()
+    const stdout = await readProcessStream(proc.stdout)
 
     expect(exitCode).toBe(0)
     expect(stdout).toBe("")
@@ -60,7 +62,7 @@ describe("bun-spawn-shim", () => {
     expect(result.exitCode).toBe(0)
     expect(result.success).toBe(true)
     expect(result.stdout).toBeDefined()
-    expect(Buffer.from(result.stdout!).toString().trim()).toBe("sync-ok")
+    expect(result.stdout?.toString().trim()).toBe("sync-ok")
   })
 
   test("#given spawnSync command #when it completes #then result.pid is a positive number", () => {
@@ -87,5 +89,39 @@ describe("bun-spawn-shim", () => {
     }
 
     expect(observedError).toBeDefined()
+  })
+
+  test("#given Windows platform #when building Node spawn options #then windowsHide is enabled", () => {
+    const options = createNodeSpawnOptions({ stdout: "pipe", stderr: "pipe" }, "win32")
+
+    expect(options.windowsHide).toBe(true)
+    expect(options.shell).toBe(false)
+  })
+
+  test("#given Windows platform #when building Node spawnSync options #then windowsHide is enabled", () => {
+    const options = createNodeSpawnSyncOptions({ stdout: "pipe", stderr: "pipe" }, "win32")
+
+    expect(options.windowsHide).toBe(true)
+    expect(options.shell).toBe(false)
+  })
+
+  test("#given Node readable output #when reading in a non-Bun host shape #then Buffer-concat returns text", async () => {
+    const stream = Readable.from([Buffer.from("node-stream-ok\n")])
+
+    const output = await readProcessStream(stream)
+
+    expect(output).toBe("node-stream-ok\n")
+  })
+
+  test("#given empty process stream #when reading process output #then returns an empty string", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const output = await readProcessStream(stream)
+
+    expect(output).toBe("")
   })
 })

--- a/src/shared/bun-spawn-shim.ts
+++ b/src/shared/bun-spawn-shim.ts
@@ -1,4 +1,9 @@
-import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from "node:child_process"
+import {
+  spawn as nodeSpawn,
+  spawnSync as nodeSpawnSync,
+  type SpawnOptions as NodeSpawnOptions,
+  type SpawnSyncOptions as NodeSpawnSyncOptions,
+} from "node:child_process"
 import { Readable, Writable } from "node:stream"
 
 type AnyRecord = Record<string, unknown>
@@ -45,7 +50,10 @@ type BunSpawnRuntime = {
 }
 
 const runtime = globalThis as typeof globalThis & { Bun?: BunSpawnRuntime }
-const IS_BUN = typeof runtime.Bun !== "undefined"
+
+function getBunRuntime(): BunSpawnRuntime | undefined {
+  return typeof Bun === "undefined" ? undefined : runtime.Bun
+}
 
 function emptyReadableStream(): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -83,6 +91,48 @@ function resolveStdio(options: SpawnOptions): StdioTuple {
   if (options.stdio) return options.stdio
 
   return [options.stdin ?? "ignore", options.stdout ?? "pipe", options.stderr ?? "inherit"]
+}
+
+export function createNodeSpawnOptions(
+  options: SpawnOptions,
+  platform: NodeJS.Platform = process.platform
+): NodeSpawnOptions {
+  const nodeOptions: NodeSpawnOptions = {
+    stdio: resolveStdio(options),
+    shell: false,
+  }
+
+  if (options.cwd !== undefined) nodeOptions.cwd = options.cwd
+  if (options.env !== undefined) nodeOptions.env = options.env
+  if (options.detached !== undefined) nodeOptions.detached = options.detached
+  if (options.signal !== undefined) nodeOptions.signal = options.signal
+
+  if (platform === "win32") {
+    // #3919: Windows Desktop utility processes must hide child consoles when spawning tools.
+    nodeOptions.windowsHide = true
+  }
+
+  return nodeOptions
+}
+
+export function createNodeSpawnSyncOptions(
+  options: SpawnOptions,
+  platform: NodeJS.Platform = process.platform
+): NodeSpawnSyncOptions {
+  const nodeOptions: NodeSpawnSyncOptions = {
+    stdio: resolveStdio(options),
+    shell: false,
+  }
+
+  if (options.cwd !== undefined) nodeOptions.cwd = options.cwd
+  if (options.env !== undefined) nodeOptions.env = options.env
+
+  if (platform === "win32") {
+    // #3919: Match async spawn so Windows sync probes do not surface a console window.
+    nodeOptions.windowsHide = true
+  }
+
+  return nodeOptions
 }
 
 function wrapNodeProcess(proc: ReturnType<typeof nodeSpawn>): SpawnedProcess {
@@ -127,20 +177,27 @@ function wrapNodeProcess(proc: ReturnType<typeof nodeSpawn>): SpawnedProcess {
   }
 }
 
+function toSpawnSyncBuffer(output: Buffer | string | null): Buffer | undefined {
+  if (output === null) {
+    return undefined
+  }
+
+  return Buffer.isBuffer(output) ? output : Buffer.from(output, "utf8")
+}
+
 export function spawn(command: string[], options?: SpawnOptions): SpawnedProcess
 export function spawn(options: SpawnOptions & { cmd: string[] }): SpawnedProcess
 export function spawn(cmdOrOpts: unknown, opts?: unknown): SpawnedProcess {
-  if (IS_BUN) return runtime.Bun!.spawn(cmdOrOpts as string[] & SpawnOptions & { cmd: string[] }, opts as SpawnOptions)
-
   const { cmd, opts: options } = resolveCommand(cmdOrOpts, opts)
+  const bun = getBunRuntime()
+  if (bun) return bun.spawn(cmd, options)
+
   const [bin, ...args] = cmd
-  const proc = nodeSpawn(bin, args, {
-    cwd: options.cwd,
-    env: options.env,
-    stdio: resolveStdio(options),
-    detached: options.detached,
-    signal: options.signal,
-  })
+  if (bin === undefined) {
+    throw new Error("Cannot spawn an empty command")
+  }
+
+  const proc = nodeSpawn(bin, args, createNodeSpawnOptions(options))
 
   return wrapNodeProcess(proc)
 }
@@ -148,20 +205,21 @@ export function spawn(cmdOrOpts: unknown, opts?: unknown): SpawnedProcess {
 export function spawnSync(command: string[], options?: SpawnOptions): SpawnSyncResult
 export function spawnSync(options: SpawnOptions & { cmd: string[] }): SpawnSyncResult
 export function spawnSync(cmdOrOpts: unknown, opts?: unknown): SpawnSyncResult {
-  if (IS_BUN) return runtime.Bun!.spawnSync(cmdOrOpts as string[] & SpawnOptions & { cmd: string[] }, opts as SpawnOptions)
-
   const { cmd, opts: options } = resolveCommand(cmdOrOpts, opts)
+  const bun = getBunRuntime()
+  if (bun) return bun.spawnSync(cmd, options)
+
   const [bin, ...args] = cmd
-  const result = nodeSpawnSync(bin, args, {
-    cwd: options.cwd,
-    env: options.env,
-    stdio: resolveStdio(options),
-  })
+  if (bin === undefined) {
+    throw new Error("Cannot spawnSync an empty command")
+  }
+
+  const result = nodeSpawnSync(bin, args, createNodeSpawnSyncOptions(options))
 
   return {
     exitCode: result.status ?? 1,
-    stdout: result.stdout ?? undefined,
-    stderr: result.stderr ?? undefined,
+    stdout: toSpawnSyncBuffer(result.stdout),
+    stderr: toSpawnSyncBuffer(result.stderr),
     success: (result.status ?? 1) === 0,
     pid: result.pid ?? -1,
   }

--- a/src/shared/process-stream-reader.ts
+++ b/src/shared/process-stream-reader.ts
@@ -1,0 +1,63 @@
+import { Readable } from "node:stream"
+
+export type ProcessReadableStream = ReadableStream<Uint8Array> | Readable | null | undefined
+
+function bufferFromChunk(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk
+  }
+
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk)
+  }
+
+  if (typeof chunk === "string") {
+    return Buffer.from(chunk, "utf8")
+  }
+
+  throw new TypeError(`Unsupported process stream chunk type: ${typeof chunk}`)
+}
+
+async function readWebStream(stream: ReadableStream<Uint8Array>): Promise<Buffer[]> {
+  const reader = stream.getReader()
+  const chunks: Buffer[] = []
+
+  try {
+    while (true) {
+      const result = await reader.read()
+      if (result.done) {
+        return chunks
+      }
+      chunks.push(Buffer.from(result.value))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+async function readNodeStream(stream: Readable): Promise<Buffer[]> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of stream) {
+    chunks.push(bufferFromChunk(chunk))
+  }
+
+  return chunks
+}
+
+function isWebReadableStream(stream: ProcessReadableStream): stream is ReadableStream<Uint8Array> {
+  return typeof ReadableStream !== "undefined" && stream instanceof ReadableStream
+}
+
+export async function readProcessStream(stream: ProcessReadableStream): Promise<string> {
+  if (!stream) {
+    return ""
+  }
+
+  // #3919: Buffer-concat avoids Response(stream).text() crashes in Windows utility processes.
+  const chunks = isWebReadableStream(stream)
+    ? await readWebStream(stream)
+    : await readNodeStream(stream)
+
+  return Buffer.concat(chunks).toString("utf8")
+}

--- a/src/shared/ripgrep-cli.ts
+++ b/src/shared/ripgrep-cli.ts
@@ -20,12 +20,19 @@ let autoInstallAttempted = false
 
 function findExecutable(name: string): string | null {
   const isWindows = process.platform === "win32"
-  const cmd = isWindows ? "where" : "which"
+  const cmd = isWindows ? "where.exe" : "which"
 
   try {
-    const result = spawnSync(cmd, [name], { encoding: "utf-8", timeout: 5000 })
-    if (result.status === 0 && result.stdout.trim()) {
-      return result.stdout.trim().split("\n")[0]
+    // #3919: Keep Windows executable probes hidden and shell-free in Desktop utility processes.
+    const result = spawnSync(cmd, [name], {
+      encoding: "utf-8",
+      timeout: 5000,
+      windowsHide: isWindows,
+      shell: false,
+    })
+    const stdout = result.stdout
+    if (result.status === 0 && stdout.trim()) {
+      return stdout.trim().split("\n")[0]
     }
   } catch {
     return null

--- a/src/shared/zip-entry-listing/powershell-zip-entry-listing.ts
+++ b/src/shared/zip-entry-listing/powershell-zip-entry-listing.ts
@@ -1,6 +1,7 @@
 import { spawn } from "../bun-spawn-shim"
 
 import type { ArchiveEntry } from "../archive-entry-validator"
+import { readProcessStream } from "../process-stream-reader"
 
 export type PowerShellZipExtractor = "pwsh" | "powershell"
 
@@ -82,8 +83,9 @@ export async function listZipEntriesWithPowerShell(
 
 	const [exitCode, stdout, stderr] = await Promise.all([
 		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
+		// #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+		readProcessStream(proc.stdout),
+		readProcessStream(proc.stderr),
 	])
 
 	if (exitCode !== 0) {

--- a/src/shared/zip-entry-listing/python-zip-entry-listing.ts
+++ b/src/shared/zip-entry-listing/python-zip-entry-listing.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "../bun-spawn-shim"
 
 import type { ArchiveEntry } from "../archive-entry-validator"
+import { readProcessStream } from "../process-stream-reader"
 
 export function isPythonZipListingAvailable(): boolean {
 	const proc = spawnSync(["python3", "--version"], {
@@ -43,8 +44,9 @@ export async function listZipEntriesWithPython(
 
 	const [exitCode, stdout, stderr] = await Promise.all([
 		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
+		// #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+		readProcessStream(proc.stdout),
+		readProcessStream(proc.stderr),
 	])
 
 	if (exitCode !== 0) {

--- a/src/shared/zip-entry-listing/read-zip-symlink-target.ts
+++ b/src/shared/zip-entry-listing/read-zip-symlink-target.ts
@@ -1,4 +1,5 @@
 import { spawn } from "../bun-spawn-shim"
+import { readProcessStream } from "../process-stream-reader"
 
 export async function readZipSymlinkTarget(
 	archivePath: string,
@@ -11,8 +12,9 @@ export async function readZipSymlinkTarget(
 
 	const [exitCode, stdout, stderr] = await Promise.all([
 		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
+		// #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+		readProcessStream(proc.stdout),
+		readProcessStream(proc.stderr),
 	])
 
 	if (exitCode !== 0) {

--- a/src/shared/zip-entry-listing/tar-zip-entry-listing.ts
+++ b/src/shared/zip-entry-listing/tar-zip-entry-listing.ts
@@ -2,6 +2,7 @@ import { spawn } from "../bun-spawn-shim"
 
 import type { ArchiveEntry } from "../archive-entry-validator"
 import { log } from "../logger"
+import { readProcessStream } from "../process-stream-reader"
 
 
 
@@ -81,8 +82,9 @@ export async function listZipEntriesWithTar(
 
 	const [exitCode, stdout, stderr] = await Promise.all([
 		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
+		// #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+		readProcessStream(proc.stdout),
+		readProcessStream(proc.stderr),
 	])
 
 	if (exitCode !== 0) {

--- a/src/shared/zip-entry-listing/zipinfo-zip-entry-listing.ts
+++ b/src/shared/zip-entry-listing/zipinfo-zip-entry-listing.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "../bun-spawn-shim"
 
 import type { ArchiveEntry } from "../archive-entry-validator"
+import { readProcessStream } from "../process-stream-reader"
 import { readZipSymlinkTarget } from "./read-zip-symlink-target"
 
 export function parseZipInfoListedEntry(line: string): ArchiveEntry | null {
@@ -45,8 +46,9 @@ export async function listZipEntriesWithZipInfo(
 
 	const [exitCode, stdout, stderr] = await Promise.all([
 		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
+		// #3919: Use Buffer-concat stream reads for Node utility-process compatibility.
+		readProcessStream(proc.stdout),
+		readProcessStream(proc.stderr),
 	])
 
 	if (exitCode !== 0) {

--- a/src/shared/zip-extractor.ts
+++ b/src/shared/zip-extractor.ts
@@ -1,7 +1,8 @@
-import { spawn, spawnSync } from "./bun-spawn-shim"
+import { spawn, spawnSync, type SpawnedProcess } from "./bun-spawn-shim"
 import { release } from "os"
 
 import { validateArchiveEntries } from "./archive-entry-validator"
+import { readProcessStream } from "./process-stream-reader"
 import {
 	isPythonZipListingAvailable,
 	isZipInfoZipListingAvailable,
@@ -53,7 +54,7 @@ export async function extractZip(archivePath: string, destDir: string): Promise<
   const entries = await listZipEntries(archivePath)
   validateArchiveEntries(entries, destDir)
 
-  let proc
+  let proc: SpawnedProcess
   
   if (process.platform === "win32") {
     const extractor = getWindowsZipExtractor()
@@ -89,7 +90,8 @@ export async function extractZip(archivePath: string, destDir: string): Promise<
   const exitCode = await proc.exited
   
   if (exitCode !== 0) {
-    const stderr = await new Response(proc.stderr).text()
+    // #3919: Avoid Response(stream).text() in Windows Desktop utility processes.
+    const stderr = await readProcessStream(proc.stderr)
     throw new Error(`zip extraction failed (exit ${exitCode}): ${stderr}`)
   }
 }

--- a/src/tools/glob/cli.test.ts
+++ b/src/tools/glob/cli.test.ts
@@ -1,5 +1,36 @@
-import { describe, it, expect } from "bun:test"
-import { buildRgArgs, buildFindArgs, buildPowerShellCommand } from "./cli"
+import { describe, it, expect, mock } from "bun:test"
+import { Writable } from "node:stream"
+import type { SpawnOptions, SpawnedProcess } from "../../shared/bun-spawn-shim"
+import { buildRgArgs, buildFindArgs, buildPowerShellCommand, runRgFiles } from "./cli"
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (text.length > 0) {
+        controller.enqueue(new TextEncoder().encode(text))
+      }
+      controller.close()
+    },
+  })
+}
+
+function createSpawnedProcess(exitCode: number, stdout = "", stderr = ""): SpawnedProcess {
+  return {
+    exitCode,
+    exited: Promise.resolve(exitCode),
+    stdout: createTextStream(stdout),
+    stderr: createTextStream(stderr),
+    stdin: new Writable({
+      write(_chunk, _encoding, callback) {
+        callback()
+      },
+    }),
+    pid: 3919,
+    kill() {},
+    ref() {},
+    unref() {},
+  }
+}
 
 describe("buildRgArgs", () => {
   // given default options (no hidden/follow specified)
@@ -165,5 +196,33 @@ describe("buildPowerShellCommand", () => {
     const args = buildPowerShellCommand({ pattern: "test's.ts" })
     const command = args.join(" ")
     expect(command).toContain("test''s.ts")
+  })
+
+  it("uses LiteralPath so fallback paths are not wildcard-expanded (#3919)", () => {
+    const args = buildPowerShellCommand({ pattern: "*.ts", paths: ["C:\\repo[1]"] })
+    const command = args.join(" ")
+    expect(args[0]).toBe("powershell.exe")
+    expect(command).toContain("Get-ChildItem -LiteralPath 'C:\\repo[1]'")
+  })
+})
+
+describe("runRgFiles", () => {
+  it("#given empty stdout #when rg exits successfully #then returns an empty result", async () => {
+    const spawnMock = mock((_command: string[], _options?: SpawnOptions): SpawnedProcess =>
+      createSpawnedProcess(0)
+    )
+
+    const result = await runRgFiles(
+      { pattern: "*.ts", paths: ["."], timeout: 1000 },
+      { path: "rg", backend: "rg" },
+      spawnMock
+    )
+
+    expect(result).toEqual({
+      files: [],
+      totalFiles: 0,
+      truncated: false,
+    })
+    expect(spawnMock).toHaveBeenCalled()
   })
 })

--- a/src/tools/glob/cli.ts
+++ b/src/tools/glob/cli.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path"
-import { spawn } from "../../shared/bun-spawn-shim"
+import { spawn, type SpawnOptions, type SpawnedProcess } from "../../shared/bun-spawn-shim"
 import {
   resolveGrepCli,
   type GrepBackend,
@@ -13,11 +13,14 @@ import {
 import type { GlobOptions, GlobResult, FileMatch } from "./types"
 import { stat } from "node:fs/promises"
 import { rgSemaphore } from "../shared/semaphore"
+import { collectSearchProcessOutput } from "../shared/search-process-output"
 
 export interface ResolvedCli {
   path: string
   backend: GrepBackend
 }
+
+export type SearchProcessSpawner = (command: string[], options?: SpawnOptions) => SpawnedProcess
 
 function buildRgArgs(options: GlobOptions): string[] {
   const args: string[] = [
@@ -65,7 +68,8 @@ function buildPowerShellCommand(options: GlobOptions): string[] {
   const escapedPath = searchPath.replace(/'/g, "''")
   const escapedPattern = options.pattern.replace(/'/g, "''")
 
-  let psCommand = `Get-ChildItem -Path '${escapedPath}' -File -Recurse -Depth ${maxDepth - 1} -Filter '${escapedPattern}'`
+  // #3919: Keep PowerShell fallback direct-spawned and single-quote escaped, not shell-interpolated.
+  let psCommand = `Get-ChildItem -LiteralPath '${escapedPath}' -File -Recurse -Depth ${maxDepth - 1} -Filter '${escapedPattern}'`
 
   if (options.hidden !== false) {
     psCommand += " -Force"
@@ -78,7 +82,7 @@ function buildPowerShellCommand(options: GlobOptions): string[] {
 
   psCommand += " -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"
 
-  return ["powershell", "-NoProfile", "-Command", psCommand]
+  return ["powershell.exe", "-NoProfile", "-Command", psCommand]
 }
 
 async function getFileMtime(filePath: string): Promise<number> {
@@ -94,11 +98,12 @@ export { buildRgArgs, buildFindArgs, buildPowerShellCommand }
 
 export async function runRgFiles(
   options: GlobOptions,
-  resolvedCli?: ResolvedCli
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
 ): Promise<GlobResult> {
   await rgSemaphore.acquire()
   try {
-    return await runRgFilesInternal(options, resolvedCli)
+    return await runRgFilesInternal(options, resolvedCli, processSpawner)
   } finally {
     rgSemaphore.release()
   }
@@ -106,7 +111,8 @@ export async function runRgFiles(
 
 async function runRgFilesInternal(
   options: GlobOptions,
-  resolvedCli?: ResolvedCli
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
 ): Promise<GlobResult> {
   const cli = resolvedCli ?? resolveGrepCli()
   const timeout = Math.min(options.timeout ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
@@ -133,24 +139,19 @@ async function runRgFilesInternal(
     command = [cli.path, ...args]
   }
 
-  const proc = spawn(command, {
-    stdout: "pipe",
-    stderr: "pipe",
-    cwd,
-  })
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    const id = setTimeout(() => {
-      proc.kill()
-      reject(new Error(`Glob search timeout after ${timeout}ms`))
-    }, timeout)
-    proc.exited.then(() => clearTimeout(id))
-  })
-
   try {
-    const stdout = await Promise.race([new Response(proc.stdout).text(), timeoutPromise])
-    const stderr = await new Response(proc.stderr).text()
-    const exitCode = await proc.exited
+    const proc = processSpawner(command, {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd,
+    })
+
+    // #3919: Read stdout/stderr with Buffer concat instead of Response(stream).text().
+    const { stdout, stderr, exitCode } = await collectSearchProcessOutput(
+      proc,
+      timeout,
+      `Glob search timeout after ${timeout}ms`
+    )
 
     if (exitCode > 1 && stderr.trim()) {
       return {

--- a/src/tools/grep/cli.test.ts
+++ b/src/tools/grep/cli.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, mock } from "bun:test"
+import { Writable } from "node:stream"
+import type { SpawnOptions, SpawnedProcess } from "../../shared/bun-spawn-shim"
+import { runRg } from "./cli"
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (text.length > 0) {
+        controller.enqueue(new TextEncoder().encode(text))
+      }
+      controller.close()
+    },
+  })
+}
+
+function createSpawnedProcess(exited: Promise<number>, stdout = "", stderr = ""): SpawnedProcess {
+  return {
+    exitCode: null,
+    exited,
+    stdout: createTextStream(stdout),
+    stderr: createTextStream(stderr),
+    stdin: new Writable({
+      write(_chunk, _encoding, callback) {
+        callback()
+      },
+    }),
+    pid: 3919,
+    kill() {},
+    ref() {},
+    unref() {},
+  }
+}
+
+describe("runRg", () => {
+  it("#given mocked spawn rejection #when grep runs #then returns a structured error result", async () => {
+    const spawnMock = mock((_command: string[], _options?: SpawnOptions): SpawnedProcess =>
+      createSpawnedProcess(Promise.reject(new Error("spawn rejected")))
+    )
+
+    const result = await runRg(
+      { pattern: "needle", paths: ["."], timeout: 1000 },
+      { path: "rg", backend: "rg" },
+      spawnMock
+    )
+
+    expect(result.matches).toEqual([])
+    expect(result.totalMatches).toBe(0)
+    expect(result.filesSearched).toBe(0)
+    expect(result.truncated).toBe(false)
+    expect(result.error).toContain("spawn rejected")
+  })
+})

--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -1,4 +1,4 @@
-import { spawn } from "../../shared/bun-spawn-shim"
+import { spawn, type SpawnOptions, type SpawnedProcess } from "../../shared/bun-spawn-shim"
 import {
   resolveGrepCli,
   type ResolvedCli,
@@ -17,6 +17,9 @@ import {
 } from "./constants"
 import type { GrepOptions, GrepMatch, GrepResult, CountResult } from "./types"
 import { rgSemaphore } from "../shared/semaphore"
+import { collectSearchProcessOutput } from "../shared/search-process-output"
+
+export type SearchProcessSpawner = (command: string[], options?: SpawnOptions) => SpawnedProcess
 
 function buildRgArgs(options: GrepOptions): string[] {
   const args: string[] = [
@@ -154,16 +157,24 @@ function parseCountOutput(output: string): CountResult[] {
   return results
 }
 
-export async function runRg(options: GrepOptions, resolvedCli?: ResolvedCli): Promise<GrepResult> {
+export async function runRg(
+  options: GrepOptions,
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
+): Promise<GrepResult> {
   await rgSemaphore.acquire()
   try {
-    return await runRgInternal(options, resolvedCli)
+    return await runRgInternal(options, resolvedCli, processSpawner)
   } finally {
     rgSemaphore.release()
   }
 }
 
-async function runRgInternal(options: GrepOptions, resolvedCli?: ResolvedCli): Promise<GrepResult> {
+async function runRgInternal(
+  options: GrepOptions,
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
+): Promise<GrepResult> {
   const cli = resolvedCli ?? resolveGrepCli()
   const args = buildArgs(options, cli.backend)
   const timeout = Math.min(options.timeout ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
@@ -176,23 +187,18 @@ async function runRgInternal(options: GrepOptions, resolvedCli?: ResolvedCli): P
 
   const paths = options.paths?.length ? options.paths : ["."]
   args.push(...paths)
-  const proc = spawn([cli.path, ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    const id = setTimeout(() => {
-      proc.kill()
-      reject(new Error(`Search timeout after ${timeout}ms`))
-    }, timeout)
-    proc.exited.then(() => clearTimeout(id))
-  })
-
   try {
-    const stdout = await Promise.race([new Response(proc.stdout).text(), timeoutPromise])
-    const stderr = await new Response(proc.stderr).text()
-    const exitCode = await proc.exited
+    const proc = processSpawner([cli.path, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    // #3919: Read stdout/stderr with Buffer concat instead of Response(stream).text().
+    const { stdout, stderr, exitCode } = await collectSearchProcessOutput(
+      proc,
+      timeout,
+      `Search timeout after ${timeout}ms`
+    )
 
     const truncated = stdout.length >= DEFAULT_MAX_OUTPUT_BYTES
     const outputToProcess = truncated ? stdout.substring(0, DEFAULT_MAX_OUTPUT_BYTES) : stdout
@@ -232,11 +238,12 @@ async function runRgInternal(options: GrepOptions, resolvedCli?: ResolvedCli): P
 
 export async function runRgCount(
   options: Omit<GrepOptions, "context">,
-  resolvedCli?: ResolvedCli
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
 ): Promise<CountResult[]> {
   await rgSemaphore.acquire()
   try {
-    return await runRgCountInternal(options, resolvedCli)
+    return await runRgCountInternal(options, resolvedCli, processSpawner)
   } finally {
     rgSemaphore.release()
   }
@@ -244,7 +251,8 @@ export async function runRgCount(
 
 async function runRgCountInternal(
   options: Omit<GrepOptions, "context">,
-  resolvedCli?: ResolvedCli
+  resolvedCli?: ResolvedCli,
+  processSpawner: SearchProcessSpawner = spawn
 ): Promise<CountResult[]> {
   const cli = resolvedCli ?? resolveGrepCli()
   const args = buildArgs({ ...options, context: 0 }, cli.backend)
@@ -259,21 +267,21 @@ async function runRgCountInternal(
   args.push(...paths)
 
   const timeout = Math.min(options.timeout ?? DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS)
-  const proc = spawn([cli.path, ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    const id = setTimeout(() => {
-      proc.kill()
-      reject(new Error(`Search timeout after ${timeout}ms`))
-    }, timeout)
-    proc.exited.then(() => clearTimeout(id))
-  })
-
   try {
-    const stdout = await Promise.race([new Response(proc.stdout).text(), timeoutPromise])
+    const proc = processSpawner([cli.path, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    // #3919: Count mode uses the same Node-safe stream reader as normal grep.
+    const { stdout, stderr, exitCode } = await collectSearchProcessOutput(
+      proc,
+      timeout,
+      `Search timeout after ${timeout}ms`
+    )
+    if (exitCode > 1 && stderr.trim()) {
+      throw new Error(stderr.trim())
+    }
     return parseCountOutput(stdout)
   } catch (e) {
     throw new Error(`Count search failed: ${e instanceof Error ? e.message : String(e)}`)

--- a/src/tools/shared/search-process-output.ts
+++ b/src/tools/shared/search-process-output.ts
@@ -1,0 +1,46 @@
+import type { SpawnedProcess } from "../../shared/bun-spawn-shim"
+import { readProcessStream } from "../../shared/process-stream-reader"
+
+export interface SearchProcessOutput {
+  readonly stdout: string
+  readonly stderr: string
+  readonly exitCode: number
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function createProcessTimeout(
+  proc: SpawnedProcess,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    const id = setTimeout(() => {
+      proc.kill()
+      reject(new Error(timeoutMessage))
+    }, timeoutMs)
+
+    // #3919: Handle rejected exits here so timeout cleanup cannot leak unhandled rejections.
+    void proc.exited.then(
+      () => clearTimeout(id),
+      () => clearTimeout(id)
+    )
+  })
+}
+
+export async function collectSearchProcessOutput(
+  proc: SpawnedProcess,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<SearchProcessOutput> {
+  const stderrPromise = readProcessStream(proc.stderr).catch(getErrorMessage)
+  const stdout = await Promise.race([
+    readProcessStream(proc.stdout),
+    createProcessTimeout(proc, timeoutMs, timeoutMessage),
+  ])
+  const [exitCode, stderr] = await Promise.all([proc.exited, stderrPromise])
+
+  return { stdout, stderr, exitCode }
+}


### PR DESCRIPTION
## Summary
OpenCode Desktop v1.14.41+ moved the local server into a separate utility
process (Node.js). OMO's custom grep/glob tools used \`new Response(proc.stdout).text()\`
(Web Response API) and Bun-specific spawn options, causing the Desktop sidecar
to disconnect on Windows when grep/glob were invoked.

This PR makes OMO grep/glob ROBUST in the Node.js utility-process runtime
WITHOUT sacrificing OMO override functionality. The ripgrep auto-download,
PowerShell fallback, and rgSemaphore concurrency control are all preserved.

## Changes
- New `src/shared/process-stream-reader.ts`: Buffer-concat stream reader compatible with Bun and Node ChildProcess stdout
- New `src/tools/shared/search-process-output.ts`: structured subprocess output collector with timeout, kill, and rejection cleanup
- `bun-spawn-shim.ts`: forces `windowsHide: true` on the Node path; spawn errors no longer escape as unhandledRejection
- `glob/cli.ts`, `grep/cli.ts`: switched from Web Response API to Node-safe reader
- `ripgrep-cli.ts`, `binary-downloader.ts`, `zip-extractor.ts`, 5 `zip-entry-listing/*` files: same hardening pattern
- New regression tests covering spawn rejection handling, empty stdout, Node host detection, Windows spawn options

## Testing
- `bun run typecheck` passes
- `bun test src/tools/glob src/tools/grep src/shared/bun-spawn-shim src/shared/process-stream-reader` passes (45/45)
- LSP diagnostics clean

## Related Issues
Fixes #3919

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make grep and glob use Node-safe subprocess streaming so Desktop’s Node utility-process doesn’t crash on Windows. Preserves ripgrep auto-install, PowerShell fallback, and `rgSemaphore`. Fixes #3919.

- **Bug Fixes**
  - Switched grep/glob to a Node-safe stream reader and structured output collector (replaces `new Response(proc.stdout).text()`).
  - Hardened subprocess handling in `ripgrep-cli`, `binary-downloader`, `zip-extractor`, and all zip-entry listing helpers.
  - Updated `bun-spawn-shim` to force `windowsHide: true` on Windows and avoid unhandled rejections; no shell usage.
  - PowerShell fallback now uses `powershell.exe` with `-LiteralPath` to avoid wildcard expansion and runs with timeouts.

- **Refactors**
  - Added `src/shared/process-stream-reader.ts` and `src/tools/shared/search-process-output.ts` for shared, robust process I/O with timeout/kill cleanup.
  - Introduced `createNodeSpawnOptions`/`createNodeSpawnSyncOptions`; normalized sync stdout/stderr buffers.
  - Added regression tests for spawn rejection, empty stdout, Node host detection, and Windows spawn options; new tests for grep/glob happy paths.

<sup>Written for commit aded57ff1fc68f90d8c81e557b64bb0827bfa6a9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4300?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

