### PR TITLE
fix(parent-wake-notifier): suppress duplicate parent wakes during promptAsync gate hold (#4256, #4019)

### DIFF
--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -238,6 +238,13 @@ export class ParentWakeNotifier {
         throw promptResult.error
       }
       if (promptResult.status === "reserved" && promptResult.reservedBy === "background-agent-parent-wake") {
+        const dispatchedWake = this.dispatchedParentWakes.get(sessionID)
+        if (dispatchedWake && this.isSameParentWake(latestWake, dispatchedWake)) {
+          // #4256/#4019: duplicated completion edges can enqueue the same wake
+          // during the gate hold. Replaying it later starts a second assistant stream.
+          log("[background-agent] Suppressed duplicate parent wake during promptAsync gate hold:", { sessionID })
+          return
+        }
         this.requeueWake(sessionID, latestWake)
         this.schedulePendingParentWakeFlush(sessionID, 2_000)
         log("[background-agent] Requeued parent wake flush reserved by promptAsync gate hold:", { sessionID })
@@ -397,6 +404,12 @@ export class ParentWakeNotifier {
     // event loop alive past the natural teardown window (issue #4120).
     unrefTimerHandle(timer)
     this.dispatchedParentWakeTimers.set(sessionID, timer)
+  }
+
+  private isSameParentWake(left: PendingParentWake, right: PendingParentWake): boolean {
+    return left.shouldReply === right.shouldReply
+      && JSON.stringify(left.notifications) === JSON.stringify(right.notifications)
+      && JSON.stringify(left.promptContext) === JSON.stringify(right.promptContext)
   }
 
   private async loadParentWakeSessionMessages(sessionID: string): Promise<ParentWakeSessionMessage[]> {

--- a/src/features/background-agent/parent-wake-same-source-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-same-source-requeue.test.ts
@@ -84,6 +84,31 @@ function releaseParentWakeHold(sessionID: string): void {
 }
 
 describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () => {
+  test("#given a duplicate parent wake is in post-dispatch hold #when the duplicate fires again #then it is dropped instead of requeued", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-hold-duplicate-wake"
+    notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+
+      // when
+      notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+      await notifier.flushPendingParentWake(sessionID)
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given a parent wake is in post-dispatch hold #when a new pending wake fires within the hold window #then the new wake is re-enqueued and dispatched after the hold expires", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier()


### PR DESCRIPTION
## Summary
In v4.1.0+, users observed duplicate assistant streams rendering the same
content in two languages simultaneously (e.g. Chinese + English), most
often at the end of a turn.

Root cause: `ParentWakeNotifier.requeueWake()` unconditionally requeued
ANY wake that arrived during the `background-agent-parent-wake`
post-dispatch hold window. When a duplicate completion edge fired during
that hold, the same wake was replayed after the hold expired, triggering
a second prompt dispatch and a parallel assistant stream.

## Fix
Compare the new wake against `dispatchedParentWakes.get(sessionID)` using
a 3-field identity check (`shouldReply` / `notifications` / `promptContext`).
Drop identical wakes during the gate hold. Preserve the existing requeue
behavior for genuinely-new wakes and failed-dispatch retries.

## Changes
- `parent-wake-notifier.ts`: 13-line surgical change — identity check before requeue, plus `isSameParentWake()` helper
- `parent-wake-same-source-requeue.test.ts`: regression test in given/when/then style (TDD red-then-green)

## Testing
- `bun run typecheck` passes
- `bun test src/features/background-agent/parent-wake` passes (22/22)
- `bun test src/shared/prompt-async-route-audit.test.ts src/shared/mock-module-lifecycle-audit.test.ts` passes (11/11 — architectural invariants preserved)
- LSP diagnostics clean

## Related Issues
Fixes #4256
Fixes #4019


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress duplicate parent wakes during the `promptAsync` gate hold to avoid double prompt dispatch and parallel assistant streams. Addresses #4256 and #4019 where users saw mixed-language duplicate output at the end of a turn.

- **Bug Fixes**
  - In `ParentWakeNotifier`, drop wakes identical to the last dispatched for the same `sessionID` during the hold using a 3-field check (`shouldReply`, `notifications`, `promptContext`); keep requeue for new wakes and retry paths.
  - Added a regression test to ensure duplicates are suppressed and new wakes still dispatch after the hold.

<sup>Written for commit 560569e3696e0ace251f1e15d928c66f5a7803ec. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

