### PR TITLE
fix: discover and load skills from other OpenCode plugins

### DIFF
--- a/src/plugin/skill-context.test.ts
+++ b/src/plugin/skill-context.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 import { OhMyOpenCodeConfigSchema } from "../config"
 import * as mcpLoader from "../features/claude-code-mcp-loader"
 import * as skillLoader from "../features/opencode-skill-loader"
+import * as pluginLoader from "../features/claude-code-plugin-loader"
 import { createSkillContext } from "./skill-context"
 
 describe("createSkillContext", () => {
@@ -147,6 +148,88 @@ describe("createSkillContext", () => {
       discoverProjectAgentsSkillsSpy.mockRestore()
       discoverGlobalAgentsSkillsSpy.mockRestore()
       getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
+
+  it("includes skills from other plugins", async () => {
+    // given
+    const pluginSkillName = "other-plugin:test-skill"
+    const pluginSkills = {
+      [pluginSkillName]: {
+        description: "Test skill from other plugin",
+        template: "Test template",
+      },
+    }
+
+    const discoverConfigSourceSkillsSpy = spyOn(
+      skillLoader,
+      "discoverConfigSourceSkills",
+    ).mockResolvedValue([])
+    const discoverUserClaudeSkillsSpy = spyOn(
+      skillLoader,
+      "discoverUserClaudeSkills",
+    ).mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(
+      skillLoader,
+      "discoverOpencodeGlobalSkills",
+    ).mockResolvedValue([])
+    const discoverProjectClaudeSkillsSpy = spyOn(
+      skillLoader,
+      "discoverProjectClaudeSkills",
+    ).mockResolvedValue([])
+    const discoverOpencodeProjectSkillsSpy = spyOn(
+      skillLoader,
+      "discoverOpencodeProjectSkills",
+    ).mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverProjectAgentsSkills",
+    ).mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverGlobalAgentsSkills",
+    ).mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(
+      mcpLoader,
+      "getSystemMcpServerNames",
+    ).mockReturnValue(new Set<string>())
+
+    const loadAllPluginComponentsSpy = spyOn(
+      pluginLoader,
+      "loadAllPluginComponents",
+    ).mockResolvedValue({
+      commands: {},
+      skills: pluginSkills,
+      agents: {},
+      mcpServers: {},
+      hooksConfigs: [],
+      plugins: [],
+      errors: [],
+    })
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({})
+
+    try {
+      // when
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+      })
+
+      // then
+      const skillNames = result.mergedSkills.map((s) => s.name)
+      expect(skillNames).toContain(pluginSkillName)
+      expect(loadAllPluginComponentsSpy).toHaveBeenCalled()
+    } finally {
+      discoverConfigSourceSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverProjectClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverOpencodeProjectSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+      loadAllPluginComponentsSpy.mockRestore()
     }
   })
 })

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -18,6 +18,7 @@ import {
 } from "../features/opencode-skill-loader"
 import { createBuiltinSkills } from "../features/builtin-skills"
 import { getSystemMcpServerNames } from "../features/claude-code-mcp-loader"
+import { loadAllPluginComponents } from "../features/claude-code-plugin-loader"
 
 export type SkillContext = {
   mergedSkills: LoadedSkill[]
@@ -73,19 +74,28 @@ export async function createSkillContext(args: {
   })
 
   const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
-  const [configSourceSkills, userSkills, globalSkills, projectSkills, opencodeProjectSkills, agentsProjectSkills, agentsGlobalSkills] =
-    await Promise.all([
-      discoverConfigSourceSkills({
-        config: pluginConfig.skills,
-        configDir: directory,
-      }),
-      includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
-      discoverOpencodeGlobalSkills(),
-      includeClaudeSkills ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
-      discoverOpencodeProjectSkills(directory),
-      discoverProjectAgentsSkills(directory),
-      discoverGlobalAgentsSkills(),
-    ])
+  const [
+    configSourceSkills,
+    userSkills,
+    globalSkills,
+    projectSkills,
+    opencodeProjectSkills,
+    agentsProjectSkills,
+    agentsGlobalSkills,
+    pluginComponents,
+  ] = await Promise.all([
+    discoverConfigSourceSkills({
+      config: pluginConfig.skills,
+      configDir: directory,
+    }),
+    includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
+    discoverOpencodeGlobalSkills(),
+    includeClaudeSkills ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
+    discoverOpencodeProjectSkills(directory),
+    discoverProjectAgentsSkills(directory),
+    discoverGlobalAgentsSkills(),
+    loadAllPluginComponents(),
+  ])
 
   const filteredConfigSourceSkills = filterProviderGatedSkills(
     configSourceSkills,
@@ -107,12 +117,21 @@ export async function createSkillContext(args: {
     browserProvider,
   )
 
+  const pluginSkills: LoadedSkill[] = Object.entries(pluginComponents.skills).map(
+    ([name, definition]) => ({
+      name,
+      definition,
+      scope: "opencode" as const,
+    }),
+  )
+  const filteredPluginSkills = filterProviderGatedSkills(pluginSkills, browserProvider)
+
   const mergedSkills = mergeSkills(
     builtinSkills,
     pluginConfig.skills,
     filteredConfigSourceSkills,
     [...filteredUserSkills, ...filteredAgentsGlobalSkills],
-    filteredGlobalSkills,
+    [...filteredGlobalSkills, ...filteredPluginSkills],
     [...filteredProjectSkills, ...filteredAgentsProjectSkills],
     filteredOpencodeProjectSkills,
     { configDir: directory },


### PR DESCRIPTION
## Summary
This PR fixes issue #4302 where skills from other OpenCode plugins (not in Claude Code plugin format) were being hidden when using `oh-my-openagent`.

The fix involves calling `loadAllPluginComponents()` in `createSkillContext` to discover skills from all installed plugins and merging them into the available skills list.

## Changes
- Modified `src/plugin/skill-context.ts` to include `loadAllPluginComponents` in the skill discovery process.
- Updated `src/plugin/skill-context.test.ts` with a new test case to verify that skills from other plugins are correctly included.

## Test Plan
- Added a unit test in `src/plugin/skill-context.test.ts` that mocks plugin discovery and verifies the presence of plugin-provided skills in `mergedSkills`.

Fixes #4302


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load skills from other OpenCode plugins into the skill context so they appear in `oh-my-openagent`, not just Claude Code–format skills. Fixes #4302.

- **Bug Fixes**
  - Call `loadAllPluginComponents()` in `createSkillContext` to discover skills from all installed plugins.
  - Map and merge discovered plugin skills into the global skills list with existing filtering.
  - Add a unit test to ensure plugin-provided skills appear in `mergedSkills`.

<sup>Written for commit 8ee0f26b98b237022053970ec3f6c2907a5a4253. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4312?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

