### PR TITLE
Fix tmux subagent auto attach retries

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -20,11 +20,6 @@ type SpawnTmuxContainerResult = {
   paneId?: string
 }
 
-type SessionReadyWaitParams = {
-  client: unknown
-  sessionId: string
-}
-
 type TmuxSessionManagerContext = ConstructorParameters<typeof import('./manager').TmuxSessionManager>[0]
 
 type TmuxSessionManagerInternals = {
@@ -66,9 +61,6 @@ const mockSpawnTmuxPane = mock(async (_sessionId?: string) => ({
   success: true,
   paneId: '%mock',
 }))
-const mockWaitForSessionReady = mock<(
-  params: SessionReadyWaitParams,
-) => Promise<boolean>>(async () => true)
 const mockSpawnTmuxWindow = mock<(
   sessionId: string,
   description: string,
@@ -90,6 +82,12 @@ const mockSpawnTmuxSession = mock<(
 }))
 const mockKillTmuxSessionIfExists = mock<(sessionName: string) => Promise<boolean>>(async () => true)
 const mockSweepStaleOmoAgentSessions = mock<() => Promise<number>>(async () => 0)
+const mockActivateTmuxPane = mock<(
+  paneId: string,
+  sessionId: string,
+  serverUrl: string,
+  directory: string,
+) => Promise<boolean>>(async () => true)
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
 
@@ -97,7 +95,6 @@ const mockTmuxDeps: TmuxUtilDeps = {
   isInsideTmux: mockIsInsideTmux,
   getCurrentPaneId: mockGetCurrentPaneId,
   queryWindowState: mockQueryWindowState,
-  waitForSessionReady: mockWaitForSessionReady,
   executeActions: mockExecuteActions,
   executeAction: mockExecuteAction,
   log: (...args) => sharedModule.log(...args),
@@ -108,10 +105,6 @@ function registerModuleMocks(): void {
     executeActions: mockExecuteActions,
     executeAction: mockExecuteAction,
     executeActionWithDeps: mockExecuteAction,
-  }))
-
-  mock.module('./session-ready-waiter', () => ({
-    waitForSessionReady: mockWaitForSessionReady,
   }))
 
   mock.module('../../shared/tmux', () => {
@@ -130,6 +123,7 @@ function registerModuleMocks(): void {
       killTmuxSessionIfExists: mockKillTmuxSessionIfExists,
       getIsolatedSessionName: (pid: number = 12345) => `omo-agents-${pid}`,
       sweepStaleOmoAgentSessions: mockSweepStaleOmoAgentSessions,
+      activateTmuxPane: mockActivateTmuxPane,
     }
   })
 }
@@ -142,7 +136,6 @@ afterEach(() => {
 })
 
 const trackedSessions = new Set<string>()
-const readySessions = new Set<string>()
 
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
@@ -158,9 +151,6 @@ function createMockContext(overrides?: {
           }
           const data: Record<string, { type: string }> = {}
           for (const sessionId of trackedSessions) {
-            data[sessionId] = { type: 'running' }
-          }
-          for (const sessionId of readySessions) {
             data[sessionId] = { type: 'running' }
           }
           return { data }
@@ -237,10 +227,6 @@ function getTrackedSessions(manager: object): Map<string, { paneId: string; clos
   return Reflect.get(manager, 'sessions') as Map<string, { paneId: string; closePending: boolean; closeRetryCount: number }>
 }
 
-function getFailedReadinessSessions(manager: object): Map<string, { sessionId: string; title: string }> {
-  return Reflect.get(manager, 'failedReadinessSessions') as Map<string, { sessionId: string; title: string }>
-}
-
 describe('TmuxSessionManager', () => {
   beforeEach(() => {
     mock.restore()
@@ -250,13 +236,12 @@ describe('TmuxSessionManager', () => {
     mockExecuteActions.mockClear()
     mockExecuteAction.mockClear()
     mockSpawnTmuxPane.mockClear()
-    mockWaitForSessionReady.mockClear()
     mockSpawnTmuxWindow.mockClear()
     mockSpawnTmuxSession.mockClear()
+    mockActivateTmuxPane.mockClear()
     mockIsInsideTmux.mockClear()
     mockGetCurrentPaneId.mockClear()
     trackedSessions.clear()
-    readySessions.clear()
 
     mockQueryWindowState.mockImplementation(async () => createWindowState())
     mockExecuteActions.mockImplementation(async (actions: PaneAction[]) => {
@@ -283,10 +268,6 @@ describe('TmuxSessionManager', () => {
         spawnedPaneId: spawnedPaneId ?? '%mock',
         results,
       }
-    })
-    mockWaitForSessionReady.mockImplementation(async ({ sessionId }: SessionReadyWaitParams) => {
-      readySessions.add(sessionId)
-      return true
     })
     mockSpawnTmuxWindow.mockImplementation(async (sessionId: string) => {
       trackedSessions.add(sessionId)
@@ -1412,18 +1393,10 @@ describe('TmuxSessionManager', () => {
       })
     })
 
-    test('#given session readiness is pending #when onSessionCreated runs #then pane spawn waits until readiness resolves', async () => {
+    test('#given session readiness is pending #when onSessionCreated runs #then pane placeholder spawns without waiting', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
       mockQueryWindowState.mockImplementation(async () => createWindowState())
-      const readiness = createDeferred<boolean>()
-      mockWaitForSessionReady.mockImplementationOnce(async ({ sessionId }: SessionReadyWaitParams) => {
-        const ready = await readiness.promise
-        if (ready) {
-          readySessions.add(sessionId)
-        }
-        return ready
-      })
 
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -1436,28 +1409,15 @@ describe('TmuxSessionManager', () => {
       await flushMicrotasks()
 
       // then
-      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(1)
-      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-
-      // when
-      readiness.resolve(true)
       await onSessionCreatedPromise
-
-      // then
       expect(mockExecuteActions).toHaveBeenCalledTimes(1)
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
       expect(getTrackedSessions(manager).has('ses_wait')).toBe(true)
     })
 
-    test('#given readiness probe fails #when onSessionCreated runs #then it logs the structured error and does not spawn a pane', async () => {
+    test('#given status polling has not seen the session #when onSessionCreated runs #then placeholder still spawns', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      const readinessError = new Error('session readiness timed out')
-      mockWaitForSessionReady.mockImplementationOnce(async () => {
-        throw readinessError
-      })
-      const logSpy = spyOn(sharedModule, 'log').mockImplementation(() => {})
 
       const { TmuxSessionManager } = await import('./manager')
       const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({ enabled: true }), mockTmuxDeps)
@@ -1468,25 +1428,14 @@ describe('TmuxSessionManager', () => {
       )
 
       // then
-      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-      expect(logSpy).toHaveBeenCalledWith(
-        '[tmux-session-manager] session readiness failed before spawn',
-        expect.objectContaining({
-          sessionId: 'ses_timeout',
-          stage: 'session.created',
-          error: String(readinessError),
-        }),
-      )
-
-      logSpy.mockRestore()
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
+      expect(getTrackedSessions(manager).has('ses_timeout')).toBe(true)
     })
 
-    test("skips pane creation when session exists but status is 'error'", async () => {
+    test("spawns placeholder even when the latest status is 'error'", async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      mockWaitForSessionReady.mockImplementationOnce(async () => true)
-      const logSpy = spyOn(sharedModule, 'log').mockImplementation(() => {})
       const sessionStatusResult = {
         data: {
           ses_error: { type: 'error' },
@@ -1506,31 +1455,14 @@ describe('TmuxSessionManager', () => {
       )
 
       // then
-      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-      expect(getTrackedSessions(manager).has('ses_error')).toBe(false)
-      expect(getFailedReadinessSessions(manager).has('ses_error')).toBe(true)
-      expect(logSpy).toHaveBeenCalledWith(
-        '[tmux-session-manager] session not attachable for pane spawn',
-        expect.objectContaining({
-          sessionId: 'ses_error',
-          stage: 'session.created',
-          status: 'error',
-        }),
-      )
-
-      logSpy.mockRestore()
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
+      expect(getTrackedSessions(manager).has('ses_error')).toBe(true)
     })
 
-    test('retries pane creation on session.idle after a readiness timeout when status becomes attachable', async () => {
+    test('does not respawn a second placeholder when status later becomes idle', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      const readinessError = new Error('session readiness timed out')
-      mockWaitForSessionReady
-        .mockImplementationOnce(async () => {
-          throw readinessError
-        })
-        .mockImplementationOnce(async () => true)
       const sessionStatusResult = {
         data: {} as Record<string, { type: string }>,
       }
@@ -1548,8 +1480,8 @@ describe('TmuxSessionManager', () => {
       )
 
       // then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-      expect(getFailedReadinessSessions(manager).has('ses_retry')).toBe(true)
+      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
+      expect(getTrackedSessions(manager).has('ses_retry')).toBe(true)
 
       // when
       sessionStatusResult.data.ses_retry = { type: 'idle' }
@@ -1558,18 +1490,11 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
-      expect(getTrackedSessions(manager).has('ses_retry')).toBe(true)
-      expect(getFailedReadinessSessions(manager).has('ses_retry')).toBe(false)
     })
 
     test('does not retry more than once per sessionID', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      mockWaitForSessionReady
-        .mockImplementationOnce(async () => {
-          throw new Error('session readiness timed out')
-        })
-        .mockImplementationOnce(async () => true)
       const sessionStatusResult = {
         data: {
           ses_retry_once: { type: 'idle' },
@@ -1592,7 +1517,6 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
-      expect(getFailedReadinessSessions(manager).has('ses_retry_once')).toBe(false)
 
       // when
       manager.onEvent({ type: 'session.idle', properties: { sessionID: 'ses_retry_once' } })
@@ -1602,76 +1526,17 @@ describe('TmuxSessionManager', () => {
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
     })
 
-    test('expires failed readiness sessions after the TTL elapses', async () => {
+    test('#given duplicate session.created triggers while spawn is pending #then only one pane spawn runs', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      const nowSpy = spyOn(Date, 'now')
-      nowSpy.mockReturnValue(0)
-      mockWaitForSessionReady.mockImplementationOnce(async () => {
-        throw new Error('session readiness timed out')
-      })
-
-      const { TmuxSessionManager } = await import('./manager')
-      const manager = new TmuxSessionManager(
-        createMockContext({ sessionStatusResult: { data: { ses_expired: { type: 'idle' } } } }),
-        createTmuxConfig({ enabled: true }),
-        mockTmuxDeps,
-      )
-
-      await manager.onSessionCreated(
-        createSessionCreatedEvent('ses_expired', 'ses_parent', 'Expired Retry Session')
-      )
-      expect(getFailedReadinessSessions(manager).has('ses_expired')).toBe(true)
-
-      // when
-      nowSpy.mockReturnValue(5 * 60 * 1000 + 1)
-      manager.onEvent({ type: 'session.idle', properties: { sessionID: 'ses_expired' } })
-      await flushMicrotasks(20)
-
-      // then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-      expect(getFailedReadinessSessions(manager).has('ses_expired')).toBe(false)
-
-      nowSpy.mockRestore()
-    })
-
-    test('does not retry failed readiness sessions after polling marked the session closed', async () => {
-      // given
-      mockIsInsideTmux.mockReturnValue(true)
-
-      const { TmuxSessionManager } = await import('./manager')
-      const manager = new TmuxSessionManager(
-        createMockContext({ sessionStatusResult: { data: { ses_bounce: { type: 'idle' } } } }),
-        createTmuxConfig({ enabled: true }),
-        mockTmuxDeps,
-      )
-
-      Reflect.get(manager, 'failedReadinessSessions').set('ses_bounce', {
-        sessionId: 'ses_bounce',
-        title: 'Bounce Session',
-        rememberedAt: Date.now(),
-      })
-      Reflect.set(manager, 'closedByPolling', new Set(['ses_bounce']))
-
-      // when
-      manager.onEvent({ type: 'session.idle', properties: { sessionID: 'ses_bounce' } })
-      await flushMicrotasks(20)
-
-      // then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
-      expect(getFailedReadinessSessions(manager).has('ses_bounce')).toBe(true)
-    })
-
-    test('#given duplicate session.created triggers while readiness is pending #when readiness resolves #then only one pane spawn runs', async () => {
-      // given
-      mockIsInsideTmux.mockReturnValue(true)
-      const readiness = createDeferred<boolean>()
-      mockWaitForSessionReady.mockImplementationOnce(async ({ sessionId }: SessionReadyWaitParams) => {
-        const ready = await readiness.promise
-        if (ready) {
-          readySessions.add(sessionId)
+      const executeGate = createDeferred<void>()
+      mockExecuteActions.mockImplementationOnce(async (actions: PaneAction[]) => {
+        await executeGate.promise
+        const spawnAction = actions.find((action) => action.type === 'spawn')
+        if (spawnAction?.type === 'spawn') {
+          await mockSpawnTmuxPane(spawnAction.sessionId)
         }
-        return ready
+        return { success: true, spawnedPaneId: '%mock', results: [] }
       })
 
       const { TmuxSessionManager } = await import('./manager')
@@ -1684,16 +1549,14 @@ describe('TmuxSessionManager', () => {
       await flushMicrotasks()
 
       // then
-      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(1)
-      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
 
       // when
-      readiness.resolve(true)
+      executeGate.resolve(undefined)
       await Promise.all([firstSpawnPromise, secondSpawnPromise])
 
       // then
-      expect(mockWaitForSessionReady).toHaveBeenCalledTimes(1)
       expect(mockExecuteActions).toHaveBeenCalledTimes(1)
       expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
       expect(getTrackedSessions(manager).has('ses_dup_pending')).toBe(true)
@@ -1701,12 +1564,9 @@ describe('TmuxSessionManager', () => {
   })
 
   describe('onSessionDeleted', () => {
-    test('does nothing when session creation stopped before tracking due to readiness failure', async () => {
+    test('finalizes tracked session when pane is already absent', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
-      mockWaitForSessionReady.mockImplementationOnce(async () => {
-        throw new Error('readiness failed')
-      })
 
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -1727,6 +1587,7 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      expect(getTrackedSessions(manager).has('ses_timeout')).toBe(false)
     })
 
     test('closes pane when tracked session is deleted', async () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -19,16 +19,13 @@ import { decideSpawnActions, decideCloseAction, type SessionMapping } from "./de
 import { executeActions, executeAction } from "./action-executor"
 import { TmuxPollingManager } from "./polling-manager"
 import { createTrackedSession, markTrackedSessionClosePending } from "./tracked-session-state"
-import { waitForSessionReady } from "./session-ready-waiter"
 import { isAttachableSessionStatus } from "./attachable-session-status"
-import { parseSessionStatusMap } from "./session-status-parser"
 type OpencodeClient = PluginInput["client"]
 
 type SpawnStage =
   | "deferred.attach"
   | "deferred.isolated-container"
   | "session.created"
-  | "session.idle.retry"
 
 interface SessionCreatedEvent {
   type: string
@@ -42,20 +39,15 @@ interface DeferredSession {
   retryIsolatedContainer: boolean
 }
 
-interface FailedReadinessSessionSeed {
+interface SpawnSessionSeed {
   sessionId: string
   title: string
-}
-
-interface FailedReadinessSession extends FailedReadinessSessionSeed {
-  rememberedAt: number
 }
 
 export interface TmuxUtilDeps {
   isInsideTmux: () => boolean
   getCurrentPaneId: () => string | undefined
   queryWindowState: (paneId: string) => Promise<WindowState | null>
-  waitForSessionReady: (params: { client: OpencodeClient; sessionId: string }) => Promise<boolean>
   executeActions: typeof executeActions
   executeAction: typeof executeAction
   log: typeof sharedModule.log
@@ -65,15 +57,12 @@ const defaultTmuxDeps: TmuxUtilDeps = {
   isInsideTmux: defaultIsInsideTmux,
   getCurrentPaneId: defaultGetCurrentPaneId,
   queryWindowState: defaultQueryWindowState,
-  waitForSessionReady,
   executeActions,
   executeAction,
   log: sharedModule.log,
 }
 
 const DEFERRED_SESSION_TTL_MS = 5 * 60 * 1000
-const FAILED_READINESS_SESSION_TTL_MS = 5 * 60 * 1000
-const FAILED_READINESS_SWEEP_INTERVAL_MS = 60 * 1000
 const MAX_DEFERRED_QUEUE_SIZE = 20
 const MAX_CLOSE_RETRY_COUNT = 3
 const MAX_ISOLATED_CONTAINER_NULL_STATE_COUNT = 2
@@ -94,9 +83,7 @@ export class TmuxSessionManager {
   private sourcePaneId: string | undefined
   private sessions = new Map<string, TrackedSession>()
   private pendingSessions = new Set<string>()
-  private failedReadinessSessions = new Map<string, FailedReadinessSession>()
   private closedByPolling = new Set<string>()
-  private failedReadinessSweepInterval?: ReturnType<typeof setInterval>
   private spawnQueue: Promise<void> = Promise.resolve()
   private deferredSessions = new Map<string, DeferredSession>()
   private deferredQueue: string[] = []
@@ -155,9 +142,7 @@ export class TmuxSessionManager {
       this.sessions,
       this.closeSessionFromPolling.bind(this),
       this.retryPendingCloses.bind(this),
-      this.queryWindowStateSafely.bind(this),
       this.activateTrackedSessionPane.bind(this),
-      this.canAutoActivatePane.bind(this),
     )
     this.deps.log("[tmux-session-manager] initialized", {
       configEnabled: this.tmuxConfig.enabled,
@@ -374,7 +359,23 @@ export class TmuxSessionManager {
     }
   }
 
-  private async activateTrackedSessionPane(tracked: TrackedSession): Promise<boolean> {
+  private async activateTrackedSessionPane(tracked: TrackedSession, knownSessionStatus?: string): Promise<boolean> {
+    if (knownSessionStatus && !isAttachableSessionStatus(knownSessionStatus)) {
+      this.deps.log("[tmux-session-manager] pane activation deferred until session is attachable", {
+        sessionId: tracked.sessionId,
+        paneId: tracked.paneId,
+        status: knownSessionStatus,
+      })
+      return false
+    }
+
+    if (!knownSessionStatus) {
+      this.deps.log("[tmux-session-manager] activating pane without current session status; attach command will retry", {
+        sessionId: tracked.sessionId,
+        paneId: tracked.paneId,
+      })
+    }
+
     return activateTmuxPane(tracked.paneId, tracked.sessionId, this.serverUrl, this.projectDirectory)
   }
 
@@ -417,11 +418,6 @@ export class TmuxSessionManager {
       isolatedPaneAlreadyClosed: true,
     })
     return true
-  }
-
-  private canAutoActivatePane(state: WindowState): boolean {
-    if (!this.isIsolated()) return true
-    return state.windowActive === true && state.sessionAttached === true
   }
 
   private async closeTrackedSessionPane(args: {
@@ -537,7 +533,6 @@ export class TmuxSessionManager {
     retryIsolatedContainer = false,
   ): void {
     if (this.shouldSkipRespawnAfterPollingClose(sessionId, "deferred enqueue")) {
-      this.clearFailedReadinessSession(sessionId)
       return
     }
 
@@ -630,167 +625,17 @@ export class TmuxSessionManager {
     return true
   }
 
-  private async ensureSessionReadyBeforeSpawn(
-    sessionId: string,
-    stage: SpawnStage,
-  ): Promise<boolean> {
-    try {
-      const ready = await this.deps.waitForSessionReady({
-        client: this.client,
-        sessionId,
-      })
-
-      if (ready) {
-        return true
-      }
-
-      const readinessError = new Error("Session readiness timed out")
-      this.deps.log("[tmux-session-manager] session readiness failed before spawn", {
-        sessionId,
-        stage,
-        error: String(readinessError),
-      })
-      return false
-    } catch (error) {
-      this.deps.log("[tmux-session-manager] session readiness failed before spawn", {
-        sessionId,
-        stage,
-        error: String(error),
-      })
-      return false
-    }
-  }
-
-  private async getSessionStatusType(sessionId: string): Promise<string | undefined> {
-    try {
-      const statusResult = await this.client.session.status({ path: undefined })
-      const allStatuses = parseSessionStatusMap(statusResult.data)
-      return allStatuses[sessionId]?.type
-    } catch (error) {
-      this.deps.log("[tmux-session-manager] failed to read session status before spawn", {
-        sessionId,
-        error: String(error),
-      })
-      return undefined
-    }
-  }
-
-  private rememberFailedReadinessSession(
-    session: FailedReadinessSessionSeed,
-  ): void {
-    this.failedReadinessSessions.set(session.sessionId, {
-      ...session,
-      rememberedAt: Date.now(),
-    })
-    this.startFailedReadinessSweep()
-  }
-
-  private clearFailedReadinessSession(sessionId: string): void {
-    this.failedReadinessSessions.delete(sessionId)
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-  }
-
-  private startFailedReadinessSweep(): void {
-    if (this.failedReadinessSweepInterval) {
-      return
-    }
-
-    this.failedReadinessSweepInterval = setInterval(() => {
-      this.sweepExpiredFailedReadinessSessions()
-    }, FAILED_READINESS_SWEEP_INTERVAL_MS)
-  }
-
-  private stopFailedReadinessSweep(): void {
-    if (!this.failedReadinessSweepInterval) {
-      return
-    }
-
-    clearInterval(this.failedReadinessSweepInterval)
-    this.failedReadinessSweepInterval = undefined
-  }
-
-  private isFailedReadinessSessionExpired(
-    session: FailedReadinessSession,
-    now: number,
-  ): boolean {
-    return now - session.rememberedAt >= FAILED_READINESS_SESSION_TTL_MS
-  }
-
-  private sweepExpiredFailedReadinessSessions(): void {
-    const now = Date.now()
-
-    for (const [sessionId, failedReadinessSession] of this.failedReadinessSessions.entries()) {
-      if (!this.isFailedReadinessSessionExpired(failedReadinessSession, now)) {
-        continue
-      }
-
-      this.failedReadinessSessions.delete(sessionId)
-      this.deps.log("[tmux-session-manager] expired failed readiness session", {
-        sessionId,
-        ttlMs: FAILED_READINESS_SESSION_TTL_MS,
-      })
-    }
-
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-  }
-
-  private getFailedReadinessSession(sessionId: string): FailedReadinessSession | undefined {
-    const failedReadinessSession = this.failedReadinessSessions.get(sessionId)
-    if (!failedReadinessSession) {
-      return undefined
-    }
-
-    if (!this.isFailedReadinessSessionExpired(failedReadinessSession, Date.now())) {
-      return failedReadinessSession
-    }
-
-    this.failedReadinessSessions.delete(sessionId)
-    this.deps.log("[tmux-session-manager] expired failed readiness session on access", {
-      sessionId,
-      ttlMs: FAILED_READINESS_SESSION_TTL_MS,
-    })
-
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-
-    return undefined
-  }
-
   private async spawnPendingSession(args: {
-    session: FailedReadinessSessionSeed
+    session: SpawnSessionSeed
     stage: SpawnStage
-    rememberReadinessFailure: boolean
   }): Promise<void> {
-    const { session, stage, rememberReadinessFailure } = args
+    const { session, stage } = args
     const { sessionId, title } = session
 
-    const readyForSpawn = await this.ensureSessionReadyBeforeSpawn(sessionId, stage)
-    if (!readyForSpawn) {
-      if (rememberReadinessFailure) {
-        this.rememberFailedReadinessSession(session)
-      }
-      return
-    }
-
-    const sessionStatus = await this.getSessionStatusType(sessionId)
-    if (!isAttachableSessionStatus(sessionStatus)) {
-      this.deps.log("[tmux-session-manager] session not attachable for pane spawn", {
-        sessionId,
-        stage,
-        status: sessionStatus,
-      })
-      if (rememberReadinessFailure) {
-        this.rememberFailedReadinessSession(session)
-      }
-      return
-    }
-
-    this.clearFailedReadinessSession(sessionId)
+    this.deps.log("[tmux-session-manager] spawning placeholder before attach readiness", {
+      sessionId,
+      stage,
+    })
 
     const isolatedPaneId = await this.spawnInIsolatedContainer(sessionId, title)
     if (isolatedPaneId) {
@@ -898,7 +743,6 @@ export class TmuxSessionManager {
           description: title,
         }),
       )
-      this.clearFailedReadinessSession(sessionId)
       this.deps.log("[tmux-session-manager] pane spawned and tracked", {
         sessionId,
         paneId: result.spawnedPaneId,
@@ -931,55 +775,6 @@ export class TmuxSessionManager {
           windowState: state,
         },
       )
-    }
-  }
-
-  private getEventSessionId(event: {
-    type: string
-    properties?: Record<string, unknown>
-  }): string | undefined {
-    const sessionId = event.properties?.sessionID
-    return typeof sessionId === "string" ? sessionId : undefined
-  }
-
-  private async retryFailedReadinessSession(sessionId: string): Promise<void> {
-    if (this.shouldSkipRespawnAfterPollingClose(sessionId, "session.idle retry")) {
-      return
-    }
-
-    const failedReadinessSession = this.getFailedReadinessSession(sessionId)
-    if (!failedReadinessSession) {
-      return
-    }
-
-    if (!this.beginPendingSession(sessionId)) {
-      return
-    }
-
-    try {
-      await this.enqueueSpawn(async () => {
-        try {
-          const sessionStatus = await this.getSessionStatusType(sessionId)
-          if (!isAttachableSessionStatus(sessionStatus)) {
-            this.deps.log("[tmux-session-manager] session.idle retry skipped because session is not attachable", {
-              sessionId,
-              status: sessionStatus,
-            })
-            return
-          }
-
-          this.clearFailedReadinessSession(sessionId)
-          await this.spawnPendingSession({
-            session: failedReadinessSession,
-            stage: "session.idle.retry",
-            rememberReadinessFailure: false,
-          })
-        } finally {
-          this.pendingSessions.delete(sessionId)
-        }
-      })
-    } finally {
-      this.pendingSessions.delete(sessionId)
     }
   }
 
@@ -1022,15 +817,6 @@ export class TmuxSessionManager {
       }
 
       if (deferred.retryIsolatedContainer) {
-        const readyForIsolatedContainer = await this.ensureSessionReadyBeforeSpawn(
-          sessionId,
-          "deferred.isolated-container",
-        )
-        if (!readyForIsolatedContainer) {
-          this.removeDeferredSession(sessionId)
-          return
-        }
-
         const isolatedPaneId = await this.spawnInIsolatedContainer(sessionId, deferred.title)
         if (isolatedPaneId) {
           this.sessions.set(
@@ -1083,15 +869,6 @@ export class TmuxSessionManager {
           sessionId,
           reason: decision.reason,
         })
-        return
-      }
-
-      const readyForDeferredAttach = await this.ensureSessionReadyBeforeSpawn(
-        sessionId,
-        "deferred.attach",
-      )
-      if (!readyForDeferredAttach) {
-        this.removeDeferredSession(sessionId)
         return
       }
 
@@ -1174,7 +951,6 @@ export class TmuxSessionManager {
           await this.spawnPendingSession({
             session,
             stage: "session.created",
-            rememberReadinessFailure: true,
           })
         } finally {
           this.pendingSessions.delete(sessionId)
@@ -1205,7 +981,6 @@ export class TmuxSessionManager {
     if (!this.isEnabled()) return
 
     this.closedByPolling.delete(event.sessionID)
-    this.clearFailedReadinessSession(event.sessionID)
     this.removeDeferredSession(event.sessionID)
 
     if (!this.getEffectiveSourcePaneId()) return
@@ -1304,18 +1079,6 @@ export class TmuxSessionManager {
 
   onEvent(event: { type: string; properties?: Record<string, unknown> }): void {
     this.pollingManager.handleEvent(event)
-
-    const sessionId = this.getEventSessionId(event)
-    if (event.type !== "session.idle" || !sessionId) {
-      return
-    }
-
-    void this.retryFailedReadinessSession(sessionId).catch((error) => {
-      this.deps.log("[tmux-session-manager] session.idle retry failed", {
-        sessionId,
-        error: String(error),
-      })
-    })
   }
 
   createEventHandler(): (input: { event: { type: string; properties?: unknown } }) => Promise<void> {
@@ -1328,9 +1091,7 @@ export class TmuxSessionManager {
     this.stopDeferredAttachLoop()
     this.deferredQueue = []
     this.deferredSessions.clear()
-    this.failedReadinessSessions.clear()
     this.closedByPolling.clear()
-    this.stopFailedReadinessSweep()
     this.pollingManager.stopPolling()
 
     if (this.sessions.size > 0) {

--- a/src/features/tmux-subagent/polling-manager.test.ts
+++ b/src/features/tmux-subagent/polling-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test"
 import { TmuxPollingManager } from "./polling-manager"
-import type { TrackedSession, WindowState } from "./types"
+import type { TrackedSession } from "./types"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
 describe("TmuxPollingManager overlap", () => {
@@ -243,7 +243,7 @@ describe("TmuxPollingManager overlap", () => {
     expect(closedSessionIds).toEqual([])
   })
 
-  test("activates focused panes once before polling statuses", async () => {
+  test("activates unstarted panes once when status polling sees an attachable session", async () => {
     //#given
     const sessions = new Map<string, TrackedSession>()
     const tracked: TrackedSession = {
@@ -266,22 +266,11 @@ describe("TmuxPollingManager overlap", () => {
         messages: async () => ({ data: [] }),
       },
     }
-    const windowState: WindowState = {
-      windowWidth: 160,
-      windowHeight: 48,
-      windowActive: true,
-      sessionAttached: true,
-      mainPane: null,
-      agentPanes: [
-        { paneId: "%1", width: 80, height: 24, left: 0, top: 0, title: "agent", isActive: true },
-      ],
-    }
     const manager = new TmuxPollingManager(
       unsafeTestValue<import("../../tools/delegate-task/types").OpencodeClient>(client),
       sessions,
       async () => {},
       undefined,
-      async () => windowState,
       async (session) => {
         activatedSessionIds.push(session.sessionId)
         return true
@@ -339,7 +328,7 @@ describe("TmuxPollingManager overlap", () => {
     expect(sessions.has("ses-1")).toBe(true)
   })
 
-  test("does not close immediately when first status is delayed after focused activation", async () => {
+  test("does not close immediately when first status is delayed after retrying activation", async () => {
     //#given
     const originalDateNow = Date.now
     let now = 0
@@ -362,12 +351,6 @@ describe("TmuxPollingManager overlap", () => {
       let activationCount = 0
       let statusCalls = 0
       const closedSessionIds: string[] = []
-      const getWindowState = async (): Promise<WindowState> => ({
-        windowWidth: 220,
-        windowHeight: 44,
-        mainPane: { paneId: "%0", width: 110, height: 44, left: 0, top: 0, title: "main", isActive: false },
-        agentPanes: [{ paneId: "%1", width: 110, height: 44, left: 110, top: 0, title: "agent", isActive: true }],
-      })
 
       const client = {
         session: {
@@ -390,7 +373,6 @@ describe("TmuxPollingManager overlap", () => {
           closedSessionIds.push(sessionId)
         },
         undefined,
-        getWindowState,
         async () => {
           activationCount += 1
           return true
@@ -414,7 +396,7 @@ describe("TmuxPollingManager overlap", () => {
     }
   })
 
-  test("can still close non-activated sessions once status is idle and stable", async () => {
+  test("does not close non-activated sessions just because status is idle and stable", async () => {
     //#given
     const sessions = new Map<string, TrackedSession>()
     sessions.set("ses-1", {
@@ -458,6 +440,53 @@ describe("TmuxPollingManager overlap", () => {
     await pollSessions.call(manager)
 
     //#then
-    expect(closedSessionIds).toEqual(["ses-1"])
+    expect(closedSessionIds).toEqual([])
+  })
+
+  test("activates panes with retrying attach command even when status polling fails", async () => {
+    //#given
+    const sessions = new Map<string, TrackedSession>()
+    const tracked: TrackedSession = {
+      sessionId: "ses-1",
+      paneId: "%1",
+      description: "test",
+      attachActivated: false,
+      createdAt: new Date(),
+      lastSeenAt: new Date(),
+      closePending: false,
+      closeRetryCount: 0,
+      activityVersion: 0,
+    }
+    sessions.set("ses-1", tracked)
+
+    const activated: Array<{ sessionId: string; status: string | undefined }> = []
+    const client = {
+      session: {
+        status: async () => {
+          throw new Error("status unavailable")
+        },
+        messages: async () => ({ data: [] }),
+      },
+    }
+
+    const manager = new TmuxPollingManager(
+      unsafeTestValue<import("../../tools/delegate-task/types").OpencodeClient>(client),
+      sessions,
+      async () => {},
+      undefined,
+      async (session, status) => {
+        activated.push({ sessionId: session.sessionId, status })
+        return true
+      },
+    )
+    const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+    //#when
+    await pollSessions.call(manager)
+    await pollSessions.call(manager)
+
+    //#then
+    expect(activated).toEqual([{ sessionId: "ses-1", status: undefined }])
+    expect(tracked.attachActivated).toBe(true)
   })
 })

--- a/src/features/tmux-subagent/polling-manager.ts
+++ b/src/features/tmux-subagent/polling-manager.ts
@@ -5,13 +5,15 @@ import {
   SESSION_READY_TIMEOUT_MS,
   SESSION_TIMEOUT_MS,
 } from "../../shared/tmux"
-import type { TrackedSession, WindowState } from "./types"
+import type { TrackedSession } from "./types"
 import { log } from "../../shared"
 import { normalizeSDKResponse } from "../../shared"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+import { isAttachableSessionStatus } from "./attachable-session-status"
 
-const MIN_STABILITY_TIME_MS = 10 * 1000
-const STABLE_POLLS_REQUIRED = 3
+const MIN_STABILITY_TIME_MS = 4 * 1000
+const STABLE_POLLS_REQUIRED = 2
+const UNACTIVATED_PLACEHOLDER_MISSING_GRACE_MS = 10 * 1000
 
 export class TmuxPollingManager {
   private pollInterval?: ReturnType<typeof setInterval>
@@ -22,9 +24,7 @@ export class TmuxPollingManager {
     private sessions: Map<string, TrackedSession>,
     private closeSessionById: (sessionId: string) => Promise<void>,
     private retryPendingCloses?: () => Promise<void>,
-    private getWindowState?: () => Promise<WindowState | null>,
-    private activateSessionPane?: (tracked: TrackedSession) => Promise<boolean>,
-    private canActivatePane: (state: WindowState) => boolean = (state) => state.windowActive !== false && state.sessionAttached !== false,
+    private activateSessionPane?: (tracked: TrackedSession, knownSessionStatus?: string) => Promise<boolean>,
   ) {}
 
   handleEvent(event: { type: string; properties?: Record<string, unknown> }): void {
@@ -44,6 +44,7 @@ export class TmuxPollingManager {
       () => this.pollSessions(),
       POLL_INTERVAL_BACKGROUND_MS, // POLL_INTERVAL_BACKGROUND_MS
     )
+    void this.pollSessions()
     log("[tmux-session-manager] polling started")
   }
 
@@ -64,10 +65,17 @@ export class TmuxPollingManager {
         return
       }
 
-      await this.activateFocusedPanes()
+      let allStatuses: Record<string, { type: string }> = {}
+      try {
+        const statusResult = await this.client.session.status({ path: undefined })
+        allStatuses = normalizeSDKResponse(statusResult, {} as Record<string, { type: string }>)
+      } catch (statusError) {
+        log("[tmux-session-manager] session status poll failed; continuing auto-attach with retrying pane command", {
+          error: String(statusError),
+        })
+      }
 
-      const statusResult = await this.client.session.status({ path: undefined })
-      const allStatuses = normalizeSDKResponse(statusResult, {} as Record<string, { type: string }>)
+      await this.activateReadyPanes(allStatuses)
 
       log("[tmux-session-manager] pollSessions", {
         trackedSessions: Array.from(this.sessions.keys()),
@@ -80,13 +88,25 @@ export class TmuxPollingManager {
       for (const [sessionId, tracked] of this.sessions.entries()) {
         const status = allStatuses[sessionId]
         const elapsedMs = now - tracked.createdAt.getTime()
-        if (!tracked.attachActivated && !status) {
-          log("[tmux-session-manager] placeholder pane has not been activated yet; skipping close checks", {
+        const missingGraceMs = !tracked.attachActivated
+          ? UNACTIVATED_PLACEHOLDER_MISSING_GRACE_MS
+          : SESSION_MISSING_GRACE_MS
+        if (!tracked.attachActivated && !status && elapsedMs < missingGraceMs) {
+          log("[tmux-session-manager] placeholder pane has not been activated yet; waiting through missing-status grace", {
             sessionId,
             paneId: tracked.paneId,
             elapsedMs,
+            graceMs: missingGraceMs,
           })
           continue
+        }
+        if (!tracked.attachActivated && !status) {
+          log("[tmux-session-manager] stale placeholder has no session status after grace; allowing cleanup checks", {
+            sessionId,
+            paneId: tracked.paneId,
+            elapsedMs,
+            graceMs: missingGraceMs,
+          })
         }
 
         const attachElapsedMs = tracked.attachActivatedAt
@@ -108,13 +128,16 @@ export class TmuxPollingManager {
           tracked.lastSeenAt = new Date(now)
         }
 
+        const activeElapsedMs = tracked.attachActivatedAt
+          ? now - tracked.attachActivatedAt.getTime()
+          : elapsedMs
         const missingSince = !status ? now - tracked.lastSeenAt.getTime() : 0
-        const missingTooLong = missingSince >= SESSION_MISSING_GRACE_MS
+        const missingTooLong = missingSince >= missingGraceMs
         const isTimedOut = elapsedMs > SESSION_TIMEOUT_MS
 
         let shouldCloseViaStability = false
 
-        if (isIdle && elapsedMs >= MIN_STABILITY_TIME_MS) {
+        if (tracked.attachActivated && isIdle && activeElapsedMs >= MIN_STABILITY_TIME_MS) {
           const activityVersion = tracked.activityVersion ?? 0
 
           if (tracked.observedIdleActivityVersion !== activityVersion) {
@@ -163,7 +186,9 @@ export class TmuxPollingManager {
           stableIdlePolls: tracked.stableIdlePolls,
           activityVersion: tracked.activityVersion,
           observedIdleActivityVersion: tracked.observedIdleActivityVersion,
+          activeElapsedMs,
           missingSince,
+          missingGraceMs,
           missingTooLong,
           isTimedOut,
           shouldCloseViaStability,
@@ -214,41 +239,42 @@ export class TmuxPollingManager {
     return undefined
   }
 
-  private async activateFocusedPanes(): Promise<void> {
-    if (!this.getWindowState || !this.activateSessionPane || this.sessions.size === 0) {
+  private markPaneActivated(tracked: TrackedSession, source: string): void {
+    tracked.attachActivated = true
+    tracked.attachActivatedAt = new Date()
+    tracked.lastSeenAt = new Date()
+    tracked.stableIdlePolls = 0
+    tracked.observedIdleActivityVersion = tracked.activityVersion
+    log("[tmux-session-manager] activated pane", {
+      sessionId: tracked.sessionId,
+      paneId: tracked.paneId,
+      source,
+    })
+  }
+
+  private async activateReadyPanes(allStatuses: Record<string, { type: string }>): Promise<void> {
+    if (!this.activateSessionPane || this.sessions.size === 0) {
       return
     }
-
-    const state = await this.getWindowState().catch(() => null)
-    if (!state) return
-    if (this.canActivatePane && !this.canActivatePane(state)) {
-      log("[tmux-session-manager] activation gate blocked auto-attach", {
-        windowActive: state.windowActive,
-        sessionAttached: state.sessionAttached,
-      })
-      return
-    }
-
-    const panes = [state.mainPane, ...state.agentPanes].filter((pane): pane is NonNullable<typeof pane> => Boolean(pane))
-    const activePaneIds = new Set(panes.filter((pane) => pane.isActive).map((pane) => pane.paneId))
-    if (activePaneIds.size === 0) return
 
     for (const tracked of this.sessions.values()) {
       if (tracked.attachActivated) continue
-      if (!activePaneIds.has(tracked.paneId)) continue
 
-      const activated = await this.activateSessionPane(tracked)
-      if (activated) {
-        tracked.attachActivated = true
-        tracked.attachActivatedAt = new Date()
-        tracked.lastSeenAt = new Date()
-        tracked.stableIdlePolls = 0
-        tracked.observedIdleActivityVersion = tracked.activityVersion
-        log("[tmux-session-manager] activated focused pane", {
+      const status = allStatuses[tracked.sessionId]?.type
+      if (status && !isAttachableSessionStatus(status)) {
+        log("[tmux-session-manager] auto-attach skipped until status is attachable", {
           sessionId: tracked.sessionId,
           paneId: tracked.paneId,
+          status,
         })
+        continue
+      }
+
+      const activated = await this.activateSessionPane(tracked, status)
+      if (activated) {
+        this.markPaneActivated(tracked, status ? "status-poll" : "retrying-attach")
       }
     }
   }
+
 }

--- a/src/features/tmux-subagent/session-created-handler.test.ts
+++ b/src/features/tmux-subagent/session-created-handler.test.ts
@@ -47,17 +47,7 @@ function makeEvent(sessionId: string, parentID = "parent-session"): SessionCreat
 
 function makeDeps(overrides: Partial<SessionCreatedHandlerDeps> = {}): {
   deps: SessionCreatedHandlerDeps
-  mockExecuteActions: ReturnType<typeof mock>
-  mockWaitForSessionReady: ReturnType<typeof mock>
 } {
-  const mockExecuteActions = mock(async () => ({
-    success: true,
-    spawnedPaneId: "%99",
-    results: [],
-  }))
-
-  const mockWaitForSessionReady = mock(async (_sessionId: string) => true)
-
   const deps: SessionCreatedHandlerDeps = {
     client: {} as never,
     tmuxConfig: { enabled: true } as never,
@@ -70,12 +60,11 @@ function makeDeps(overrides: Partial<SessionCreatedHandlerDeps> = {}): {
     isEnabled: () => true,
     getCapacityConfig: () => ({ mainPaneMinWidth: 130, agentPaneWidth: 52 }),
     getSessionMappings: () => [],
-    waitForSessionReady: mockWaitForSessionReady,
     startPolling: mock(() => {}),
     ...overrides,
   }
 
-  return { deps, mockExecuteActions, mockWaitForSessionReady }
+  return { deps }
 }
 
 // ---------------------------------------------------------------------------
@@ -84,16 +73,10 @@ function makeDeps(overrides: Partial<SessionCreatedHandlerDeps> = {}): {
 
 // We test ordering by observing call order via a shared call-log array.
 
-describe("handleSessionCreated – #3505 session readiness race", () => {
-  test("#given session not yet ready #when session.created fires #then pane is NOT spawned", async () => {
+describe("handleSessionCreated – #3505 session attach race", () => {
+  test("#given no source pane #when session.created fires #then pane is NOT spawned", async () => {
     const callLog: string[] = []
-
-    const waitForSessionReady = mock(async (_id: string) => {
-      callLog.push("waitForSessionReady")
-      return false // session never becomes ready
-    })
-
-    const { deps } = makeDeps({ waitForSessionReady })
+    const { deps } = makeDeps()
 
     // Patch executeActions on the module after import — use the real module path
     // but intercept via deps indirection through action-executor by spying on
@@ -113,71 +96,48 @@ describe("handleSessionCreated – #3505 session readiness race", () => {
 
     // No pane spawned, no polling started
     expect(startPolling).not.toHaveBeenCalled()
-    expect(waitForSessionReady).not.toHaveBeenCalled() // short-circuits at sourcePaneId check
+    expect(mockExecuteActions).not.toHaveBeenCalled()
   })
 
-  test("#given spawn path reached #when waitForSessionReady is pending #then executeActions is deferred until readiness resolves", async () => {
-    // Regression test for #3505: the handler must `await waitForSessionReady`
-    // BEFORE calling executeActions. This test actually exercises the spawn
-    // path (mocked queryWindowState returns a valid window state, mocked
-    // executeActions is a spy) so the readiness-then-spawn ordering is
-    // observable and asserted, not assumed.
+  test("#given spawn path reached #when session status is not ready #then placeholder spawn does not wait", async () => {
     const callLog: string[] = []
-    let resolveReadiness: ((ready: boolean) => void) | undefined
-    const readinessGate = new Promise<boolean>((resolve) => { resolveReadiness = resolve })
 
-    const waitForSessionReady = mock(async (_id: string): Promise<boolean> => {
-      callLog.push("waitForSessionReady:start")
-      const ready = await readinessGate
-      callLog.push("waitForSessionReady:end")
-      return ready
-    })
     mockExecuteActions.mockImplementation(async (_actions, _ctx) => {
       callLog.push("executeActions")
       return { success: true, spawnedPaneId: "%99", results: [] }
     })
 
-    const { deps } = makeDeps({ waitForSessionReady })
+    const { deps } = makeDeps()
     const handlerPromise = handleSessionCreated(deps, makeEvent("ses_race"))
 
-    // Yield so the handler reaches the readiness gate; executeActions must NOT
-    // have been invoked yet because waitForSessionReady has not resolved.
     await Promise.resolve()
     await Promise.resolve()
-    expect(waitForSessionReady).toHaveBeenCalledTimes(1)
-    expect(mockExecuteActions).not.toHaveBeenCalled()
-
-    resolveReadiness!(true)
     await handlerPromise
 
-    // Now executeActions must have fired exactly once, AFTER waitForSessionReady.
     expect(mockExecuteActions).toHaveBeenCalledTimes(1)
-    expect(callLog).toEqual(["waitForSessionReady:start", "waitForSessionReady:end", "executeActions"])
+    expect(callLog).toEqual(["executeActions"])
   })
 
-  test("#given spawn path reached #when waitForSessionReady resolves false #then executeActions is never called", async () => {
-    const waitForSessionReady = mock(async (_id: string) => false)
-    const { deps } = makeDeps({ waitForSessionReady })
+  test("#given spawn path reached #when readiness is unknown #then placeholder still spawns", async () => {
+    const { deps } = makeDeps()
 
     await handleSessionCreated(deps, makeEvent("ses_notready_spawn"))
 
-    expect(waitForSessionReady).toHaveBeenCalledTimes(1)
-    expect(mockExecuteActions).not.toHaveBeenCalled()
+    expect(mockExecuteActions).toHaveBeenCalledTimes(1)
   })
 
   test("#given duplicate session.created events #when first is pending #then second is deduplicated", async () => {
-    const { deps, mockWaitForSessionReady } = makeDeps()
+    const { deps } = makeDeps()
     deps.pendingSessions.add("ses_dup")
 
     const event = makeEvent("ses_dup")
     await handleSessionCreated(deps, event)
 
-    // Should bail out at the duplicate guard, never reaching readiness check
-    expect(mockWaitForSessionReady).not.toHaveBeenCalled()
+    expect(mockExecuteActions).not.toHaveBeenCalled()
   })
 
   test("#given non session.created event #when handler called #then no action taken", async () => {
-    const { deps, mockWaitForSessionReady } = makeDeps()
+    const { deps } = makeDeps()
 
     const event: SessionCreatedEvent = {
       type: "session.idle",
@@ -185,11 +145,11 @@ describe("handleSessionCreated – #3505 session readiness race", () => {
     }
 
     await handleSessionCreated(deps, event as never)
-    expect(mockWaitForSessionReady).not.toHaveBeenCalled()
+    expect(mockExecuteActions).not.toHaveBeenCalled()
   })
 
   test("#given session already tracked #when session.created fires again #then idempotent", async () => {
-    const { deps, mockWaitForSessionReady } = makeDeps()
+    const { deps } = makeDeps()
     // Pre-populate sessions map as if pane was already spawned
     deps.sessions.set("ses_existing", {
       sessionId: "ses_existing",
@@ -204,6 +164,6 @@ describe("handleSessionCreated – #3505 session readiness race", () => {
     const event = makeEvent("ses_existing")
     await handleSessionCreated(deps, event)
 
-    expect(mockWaitForSessionReady).not.toHaveBeenCalled()
+    expect(mockExecuteActions).not.toHaveBeenCalled()
   })
 })

--- a/src/features/tmux-subagent/session-created-handler.ts
+++ b/src/features/tmux-subagent/session-created-handler.ts
@@ -23,7 +23,6 @@ export interface SessionCreatedHandlerDeps {
   isEnabled: () => boolean
   getCapacityConfig: () => CapacityConfig
   getSessionMappings: () => SessionMapping[]
-  waitForSessionReady: (sessionId: string) => Promise<boolean>
   startPolling: () => void
 }
 
@@ -102,18 +101,10 @@ export async function handleSessionCreated(
       return
     }
 
-    // Wait for the child session to be registered in the opencode server's status
-    // map BEFORE spawning the tmux pane. If we spawn first, `opencode attach`
-    // exits immediately (session not yet visible), tmux auto-closes the pane, and
-    // the subagent runs invisibly in the background — the bug described in #3505.
-    const sessionReady = await deps.waitForSessionReady(sessionId)
-    if (!sessionReady) {
-      log("[tmux-session-manager] session readiness failed before spawn", {
-        sessionId,
-        stage: "session.created",
-      })
-      return
-    }
+    log("[tmux-session-manager] spawning placeholder before attach readiness", {
+      sessionId,
+      stage: "session.created",
+    })
 
     const result = await executeActions(decision.actions, {
       config: deps.tmuxConfig,
@@ -162,7 +153,6 @@ export async function handleSessionCreated(
     log("[tmux-session-manager] pane spawned and tracked", {
       sessionId,
       paneId: result.spawnedPaneId,
-      sessionReady,
     })
 
     deps.startPolling()

--- a/src/features/tmux-subagent/zombie-pane.test.ts
+++ b/src/features/tmux-subagent/zombie-pane.test.ts
@@ -65,7 +65,6 @@ const mockTmuxDeps: TmuxUtilDeps = {
   isInsideTmux: mockIsInsideTmux,
   getCurrentPaneId: mockGetCurrentPaneId,
   queryWindowState: mockQueryWindowState,
-  waitForSessionReady: async () => true,
   executeActions: mockExecuteActions,
   executeAction: mockExecuteAction,
   log: () => {},

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -257,7 +257,7 @@ describe("createEventHandler - idle deduplication", () => {
 		})
 	})
 
-	it("#given a readiness retry is pending #when session.idle arrives through the plugin handler #then tmux retry spawns the pane", async () => {
+	it("#given session status is initially missing #when session.idle arrives through the plugin handler #then tmux does not respawn the pane", async () => {
 		//#given
 		const sessionStatusData: Record<string, { type: string }> = {}
 		const sessionStatusResult = {
@@ -267,8 +267,6 @@ describe("createEventHandler - idle deduplication", () => {
 			success: true,
 			paneId: "%mock",
 		}))
-		let waitForSessionReadyCallCount = 0
-
 		const executeActions = mock(async (actions: Array<{ type: string; sessionId: string }>) => {
 			for (const action of actions) {
 				if (action.type === "spawn") {
@@ -297,15 +295,6 @@ describe("createEventHandler - idle deduplication", () => {
 			},
 			agentPanes: [],
 		}))
-		const waitForSessionReady = mock(async () => {
-			waitForSessionReadyCallCount += 1
-			if (waitForSessionReadyCallCount === 1) {
-				throw new Error("session readiness timed out")
-			}
-
-			return true
-		})
-
 		const { TmuxSessionManager } = await import(`../features/tmux-subagent/manager?test=${crypto.randomUUID()}`)
 		const managerContext = asPluginInput({
 			serverUrl: new URL("http://localhost:4096"),
@@ -327,14 +316,13 @@ describe("createEventHandler - idle deduplication", () => {
 			main_pane_size: 60,
 			main_pane_min_width: 80,
 			agent_pane_min_width: 40,
-		}, {
-			isInsideTmux: () => true,
-			getCurrentPaneId: () => "%0",
-			queryWindowState,
-			waitForSessionReady,
-			executeActions,
-			executeAction,
-			log: () => {},
+			}, {
+				isInsideTmux: () => true,
+				getCurrentPaneId: () => "%0",
+				queryWindowState,
+				executeActions,
+				executeAction,
+				log: () => {},
 		})
 		const eventHandler = createEventHandler({
 			ctx: asEventHandlerContext({
@@ -372,7 +360,7 @@ describe("createEventHandler - idle deduplication", () => {
 		})
 
 		//#then
-		expect(spawnTmuxPane).toHaveBeenCalledTimes(0)
+		expect(spawnTmuxPane).toHaveBeenCalledTimes(1)
 
 		//#when
 		sessionStatusData.ses_retry_via_plugin = { type: "idle" }
@@ -385,7 +373,6 @@ describe("createEventHandler - idle deduplication", () => {
 			},
 		}))
 		await flushMicrotasks(20)
-		await waitUntil(() => spawnTmuxPane.mock.calls.length === 1)
 
 		//#then
 		expect(spawnTmuxPane).toHaveBeenCalledTimes(1)

--- a/src/shared/tmux/constants.ts
+++ b/src/shared/tmux/constants.ts
@@ -1,5 +1,5 @@
 // Polling interval for background session status checks
-export const POLL_INTERVAL_BACKGROUND_MS = 2000
+export const POLL_INTERVAL_BACKGROUND_MS = 1000
 
 // Long-running subagent work can legitimately stay open for a while.
 // The tmux-subagent stability fixes raised this guard from 10 minutes after

--- a/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -8,7 +8,7 @@ describe("buildTmuxAttachCommand", () => {
 
     try {
       const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
-      expect(cmd.startsWith('/bin/sh -c "')).toBe(true)
+      expect(cmd.startsWith("/bin/sh -c '")).toBe(true)
       expect(cmd).not.toContain("/bin/tcsh -c")
     } finally {
       process.env.SHELL = originalShell
@@ -17,15 +17,40 @@ describe("buildTmuxAttachCommand", () => {
 
   it("escapes serverUrl shell metacharacters", () => {
     const cmd = buildTmuxAttachCommand("http://localhost:3000$(whoami);rm -rf /", "ses_abc123")
-    expect(cmd).toContain("\\$")
-    expect(cmd).toContain("\\;")
-    expect(cmd).not.toMatch(/[^\\];\s*rm/)
+    expect(cmd).toContain("http://localhost:3000$(whoami);rm -rf /")
+    expect(cmd).toContain("'\\''http://localhost:3000$(whoami);rm -rf /'\\''")
   })
 
   it("escapes session id shell metacharacters", () => {
     const cmd = buildTmuxAttachCommand("http://localhost:3000", 'ses_abc"$(whoami)"')
-    expect(cmd).toContain('\\"')
-    expect(cmd).toContain("\\$")
+    expect(cmd).toContain("--session")
+    expect(cmd).toContain(`'\\''ses_abc"$(whoami)"'\\''`)
+  })
+
+  it("uses an explicit opencode binary path when provided", () => {
+    const originalBin = process.env.OPENCODE_BIN
+    process.env.OPENCODE_BIN = "/tmp/opencode bin/opencode"
+
+    try {
+      const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
+      expect(cmd).toContain("/tmp/opencode bin/opencode")
+      expect(cmd).toContain("attach")
+    } finally {
+      if (originalBin === undefined) {
+        delete process.env.OPENCODE_BIN
+      } else {
+        process.env.OPENCODE_BIN = originalBin
+      }
+    }
+  })
+
+  it("keeps attach alive with a retry loop until opencode can attach or exits normally", () => {
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
+    expect(cmd).toContain("while true; do")
+    expect(cmd).toContain("OMO attach not ready for ses_abc123; retrying in 1s...")
+    expect(cmd).toContain('[ \"$code\" -eq 0 ]')
+    expect(cmd).toContain('[ \"$code\" -eq 130 ]')
+    expect(cmd).toContain('[ \"$code\" -eq 143 ]')
   })
 })
 
@@ -36,7 +61,7 @@ describe("buildTmuxPlaceholderCommand", () => {
 
     try {
       const cmd = buildTmuxPlaceholderCommand("My Task")
-      expect(cmd.startsWith('/bin/sh -c "')).toBe(true)
+      expect(cmd.startsWith("/bin/sh -c '")).toBe(true)
       expect(cmd).not.toContain("/bin/csh -c")
     } finally {
       process.env.SHELL = originalShell
@@ -45,14 +70,15 @@ describe("buildTmuxPlaceholderCommand", () => {
 
   it("produces inert placeholder command instead of immediate attach", () => {
     const cmd = buildTmuxPlaceholderCommand("My Task")
-    expect(cmd).toContain("Focus this pane to attach.")
+    expect(cmd).toContain("Attaching automatically when the session is ready.")
     expect(cmd).toContain("tail -f /dev/null")
     expect(cmd).not.toContain("opencode attach")
   })
 
   it("keeps single quotes and percent signs inside safe printf arguments", () => {
     const cmd = buildTmuxPlaceholderCommand("Fix Bob's 100% broken pane")
-    expect(cmd).toContain(`printf '%s\\n%s\\n'`)
-    expect(cmd).toContain(`"OMO subagent pane ready: Fix Bob's 100% broken pane"`)
+    expect(cmd).toContain("printf")
+    expect(cmd).toContain("OMO subagent pane ready: Fix Bob")
+    expect(cmd).toContain("100% broken pane")
   })
 })

--- a/src/shared/tmux/tmux-utils/pane-command.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.ts
@@ -1,15 +1,50 @@
-import { shellEscapeForDoubleQuotedCommand } from "../../shell-env"
+import { shellSingleQuote } from "../../shell-env"
 
 const TMUX_COMMAND_SHELL = "/bin/sh"
 
+function looksLikeOpencodeCommand(value: unknown): value is string {
+  return typeof value === "string" && /(^|[/\\])opencode(?:$|[.-])/.test(value)
+}
+
+function resolveOpencodeCommand(): string {
+  if (process.env.OPENCODE_BIN) {
+    return process.env.OPENCODE_BIN
+  }
+  if (process.env.OPENCODE_BIN_PATH) {
+    return process.env.OPENCODE_BIN_PATH
+  }
+  if (looksLikeOpencodeCommand(process.execPath)) {
+    return process.execPath
+  }
+
+  const argvCommand = process.argv.find((value) => looksLikeOpencodeCommand(value))
+  return argvCommand ?? "opencode"
+}
+
+function shellCommandExecutable(value: string): string {
+  return value.includes("/") || value.includes("\\") ? shellSingleQuote(value) : value
+}
+
+function buildCommandPathPrefix(): string {
+  return process.env.PATH ? `PATH=${shellSingleQuote(process.env.PATH)}:$PATH; ` : ""
+}
+
 export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, directory: string = process.cwd()): string {
-  const escapedUrl = shellEscapeForDoubleQuotedCommand(serverUrl)
-  const escapedSessionId = shellEscapeForDoubleQuotedCommand(sessionId)
-  const escapedDirectory = shellEscapeForDoubleQuotedCommand(directory || process.cwd())
-  return `${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
+  const attachCommand = [
+    shellCommandExecutable(resolveOpencodeCommand()),
+    "attach",
+    shellSingleQuote(serverUrl),
+    "--session",
+    shellSingleQuote(sessionId),
+    "--dir",
+    shellSingleQuote(directory || process.cwd()),
+  ].join(" ")
+  const retryMessage = shellSingleQuote(`OMO attach not ready for ${sessionId}; retrying in 1s...`)
+  const command = `${buildCommandPathPrefix()}while true; do ${attachCommand}; code=$?; if [ "$code" -eq 0 ] || [ "$code" -eq 130 ] || [ "$code" -eq 143 ]; then exit "$code"; fi; printf '%s\\n' ${retryMessage}; sleep 1; done`
+  return `${TMUX_COMMAND_SHELL} -c ${shellSingleQuote(command)}`
 }
 
 export function buildTmuxPlaceholderCommand(description: string): string {
-  const escapedDescription = shellEscapeForDoubleQuotedCommand(description)
-  return `${TMUX_COMMAND_SHELL} -c "printf '%s\\n%s\\n' \"OMO subagent pane ready: ${escapedDescription}\" \"Focus this pane to attach.\"; exec tail -f /dev/null"`
+  const command = `printf '%s\\n%s\\n' ${shellSingleQuote(`OMO subagent pane ready: ${description}`)} ${shellSingleQuote("Attaching automatically when the session is ready.")}; exec tail -f /dev/null`
+  return `${TMUX_COMMAND_SHELL} -c ${shellSingleQuote(command)}`
 }

--- a/src/shared/tmux/tmux-utils/pane-replace.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-replace.test.ts
@@ -112,7 +112,7 @@ describe("replaceTmuxPane runner integration", () => {
 		expect(sendKeysCall[1]).toEqual(["send-keys", "-t", "%42", "C-c"])
 		expect(respawnCall[1].slice(0, 4)).toEqual(["respawn-pane", "-k", "-t", "%42"])
 		expect(selectPaneCall[1]).toEqual(["select-pane", "-t", "%42", "-T", "omo-subagent-worker"])
-		expect(getRespawnCommand()).toContain("Focus this pane to attach.")
+		expect(getRespawnCommand()).toContain("Attaching automatically when the session is ready.")
 		expect(getRespawnCommand()).toContain("tail -f /dev/null")
 		expect(getRespawnCommand()).not.toContain("opencode attach")
 	})
@@ -147,7 +147,7 @@ describe("replaceTmuxPane runner integration", () => {
 		await replaceTmuxPane("%42", "session-1", 'worker "$(whoami)"', enabledTmuxConfig, "http://127.0.0.1:1234", "/path/with'quote", createDeps())
 
 		// then
-		expect(getRespawnCommand()).toContain('\\"')
-		expect(getRespawnCommand()).toContain("\\$")
+		expect(getRespawnCommand()).toContain('worker "$(whoami)"')
+		expect(getRespawnCommand()).toContain("'\\''OMO subagent pane ready")
 	})
 })

--- a/src/shared/tmux/tmux-utils/pane-spawn-runner.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-spawn-runner.test.ts
@@ -115,7 +115,7 @@ describe("spawnTmuxPane runner integration", () => {
 		expect(result).toEqual({ success: true, paneId: "%42" })
 		expect(firstCall[1].slice(0, 8)).toEqual(["split-window", "-h", "-d", "-P", "-F", "#{pane_id}", "-t", "%0"])
 		expect(secondCall[1]).toEqual(["select-pane", "-t", "%42", "-T", "omo-subagent-worker"])
-		expect(getSplitWindowCommand()).toContain("Focus this pane to attach.")
+		expect(getSplitWindowCommand()).toContain("Attaching automatically when the session is ready.")
 		expect(getSplitWindowCommand()).toContain("tail -f /dev/null")
 		expect(getSplitWindowCommand()).not.toContain("opencode attach")
 	})
@@ -150,7 +150,7 @@ describe("spawnTmuxPane runner integration", () => {
 		await spawnTmuxPane("session-1", 'worker "$(whoami)"', enabledTmuxConfig, "http://127.0.0.1:1234", "/path/with'quote", "%0", "-h", createDeps())
 
 		// then
-		expect(getSplitWindowCommand()).toContain('\\"')
-		expect(getSplitWindowCommand()).toContain("\\$")
+		expect(getSplitWindowCommand()).toContain('worker "$(whoami)"')
+		expect(getSplitWindowCommand()).toContain("'\\''OMO subagent pane ready")
 	})
 })

--- a/src/shared/tmux/tmux-utils/session-spawn.test.ts
+++ b/src/shared/tmux/tmux-utils/session-spawn.test.ts
@@ -102,7 +102,7 @@ describe("spawnTmuxSession runner integration", () => {
 		expect(newSessionCall[1].slice(0, 4)).toEqual(["new-session", "-d", "-s", newSessionCall[1][3]])
 		expect(String(newSessionCall[1][3]).startsWith("omo-agents-")).toBe(true)
 		expect(selectPaneCall[1]).toEqual(["select-pane", "-t", "%42", "-T", "omo-subagent-worker"])
-		expect(harness.getSpawnCommand()).toContain("Focus this pane to attach.")
+		expect(harness.getSpawnCommand()).toContain("Attaching automatically when the session is ready.")
 		expect(harness.getSpawnCommand()).toContain("tail -f /dev/null")
 		expect(harness.getSpawnCommand()).not.toContain("opencode attach")
 	})
@@ -137,7 +137,7 @@ describe("spawnTmuxSession runner integration", () => {
 		await spawnTmuxSession("session-1", 'worker "$(whoami)"', enabledTmuxConfig, "http://127.0.0.1:1234", "/path/with'quote", "%0", harness.deps)
 
 		// then
-		expect(harness.getSpawnCommand()).toContain('\\"')
-		expect(harness.getSpawnCommand()).toContain("\\$")
+		expect(harness.getSpawnCommand()).toContain('worker "$(whoami)"')
+		expect(harness.getSpawnCommand()).toContain("'\\''OMO subagent pane ready")
 	})
 })

--- a/src/shared/tmux/tmux-utils/window-spawn.test.ts
+++ b/src/shared/tmux/tmux-utils/window-spawn.test.ts
@@ -90,7 +90,7 @@ describe("spawnTmuxWindow runner integration", () => {
 		expect(result).toEqual({ success: true, paneId: "%42" })
 		expect(firstCall[1].slice(0, 7)).toEqual(["new-window", "-d", "-n", "omo-agents", "-P", "-F", "#{pane_id}"])
 		expect(secondCall[1]).toEqual(["select-pane", "-t", "%42", "-T", "omo-subagent-worker"])
-		expect(harness.getNewWindowCommand()).toContain("Focus this pane to attach.")
+		expect(harness.getNewWindowCommand()).toContain("Attaching automatically when the session is ready.")
 		expect(harness.getNewWindowCommand()).toContain("tail -f /dev/null")
 		expect(harness.getNewWindowCommand()).not.toContain("opencode attach")
 	})
@@ -125,7 +125,7 @@ describe("spawnTmuxWindow runner integration", () => {
 		await spawnTmuxWindow("session-1", 'worker "$(whoami)"', enabledTmuxConfig, "http://127.0.0.1:1234", "/path/with'quote", harness.deps)
 
 		// then
-		expect(harness.getNewWindowCommand()).toContain('\\"')
-		expect(harness.getNewWindowCommand()).toContain("\\$")
+		expect(harness.getNewWindowCommand()).toContain('worker "$(whoami)"')
+		expect(harness.getNewWindowCommand()).toContain("'\\''OMO subagent pane ready")
 	})
 })


### PR DESCRIPTION
## Summary
- replace focus-only tmux subagent activation with polling-driven auto activation
- make `opencode attach` run in a retry loop so a pane survives transient session/status readiness gaps
- remove the pre-spawn readiness gate and failed-readiness retry state now that attach owns readiness retrying
- speed up polling/idle cleanup and update placeholder text to reflect automatic attach

## Why
The previous lifecycle still let subagent panes get stuck at `OMO subagent pane ready` unless the user focused the pane, and a single failed `opencode attach` could leave the pane hidden or dead while the subagent kept running. The pane should be created immediately, then the attach command should keep retrying until the opencode session is actually attachable.

## Validation
- `bun test src/features/tmux-subagent/polling-manager.test.ts src/features/tmux-subagent/manager.test.ts src/features/tmux-subagent/session-created-handler.test.ts src/features/tmux-subagent/zombie-pane.test.ts src/plugin/event.test.ts src/shared/tmux/tmux-utils/pane-command.test.ts src/shared/tmux/tmux-utils/pane-spawn-runner.test.ts src/shared/tmux/tmux-utils/pane-replace.test.ts src/shared/tmux/tmux-utils/window-spawn.test.ts src/shared/tmux/tmux-utils/session-spawn.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tmux subagent panes auto-attach reliably by spawning a placeholder immediately and running a retrying `opencode attach` loop, removing readiness waits and focus-only activation. Fixes panes stuck at “OMO subagent pane ready” and panes dying on transient session gaps.

- **Bug Fixes**
  - Spawn a placeholder pane immediately; do not wait for server “ready” status.
  - Auto-attach via polling; activate when status is attachable, or proceed with a retrying attach when status fetch fails.
  - Keep `opencode attach` alive in a loop; exit only on success or normal user exits (0/130/143).
  - Add a 10s grace for unactivated placeholders before missing-status cleanup; prevent premature closes.
  - Faster, tighter polling and stability checks: 1s poll, 4s minimum idle, 2 stable polls.

- **Refactors**
  - Removed readiness gate and all failed-readiness retry state from `TmuxSessionManager`.
  - Simplified `TmuxPollingManager` activation flow; no focus-only/attached session gating.
  - Updated placeholder text to reflect automatic attach.
  - Improved command construction: strong single-quote escaping, optional `OPENCODE_BIN`/`OPENCODE_BIN_PATH`, and PATH prefix handling.

<sup>Written for commit 906973ce59b318dcb14d4cb62aa65e7deacbe761. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

