### PR TITLE
fix(model-fallback): drop opencode provider from deprecated haiku-4-5 / gpt-5.4-nano routings (#3757)

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -237,7 +237,7 @@ These agents do grep, search, and retrieval. They intentionally use the fastest,
 
 | Agent | Role | Fallback Chain |
 |---|---|---|
-| **Explore** | Fast codebase grep | `openai/gpt-5.4-mini-fast` → `opencode-go/qwen3.5-plus` → `vercel/minimax-m2.7-highspeed` → `opencode-go\|vercel/minimax-m2.7` → `anthropic\|opencode\|vercel/claude-haiku-4-5` → `openai\|opencode\|vercel/gpt-5.4-nano` |
+| **Explore** | Fast codebase grep | `openai/gpt-5.4-mini-fast` → `opencode-go/qwen3.5-plus` → `vercel/minimax-m2.7-highspeed` → `opencode-go\|vercel/minimax-m2.7` → `anthropic\|vercel/claude-haiku-4-5` → `openai\|vercel/gpt-5.4-nano` |
 | **Librarian** | Docs/code search | same as Explore |
 | **Multimodal Looker** | Vision/screenshots | `openai\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/kimi-k2.6` → `zai-coding-plan\|vercel/glm-4.6v` → `openai\|github-copilot\|opencode\|vercel/gpt-5-nano` |
 | **Sisyphus-Junior** | Category executor | `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `opencode-go\|vercel/kimi-k2.6` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/minimax-m2.7` → `opencode/big-pickle` |

--- a/packages/model-core/src/model-requirements.test.ts
+++ b/packages/model-core/src/model-requirements.test.ts
@@ -656,4 +656,43 @@ describe("gpt-5.3-codex provider restrictions", () => {
       expect(entry.providers).not.toContain("github-copilot")
     }
   })
+
+  test("no claude-haiku-4-5 entry routes through opencode (#3757)", () => {
+    // given - every fallback entry across agents + categories
+    const allEntries = [
+      ...Object.values(AGENT_MODEL_REQUIREMENTS).flatMap((req) => req.fallbackChain),
+      ...Object.values(CATEGORY_MODEL_REQUIREMENTS).flatMap((req) => req.fallbackChain),
+    ]
+
+    // when - filtering entries targeting claude-haiku-4-5
+    const haikuEntries = allEntries.filter((entry) => entry.model === "claude-haiku-4-5")
+
+    // then - sanity: it is still referenced (anthropic native + vercel cover it),
+    //        but OpenCode Zen no longer serves this id, so listing "opencode"
+    //        as a provider produces "Model not found: opencode/claude-haiku-4-5"
+    //        when the chain rolls over to that branch.
+    expect(haikuEntries.length).toBeGreaterThan(0)
+    for (const entry of haikuEntries) {
+      expect(entry.providers).not.toContain("opencode")
+    }
+  })
+
+  test("no gpt-5.4-nano entry routes through opencode (#3757)", () => {
+    // given - every fallback entry across agents + categories
+    const allEntries = [
+      ...Object.values(AGENT_MODEL_REQUIREMENTS).flatMap((req) => req.fallbackChain),
+      ...Object.values(CATEGORY_MODEL_REQUIREMENTS).flatMap((req) => req.fallbackChain),
+    ]
+
+    // when - filtering entries targeting gpt-5.4-nano
+    const nanoEntries = allEntries.filter((entry) => entry.model === "gpt-5.4-nano")
+
+    // then - OpenCode Zen catalog no longer contains gpt-5.4-nano; native
+    //        OpenAI and Vercel AI Gateway still do, so the model stays but
+    //        the opencode provider must be dropped.
+    expect(nanoEntries.length).toBeGreaterThan(0)
+    for (const entry of nanoEntries) {
+      expect(entry.providers).not.toContain("opencode")
+    }
+  })
 })

--- a/packages/model-core/src/model-requirements.ts
+++ b/packages/model-core/src/model-requirements.ts
@@ -81,8 +81,8 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["opencode-go"], model: "qwen3.5-plus" },
       { providers: ["vercel"], model: "minimax-m2.7-highspeed" },
       { providers: ["opencode-go", "vercel"], model: "minimax-m2.7" },
-      { providers: ["anthropic", "opencode", "vercel"], model: "claude-haiku-4-5" },
-      { providers: ["openai", "opencode", "vercel"], model: "gpt-5.4-nano" },
+      { providers: ["anthropic", "vercel"], model: "claude-haiku-4-5" },
+      { providers: ["openai", "vercel"], model: "gpt-5.4-nano" },
     ],
   },
   explore: {
@@ -91,8 +91,8 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["opencode-go"], model: "qwen3.5-plus" },
       { providers: ["vercel"], model: "minimax-m2.7-highspeed" },
       { providers: ["opencode-go", "vercel"], model: "minimax-m2.7" },
-      { providers: ["anthropic", "opencode", "vercel"], model: "claude-haiku-4-5" },
-      { providers: ["openai", "opencode", "vercel"], model: "gpt-5.4-nano" },
+      { providers: ["anthropic", "vercel"], model: "claude-haiku-4-5" },
+      { providers: ["openai", "vercel"], model: "gpt-5.4-nano" },
     ],
   },
   "multimodal-looker": {
@@ -272,7 +272,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gpt-5.4-mini",
       },
       {
-        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+        providers: ["anthropic", "github-copilot", "vercel"],
         model: "claude-haiku-4-5",
       },
       {

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -973,12 +973,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
       "model": "opencode/claude-sonnet-4-6",
     },
     "explore": {
-      "fallback_models": [
-        {
-          "model": "opencode/gpt-5.4-nano",
-        },
-      ],
-      "model": "opencode/claude-haiku-4-5",
+      "model": "opencode/gpt-5-nano",
     },
     "hephaestus": {
       "model": "opencode/gpt-5.5",
@@ -1109,9 +1104,6 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
     },
     "quick": {
       "fallback_models": [
-        {
-          "model": "opencode/claude-haiku-4-5",
-        },
         {
           "model": "opencode/gemini-3-flash",
         },
@@ -1198,12 +1190,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
       "model": "opencode/claude-sonnet-4-6",
     },
     "explore": {
-      "fallback_models": [
-        {
-          "model": "opencode/gpt-5.4-nano",
-        },
-      ],
-      "model": "opencode/claude-haiku-4-5",
+      "model": "opencode/gpt-5-nano",
     },
     "hephaestus": {
       "model": "opencode/gpt-5.5",
@@ -1334,9 +1321,6 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
     },
     "quick": {
       "fallback_models": [
-        {
-          "model": "opencode/claude-haiku-4-5",
-        },
         {
           "model": "opencode/gemini-3-flash",
         },
@@ -1928,14 +1912,6 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
       "model": "anthropic/claude-sonnet-4-6",
     },
     "explore": {
-      "fallback_models": [
-        {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
-        },
-      ],
       "model": "anthropic/claude-haiku-4-5",
     },
     "hephaestus": {
@@ -2103,9 +2079,6 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
       "fallback_models": [
         {
           "model": "anthropic/claude-haiku-4-5",
-        },
-        {
-          "model": "opencode/claude-haiku-4-5",
         },
         {
           "model": "opencode/gemini-3-flash",
@@ -2708,12 +2681,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "model": "github-copilot/claude-sonnet-4.6",
     },
     "explore": {
-      "fallback_models": [
-        {
-          "model": "opencode/gpt-5.4-nano",
-        },
-      ],
-      "model": "opencode/claude-haiku-4-5",
+      "model": "opencode/gpt-5-nano",
     },
     "hephaestus": {
       "fallback_models": [
@@ -2726,14 +2694,6 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "variant": "medium",
     },
     "librarian": {
-      "fallback_models": [
-        {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
-        },
-      ],
       "model": "zai-coding-plan/glm-4.7",
     },
     "metis": {
@@ -2961,9 +2921,6 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
           "model": "github-copilot/claude-haiku-4.5",
         },
         {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
           "model": "github-copilot/gemini-3-flash-preview",
         },
         {
@@ -3108,13 +3065,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
           "model": "anthropic/claude-haiku-4-5",
         },
         {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
           "model": "openai/gpt-5.4-nano",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
         },
       ],
       "model": "openai/gpt-5.4-mini-fast",
@@ -3139,13 +3090,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
           "model": "anthropic/claude-haiku-4-5",
         },
         {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
           "model": "openai/gpt-5.4-nano",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
         },
       ],
       "model": "openai/gpt-5.4-mini-fast",
@@ -3470,9 +3415,6 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-haiku-4.5",
-        },
-        {
-          "model": "opencode/claude-haiku-4-5",
         },
         {
           "model": "google/gemini-3-flash-preview",
@@ -3668,13 +3610,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
           "model": "anthropic/claude-haiku-4-5",
         },
         {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
           "model": "openai/gpt-5.4-nano",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
         },
       ],
       "model": "openai/gpt-5.4-mini-fast",
@@ -3699,13 +3635,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
           "model": "anthropic/claude-haiku-4-5",
         },
         {
-          "model": "opencode/claude-haiku-4-5",
-        },
-        {
           "model": "openai/gpt-5.4-nano",
-        },
-        {
-          "model": "opencode/gpt-5.4-nano",
         },
       ],
       "model": "openai/gpt-5.4-mini-fast",
@@ -4030,9 +3960,6 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-haiku-4.5",
-        },
-        {
-          "model": "opencode/claude-haiku-4-5",
         },
         {
           "model": "google/gemini-3-flash-preview",

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -686,4 +686,48 @@ describe("generateModelConfig", () => {
       )
     })
   })
+
+  describe("opencode zen deprecated model regression (#3757)", () => {
+    // OpenCode Zen's catalog no longer ships claude-haiku-4-5 or gpt-5.4-nano,
+    // so any generated config that hands those ids to the opencode provider
+    // dies with "Model not found: opencode/<id>" the moment a subagent spawns.
+    // These checks back-stop the snapshots so a careless `-u` regen cannot
+    // silently re-introduce the deprecated routings.
+    const deprecatedIds = ["opencode/claude-haiku-4-5", "opencode/gpt-5.4-nano"]
+
+    test("explore does not hardcode opencode/claude-haiku-4-5 in OpenCode Zen-only setups", () => {
+      // #given only OpenCode Zen is available
+      const config = createConfig({ hasOpencodeZen: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then explore must route to an id OpenCode Zen still serves
+      expect(result.agents?.explore?.model).not.toBe("opencode/claude-haiku-4-5")
+    })
+
+    test("no agent or category routes through any deprecated opencode model", () => {
+      // #given every provider available, exercising every fallback branch
+      const config = createConfig({
+        hasClaude: true,
+        hasOpenAI: true,
+        hasGemini: true,
+        hasCopilot: true,
+        hasOpencodeZen: true,
+        hasZaiCodingPlan: true,
+        hasKimiForCoding: true,
+        hasOpencodeGo: true,
+        hasVercelAiGateway: true,
+      })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then no produced model id (primary or fallback) matches a deprecated routing
+      const serialized = JSON.stringify(result)
+      for (const id of deprecatedIds) {
+        expect(serialized).not.toContain(id)
+      }
+    })
+  })
 })

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -149,7 +149,10 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       } else if (avail.native.claude) {
         agentConfig = { model: "anthropic/claude-haiku-4-5" }
       } else if (avail.opencodeZen) {
-        agentConfig = { model: "opencode/claude-haiku-4-5" }
+        // OpenCode Zen no longer serves opencode/claude-haiku-4-5 (#3757) — fall
+        // back to opencode/gpt-5-nano, which is the ultimate-fallback default
+        // and one of the few nano-class ids still in the Zen catalog.
+        agentConfig = { model: "opencode/gpt-5-nano" }
       } else if (avail.opencodeGo) {
         agentConfig = { model: "opencode-go/qwen3.5-plus" }
       } else if (avail.copilot) {


### PR DESCRIPTION
## Summary

Fixes #3757. OpenCode Zen no longer ships `opencode/claude-haiku-4-5` or `opencode/gpt-5.4-nano` in its catalog, so background subagents spawned under a Zen-backed setup die with `Model not found: opencode/<id>` the moment the chain rolls over to those entries.

## Changes

- **`packages/model-core/src/model-requirements.ts`** — three fallback entries (librarian tail, explore tail, `quick` category secondary) keep their model ids but drop `opencode` from `providers`. `anthropic` + `vercel` still serve `claude-haiku-4-5`; `openai` + `vercel` still serve `gpt-5.4-nano`, so live chains stay populated.
- **`src/cli/model-fallback.ts`** — `generateModelConfig`'s explore opencodeZen-only branch (the one OP's `opencode debug agent explore` hit) replaces the dead `opencode/claude-haiku-4-5` hardcode with `opencode/gpt-5-nano`, matching the existing `ULTIMATE_FALLBACK` and staying inside the current Zen catalog.
- **Regression tests** — `model-requirements.test.ts` (2 new) assert no fallback entry can route either deprecated id through the `opencode` provider again, and `model-fallback.test.ts` (2 new) lock the explore opencodeZen-only resolution + a deep scan over every produced agent / category for the deprecated routings, back-stopping the snapshot so a careless `-u` regen cannot silently re-introduce them.
- **`src/cli/__snapshots__/model-fallback.test.ts.snap`** — regenerated; 73 lines of `opencode/claude-haiku-4-5` / `opencode/gpt-5.4-nano` removed from the fallback-chain outputs.
- **`docs/guide/agent-model-matching.md`** — Explore fallback table row updated to match.

## Test plan

- [x] `bun test packages/model-core/src/model-requirements.test.ts` — 33 pass, 0 fail
- [x] `bun test src/cli/model-fallback.test.ts` — 52 pass, 0 fail (24 snapshots regenerated)
- [x] `bun test src/cli` — 439 pass, 0 fail across 62 files
- [x] `bun test packages/model-core/src` — 252 pass, 0 fail across 15 files
- [x] Reviewed snapshot diff: only `opencode/claude-haiku-4-5` and `opencode/gpt-5.4-nano` entries removed; no other ids dropped.
- [x] `claude-code-agent-loader/claude-model-mapper.ts` and `shared/migration/agent-category.ts` still reference `anthropic/claude-haiku-4-5` — these are correct (Anthropic native still serves haiku-4-5) and intentionally left alone.

## Notes

@jaimeagudo flagged this as blocking for them. The fix is intentionally minimal — same model ids, fewer providers — so it should not affect anyone whose chain currently lands on Anthropic native / OpenAI native / Vercel AI Gateway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `opencode` routing for deprecated `claude-haiku-4-5` and `gpt-5.4-nano`, and switches Explore’s Zen-only default to `opencode/gpt-5-nano` to stop “Model not found: opencode/<id>” errors in OpenCode Zen setups. Fixes #3757.

- **Bug Fixes**
  - Dropped `opencode` from providers for `claude-haiku-4-5` and `gpt-5.4-nano` in librarian/explore fallback tails and `quick` category; IDs stay so `anthropic`/`openai`/`vercel` still serve them.
  - Updated Explore (Zen-only) to use `opencode/gpt-5-nano` instead of `opencode/claude-haiku-4-5`.
  - Added regression tests to block any `opencode` routing to the deprecated IDs; updated CLI snapshots accordingly.
  - Synced the Explore fallback table in `docs/guide/agent-model-matching.md`.

<sup>Written for commit b51b132d8311df4f47808241af41399a3bbfd1ff. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

