### PR TITLE
feat(mcp): add @modelcontextprotocol/server-sequential-thinking as a builtin MCP

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -620,10 +620,10 @@ Force-enable session notifications:
 
 ### MCPs
 
-Built-in MCPs (enabled by default): `websearch` (Exa AI), `context7` (library docs), `grep_app` (GitHub code search), `lsp` (local language-server tools), and `ast_grep` (local structural search/rewrite tools).
+Built-in MCPs (enabled by default): `websearch` (Exa AI), `context7` (library docs), `grep_app` (GitHub code search), `lsp` (local language-server tools), `ast_grep` (local structural search/rewrite tools), and `sequential_thinking` (`@modelcontextprotocol/server-sequential-thinking` — a scratchpad for multi-step reasoning, most useful for small no-thinking-mode models).
 
 ```json
-{ "disabled_mcps": ["websearch", "context7", "grep_app", "lsp", "ast_grep"] }
+{ "disabled_mcps": ["websearch", "context7", "grep_app", "lsp", "ast_grep", "sequential_thinking"] }
 ```
 
 ### LSP

--- a/src/cli/doctor/checks/tools-mcp.ts
+++ b/src/cli/doctor/checks/tools-mcp.ts
@@ -5,7 +5,14 @@ import { join } from "node:path"
 import type { McpServerInfo } from "../types"
 import { parseJsonc } from "../../../shared"
 
-const BUILTIN_MCP_SERVERS = ["websearch", "context7", "grep_app", "lsp", "ast_grep"]
+const BUILTIN_MCP_SERVERS = [
+  "websearch",
+  "context7",
+  "grep_app",
+  "lsp",
+  "ast_grep",
+  "sequential_thinking",
+]
 
 interface McpConfigShape {
   mcpServers?: Record<string, unknown>

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -27,7 +27,7 @@ Tier 1 of the three-tier MCP system. Built-ins are created by `createBuiltinMcps
 
 | Tier | Source | Mechanism |
 |------|--------|-----------|
-| 1. Built-in | `src/mcp/` | 3 remote HTTP MCPs + 2 local stdio MCPs (`lsp`, `ast_grep`) via `createBuiltinMcps()` |
+| 1. Built-in | `src/mcp/` | 3 remote HTTP MCPs + 3 local stdio MCPs (`lsp`, `ast_grep`, `sequential_thinking`) via `createBuiltinMcps()` |
 | 2. Claude Code | `.mcp.json` | `${VAR}` expansion via `claude-code-mcp-loader` |
 | 3. Skill-embedded | SKILL.md YAML | Managed by `SkillMcpManager` (stdio + HTTP) |
 
@@ -36,9 +36,10 @@ Tier 1 of the three-tier MCP system. Built-ins are created by `createBuiltinMcps
 | File | Purpose |
 |------|---------|
 | `index.ts` | `createBuiltinMcps()` registry for built-in MCPs |
-| `types.ts` | `McpNameSchema`: `"websearch" \| "context7" \| "grep_app" \| "lsp" \| "ast_grep"` |
+| `types.ts` | `McpNameSchema`: `"websearch" \| "context7" \| "grep_app" \| "lsp" \| "ast_grep" \| "sequential_thinking"` |
 | `websearch.ts` | Exa/Tavily provider with config |
 | `context7.ts` | Context7 with optional auth header |
 | `grep-app.ts` | Grep.app (no auth) |
 | `lsp.ts` | Local stdio MCP config for packaged `lsp-tools-mcp` |
 | `ast-grep.ts` | Local stdio MCP config for packaged `ast-grep-mcp` |
+| `server-sequential-thinking.ts` | Local stdio MCP config wrapping `@modelcontextprotocol/server-sequential-thinking` |

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,6 +3,7 @@ import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
 import { createAstGrepMcpConfig } from "./ast-grep"
 import { createLspMcpConfig, type LocalMcpConfig } from "./lsp"
+import { createServerSequentialThinkingConfig } from "./server-sequential-thinking"
 import type { RuntimeExecutableResolver } from "./runtime-executable"
 import type { OhMyOpenCodeConfig } from "../config/schema"
 
@@ -49,6 +50,12 @@ export function createBuiltinMcps(disabledMcps: string[] = [], config?: OhMyOpen
     mcps.ast_grep = createAstGrepMcpConfig({
       cwd: options.cwd,
       disabledTools: config?.disabled_tools,
+      resolveExecutable: options.resolveExecutable,
+    })
+  }
+
+  if (!disabledMcps.includes("sequential_thinking")) {
+    mcps.sequential_thinking = createServerSequentialThinkingConfig({
       resolveExecutable: options.resolveExecutable,
     })
   }

--- a/src/mcp/server-sequential-thinking.test.ts
+++ b/src/mcp/server-sequential-thinking.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { createServerSequentialThinkingConfig } from "./server-sequential-thinking"
+import type { RuntimeExecutableResolver } from "./runtime-executable"
+
+const npxAvailable: RuntimeExecutableResolver = (name) => ({
+  command: name === "npx" ? "/usr/local/bin/npx" : name,
+  available: name === "npx",
+})
+
+const npxMissing: RuntimeExecutableResolver = (name) => ({
+  command: name,
+  available: false,
+})
+
+describe("createServerSequentialThinkingConfig", () => {
+  test("returns a LocalMcpConfig that launches the official server-sequential-thinking package", () => {
+    const config = createServerSequentialThinkingConfig({ resolveExecutable: npxAvailable })
+    expect(config.type).toBe("local")
+    expect(config.enabled).toBe(true)
+    expect(config.command).toEqual([
+      "/usr/local/bin/npx",
+      "-y",
+      "@modelcontextprotocol/server-sequential-thinking",
+    ])
+  })
+
+  test("disables itself when npx is not on PATH (instead of failing at runtime)", () => {
+    const config = createServerSequentialThinkingConfig({ resolveExecutable: npxMissing })
+    expect(config.enabled).toBe(false)
+    // The command is still recorded so we can show the user what would have
+    // run; only `enabled: false` should keep opencode from launching it.
+    expect(config.command[0]).toBe("npx")
+    expect(config.command[2]).toBe("@modelcontextprotocol/server-sequential-thinking")
+  })
+
+  test("does not set any environment variables (server is stateless)", () => {
+    const config = createServerSequentialThinkingConfig({ resolveExecutable: npxAvailable })
+    expect(config.environment).toBeUndefined()
+  })
+
+  test("falls back to resolveRuntimeExecutable when no resolver is injected", () => {
+    // The default code path must still hand back a config object (the boolean
+    // value of `enabled` depends on whether npx is on this machine's PATH,
+    // which we deliberately do not assert on).
+    const config = createServerSequentialThinkingConfig()
+    expect(config.type).toBe("local")
+    expect(config.command[2]).toBe("@modelcontextprotocol/server-sequential-thinking")
+  })
+})

--- a/src/mcp/server-sequential-thinking.ts
+++ b/src/mcp/server-sequential-thinking.ts
@@ -1,0 +1,30 @@
+import type { LocalMcpConfig } from "./lsp"
+import { resolveRuntimeExecutable, type RuntimeExecutableResolver } from "./runtime-executable"
+
+type ServerSequentialThinkingOptions = {
+  readonly resolveExecutable?: RuntimeExecutableResolver
+}
+
+// Wires the official @modelcontextprotocol/server-sequential-thinking package
+// into oh-my-openagent's builtin MCP set. The server exposes one tool —
+// `sequentialthinking` — that lets a model externalise a multi-step plan and
+// revise individual steps without burning thinking-budget tokens. This is most
+// useful for the small, no-thinking-mode models in our fallback chains
+// (gpt-5-nano, minimax, kimi etc.) where the model otherwise has nowhere to
+// stash partial reasoning between tool calls.
+//
+// The server is stateless (no on-disk state, no env vars), so we just hand it
+// to `npx -y` and let it warm up on demand. When npx is not on PATH we mark
+// the MCP disabled rather than scheduling a launch that would fail at the
+// first request and confuse the user.
+export function createServerSequentialThinkingConfig(
+  options: ServerSequentialThinkingOptions = {},
+): LocalMcpConfig {
+  const resolveExecutable = options.resolveExecutable ?? resolveRuntimeExecutable
+  const npx = resolveExecutable("npx")
+  return {
+    type: "local",
+    command: [npx.command, "-y", "@modelcontextprotocol/server-sequential-thinking"],
+    enabled: npx.available,
+  }
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,13 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "lsp", "ast_grep"])
+export const McpNameSchema = z.enum([
+  "websearch",
+  "context7",
+  "grep_app",
+  "lsp",
+  "ast_grep",
+  "sequential_thinking",
+])
 
 export type McpName = z.infer<typeof McpNameSchema>
 

--- a/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -11,6 +11,13 @@ function mockLocalMcps(): void {
   mock.module("../ast-grep", () => ({
     createAstGrepMcpConfig: () => ({ type: "local", command: ["node", "ast-grep-mcp", "mcp"], enabled: true }),
   }))
+  mock.module("../server-sequential-thinking", () => ({
+    createServerSequentialThinkingConfig: () => ({
+      type: "local",
+      command: ["node", "server-sequential-thinking", "mcp"],
+      enabled: true,
+    }),
+  }))
 }
 
 describe("createBuiltinMcps", () => {
@@ -30,6 +37,7 @@ describe("createBuiltinMcps", () => {
     expect(result.grep_app).toBeDefined()
     expect(result.lsp).toBeDefined()
     expect(result.ast_grep).toBeDefined()
+    expect(result.sequential_thinking).toBeDefined()
   })
 
   test("should filter out disabled MCPs", () => {
@@ -47,6 +55,7 @@ describe("createBuiltinMcps", () => {
     expect(result.grep_app).toBeDefined()
     expect(result.lsp).toBeDefined()
     expect(result.ast_grep).toBeDefined()
+    expect(result.sequential_thinking).toBeDefined()
   })
 
   test("should keep lsp when it uses a bootstrap command", () => {
@@ -67,7 +76,14 @@ describe("createBuiltinMcps", () => {
     // given
     mockLocalMcps()
     const { createBuiltinMcps } = require("../index") as typeof import("../index")
-    const disabledMcps = ["websearch", "context7", "grep_app", "lsp", "ast_grep"]
+    const disabledMcps = [
+      "websearch",
+      "context7",
+      "grep_app",
+      "lsp",
+      "ast_grep",
+      "sequential_thinking",
+    ]
 
     // when
     const result = createBuiltinMcps(disabledMcps)
@@ -79,6 +95,7 @@ describe("createBuiltinMcps", () => {
     expect(remainingMcpNames).not.toContain("grep_app")
     expect(remainingMcpNames).not.toContain("lsp")
     expect(remainingMcpNames).not.toContain("ast_grep")
+    expect(remainingMcpNames).not.toContain("sequential_thinking")
     expect(remainingMcpNames).toEqual([])
   })
 


### PR DESCRIPTION
## Summary

Adds `@modelcontextprotocol/server-sequential-thinking` to the builtin MCP set as `sequential_thinking`. The server exposes one tool — `sequentialthinking` — that lets a model externalise a multi-step plan and revise individual steps without burning thinking-budget tokens.

## Why

Most useful for the small no-thinking-mode models on omo's fallback chains (`gpt-5-nano`, `minimax-m2.7`, `kimi-k2.x` etc.). Without thinking-mode support, those models have nowhere to stash partial reasoning between tool calls and tend to either skip planning or hallucinate it back from scratch each turn. The official sequential-thinking server gives them an explicit scratchpad that survives tool round-trips.

Follows the same wiring pattern as the existing `server-memory` PR (#4286).

## Changes

- **`src/mcp/server-sequential-thinking.ts`** — thin factory wrapping the stateless server behind `npx -y @modelcontextprotocol/server-sequential-thinking`. Returns `enabled: false` when `npx` is missing so we never schedule a launch that would die on the first request.
- **`src/mcp/types.ts`** — extend `McpNameSchema` with `sequential_thinking` so `disabled_mcps: [\"sequential_thinking\"]` is recognised as a known builtin name (not just a free-form string).
- **`src/mcp/index.ts`** — register it in `createBuiltinMcps`, behind the same `disabled_mcps` gate the other builtins use.
- **`src/cli/doctor/checks/tools-mcp.ts`** — include it in `BUILTIN_MCP_SERVERS` so `omo doctor` does not flag it as an unknown external MCP.
- **Tests** — `server-sequential-thinking.test.ts` (4 cases: happy path, missing-npx fallback, stateless-environment invariant, default-resolver branch) and an extension of `zauc-mocks-mcp-index/index.test.ts` to mock the new factory and lock the registration through every `createBuiltinMcps` scenario.
- **Docs** — `docs/reference/configuration.md` and `src/mcp/AGENTS.md` list the new builtin alongside the others.

## Test plan

- [x] `bun test src/mcp` — 40 pass, 0 fail
- [x] `bun test src/mcp src/cli/doctor src/config` — 222 pass, 0 fail across 32 files
- [x] Manual: `disabled_mcps: [\"sequential_thinking\"]` removes it from `createBuiltinMcps` output without touching the other builtins.
- [x] Manual: missing-npx environments produce `{ enabled: false }` rather than a broken launch attempt.

## Notes

The server is stateless — no env vars, no on-disk state, no per-project setup. If the package isn't already cached, `npx -y` warms it up on first request. Users who don't want the auto-launch can opt out with `disabled_mcps: [\"sequential_thinking\"]`.

If both this PR and #4286 (`server-memory`) land, the builtin MCP roster grows from 5 to 7. No conflict between the two diffs — they touch disjoint files except `src/mcp/types.ts` and `src/mcp/index.ts`, both of which are append-only additions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@modelcontextprotocol/server-sequential-thinking` as a built-in MCP named `sequential_thinking` to give models a scratchpad for multi-step plans via the `sequentialthinking` tool. This helps small no-thinking-mode models persist plans across tool calls.

- **New Features**
  - Launches the stateless server via `npx -y`; auto-disables when `npx` isn’t available.
  - Registered in `createBuiltinMcps`; `McpNameSchema` extended; `omo doctor` recognizes it; docs updated. Opt out with `disabled_mcps: ["sequential_thinking"]`.
  - Tests cover launch, missing `npx`, stateless env, and default resolver; registration tests updated.

<sup>Written for commit 4217e040dfc10c68ec843d50827de35621305e7f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

