### PR TITLE
fix(mcp): disable ast_grep MCP when cli.js missing instead of letting OpenCode spawn it (#4188, #4220)

### DIFF
--- a/src/mcp/ast-grep.test.ts
+++ b/src/mcp/ast-grep.test.ts
@@ -67,8 +67,11 @@ describe("createAstGrepMcpConfig", () => {
     expect(config.command).toEqual([bunPath, sourceCliPath, "mcp"])
   })
 
-  it("still returns a built-in MCP config when the cli has not been built yet", () => {
-    // given
+  it("disables the MCP config when the cli has not been built or unpacked (#4188, #4220)", () => {
+    // given - dist/index.js shipped but packages/ast-grep-mcp not unpacked.
+    // Pre-fix this returned enabled=true with a non-existent cli.js path,
+    // which caused OpenCode to spawn the missing binary and report
+    // "MCP error -32000: Connection closed" on Windows.
     const packageRoot = createTemporaryDirectory("omo-ast-grep-missing-root-")
     const moduleFilePath = join(packageRoot, "dist", "index.js")
     const nodePath = join(packageRoot, "bin", "node")
@@ -81,11 +84,38 @@ describe("createAstGrepMcpConfig", () => {
       resolveExecutable: createResolver({ node: nodePath }),
     })
 
-    // then
-    expect(config.enabled).toBe(true)
+    // then - command shape is preserved so doctor/diagnostics still display
+    // a meaningful path, but enabled=false stops OpenCode from spawning it.
+    expect(config.enabled).toBe(false)
     expect(config.command[0]).toBe(nodePath)
     expect(config.command[1]).toContain(join("packages", "ast-grep-mcp", "dist", "cli.js"))
     expect(config.command[2]).toBe("mcp")
+  })
+
+  it("disables the MCP config when only the dist/index.js was unpacked but packages/ was not (Windows cache scenario, #4188 #4220)", () => {
+    // given - simulates `~/.cache/opencode/packages/oh-my-openagent@.../dist/`
+    // being present while `packages/ast-grep-mcp/dist/cli.js` is missing
+    // because the npm extractor only unpacked `dist/`. Pre-fix the fallback
+    // path resolution returned `enabled: runtime.available` regardless of
+    // whether the cli existed, leading to MCP -32000 on connect.
+    const cacheRoot = createTemporaryDirectory("omo-ast-grep-cache-root-")
+    const ohMyDistDir = join(cacheRoot, "node_modules", "oh-my-openagent", "dist")
+    const moduleFilePath = join(ohMyDistDir, "index.js")
+    const nodePath = join(cacheRoot, "bin", "node")
+    mkdirSync(ohMyDistDir, { recursive: true })
+
+    // when
+    const config = createAstGrepMcpConfig({
+      cwd: createTemporaryDirectory("omo-ast-grep-cache-cwd-"),
+      moduleUrl: pathToFileURL(moduleFilePath).href,
+      resolveExecutable: createResolver({ node: nodePath }),
+    })
+
+    // then - MCP must be disabled so OpenCode never tries to spawn the
+    // missing cli.js. The error users saw was:
+    // "ast_grep MCP error -32000: Connection closed
+    //  node C:\Users\...\oh-my-openagent\dist\packages\ast-grep-mcp\dist\cli.js mcp"
+    expect(config.enabled).toBe(false)
   })
 
   it("disables the MCP config when no runtime can launch ast-grep", () => {

--- a/src/mcp/ast-grep.ts
+++ b/src/mcp/ast-grep.ts
@@ -83,10 +83,18 @@ function getModuleDirectory(moduleUrl: string): string | null {
   }
 }
 
-function createFallbackCandidate(resolveExecutable: RuntimeExecutableResolver): CommandCandidate {
+function createFallbackCandidate(
+  resolveExecutable: RuntimeExecutableResolver,
+  pathExists: (path: string) => boolean,
+): CommandCandidate {
   const runtime = resolveJavaScriptRuntime(resolveExecutable);
   const path = resolve(PACKAGE_REL, DIST_CLI_REL);
-  return { command: [runtime.command, path, "mcp"], path, exists: runtime.available, runtimeAvailable: runtime.available };
+  return {
+    command: [runtime.command, path, "mcp"],
+    path,
+    exists: runtime.available && pathExists(path),
+    runtimeAvailable: runtime.available,
+  };
 }
 
 function resolveAstGrepCommand(options: AstGrepMcpConfigOptions = {}): CommandCandidate {
@@ -101,9 +109,14 @@ function resolveAstGrepCommand(options: AstGrepMcpConfigOptions = {}): CommandCa
   if (distCandidate) return distCandidate;
   const sourceCandidate = candidates.find((candidate) => hasCliSuffix(candidate.path, SOURCE_CLI_REL) && candidate.exists);
   if (sourceCandidate) return sourceCandidate;
+  // When neither dist nor source cli exists on disk, surface a disabled MCP
+  // config instead of advertising a path that OpenCode will try to spawn and
+  // fail with "MCP error -32000: Connection closed" (#4188, #4220). Common
+  // cause is OpenCode cache unpacking `dist/` but not `packages/` on Windows.
   const fallbackCandidate =
-    candidates.find((candidate) => hasCliSuffix(candidate.path, DIST_CLI_REL)) ?? createFallbackCandidate(resolveExecutable);
-  return { ...fallbackCandidate, exists: fallbackCandidate.runtimeAvailable };
+    candidates.find((candidate) => hasCliSuffix(candidate.path, DIST_CLI_REL)) ??
+    createFallbackCandidate(resolveExecutable, pathExists);
+  return fallbackCandidate;
 }
 
 function astGrepDisabledTools(disabledTools: readonly string[] | undefined): string {


### PR DESCRIPTION
## Summary

Stops OpenCode from spawning the `ast_grep` MCP when its `cli.js` is absent. The prior behavior surfaced as `MCP error -32000: Connection closed` on Windows whenever the OpenCode cache extractor unpacked `dist/` but skipped `packages/`.

## Why this happens

`src/mcp/ast-grep.ts` returns a `LocalMcpConfig` with `enabled: resolvedCommand.exists`. When neither a built `packages/ast-grep-mcp/dist/cli.js` nor a source `packages/ast-grep-mcp/src/cli.ts` is on disk, we fell through to `createFallbackCandidate`, which set `exists: runtime.available` — i.e. \"a node binary exists somewhere, so call it enabled.\" That was technically false: OpenCode then tried to spawn `node <missing-cli> mcp` and the MCP transport closed immediately.

`ed6e9955` (path-separator fix) and `ccaf61e0` (Windows backslash test) already addressed the *first* failure mode (`MODULE_NOT_FOUND` due to slash mismatch). What was left after those fixes is the followup reported by @Hoshino-Yumetsuki on #4188:

> When I upgrade omo to 1.15.6, the error changed to `ast_grep MCP error -32000: Connection closed`

That comment matches exactly the path this PR closes.

## Fix

- `createFallbackCandidate` now checks `runtime.available && pathExists(path)`, so a missing `cli.js` produces `enabled: false`.
- `resolveAstGrepCommand` keeps returning a representative command (path + `node`) so `doctor` and config inspection still display something meaningful — only the `enabled` flag flips.

## Tests

- **Updated**: `disables the MCP config when the cli has not been built or unpacked (#4188, #4220)` — was previously asserting `enabled: true`, which is exactly the bug. Comment explains the historical contract change.
- **Added**: `disables the MCP config when only the dist/index.js was unpacked but packages/ was not (Windows cache scenario, #4188 #4220)` — pins the specific Windows path that produced the -32000 error in user reports.
- Existing happy-path / source-checkout / no-runtime tests still pass: `bun test src/mcp/ast-grep.test.ts` → 6 pass, 0 fail.

## What this does *not* fix

The doctor `BUILTIN_MCP_SERVERS` list still reports `ast_grep` as a built-in (it always is), but `enabled` will be `false` on machines where the cli was never unpacked. That's the expected user-visible signal — \"the tool isn't usable here\" — and is preferable to OpenCode silently dropping a `-32000` error during every session start.

Doctor verbosity could be improved to highlight `enabled: false` builtins with the *reason* (cli missing), but that's a separate enhancement.

## Closes

- #4188 (4.2.x: ast_grep MCP -32000 follow-up after the path-separator fix)
- #4220 (Bug: ast_grep MCP fails to start on Windows — the -32000 surface, not the slash mismatch which was closed by #4272)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the `ast_grep` MCP when `packages/ast-grep-mcp/dist/cli.js` is missing to stop `OpenCode` from spawning a non-existent command and throwing MCP error -32000 on Windows. Doctor still shows the command, but the config is `enabled: false`.

- **Bug Fixes**
  - Fallback now requires both a JS runtime and an existing `cli.js` path; missing path → MCP disabled (Fixes #4188, #4220).
  - Preserves command shape for doctor/config; updated and added tests to cover the Windows cache scenario.

<sup>Written for commit a41dc86729ba928996bcc4bb59ad103e2f54da8d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

