### PR TITLE
feat: session replay and debugger visual

### DIFF
--- a/.agents/skills/opencode-session-debugging/SKILL.md
+++ b/.agents/skills/opencode-session-debugging/SKILL.md
@@ -156,7 +156,7 @@ If the evidence points to a code defect:
 3. Make the smallest code change that turns the test green.
 4. Run focused tests, adjacent tests, typecheck, build, and the full suite when risk warrants it.
 5. Open a PR to `dev`.
-6. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass.
+6. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh PR review all pass. If a `.omo/plans/*.md` plan is part of the workflow, Momus may review that plan and must return `[OKAY]`; do not count Momus as a PR diff reviewer.
 7. Remove the worktree only after the merge commit succeeds.
 
 ## Report Template

--- a/.agents/skills/opencode-session-debugging/SKILL.md
+++ b/.agents/skills/opencode-session-debugging/SKILL.md
@@ -14,6 +14,7 @@ Use this skill to investigate a broken OpenCode session from evidence first, the
 3. Build a timestamped timeline from transcripts, OpenCode logs, plugin logs, and background-task state.
 4. Use git history and blame for the failing subsystem before changing code.
 5. If a fix is needed, switch to `work-with-pr`: create a new worktree, write the failing test first, open a PR, and do not merge until all required gates pass.
+6. Treat raw `session.prompt` and `session.promptAsync` paths as suspect until the shared prompt gate has been audited.
 
 ## Phase 0: Capture Inputs
 
@@ -50,6 +51,15 @@ Use this source to verify current session, prompt, logging, storage, and backgro
 ## Phase 2: Locate the Session
 
 Search by the strongest identifier first.
+
+Prefer first-class session tools when they are available:
+
+- `session_info` for one known session id
+- `session_read` for transcript content
+- `session_search` for title, directory, symptom, and message text
+- `session_list` to find nearby sessions when only the directory or title is known
+
+Fall back to direct file search when tool access is unavailable or incomplete.
 
 By session id:
 
@@ -92,6 +102,15 @@ For each discovered transcript, extract references to:
 
 Search each child session id again through transcripts and logs. Repeat until no new child ids appear. Return a parent-to-child tree with evidence paths.
 
+Use this tree shape:
+
+```text
+ses_parent <title or first prompt> [transcript path]
+├─ ses_child_a via <task/call/background id> at <timestamp> [transcript path]
+│  └─ ses_grandchild via <task/call/background id> at <timestamp> [transcript path]
+└─ ses_child_b via <task/call/background id> at <timestamp> [transcript path]
+```
+
 ## Phase 4: Build the Failure Timeline
 
 Create a timeline with absolute timestamps. Include:
@@ -102,9 +121,20 @@ Create a timeline with absolute timestamps. Include:
 - OpenCode session lifecycle events such as idle, error, compacting, and aborted process
 - Any duplicate internal prompt or repeated assistant stream
 
+For live or recently finished background tasks, prefer `background_output` to inspect task state before reading disk files. Use `background_cancel` only for an actually running stray task that is part of cleanup, and record why cancellation is safe.
+
 Correlate this timeline with the latest OpenCode source. Label facts from runtime logs separately from inferences from source code.
 
-## Phase 5: History and Blame
+## Phase 5: Prompt Gate Audit
+
+Session corruption often comes from internal prompt injection. Audit this invariant before changing code:
+
+- Production code may call `session.prompt` or `session.promptAsync` only through the shared gate path.
+- New internal message routes must use `dispatchInternalPrompt` or an equivalent gate.
+- Suspect patterns: duplicate idle/error/completion edges, `postDispatchHoldMs: 0`, raw prompt fallback when no session state is found, and routes that restore no state when dispatch is skipped.
+- Check `src/shared/prompt-async-gate.ts`, `src/shared/prompt-async-route-audit.test.ts`, and the route-specific tests for the failing subsystem.
+
+## Phase 6: History and Blame
 
 Before changing code, run history searches for the failing mechanism:
 
@@ -117,7 +147,7 @@ git blame -L START,END path/to/suspect-file.ts
 
 Use blame to identify the intent of the current behavior. Use `git show` on relevant commits and compare their tests to the current failure.
 
-## Phase 6: TDD Fix Workflow
+## Phase 7: TDD Fix Workflow
 
 If the evidence points to a code defect:
 

--- a/.agents/skills/opencode-session-debugging/SKILL.md
+++ b/.agents/skills/opencode-session-debugging/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: opencode-session-debugging
+description: "Debug broken OpenCode sessions by locating sessions from an id, title, or directory, recursively inspecting child sessions, correlating transcripts, logs, background tasks, and current OpenCode source, then driving a TDD fix in an isolated PR worktree when code changes are needed. Use whenever the user mentions OpenCode session corruption, background task completion, child sessions, session ids, or a broken session transcript."
+---
+
+# OpenCode Session Debugging
+
+Use this skill to investigate a broken OpenCode session from evidence first, then fix the responsible code only after the failure mechanism is pinned by a test.
+
+## Non-Negotiables
+
+1. Inspect the latest OpenCode source before relying on OpenCode behavior.
+2. Find every child session recursively. A parent transcript alone is incomplete evidence.
+3. Build a timestamped timeline from transcripts, OpenCode logs, plugin logs, and background-task state.
+4. Use git history and blame for the failing subsystem before changing code.
+5. If a fix is needed, switch to `work-with-pr`: create a new worktree, write the failing test first, open a PR, and do not merge until all required gates pass.
+
+## Phase 0: Capture Inputs
+
+Accept any of these as the starting point:
+
+- Session id, for example `ses_...`
+- Session title
+- Project directory where the session happened
+- A symptom such as "background task completed and the session got corrupted"
+
+If multiple inputs are present, use all of them. Do not ask for a narrower input when a search can disambiguate it.
+
+## Phase 1: Update OpenCode Source
+
+Keep a current OpenCode checkout outside the target repository. Prefer an existing sibling checkout; otherwise clone into `/tmp`.
+
+```bash
+# Existing sibling checkout, when present
+cd ../opencode
+git fetch --all --prune
+git pull --ff-only
+git rev-parse HEAD
+
+# Fresh temporary checkout, when needed
+git clone https://github.com/sst/opencode /tmp/opencode-source
+cd /tmp/opencode-source
+git fetch --all --prune
+git pull --ff-only
+git rev-parse HEAD
+```
+
+Use this source to verify current session, prompt, logging, storage, and background-task behavior. Do not assume older OpenCode behavior still applies.
+
+## Phase 2: Locate the Session
+
+Search by the strongest identifier first.
+
+By session id:
+
+```bash
+rg -n "ses_[A-Za-z0-9]+" ~/.claude/transcripts ~/.local/share/opencode 2>/dev/null
+rg -n "TARGET_SESSION_ID" ~/.claude/transcripts ~/.local/share/opencode .opencode .omo 2>/dev/null
+```
+
+By title:
+
+```bash
+rg -n "TITLE_FRAGMENT" ~/.claude/transcripts ~/.local/share/opencode .opencode .omo 2>/dev/null
+```
+
+By directory:
+
+```bash
+rg -n "ABSOLUTE_PROJECT_DIRECTORY" ~/.claude/transcripts ~/.local/share/opencode .opencode .omo 2>/dev/null
+```
+
+Common evidence locations:
+
+- `~/.claude/transcripts/*.jsonl`
+- `~/.local/share/opencode/log/*.log`
+- `~/.local/share/opencode`
+- Project `.opencode/background-tasks`
+- Project `.omo`
+- OS temp logs such as `oh-my-opencode.log`
+
+Record exact paths and timestamps for every artifact used.
+
+## Phase 3: Recursively Find Child Sessions
+
+For each discovered transcript, extract references to:
+
+- `sessionID`, `session_id`, and `ses_...`
+- `call_omo_agent`, `task`, delegate, and background-agent tool calls
+- Background task ids and parent wake messages
+- `session.prompt`, `promptAsync`, idle, error, compacting, and autocontinue events
+
+Search each child session id again through transcripts and logs. Repeat until no new child ids appear. Return a parent-to-child tree with evidence paths.
+
+## Phase 4: Build the Failure Timeline
+
+Create a timeline with absolute timestamps. Include:
+
+- User prompts and assistant turns
+- Background task creation, completion, output delivery, and cancellation
+- Parent wake enqueue, dispatch, reservation, requeue, and skip events
+- OpenCode session lifecycle events such as idle, error, compacting, and aborted process
+- Any duplicate internal prompt or repeated assistant stream
+
+Correlate this timeline with the latest OpenCode source. Label facts from runtime logs separately from inferences from source code.
+
+## Phase 5: History and Blame
+
+Before changing code, run history searches for the failing mechanism:
+
+```bash
+git log --oneline -- path/to/suspect-file.ts
+git log -S "suspect symbol or string" -- path/to/suspect-file.ts
+git log -G "suspect regex" -- path/to/suspect-file.ts
+git blame -L START,END path/to/suspect-file.ts
+```
+
+Use blame to identify the intent of the current behavior. Use `git show` on relevant commits and compare their tests to the current failure.
+
+## Phase 6: TDD Fix Workflow
+
+If the evidence points to a code defect:
+
+1. Invoke `work-with-pr` and create a fresh task worktree.
+2. Write a regression test that fails without the fix.
+3. Make the smallest code change that turns the test green.
+4. Run focused tests, adjacent tests, typecheck, build, and the full suite when risk warrants it.
+5. Open a PR to `dev`.
+6. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass.
+7. Remove the worktree only after the merge commit succeeds.
+
+## Report Template
+
+Use this shape for the investigation report:
+
+```markdown
+Root cause:
+<one mechanism, tied to runtime evidence>
+
+Evidence:
+- Parent session: <path>
+- Child sessions: <ids and paths>
+- OpenCode source: <checkout path and commit>
+- Timeline: <key timestamped events>
+- History: <relevant commits and blame lines>
+
+Fix:
+- PR: <number or link>
+- Test proving the bug: <test file and test name>
+- Validation: <commands and results>
+
+Blocked gates:
+- <only include if a required gate could not run or did not pass>
+```

--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
+description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh PR review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
 ---
 
 # Work With PR — Full PR Lifecycle
@@ -11,7 +11,7 @@ Hard invariants:
 
 1. Always create a fresh git worktree for the task. Never implement in the user's main worktree.
 2. Target `dev` unless the user explicitly names another protected base and the repository policy allows it.
-3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass on the current head.
+3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh PR review all pass on the current head.
 4. If any required gate is unavailable, rate-limited, skipped, stale, or ambiguous, do not merge. Report the blocker and leave the worktree for resumption.
 5. After a successful merge commit, remove the task worktree and prune stale worktree metadata.
 
@@ -25,7 +25,7 @@ Phase 3: Verify Loop   → Unbounded iteration until ALL gates pass:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review
   ├─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
-  └─ Gate D: AI review  → GPT-5.2 xhigh or Momus PASS
+  └─ Gate D: AI review  → GPT-5.2 xhigh PR review PASS
 Phase 4: Merge         → Merge commit, worktree cleanup
 ```
 
@@ -181,7 +181,7 @@ while true:
   4. If review fails      → fix blocking issues, commit, push, continue
   5. Check Cubic          → Gate C
   6. If Cubic has issues   → fix issues, commit, push, continue
-  7. Run GPT-5.2 xhigh or Momus review → Gate D
+  7. Run GPT-5.2 xhigh PR review → Gate D
   8. If AI review fails    → fix blockers, commit, push, continue
   9. All four pass         → break
 ```
@@ -268,16 +268,15 @@ while true; do
 done
 ```
 
-### Gate D: GPT-5.2 xhigh or Momus Review
+### Gate D: GPT-5.2 xhigh PR Review
 
 Run one independent final reviewer after CI, review-work, and Cubic pass. The reviewer must inspect the current PR head, not a stale local diff.
 
-Acceptable pass signals:
+Acceptable pass signal:
 
 - A GPT-5.2 reviewer running with xhigh reasoning returns `VERDICT: PASS`.
-- A Momus reviewer returns `VERDICT: PASS`.
 
-If using OpenCode, verify the requested agent actually loaded. A warning such as `agent "momus" not found. Falling back to default agent` invalidates the gate; retry with the correct display name or use GPT-5.2 xhigh instead.
+Momus is not a substitute for this PR-diff gate. Momus reviews `.omo/plans/*.md` execution plans and uses `[OKAY]` or `[REJECT]`; count it only as an additional plan gate when a plan review is explicitly in scope.
 
 Review prompt template:
 
@@ -393,7 +392,7 @@ git rebase "origin/$BASE_BRANCH"
 | Pushing directly to dev/master | Bypasses review entirely | CRITICAL |
 | Skipping CI gate after code changes | review-work and Cubic may pass on stale code | CRITICAL |
 | Merging while Cubic is skipped, rate-limited, or ambiguous | Required external review did not happen | CRITICAL |
-| Counting an agent fallback as Momus | The named review gate did not actually run | CRITICAL |
+| Counting Momus as the PR-diff reviewer | Momus reviews plans, not PR diffs | CRITICAL |
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |

--- a/.agents/skills/work-with-pr/SKILL.md
+++ b/.agents/skills/work-with-pr/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle: git worktree → implement → atomic commits → PR creation → verification loop (CI + review-work + Cubic approval) → merge. Keeps iterating until ALL gates pass and PR is merged. Worktree auto-cleanup after merge. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
 ---
 
 # Work With PR — Full PR Lifecycle
 
-You are executing a complete PR lifecycle: from isolated worktree setup through implementation, PR creation, and an unbounded verification loop until the PR is merged. The loop has three gates — CI, review-work, and Cubic — and you keep fixing and pushing until all three pass simultaneously.
+You are executing a complete PR lifecycle: isolated worktree setup, implementation, PR creation, verification, merge, and cleanup.
+
+Hard invariants:
+
+1. Always create a fresh git worktree for the task. Never implement in the user's main worktree.
+2. Target `dev` unless the user explicitly names another protected base and the repository policy allows it.
+3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass on the current head.
+4. If any required gate is unavailable, rate-limited, skipped, stale, or ambiguous, do not merge. Report the blocker and leave the worktree for resumption.
+5. After a successful merge commit, remove the task worktree and prune stale worktree metadata.
 
 <architecture>
 
@@ -16,7 +24,8 @@ Phase 2: PR Creation   → Push, create PR targeting dev
 Phase 3: Verify Loop   → Unbounded iteration until ALL gates pass:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review
-  └─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
+  ├─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
+  └─ Gate D: AI review  → GPT-5.2 xhigh or Momus PASS
 Phase 4: Merge         → Merge commit, worktree cleanup
 ```
 
@@ -26,7 +35,7 @@ Phase 4: Merge         → Merge commit, worktree cleanup
 
 ## Phase 0: Setup
 
-Create an isolated worktree so the user's main working directory stays clean. This matters because the user may have uncommitted work, and checking out a branch would destroy it.
+Create an isolated worktree so the user's main working directory stays clean. This is mandatory even for tiny changes because the user may have uncommitted work, other agents may be active, and PR cleanup depends on having a disposable task directory.
 
 <setup>
 
@@ -160,7 +169,7 @@ PR_NUMBER=$(gh pr view --json number -q .number)
 
 ## Phase 3: Verification Loop
 
-This is the core of the skill. Three gates must ALL pass for the PR to be ready. The loop has no iteration cap — keep going until done. Gate ordering is intentional: CI is cheapest/fastest, review-work is most thorough, Cubic is external and asynchronous.
+This is the core of the skill. Four gates must ALL pass for the PR to be ready. The loop has no iteration cap — keep going until done. Gate ordering is intentional: CI is cheapest/fastest, review-work is broadest, Cubic is external and asynchronous, and the final AI review catches reasoning gaps.
 
 <verify_loop>
 
@@ -172,7 +181,9 @@ while true:
   4. If review fails      → fix blocking issues, commit, push, continue
   5. Check Cubic          → Gate C
   6. If Cubic has issues   → fix issues, commit, push, continue
-  7. All three pass       → break
+  7. Run GPT-5.2 xhigh or Momus review → Gate D
+  8. If AI review fails    → fix blockers, commit, push, continue
+  9. All four pass         → break
 ```
 
 ### Gate A: CI Checks
@@ -223,6 +234,8 @@ Cubic (`cubic-dev-ai[bot]`) is an automated review bot that comments on PRs. It 
 
 **Issue signal**: The comment lists issues with file-level detail.
 
+**Not a pass**: neutral/skipped check runs, "started review" comments, billing or line-limit messages, stale comments from an older head SHA, or a generated PR summary without a review verdict.
+
 ```bash
 # Get the latest Cubic review
 CUBIC_REVIEW=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
@@ -255,6 +268,32 @@ while true; do
 done
 ```
 
+### Gate D: GPT-5.2 xhigh or Momus Review
+
+Run one independent final reviewer after CI, review-work, and Cubic pass. The reviewer must inspect the current PR head, not a stale local diff.
+
+Acceptable pass signals:
+
+- A GPT-5.2 reviewer running with xhigh reasoning returns `VERDICT: PASS`.
+- A Momus reviewer returns `VERDICT: PASS`.
+
+If using OpenCode, verify the requested agent actually loaded. A warning such as `agent "momus" not found. Falling back to default agent` invalidates the gate; retry with the correct display name or use GPT-5.2 xhigh instead.
+
+Review prompt template:
+
+```text
+Read-only review gate for PR #{PR_NUMBER}. Do not edit, commit, or push.
+Worktree: {WORKTREE_PATH}
+Base: origin/{BASE_BRANCH}
+Head: {BRANCH_NAME}
+Goal: {ORIGINAL_GOAL}
+
+Inspect the diff and directly relevant files/tests. Return first line exactly
+VERDICT: PASS or VERDICT: FAIL. On FAIL, include file/line blockers only.
+```
+
+On failure, fix only the blocking issues, commit atomically, push, and restart from Gate A.
+
 ### Iteration discipline
 
 Each iteration through the loop:
@@ -271,7 +310,7 @@ Avoid the temptation to "improve" unrelated code during fix iterations. Scope cr
 
 ## Phase 4: Merge & Cleanup
 
-Once all three gates pass:
+Once all four gates pass:
 
 <merge_cleanup>
 
@@ -315,7 +354,7 @@ Summarize what happened:
 - **PR**: #{PR_NUMBER} — {PR_TITLE}
 - **Branch**: {BRANCH_NAME} → {BASE_BRANCH}
 - **Iterations**: {N} verification loops
-- **Gates passed**: CI ✅ | review-work ✅ | Cubic ✅
+- **Gates passed**: CI passed | review-work passed | Cubic passed | AI review passed
 - **Worktree**: cleaned up
 ```
 
@@ -353,6 +392,8 @@ git rebase "origin/$BASE_BRANCH"
 | Working in main worktree instead of isolated worktree | Pollutes user's working directory, may destroy uncommitted work | CRITICAL |
 | Pushing directly to dev/master | Bypasses review entirely | CRITICAL |
 | Skipping CI gate after code changes | review-work and Cubic may pass on stale code | CRITICAL |
+| Merging while Cubic is skipped, rate-limited, or ambiguous | Required external review did not happen | CRITICAL |
+| Counting an agent fallback as Momus | The named review gate did not actually run | CRITICAL |
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
+description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh PR review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
 ---
 
 # Work With PR — Full PR Lifecycle
@@ -11,7 +11,7 @@ Hard invariants:
 
 1. Always create a fresh git worktree for the task. Never implement in the user's main worktree.
 2. Target `dev` unless the user explicitly names another protected base and the repository policy allows it.
-3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass on the current head.
+3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh PR review all pass on the current head.
 4. If any required gate is unavailable, rate-limited, skipped, stale, or ambiguous, do not merge. Report the blocker and leave the worktree for resumption.
 5. After a successful merge commit, remove the task worktree and prune stale worktree metadata.
 
@@ -25,7 +25,7 @@ Phase 3: Verify Loop   → Unbounded iteration until ALL gates pass:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review
   ├─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
-  └─ Gate D: AI review  → GPT-5.2 xhigh or Momus PASS
+  └─ Gate D: AI review  → GPT-5.2 xhigh PR review PASS
 Phase 4: Merge         → Merge commit, worktree cleanup
 ```
 
@@ -181,7 +181,7 @@ while true:
   4. If review fails      → fix blocking issues, commit, push, continue
   5. Check Cubic          → Gate C
   6. If Cubic has issues   → fix issues, commit, push, continue
-  7. Run GPT-5.2 xhigh or Momus review → Gate D
+  7. Run GPT-5.2 xhigh PR review → Gate D
   8. If AI review fails    → fix blockers, commit, push, continue
   9. All four pass         → break
 ```
@@ -268,16 +268,15 @@ while true; do
 done
 ```
 
-### Gate D: GPT-5.2 xhigh or Momus Review
+### Gate D: GPT-5.2 xhigh PR Review
 
 Run one independent final reviewer after CI, review-work, and Cubic pass. The reviewer must inspect the current PR head, not a stale local diff.
 
-Acceptable pass signals:
+Acceptable pass signal:
 
 - A GPT-5.2 reviewer running with xhigh reasoning returns `VERDICT: PASS`.
-- A Momus reviewer returns `VERDICT: PASS`.
 
-If using OpenCode, verify the requested agent actually loaded. A warning such as `agent "momus" not found. Falling back to default agent` invalidates the gate; retry with the correct display name or use GPT-5.2 xhigh instead.
+Momus is not a substitute for this PR-diff gate. Momus reviews `.omo/plans/*.md` execution plans and uses `[OKAY]` or `[REJECT]`; count it only as an additional plan gate when a plan review is explicitly in scope.
 
 Review prompt template:
 
@@ -393,7 +392,7 @@ git rebase "origin/$BASE_BRANCH"
 | Pushing directly to dev/master | Bypasses review entirely | CRITICAL |
 | Skipping CI gate after code changes | review-work and Cubic may pass on stale code | CRITICAL |
 | Merging while Cubic is skipped, rate-limited, or ambiguous | Required external review did not happen | CRITICAL |
-| Counting an agent fallback as Momus | The named review gate did not actually run | CRITICAL |
+| Counting Momus as the PR-diff reviewer | Momus reviews plans, not PR diffs | CRITICAL |
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |

--- a/.opencode/skills/work-with-pr/SKILL.md
+++ b/.opencode/skills/work-with-pr/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: work-with-pr
-description: "Full PR lifecycle: git worktree → implement → atomic commits → PR creation → verification loop (CI + review-work + Cubic approval) → merge. Keeps iterating until ALL gates pass and PR is merged. Worktree auto-cleanup after merge. Use whenever implementation work needs to land as a PR. Triggers: 'create a PR', 'implement and PR', 'work on this and make a PR', 'implement issue', 'land this as a PR', 'work-with-pr', 'PR workflow', 'implement end to end', even when user just says 'implement X' if the context implies PR delivery."
+description: "Full PR lifecycle: always create a new git worktree, implement there, make atomic commits, open a PR to dev, and keep iterating until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass. Never merge early. After a merge commit, delete the worktree. Use whenever implementation work needs PR delivery: create a PR, implement and PR, work-with-pr, land this, or implement end to end."
 ---
 
 # Work With PR — Full PR Lifecycle
 
-You are executing a complete PR lifecycle: from isolated worktree setup through implementation, PR creation, and an unbounded verification loop until the PR is merged. The loop has three gates — CI, review-work, and Cubic — and you keep fixing and pushing until all three pass simultaneously.
+You are executing a complete PR lifecycle: isolated worktree setup, implementation, PR creation, verification, merge, and cleanup.
+
+Hard invariants:
+
+1. Always create a fresh git worktree for the task. Never implement in the user's main worktree.
+2. Target `dev` unless the user explicitly names another protected base and the repository policy allows it.
+3. Do not merge until CI, review-work, Cubic, and GPT-5.2 xhigh or Momus review all pass on the current head.
+4. If any required gate is unavailable, rate-limited, skipped, stale, or ambiguous, do not merge. Report the blocker and leave the worktree for resumption.
+5. After a successful merge commit, remove the task worktree and prune stale worktree metadata.
 
 <architecture>
 
@@ -16,8 +24,9 @@ Phase 2: PR Creation   → Push, create PR targeting dev
 Phase 3: Verify Loop   → Unbounded iteration until ALL gates pass:
   ├─ Gate A: CI         → gh pr checks (bun test, typecheck, build)
   ├─ Gate B: review-work → 5-agent parallel review
-  └─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
-Phase 4: Merge         → Squash merge, worktree cleanup
+  ├─ Gate C: Cubic      → cubic-dev-ai[bot] "No issues found"
+  └─ Gate D: AI review  → GPT-5.2 xhigh or Momus PASS
+Phase 4: Merge         → Merge commit, worktree cleanup
 ```
 
 </architecture>
@@ -26,7 +35,7 @@ Phase 4: Merge         → Squash merge, worktree cleanup
 
 ## Phase 0: Setup
 
-Create an isolated worktree so the user's main working directory stays clean. This matters because the user may have uncommitted work, and checking out a branch would destroy it.
+Create an isolated worktree so the user's main working directory stays clean. This is mandatory even for tiny changes because the user may have uncommitted work, other agents may be active, and PR cleanup depends on having a disposable task directory.
 
 <setup>
 
@@ -160,7 +169,7 @@ PR_NUMBER=$(gh pr view --json number -q .number)
 
 ## Phase 3: Verification Loop
 
-This is the core of the skill. Three gates must ALL pass for the PR to be ready. The loop has no iteration cap — keep going until done. Gate ordering is intentional: CI is cheapest/fastest, review-work is most thorough, Cubic is external and asynchronous.
+This is the core of the skill. Four gates must ALL pass for the PR to be ready. The loop has no iteration cap — keep going until done. Gate ordering is intentional: CI is cheapest/fastest, review-work is broadest, Cubic is external and asynchronous, and the final AI review catches reasoning gaps.
 
 <verify_loop>
 
@@ -172,7 +181,9 @@ while true:
   4. If review fails      → fix blocking issues, commit, push, continue
   5. Check Cubic          → Gate C
   6. If Cubic has issues   → fix issues, commit, push, continue
-  7. All three pass       → break
+  7. Run GPT-5.2 xhigh or Momus review → Gate D
+  8. If AI review fails    → fix blockers, commit, push, continue
+  9. All four pass         → break
 ```
 
 ### Gate A: CI Checks
@@ -223,6 +234,8 @@ Cubic (`cubic-dev-ai[bot]`) is an automated review bot that comments on PRs. It 
 
 **Issue signal**: The comment lists issues with file-level detail.
 
+**Not a pass**: neutral/skipped check runs, "started review" comments, billing or line-limit messages, stale comments from an older head SHA, or a generated PR summary without a review verdict.
+
 ```bash
 # Get the latest Cubic review
 CUBIC_REVIEW=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
@@ -255,6 +268,32 @@ while true; do
 done
 ```
 
+### Gate D: GPT-5.2 xhigh or Momus Review
+
+Run one independent final reviewer after CI, review-work, and Cubic pass. The reviewer must inspect the current PR head, not a stale local diff.
+
+Acceptable pass signals:
+
+- A GPT-5.2 reviewer running with xhigh reasoning returns `VERDICT: PASS`.
+- A Momus reviewer returns `VERDICT: PASS`.
+
+If using OpenCode, verify the requested agent actually loaded. A warning such as `agent "momus" not found. Falling back to default agent` invalidates the gate; retry with the correct display name or use GPT-5.2 xhigh instead.
+
+Review prompt template:
+
+```text
+Read-only review gate for PR #{PR_NUMBER}. Do not edit, commit, or push.
+Worktree: {WORKTREE_PATH}
+Base: origin/{BASE_BRANCH}
+Head: {BRANCH_NAME}
+Goal: {ORIGINAL_GOAL}
+
+Inspect the diff and directly relevant files/tests. Return first line exactly
+VERDICT: PASS or VERDICT: FAIL. On FAIL, include file/line blockers only.
+```
+
+On failure, fix only the blocking issues, commit atomically, push, and restart from Gate A.
+
 ### Iteration discipline
 
 Each iteration through the loop:
@@ -271,15 +310,15 @@ Avoid the temptation to "improve" unrelated code during fix iterations. Scope cr
 
 ## Phase 4: Merge & Cleanup
 
-Once all three gates pass:
+Once all four gates pass:
 
 <merge_cleanup>
 
 ### Merge the PR
 
 ```bash
-# Squash merge to keep history clean
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+# This repository requires merge commits. Never use --squash or --rebase here.
+gh pr merge "$PR_NUMBER" --merge --delete-branch
 ```
 
 ### Sync .omo state back to main repo
@@ -315,7 +354,7 @@ Summarize what happened:
 - **PR**: #{PR_NUMBER} — {PR_TITLE}
 - **Branch**: {BRANCH_NAME} → {BASE_BRANCH}
 - **Iterations**: {N} verification loops
-- **Gates passed**: CI ✅ | review-work ✅ | Cubic ✅
+- **Gates passed**: CI passed | review-work passed | Cubic passed | AI review passed
 - **Worktree**: cleaned up
 ```
 
@@ -353,6 +392,8 @@ git rebase "origin/$BASE_BRANCH"
 | Working in main worktree instead of isolated worktree | Pollutes user's working directory, may destroy uncommitted work | CRITICAL |
 | Pushing directly to dev/master | Bypasses review entirely | CRITICAL |
 | Skipping CI gate after code changes | review-work and Cubic may pass on stale code | CRITICAL |
+| Merging while Cubic is skipped, rate-limited, or ambiguous | Required external review did not happen | CRITICAL |
+| Counting an agent fallback as Momus | The named review gate did not actually run | CRITICAL |
 | Fixing unrelated code during verification loop | Scope creep causes new failures | HIGH |
 | Deleting worktree on failure | User loses ability to inspect/resume | HIGH |
 | Ignoring Cubic false positives without justification | Cubic issues should be evaluated, not blindly dismissed | MEDIUM |

--- a/src/features/background-agent/parent-wake-same-source-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-same-source-requeue.test.ts
@@ -135,6 +135,7 @@ describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () =>
     }
   })
 
+<<<<<<< HEAD
   test("#given a dispatched parent wake is still tracked after the hold expires #when the same wake arrives again #then it is dropped instead of starting a second stream", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier()

--- a/src/features/session-replay/README.md
+++ b/src/features/session-replay/README.md
@@ -1,0 +1,19 @@
+# Session Replay & Debugger Visual
+
+Step-by-step replay of agent sessions with decision tree visualization.
+
+## API
+
+### Snapshot Capture
+- `captureSnapshot(params)` — Capture a tool call, result, decision, error, or state change
+- `captureDecision(params)` — Capture a decision node with reasoning and outcome
+
+### Replay
+- `startReplay(sessionId)` — Load session snapshots into replay buffer
+- `nextStep(replayId)` / `prevStep(replayId)` — Navigate forward/backward
+- `goToStep(replayId, index)` — Jump to specific step
+- `listReplayableSessions()` — List sessions with snapshots
+
+### Diff & Analysis
+- `computeDiff(snapshots)` — Compute diffs between consecutive snapshots
+- `formatReplayStep(step)` — Human-readable step output

--- a/src/features/session-replay/index.ts
+++ b/src/features/session-replay/index.ts
@@ -1,0 +1,7 @@
+export type { SessionSnapshot, ReplaySession, ReplayStep, DecisionNode, ReplaySummary, SessionDiff } from "./types"
+export { captureSnapshot, captureDecision, resetSequence } from "./snapshot"
+export {
+  startReplay, nextStep, prevStep, goToStep, getReplayState,
+  listReplayableSessions, computeDiff, formatReplayStep,
+} from "./replay"
+export { getSnapshots, getDecisionTree, buildDecisionTree, listSessions, clearReplayData } from "./storage"

--- a/src/features/session-replay/replay.ts
+++ b/src/features/session-replay/replay.ts
@@ -1,0 +1,141 @@
+import { ReplaySession, ReplayStep, SessionSnapshot, SessionDiff } from "./types"
+import { getSnapshots, buildDecisionTree, getReplaySummary, listSessions } from "./storage"
+
+const activeReplays = new Map<string, ReplaySession>()
+
+export function startReplay(sessionId: string): ReplaySession {
+  const snapshots = getSnapshots(sessionId)
+  const replay: ReplaySession = {
+    id: sessionId,
+    snapshots,
+    currentIndex: -1,
+    totalSnapshots: snapshots.length,
+  }
+  activeReplays.set(sessionId, replay)
+  return replay
+}
+
+export function nextStep(replayId: string): ReplayStep | null {
+  const replay = activeReplays.get(replayId)
+  if (!replay) return null
+
+  const nextIndex = replay.currentIndex + 1
+  if (nextIndex >= replay.totalSnapshots) return null
+
+  replay.currentIndex = nextIndex
+  const snapshot = replay.snapshots[nextIndex]
+
+  const decisionTree = buildDecisionTree(replayId)
+
+  return {
+    snapshot,
+    index: nextIndex,
+    total: replay.totalSnapshots,
+    canGoBack: nextIndex > 0,
+    canGoForward: nextIndex < replay.totalSnapshots - 1,
+    decisionTree: decisionTree ?? undefined,
+  }
+}
+
+export function prevStep(replayId: string): ReplayStep | null {
+  const replay = activeReplays.get(replayId)
+  if (!replay) return null
+
+  const prevIndex = replay.currentIndex - 1
+  if (prevIndex < 0) return null
+
+  replay.currentIndex = prevIndex
+  const snapshot = replay.snapshots[prevIndex]
+  const decisionTree = buildDecisionTree(replayId)
+
+  return {
+    snapshot,
+    index: prevIndex,
+    total: replay.totalSnapshots,
+    canGoBack: prevIndex > 0,
+    canGoForward: prevIndex < replay.totalSnapshots - 1,
+    decisionTree: decisionTree ?? undefined,
+  }
+}
+
+export function goToStep(replayId: string, index: number): ReplayStep | null {
+  const replay = activeReplays.get(replayId)
+  if (!replay) return null
+  if (index < 0 || index >= replay.totalSnapshots) return null
+
+  replay.currentIndex = index
+  const snapshot = replay.snapshots[index]
+  const decisionTree = buildDecisionTree(replayId)
+
+  return {
+    snapshot,
+    index,
+    total: replay.totalSnapshots,
+    canGoBack: index > 0,
+    canGoForward: index < replay.totalSnapshots - 1,
+    decisionTree: decisionTree ?? undefined,
+  }
+}
+
+export function getReplayState(replayId: string): ReplaySession | null {
+  return activeReplays.get(replayId) ?? null
+}
+
+export function listReplayableSessions(): Array<{ sessionId: string; summary: ReturnType<typeof getReplaySummary> }> {
+  const sessions = listSessions()
+  return sessions.map(s => ({
+    sessionId: s.sessionId,
+    summary: getReplaySummary(s.sessionId),
+  }))
+}
+
+export function computeDiff(snapshots: SessionSnapshot[]): SessionDiff[] {
+  const diffs: SessionDiff[] = []
+
+  for (let i = 1; i < snapshots.length; i++) {
+    const current = snapshots[i]
+    const previous = snapshots[i - 1]
+
+    const changes: SessionDiff["changes"] = []
+
+    if (current.eventType === "state_change" && current.stateDiff) {
+      for (const [path, diff] of Object.entries(current.stateDiff)) {
+        changes.push({ path, before: diff.before, after: diff.after })
+      }
+    }
+
+    if (changes.length > 0) {
+      diffs.push({
+        snapshotId: current.id,
+        sequence: current.sequence,
+        eventType: current.eventType,
+        changes,
+      })
+    }
+  }
+
+  return diffs
+}
+
+export function formatReplayStep(step: ReplayStep): string {
+  const { snapshot, index, total } = step
+  const lines: string[] = []
+
+  lines.push(`[${index + 1}/${total}] ${snapshot.eventType.toUpperCase()}`)
+  lines.push(`Agent: ${snapshot.agentName}`)
+  lines.push(`Time: ${snapshot.timestamp.toISOString()}`)
+
+  if (snapshot.toolName) lines.push(`Tool: ${snapshot.toolName}`)
+  if (snapshot.decision) lines.push(`Decision: ${snapshot.decision}`)
+  if (snapshot.reasoning) lines.push(`Reasoning: ${snapshot.reasoning}`)
+  if (snapshot.durationMs != null) lines.push(`Duration: ${snapshot.durationMs}ms`)
+  if (snapshot.error) lines.push(`Error: ${snapshot.error}`)
+  if (snapshot.input) lines.push(`Input: ${JSON.stringify(snapshot.input).slice(0, 200)}`)
+  if (snapshot.output) lines.push(`Output: ${JSON.stringify(snapshot.output).slice(0, 200)}`)
+
+  if (step.canGoBack) lines.push("[b]ack |", "")
+  if (step.canGoForward) lines.push("[f]orward |", "")
+  lines.push("[q]uit")
+
+  return lines.join("\n")
+}

--- a/src/features/session-replay/session-replay.test.ts
+++ b/src/features/session-replay/session-replay.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from "bun:test"
+import { captureSnapshot, captureDecision, resetSequence } from "./snapshot"
+import {
+  startReplay, nextStep, prevStep, goToStep,
+  listReplayableSessions, computeDiff, formatReplayStep,
+} from "./replay"
+import { clearReplayData, getSnapshots } from "./storage"
+import { ReplayStep, SessionSnapshot } from "./types"
+
+describe("Session Replay", () => {
+  beforeEach(() => {
+    clearReplayData()
+    resetSequence(SESSION_ID)
+    resetSequence("session-2")
+  })
+
+  const SESSION_ID = "test-session-1"
+
+  describe("#given snapshots are captured", () => {
+    it("should capture a tool call snapshot", () => {
+      // when
+      const snap = captureSnapshot({
+        sessionId: SESSION_ID,
+        agentName: "sisyphus",
+        eventType: "tool_call",
+        toolName: "delegate",
+        input: { task: "test" },
+        durationMs: 1500,
+      })
+
+      // then
+      expect(snap.id).toContain("snap_")
+      expect(snap.sessionId).toBe(SESSION_ID)
+      expect(snap.agentName).toBe("sisyphus")
+      expect(snap.toolName).toBe("delegate")
+      expect(snap.sequence).toBe(1)
+    })
+
+    it("should increment sequence per session", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_result" })
+
+      // when
+      const snapshots = getSnapshots(SESSION_ID)
+
+      // then
+      expect(snapshots.length).toBe(2)
+      expect(snapshots[0].sequence).toBe(1)
+      expect(snapshots[1].sequence).toBe(2)
+    })
+
+    it("should capture a decision node", () => {
+      // given
+      const snap = captureSnapshot({
+        sessionId: SESSION_ID, agentName: "sisyphus", eventType: "tool_call",
+        toolName: "search", input: { query: "test" },
+      })
+
+      // when
+      const decision = captureDecision({
+        sessionId: SESSION_ID,
+        snapshotId: snap.id,
+        agentName: "sisyphus",
+        decision: "Use search tool for query resolution",
+        reasoning: "Query requires external data lookup",
+        outcome: "success",
+      })
+
+      // then
+      expect(decision.id).toContain("dec_")
+      expect(decision.snapshotId).toBe(snap.id)
+      expect(decision.decision).toContain("search")
+      expect(decision.outcome).toBe("success")
+    })
+
+    it("should capture errors", () => {
+      // when
+      const snap = captureSnapshot({
+        sessionId: SESSION_ID,
+        agentName: "oracle",
+        eventType: "error",
+        toolName: "search",
+        error: "Network timeout",
+      })
+
+      // then
+      expect(snap.error).toBe("Network timeout")
+      expect(snap.eventType).toBe("error")
+    })
+
+    it("should capture state diffs", () => {
+      // when
+      const snap = captureSnapshot({
+        sessionId: SESSION_ID,
+        agentName: "sisyphus",
+        eventType: "state_change",
+        stateDiff: {
+          "config.model": { before: "claude-sonnet-4", after: "gpt-4o" },
+          "config.temperature": { before: 0.7, after: 0.3 },
+        },
+      })
+
+      // then
+      expect(snap.stateDiff).toBeDefined()
+      expect(Object.keys(snap.stateDiff!)).toContain("config.model")
+    })
+  })
+
+  describe("#given snapshots exist", () => {
+    it("should start replay for a session", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call", toolName: "t1" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_result", toolName: "t1" })
+
+      // when
+      const replay = startReplay(SESSION_ID)
+
+      // then
+      expect(replay.totalSnapshots).toBe(2)
+      expect(replay.currentIndex).toBe(-1)
+    })
+
+    it("should step forward through snapshots", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call", toolName: "t1" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_result", toolName: "t1" })
+      startReplay(SESSION_ID)
+
+      // when
+      const step1 = nextStep(SESSION_ID)
+      const step2 = nextStep(SESSION_ID)
+      const step3 = nextStep(SESSION_ID)
+
+      // then
+      expect(step1).not.toBeNull()
+      expect(step1!.snapshot.toolName).toBe("t1")
+      expect(step2).not.toBeNull()
+      expect(step2!.snapshot.toolName).toBe("t1")
+      expect(step3).toBeNull()
+    })
+
+    it("should step backward through snapshots", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_result" })
+      startReplay(SESSION_ID)
+      nextStep(SESSION_ID)
+      nextStep(SESSION_ID)
+
+      // when
+      const back = prevStep(SESSION_ID)
+      const noBack = prevStep(SESSION_ID)
+
+      // then
+      expect(back).not.toBeNull()
+      expect(back!.snapshot.eventType).toBe("tool_call")
+      expect(noBack).toBeNull()
+    })
+
+    it("should jump to specific step", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call", toolName: "t1" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_result", toolName: "t1" })
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "b", eventType: "tool_call", toolName: "t2" })
+      startReplay(SESSION_ID)
+
+      // when
+      const step = goToStep(SESSION_ID, 2)
+
+      // then
+      expect(step).not.toBeNull()
+      expect(step!.snapshot.toolName).toBe("t2")
+      expect(step!.index).toBe(2)
+    })
+
+    it("should list replayable sessions", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "tool_call" })
+      captureSnapshot({ sessionId: "session-2", agentName: "b", eventType: "tool_call" })
+
+      // when
+      const sessions = listReplayableSessions()
+
+      // then
+      expect(sessions.length).toBe(2)
+    })
+
+    it("should format replay step", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "sisyphus", eventType: "tool_call", toolName: "delegate" })
+      startReplay(SESSION_ID)
+      const step = nextStep(SESSION_ID)
+
+      // when
+      const formatted = formatReplayStep(step!)
+
+      // then
+      expect(formatted).toContain("TOOL_CALL")
+      expect(formatted).toContain("sisyphus")
+    })
+
+    it("should compute diffs between snapshots", () => {
+      // given
+      captureSnapshot({ sessionId: SESSION_ID, agentName: "a", eventType: "state_change", stateDiff: { "key": { before: "old", after: "new" } } })
+      const snapshots = getSnapshots(SESSION_ID)
+
+      // when
+      const diffs = computeDiff(snapshots)
+
+      // then
+      expect(diffs.length).toBe(0) // only 1 snapshot, no pair
+    })
+  })
+})

--- a/src/features/session-replay/snapshot.ts
+++ b/src/features/session-replay/snapshot.ts
@@ -1,0 +1,74 @@
+import { SessionSnapshot, DecisionNode } from "./types"
+import { insertSnapshot, insertDecisionNode } from "./storage"
+
+let sequenceCounters = new Map<string, number>()
+
+function getNextSequence(sessionId: string): number {
+  const next = (sequenceCounters.get(sessionId) ?? 0) + 1
+  sequenceCounters.set(sessionId, next)
+  return next
+}
+
+export function resetSequence(sessionId: string): void {
+  sequenceCounters.set(sessionId, 0)
+}
+
+export function captureSnapshot(params: {
+  sessionId: string
+  agentName: string
+  eventType: SessionSnapshot["eventType"]
+  toolName?: string
+  input?: unknown
+  output?: unknown
+  decision?: string
+  reasoning?: string
+  durationMs?: number
+  stateDiff?: Record<string, { before: unknown; after: unknown }>
+  error?: string
+}): SessionSnapshot {
+  const snapshot: SessionSnapshot = {
+    id: `snap_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: params.sessionId,
+    sequence: getNextSequence(params.sessionId),
+    agentName: params.agentName,
+    eventType: params.eventType,
+    toolName: params.toolName,
+    input: params.input,
+    output: params.output,
+    decision: params.decision,
+    reasoning: params.reasoning,
+    durationMs: params.durationMs,
+    stateDiff: params.stateDiff,
+    error: params.error,
+    timestamp: new Date(),
+  }
+
+  insertSnapshot(snapshot)
+  return snapshot
+}
+
+export function captureDecision(params: {
+  sessionId: string
+  snapshotId: string
+  agentName: string
+  decision: string
+  reasoning?: string
+  parentId?: string
+  durationMs?: number
+  outcome?: DecisionNode["outcome"]
+}): DecisionNode {
+  const node: DecisionNode = {
+    id: `dec_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    snapshotId: params.snapshotId,
+    agentName: params.agentName,
+    decision: params.decision,
+    reasoning: params.reasoning,
+    children: [],
+    parentId: params.parentId,
+    durationMs: params.durationMs,
+    outcome: params.outcome ?? "pending",
+  }
+
+  insertDecisionNode(node)
+  return node
+}

--- a/src/features/session-replay/storage.ts
+++ b/src/features/session-replay/storage.ts
@@ -1,0 +1,208 @@
+import { Database } from "bun:sqlite"
+import { join, dirname } from "path"
+import { tmpdir } from "os"
+import { mkdirSync } from "fs"
+import { SessionSnapshot, DecisionNode } from "./types"
+
+const DB_PATH = process.env.REPLAY_DB_PATH ?? join(tmpdir(), "oh-my-opencode", "session-replay.db")
+
+let db: Database | null = null
+
+export function getReplayDb(): Database {
+  if (db) return db
+
+  const dbDir = dirname(DB_PATH)
+  try {
+    mkdirSync(dbDir, { recursive: true })
+  } catch {
+    // Directory may already exist
+  }
+
+  db = new Database(DB_PATH)
+  db.run("PRAGMA journal_mode = WAL")
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS session_snapshots (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL,
+      agent_name TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      tool_name TEXT,
+      input_json TEXT,
+      output_json TEXT,
+      decision TEXT,
+      reasoning TEXT,
+      duration_ms INTEGER,
+      state_diff_json TEXT,
+      error TEXT,
+      timestamp INTEGER NOT NULL
+    )
+  `)
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS decision_nodes (
+      id TEXT PRIMARY KEY,
+      snapshot_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      reasoning TEXT,
+      parent_id TEXT,
+      duration_ms INTEGER,
+      outcome TEXT NOT NULL DEFAULT 'pending'
+    )
+  `)
+
+  db.run(`CREATE INDEX IF NOT EXISTS idx_snapshots_session ON session_snapshots(session_id)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_snapshots_seq ON session_snapshots(session_id, sequence)`)
+  db.run(`CREATE INDEX IF NOT EXISTS idx_decisions_snapshot ON decision_nodes(snapshot_id)`)
+
+  return db
+}
+
+export function closeReplayDb(): void {
+  if (db) {
+    db.close()
+    db = null
+  }
+}
+
+export function insertSnapshot(snapshot: SessionSnapshot): void {
+  const d = getReplayDb()
+  d.run(
+    `INSERT INTO session_snapshots (id, session_id, sequence, agent_name, event_type, tool_name, input_json, output_json, decision, reasoning, duration_ms, state_diff_json, error, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      snapshot.id,
+      snapshot.sessionId,
+      snapshot.sequence,
+      snapshot.agentName,
+      snapshot.eventType,
+      snapshot.toolName ?? null,
+      snapshot.input ? JSON.stringify(snapshot.input) : null,
+      snapshot.output ? JSON.stringify(snapshot.output) : null,
+      snapshot.decision ?? null,
+      snapshot.reasoning ?? null,
+      snapshot.durationMs ?? null,
+      snapshot.stateDiff ? JSON.stringify(snapshot.stateDiff) : null,
+      snapshot.error ?? null,
+      snapshot.timestamp.getTime(),
+    ],
+  )
+}
+
+export function insertDecisionNode(node: DecisionNode): void {
+  const d = getReplayDb()
+  d.run(
+    `INSERT INTO decision_nodes (id, snapshot_id, agent_name, decision, reasoning, parent_id, duration_ms, outcome)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [node.id, node.snapshotId, node.agentName, node.decision, node.reasoning ?? null, node.parentId ?? null, node.durationMs ?? null, node.outcome ?? 'pending'],
+  )
+}
+
+export function getSnapshots(sessionId: string): SessionSnapshot[] {
+  const d = getReplayDb()
+  const rows = d.query(
+    `SELECT * FROM session_snapshots WHERE session_id = ? ORDER BY sequence ASC`,
+  ).all(sessionId) as Array<{
+    id: string; session_id: string; sequence: number; agent_name: string; event_type: string
+    tool_name: string | null; input_json: string | null; output_json: string | null
+    decision: string | null; reasoning: string | null; duration_ms: number | null
+    state_diff_json: string | null; error: string | null; timestamp: number
+  }>
+
+  return rows.map(r => ({
+    id: r.id,
+    sessionId: r.session_id,
+    sequence: r.sequence,
+    agentName: r.agent_name,
+    eventType: r.event_type as SessionSnapshot["eventType"],
+    toolName: r.tool_name ?? undefined,
+    input: r.input_json ? JSON.parse(r.input_json) : undefined,
+    output: r.output_json ? JSON.parse(r.output_json) : undefined,
+    decision: r.decision ?? undefined,
+    reasoning: r.reasoning ?? undefined,
+    durationMs: r.duration_ms ?? undefined,
+    stateDiff: r.state_diff_json ? JSON.parse(r.state_diff_json) : undefined,
+    error: r.error ?? undefined,
+    timestamp: new Date(r.timestamp),
+  }))
+}
+
+export function getDecisionTree(sessionId: string): DecisionNode[] {
+  const d = getReplayDb()
+  const rows = d.query(
+    `SELECT dn.* FROM decision_nodes dn
+     INNER JOIN session_snapshots ss ON ss.id = dn.snapshot_id
+     WHERE ss.session_id = ?
+     ORDER BY ss.sequence ASC`,
+  ).all(sessionId) as Array<{
+    id: string; snapshot_id: string; agent_name: string; decision: string
+    reasoning: string | null; parent_id: string | null; duration_ms: number | null; outcome: string
+  }>
+
+  return rows.map(r => ({
+    id: r.id,
+    snapshotId: r.snapshot_id,
+    agentName: r.agent_name,
+    decision: r.decision,
+    reasoning: r.reasoning ?? undefined,
+    parentId: r.parent_id ?? undefined,
+    durationMs: r.duration_ms ?? undefined,
+    outcome: r.outcome as DecisionNode["outcome"],
+    children: [],
+  }))
+}
+
+export function buildDecisionTree(sessionId: string): DecisionNode | null {
+  const nodes = getDecisionTree(sessionId)
+  if (nodes.length === 0) return null
+
+  // Find root (no parent)
+  const root = nodes.find(n => !n.parentId)
+  if (!root) return null
+
+  // Build tree
+  const nodeMap = new Map(nodes.map(n => [n.id, n]))
+  for (const node of nodes) {
+    if (node.parentId) {
+      const parent = nodeMap.get(node.parentId)
+      if (parent) parent.children.push(node)
+    }
+  }
+
+  return root
+}
+
+export function listSessions(): Array<{ sessionId: string; snapshotCount: number }> {
+  const d = getReplayDb()
+  const rows = d.query(
+    `SELECT session_id, COUNT(*) as cnt FROM session_snapshots GROUP BY session_id ORDER BY MAX(timestamp) DESC LIMIT 50`,
+  ).all() as Array<{ session_id: string; cnt: number }>
+  return rows.map(r => ({ sessionId: r.session_id, snapshotCount: r.cnt }))
+}
+
+export function getReplaySummary(sessionId: string): {
+  totalSnapshots: number; totalToolCalls: number; totalErrors: number; agents: string[]; tools: string[]
+} {
+  const d = getReplayDb()
+  const count = d.query("SELECT COUNT(*) as c FROM session_snapshots WHERE session_id = ?").get(sessionId) as { c: number }
+  const toolCalls = d.query("SELECT COUNT(*) as c FROM session_snapshots WHERE session_id = ? AND event_type = 'tool_call'").get(sessionId) as { c: number }
+  const errors = d.query("SELECT COUNT(*) as c FROM session_snapshots WHERE session_id = ? AND event_type = 'error'").get(sessionId) as { c: number }
+  const agents = d.query("SELECT DISTINCT agent_name FROM session_snapshots WHERE session_id = ?").all(sessionId) as Array<{ agent_name: string }>
+  const tools = d.query("SELECT DISTINCT tool_name FROM session_snapshots WHERE session_id = ? AND tool_name IS NOT NULL").all(sessionId) as Array<{ tool_name: string }>
+
+  return {
+    totalSnapshots: count?.c ?? 0,
+    totalToolCalls: toolCalls?.c ?? 0,
+    totalErrors: errors?.c ?? 0,
+    agents: agents.map(a => a.agent_name),
+    tools: tools.map(t => t.tool_name).filter(Boolean),
+  }
+}
+
+export function clearReplayData(): void {
+  const d = getReplayDb()
+  d.run("DELETE FROM session_snapshots")
+  d.run("DELETE FROM decision_nodes")
+}

--- a/src/features/session-replay/types.ts
+++ b/src/features/session-replay/types.ts
@@ -1,0 +1,67 @@
+export interface SessionSnapshot {
+  id: string
+  sessionId: string
+  sequence: number
+  agentName: string
+  eventType: "tool_call" | "tool_result" | "decision" | "state_change" | "error" | "message"
+  toolName?: string
+  input?: unknown
+  output?: unknown
+  decision?: string
+  reasoning?: string
+  durationMs?: number
+  stateDiff?: Record<string, { before: unknown; after: unknown }>
+  error?: string
+  timestamp: Date
+}
+
+export interface ReplaySession {
+  id: string
+  snapshots: SessionSnapshot[]
+  currentIndex: number
+  totalSnapshots: number
+}
+
+export interface DecisionNode {
+  id: string
+  snapshotId: string
+  agentName: string
+  decision: string
+  reasoning?: string
+  children: DecisionNode[]
+  parentId?: string
+  durationMs?: number
+  outcome?: "success" | "failure" | "pending"
+}
+
+export interface ReplayStep {
+  snapshot: SessionSnapshot
+  index: number
+  total: number
+  canGoBack: boolean
+  canGoForward: boolean
+  decisionTree?: DecisionNode
+}
+
+export interface ReplaySummary {
+  sessionId: string
+  totalSnapshots: number
+  totalToolCalls: number
+  totalDecisions: number
+  totalErrors: number
+  totalDurationMs: number
+  agents: string[]
+  tools: string[]
+  errorRate: number
+}
+
+export interface SessionDiff {
+  snapshotId: string
+  sequence: number
+  eventType: string
+  changes: Array<{
+    path: string
+    before: unknown
+    after: unknown
+  }>
+}


### PR DESCRIPTION
## Session Replay & Debugger Visual

Step-by-step replay of agent sessions with decision tree visualization.

### Features
- Snapshot capture for tool calls, results, decisions, errors, and state changes
- Decision tree capture with reasoning and outcomes
- Forward/backward replay through session snapshots
- Jump to any step by index
- Diff computation between consecutive snapshots
- Human-readable step formatting
- SQLite storage for all snapshots and decision nodes

### Files
- `snapshot.ts` — Capture system
- `replay.ts` — Replay engine  
- `storage.ts` — SQLite storage
- `types.ts` — Type definitions

### Tests
12 tests passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds step-by-step session replay with a decision‑tree debugger, backed by SQLite, and suppresses duplicate parent wakes during the gate hold window. Also updates PR workflow docs to require CI, `review-work`, Cubic, and GPT‑5.2 xhigh review before a merge commit, and adds an OpenCode session debugging skill.

- **New Features**
  - Snapshot capture for tool calls/results, decisions, errors, and state changes (sequenced with timestamps).
  - Decision tree built from captured decisions to visualize reasoning paths.
  - Replay API: start, next/prev, go to index, get state, list sessions with summaries.
  - Diff and formatting helpers (`computeDiff`, `formatReplayStep`); SQLite persistence via `bun:sqlite` with `REPLAY_DB_PATH`.

- **Bug Fixes**
  - Background agent: drop redundant parent wakes while the gate hold is active to prevent duplicate streams.

<sup>Written for commit dfa84955da474a9a1da3883f16e67b7b14ec299a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

