### PR TITLE
fix(background-agent): suppress redundant parent wakes during gate hold

### DIFF
--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -239,7 +239,7 @@ export class ParentWakeNotifier {
       }
       if (promptResult.status === "reserved" && promptResult.reservedBy === "background-agent-parent-wake") {
         const dispatchedWake = this.dispatchedParentWakes.get(sessionID)
-        if (dispatchedWake && this.isSameParentWake(latestWake, dispatchedWake)) {
+        if (dispatchedWake && this.isRedundantParentWake(latestWake, dispatchedWake)) {
           // #4256/#4019: duplicated completion edges can enqueue the same wake
           // during the gate hold. Replaying it later starts a second assistant stream.
           log("[background-agent] Suppressed duplicate parent wake during promptAsync gate hold:", { sessionID })
@@ -406,10 +406,23 @@ export class ParentWakeNotifier {
     this.dispatchedParentWakeTimers.set(sessionID, timer)
   }
 
-  private isSameParentWake(left: PendingParentWake, right: PendingParentWake): boolean {
-    return left.shouldReply === right.shouldReply
-      && JSON.stringify(left.notifications) === JSON.stringify(right.notifications)
-      && JSON.stringify(left.promptContext) === JSON.stringify(right.promptContext)
+  private isRedundantParentWake(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
+    return this.parentWakePromptContextMatches(latestWake, dispatchedWake)
+      && this.parentWakeReplyModeIsCovered(latestWake, dispatchedWake)
+      && this.parentWakeNotificationsAreCovered(latestWake, dispatchedWake)
+  }
+
+  private parentWakePromptContextMatches(left: PendingParentWake, right: PendingParentWake): boolean {
+    return JSON.stringify(left.promptContext) === JSON.stringify(right.promptContext)
+  }
+
+  private parentWakeReplyModeIsCovered(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
+    return !latestWake.shouldReply || dispatchedWake.shouldReply
+  }
+
+  private parentWakeNotificationsAreCovered(latestWake: PendingParentWake, dispatchedWake: PendingParentWake): boolean {
+    const dispatchedNotifications = new Set(dispatchedWake.notifications)
+    return latestWake.notifications.every((notification) => dispatchedNotifications.has(notification))
   }
 
   private async loadParentWakeSessionMessages(sessionID: string): Promise<ParentWakeSessionMessage[]> {

--- a/src/features/background-agent/parent-wake-same-source-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-same-source-requeue.test.ts
@@ -109,6 +109,32 @@ describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () =>
     }
   })
 
+  test("#given redundant duplicate notifications collect during post-dispatch hold #when the wake flushes again #then no second parent prompt is sent", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-hold-redundant-duplicate-burst"
+    notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+
+      // when
+      notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+      notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+      await notifier.flushPendingParentWake(sessionID)
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given a parent wake is in post-dispatch hold #when a new pending wake fires within the hold window #then the new wake is re-enqueued and dispatched after the hold expires", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier()
@@ -132,6 +158,70 @@ describe("ParentWakeNotifier — same-source reservation requeue (BUG-E)", () =>
       await notifier.flushPendingParentWake(sessionID)
 
       expect(promptAsyncCalls).toHaveLength(2)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a silent parent wake is in post-dispatch hold #when the duplicate requests a reply #then the reply upgrade is preserved", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-hold-reply-upgrade"
+    notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, false)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+
+      // when
+      notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a parent wake is in post-dispatch hold #when the duplicate has a different prompt context #then the context change is preserved", async () => {
+    // given
+    const { notifier, promptAsyncCalls } = createNotifier()
+    const sessionID = "parent-hold-context-change"
+    notifier.queuePendingParentWake(sessionID, "wake A", { agent: "sisyphus" }, true)
+
+    try {
+      await notifier.flushPendingParentWake(sessionID)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.agent).toBe("sisyphus")
+
+      // when
+      notifier.queuePendingParentWake(sessionID, "wake A", { agent: "atlas" }, true)
+      await notifier.flushPendingParentWake(sessionID)
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.promptContext.agent).toBe("atlas")
+      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
+
+      releaseParentWakeHold(sessionID)
+      await notifier.flushPendingParentWake(sessionID)
+
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.agent).toBe("atlas")
       expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
     } finally {
       notifier.shutdown()


### PR DESCRIPTION
## Summary
- Suppress redundant background-agent parent wakes while the promptAsync gate is still holding the already-dispatched wake.
- Preserve meaningful follow-up wakes: new notification content, reply-mode upgrades, and prompt-context changes still requeue and dispatch after the hold.

## Root Cause
The parent wake notifier tracked the last dispatched wake, but the same-source reserved-path check only suppressed byte-for-byte identical pending wake arrays. Duplicate background completion edges could collect repeated copies of the already-dispatched notification during the post-dispatch hold, turning `["wake A"]` into `["wake A", "wake A"]`. Strict equality treated that as new work, requeued it, and launched a second internal parent prompt after the hold released.

## Changes
- Replace strict same-wake comparison with redundant-wake coverage semantics.
- Add regression coverage for redundant duplicate bursts.
- Add boundary coverage proving reply upgrades and prompt-context changes are preserved.

## Testing
- `bun test src/features/background-agent/parent-wake-same-source-requeue.test.ts` - 6 pass, 0 fail, 41 expectations.
- `bun test src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/task-completion-cleanup.test.ts src/shared/prompt-async-route-audit.test.ts` - 52 pass, 0 fail, 176 expectations.
- `bun run typecheck` - pass.
- `bun run build` - pass.
- `bun test > /tmp/omo-bugfix-bun-test-after-merge.log 2>&1` - exit 0, 3,401 pass lines, no fail/error lines.

## Evidence
- Investigated live session `ses_1ace82b4dffeDeez3U2yA4eONr` and child sessions from the transcript/logs.
- Updated sibling OpenCode checkout with `git fetch --all --prune && git pull --ff-only`; current OpenCode `promptAsync` still returns before the prompt run durably settles.
- Git history/blame identifies the relevant sequence: same-source requeue in `11d2cfb8a` and strict duplicate suppression in `560569e36`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate parent prompts by suppressing redundant background-agent wakes while `promptAsync` holds a reservation. Keeps meaningful follow-ups (new notifications, reply upgrades, and prompt-context changes) so they dispatch after the hold.

- **Bug Fixes**
  - Switch from strict equality to redundancy coverage: same prompt context, reply mode coverage, and notification subset.
  - Suppress duplicate bursts collected during the hold to avoid a second parent prompt.
  - Preserve meaningful changes and add regression tests for duplicates and upgrades.

<sup>Written for commit 102384197be3c881f9c673fd8c511491f33bde90. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

