### PR TITLE
fix: add type guards in fallback-state to prevent .toLowerCase() crash on object-shaped model inputs

### DIFF
--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -50,6 +50,12 @@ function parseCanonicalModel(model: string): { providerID: string; modelID: stri
 }
 
 function isEquivalentModel(candidate: string, current: string): boolean {
+  // Guard against non-string values which can occur when FallbackModelObject
+  // instances are incorrectly passed through the fallback chain.
+  if (typeof candidate !== "string" || typeof current !== "string") {
+    return false
+  }
+
   const parsedCandidate = parseCanonicalModel(candidate)
   const parsedCurrent = parseCanonicalModel(current)
 


### PR DESCRIPTION
Closing - superseded by broader fix in #4343