### PR TITLE
fix: add node_modules walk-up fallback for version resolution in sandboxed hash dirs

### DIFF
--- a/src/hooks/auto-update-checker/checker/cached-version.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.ts
@@ -3,7 +3,7 @@ import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import { log } from "../../../shared/logger"
 import type { PackageJson } from "../types"
-import { INSTALLED_PACKAGE_JSON_CANDIDATES } from "../constants"
+import { INSTALLED_PACKAGE_JSON_CANDIDATES, ACCEPTED_PACKAGE_NAMES } from "../constants"
 import { findPackageJsonUp } from "./package-json-locator"
 
 interface CachedVersionOptions {
@@ -17,6 +17,41 @@ function readPackageVersion(packageJsonPath: string): string | null {
   const content = fs.readFileSync(packageJsonPath, "utf-8")
   const pkg = JSON.parse(content) as PackageJson
   return pkg.version ?? null
+}
+
+/**
+ * Walk up from startPath looking for `node_modules/<accepted-name>/package.json`.
+ * Handles the case where the compiled bundle lives in a sandboxed hash directory
+ * (e.g., `<CACHE>/packages/<hash>/dist/index.js`) without a `package.json` in the
+ * ancestor chain, but the actual package is at
+ * `<CACHE>/packages/<hash>/node_modules/oh-my-opencode/package.json`.
+ */
+function findNodeModulesPackageJson(startPath: string): string | null {
+  const acceptedNameSet = new Set<string>(ACCEPTED_PACKAGE_NAMES)
+  try {
+    const stat = fs.statSync(startPath)
+    let dir = stat.isDirectory() ? startPath : path.dirname(startPath)
+
+    for (let i = 0; i < 10; i++) {
+      const nmDir = path.join(dir, "node_modules")
+      if (fs.existsSync(nmDir) && fs.statSync(nmDir).isDirectory()) {
+        for (const pkgName of fs.readdirSync(nmDir)) {
+          if (acceptedNameSet.has(pkgName)) {
+            const pkgPath = path.join(nmDir, pkgName, "package.json")
+            if (fs.existsSync(pkgPath)) {
+              return pkgPath
+            }
+          }
+        }
+      }
+      const parent = path.dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+  } catch {
+    // ignore
+  }
+  return null
 }
 
 export function getCachedVersion(options: CachedVersionOptions = {}): string | null {
@@ -39,6 +74,22 @@ export function getCachedVersion(options: CachedVersionOptions = {}): string | n
     }
   } catch (err) {
     log("[auto-update-checker] Failed to resolve version from current directory:", err)
+  }
+
+  // If module-relative walk-up fails, check node_modules/<pkg>/package.json in
+  // ancestor directories. The compiled bundle may be in a sandboxed hash directory
+  // (<CACHE>/packages/<hash>/dist/index.js) while the package lives at
+  // <CACHE>/packages/<hash>/node_modules/oh-my-opencode/package.json.
+  try {
+    const currentDir = options.currentDir === undefined ? path.dirname(fileURLToPath(import.meta.url)) : options.currentDir
+    if (currentDir) {
+      const pkgPath = findNodeModulesPackageJson(currentDir)
+      if (pkgPath) {
+        return readPackageVersion(pkgPath)
+      }
+    }
+  } catch (err) {
+    log("[auto-update-checker] Failed to resolve version from node_modules walk-up:", err)
   }
 
   for (const candidate of packageJsonCandidates) {


### PR DESCRIPTION
## Description

Adds `findNodeModulesPackageJson()` as a new fallback path in `getCachedVersion()` that walks up from the bundle location searching for `node_modules/<accepted-name>/package.json` in each ancestor directory.

## Problem

When OpenCode loads the compiled plugin from a sandboxed hash directory (e.g., `<CACHE>/packages/<hash>/dist/index.js`), the existing module-relative walk-up (`findPackageJsonUp`) fails because no ancestor directory has a `package.json` with matching name. The code then falls through to stale cache candidates, causing the banner to show an older version.

## Fix

Added a 4-module fallback chain:
1. Module-relative walk-up (existing, unchanged)
2. **NEW: node_modules ancestor search** — walks up from bundle location looking for `node_modules/oh-my-opencode/package.json` in each ancestor
3. Cached candidates (existing, unchanged)
4. ExecPath walk-up (existing, unchanged)

Fixes #4211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version resolution when the plugin runs from sandboxed hash directories. Adds a node_modules walk-up fallback so the version banner shows the correct version.

- **Bug Fixes**
  - Version resolution: added `findNodeModulesPackageJson` in `getCachedVersion`, searching ancestor `node_modules/<accepted-name>/package.json` (via `ACCEPTED_PACKAGE_NAMES`) after module-relative walk-up and before cached candidates/execPath. Works for bundles under `<CACHE>/packages/<hash>/dist`. Fixes #4211.

<sup>Written for commit c7f0a9387850e862fd8c814f3cb56b941081538f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

