### PR TITLE
fix: add Limit Exhausted error pattern recognition for ZAI provider in runtime-fallback

### DIFF
--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -30,6 +30,7 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /exceeded.*quota/i,
   /usage\s*quota/i,
   /exhausted\s+your\s+capacity/i,
+  /limit\s+exhausted/i,
   /all\s+credentials\s+for\s+model/i,
   /cool(?:ing)?\s+down/i,
   /model.{0,20}?not.{0,10}?supported/i,

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -165,6 +165,7 @@ export function classifyErrorType(error: unknown): string | undefined {
     /insufficient.?(?:quota|balance|funds?)/i.test(message) ||
     /billing.?(?:hard.?)?limit/i.test(message) ||
     /exhausted\s+your\s+capacity/i.test(message) ||
+    /limit\s+exhausted/i.test(message) ||
     /resource.?exhausted/i.test(message) ||
     /out\s+of\s+credits?/i.test(message) ||
     /payment.?required/i.test(message) ||


### PR DESCRIPTION
## Description

Adds `/limit\\s+exhausted/i` pattern recognition in runtime-fallback for ZAI provider errors.

## Problem

The ZAI provider returns "Limit Exhausted" errors when the user has hit their usage quota, but the runtime-fallback hook did not recognize this pattern:
- `RETRYABLE_ERROR_PATTERNS` did not match "Limit Exhausted" → retry was not triggered
- `classifyErrorType()` quota_exceeded checks did not match → wrong error type was returned

## Fix

- Added `/limit\\s+exhausted/i` to `RETRYABLE_ERROR_PATTERNS` in `constants.ts`
- Added `/limit\\s+exhausted/i.test(message) ||` to the `quota_exceeded` classification in `error-classifier.ts`

Fixes #4207