### PR TITLE
fix(keyword-detector): add idempotency guard against duplicate mode injection

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -225,6 +225,16 @@ export function createKeywordDetectorHook(
       const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
+      // Idempotency guard: if ANY mode message is already in the text, skip injection
+      // Prevents duplicate [search-mode]/[analyze-mode]/[team-mode] on undo+resend
+      if (detectedKeywords.some((k) => originalText.includes(k.message))) {
+        log(`[keyword-detector] Skipping injection - mode already present`, {
+          sessionID: input.sessionID,
+          types: detectedKeywords.map((k) => k.type),
+        })
+        return
+      }
+
       output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {


### PR DESCRIPTION
## Issue #4251

### Root Cause
The keyword-detector hook (`hook.ts`) has no deduplication check for injected mode messages (`[search-mode]`, `[analyze-mode]`, `[team-mode]`, `[ultrawork]`). When a user undoes and resends a message that triggered a keyword match, the `chat.message` handler fires again, detects the same keywords in the text, and prepends another copy of the mode message.

### Fix
Added an idempotency check (lines 228-237): before injecting, check if any detected keyword's mode message string is already present in the user's text part. If so, skip injection.

This is a zero-risk guard — the text content of the mode messages (`[search-mode]\nMAXIMIZE SEARCH EFFORT...`) is unique enough that a collision with legitimate user text is virtually impossible.

### Verification
- `bun test src/hooks/keyword-detector` → 92/92 pass
- `lsp_diagnostics` → clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate mode banners (`[search-mode]`, `[analyze-mode]`, `[team-mode]`, `[ultrawork]`) by adding an idempotency check in `src/hooks/keyword-detector/hook.ts` that skips injection when a mode message is already in the user text. Fixes #4251; undo+resend no longer stacks mode prefixes.

<sup>Written for commit 65b3f10c21de2a39530677844118084e868f6758. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4332?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

