### PR TITLE
fix(babysitter): remove hardcoded message_limit=50 from suggested background_output command

### DIFF
--- a/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
+++ b/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
@@ -127,7 +127,7 @@ Thinking summary (first ${THINKING_SUMMARY_MAX_CHARS} chars):
 ${summaryText}
 
 Suggested actions:
-- background_output task_id="${task.id}" full_session=true include_thinking=true include_tool_results=true message_limit=50
+- background_output task_id="${task.id}" full_session=true include_thinking=true include_tool_results=true
 - background_cancel taskId="${task.id}"
 
 This is a reminder only. No automatic action was taken.`


### PR DESCRIPTION
## Issue #4210

### Root Cause
The unstable-agent-babysitter's `task-message-analyzer.ts` hardcodes `message_limit=50` in its suggested `background_output` command. When `message_limit` is provided, `formatFullSession` in `full-session-format.ts` caps output at `Math.min(messageLimit, MAX_MESSAGE_LIMIT)` = 50. Background tasks producing more than 50 messages return truncated results, forcing agents to re-explore because they can't paginate the rest (no offset parameter exists).

### Fix
Removed `message_limit=50` from the suggested command. When no `message_limit` is provided, `formatFullSession` returns ALL messages (the code paths sets `limit = undefined` and skips the slice), giving agents complete results on the first call.

### Verification
- `bun test src/hooks/unstable-agent-babysitter` → 17/17 pass
- `lsp_diagnostics` → clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded `message_limit=50` from the unstable-agent-babysitter’s suggested `background_output` command so background tasks return full sessions without truncation. Fixes #4210 by letting `formatFullSession` return all messages when no limit is provided.

<sup>Written for commit 1e21a93d03dd776e4702594174fdd027fae74cf3. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

