### PR TITLE
fix(transcript): keep cached baseEntries pinned to last session fetch (#3647)

### DIFF
--- a/src/hooks/claude-code-hooks/transcript.test.ts
+++ b/src/hooks/claude-code-hooks/transcript.test.ts
@@ -100,48 +100,81 @@ describe("transcript caching", () => {
     expect(client.session.messages).toHaveBeenCalledTimes(2)
   })
 
-  it("keeps intermediate tool calls across sequential transcript rebuilds", async () => {
-    // given
-    const client = createMockClient([])
+  it("does not grow the cached baseEntries across sequential rebuilds (#3647)", async () => {
+    // given: an initial fetch returning one completed tool, so baseEntries
+    //        has length 1 after the first call's cache-miss path
+    const client = createMockClient([
+      {
+        info: { role: "assistant" },
+        parts: [
+          {
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: { command: "echo zero" } },
+          },
+        ],
+      },
+    ])
 
-    // when
+    // when: three back-to-back PostToolUse rebuilds within the cache TTL.
+    // Snapshot each transcript's line count immediately, because
+    // buildTranscriptFromSession unlinks the previous temp file on the
+    // next call.
+    const countLines = (path: string | null): number => {
+      if (!path) return -1
+      return readFileSync(path, "utf-8").trim().split("\n").length
+    }
+
     const firstPath = await buildTranscriptFromSession(
       client,
-      "ses_sequential",
+      "ses_no_growth",
       "/tmp",
       "bash",
       { command: "echo first" }
     )
+    const firstLines = countLines(firstPath)
+
     const secondPath = await buildTranscriptFromSession(
       client,
-      "ses_sequential",
+      "ses_no_growth",
       "/tmp",
       "read",
       { filePath: "/tmp/second.txt" }
     )
+    const secondLines = countLines(secondPath)
+
     const thirdPath = await buildTranscriptFromSession(
       client,
-      "ses_sequential",
+      "ses_no_growth",
       "/tmp",
       "write",
       { filePath: "/tmp/third.txt", content: "third" }
     )
+    const thirdContent = thirdPath ? readFileSync(thirdPath, "utf-8") : ""
+    const thirdLines = thirdContent ? thirdContent.trim().split("\n").length : -1
 
-    // then
+    // then: session.messages() is fetched once and each transcript file is
+    //       exactly `baseEntries (1) + current synthetic entry (1)` lines.
+    //       Before #3647 was fixed the third file would have grown to 4
+    //       lines because the synthetic current entry was being written
+    //       back into the cached baseEntries on every call.
+    expect(client.session.messages).toHaveBeenCalledTimes(1)
     expect(firstPath).not.toBeNull()
     expect(secondPath).not.toBeNull()
     expect(thirdPath).not.toBeNull()
 
-    if (thirdPath) {
-      const content = readFileSync(thirdPath, "utf-8")
+    expect(firstLines).toBe(2)
+    expect(secondLines).toBe(2)
+    expect(thirdLines).toBe(2)
 
-      expect(content).toContain("Bash")
-      expect(content).toContain("Read")
-      expect(content).toContain("Write")
-    }
+    // baseEntries contribution: the originally-fetched Bash entry
+    expect(thirdContent).toContain("Bash")
+    // current synthetic entry for this rebuild: Write
+    expect(thirdContent).toContain("Write")
+    // Read was a transient currentEntry from an earlier rebuild and must
+    // not leak into a later transcript file via the cached baseline
+    expect(thirdContent).not.toContain("Read")
 
-    deleteTempTranscript(firstPath)
-    deleteTempTranscript(secondPath)
     deleteTempTranscript(thirdPath)
   })
 

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -216,9 +216,15 @@ export async function buildTranscriptFromSession(
 
     const cacheEntry = transcriptCache.get(sessionId)
     if (cacheEntry) {
-      cacheEntry.baseEntries = allEntries
+      // baseEntries MUST stay pinned to the last session.messages() fetch.
+      // Previously we wrote `allEntries` (= baseEntries + synthetic current
+      // tool entry) back here and also reset createdAt on every call, so the
+      // cached baseline grew by one entry per PostToolUse and the TTL never
+      // expired — long sessions accumulated arbitrarily large transcript
+      // state and re-opening the session jumped to multi-GB JS retention
+      // (#3647). Refreshing baseEntries happens on TTL expiry via the
+      // normal cache-miss path; do NOT mutate it here.
       cacheEntry.tempPath = tempPath
-      cacheEntry.createdAt = Date.now()
     }
 
     return tempPath


### PR DESCRIPTION
## Summary

Closes #3647. `buildTranscriptFromSession` was writing the *transient* `allEntries` (= `baseEntries + synthetic current tool entry`) back into `cacheEntry.baseEntries` and also resetting `cacheEntry.createdAt = Date.now()` on every call. This meant:

1. The cached baseline grew by exactly one entry on every `PostToolUse`.
2. The TTL was refreshed each time, so the entry was never invalidated.

For a long-running session with many tool invocations and large artifact payloads, the cached array therefore accumulated arbitrarily. The reporter captured ~480 MB live JS retention in a TUI heap snapshot after only ~10 minutes of further activity on top of an already-grown session, with the dominant retained strings being repeated tool-output artifacts from earlier in the session.

Maintainer already confirmed the root cause and identified the test that encoded the faulty behavior (`src/hooks/claude-code-hooks/transcript.test.ts:103`).

## Fix

`src/hooks/claude-code-hooks/transcript.ts` — at the end of the cache-hit branch, only rotate `cacheEntry.tempPath`. Do **not** mutate `cacheEntry.baseEntries` and do **not** refresh `cacheEntry.createdAt`. The existing cache-miss path remains the single source of truth for refreshing the baseline.

```diff
   const cacheEntry = transcriptCache.get(sessionId)
   if (cacheEntry) {
-    cacheEntry.baseEntries = allEntries
+    // baseEntries MUST stay pinned to the last session.messages() fetch.
+    // Refreshing it on every call (with `allEntries` = baseEntries +
+    // synthetic current tool entry) grew the cached baseline by one entry
+    // per PostToolUse and reset the TTL, so long sessions accumulated
+    // arbitrarily large transcript state (#3647).
     cacheEntry.tempPath = tempPath
-    cacheEntry.createdAt = Date.now()
   }
```

## Tests

- **Replaced** the misleading `\"keeps intermediate tool calls across sequential transcript rebuilds\"` test. It asserted that an earlier transient tool name (`Read`) leaks into a later rebuild's transcript — which is exactly the regression we're fixing.
- **Added** `\"does not grow the cached baseEntries across sequential rebuilds (#3647)\"`:
  - Three back-to-back `buildTranscriptFromSession` calls within the TTL.
  - `client.session.messages` is hit exactly once (cache-miss path still works correctly).
  - Each rebuild file is exactly `baseEntries (1) + current synthetic (1) = 2` lines — i.e. no growth.
  - The third rebuild's content contains the synthetic current entry (`Write`) and the baseEntries contribution (`Bash`), but does **not** contain the second rebuild's transient entry (`Read`).
- `bun test src/hooks/claude-code-hooks/` — 90 pass / 0 fail.

## What this does *not* fix

Heap retention in OpenCode's own TUI rehydration (the user also filed `anomalyco/opencode#24445`). That's out of scope here; this PR only fixes the omo-side cache growth bug.

## Closes

- #3647

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transcript cache growth by keeping `baseEntries` pinned to the last `session.messages()` fetch and letting TTL expire, so transcripts no longer grow on each PostToolUse. Addresses #3647.

- **Bug Fixes**
  - Stop writing transient `allEntries` back into `cacheEntry.baseEntries` and stop refreshing `createdAt`; only rotate `tempPath`.
  - Prevents baseline growth and unbounded memory use in long sessions.
  - Replaced the faulty test that expected transient entries to persist and added a regression test to ensure no growth and a single `session.messages()` fetch within TTL.

<sup>Written for commit c7ae1b3e569d3500b131e58a4fa789afc1bde262. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

