### PR TITLE
fix(comment-checker): fall back to PATH lookup so PATH-installed binary is found (#3315)

### DIFF
--- a/src/hooks/comment-checker/cli.test.ts
+++ b/src/hooks/comment-checker/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock, afterAll } from "bun:test"
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -46,6 +46,74 @@ describe("comment-checker CLI", () => {
       // when
       // then
       expect("COMMENT_CHECKER_CLI_PATH" in cliModule).toBe(false)
+    })
+  })
+
+  describe("PATH lookup fallback (#3315)", () => {
+    test("falls back to PATH when cached and package-local binaries are absent", async () => {
+      // given - a real on-disk binary outside any package directory, the way
+      //         `npm install -g @code-yeongyu/comment-checker` would land it
+      //         in PATH but never inside our `node_modules/.../bin/`. Pre-fix
+      //         the resolver returned null here and the hook silently no-op'd
+      //         while doctor still reported "System OK".
+      const { __resolveCommentCheckerBinaryForTesting } = await import("./cli")
+      const directory = mkdtempSync(join(tmpdir(), "comment-checker-path-fallback-"))
+      const pathBinary = join(directory, "comment-checker")
+      writeFileSync(pathBinary, "#!/bin/sh\nexit 0\n")
+      chmodSync(pathBinary, 0o755)
+
+      try {
+        // when
+        const resolved = __resolveCommentCheckerBinaryForTesting(() => pathBinary)
+
+        // then
+        expect(resolved).toBe(pathBinary)
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    })
+
+    test("ignores PATH binary that does not exist on disk", async () => {
+      // given - `which` reports a path that's stale or rotated out
+      const { __resolveCommentCheckerBinaryForTesting } = await import("./cli")
+
+      // when
+      const resolved = __resolveCommentCheckerBinaryForTesting(
+        () => "/definitely/not/a/real/path/comment-checker",
+      )
+
+      // then - we never advertise a non-existent binary; runCommentChecker
+      //        would otherwise spawn a missing binary and produce a confusing
+      //        error instead of cleanly disabling the hook.
+      expect(resolved).toBeNull()
+    })
+
+    test("treats a throwing `which` as 'not found'", async () => {
+      // given - Bun.which can throw on some platforms (e.g. permission
+      //         denied while traversing PATH), the resolver must not surface
+      //         that as a hook crash.
+      const { __resolveCommentCheckerBinaryForTesting } = await import("./cli")
+
+      // when
+      const resolved = __resolveCommentCheckerBinaryForTesting(() => {
+        throw new Error("which exploded")
+      })
+
+      // then
+      expect(resolved).toBeNull()
+    })
+
+    test("returns null when `which` returns null/undefined (typical not-found signal)", async () => {
+      // given
+      const { __resolveCommentCheckerBinaryForTesting } = await import("./cli")
+
+      // when
+      const resolvedNull = __resolveCommentCheckerBinaryForTesting(() => null)
+      const resolvedUndef = __resolveCommentCheckerBinaryForTesting(() => undefined)
+
+      // then
+      expect(resolvedNull).toBeNull()
+      expect(resolvedUndef).toBeNull()
     })
   })
 

--- a/src/hooks/comment-checker/cli.ts
+++ b/src/hooks/comment-checker/cli.ts
@@ -25,7 +25,15 @@ function getBinaryName(): string {
   return process.platform === "win32" ? "comment-checker.exe" : "comment-checker"
 }
 
-function findCommentCheckerPathSync(): string | null {
+/**
+ * PATH lookup hook. Defaults to `Bun.which`, mirroring how the doctor
+ * dependency check resolves `comment-checker` (`src/cli/doctor/checks/
+ * dependencies.ts`). Exposed as a parameter so tests can inject a
+ * deterministic mock. #3315.
+ */
+export type WhichFn = (command: string) => string | null | undefined
+
+function findCommentCheckerPathSync(which: WhichFn = Bun.which): string | null {
   const resolvedPath = resolveCommentCheckerBinary({
     binaryName: getBinaryName(),
     cachedBinaryPath: getCachedBinaryPath(),
@@ -35,6 +43,21 @@ function findCommentCheckerPathSync(): string | null {
   if (resolvedPath !== null) {
     debugLog("resolved binary path:", resolvedPath)
     return resolvedPath
+  }
+
+  // Fall back to PATH lookup so users who install via `npm install -g
+  // @code-yeongyu/comment-checker` (binary lands in PATH) match the same
+  // outcome doctor already reports — without this, doctor said "System OK"
+  // but the hook silently no-op'd because the resolver only checked the
+  // cached download path and the package-local `bin/` directory. #3315.
+  try {
+    const pathBinary = which(getBinaryName())
+    if (pathBinary && existsSync(pathBinary)) {
+      debugLog("resolved binary via PATH lookup:", pathBinary)
+      return pathBinary
+    }
+  } catch {
+    // Bun.which can throw on some platforms; treat as "not found".
   }
 
   debugLog("no binary found in known locations")
@@ -91,6 +114,16 @@ export async function getCommentCheckerPath(): Promise<string | null> {
  */
 export function getCommentCheckerPathSync(): string | null {
   return resolvedCliPath ?? findCommentCheckerPathSync()
+}
+
+/**
+ * Test-only entry point for the binary resolver. Lets unit tests assert the
+ * `cached → package-local → PATH` lookup order (#3315) without monkey-patching
+ * `Bun.which` globally. Not part of the public API surface; do not call from
+ * production code.
+ */
+export function __resolveCommentCheckerBinaryForTesting(which: WhichFn): string | null {
+  return findCommentCheckerPathSync(which)
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #3315. The comment-checker hook silently no-op'd on Windows even though `bunx oh-my-opencode doctor` reported "System OK" — because doctor and the runtime resolver disagreed on where to look for the binary.

## Root cause

`resolveCommentCheckerBinary` (in \`packages/comment-checker-core/src/runner.ts\`) checks two locations in order:

1. The cached download path (\`getCachedBinaryPath()\` from OMO's downloader).
2. The package-local \`bin/<binary-name>\` directory under \`@code-yeongyu/comment-checker\`'s install location, resolved via \`createRequire(import.meta.url).resolve(...)\`.

That's it. Users who installed via \`npm install -g @code-yeongyu/comment-checker\` end up with the binary on PATH but **not** in either of those two locations — so the resolver returned null. Meanwhile \`src/cli/doctor/checks/dependencies.ts:15\` uses \`Bun.which(binary)\` and happily found the same binary, leading to the contradiction the user reported:

> Result: System OK (binary detected) [...] Hook does not trigger

Maintainer already confirmed this resolver/doctor mismatch is OMO-owned.

## Fix

`src/hooks/comment-checker/cli.ts` — `findCommentCheckerPathSync` gains a PATH lookup fallback (defaulting to \`Bun.which\`) after the existing cached/package-local checks fail:

```ts
function findCommentCheckerPathSync(which: WhichFn = Bun.which): string | null {
  const resolvedPath = resolveCommentCheckerBinary({...})
  if (resolvedPath !== null) return resolvedPath

  // Fall back to PATH lookup — mirrors doctor's dependency check.
  try {
    const pathBinary = which(getBinaryName())
    if (pathBinary && existsSync(pathBinary)) return pathBinary
  } catch {
    // Bun.which can throw on some platforms; treat as 'not found'.
  }
  return null
}
```

Order is preserved (cached → package-local → PATH) so the existing happy path (`npm install` putting the binary inside the package) keeps winning over PATH binaries on machines where both exist.

## Tests

\`src/hooks/comment-checker/cli.test.ts\` gains a new \"PATH lookup fallback (#3315)\" suite (4 tests). All routed through a new \`__resolveCommentCheckerBinaryForTesting(which)\` export so the resolver order can be asserted deterministically without monkey-patching \`Bun.which\` globally:

- Returns the PATH binary when the cached and package-local paths are absent (the actual repro from the issue).
- Ignores a PATH binary that doesn't actually exist on disk (so we never advertise a bogus path that would crash on \`spawn\`).
- Treats a throwing \`which\` as \"not found\" (some platforms throw while traversing PATH).
- Returns null when \`which\` returns \`null\`/\`undefined\` (the typical not-found signal from \`Bun.which\`).

\`bun test src/hooks/comment-checker/\` — 24 pass / 0 fail.

## Closes

- #3315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the comment-checker hook not running when the CLI is installed globally by falling back to a PATH lookup, matching the doctor check. Addresses #3315 and prevents silent no-ops on Windows.

- **Bug Fixes**
  - Added PATH lookup fallback using `Bun.which(getBinaryName())` after cached and package-local checks; returns only if the file exists and preserves the original resolution order. This matches the doctor's dependency check.
  - Added tests for the fallback behavior and introduced `__resolveCommentCheckerBinaryForTesting(which)` to assert lookup order; handles throwing/null `which` safely.

<sup>Written for commit 77682055fa2e0865a23ca48608745348b6ea46c9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

