### PR TITLE
feat: add cloakbrowser as browser automation engine provider

### DIFF
--- a/src/config/schema/browser-automation.ts
+++ b/src/config/schema/browser-automation.ts
@@ -5,6 +5,7 @@ export const BrowserAutomationProviderSchema = z.enum([
   "agent-browser",
   "dev-browser",
   "playwright-cli",
+  "cloakbrowser",
 ])
 
 export const BrowserAutomationConfigSchema = z.object({
@@ -14,6 +15,7 @@ export const BrowserAutomationConfigSchema = z.object({
    * - "agent-browser": Uses Vercel's agent-browser CLI (requires: bun add -g agent-browser)
    * - "dev-browser": Uses dev-browser skill with persistent browser state
    * - "playwright-cli": Uses Playwright CLI (@playwright/cli) - token-efficient CLI alternative
+   * - "cloakbrowser": Uses CloakBrowser — drop-in Playwright replacement with anti-detection patches (requires: npm install cloakbrowser playwright-core)
    */
   provider: BrowserAutomationProviderSchema.default("playwright"),
 })

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -5,6 +5,7 @@ import {
   playwrightSkill,
   agentBrowserSkill,
   playwrightCliSkill,
+  cloakbrowserSkill,
   frontendUiUxSkill,
   gitMasterSkill,
   devBrowserSkill,
@@ -26,13 +27,15 @@ export interface CreateBuiltinSkillsOptions {
 export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): BuiltinSkill[] {
   const { browserProvider = "playwright", disabledSkills, teamModeEnabled = false } = options
 
-  let browserSkill: BuiltinSkill
+	let browserSkill: BuiltinSkill
 	if (browserProvider === "agent-browser") {
 		browserSkill = agentBrowserSkill
 	} else if (browserProvider === "dev-browser") {
 		browserSkill = devBrowserSkill
 	} else if (browserProvider === "playwright-cli") {
 		browserSkill = playwrightCliSkill
+	} else if (browserProvider === "cloakbrowser") {
+		browserSkill = cloakbrowserSkill
 	} else {
 		browserSkill = playwrightSkill
 	}

--- a/src/features/builtin-skills/skills/cloakbrowser.ts
+++ b/src/features/builtin-skills/skills/cloakbrowser.ts
@@ -1,0 +1,119 @@
+import type { BuiltinSkill } from "../types"
+
+export const cloakbrowserSkill: BuiltinSkill = {
+  name: "cloakbrowser",
+  description: "Use for browser-related tasks when anti-detection/stealth is needed. CloakBrowser is a drop-in Playwright replacement with source-level C++ fingerprint patches that passes bot detection (reCAPTCHA v3 score 0.9, Cloudflare Turnstile, FingerprintJS). Same API as Playwright — import { launch } from 'cloakbrowser' instead of import { chromium } from 'playwright'. Triggers: 'browser', 'stealth', 'anti-detection', 'cloakbrowser', 'headless browser', 'web scraping', 'bot detection'.",
+  template: `# CloakBrowser — Stealth Chromium Automation
+
+CloakBrowser is a drop-in Playwright replacement with 48 source-level C++ fingerprint patches.
+Same API surface — everything you know about Playwright works identically.
+
+## Install
+
+\`\`\`bash
+npm install cloakbrowser playwright-core
+\`\`\`
+
+On first launch, the stealth Chromium binary auto-downloads (~200MB, cached at ~/.cloakbrowser/).
+
+## Usage
+
+\`\`\`javascript
+import { launch, launchContext, launchPersistentContext } from 'cloakbrowser';
+
+// Basic — same as playwright's chromium.launch()
+const browser = await launch();
+const page = await browser.newPage();
+await page.goto('https://example.com');
+console.log(await page.title());
+await browser.close();
+
+// Convenience: browser + context in one call
+const context = await launchContext({
+  userAgent: 'Mozilla/5.0...',
+  viewport: { width: 1920, height: 1080 },
+});
+const page = await context.newPage();
+await page.goto('https://example.com');
+await context.close(); // also closes browser
+
+// Persistent profile — stay logged in, bypass incognito detection
+const ctx = await launchPersistentContext({
+  userDataDir: './chrome-profile',
+  headless: false,
+});
+const page = ctx.pages()[0] || await ctx.newPage();
+await page.goto('https://example.com');
+await ctx.close();
+\`\`\`
+
+## Options
+
+\`\`\`javascript
+// Headed mode (visible browser window)
+const browser = await launch({ headless: false });
+
+// With proxy
+const browser = await launch({
+  proxy: 'http://user:pass@proxy:8080',
+});
+
+// With timezone and locale
+const browser = await launch({
+  timezone: 'America/New_York',
+  locale: 'en-US',
+});
+
+// Extra Chrome args (48 C++ patches already applied)
+const browser = await launch({
+  args: ['--fingerprint=12345'],
+});
+
+// Auto-detect timezone/locale from proxy IP (requires: npm install mmdb-lib)
+const browser = await launch({
+  proxy: 'http://proxy:8080',
+  geoip: true,
+});
+\`\`\`
+
+## Human-like behavior
+
+\`\`\`javascript
+import { launch } from 'cloakbrowser';
+
+const browser = await launch({ humanize: true });
+// Adds randomized typing delays, mouse movements, scroll behavior
+\`\`\`
+
+## CLI
+
+Pre-download the binary or check installation:
+
+\`\`\`bash
+npx cloakbrowser install      # Download binary
+npx cloakbrowser info         # Show version, path, platform
+npx cloakbrowser update       # Check for newer binary
+\`\`\`
+
+## Key differences from vanilla Playwright
+
+- \`navigator.webdriver\` is \`false\` (not detected as automation)
+- WebGL vendor/renderer spoofed to look like real GPU hardware
+- Canvas fingerprint randomized (non-deterministic rendering)
+- CDP detection prevented (Playwright's protocol is invisible)
+- TLS fingerprint identical to stock Chrome
+- User-Agent auto-spoofed to Windows Chrome
+
+## reCAPTCHA Tips
+
+- Use \`page.type()\` instead of \`page.fill()\` for form filling
+- Spend 15+ seconds on the page before triggering reCAPTCHA
+- Avoid \`page.waitForTimeout()\` — use native \`setTimeout\` wrapped in Promise
+- Space out \`grecaptcha.execute()\` calls (30+ seconds apart)
+
+## Full Playwright API Available
+
+All standard Playwright APIs work: \`page.click()\`, \`page.fill()\`, \`page.evaluate()\`,
+\`page.screenshot()\`, \`page.waitForSelector()\`, \`page.keyboard\`, \`page.mouse\`, etc.
+See https://playwright.dev for the complete API reference.`,
+}

--- a/src/features/builtin-skills/skills/index.ts
+++ b/src/features/builtin-skills/skills/index.ts
@@ -1,5 +1,6 @@
 export { playwrightSkill, agentBrowserSkill } from "./playwright"
 export { playwrightCliSkill } from "./playwright-cli"
+export { cloakbrowserSkill } from "./cloakbrowser"
 export { frontendUiUxSkill } from "./frontend-ui-ux"
 export { gitMasterSkill } from "./git-master"
 export { devBrowserSkill } from "./dev-browser"


### PR DESCRIPTION
## Summary

Add **CloakBrowser** as a new `browser_automation_engine.provider` option in Oh-My-OpenCode.

## Problem

Currently OMO only supports `playwright`, `agent-browser`, `dev-browser`, and `playwright-cli` as browser automation providers. Many users need anti-detection capabilities (bypassing Cloudflare, reCAPTCHA, FingerprintJS) that standard Playwright cannot provide.

When users say "use cloakbrowser", the agent currently falls back to Playwright because:
1. The Playwright skill description says "MUST USE for any browser-related tasks" — this overrides specific tool names
2. There's no `cloakbrowser` option in the provider enum
3. Without structured skill guidance, agents don't know how to use cloakbrowser's API

## Solution

This PR adds `cloakbrowser` as a first-class browser automation provider:

### Changes (4 files, +126 lines)

| File | Change |
|---|---|
| `src/config/schema/browser-automation.ts` | Add `"cloakbrowser"` to `BrowserAutomationProviderSchema` enum |
| `src/features/builtin-skills/skills/cloakbrowser.ts` | New skill with full API reference (119 lines) |
| `src/features/builtin-skills/skills/index.ts` | Export `cloakbrowserSkill` |
| `src/features/builtin-skills/skills.ts` | Wire into `createBuiltinSkills` provider selection |

### CloakBrowser Skill Coverage

The skill provides agents with:
- Installation (`npm install cloakbrowser playwright-core`)
- API usage (`launch()`, `launchContext()`, `launchPersistentContext()`)
- Configuration options (headless, proxy, timezone, locale, geoip, humanize)
- CLI utilities (`cloakbrowser install/info/update`)
- reCAPTCHA optimization tips
- Key differences from vanilla Playwright (WebDriver flag, WebGL spoofing, Canvas FP)

### Usage

```json
// oh-my-openagent.json
{
  "browser_automation_engine": {
    "provider": "cloakbrowser"
  }
}
```

### Testing

- TypeScript type-check: ✅ no errors
- Schema tests (`browser_automation_engine`): ✅ 3/3 pass
- Build: ✅ successful
- Pre-existing test failures are unrelated to this change

### About CloakBrowser

CloakBrowser is a drop-in Playwright replacement with 48 source-level C++ fingerprint patches. It passes:
- reCAPTCHA v3 (score 0.9, human-level)
- Cloudflare Turnstile
- FingerprintJS
- BrowserScan (4/4 normal)
- `navigator.webdriver`: false

Repository: https://github.com/CloakHQ/cloakbrowser
npm: https://www.npmjs.com/package/cloakbrowser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cloakbrowser` as a drop-in Playwright provider for stealth/anti-detection. Includes a new skill and provider wiring.

- **New Features**
  - Added `cloakbrowser` to `BrowserAutomationProviderSchema`.
  - New `cloakbrowser` skill with `launch`, `launchContext`, `launchPersistentContext`, options (`proxy`, `timezone`, `locale`, `geoip`, `humanize`), plus CLI and reCAPTCHA tips.
  - Integrated into provider selection in `createBuiltinSkills` and exported from the skills index.

- **Migration**
  - Set `browser_automation_engine.provider` to `cloakbrowser` in `oh-my-openagent.json`.
  - Install `cloakbrowser` and `playwright-core`.

<sup>Written for commit 059a9311f7f17b77c6334bfea39ccc1f015efc39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

