### PR TITLE
fix(runtime-fallback): normalize runtime model payloads

### DIFF
--- a/src/features/team-mode/team-runtime/resolve-member.test.ts
+++ b/src/features/team-mode/team-runtime/resolve-member.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs"
-declare const require: (name: string) => any
-const { describe, expect, mock, test, beforeEach } = require("bun:test")
+/// <reference types="bun-types" />
+
+const { describe, expect, mock, test, beforeEach } = await import("bun:test")
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
 import type { Member } from "../types"
 
@@ -88,6 +88,7 @@ describe("resolveMember", () => {
     const ctxWithJuniorOverride: ExecutorContext = {
       ...createExecutorContext(),
       sisyphusJuniorModel: "anthropic/claude-sonnet-4-6",
+      disabledProviders: ["github-copilot"],
     }
     resolveCategoryExecutionMock.mockResolvedValue({
       agentToUse: "sisyphus-junior",
@@ -102,6 +103,41 @@ describe("resolveMember", () => {
 
     // then
     const [, executorCtxArg] = resolveCategoryExecutionMock.mock.calls[0]
+    expect(executorCtxArg.sisyphusJuniorModel).toBeUndefined()
+    expect(executorCtxArg.disabledProviders).toEqual(["github-copilot"])
+  })
+
+  test("forwards category member runtime model and variant while stripping only the global junior override", async () => {
+    // given
+    const member = {
+      backendType: "in-process",
+      isActive: true,
+      kind: "category",
+      name: "architect",
+      category: "deep",
+      prompt: "design X",
+      model: "openai/gpt-5.5",
+      variant: "xhigh",
+    } satisfies Member
+    const ctxWithJuniorOverride: ExecutorContext = {
+      ...createExecutorContext(),
+      sisyphusJuniorModel: "anthropic/claude-sonnet-4-6",
+    }
+    resolveCategoryExecutionMock.mockResolvedValue({
+      agentToUse: "sisyphus-junior",
+      categoryModel: { providerID: "openai", modelID: "gpt-5.5", variant: "xhigh" },
+      categoryPromptAppend: "appendix",
+      maxPromptTokens: 256,
+      fallbackChain: [],
+    })
+
+    // when
+    await resolveMember(member, ctxWithJuniorOverride, "deep, quick")
+
+    // then
+    const [argsArg, executorCtxArg] = resolveCategoryExecutionMock.mock.calls[0]
+    expect(argsArg.model).toBe("openai/gpt-5.5")
+    expect(argsArg.variant).toBe("xhigh")
     expect(executorCtxArg.sisyphusJuniorModel).toBeUndefined()
   })
 
@@ -148,6 +184,37 @@ describe("resolveMember", () => {
     expect(result.systemContent).toBe("resolved-system-content")
   })
 
+  test("forwards subagent member runtime model and variant", async () => {
+    // given
+    const member = {
+      backendType: "in-process",
+      isActive: true,
+      kind: "subagent_type",
+      name: "m2",
+      subagent_type: "atlas",
+      prompt: "addendum",
+      model: "openai/gpt-5.4",
+      variant: "xhigh",
+    } satisfies Member
+
+    resolveSubagentExecutionMock.mockResolvedValue({
+      agentToUse: "atlas",
+      categoryModel: { providerID: "openai", modelID: "gpt-5.4", variant: "xhigh" },
+      fallbackChain: [],
+    })
+
+    // when
+    await resolveMember(member, createExecutorContext(), "deep, quick", "sisyphus")
+
+    // then
+    const [argsArg] = resolveSubagentExecutionMock.mock.calls[0]
+    expect(argsArg).toMatchObject({
+      subagent_type: "atlas",
+      model: "openai/gpt-5.4",
+      variant: "xhigh",
+    })
+  })
+
   test("throws TeamMemberResolutionError without category fallback when subagent resolution fails", async () => {
     // given
     const member = {
@@ -161,11 +228,16 @@ describe("resolveMember", () => {
     resolveSubagentExecutionMock.mockRejectedValue(new Error("unknown agent"))
 
     // when
-    const result = resolveMember(member, createExecutorContext(), "deep, quick")
+    let caught: unknown
+    try {
+      await resolveMember(member, createExecutorContext(), "deep, quick")
+    } catch (error) {
+      caught = error
+    }
 
     // then
-    await expect(result).rejects.toBeInstanceOf(TeamMemberResolutionError)
-    await expect(result).rejects.toThrow("Failed to resolve member 'unknown': unknown agent")
+    expect(caught).toBeInstanceOf(TeamMemberResolutionError)
+    expect(caught instanceof Error ? caught.message : String(caught)).toBe("Failed to resolve member 'unknown': unknown agent")
     expect(resolveCategoryExecutionMock).not.toHaveBeenCalled()
   })
 
@@ -200,7 +272,7 @@ describe("resolveMember", () => {
       categoryModel: { providerID: "openai", modelID: "gpt-5.4-mini" },
       fallbackChain: [],
     })
-    const source = readFileSync(new URL("./resolve-member.ts", import.meta.url), "utf8")
+    const source = await Bun.file(new URL("./resolve-member.ts", import.meta.url)).text()
 
     // when
     await resolveMember(categoryMember, createExecutorContext(), "deep, quick")

--- a/src/features/team-mode/team-runtime/resolve-member.ts
+++ b/src/features/team-mode/team-runtime/resolve-member.ts
@@ -71,6 +71,8 @@ export async function resolveMember(
         {
           ...createBaseDelegateTaskArgs(member.prompt),
           category: member.category,
+          model: member.model,
+          variant: member.variant,
           subagent_type: "sisyphus-junior",
         },
         withoutSisyphusJuniorOverride(ctx),
@@ -99,6 +101,8 @@ export async function resolveMember(
     const execution = await resolveSubagentExecution(
       {
         ...createBaseDelegateTaskArgs(member.prompt ?? ""),
+        model: member.model,
+        variant: member.variant,
         subagent_type: member.subagent_type,
       },
       ctx,

--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -161,6 +161,7 @@ export type TeamCreateExecutorConfig = {
   userCategories?: CategoriesConfig
   sisyphusJuniorModel?: string
   agentOverrides?: AgentOverrides
+  disabledProviders?: string[]
 }
 
 type TeamCreateToolDeps = {
@@ -224,6 +225,7 @@ export function createTeamCreateTool(
           userCategories: executorConfig?.userCategories,
           sisyphusJuniorModel: executorConfig?.sisyphusJuniorModel,
           agentOverrides: executorConfig?.agentOverrides,
+          disabledProviders: executorConfig?.disabledProviders,
         },
         config,
         bgMgr,

--- a/src/features/team-mode/types.test.ts
+++ b/src/features/team-mode/types.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import {
   AGENT_ELIGIBILITY_REGISTRY,
@@ -160,9 +162,44 @@ describe("team-mode types", () => {
     expect(result).toMatchObject(member)
   })
 
+  test("parseMember returns category member with runtime model and variant", () => {
+    // given
+    const member = {
+      name: "m1",
+      kind: "category",
+      category: "deep",
+      prompt: "impl X",
+      model: "openai/gpt-5.5",
+      variant: "xhigh",
+    }
+
+    // when
+    const result = parseMember(member)
+
+    // then
+    expect(result).toMatchObject(member)
+  })
+
   test("parseMember returns valid subagent member", () => {
     // given
     const member = { name: "m1", kind: "subagent_type", subagent_type: "sisyphus" }
+
+    // when
+    const result = parseMember(member)
+
+    // then
+    expect(result).toMatchObject(member)
+  })
+
+  test("parseMember returns subagent member with runtime model and variant", () => {
+    // given
+    const member = {
+      name: "m1",
+      kind: "subagent_type",
+      subagent_type: "sisyphus-junior",
+      model: "openai/gpt-5.5",
+      variant: "medium",
+    }
 
     // when
     const result = parseMember(member)

--- a/src/features/team-mode/types.ts
+++ b/src/features/team-mode/types.ts
@@ -28,6 +28,8 @@ const MemberBaseSchema = z.object({
   cwd: z.string().optional(),
   worktreePath: z.string().optional(),
   subscriptions: z.array(z.string()).optional(),
+  model: z.string().optional(),
+  variant: z.string().optional(),
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
   isActive: z.boolean().default(true),
@@ -89,7 +91,7 @@ export const TeamSpecSchema = z.object({
 
 export const MessageSchema = z.object({
   version: z.literal(1),
-  messageId: z.string().uuid(),
+  messageId: z.uuid(),
   from: z.string(),
   to: z.string(),
   kind: z.enum(MESSAGE_KINDS),
@@ -97,7 +99,7 @@ export const MessageSchema = z.object({
   summary: z.string().optional(),
   references: z.array(TeamReferenceSchema).optional(),
   timestamp: z.number().int().positive(),
-  correlationId: z.string().uuid().optional(),
+  correlationId: z.uuid().optional(),
   color: z.string().optional(),
 })
 
@@ -173,7 +175,7 @@ const RuntimeStateTmuxLayoutSchema = z.object({
 
 export const RuntimeStateSchema = z.object({
   version: z.literal(1),
-  teamRunId: z.string().uuid(),
+  teamRunId: z.uuid(),
   teamName: z.string(),
   specSource: z.enum(["project", "user"]),
   createdAt: z.number().int().positive(),

--- a/src/hooks/model-fallback/fallback-state-controller.ts
+++ b/src/hooks/model-fallback/fallback-state-controller.ts
@@ -25,6 +25,35 @@ function isSameFailedModel(
     && canonicalizeModelIDForDuplicateCheck(state.modelID) === canonicalizeModelIDForDuplicateCheck(modelID)
 }
 
+function isProviderNameDisabled(
+  providerID: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): boolean {
+  if (!providerID || !disabledProviders || disabledProviders.length === 0) return false
+
+  const provider = providerID.trim().toLowerCase()
+  if (!provider) return false
+
+  return disabledProviders.some((entry) => entry.trim().toLowerCase() === provider)
+}
+
+function filterDisabledProvidersFromFallbackChain(
+  fallbackChain: readonly FallbackEntry[] | undefined,
+  disabledProviders: readonly string[] | undefined,
+): FallbackEntry[] | undefined {
+  if (!fallbackChain) return undefined
+  if (!disabledProviders || disabledProviders.length === 0) return [...fallbackChain]
+
+  const filteredChain = fallbackChain
+    .map((entry) => ({
+      ...entry,
+      providers: entry.providers.filter((provider) => !isProviderNameDisabled(provider, disabledProviders)),
+    }))
+    .filter((entry) => entry.providers.length > 0)
+
+  return filteredChain.length > 0 ? filteredChain : undefined
+}
+
 export type ModelFallbackStateController = {
   lastToastKey: Map<string, string>
   setSessionFallbackChain: (sessionID: string, fallbackChain: FallbackEntry[] | undefined) => void
@@ -47,12 +76,14 @@ export function createModelFallbackStateController(input: {
   pendingModelFallbacks: Map<string, ModelFallbackStateLike>
   lastToastKey: Map<string, string>
   sessionFallbackChains: Map<string, FallbackEntry[]>
+  disabledProviders?: readonly string[]
 }): ModelFallbackStateController {
-  const { pendingModelFallbacks, lastToastKey, sessionFallbackChains } = input
+  const { pendingModelFallbacks, lastToastKey, sessionFallbackChains, disabledProviders } = input
 
   function setSessionFallbackChain(sessionID: string, fallbackChain: FallbackEntry[] | undefined): void {
     if (!sessionID) return
-    sessionFallbackChains.set(sessionID, fallbackChain?.length ? [...fallbackChain] : [])
+    const filteredFallbackChain = filterDisabledProvidersFromFallbackChain(fallbackChain, disabledProviders)
+    sessionFallbackChains.set(sessionID, filteredFallbackChain?.length ? filteredFallbackChain : [])
   }
 
   function clearSessionFallbackChain(sessionID: string): void {
@@ -72,7 +103,8 @@ export function createModelFallbackStateController(input: {
   ): boolean {
     const agentKey = getAgentConfigKey(agentName)
     const requirements = AGENT_MODEL_REQUIREMENTS[agentKey]
-    const fallbackChain = sessionFallbackChains.get(sessionID) ?? requirements?.fallbackChain
+    const fallbackChain = sessionFallbackChains.get(sessionID)
+      ?? filterDisabledProvidersFromFallbackChain(requirements?.fallbackChain, disabledProviders)
 
     if (!fallbackChain?.length) {
       log(`[model-fallback] No fallback chain for agent: ${agentName} (key: ${agentKey})`)

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -1,9 +1,8 @@
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
-declare const require: (name: string) => any
-const { beforeEach, describe, expect, mock, test, afterAll } = require("bun:test")
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test"
 
-const readConnectedProvidersCacheMock = mock(() => null)
-const readProviderModelsCacheMock = mock(() => null)
+const readConnectedProvidersCacheMock = mock((): string[] | null => null)
+const readProviderModelsCacheMock = mock((): { models: Record<string, string[]>; connected: string[]; updatedAt: string } | null => null)
 const selectFallbackProviderMock = mock((providers: string[], preferredProviderID?: string) => {
   const connectedProviders = readConnectedProvidersCacheMock()
   if (connectedProviders) {
@@ -73,6 +72,10 @@ const {
 } = await importFreshModelFallbackHookModule()
 
 type ModelFallbackHook = ReturnType<typeof createModelFallbackHook>
+type ChatMessageOutput = {
+  message: Record<string, unknown>
+  parts: Array<{ type: string; text?: string }>
+}
 
 describe("model fallback hook", () => {
   let modelFallback: ModelFallbackHook
@@ -103,7 +106,7 @@ describe("model fallback hook", () => {
     )
     expect(set).toBe(true)
 
-    const output = {
+    const output: ChatMessageOutput = {
       message: {
         model: { providerID: "anthropic", modelID: "claude-opus-4-7-thinking" },
         variant: "max",
@@ -154,7 +157,7 @@ describe("model fallback hook", () => {
       setPendingModelFallback(modelFallback, sessionID, "Sisyphus - Ultraworker", "anthropic", "claude-opus-4-7"),
     ).toBe(true)
 
-    const secondOutput = {
+    const secondOutput: ChatMessageOutput = {
       message: {
         model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
       },
@@ -235,7 +238,7 @@ describe("model fallback hook", () => {
       ),
     ).toBe(true)
 
-    const output = {
+    const output: ChatMessageOutput = {
       message: {
         model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
       },
@@ -354,6 +357,83 @@ describe("model fallback hook", () => {
     clearPendingModelFallback(modelFallback, sessionID)
   })
 
+  test("filters disabled providers from hardcoded agent fallback chains", async () => {
+    const sessionID = "ses_model_fallback_disabled_hardcoded"
+    const disabledModelFallback = createModelFallbackHook({
+      disabledProviders: ["anthropic", "github-copilot", "vercel"],
+    })
+    const hook = unsafeTestValue<{
+      "chat.message"?: (
+        input: { sessionID: string },
+        output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
+      ) => Promise<void>
+    }>(disabledModelFallback)
+
+    const set = setPendingModelFallback(
+      disabledModelFallback,
+      sessionID,
+      "Sisyphus - Ultraworker",
+      "anthropic",
+      "claude-opus-4-7-thinking",
+    )
+    expect(set).toBe(true)
+
+    const output: ChatMessageOutput = {
+      message: {
+        model: { providerID: "anthropic", modelID: "claude-opus-4-7-thinking" },
+      },
+      parts: [{ type: "text", text: "continue" }],
+    }
+
+    await hook["chat.message"]?.({ sessionID }, output)
+
+    expect(output.message["model"]).toEqual({
+      providerID: "opencode",
+      modelID: "claude-opus-4-7",
+    })
+    expect(output.message["variant"]).toBe("max")
+  })
+
+  test("filters disabled providers from session fallback chains", async () => {
+    const sessionID = "ses_model_fallback_disabled_session_chain"
+    const disabledModelFallback = createModelFallbackHook({
+      disabledProviders: ["github-copilot"],
+    })
+    const hook = unsafeTestValue<{
+      "chat.message"?: (
+        input: { sessionID: string },
+        output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
+      ) => Promise<void>
+    }>(disabledModelFallback)
+
+    setSessionFallbackChain(disabledModelFallback, sessionID, [
+      { providers: ["github-copilot"], model: "gpt-5.5" },
+      { providers: ["openai"], model: "gpt-5.5" },
+    ])
+    const set = setPendingModelFallback(
+      disabledModelFallback,
+      sessionID,
+      "Oracle",
+      "anthropic",
+      "claude-opus-4-7",
+    )
+    expect(set).toBe(true)
+
+    const output = {
+      message: {
+        model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      },
+      parts: [{ type: "text", text: "continue" }],
+    }
+
+    await hook["chat.message"]?.({ sessionID }, output)
+
+    expect(output.message["model"]).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.5",
+    })
+  })
+
   test("shows toast when fallback is applied", async () => {
     const toastCalls: Array<{ title: string; message: string }> = []
     const hook = unsafeTestValue<{
@@ -362,7 +442,7 @@ describe("model fallback hook", () => {
         output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
       ) => Promise<void>
     }>(createModelFallbackHook({
-      toast: async ({ title, message }) => {
+      toast: async ({ title, message }: { title: string; message: string }) => {
         toastCalls.push({ title, message })
       },
     }))

--- a/src/hooks/model-fallback/hook.ts
+++ b/src/hooks/model-fallback/hook.ts
@@ -54,6 +54,7 @@ type ModelFallbackHookArgs = {
   toast?: FallbackToast
   onApplied?: FallbackCallback
   controllerAccessor?: ModelFallbackControllerAccessor
+  disabledProviders?: readonly string[]
 }
 
 export function setSessionFallbackChain(
@@ -150,6 +151,7 @@ export function createModelFallbackHook(args?: ModelFallbackHookArgs): ModelFall
     pendingModelFallbacks,
     lastToastKey,
     sessionFallbackChains,
+    disabledProviders: args?.disabledProviders,
   })
 
   args?.controllerAccessor?.register(controller)

--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -1,8 +1,18 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createEventHandler } from "./event-handler"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -32,7 +42,7 @@ function createDeps(): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
@@ -43,7 +53,7 @@ function createDeps(): HookDeps {
   }
 }
 
-function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async (sessionID: string) => {
       abortCalls.push(sessionID)
@@ -53,8 +63,10 @@ function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[
       deps.sessionFallbackTimeouts.delete(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -103,7 +115,7 @@ describe("createEventHandler", () => {
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
     expect(clearCalls).toEqual([sessionID])
     expect(abortCalls).toEqual([])
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
   })
 
   it("#given a cancelled session #when session.error receives an abort error #then fallback retry state is reset", async () => {
@@ -247,5 +259,229 @@ describe("createEventHandler", () => {
 
     // then - counter is at 2, not reset to 0
     expect(deps.sessionStates.get(sessionID)?.attemptCount).toBe(2)
+  })
+
+  it("#given an object-shaped pending fallback model #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a model object without variant and a top-level variant #when session.error arrives #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-mixed-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a top-level event model with a variant #when session.error bootstraps fallback state #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-top-level-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a session.created info model object and separate variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-info-mixed-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          info: {
+            id: sessionID,
+            model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+            variant: "high",
+          },
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  it("#given top-level session.created provider model fields with a variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-top-level-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
   })
 })

--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -346,6 +346,50 @@ describe("createEventHandler", () => {
     expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
   })
 
+  it("#given an OpenCode id-shaped pending fallback model with a variant #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-id-shaped-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", id: "claude-haiku-4.5", variant: "high" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
   it("#given a model object without variant and a top-level variant #when session.error arrives #then the fallback chain advances", async () => {
     // given
     const sessionID = "session-error-mixed-model-variant"
@@ -456,6 +500,33 @@ describe("createEventHandler", () => {
     const state = deps.sessionStates.get(sessionID)
     expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
     expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  it("#given a session.created info model with OpenCode id shape #when the event is handled #then fallback state keeps the model and variant", async () => {
+    // given
+    const sessionID = "session-created-info-id-shaped-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          info: {
+            id: sessionID,
+            model: { providerID: "openai", id: "gpt-5.3-codex-spark", variant: "medium" },
+          },
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("openai/gpt-5.3-codex-spark(medium)")
+    expect(state?.currentModel).toBe("openai/gpt-5.3-codex-spark(medium)")
   })
 
   it("#given top-level session.created provider model fields with a variant #when the event is handled #then fallback state keeps the variant", async () => {

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -3,7 +3,7 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
@@ -11,20 +11,10 @@ import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 function resolveEventModel(props: Record<string, unknown> | undefined): string | undefined {
-  const model = props?.model
-  if (typeof model === "string") {
-    return model
-  }
-
-  const providerID = props?.providerID
-  const modelID = props?.modelID
-  if (typeof providerID === "string" && typeof modelID === "string") {
-    return `${providerID}/${modelID}`
-  }
-
-  return undefined
+  return resolveRuntimeModelFromEventRecord(props)
 }
 
 export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
@@ -45,9 +35,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = props?.info as Record<string, unknown> | undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = resolveRuntimeModelFromEventRecord(sessionInfo) ?? resolveRuntimeModelFromEventRecord(props)
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -164,7 +154,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     if (sessionAwaitingFallbackResult.has(sessionID)) {
       const pendingFallbackModel = sessionStates.get(sessionID)?.pendingFallbackModel
       const eventModel = resolveEventModel(props)
-      if (!pendingFallbackModel || eventModel !== pendingFallbackModel) {
+      if (!areRuntimeModelsEquivalent(eventModel, pendingFallbackModel)) {
         log(`[${HOOK_NAME}] session.error skipped - awaiting fallback result`, {
           sessionID,
           pendingFallbackModel,
@@ -209,7 +199,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: resolveEventModel(props),
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
+++ b/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
@@ -2,11 +2,12 @@ import type { OhMyOpenCodeConfig } from "../../config"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import { stringifyRuntimeModel } from "./fallback-state"
 
 type ResolveFallbackBootstrapModelOptions = {
   sessionID: string
   source: string
-  eventModel?: string
+  eventModel?: unknown
   resolvedAgent?: string
   pluginConfig?: OhMyOpenCodeConfig
 }
@@ -14,15 +15,18 @@ type ResolveFallbackBootstrapModelOptions = {
 export function resolveFallbackBootstrapModel(
   options: ResolveFallbackBootstrapModelOptions,
 ): string | undefined {
-  if (options.eventModel) {
-    return options.eventModel
+  const eventModel = stringifyRuntimeModel(options.eventModel)
+  if (eventModel) {
+    return eventModel
   }
 
   const agentConfigs = options.pluginConfig?.agents
   const agentConfig = options.resolvedAgent && agentConfigs
     ? agentConfigs[options.resolvedAgent as keyof typeof agentConfigs]
     : undefined
-  const agentModel = typeof agentConfig?.model === "string" ? agentConfig.model : undefined
+  const agentConfigRecord = agentConfig as Record<string, unknown> | undefined
+  const agentModelCandidate = agentConfigRecord?.model
+  const agentModel = typeof agentModelCandidate === "string" ? agentModelCandidate : undefined
   if (agentModel) {
     log(`[${HOOK_NAME}] Derived model from agent config for ${options.source}`, {
       sessionID: options.sessionID,

--- a/src/hooks/runtime-fallback/fallback-state.test.ts
+++ b/src/hooks/runtime-fallback/fallback-state.test.ts
@@ -1,0 +1,40 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { createFallbackState, findNextAvailableFallback, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+describe("runtime-fallback fallback state", () => {
+  test("#given object-shaped current model #when finding the next fallback #then equivalent models are skipped without crashing", () => {
+    // given
+    const state = createFallbackState({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+    const fallbackModels = ["github-copilot/claude-sonnet-4.6", "openai/gpt-5.4"]
+
+    // when
+    const nextModel = findNextAvailableFallback(state, fallbackModels, 60)
+
+    // then
+    expect(nextModel).toBe("openai/gpt-5.4")
+  })
+
+  test("#given model object without variant and top-level variant #when stringifying runtime model #then top-level variant is preserved", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  test("#given model object with its own variant #when stringifying with a top-level variant #then model variant wins", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "low" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(low)")
+  })
+})

--- a/src/hooks/runtime-fallback/fallback-state.test.ts
+++ b/src/hooks/runtime-fallback/fallback-state.test.ts
@@ -16,6 +16,18 @@ describe("runtime-fallback fallback state", () => {
     expect(nextModel).toBe("openai/gpt-5.4")
   })
 
+  test("#given OpenCode id-shaped current model #when creating fallback state #then the model and variant are preserved", () => {
+    // given
+    const currentModel = { providerID: "openai", id: "gpt-5.3-codex-spark", variant: "medium" }
+
+    // when
+    const state = createFallbackState(currentModel)
+
+    // then
+    expect(state.originalModel).toBe("openai/gpt-5.3-codex-spark(medium)")
+    expect(state.currentModel).toBe("openai/gpt-5.3-codex-spark(medium)")
+  })
+
   test("#given model object without variant and top-level variant #when stringifying runtime model #then top-level variant is preserved", () => {
     // given
     const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5" }

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -8,10 +8,11 @@ export function stringifyRuntimeModel(model: unknown): string | undefined {
   if (typeof model === "string") return model
 
   if (typeof model === "object" && model !== null) {
-    const candidate = model as { providerID?: unknown; modelID?: unknown; variant?: unknown }
-    if (typeof candidate.providerID === "string" && typeof candidate.modelID === "string") {
+    const candidate = model as { providerID?: unknown; modelID?: unknown; id?: unknown; variant?: unknown }
+    const candidateModelID = typeof candidate.modelID === "string" ? candidate.modelID : candidate.id
+    if (typeof candidate.providerID === "string" && typeof candidateModelID === "string") {
       const providerID = candidate.providerID.trim()
-      const modelID = candidate.modelID.trim()
+      const modelID = candidateModelID.trim()
       const variant = typeof candidate.variant === "string" ? candidate.variant.trim() : undefined
 
       if (!providerID || !modelID) return undefined

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -4,6 +4,39 @@ import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
 import { parseModelString } from "../../tools/delegate-task/model-string-parser"
 
+export function stringifyRuntimeModel(model: unknown): string | undefined {
+  if (typeof model === "string") return model
+
+  if (typeof model === "object" && model !== null) {
+    const candidate = model as { providerID?: unknown; modelID?: unknown; variant?: unknown }
+    if (typeof candidate.providerID === "string" && typeof candidate.modelID === "string") {
+      const providerID = candidate.providerID.trim()
+      const modelID = candidate.modelID.trim()
+      const variant = typeof candidate.variant === "string" ? candidate.variant.trim() : undefined
+
+      if (!providerID || !modelID) return undefined
+
+      const baseModel = `${providerID}/${modelID}`
+      return variant
+        ? `${baseModel}(${variant})`
+        : baseModel
+    }
+  }
+
+  return undefined
+}
+
+export function stringifyRuntimeModelWithVariant(model: unknown, variant: unknown): string | undefined {
+  const baseModel = stringifyRuntimeModel(model)
+  const fallbackVariant = typeof variant === "string" ? variant.trim() : undefined
+  if (!baseModel || !fallbackVariant) return baseModel
+
+  const parsed = parseModelString(baseModel)
+  if (!parsed?.providerID || !parsed.modelID || parsed.variant) return baseModel
+
+  return `${parsed.providerID}/${parsed.modelID}(${fallbackVariant})`
+}
+
 function canonicalizeModelID(modelID: string): string {
   const loweredModelID = modelID.toLowerCase()
   const dottedModelID = loweredModelID.replace(/\./g, "-")
@@ -63,10 +96,17 @@ function isEquivalentModel(candidate: string, current: string): boolean {
   )
 }
 
-export function createFallbackState(originalModel: string): FallbackState {
+export function areRuntimeModelsEquivalent(candidate: string | undefined, current: string | undefined): boolean {
+  if (!candidate || !current) return false
+  return isEquivalentModel(candidate, current)
+}
+
+export function createFallbackState(originalModel: unknown): FallbackState {
+  const model = stringifyRuntimeModel(originalModel) ?? String(originalModel)
+
   return {
-    originalModel,
-    currentModel: originalModel,
+    originalModel: model,
+    currentModel: model,
     fallbackIndex: -1,
     failedModels: new Map<string, number>(),
     attemptCount: 0,

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -337,6 +337,47 @@ describe("first-prompt-watchdog", () => {
     watchdog.dispose()
   })
 
+  it("#given a user message with OpenCode id-shaped model object and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
+    // given
+    const sessionID = "session-watchdog-id-shaped-variant"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_VARIANT_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            sessionID,
+            role: "user",
+            agent: AGENT,
+            model: { providerID: "github-copilot", id: "claude-haiku-4.5", variant: "high" },
+          },
+        },
+      },
+      watchdog,
+    )
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe(VARIANT_PRIMARY_MODEL)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([
+      {
+        sessionID,
+        newModel: VARIANT_FALLBACK_MODEL,
+        resolvedAgent: AGENT,
+        source: "first-prompt-watchdog",
+      },
+    ])
+
+    watchdog.dispose()
+  })
+
   it("#given a user message with top-level provider model fields and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
     // given
     const sessionID = "session-watchdog-top-level-variant"

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
@@ -81,6 +83,8 @@ function createHelpers(calls: RecordedCalls, resolvedAgentName?: string): AutoRe
 const AGENT = "sisyphus-junior"
 const PRIMARY_MODEL = "openai/gpt-5.4-mini"
 const FALLBACK_MODEL = "anthropic/claude-haiku-4-5"
+const VARIANT_PRIMARY_MODEL = "github-copilot/claude-haiku-4.5(high)"
+const VARIANT_FALLBACK_MODEL = "openai/gpt-5.4"
 const PLUGIN_CONFIG_WITH_FALLBACK = {
   git_master: {
     commit_footer: true,
@@ -91,6 +95,22 @@ const PLUGIN_CONFIG_WITH_FALLBACK = {
     [AGENT]: {
       model: PRIMARY_MODEL,
       fallback_models: [{ model: FALLBACK_MODEL }],
+    },
+  },
+}
+const PLUGIN_CONFIG_WITH_VARIANT_FALLBACK = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+  agents: {
+    [AGENT]: {
+      model: VARIANT_PRIMARY_MODEL,
+      fallback_models: [
+        { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+        VARIANT_FALLBACK_MODEL,
+      ],
     },
   },
 }
@@ -274,6 +294,91 @@ describe("first-prompt-watchdog", () => {
 
     watchdog.dispose()
   })
+
+  it("#given a user message with mixed model object and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
+    // given
+    const sessionID = "session-watchdog-mixed-variant"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_VARIANT_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            sessionID,
+            role: "user",
+            agent: AGENT,
+            model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+            variant: "high",
+          },
+        },
+      },
+      watchdog,
+    )
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe(VARIANT_PRIMARY_MODEL)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([
+      {
+        sessionID,
+        newModel: VARIANT_FALLBACK_MODEL,
+        resolvedAgent: AGENT,
+        source: "first-prompt-watchdog",
+      },
+    ])
+
+    watchdog.dispose()
+  })
+
+  it("#given a user message with top-level provider model fields and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
+    // given
+    const sessionID = "session-watchdog-top-level-variant"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_VARIANT_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: {
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+          info: {
+            sessionID,
+            role: "user",
+            agent: AGENT,
+          },
+        },
+      },
+      watchdog,
+    )
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe(VARIANT_PRIMARY_MODEL)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([
+      {
+        sessionID,
+        newModel: VARIANT_FALLBACK_MODEL,
+        resolvedAgent: AGENT,
+        source: "first-prompt-watchdog",
+      },
+    ])
+
+    watchdog.dispose()
+  })
 })
 
 interface RecordedWatchdogCalls {
@@ -329,29 +434,33 @@ describe("observeEventForWatchdog", () => {
     ["file", { type: "file" }],
   ]
 
-  it.each(assistantProgressParts)("#given a message.updated assistant event whose only part is type=%s #when observed #then onAssistantProgress is called (model is *working*, not silent)", (_label: string, part: { readonly type: string; readonly text?: string; readonly id?: string; readonly name?: string; readonly tool_use_id?: string }) => {
-    const calls = freshCalls()
-    observeEventForWatchdog(
-      {
-        type: "message.updated",
-        properties: { info: { sessionID, role: "assistant" }, parts: [part] },
-      },
-      createRecordingWatchdog(calls),
-    )
-    expect(calls.progress).toEqual([sessionID])
-  })
+  for (const [label, part] of assistantProgressParts) {
+    it(`#given a message.updated assistant event whose only part is type=${label} #when observed #then onAssistantProgress is called`, () => {
+      const calls = freshCalls()
+      observeEventForWatchdog(
+        {
+          type: "message.updated",
+          properties: { info: { sessionID, role: "assistant" }, parts: [part] },
+        },
+        createRecordingWatchdog(calls),
+      )
+      expect(calls.progress).toEqual([sessionID])
+    })
+  }
 
-  it.each(assistantProgressParts)("#given a message.part.updated event whose part is type=%s #when observed #then onAssistantProgress is called", (_label: string, part: { readonly type: string; readonly text?: string; readonly id?: string; readonly name?: string; readonly tool_use_id?: string }) => {
-    const calls = freshCalls()
-    observeEventForWatchdog(
-      {
-        type: "message.part.updated",
-        properties: { sessionID, part },
-      },
-      createRecordingWatchdog(calls),
-    )
-    expect(calls.progress).toEqual([sessionID])
-  })
+  for (const [label, part] of assistantProgressParts) {
+    it(`#given a message.part.updated event whose part is type=${label} #when observed #then onAssistantProgress is called`, () => {
+      const calls = freshCalls()
+      observeEventForWatchdog(
+        {
+          type: "message.part.updated",
+          properties: { sessionID, part },
+        },
+        createRecordingWatchdog(calls),
+      )
+      expect(calls.progress).toEqual([sessionID])
+    })
+  }
 
   it("#given a message.updated assistant event with parts: [] and no error/finish #when observed #then no progress is signalled (no activity yet)", () => {
     const calls = freshCalls()
@@ -391,17 +500,16 @@ describe("observeEventForWatchdog", () => {
 
   const terminalEventTypes: ReadonlyArray<readonly [string]> = [["session.idle"], ["session.stop"], ["session.deleted"], ["session.error"]]
 
-  it.each(terminalEventTypes)(
-    "#given a %s event #when observed #then onSessionTerminal is called",
-    (eventType: string) => {
+  for (const [eventType] of terminalEventTypes) {
+    it(`#given a ${eventType} event #when observed #then onSessionTerminal is called`, () => {
       const calls = freshCalls()
       observeEventForWatchdog(
         { type: eventType, properties: { sessionID } },
         createRecordingWatchdog(calls),
       )
       expect(calls.terminal).toEqual([sessionID])
-    },
-  )
+    })
+  }
 
   it("#given a session.deleted event whose sessionID is carried under properties.info.id #when observed #then onSessionTerminal is still called (matches event-handler shape)", () => {
     const calls = freshCalls()

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -9,6 +9,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 const SOURCE = "first-prompt-watchdog"
 const SESSION_NEXT_EVENT_PREFIX = "session.next."
@@ -89,7 +90,7 @@ export function observeEventForWatchdog(
     if (!sessionID || !role) return
 
     if (role === "user") {
-      const model = info?.model as string | undefined
+      const model = resolveRuntimeModelFromEventRecord(info) ?? resolveRuntimeModelFromEventRecord(props)
       const agent = info?.agent as string | undefined
       watchdog.onUserMessage(sessionID, model, agent)
       return

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -3,15 +3,27 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError, extractAutoRetrySignal, containsErrorContent } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export { hasVisibleAssistantResponse } from "./visible-assistant-response"
+
+function resolveRecordModel(record: Record<string, unknown> | undefined): string | undefined {
+  return resolveRuntimeModelFromEventRecord(record)
+}
+
+function resolveMessageUpdateModel(
+  props: Record<string, unknown> | undefined,
+  info: Record<string, unknown> | undefined,
+): string | undefined {
+  return resolveRecordModel(info) ?? resolveRecordModel(props)
+}
 
 export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   const { ctx, config, pluginConfig, sessionStates, sessionLastAccess, sessionRetryInFlight, sessionAwaitingFallbackResult, sessionStatusRetryKeys } = deps
@@ -39,7 +51,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       (retrySignal && timeoutEnabled ? { name: "ProviderRateLimitError", message: retrySignal } : undefined) ??
       (errorContentResult.hasError ? { name: "MessageContentError", message: errorContentResult.errorMessage || "Message contains error content" } : undefined)
     const role = info?.role as string | undefined
-    const model = info?.model as string | undefined
+    const model = resolveMessageUpdateModel(props, info)
 
     if (sessionID && role === "assistant" && !error) {
       if (!sessionAwaitingFallbackResult.has(sessionID)) {
@@ -75,7 +87,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         wasAwaitingFallbackResult &&
         pendingFallbackModel &&
         !retrySignal &&
-        model !== pendingFallbackModel
+        !areRuntimeModelsEquivalent(model, pendingFallbackModel)
       ) {
         log(`[${HOOK_NAME}] message.updated fallback skipped - awaiting fallback result`, {
           sessionID,
@@ -86,6 +98,10 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       }
       if (wasAwaitingFallbackResult) {
         sessionAwaitingFallbackResult.delete(sessionID)
+        if (state && areRuntimeModelsEquivalent(model, pendingFallbackModel)) {
+          state.pendingFallbackModel = undefined
+          state.pendingFallbackPromptMayHaveBeenAccepted = false
+        }
       }
       if (sessionRetryInFlight.has(sessionID) && !retrySignal) {
         log(`[${HOOK_NAME}] message.updated fallback skipped (retry in flight)`, { sessionID })

--- a/src/hooks/runtime-fallback/runtime-model-event-record.ts
+++ b/src/hooks/runtime-fallback/runtime-model-event-record.ts
@@ -1,0 +1,14 @@
+import { stringifyRuntimeModel, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+export function resolveRuntimeModelFromEventRecord(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  const model = stringifyRuntimeModelWithVariant(record?.model, record?.variant)
+  if (model) return model
+
+  return stringifyRuntimeModel({
+    providerID: record?.providerID,
+    modelID: record?.modelID,
+    variant: record?.variant,
+  })
+}

--- a/src/hooks/runtime-fallback/runtime-model-event-record.ts
+++ b/src/hooks/runtime-fallback/runtime-model-event-record.ts
@@ -8,7 +8,7 @@ export function resolveRuntimeModelFromEventRecord(
 
   return stringifyRuntimeModel({
     providerID: record?.providerID,
-    modelID: record?.modelID,
+    modelID: record?.modelID ?? record?.id,
     variant: record?.variant,
   })
 }

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -1,9 +1,19 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -34,6 +44,7 @@ function createDeps(): HookDeps {
     },
     options: undefined,
     pluginConfig: {
+      ...testPluginConfig,
       categories: {
         test: {
           fallback_models: ["openai/gpt-5.4", "google/gemini-2.5-pro"],
@@ -46,6 +57,7 @@ function createDeps(): HookDeps {
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
@@ -145,6 +157,101 @@ describe("createSessionStatusHandler", () => {
     ])
     expect(state.currentModel).toBe("google/gemini-2.5-pro")
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given top-level provider model fields with a variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-top-level-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given a model object and separate variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-mixed-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
     SessionCategoryRegistry.clear()
   })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -254,4 +254,50 @@ describe("createSessionStatusHandler", () => {
     ])
     SessionCategoryRegistry.clear()
   })
+
+  it("#given an OpenCode id-shaped model object with variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-id-shaped-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: { providerID: "github-copilot", id: "claude-haiku-4.5", variant: "high" },
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    SessionCategoryRegistry.clear()
+  })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -9,6 +9,7 @@ import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/r
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -26,7 +27,7 @@ export function createSessionStatusHandler(
     const sessionID = resolveSessionEventID(props)
     const status = props?.status as { type?: string; message?: string; attempt?: number } | undefined
     const agent = props?.agent as string | undefined
-    const model = props?.model as string | undefined
+    const model = resolveRuntimeModelFromEventRecord(props)
     const timeoutEnabled = deps.config.timeout_seconds > 0
 
     if (!sessionID || status?.type !== "retry") return

--- a/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -3,6 +3,14 @@ import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
+
 type MessageUpdateHandlerModule = typeof import("./message-update-handler")
 
 async function importFreshMessageUpdateHandlerModule(): Promise<MessageUpdateHandlerModule> {
@@ -37,25 +45,28 @@ function createDeps(messagesResponse: unknown): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
-function createHelpers(clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async () => {},
     clearSessionFallbackTimeout: (sessionID: string) => {
       clearCalls.push(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -91,7 +102,175 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
     // then
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
     expect(clearCalls).toEqual([sessionID])
+  })
+
+  it("#given an object-shaped pending fallback model #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a pending fallback model and mixed message model variant payload #when message.updated errors #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-mixed-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        variant: "high",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a top-level pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-top-level-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      info: {
+        sessionID,
+        role: "assistant",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
   })
 })

--- a/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -187,6 +187,48 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
     expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
   })
 
+  it("#given an OpenCode id-shaped pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-id-shaped-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", id: "claude-haiku-4.5", variant: "high" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
   it("#given a pending fallback model and mixed message model variant payload #when message.updated errors #then the fallback chain advances", async () => {
     // given
     const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -176,6 +176,7 @@ export function createSessionHooks(args: {
         },
         onApplied: enableFallbackTitle ? updateFallbackTitle : undefined,
         controllerAccessor: modelFallbackControllerAccessor,
+        disabledProviders: pluginConfig.disabled_providers,
       }))
     : null
 

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -219,6 +219,7 @@ export function createToolRegistry(args: {
     directory: ctx.directory,
     userCategories: pluginConfig.categories,
     agentOverrides: pluginConfig.agents,
+    disabledProviders: pluginConfig.disabled_providers,
     gitMasterConfig: pluginConfig.git_master,
     sisyphusJuniorModel: getSisyphusJuniorModelOverride(pluginConfig.agents?.["sisyphus-junior"]),
     browserProvider: skillContext.browserProvider,
@@ -313,6 +314,7 @@ export function createToolRegistry(args: {
             userCategories: pluginConfig.categories,
             sisyphusJuniorModel: getSisyphusJuniorModelOverride(pluginConfig.agents?.["sisyphus-junior"]),
             agentOverrides: pluginConfig.agents,
+            disabledProviders: pluginConfig.disabled_providers,
           },
         ),
         team_delete: factories.createTeamDeleteTool(

--- a/src/shared/disabled-providers.test.ts
+++ b/src/shared/disabled-providers.test.ts
@@ -22,6 +22,11 @@ describe("getModelProvider", () => {
     expect(getModelProvider("vercel/openai/gpt-5.5")).toBe("vercel")
   })
 
+  test("trims provider whitespace before returning", () => {
+    expect(getModelProvider(" github-copilot/gpt-5.5")).toBe("github-copilot")
+    expect(getModelProvider("github-copilot /gpt-5.5")).toBe("github-copilot")
+  })
+
   test("returns undefined when the string has no provider prefix", () => {
     expect(getModelProvider("gpt-5.5")).toBeUndefined()
     expect(getModelProvider("")).toBeUndefined()
@@ -49,6 +54,11 @@ describe("isProviderDisabled", () => {
     expect(isProviderDisabled("github-copilot/gpt-5.5", ["GitHub-Copilot"])).toBe(true)
     expect(isProviderDisabled("OPENAI/gpt-5.5", ["openai"])).toBe(true)
     expect(isProviderDisabled("openai/gpt-5.5", ["VERCEL"])).toBe(false)
+  })
+
+  test("trims provider and disabled-list entries before comparing", () => {
+    expect(isProviderDisabled(" github-copilot/gpt-5.5", ["github-copilot"])).toBe(true)
+    expect(isProviderDisabled("github-copilot /gpt-5.5", [" github-copilot "])).toBe(true)
   })
 })
 

--- a/src/shared/disabled-providers.ts
+++ b/src/shared/disabled-providers.ts
@@ -1,5 +1,6 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { FallbackModelObject } from "../config/schema/fallback-models"
+import type { FallbackEntry } from "./model-requirements"
 import { addConfigLoadError } from "./config-errors"
 import { log } from "./logger"
 import { normalizeFallbackModels } from "./model-resolver"
@@ -22,6 +23,35 @@ export function isProviderDisabled(
   if (provider === undefined) return false
   const providerLower = provider.toLowerCase()
   return disabled.some((entry) => entry.trim().toLowerCase() === providerLower)
+}
+
+export function isProviderNameDisabled(
+  providerID: string | undefined,
+  disabled: readonly string[] | undefined,
+): boolean {
+  if (!providerID || !disabled || disabled.length === 0) return false
+
+  const provider = providerID.trim().toLowerCase()
+  if (!provider) return false
+
+  return disabled.some((entry) => entry.trim().toLowerCase() === provider)
+}
+
+export function filterDisabledProvidersFromFallbackChain(
+  fallbackChain: readonly FallbackEntry[] | undefined,
+  disabled: readonly string[] | undefined,
+): FallbackEntry[] | undefined {
+  if (!fallbackChain) return undefined
+  if (!disabled || disabled.length === 0) return [...fallbackChain]
+
+  const filteredChain = fallbackChain
+    .map((entry) => ({
+      ...entry,
+      providers: entry.providers.filter((provider) => !isProviderNameDisabled(provider, disabled)),
+    }))
+    .filter((entry) => entry.providers.length > 0)
+
+  return filteredChain.length > 0 ? filteredChain : undefined
 }
 
 export function filterDisabledProviderModels<T extends string | FallbackModelObject>(

--- a/src/shared/disabled-providers.ts
+++ b/src/shared/disabled-providers.ts
@@ -9,7 +9,8 @@ const HOOK_NAME = "disabled-providers"
 export function getModelProvider(model: string): string | undefined {
   const slash = model.indexOf("/")
   if (slash <= 0) return undefined
-  return model.slice(0, slash)
+  const provider = model.slice(0, slash).trim()
+  return provider || undefined
 }
 
 export function isProviderDisabled(
@@ -20,7 +21,7 @@ export function isProviderDisabled(
   const provider = getModelProvider(model)
   if (provider === undefined) return false
   const providerLower = provider.toLowerCase()
-  return disabled.some((entry) => entry.toLowerCase() === providerLower)
+  return disabled.some((entry) => entry.trim().toLowerCase() === providerLower)
 }
 
 export function filterDisabledProviderModels<T extends string | FallbackModelObject>(

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -1,9 +1,32 @@
-declare const require: (name: string) => any
-const { describe, test, expect, beforeEach, afterEach, spyOn, mock } = require("bun:test")
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from "bun:test"
 import { resolveCategoryExecution } from "./category-resolver"
 import type { ExecutorContext } from "./executor-types"
 import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+
+function mockConnectedProviders(value: ReturnType<typeof connectedProvidersCache.readConnectedProvidersCache>) {
+	const spy = spyOn(connectedProvidersCache, "readConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockProviderModels(value: ReturnType<typeof connectedProvidersCache.readProviderModelsCache>) {
+	const spy = spyOn(connectedProvidersCache, "readProviderModelsCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasConnectedProviders(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasProviderModels(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasProviderModelsCache")
+	spy.mockReturnValue(value)
+	return spy
+}
 
 describe("resolveCategoryExecution", () => {
 	let connectedProvidersSpy: ReturnType<typeof spyOn> | undefined
@@ -13,10 +36,10 @@ describe("resolveCategoryExecution", () => {
 
 	beforeEach(() => {
 		mock.restore()
-		connectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
-		providerModelsSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue(null)
-		hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(false)
-		hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(false)
+		connectedProvidersSpy = mockConnectedProviders(null)
+		providerModelsSpy = mockProviderModels(null)
+		hasConnectedProvidersSpy = mockHasConnectedProviders(false)
+		hasProviderModelsSpy = mockHasProviderModels(false)
 	})
 
 	afterEach(() => {
@@ -118,12 +141,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("promotes object-style fallback model settings to categoryModel when fallback becomes initial model", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-5.4"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "quick",
 			prompt: "test prompt",
@@ -208,12 +231,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("does not apply object-style fallback settings when the configured primary model matches directly", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-5.4-preview"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "quick",
 			prompt: "test prompt",
@@ -254,12 +277,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("matches promoted fallback settings after fuzzy model resolution", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-5.4-preview"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "quick",
 			prompt: "test prompt",
@@ -308,12 +331,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("prefers exact promoted fallback match over earlier fuzzy prefix match", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-5.4-preview"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "quick",
 			prompt: "test prompt",
@@ -359,12 +382,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("matches promoted fallback settings when fuzzy resolution extends configured model without hyphen", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-5.4o"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "quick",
 			prompt: "test prompt",
@@ -405,12 +428,12 @@ describe("resolveCategoryExecution", () => {
 
 	test("prefers the most specific prefix match when fallback entries share a prefix", async () => {
 		//#given
-		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+		const cacheSpy = mockProviderModels({
 			models: { openai: ["gpt-4o"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
-		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const agentsSpy = mockConnectedProviders(["openai"])
 		const args = {
 			category: "deep",
 			prompt: "test prompt",
@@ -622,5 +645,161 @@ describe("resolveCategoryExecution", () => {
 		expect(result.error).toBeUndefined()
 		expect(result.categoryPromptAppend).toContain("GOAL-ORIENTED AUTONOMOUS")
 		expect(result.categoryPromptAppend).toContain("USER_CUSTOM_INSTRUCTION_LEGACY")
+	})
+
+	test("uses runtime model and variant args before category and sisyphus-junior configured models", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			model: "openai/gpt-5.4-mini",
+			variant: "xhigh",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.sisyphusJuniorModel = "anthropic/claude-sonnet-4-6"
+		executorCtx.userCategories = {
+			deep: { model: "anthropic/claude-opus-4-7", variant: "max" },
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4-mini")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4-mini",
+			variant: "xhigh",
+		})
+		expect(result.modelInfo).toEqual({
+			model: "openai/gpt-5.4-mini",
+			type: "user-defined",
+			source: "override",
+		})
+		expect(result.fallbackChain).toBeUndefined()
+	})
+
+	test("uses inline variant from runtime model before category configured variant", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			model: "openai/gpt-5.4-mini high",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: { variant: "max" },
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.categoryModel).toMatchObject({
+			providerID: "openai",
+			modelID: "gpt-5.4-mini",
+			variant: "high",
+		})
+	})
+
+	test("keeps inline runtime model variant when promoted fallback applies object settings", async () => {
+		//#given
+		const cacheSpy = mockProviderModels({
+			models: { openai: ["gpt-5.4"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = mockConnectedProviders(["openai"])
+		const args = {
+			category: "quick",
+			model: "opencode/gemini-3.1-pro high",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			quick: {
+				fallback_models: [
+					{ model: "openai/gpt-5.4", variant: "low", reasoningEffort: "high" },
+				],
+			}
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4",
+			variant: "high",
+			reasoningEffort: "high",
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
+	test("rejects runtime model overrides that use disabled providers", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			model: " github-copilot /gpt-5.5 ",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.disabledProviders = ["github-copilot"]
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.agentToUse).toBe("")
+		expect(result.categoryModel).toBeUndefined()
+		expect(result.error).toBeDefined()
+		if (!result.error) throw new Error("Expected disabled provider error")
+		expect(result.error).toContain("disabled provider")
+		expect(result.error).toContain("github-copilot")
+	})
+
+	test("rejects custom category models that use disabled providers", async () => {
+		//#given
+		const args = {
+			category: "custom-disabled",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.disabledProviders = ["github-copilot"]
+		executorCtx.userCategories = {
+			"custom-disabled": { model: "github-copilot/gpt-5.5" },
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "openai/gpt-5.5")
+
+		//#then
+		expect(result.agentToUse).toBe("")
+		expect(result.categoryModel).toBeUndefined()
+		expect(result.error).toBeDefined()
+		if (!result.error) throw new Error("Expected disabled provider error")
+		expect(result.error).toContain("disabled provider")
+		expect(result.error).toContain("github-copilot")
 	})
 })

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -13,6 +13,7 @@ import { buildFallbackChainFromModels, findMostSpecificFallbackEntry } from "../
 import { CONFIG_BASENAME } from "../../shared/plugin-identity"
 import { getAvailableModelsForDelegateTask } from "./available-models"
 import { resolveModelForDelegateTask } from "./model-selection"
+import { filterDisabledProvidersFromFallbackChain, isModelProviderDisabled, validateRuntimeModelProvider } from "./runtime-model-policy"
 
 import type { CategoryConfig } from "../../config/schema"
 import type { DelegatedModelConfig } from "./types"
@@ -127,6 +128,7 @@ Available categories: ${allCategoryNames}`,
   }
 
   const requirement = CATEGORY_MODEL_REQUIREMENTS[args.category!]
+  const requirementFallbackChain = filterDisabledProvidersFromFallbackChain(requirement?.fallbackChain, executorCtx.disabledProviders)
   const normalizedConfiguredFallbackModels = normalizeFallbackModels(resolved.config.fallback_models)
   let actualModel: string | undefined
   let modelInfo: ModelFallbackInfo | undefined
@@ -135,42 +137,59 @@ Available categories: ${allCategoryNames}`,
   let fallbackEntry: FallbackEntry | undefined
   let matchedFallback = false
 
+  const runtimeModel = args.model?.trim() || undefined
+  const runtimeVariant = args.variant?.trim() || undefined
+  const runtimeModelVariant = runtimeModel ? parseModelString(runtimeModel)?.variant : undefined
+  const runtimeModelError = validateRuntimeModelProvider(runtimeModel, executorCtx.disabledProviders)
+  if (runtimeModelError) {
+    return {
+      agentToUse: "",
+      categoryModel: undefined,
+      categoryPromptAppend: undefined,
+      maxPromptTokens: undefined,
+      modelInfo: undefined,
+      actualModel: undefined,
+      isUnstableAgent: false,
+      error: runtimeModelError,
+    }
+  }
   const overrideModel = sisyphusJuniorModel
   const explicitCategoryModel = userCategories?.[args.category!]?.model
+  const userModelOverride = runtimeModel ?? explicitCategoryModel ?? overrideModel
 
   if (!requirement) {
-    // Precedence: explicit category model > sisyphus-junior default > category resolved model
+    // Precedence: runtime model > explicit category model > sisyphus-junior default > category resolved model
     // This keeps `sisyphus-junior.model` useful as a global default while allowing
-    // per-category overrides via `categories[category].model`.
-    actualModel = explicitCategoryModel ?? overrideModel ?? resolved.model
+    // per-invocation and per-category overrides to beat that global default.
+    actualModel = userModelOverride ?? resolved.model
     if (actualModel) {
-      modelInfo = explicitCategoryModel || overrideModel
+      modelInfo = userModelOverride
         ? { model: actualModel, type: "user-defined", source: "override" }
         : { model: actualModel, type: "system-default", source: "system-default" }
       const parsedModel = parseModelString(actualModel)
-      const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
+      const variantToUse = runtimeVariant ?? runtimeModelVariant ?? userCategories?.[args.category!]?.variant ?? resolved.config.variant
       categoryModel = parsedModel
         ? applyCategoryParams({ ...parsedModel, variant: variantToUse ?? parsedModel.variant }, resolved.config)
         : undefined
     }
   } else {
     const resolution = resolveModelForDelegateTask({
-      userModel: explicitCategoryModel ?? overrideModel,
+      userModel: userModelOverride,
       userFallbackModels: flattenToFallbackModelStrings(normalizedConfiguredFallbackModels),
       categoryDefaultModel: resolved.model,
       isUserConfiguredCategoryModel: resolved.isUserConfiguredModel,
-      fallbackChain: requirement.fallbackChain,
+      fallbackChain: requirementFallbackChain,
       availableModels,
       systemDefaultModel,
+      disabledProviders: executorCtx.disabledProviders,
     })
 
     if (resolution && "skipped" in resolution) {
       isModelResolutionSkipped = true
-      const userModelOverride = explicitCategoryModel ?? overrideModel
       if (userModelOverride) {
         actualModel = userModelOverride
         const parsedModel = parseModelString(userModelOverride)
-        const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
+        const variantToUse = runtimeVariant ?? runtimeModelVariant ?? userCategories?.[args.category!]?.variant ?? resolved.config.variant
         categoryModel = parsedModel
           ? applyCategoryParams({ ...parsedModel, variant: variantToUse ?? parsedModel.variant }, resolved.config)
           : undefined
@@ -201,7 +220,7 @@ Available categories: ${allCategoryNames}`,
       }
 
       const type: "user-defined" | "inherited" | "category-default" | "system-default" =
-        (explicitCategoryModel || overrideModel)
+        userModelOverride
           ? "user-defined"
           : (systemDefaultModel && actualModel === systemDefaultModel)
               ? "system-default"
@@ -217,7 +236,7 @@ Available categories: ${allCategoryNames}`,
       modelInfo = { model: actualModel, type, source }
 
       const parsedModel = parseModelString(actualModel)
-      const variantToUse = userCategories?.[args.category!]?.variant ?? resolvedVariant ?? resolved.config.variant
+      const variantToUse = runtimeVariant ?? runtimeModelVariant ?? userCategories?.[args.category!]?.variant ?? resolvedVariant ?? resolved.config.variant
       categoryModel = parsedModel
         ? applyCategoryParams({ ...parsedModel, variant: variantToUse ?? parsedModel.variant }, resolved.config)
         : undefined
@@ -228,6 +247,23 @@ Available categories: ${allCategoryNames}`,
     const parsedModel = parseModelString(actualModel)
     categoryModel = parsedModel ?? undefined
   }
+
+  if (isModelProviderDisabled(actualModel, executorCtx.disabledProviders)) {
+    const provider = actualModel ? parseModelString(actualModel)?.providerID : undefined
+    return {
+      agentToUse: "",
+      categoryModel: undefined,
+      categoryPromptAppend: undefined,
+      maxPromptTokens: undefined,
+      modelInfo: undefined,
+      actualModel: undefined,
+      isUnstableAgent: false,
+      error: provider
+        ? `Resolved category model "${actualModel}" uses disabled provider "${provider}". Remove the category model or remove "${provider}" from disabled_providers.`
+        : `Resolved category model uses a disabled provider. Remove the category model or update disabled_providers.`,
+    }
+  }
+
   const categoryPromptAppend = resolveCategoryPromptAppendForModel(
     args.category!,
     actualModel,
@@ -263,9 +299,12 @@ Available categories: ${categoryNames.join(", ")}`,
   const defaultProviderID = categoryModel?.providerID
     ?? parseModelString(actualModel ?? "")?.providerID
     ?? "opencode"
-  const configuredFallbackChain = buildFallbackChainFromModels(
-    normalizedConfiguredFallbackModels,
-    defaultProviderID,
+  const configuredFallbackChain = filterDisabledProvidersFromFallbackChain(
+    buildFallbackChainFromModels(
+      normalizedConfiguredFallbackModels,
+      defaultProviderID,
+    ),
+    executorCtx.disabledProviders,
   )
 
   // Only promote fallback-only settings when resolution actually selected a fallback model.
@@ -281,7 +320,7 @@ Available categories: ${categoryNames.join(", ")}`,
   if (categoryModel && effectiveEntry) {
     categoryModel = {
       ...categoryModel,
-      variant: userCategories?.[args.category!]?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
+      variant: runtimeVariant ?? runtimeModelVariant ?? userCategories?.[args.category!]?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
       reasoningEffort: effectiveEntry.reasoningEffort ?? categoryModel.reasoningEffort,
       temperature: effectiveEntry.temperature ?? categoryModel.temperature,
       top_p: effectiveEntry.top_p ?? categoryModel.top_p,
@@ -299,6 +338,6 @@ Available categories: ${categoryNames.join(", ")}`,
     actualModel,
     isUnstableAgent,
     // Don't use hardcoded fallback chain when resolution was skipped (cold cache)
-    fallbackChain: configuredFallbackChain ?? ((isModelResolutionSkipped || explicitCategoryModel || overrideModel) ? undefined : requirement?.fallbackChain),
+    fallbackChain: configuredFallbackChain ?? ((isModelResolutionSkipped || userModelOverride) ? undefined : requirementFallbackChain),
   }
 }

--- a/src/tools/delegate-task/executor-types.ts
+++ b/src/tools/delegate-task/executor-types.ts
@@ -12,6 +12,7 @@ export interface ExecutorContext {
   sisyphusJuniorModel?: string
   browserProvider?: BrowserAutomationProvider
   agentOverrides?: AgentOverrides
+  disabledProviders?: string[]
   sisyphusAgentConfig?: SisyphusAgentConfig
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -4,6 +4,24 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:
 import { resolveModelForDelegateTask } from "./model-selection"
 import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 
+function mockConnectedProviders(value: ReturnType<typeof connectedProvidersCache.readConnectedProvidersCache>) {
+	const spy = spyOn(connectedProvidersCache, "readConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasConnectedProviders(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasProviderModels(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasProviderModelsCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
 describe("resolveModelForDelegateTask", () => {
 	let hasConnectedProvidersSpy: ReturnType<typeof spyOn> | undefined
 	let hasProviderModelsSpy: ReturnType<typeof spyOn> | undefined
@@ -19,8 +37,8 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given no provider cache exists (pre-cache scenario)", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(false)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(false)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(false)
+			hasProviderModelsSpy = mockHasProviderModels(false)
 		})
 
 		describe("#when availableModels is empty and no user model override", () => {
@@ -72,13 +90,13 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given provider cache exists", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		describe("#when availableModels is empty (cache exists but empty)", () => {
 			test("#then keeps the category default when its provider is connected", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
@@ -94,7 +112,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then skips a disconnected category default and resolves via a connected fallback", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
@@ -115,7 +133,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then skips disconnected user fallback models and keeps the first connected fallback", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					userFallbackModels: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"],
@@ -138,6 +156,25 @@ describe("resolveModelForDelegateTask", () => {
 				})
 
 				expect(result).toEqual({ model: "anthropic/claude-sonnet-4.6" })
+			})
+
+			test("#then skips disabled hardcoded defaults and chooses an allowed fallback", () => {
+				const result = resolveModelForDelegateTask({
+					categoryDefaultModel: "github-copilot/gpt-5.5",
+					fallbackChain: [
+						{ providers: ["github-copilot"], model: "gpt-5.5", variant: "medium" },
+						{ providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					],
+					availableModels: new Set(["github-copilot/gpt-5.5", "openai/gpt-5.5"]),
+					disabledProviders: ["github-copilot"],
+				})
+
+				expect(result).toEqual({
+					model: "openai/gpt-5.5",
+					variant: "medium",
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					matchedFallback: true,
+				})
 			})
 
 			test("#then trusts user-configured category model without fuzzy validation", () => {
@@ -220,8 +257,8 @@ describe("resolveModelForDelegateTask", () => {
 		let readConnectedProvidersSpy: ReturnType<typeof spyOn> | undefined
 
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		afterEach(() => {
@@ -229,8 +266,27 @@ describe("resolveModelForDelegateTask", () => {
 		})
 
 		describe("#when availableModels is empty and fallback chain starts with unauthenticated provider", () => {
+			test("#then skips disabled providers inside connected hardcoded fallback entries", () => {
+				readConnectedProvidersSpy = mockConnectedProviders(["github-copilot", "openai"])
+
+				const result = resolveModelForDelegateTask({
+					fallbackChain: [
+						{ providers: ["github-copilot", "openai"], model: "gpt-5.5", variant: "medium" },
+					],
+					availableModels: new Set(),
+					disabledProviders: ["github-copilot"],
+				})
+
+				expect(result).toEqual({
+					model: "openai/gpt-5.5",
+					variant: "medium",
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					matchedFallback: true,
+				})
+			})
+
 			test("#then skips unauthenticated providers and resolves to first connected one", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai", "anthropic"])
+				readConnectedProvidersSpy = mockConnectedProviders(["openai", "anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -249,7 +305,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then resolves first provider in entry that is connected", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai", "github-copilot"])
+				readConnectedProvidersSpy = mockConnectedProviders(["openai", "github-copilot"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -266,7 +322,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then falls through to system default when no provider in chain is connected", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
+				readConnectedProvidersSpy = mockConnectedProviders(["anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -283,7 +339,7 @@ describe("resolveModelForDelegateTask", () => {
 
 		describe("#when connected providers cache is null (not yet populated)", () => {
 			test("#then falls back to first entry in chain (legacy behavior)", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+				readConnectedProvidersSpy = mockConnectedProviders(null)
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -352,8 +408,8 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given user-configured category model includes variant syntax", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		describe("#when categoryDefaultModel with isUserConfiguredCategoryModel contains a space-separated variant", () => {
@@ -395,13 +451,13 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given only connected providers cache exists (no provider-models cache)", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(false)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(false)
 		})
 
 		describe("#when availableModels is empty", () => {
 			test("#then uses connected providers to avoid disconnected category defaults", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -5,6 +5,7 @@ import { transformModelForProvider } from "../../shared/provider-model-id-transf
 import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 import { log } from "../../shared/logger"
 import { parseModelString, parseVariantFromModelID } from "../../shared/model-string-parser"
+import { filterDisabledProvidersFromFallbackChain, isModelProviderDisabled, isProviderNameDisabled } from "./runtime-model-policy"
 
 function isExplicitHighModel(model: string): boolean {
   return /(?:^|\/)[^/]+-high$/.test(model)
@@ -12,6 +13,11 @@ function isExplicitHighModel(model: string): boolean {
 
 function getExplicitHighBaseModel(model: string): string | null {
   return isExplicitHighModel(model) ? model.replace(/-high$/, "") : null
+}
+
+function filterAvailableModels(availableModels: Set<string>, disabledProviders: readonly string[] | undefined): Set<string> {
+  if (!disabledProviders || disabledProviders.length === 0) return availableModels
+  return new Set([...availableModels].filter((model) => !isModelProviderDisabled(model, disabledProviders)))
 }
 
 function parseUserFallbackModel(fallbackModel: string): {
@@ -53,7 +59,10 @@ export function resolveModelForDelegateTask(input: {
   fallbackChain?: FallbackEntry[]
   availableModels: Set<string>
   systemDefaultModel?: string
+  disabledProviders?: readonly string[]
 }): { model: string; variant?: string; fallbackEntry?: FallbackEntry; matchedFallback?: boolean } | { skipped: true } | undefined {
+  const disabledProviders = input.disabledProviders
+  const availableModels = filterAvailableModels(input.availableModels, disabledProviders)
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     const parsed = parseUserFallbackModel(userModel)
@@ -67,20 +76,21 @@ export function resolveModelForDelegateTask(input: {
     // instead of returning an unreachable model. Cold cache (no availability
     // data yet) preserves the legacy "trust the user" behavior.
     const userFallbackModels = input.userFallbackModels
+      ?.filter((fallbackModel) => !isModelProviderDisabled(fallbackModel, disabledProviders))
     if (
-      input.availableModels.size > 0 &&
+      availableModels.size > 0 &&
       userFallbackModels &&
       userFallbackModels.length > 0
     ) {
       const providerHint = parsed?.providerHint
-      const primaryMatch = fuzzyMatchModel(userResult.model, input.availableModels, providerHint)
+      const primaryMatch = fuzzyMatchModel(userResult.model, availableModels, providerHint)
       if (!primaryMatch) {
         for (const fallbackModel of userFallbackModels) {
           const parsedFallback = parseUserFallbackModel(fallbackModel)
           if (!parsedFallback) continue
           const fbMatch = fuzzyMatchModel(
             parsedFallback.baseModel,
-            input.availableModels,
+            availableModels,
             parsedFallback.providerHint,
           )
           if (fbMatch) {
@@ -98,15 +108,21 @@ export function resolveModelForDelegateTask(input: {
       }
     }
 
-    return userResult
+    if (!isModelProviderDisabled(userResult.model, disabledProviders)) {
+      return userResult
+    }
+    return undefined
   }
 
-  const connectedProviders = input.availableModels.size === 0 ? connectedProvidersCache.readConnectedProvidersCache() : null
+  const rawConnectedProviders = availableModels.size === 0 ? connectedProvidersCache.readConnectedProvidersCache() : null
+  const connectedProviders = rawConnectedProviders
+    ? rawConnectedProviders.filter((provider) => !isProviderNameDisabled(provider, disabledProviders))
+    : null
 
   // Before provider cache is created (first run), skip model resolution entirely.
   // OpenCode will use its system default model when no model is specified in the prompt.
   if (
-    input.availableModels.size === 0 &&
+    availableModels.size === 0 &&
     !connectedProvidersCache.hasProviderModelsCache() &&
     !connectedProvidersCache.hasConnectedProvidersCache()
   ) {
@@ -116,7 +132,7 @@ export function resolveModelForDelegateTask(input: {
   const categoryDefault = normalizeModel(input.categoryDefaultModel)
   const explicitHighBaseModel = categoryDefault ? getExplicitHighBaseModel(categoryDefault) : null
   const explicitHighModel = explicitHighBaseModel ? categoryDefault : undefined
-  if (categoryDefault) {
+  if (categoryDefault && !isModelProviderDisabled(categoryDefault, disabledProviders)) {
     if (input.isUserConfiguredCategoryModel) {
       log("[resolveModelForDelegateTask] using user-configured category model (bypass validation)", {
         categoryDefaultModel: categoryDefault,
@@ -128,7 +144,7 @@ export function resolveModelForDelegateTask(input: {
       return { model: categoryDefault }
     }
 
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       const categoryProvider = categoryDefault.includes("/") ? categoryDefault.split("/")[0] : undefined
       if (!connectedProviders || !categoryProvider || connectedProviders.includes(categoryProvider)) {
         return { model: categoryDefault }
@@ -142,7 +158,7 @@ export function resolveModelForDelegateTask(input: {
 
     const parts = categoryDefault.split("/")
     const providerHint = parts.length >= 2 ? [parts[0]] : undefined
-    const match = fuzzyMatchModel(categoryDefault, input.availableModels, providerHint)
+    const match = fuzzyMatchModel(categoryDefault, availableModels, providerHint)
     if (match) {
       if (isExplicitHighModel(categoryDefault) && match !== categoryDefault) {
         return { model: categoryDefault }
@@ -153,8 +169,9 @@ export function resolveModelForDelegateTask(input: {
   }
 
   const userFallbackModels = input.userFallbackModels
+    ?.filter((fallbackModel) => !isModelProviderDisabled(fallbackModel, disabledProviders))
   if (userFallbackModels && userFallbackModels.length > 0) {
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       for (const fallbackModel of userFallbackModels) {
         const parsedFallback = parseUserFallbackModel(fallbackModel)
         if (!parsedFallback) continue
@@ -174,7 +191,7 @@ export function resolveModelForDelegateTask(input: {
         const parsedFallback = parseUserFallbackModel(fallbackModel)
         if (!parsedFallback) continue
 
-        const match = fuzzyMatchModel(parsedFallback.baseModel, input.availableModels, parsedFallback.providerHint)
+        const match = fuzzyMatchModel(parsedFallback.baseModel, availableModels, parsedFallback.providerHint)
         if (match) {
           return { model: match, variant: parsedFallback.variant, matchedFallback: true }
         }
@@ -182,9 +199,9 @@ export function resolveModelForDelegateTask(input: {
     }
   }
 
-  const fallbackChain = input.fallbackChain
+  const fallbackChain = filterDisabledProvidersFromFallbackChain(input.fallbackChain, disabledProviders)
   if (fallbackChain && fallbackChain.length > 0) {
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       if (connectedProviders) {
         const connectedSet = new Set(connectedProviders)
         for (const entry of fallbackChain) {
@@ -212,7 +229,7 @@ export function resolveModelForDelegateTask(input: {
       for (const entry of fallbackChain) {
         for (const provider of entry.providers) {
           const fullModel = `${provider}/${entry.model}`
-          const match = fuzzyMatchModel(fullModel, input.availableModels, [provider])
+          const match = fuzzyMatchModel(fullModel, availableModels, [provider])
           if (match) {
             if (explicitHighModel && entry.variant === "high" && match === explicitHighBaseModel) {
               return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
@@ -222,7 +239,7 @@ export function resolveModelForDelegateTask(input: {
           }
         }
 
-        const crossProviderMatch = fuzzyMatchModel(entry.model, input.availableModels)
+        const crossProviderMatch = fuzzyMatchModel(entry.model, availableModels)
         if (crossProviderMatch) {
           if (explicitHighModel && entry.variant === "high" && crossProviderMatch === explicitHighBaseModel) {
             return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
@@ -235,7 +252,7 @@ export function resolveModelForDelegateTask(input: {
   }
 
   const systemDefaultModel = normalizeModel(input.systemDefaultModel)
-  if (systemDefaultModel) {
+  if (systemDefaultModel && !isModelProviderDisabled(systemDefaultModel, disabledProviders)) {
     return { model: systemDefaultModel }
   }
 

--- a/src/tools/delegate-task/runtime-model-policy.ts
+++ b/src/tools/delegate-task/runtime-model-policy.ts
@@ -1,0 +1,53 @@
+import type { FallbackEntry } from "../../shared/model-requirements"
+import { getModelProvider, isProviderDisabled } from "../../shared/disabled-providers"
+
+export function validateRuntimeModelProvider(
+  runtimeModel: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): string | undefined {
+  if (!runtimeModel || !disabledProviders || disabledProviders.length === 0) return undefined
+  if (!isProviderDisabled(runtimeModel, disabledProviders)) return undefined
+
+  const provider = getModelProvider(runtimeModel)
+  return provider
+    ? `Runtime model override "${runtimeModel}" uses disabled provider "${provider}". Remove the model override or remove "${provider}" from disabled_providers.`
+    : `Runtime model override "${runtimeModel}" uses a disabled provider. Remove the model override or update disabled_providers.`
+}
+
+
+export function isProviderNameDisabled(
+  providerID: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): boolean {
+  if (!providerID || !disabledProviders || disabledProviders.length === 0) return false
+
+  const provider = providerID.trim().toLowerCase()
+  if (!provider) return false
+
+  return disabledProviders.some((entry) => entry.trim().toLowerCase() === provider)
+}
+
+export function isModelProviderDisabled(
+  model: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): boolean {
+  if (!model || !disabledProviders || disabledProviders.length === 0) return false
+  return isProviderDisabled(model, disabledProviders)
+}
+
+export function filterDisabledProvidersFromFallbackChain(
+  fallbackChain: readonly FallbackEntry[] | undefined,
+  disabledProviders: readonly string[] | undefined,
+): FallbackEntry[] | undefined {
+  if (!fallbackChain) return undefined
+  if (!disabledProviders || disabledProviders.length === 0) return [...fallbackChain]
+
+  const filteredChain = fallbackChain
+    .map((entry) => ({
+      ...entry,
+      providers: entry.providers.filter((provider) => !isProviderNameDisabled(provider, disabledProviders)),
+    }))
+    .filter((entry) => entry.providers.length > 0)
+
+  return filteredChain.length > 0 ? filteredChain : undefined
+}

--- a/src/tools/delegate-task/runtime-model-policy.ts
+++ b/src/tools/delegate-task/runtime-model-policy.ts
@@ -1,5 +1,14 @@
-import type { FallbackEntry } from "../../shared/model-requirements"
-import { getModelProvider, isProviderDisabled } from "../../shared/disabled-providers"
+import {
+  filterDisabledProvidersFromFallbackChain as filterSharedDisabledProvidersFromFallbackChain,
+  getModelProvider,
+  isProviderDisabled,
+  isProviderNameDisabled as isSharedProviderNameDisabled,
+} from "../../shared/disabled-providers"
+
+export {
+  filterSharedDisabledProvidersFromFallbackChain as filterDisabledProvidersFromFallbackChain,
+  isSharedProviderNameDisabled as isProviderNameDisabled,
+}
 
 export function validateRuntimeModelProvider(
   runtimeModel: string | undefined,
@@ -15,39 +24,10 @@ export function validateRuntimeModelProvider(
 }
 
 
-export function isProviderNameDisabled(
-  providerID: string | undefined,
-  disabledProviders: readonly string[] | undefined,
-): boolean {
-  if (!providerID || !disabledProviders || disabledProviders.length === 0) return false
-
-  const provider = providerID.trim().toLowerCase()
-  if (!provider) return false
-
-  return disabledProviders.some((entry) => entry.trim().toLowerCase() === provider)
-}
-
 export function isModelProviderDisabled(
   model: string | undefined,
   disabledProviders: readonly string[] | undefined,
 ): boolean {
   if (!model || !disabledProviders || disabledProviders.length === 0) return false
   return isProviderDisabled(model, disabledProviders)
-}
-
-export function filterDisabledProvidersFromFallbackChain(
-  fallbackChain: readonly FallbackEntry[] | undefined,
-  disabledProviders: readonly string[] | undefined,
-): FallbackEntry[] | undefined {
-  if (!fallbackChain) return undefined
-  if (!disabledProviders || disabledProviders.length === 0) return [...fallbackChain]
-
-  const filteredChain = fallbackChain
-    .map((entry) => ({
-      ...entry,
-      providers: entry.providers.filter((provider) => !isProviderNameDisabled(provider, disabledProviders)),
-    }))
-    .filter((entry) => entry.providers.length > 0)
-
-  return filteredChain.length > 0 ? filteredChain : undefined
 }

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -26,6 +26,8 @@ import { normalizeSDKResponse } from "../../shared"
 import { normalizeModelFormat } from "../../shared/model-format-normalizer"
 import { flattenToFallbackModelStrings, normalizeFallbackModels } from "../../shared/model-resolver"
 import { log } from "../../shared/logger"
+import { filterDisabledProvidersFromFallbackChain, isModelProviderDisabled, validateRuntimeModelProvider } from "./runtime-model-policy"
+import { parseModelString } from "./model-string-parser"
 
 const DEFAULT_PLAN_FALLBACK_AGENT = "plan"
 const RESERVED_HIDDEN_NATIVE_AGENTS = new Set(["build"])
@@ -118,6 +120,12 @@ Create the work plan directly - that's your job as the planning agent.`,
   let agentToUse = agentName
   let categoryModel: DelegatedModelConfig | undefined
   let fallbackChain: FallbackEntry[] | undefined
+  const runtimeModel = args.model?.trim() || undefined
+  const runtimeModelVariant = runtimeModel ? parseModelString(runtimeModel)?.variant : undefined
+  const runtimeModelError = validateRuntimeModelProvider(runtimeModel, executorCtx.disabledProviders)
+  if (runtimeModelError) {
+    return { agentToUse: "", categoryModel: undefined, error: runtimeModelError }
+  }
 
   try {
     const agentsResult = await client.app.agents()
@@ -178,10 +186,12 @@ Create the work plan directly - that's your job as the planning agent.`,
       ? matchedAgent.name
       : stripAgentListSortPrefix(matchedAgent.name)
 
+    const runtimeVariant = args.variant?.trim() || undefined
     const agentConfigKey = getAgentConfigKey(agentToUse)
     const agentOverride = agentOverrides?.[agentConfigKey as keyof typeof agentOverrides]
       ?? (agentOverrides ? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1] : undefined)
     const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentConfigKey]
+    const agentRequirementFallbackChain = filterDisabledProvidersFromFallbackChain(agentRequirement?.fallbackChain, executorCtx.disabledProviders)
     const agentCategoryConfig = agentOverride?.category
       ? userCategories?.[agentOverride.category]
       : undefined
@@ -190,10 +200,17 @@ Create the work plan directly - that's your job as the planning agent.`,
       agentOverride?.fallback_models
       ?? agentCategoryConfig?.fallback_models
     )
+    const agentOverrideModelCandidate = agentOverride
+      ? (agentOverride as Record<string, unknown>).model
+      : undefined
+    const agentOverrideModel = typeof agentOverrideModelCandidate === "string"
+      ? agentOverrideModelCandidate
+      : undefined
+    const userModelOverride = runtimeModel ?? agentOverrideModel ?? agentCategoryModel
 
     const availableModels = await getAvailableModelsForDelegateTask(client)
 
-    if (agentOverride?.model || agentCategoryModel || agentRequirement || matchedAgent.model) {
+    if (userModelOverride || agentRequirement || matchedAgent.model) {
 
       const normalizedMatchedModel = matchedAgent.model
         ? normalizeModelFormat(matchedAgent.model)
@@ -203,12 +220,13 @@ Create the work plan directly - that's your job as the planning agent.`,
         : undefined
 
       const resolution = resolveModelForDelegateTask({
-        userModel: agentOverride?.model ?? agentCategoryModel,
+        userModel: userModelOverride,
         userFallbackModels: flattenToFallbackModelStrings(normalizedAgentFallbackModels),
         categoryDefaultModel: matchedAgentModelStr,
-        fallbackChain: agentRequirement?.fallbackChain,
+        fallbackChain: agentRequirementFallbackChain,
         availableModels,
         systemDefaultModel: undefined,
+        disabledProviders: executorCtx.disabledProviders,
       })
 
       const resolutionSkipped = resolution && 'skipped' in resolution
@@ -216,20 +234,20 @@ Create the work plan directly - that's your job as the planning agent.`,
       if (resolution && !resolutionSkipped) {
         const normalized = normalizeModelFormat(resolution.model)
         if (normalized) {
-          const variantToUse = agentOverride?.variant ?? resolution.variant ?? agentCategoryConfig?.variant
+          const variantToUse = runtimeVariant ?? runtimeModelVariant ?? agentOverride?.variant ?? resolution.variant ?? agentCategoryConfig?.variant
           const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
           categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
         }
-      } else if (resolutionSkipped && (agentOverride?.model ?? agentCategoryModel)) {
-        const explicitModel = agentOverride?.model ?? agentCategoryModel
+      } else if (resolutionSkipped && userModelOverride) {
+        const explicitModel = userModelOverride
         const normalized = explicitModel ? normalizeModelFormat(explicitModel) : undefined
         if (normalized) {
-          const variantToUse = agentOverride?.variant ?? agentCategoryConfig?.variant
+          const variantToUse = runtimeVariant ?? runtimeModelVariant ?? agentOverride?.variant ?? agentCategoryConfig?.variant
           const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
           categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
           log("[delegate-task] Cold cache: using explicit user override for subagent", {
             agent: agentToUse,
-            model: agentOverride?.model ?? agentCategoryModel,
+            model: explicitModel,
           })
         }
       }
@@ -237,11 +255,14 @@ Create the work plan directly - that's your job as the planning agent.`,
       const defaultProviderID = categoryModel?.providerID
         ?? normalizedMatchedModel?.providerID
         ?? "opencode"
-      const configuredFallbackChain = buildFallbackChainFromModels(
-        normalizedAgentFallbackModels,
-        defaultProviderID,
+      const configuredFallbackChain = filterDisabledProvidersFromFallbackChain(
+        buildFallbackChainFromModels(
+          normalizedAgentFallbackModels,
+          defaultProviderID,
+        ),
+        executorCtx.disabledProviders,
       )
-      fallbackChain = configuredFallbackChain ?? (resolutionSkipped ? undefined : agentRequirement?.fallbackChain)
+      fallbackChain = configuredFallbackChain ?? ((resolutionSkipped || userModelOverride) ? undefined : agentRequirementFallbackChain)
       const effectiveEntry = resolveEffectiveFallbackEntry({
         categoryModel,
         configuredFallbackChain,
@@ -252,7 +273,7 @@ Create the work plan directly - that's your job as the planning agent.`,
         categoryModel = applyFallbackEntrySettings({
           categoryModel,
           effectiveEntry,
-          variantOverride: agentOverride?.variant,
+          variantOverride: runtimeVariant ?? runtimeModelVariant ?? agentOverride?.variant,
         })
       }
     }
@@ -261,7 +282,10 @@ Create the work plan directly - that's your job as the planning agent.`,
       const normalizedMatchedModel = normalizeModelFormat(matchedAgent.model)
       if (normalizedMatchedModel) {
         const fullModel = `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
-        if (availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID])) {
+        if (
+          !isModelProviderDisabled(fullModel, executorCtx.disabledProviders) &&
+          (availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID]))
+        ) {
           categoryModel = normalizedMatchedModel
         } else {
           log("[delegate-task] Skipping unavailable agent default model", {

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -282,9 +282,15 @@ Create the work plan directly - that's your job as the planning agent.`,
       const normalizedMatchedModel = normalizeModelFormat(matchedAgent.model)
       if (normalizedMatchedModel) {
         const fullModel = `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
+        if (isModelProviderDisabled(fullModel, executorCtx.disabledProviders)) {
+          return {
+            agentToUse: "",
+            categoryModel: undefined,
+            error: `Discovered default model "${fullModel}" for agent "${agentToUse}" uses a disabled provider. Configure an allowed model for this agent or remove the provider from disabled_providers.`,
+          }
+        }
         if (
-          !isModelProviderDisabled(fullModel, executorCtx.disabledProviders) &&
-          (availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID]))
+          availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID])
         ) {
           categoryModel = normalizedMatchedModel
         } else {

--- a/src/tools/delegate-task/tool-argument-preparation.test.ts
+++ b/src/tools/delegate-task/tool-argument-preparation.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { prepareDelegateTaskArgs } from "./tool-argument-preparation"
+import type { ToolContextWithMetadata } from "./types"
+
+function createToolContext(): ToolContextWithMetadata {
+	return {
+		sessionID: "ses_test",
+		messageID: "msg_test",
+		agent: "sisyphus",
+		abort: new AbortController().signal,
+	}
+}
+
+describe("prepareDelegateTaskArgs", () => {
+	test("preserves runtime model and variant arguments", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			model: "openai/gpt-5.5",
+			variant: "xhigh",
+			prompt: "Implement the thing",
+			run_in_background: false,
+			load_skills: [],
+		}
+
+		//#when
+		const result = await prepareDelegateTaskArgs(args, createToolContext())
+
+		//#then
+		expect(result.model).toBe("openai/gpt-5.5")
+		expect(result.variant).toBe("xhigh")
+		expect(args.model).toBe("openai/gpt-5.5")
+		expect(args.variant).toBe("xhigh")
+	})
+})

--- a/src/tools/delegate-task/tool-argument-preparation.ts
+++ b/src/tools/delegate-task/tool-argument-preparation.ts
@@ -80,10 +80,14 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
 
   const taskID = typeof args.task_id === "string" ? args.task_id : undefined
   const command = typeof args.command === "string" ? args.command : undefined
+  const model = typeof args.model === "string" && args.model.trim() !== "" ? args.model.trim() : undefined
+  const variant = typeof args.variant === "string" && args.variant.trim() !== "" ? args.variant.trim() : undefined
 
   args.category = category
   args.subagent_type = subagentType
   args.requested_subagent_type = originalSubagentType
+  args.model = model
+  args.variant = variant
   args.description = description
   args.prompt = prompt
   args.run_in_background = runInBackground
@@ -95,6 +99,8 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
     category,
     subagent_type: subagentType,
     requested_subagent_type: originalSubagentType,
+    model,
+    variant,
     description,
     prompt,
     run_in_background: runInBackground === true,

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -47,6 +47,8 @@ const delegateTaskArgsSchema = {
     .describe("Optional; defaults to false (sync). true=async (returns background task ID `bg_...` for background_output), false=sync (waits). Use true ONLY for parallel exploration; otherwise omit or pass false for task delegation."),
   category: tool.schema.string().optional().describe("REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type."),
   subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type."),
+  model: tool.schema.string().optional().describe("Optional runtime model override for this delegated task, in provider/model format. Overrides category and agent config for this invocation only."),
+  variant: tool.schema.string().optional().describe("Optional runtime model variant for this delegated task, such as low, medium, high, xhigh, or max."),
   task_id: tool.schema
     .string()
     .optional()

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -15,6 +15,8 @@ export interface DelegateTaskArgs {
   category?: string
   subagent_type?: string
   requested_subagent_type?: string
+  model?: string
+  variant?: string
   run_in_background: boolean
   task_id?: string
   command?: string
@@ -66,6 +68,7 @@ export interface DelegateTaskToolOptions {
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]
   agentOverrides?: AgentOverrides
+  disabledProviders?: string[]
   sisyphusAgentConfig?: SisyphusAgentConfig
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -219,6 +219,111 @@ describe("resolveSubagentExecution", () => {
     expect(result.agentToUse).toBe("Sisyphus-Junior")
   })
 
+  test("uses runtime model and variant before subagent config models", async () => {
+    //#given
+    readProviderModelsCacheMock.mockReturnValue({
+      models: {
+        anthropic: ["claude-opus-4-7"],
+        openai: ["gpt-5.5"],
+      },
+      connected: ["anthropic", "openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({
+      subagent_type: "sisyphus-junior",
+      model: "openai/gpt-5.5",
+      variant: "xhigh",
+    })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "Sisyphus-Junior", mode: "subagent", model: "anthropic/claude-opus-4-7" },
+        { name: "oracle", mode: "subagent" },
+      ]),
+      {
+        agentOverrides: {
+          "sisyphus-junior": { model: "anthropic/claude-opus-4-7", variant: "max" },
+        } as ExecutorContext["agentOverrides"],
+      },
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {
+      allowSisyphusJuniorDirect: true,
+    })
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("Sisyphus-Junior")
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      variant: "xhigh",
+    })
+    expect(result.fallbackChain).toBeUndefined()
+  })
+
+  test("uses inline variant from runtime model before subagent configured variant", async () => {
+    //#given
+    readProviderModelsCacheMock.mockReturnValue({
+      models: {
+        openai: ["gpt-5.5"],
+      },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({
+      subagent_type: "sisyphus-junior",
+      model: "openai/gpt-5.5 high",
+    })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "Sisyphus-Junior", mode: "subagent", model: "openai/gpt-5.5" },
+      ]),
+      {
+        agentOverrides: {
+          "sisyphus-junior": { variant: "max" },
+        } as ExecutorContext["agentOverrides"],
+      },
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {
+      allowSisyphusJuniorDirect: true,
+    })
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      variant: "high",
+    })
+  })
+
+  test("rejects runtime model overrides that use disabled providers", async () => {
+    //#given
+    const args = createBaseArgs({
+      subagent_type: "sisyphus-junior",
+      model: " github-copilot /gpt-5.5 ",
+    })
+    const executorCtx = createExecutorContext(async () => {
+      throw new Error("agent discovery should not be called")
+    }, {
+      disabledProviders: ["github-copilot"],
+    })
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep", {
+      allowSisyphusJuniorDirect: true,
+    })
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.categoryModel).toBeUndefined()
+    expect(result.error).toContain("disabled provider")
+    expect(result.error).toContain("github-copilot")
+  })
+
   test("renders a usable fallback hint when categoryExamples is empty for the default Sisyphus-Junior block", async () => {
     //#given
     const args = createBaseArgs({ subagent_type: "sisyphus-junior" })

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -324,6 +324,25 @@ describe("resolveSubagentExecution", () => {
     expect(result.error).toContain("github-copilot")
   })
 
+  test("rejects disabled discovered agent defaults when no allowed model is selected", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "worker" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "worker", mode: "subagent", model: "github-copilot/gpt-5.5" },
+    ]), {
+      disabledProviders: ["github-copilot"],
+    })
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.categoryModel).toBeUndefined()
+    expect(result.error).toContain("disabled provider")
+    expect(result.error).toContain("github-copilot/gpt-5.5")
+  })
+
   test("renders a usable fallback hint when categoryExamples is empty for the default Sisyphus-Junior block", async () => {
     //#given
     const args = createBaseArgs({ subagent_type: "sisyphus-junior" })


### PR DESCRIPTION
## Summary

- Normalize string/object/top-level/mixed runtime model payloads in runtime-fallback events, including OpenCode's `{ id, providerID, variant }` model shape.
- Preserve model variants across `session.error`, `message.updated`, `session.status`, `session.created`, and first-prompt watchdog paths.
- Compare fallback candidates using canonical runtime model equivalence instead of raw payload shapes.

Fixes #4315.

## Why

OpenCode 1.15.x can emit model payloads as objects instead of strings. The runtime-fallback code previously stored objects that used `id` instead of `modelID` and later called string methods during equivalence checks, causing `current.toLowerCase is not a function`.

## Review notes

This is broader than #4326: it normalizes payloads at hook boundaries instead of only adding defensive string guards, and it covers both `modelID` and `id` object keys.

## Testing

- `bun test src/hooks/runtime-fallback/fallback-state.test.ts src/hooks/runtime-fallback/event-handler.test.ts src/hooks/runtime-fallback/session-status-handler.test.ts src/hooks/runtime-fallback/first-prompt-watchdog.test.ts src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts`
- `bun test src/hooks/runtime-fallback/*.test.ts`
- `bun run typecheck`
- `bun run build`
- Manual driver for `id`-shaped runtime model normalization plus session.status/session.created/message.updated/watchdog variant preservation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes runtime model payloads across runtime-fallback and preserves variants, accepting object-shaped `{ id, providerID, variant }` models to prevent crashes. Adds per-task runtime model overrides and enforces `disabled_providers` during model selection and fallback; fixes #4315.

- **Bug Fixes**
  - Normalize event models from strings or objects (including OpenCode’s `{ id, providerID, variant }`) and compare using canonical equivalence.
  - Preserve variants through `session.error`, `message.updated`, `session.status`, `session.created`, and first-prompt watchdog.
  - Accept object-shaped models when bootstrapping fallback and when resolving models from event records.

- **New Features**
  - Delegate tasks accept runtime `model` and `variant` overrides; team-mode forwards these to category and subagent executions.
  - Enforce `disabled_providers` by filtering fallback chains and available models; reject runtime overrides that target disabled providers.
  - Pass `disabled_providers` into model-fallback and tool execution contexts for consistent policy application.

<sup>Written for commit cf22b8043268d2ec755933de3483f8e6eeefc4c9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4338?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

