### PR TITLE
feat(delegate-task): accept runtime model arguments

### DIFF
--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -1,8 +1,18 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createEventHandler } from "./event-handler"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -32,7 +42,7 @@ function createDeps(): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
@@ -43,7 +53,7 @@ function createDeps(): HookDeps {
   }
 }
 
-function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async (sessionID: string) => {
       abortCalls.push(sessionID)
@@ -53,8 +63,10 @@ function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[
       deps.sessionFallbackTimeouts.delete(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -103,7 +115,7 @@ describe("createEventHandler", () => {
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
     expect(clearCalls).toEqual([sessionID])
     expect(abortCalls).toEqual([])
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
   })
 
   it("#given a cancelled session #when session.error receives an abort error #then fallback retry state is reset", async () => {
@@ -247,5 +259,229 @@ describe("createEventHandler", () => {
 
     // then - counter is at 2, not reset to 0
     expect(deps.sessionStates.get(sessionID)?.attemptCount).toBe(2)
+  })
+
+  it("#given an object-shaped pending fallback model #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a model object without variant and a top-level variant #when session.error arrives #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-mixed-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a top-level event model with a variant #when session.error bootstraps fallback state #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-top-level-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a session.created info model object and separate variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-info-mixed-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          info: {
+            id: sessionID,
+            model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+            variant: "high",
+          },
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  it("#given top-level session.created provider model fields with a variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-top-level-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
   })
 })

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -3,7 +3,7 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
@@ -11,20 +11,10 @@ import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 function resolveEventModel(props: Record<string, unknown> | undefined): string | undefined {
-  const model = props?.model
-  if (typeof model === "string") {
-    return model
-  }
-
-  const providerID = props?.providerID
-  const modelID = props?.modelID
-  if (typeof providerID === "string" && typeof modelID === "string") {
-    return `${providerID}/${modelID}`
-  }
-
-  return undefined
+  return resolveRuntimeModelFromEventRecord(props)
 }
 
 export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
@@ -45,9 +35,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = props?.info as Record<string, unknown> | undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = resolveRuntimeModelFromEventRecord(sessionInfo) ?? resolveRuntimeModelFromEventRecord(props)
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -164,7 +154,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     if (sessionAwaitingFallbackResult.has(sessionID)) {
       const pendingFallbackModel = sessionStates.get(sessionID)?.pendingFallbackModel
       const eventModel = resolveEventModel(props)
-      if (!pendingFallbackModel || eventModel !== pendingFallbackModel) {
+      if (!areRuntimeModelsEquivalent(eventModel, pendingFallbackModel)) {
         log(`[${HOOK_NAME}] session.error skipped - awaiting fallback result`, {
           sessionID,
           pendingFallbackModel,
@@ -209,7 +199,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: resolveEventModel(props),
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
+++ b/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
@@ -2,11 +2,12 @@ import type { OhMyOpenCodeConfig } from "../../config"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import { stringifyRuntimeModel } from "./fallback-state"
 
 type ResolveFallbackBootstrapModelOptions = {
   sessionID: string
   source: string
-  eventModel?: string
+  eventModel?: unknown
   resolvedAgent?: string
   pluginConfig?: OhMyOpenCodeConfig
 }
@@ -14,15 +15,18 @@ type ResolveFallbackBootstrapModelOptions = {
 export function resolveFallbackBootstrapModel(
   options: ResolveFallbackBootstrapModelOptions,
 ): string | undefined {
-  if (options.eventModel) {
-    return options.eventModel
+  const eventModel = stringifyRuntimeModel(options.eventModel)
+  if (eventModel) {
+    return eventModel
   }
 
   const agentConfigs = options.pluginConfig?.agents
   const agentConfig = options.resolvedAgent && agentConfigs
     ? agentConfigs[options.resolvedAgent as keyof typeof agentConfigs]
     : undefined
-  const agentModel = typeof agentConfig?.model === "string" ? agentConfig.model : undefined
+  const agentConfigRecord = agentConfig as Record<string, unknown> | undefined
+  const agentModelCandidate = agentConfigRecord?.model
+  const agentModel = typeof agentModelCandidate === "string" ? agentModelCandidate : undefined
   if (agentModel) {
     log(`[${HOOK_NAME}] Derived model from agent config for ${options.source}`, {
       sessionID: options.sessionID,

--- a/src/hooks/runtime-fallback/fallback-state.test.ts
+++ b/src/hooks/runtime-fallback/fallback-state.test.ts
@@ -1,0 +1,40 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { createFallbackState, findNextAvailableFallback, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+describe("runtime-fallback fallback state", () => {
+  test("#given object-shaped current model #when finding the next fallback #then equivalent models are skipped without crashing", () => {
+    // given
+    const state = createFallbackState({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+    const fallbackModels = ["github-copilot/claude-sonnet-4.6", "openai/gpt-5.4"]
+
+    // when
+    const nextModel = findNextAvailableFallback(state, fallbackModels, 60)
+
+    // then
+    expect(nextModel).toBe("openai/gpt-5.4")
+  })
+
+  test("#given model object without variant and top-level variant #when stringifying runtime model #then top-level variant is preserved", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  test("#given model object with its own variant #when stringifying with a top-level variant #then model variant wins", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "low" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(low)")
+  })
+})

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -4,6 +4,39 @@ import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
 import { parseModelString } from "../../tools/delegate-task/model-string-parser"
 
+export function stringifyRuntimeModel(model: unknown): string | undefined {
+  if (typeof model === "string") return model
+
+  if (typeof model === "object" && model !== null) {
+    const candidate = model as { providerID?: unknown; modelID?: unknown; variant?: unknown }
+    if (typeof candidate.providerID === "string" && typeof candidate.modelID === "string") {
+      const providerID = candidate.providerID.trim()
+      const modelID = candidate.modelID.trim()
+      const variant = typeof candidate.variant === "string" ? candidate.variant.trim() : undefined
+
+      if (!providerID || !modelID) return undefined
+
+      const baseModel = `${providerID}/${modelID}`
+      return variant
+        ? `${baseModel}(${variant})`
+        : baseModel
+    }
+  }
+
+  return undefined
+}
+
+export function stringifyRuntimeModelWithVariant(model: unknown, variant: unknown): string | undefined {
+  const baseModel = stringifyRuntimeModel(model)
+  const fallbackVariant = typeof variant === "string" ? variant.trim() : undefined
+  if (!baseModel || !fallbackVariant) return baseModel
+
+  const parsed = parseModelString(baseModel)
+  if (!parsed?.providerID || !parsed.modelID || parsed.variant) return baseModel
+
+  return `${parsed.providerID}/${parsed.modelID}(${fallbackVariant})`
+}
+
 function canonicalizeModelID(modelID: string): string {
   const loweredModelID = modelID.toLowerCase()
   const dottedModelID = loweredModelID.replace(/\./g, "-")
@@ -63,10 +96,17 @@ function isEquivalentModel(candidate: string, current: string): boolean {
   )
 }
 
-export function createFallbackState(originalModel: string): FallbackState {
+export function areRuntimeModelsEquivalent(candidate: string | undefined, current: string | undefined): boolean {
+  if (!candidate || !current) return false
+  return isEquivalentModel(candidate, current)
+}
+
+export function createFallbackState(originalModel: unknown): FallbackState {
+  const model = stringifyRuntimeModel(originalModel) ?? String(originalModel)
+
   return {
-    originalModel,
-    currentModel: originalModel,
+    originalModel: model,
+    currentModel: model,
     fallbackIndex: -1,
     failedModels: new Map<string, number>(),
     attemptCount: 0,

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -3,15 +3,27 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError, extractAutoRetrySignal, containsErrorContent } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export { hasVisibleAssistantResponse } from "./visible-assistant-response"
+
+function resolveRecordModel(record: Record<string, unknown> | undefined): string | undefined {
+  return resolveRuntimeModelFromEventRecord(record)
+}
+
+function resolveMessageUpdateModel(
+  props: Record<string, unknown> | undefined,
+  info: Record<string, unknown> | undefined,
+): string | undefined {
+  return resolveRecordModel(info) ?? resolveRecordModel(props)
+}
 
 export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   const { ctx, config, pluginConfig, sessionStates, sessionLastAccess, sessionRetryInFlight, sessionAwaitingFallbackResult, sessionStatusRetryKeys } = deps
@@ -39,7 +51,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       (retrySignal && timeoutEnabled ? { name: "ProviderRateLimitError", message: retrySignal } : undefined) ??
       (errorContentResult.hasError ? { name: "MessageContentError", message: errorContentResult.errorMessage || "Message contains error content" } : undefined)
     const role = info?.role as string | undefined
-    const model = info?.model as string | undefined
+    const model = resolveMessageUpdateModel(props, info)
 
     if (sessionID && role === "assistant" && !error) {
       if (!sessionAwaitingFallbackResult.has(sessionID)) {
@@ -75,7 +87,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         wasAwaitingFallbackResult &&
         pendingFallbackModel &&
         !retrySignal &&
-        model !== pendingFallbackModel
+        !areRuntimeModelsEquivalent(model, pendingFallbackModel)
       ) {
         log(`[${HOOK_NAME}] message.updated fallback skipped - awaiting fallback result`, {
           sessionID,
@@ -86,6 +98,10 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       }
       if (wasAwaitingFallbackResult) {
         sessionAwaitingFallbackResult.delete(sessionID)
+        if (state && areRuntimeModelsEquivalent(model, pendingFallbackModel)) {
+          state.pendingFallbackModel = undefined
+          state.pendingFallbackPromptMayHaveBeenAccepted = false
+        }
       }
       if (sessionRetryInFlight.has(sessionID) && !retrySignal) {
         log(`[${HOOK_NAME}] message.updated fallback skipped (retry in flight)`, { sessionID })

--- a/src/hooks/runtime-fallback/runtime-model-event-record.ts
+++ b/src/hooks/runtime-fallback/runtime-model-event-record.ts
@@ -1,0 +1,14 @@
+import { stringifyRuntimeModel, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+export function resolveRuntimeModelFromEventRecord(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  const model = stringifyRuntimeModelWithVariant(record?.model, record?.variant)
+  if (model) return model
+
+  return stringifyRuntimeModel({
+    providerID: record?.providerID,
+    modelID: record?.modelID,
+    variant: record?.variant,
+  })
+}

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -1,9 +1,19 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -34,6 +44,7 @@ function createDeps(): HookDeps {
     },
     options: undefined,
     pluginConfig: {
+      ...testPluginConfig,
       categories: {
         test: {
           fallback_models: ["openai/gpt-5.4", "google/gemini-2.5-pro"],
@@ -46,6 +57,7 @@ function createDeps(): HookDeps {
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
@@ -145,6 +157,101 @@ describe("createSessionStatusHandler", () => {
     ])
     expect(state.currentModel).toBe("google/gemini-2.5-pro")
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given top-level provider model fields with a variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-top-level-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given a model object and separate variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-mixed-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
     SessionCategoryRegistry.clear()
   })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -9,6 +9,7 @@ import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/r
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -26,7 +27,7 @@ export function createSessionStatusHandler(
     const sessionID = resolveSessionEventID(props)
     const status = props?.status as { type?: string; message?: string; attempt?: number } | undefined
     const agent = props?.agent as string | undefined
-    const model = props?.model as string | undefined
+    const model = resolveRuntimeModelFromEventRecord(props)
     const timeoutEnabled = deps.config.timeout_seconds > 0
 
     if (!sessionID || status?.type !== "retry") return

--- a/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -3,6 +3,14 @@ import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
+
 type MessageUpdateHandlerModule = typeof import("./message-update-handler")
 
 async function importFreshMessageUpdateHandlerModule(): Promise<MessageUpdateHandlerModule> {
@@ -37,25 +45,28 @@ function createDeps(messagesResponse: unknown): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
-function createHelpers(clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async () => {},
     clearSessionFallbackTimeout: (sessionID: string) => {
       clearCalls.push(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -91,7 +102,175 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
     // then
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
     expect(clearCalls).toEqual([sessionID])
+  })
+
+  it("#given an object-shaped pending fallback model #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a pending fallback model and mixed message model variant payload #when message.updated errors #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-mixed-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        variant: "high",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a top-level pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-top-level-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      info: {
+        sessionID,
+        role: "assistant",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
   })
 })


### PR DESCRIPTION
## Summary

- Add optional `model` and `variant` arguments to the delegate `task()` tool schema and argument preparation.
- Give runtime model/variant highest precedence for category delegation.
- Give runtime model/variant highest precedence for subagent delegation.

## Why

Per-invocation model selection lets callers choose the right model for a single delegated task without changing global agent or category config.

## Dependency

This is intended to stack after the disabled-provider foundation PR so runtime overrides are already checked against `disabled_providers` in category/model selection.

## Testing

- `bun test src/tools/delegate-task/tool-argument-preparation.test.ts src/tools/delegate-task/category-resolver.test.ts src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts`
- `bun run typecheck`
- `bun run build`
- Manual driver for runtime model/variant precedence


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes runtime model and variant handling across runtime-fallback so models compare correctly and the fallback chain advances reliably. Improves support for object-shaped models and top-level provider/model fields with variants across all relevant events.

- **Bug Fixes**
  - Preserve and canonicalize variants from `session.created`, `session.status`, `session.error`, and `message.updated`.
  - Normalize model payloads (string or object) via `stringifyRuntimeModel*` and `resolveRuntimeModelFromEventRecord`.
  - Compare models using `areRuntimeModelsEquivalent` to avoid false mismatches; clear `pendingFallbackModel` when accepted.
  - Bootstrap fallback with normalized event model; advance past equivalent fallbacks.
  - Added tests covering mixed model/variant shapes and fallback progression.

<sup>Written for commit 1159eb8a22afc070318e05868ea0e287919596a7. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4340?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

