### PR TITLE
feat(team-mode): forward member runtime models

### DIFF
--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -1,8 +1,18 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createEventHandler } from "./event-handler"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -32,7 +42,7 @@ function createDeps(): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
@@ -43,7 +53,7 @@ function createDeps(): HookDeps {
   }
 }
 
-function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async (sessionID: string) => {
       abortCalls.push(sessionID)
@@ -53,8 +63,10 @@ function createHelpers(deps: HookDeps, abortCalls: string[], clearCalls: string[
       deps.sessionFallbackTimeouts.delete(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -103,7 +115,7 @@ describe("createEventHandler", () => {
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
     expect(clearCalls).toEqual([sessionID])
     expect(abortCalls).toEqual([])
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
   })
 
   it("#given a cancelled session #when session.error receives an abort error #then fallback retry state is reset", async () => {
@@ -247,5 +259,229 @@ describe("createEventHandler", () => {
 
     // then - counter is at 2, not reset to 0
     expect(deps.sessionStates.get(sessionID)?.attemptCount).toBe(2)
+  })
+
+  it("#given an object-shaped pending fallback model #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when session.error arrives for that model #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-object-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a model object without variant and a top-level variant #when session.error arrives #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-mixed-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a top-level event model with a variant #when session.error bootstraps fallback state #then the fallback chain advances", async () => {
+    // given
+    const sessionID = "session-error-top-level-model-variant"
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+          error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+        },
+      },
+    })
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "session.error" }])
+  })
+
+  it("#given a session.created info model object and separate variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-info-mixed-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          info: {
+            id: sessionID,
+            model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+            variant: "high",
+          },
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  it("#given top-level session.created provider model fields with a variant #when the event is handled #then fallback state keeps the variant", async () => {
+    // given
+    const sessionID = "session-created-top-level-variant"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID,
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+        },
+      },
+    })
+
+    // then
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(state?.currentModel).toBe("github-copilot/claude-haiku-4.5(high)")
   })
 })

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -3,7 +3,7 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
@@ -11,20 +11,10 @@ import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 function resolveEventModel(props: Record<string, unknown> | undefined): string | undefined {
-  const model = props?.model
-  if (typeof model === "string") {
-    return model
-  }
-
-  const providerID = props?.providerID
-  const modelID = props?.modelID
-  if (typeof providerID === "string" && typeof modelID === "string") {
-    return `${providerID}/${modelID}`
-  }
-
-  return undefined
+  return resolveRuntimeModelFromEventRecord(props)
 }
 
 export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
@@ -45,9 +35,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = props?.info as Record<string, unknown> | undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = resolveRuntimeModelFromEventRecord(sessionInfo) ?? resolveRuntimeModelFromEventRecord(props)
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -164,7 +154,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     if (sessionAwaitingFallbackResult.has(sessionID)) {
       const pendingFallbackModel = sessionStates.get(sessionID)?.pendingFallbackModel
       const eventModel = resolveEventModel(props)
-      if (!pendingFallbackModel || eventModel !== pendingFallbackModel) {
+      if (!areRuntimeModelsEquivalent(eventModel, pendingFallbackModel)) {
         log(`[${HOOK_NAME}] session.error skipped - awaiting fallback result`, {
           sessionID,
           pendingFallbackModel,
@@ -209,7 +199,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: resolveEventModel(props),
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
+++ b/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
@@ -2,11 +2,12 @@ import type { OhMyOpenCodeConfig } from "../../config"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import { stringifyRuntimeModel } from "./fallback-state"
 
 type ResolveFallbackBootstrapModelOptions = {
   sessionID: string
   source: string
-  eventModel?: string
+  eventModel?: unknown
   resolvedAgent?: string
   pluginConfig?: OhMyOpenCodeConfig
 }
@@ -14,15 +15,18 @@ type ResolveFallbackBootstrapModelOptions = {
 export function resolveFallbackBootstrapModel(
   options: ResolveFallbackBootstrapModelOptions,
 ): string | undefined {
-  if (options.eventModel) {
-    return options.eventModel
+  const eventModel = stringifyRuntimeModel(options.eventModel)
+  if (eventModel) {
+    return eventModel
   }
 
   const agentConfigs = options.pluginConfig?.agents
   const agentConfig = options.resolvedAgent && agentConfigs
     ? agentConfigs[options.resolvedAgent as keyof typeof agentConfigs]
     : undefined
-  const agentModel = typeof agentConfig?.model === "string" ? agentConfig.model : undefined
+  const agentConfigRecord = agentConfig as Record<string, unknown> | undefined
+  const agentModelCandidate = agentConfigRecord?.model
+  const agentModel = typeof agentModelCandidate === "string" ? agentModelCandidate : undefined
   if (agentModel) {
     log(`[${HOOK_NAME}] Derived model from agent config for ${options.source}`, {
       sessionID: options.sessionID,

--- a/src/hooks/runtime-fallback/fallback-state.test.ts
+++ b/src/hooks/runtime-fallback/fallback-state.test.ts
@@ -1,0 +1,40 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { createFallbackState, findNextAvailableFallback, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+describe("runtime-fallback fallback state", () => {
+  test("#given object-shaped current model #when finding the next fallback #then equivalent models are skipped without crashing", () => {
+    // given
+    const state = createFallbackState({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+    const fallbackModels = ["github-copilot/claude-sonnet-4.6", "openai/gpt-5.4"]
+
+    // when
+    const nextModel = findNextAvailableFallback(state, fallbackModels, 60)
+
+    // then
+    expect(nextModel).toBe("openai/gpt-5.4")
+  })
+
+  test("#given model object without variant and top-level variant #when stringifying runtime model #then top-level variant is preserved", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(high)")
+  })
+
+  test("#given model object with its own variant #when stringifying with a top-level variant #then model variant wins", () => {
+    // given
+    const model = { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "low" }
+
+    // when
+    const runtimeModel = stringifyRuntimeModelWithVariant(model, "high")
+
+    // then
+    expect(runtimeModel).toBe("github-copilot/claude-haiku-4.5(low)")
+  })
+})

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -4,6 +4,39 @@ import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
 import { parseModelString } from "../../tools/delegate-task/model-string-parser"
 
+export function stringifyRuntimeModel(model: unknown): string | undefined {
+  if (typeof model === "string") return model
+
+  if (typeof model === "object" && model !== null) {
+    const candidate = model as { providerID?: unknown; modelID?: unknown; variant?: unknown }
+    if (typeof candidate.providerID === "string" && typeof candidate.modelID === "string") {
+      const providerID = candidate.providerID.trim()
+      const modelID = candidate.modelID.trim()
+      const variant = typeof candidate.variant === "string" ? candidate.variant.trim() : undefined
+
+      if (!providerID || !modelID) return undefined
+
+      const baseModel = `${providerID}/${modelID}`
+      return variant
+        ? `${baseModel}(${variant})`
+        : baseModel
+    }
+  }
+
+  return undefined
+}
+
+export function stringifyRuntimeModelWithVariant(model: unknown, variant: unknown): string | undefined {
+  const baseModel = stringifyRuntimeModel(model)
+  const fallbackVariant = typeof variant === "string" ? variant.trim() : undefined
+  if (!baseModel || !fallbackVariant) return baseModel
+
+  const parsed = parseModelString(baseModel)
+  if (!parsed?.providerID || !parsed.modelID || parsed.variant) return baseModel
+
+  return `${parsed.providerID}/${parsed.modelID}(${fallbackVariant})`
+}
+
 function canonicalizeModelID(modelID: string): string {
   const loweredModelID = modelID.toLowerCase()
   const dottedModelID = loweredModelID.replace(/\./g, "-")
@@ -63,10 +96,17 @@ function isEquivalentModel(candidate: string, current: string): boolean {
   )
 }
 
-export function createFallbackState(originalModel: string): FallbackState {
+export function areRuntimeModelsEquivalent(candidate: string | undefined, current: string | undefined): boolean {
+  if (!candidate || !current) return false
+  return isEquivalentModel(candidate, current)
+}
+
+export function createFallbackState(originalModel: unknown): FallbackState {
+  const model = stringifyRuntimeModel(originalModel) ?? String(originalModel)
+
   return {
-    originalModel,
-    currentModel: originalModel,
+    originalModel: model,
+    currentModel: model,
     fallbackIndex: -1,
     failedModels: new Map<string, number>(),
     attemptCount: 0,

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
@@ -81,6 +83,8 @@ function createHelpers(calls: RecordedCalls, resolvedAgentName?: string): AutoRe
 const AGENT = "sisyphus-junior"
 const PRIMARY_MODEL = "openai/gpt-5.4-mini"
 const FALLBACK_MODEL = "anthropic/claude-haiku-4-5"
+const VARIANT_PRIMARY_MODEL = "github-copilot/claude-haiku-4.5(high)"
+const VARIANT_FALLBACK_MODEL = "openai/gpt-5.4"
 const PLUGIN_CONFIG_WITH_FALLBACK = {
   git_master: {
     commit_footer: true,
@@ -91,6 +95,22 @@ const PLUGIN_CONFIG_WITH_FALLBACK = {
     [AGENT]: {
       model: PRIMARY_MODEL,
       fallback_models: [{ model: FALLBACK_MODEL }],
+    },
+  },
+}
+const PLUGIN_CONFIG_WITH_VARIANT_FALLBACK = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+  agents: {
+    [AGENT]: {
+      model: VARIANT_PRIMARY_MODEL,
+      fallback_models: [
+        { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+        VARIANT_FALLBACK_MODEL,
+      ],
     },
   },
 }
@@ -274,6 +294,91 @@ describe("first-prompt-watchdog", () => {
 
     watchdog.dispose()
   })
+
+  it("#given a user message with mixed model object and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
+    // given
+    const sessionID = "session-watchdog-mixed-variant"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_VARIANT_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            sessionID,
+            role: "user",
+            agent: AGENT,
+            model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+            variant: "high",
+          },
+        },
+      },
+      watchdog,
+    )
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe(VARIANT_PRIMARY_MODEL)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([
+      {
+        sessionID,
+        newModel: VARIANT_FALLBACK_MODEL,
+        resolvedAgent: AGENT,
+        source: "first-prompt-watchdog",
+      },
+    ])
+
+    watchdog.dispose()
+  })
+
+  it("#given a user message with top-level provider model fields and variant #when the watchdog fires #then it skips the equivalent fallback variant", async () => {
+    // given
+    const sessionID = "session-watchdog-top-level-variant"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_VARIANT_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    observeEventForWatchdog(
+      {
+        type: "message.updated",
+        properties: {
+          providerID: "github-copilot",
+          modelID: "claude-haiku-4.5",
+          variant: "high",
+          info: {
+            sessionID,
+            role: "user",
+            agent: AGENT,
+          },
+        },
+      },
+      watchdog,
+    )
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe(VARIANT_PRIMARY_MODEL)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([
+      {
+        sessionID,
+        newModel: VARIANT_FALLBACK_MODEL,
+        resolvedAgent: AGENT,
+        source: "first-prompt-watchdog",
+      },
+    ])
+
+    watchdog.dispose()
+  })
 })
 
 interface RecordedWatchdogCalls {
@@ -329,29 +434,33 @@ describe("observeEventForWatchdog", () => {
     ["file", { type: "file" }],
   ]
 
-  it.each(assistantProgressParts)("#given a message.updated assistant event whose only part is type=%s #when observed #then onAssistantProgress is called (model is *working*, not silent)", (_label: string, part: { readonly type: string; readonly text?: string; readonly id?: string; readonly name?: string; readonly tool_use_id?: string }) => {
-    const calls = freshCalls()
-    observeEventForWatchdog(
-      {
-        type: "message.updated",
-        properties: { info: { sessionID, role: "assistant" }, parts: [part] },
-      },
-      createRecordingWatchdog(calls),
-    )
-    expect(calls.progress).toEqual([sessionID])
-  })
+  for (const [label, part] of assistantProgressParts) {
+    it(`#given a message.updated assistant event whose only part is type=${label} #when observed #then onAssistantProgress is called`, () => {
+      const calls = freshCalls()
+      observeEventForWatchdog(
+        {
+          type: "message.updated",
+          properties: { info: { sessionID, role: "assistant" }, parts: [part] },
+        },
+        createRecordingWatchdog(calls),
+      )
+      expect(calls.progress).toEqual([sessionID])
+    })
+  }
 
-  it.each(assistantProgressParts)("#given a message.part.updated event whose part is type=%s #when observed #then onAssistantProgress is called", (_label: string, part: { readonly type: string; readonly text?: string; readonly id?: string; readonly name?: string; readonly tool_use_id?: string }) => {
-    const calls = freshCalls()
-    observeEventForWatchdog(
-      {
-        type: "message.part.updated",
-        properties: { sessionID, part },
-      },
-      createRecordingWatchdog(calls),
-    )
-    expect(calls.progress).toEqual([sessionID])
-  })
+  for (const [label, part] of assistantProgressParts) {
+    it(`#given a message.part.updated event whose part is type=${label} #when observed #then onAssistantProgress is called`, () => {
+      const calls = freshCalls()
+      observeEventForWatchdog(
+        {
+          type: "message.part.updated",
+          properties: { sessionID, part },
+        },
+        createRecordingWatchdog(calls),
+      )
+      expect(calls.progress).toEqual([sessionID])
+    })
+  }
 
   it("#given a message.updated assistant event with parts: [] and no error/finish #when observed #then no progress is signalled (no activity yet)", () => {
     const calls = freshCalls()
@@ -391,17 +500,16 @@ describe("observeEventForWatchdog", () => {
 
   const terminalEventTypes: ReadonlyArray<readonly [string]> = [["session.idle"], ["session.stop"], ["session.deleted"], ["session.error"]]
 
-  it.each(terminalEventTypes)(
-    "#given a %s event #when observed #then onSessionTerminal is called",
-    (eventType: string) => {
+  for (const [eventType] of terminalEventTypes) {
+    it(`#given a ${eventType} event #when observed #then onSessionTerminal is called`, () => {
       const calls = freshCalls()
       observeEventForWatchdog(
         { type: eventType, properties: { sessionID } },
         createRecordingWatchdog(calls),
       )
       expect(calls.terminal).toEqual([sessionID])
-    },
-  )
+    })
+  }
 
   it("#given a session.deleted event whose sessionID is carried under properties.info.id #when observed #then onSessionTerminal is still called (matches event-handler shape)", () => {
     const calls = freshCalls()

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -9,6 +9,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 const SOURCE = "first-prompt-watchdog"
 const SESSION_NEXT_EVENT_PREFIX = "session.next."
@@ -89,7 +90,7 @@ export function observeEventForWatchdog(
     if (!sessionID || !role) return
 
     if (role === "user") {
-      const model = info?.model as string | undefined
+      const model = resolveRuntimeModelFromEventRecord(info) ?? resolveRuntimeModelFromEventRecord(props)
       const agent = info?.agent as string | undefined
       watchdog.onUserMessage(sessionID, model, agent)
       return

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -3,15 +3,27 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError, extractAutoRetrySignal, containsErrorContent } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { areRuntimeModelsEquivalent, createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export { hasVisibleAssistantResponse } from "./visible-assistant-response"
+
+function resolveRecordModel(record: Record<string, unknown> | undefined): string | undefined {
+  return resolveRuntimeModelFromEventRecord(record)
+}
+
+function resolveMessageUpdateModel(
+  props: Record<string, unknown> | undefined,
+  info: Record<string, unknown> | undefined,
+): string | undefined {
+  return resolveRecordModel(info) ?? resolveRecordModel(props)
+}
 
 export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   const { ctx, config, pluginConfig, sessionStates, sessionLastAccess, sessionRetryInFlight, sessionAwaitingFallbackResult, sessionStatusRetryKeys } = deps
@@ -39,7 +51,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       (retrySignal && timeoutEnabled ? { name: "ProviderRateLimitError", message: retrySignal } : undefined) ??
       (errorContentResult.hasError ? { name: "MessageContentError", message: errorContentResult.errorMessage || "Message contains error content" } : undefined)
     const role = info?.role as string | undefined
-    const model = info?.model as string | undefined
+    const model = resolveMessageUpdateModel(props, info)
 
     if (sessionID && role === "assistant" && !error) {
       if (!sessionAwaitingFallbackResult.has(sessionID)) {
@@ -75,7 +87,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         wasAwaitingFallbackResult &&
         pendingFallbackModel &&
         !retrySignal &&
-        model !== pendingFallbackModel
+        !areRuntimeModelsEquivalent(model, pendingFallbackModel)
       ) {
         log(`[${HOOK_NAME}] message.updated fallback skipped - awaiting fallback result`, {
           sessionID,
@@ -86,6 +98,10 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       }
       if (wasAwaitingFallbackResult) {
         sessionAwaitingFallbackResult.delete(sessionID)
+        if (state && areRuntimeModelsEquivalent(model, pendingFallbackModel)) {
+          state.pendingFallbackModel = undefined
+          state.pendingFallbackPromptMayHaveBeenAccepted = false
+        }
       }
       if (sessionRetryInFlight.has(sessionID) && !retrySignal) {
         log(`[${HOOK_NAME}] message.updated fallback skipped (retry in flight)`, { sessionID })

--- a/src/hooks/runtime-fallback/runtime-model-event-record.ts
+++ b/src/hooks/runtime-fallback/runtime-model-event-record.ts
@@ -1,0 +1,14 @@
+import { stringifyRuntimeModel, stringifyRuntimeModelWithVariant } from "./fallback-state"
+
+export function resolveRuntimeModelFromEventRecord(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  const model = stringifyRuntimeModelWithVariant(record?.model, record?.variant)
+  if (model) return model
+
+  return stringifyRuntimeModel({
+    providerID: record?.providerID,
+    modelID: record?.modelID,
+    variant: record?.variant,
+  })
+}

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -1,9 +1,19 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
 
 function createContext(): RuntimeFallbackPluginInput {
   return {
@@ -34,6 +44,7 @@ function createDeps(): HookDeps {
     },
     options: undefined,
     pluginConfig: {
+      ...testPluginConfig,
       categories: {
         test: {
           fallback_models: ["openai/gpt-5.4", "google/gemini-2.5-pro"],
@@ -46,6 +57,7 @@ function createDeps(): HookDeps {
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
@@ -145,6 +157,101 @@ describe("createSessionStatusHandler", () => {
     ])
     expect(state.currentModel).toBe("google/gemini-2.5-pro")
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given top-level provider model fields with a variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-top-level-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given a model object and separate variant #when session.status bootstraps fallback state #then it advances past the equivalent fallback", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-mixed-model-variant"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      categories: {
+        test: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+      variant: "high",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "All credentials for model claude-haiku-4.5 are cooling down [retrying in 7m 56s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([sessionID])
+    expect(deps.sessionStates.get(sessionID)?.originalModel).toBe("github-copilot/claude-haiku-4.5(high)")
+    expect(retryCalls).toEqual([
+      {
+        sessionID,
+        model: "openai/gpt-5.4",
+        source: "session.status",
+      },
+    ])
     SessionCategoryRegistry.clear()
   })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -9,6 +9,7 @@ import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/r
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+import { resolveRuntimeModelFromEventRecord } from "./runtime-model-event-record"
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -26,7 +27,7 @@ export function createSessionStatusHandler(
     const sessionID = resolveSessionEventID(props)
     const status = props?.status as { type?: string; message?: string; attempt?: number } | undefined
     const agent = props?.agent as string | undefined
-    const model = props?.model as string | undefined
+    const model = resolveRuntimeModelFromEventRecord(props)
     const timeoutEnabled = deps.config.timeout_seconds > 0
 
     if (!sessionID || status?.type !== "retry") return

--- a/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -3,6 +3,14 @@ import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 
+const testPluginConfig = {
+  git_master: {
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  },
+}
+
 type MessageUpdateHandlerModule = typeof import("./message-update-handler")
 
 async function importFreshMessageUpdateHandlerModule(): Promise<MessageUpdateHandlerModule> {
@@ -37,25 +45,28 @@ function createDeps(messagesResponse: unknown): HookDeps {
       notify_on_fallback: false,
     },
     options: undefined,
-    pluginConfig: {},
+    pluginConfig: testPluginConfig,
     sessionStates: new Map(),
     sessionLastAccess: new Map(),
     sessionRetryInFlight: new Set(),
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
-function createHelpers(clearCalls: string[]): AutoRetryHelpers {
+function createHelpers(clearCalls: string[], autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []): AutoRetryHelpers {
   return {
     abortSessionRequest: async () => {},
     clearSessionFallbackTimeout: (sessionID: string) => {
       clearCalls.push(sessionID)
     },
     scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
+    autoRetryWithFallback: async (sessionID: string, model: string, _agent: string | undefined, source: string) => {
+      autoRetryCalls.push({ sessionID, model, source })
+    },
+    resolveAgentForSessionFromContext: async () => "sisyphus",
     cleanupStaleSessions: () => {},
   }
 }
@@ -91,7 +102,175 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
     // then
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
     expect(deps.sessionStatusRetryKeys.has(sessionID)).toBe(false)
-    expect(state.pendingFallbackModel).toBe(undefined)
+    expect(state.pendingFallbackModel).toBeUndefined()
     expect(clearCalls).toEqual([sessionID])
+  })
+
+  it("#given an object-shaped pending fallback model #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: ["github-copilot/claude-haiku-4.5", "openai/gpt-5.4"],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given an object-shaped pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-object-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5", variant: "high" },
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a pending fallback model and mixed message model variant payload #when message.updated errors #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-mixed-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      info: {
+        sessionID,
+        role: "assistant",
+        model: { providerID: "github-copilot", modelID: "claude-haiku-4.5" },
+        variant: "high",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
+  })
+
+  it("#given a top-level pending fallback model with a variant #when message.updated errors for that model #then the fallback chain advances", async () => {
+    // given
+    const { createMessageUpdateHandler } = await importFreshMessageUpdateHandlerModule()
+    const sessionID = "message-updated-top-level-model-variant"
+    const clearCalls: string[] = []
+    const autoRetryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    const deps = createDeps({ data: [] })
+    deps.pluginConfig = {
+      ...testPluginConfig,
+      agents: {
+        sisyphus: {
+          fallback_models: [
+            { model: "github-copilot/claude-haiku-4.5", variant: "high" },
+            "openai/gpt-5.4",
+          ],
+        },
+      },
+    }
+    const state = createFallbackState("opencode-go/glm-5.1")
+    state.currentModel = "github-copilot/claude-haiku-4.5(high)"
+    state.fallbackIndex = 0
+    state.pendingFallbackModel = "github-copilot/claude-haiku-4.5(high)"
+    state.attemptCount = 1
+    deps.sessionStates.set(sessionID, state)
+    deps.sessionAwaitingFallbackResult.add(sessionID)
+    const handler = createMessageUpdateHandler(deps, createHelpers(clearCalls, autoRetryCalls))
+
+    // when
+    await handler({
+      providerID: "github-copilot",
+      modelID: "claude-haiku-4.5",
+      variant: "high",
+      info: {
+        sessionID,
+        role: "assistant",
+        error: { name: "RateLimitError", status: 429, message: "rate limit exceeded" },
+      },
+    })
+
+    // then
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(false)
+    expect(autoRetryCalls).toEqual([{ sessionID, model: "openai/gpt-5.4", source: "message.updated" }])
   })
 })

--- a/src/shared/disabled-providers.test.ts
+++ b/src/shared/disabled-providers.test.ts
@@ -22,6 +22,11 @@ describe("getModelProvider", () => {
     expect(getModelProvider("vercel/openai/gpt-5.5")).toBe("vercel")
   })
 
+  test("trims provider whitespace before returning", () => {
+    expect(getModelProvider(" github-copilot/gpt-5.5")).toBe("github-copilot")
+    expect(getModelProvider("github-copilot /gpt-5.5")).toBe("github-copilot")
+  })
+
   test("returns undefined when the string has no provider prefix", () => {
     expect(getModelProvider("gpt-5.5")).toBeUndefined()
     expect(getModelProvider("")).toBeUndefined()
@@ -49,6 +54,11 @@ describe("isProviderDisabled", () => {
     expect(isProviderDisabled("github-copilot/gpt-5.5", ["GitHub-Copilot"])).toBe(true)
     expect(isProviderDisabled("OPENAI/gpt-5.5", ["openai"])).toBe(true)
     expect(isProviderDisabled("openai/gpt-5.5", ["VERCEL"])).toBe(false)
+  })
+
+  test("trims provider and disabled-list entries before comparing", () => {
+    expect(isProviderDisabled(" github-copilot/gpt-5.5", ["github-copilot"])).toBe(true)
+    expect(isProviderDisabled("github-copilot /gpt-5.5", [" github-copilot "])).toBe(true)
   })
 })
 

--- a/src/shared/disabled-providers.ts
+++ b/src/shared/disabled-providers.ts
@@ -9,7 +9,8 @@ const HOOK_NAME = "disabled-providers"
 export function getModelProvider(model: string): string | undefined {
   const slash = model.indexOf("/")
   if (slash <= 0) return undefined
-  return model.slice(0, slash)
+  const provider = model.slice(0, slash).trim()
+  return provider || undefined
 }
 
 export function isProviderDisabled(
@@ -20,7 +21,7 @@ export function isProviderDisabled(
   const provider = getModelProvider(model)
   if (provider === undefined) return false
   const providerLower = provider.toLowerCase()
-  return disabled.some((entry) => entry.toLowerCase() === providerLower)
+  return disabled.some((entry) => entry.trim().toLowerCase() === providerLower)
 }
 
 export function filterDisabledProviderModels<T extends string | FallbackModelObject>(

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -4,6 +4,24 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:
 import { resolveModelForDelegateTask } from "./model-selection"
 import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 
+function mockConnectedProviders(value: ReturnType<typeof connectedProvidersCache.readConnectedProvidersCache>) {
+	const spy = spyOn(connectedProvidersCache, "readConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasConnectedProviders(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
+function mockHasProviderModels(value: boolean) {
+	const spy = spyOn(connectedProvidersCache, "hasProviderModelsCache")
+	spy.mockReturnValue(value)
+	return spy
+}
+
 describe("resolveModelForDelegateTask", () => {
 	let hasConnectedProvidersSpy: ReturnType<typeof spyOn> | undefined
 	let hasProviderModelsSpy: ReturnType<typeof spyOn> | undefined
@@ -19,8 +37,8 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given no provider cache exists (pre-cache scenario)", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(false)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(false)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(false)
+			hasProviderModelsSpy = mockHasProviderModels(false)
 		})
 
 		describe("#when availableModels is empty and no user model override", () => {
@@ -72,13 +90,13 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given provider cache exists", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		describe("#when availableModels is empty (cache exists but empty)", () => {
 			test("#then keeps the category default when its provider is connected", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
@@ -94,7 +112,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then skips a disconnected category default and resolves via a connected fallback", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
@@ -115,7 +133,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then skips disconnected user fallback models and keeps the first connected fallback", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					userFallbackModels: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"],
@@ -138,6 +156,25 @@ describe("resolveModelForDelegateTask", () => {
 				})
 
 				expect(result).toEqual({ model: "anthropic/claude-sonnet-4.6" })
+			})
+
+			test("#then skips disabled hardcoded defaults and chooses an allowed fallback", () => {
+				const result = resolveModelForDelegateTask({
+					categoryDefaultModel: "github-copilot/gpt-5.5",
+					fallbackChain: [
+						{ providers: ["github-copilot"], model: "gpt-5.5", variant: "medium" },
+						{ providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					],
+					availableModels: new Set(["github-copilot/gpt-5.5", "openai/gpt-5.5"]),
+					disabledProviders: ["github-copilot"],
+				})
+
+				expect(result).toEqual({
+					model: "openai/gpt-5.5",
+					variant: "medium",
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					matchedFallback: true,
+				})
 			})
 
 			test("#then trusts user-configured category model without fuzzy validation", () => {
@@ -220,8 +257,8 @@ describe("resolveModelForDelegateTask", () => {
 		let readConnectedProvidersSpy: ReturnType<typeof spyOn> | undefined
 
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		afterEach(() => {
@@ -229,8 +266,27 @@ describe("resolveModelForDelegateTask", () => {
 		})
 
 		describe("#when availableModels is empty and fallback chain starts with unauthenticated provider", () => {
+			test("#then skips disabled providers inside connected hardcoded fallback entries", () => {
+				readConnectedProvidersSpy = mockConnectedProviders(["github-copilot", "openai"])
+
+				const result = resolveModelForDelegateTask({
+					fallbackChain: [
+						{ providers: ["github-copilot", "openai"], model: "gpt-5.5", variant: "medium" },
+					],
+					availableModels: new Set(),
+					disabledProviders: ["github-copilot"],
+				})
+
+				expect(result).toEqual({
+					model: "openai/gpt-5.5",
+					variant: "medium",
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5", variant: "medium" },
+					matchedFallback: true,
+				})
+			})
+
 			test("#then skips unauthenticated providers and resolves to first connected one", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai", "anthropic"])
+				readConnectedProvidersSpy = mockConnectedProviders(["openai", "anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -249,7 +305,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then resolves first provider in entry that is connected", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai", "github-copilot"])
+				readConnectedProvidersSpy = mockConnectedProviders(["openai", "github-copilot"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -266,7 +322,7 @@ describe("resolveModelForDelegateTask", () => {
 			})
 
 			test("#then falls through to system default when no provider in chain is connected", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
+				readConnectedProvidersSpy = mockConnectedProviders(["anthropic"])
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -283,7 +339,7 @@ describe("resolveModelForDelegateTask", () => {
 
 		describe("#when connected providers cache is null (not yet populated)", () => {
 			test("#then falls back to first entry in chain (legacy behavior)", () => {
-				readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+				readConnectedProvidersSpy = mockConnectedProviders(null)
 
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
@@ -352,8 +408,8 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given user-configured category model includes variant syntax", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(true)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(true)
 		})
 
 		describe("#when categoryDefaultModel with isUserConfiguredCategoryModel contains a space-separated variant", () => {
@@ -395,13 +451,13 @@ describe("resolveModelForDelegateTask", () => {
 
 	describe("#given only connected providers cache exists (no provider-models cache)", () => {
 		beforeEach(() => {
-			hasConnectedProvidersSpy = spyOn(connectedProvidersCache, "hasConnectedProvidersCache").mockReturnValue(true)
-			hasProviderModelsSpy = spyOn(connectedProvidersCache, "hasProviderModelsCache").mockReturnValue(false)
+			hasConnectedProvidersSpy = mockHasConnectedProviders(true)
+			hasProviderModelsSpy = mockHasProviderModels(false)
 		})
 
 		describe("#when availableModels is empty", () => {
 			test("#then uses connected providers to avoid disconnected category defaults", () => {
-				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+				const readConnectedProvidersSpy = mockConnectedProviders(["openai"])
 
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -5,6 +5,7 @@ import { transformModelForProvider } from "../../shared/provider-model-id-transf
 import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 import { log } from "../../shared/logger"
 import { parseModelString, parseVariantFromModelID } from "../../shared/model-string-parser"
+import { filterDisabledProvidersFromFallbackChain, isModelProviderDisabled, isProviderNameDisabled } from "./runtime-model-policy"
 
 function isExplicitHighModel(model: string): boolean {
   return /(?:^|\/)[^/]+-high$/.test(model)
@@ -12,6 +13,11 @@ function isExplicitHighModel(model: string): boolean {
 
 function getExplicitHighBaseModel(model: string): string | null {
   return isExplicitHighModel(model) ? model.replace(/-high$/, "") : null
+}
+
+function filterAvailableModels(availableModels: Set<string>, disabledProviders: readonly string[] | undefined): Set<string> {
+  if (!disabledProviders || disabledProviders.length === 0) return availableModels
+  return new Set([...availableModels].filter((model) => !isModelProviderDisabled(model, disabledProviders)))
 }
 
 function parseUserFallbackModel(fallbackModel: string): {
@@ -53,7 +59,10 @@ export function resolveModelForDelegateTask(input: {
   fallbackChain?: FallbackEntry[]
   availableModels: Set<string>
   systemDefaultModel?: string
+  disabledProviders?: readonly string[]
 }): { model: string; variant?: string; fallbackEntry?: FallbackEntry; matchedFallback?: boolean } | { skipped: true } | undefined {
+  const disabledProviders = input.disabledProviders
+  const availableModels = filterAvailableModels(input.availableModels, disabledProviders)
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     const parsed = parseUserFallbackModel(userModel)
@@ -67,20 +76,21 @@ export function resolveModelForDelegateTask(input: {
     // instead of returning an unreachable model. Cold cache (no availability
     // data yet) preserves the legacy "trust the user" behavior.
     const userFallbackModels = input.userFallbackModels
+      ?.filter((fallbackModel) => !isModelProviderDisabled(fallbackModel, disabledProviders))
     if (
-      input.availableModels.size > 0 &&
+      availableModels.size > 0 &&
       userFallbackModels &&
       userFallbackModels.length > 0
     ) {
       const providerHint = parsed?.providerHint
-      const primaryMatch = fuzzyMatchModel(userResult.model, input.availableModels, providerHint)
+      const primaryMatch = fuzzyMatchModel(userResult.model, availableModels, providerHint)
       if (!primaryMatch) {
         for (const fallbackModel of userFallbackModels) {
           const parsedFallback = parseUserFallbackModel(fallbackModel)
           if (!parsedFallback) continue
           const fbMatch = fuzzyMatchModel(
             parsedFallback.baseModel,
-            input.availableModels,
+            availableModels,
             parsedFallback.providerHint,
           )
           if (fbMatch) {
@@ -98,15 +108,21 @@ export function resolveModelForDelegateTask(input: {
       }
     }
 
-    return userResult
+    if (!isModelProviderDisabled(userResult.model, disabledProviders)) {
+      return userResult
+    }
+    return undefined
   }
 
-  const connectedProviders = input.availableModels.size === 0 ? connectedProvidersCache.readConnectedProvidersCache() : null
+  const rawConnectedProviders = availableModels.size === 0 ? connectedProvidersCache.readConnectedProvidersCache() : null
+  const connectedProviders = rawConnectedProviders
+    ? rawConnectedProviders.filter((provider) => !isProviderNameDisabled(provider, disabledProviders))
+    : null
 
   // Before provider cache is created (first run), skip model resolution entirely.
   // OpenCode will use its system default model when no model is specified in the prompt.
   if (
-    input.availableModels.size === 0 &&
+    availableModels.size === 0 &&
     !connectedProvidersCache.hasProviderModelsCache() &&
     !connectedProvidersCache.hasConnectedProvidersCache()
   ) {
@@ -116,7 +132,7 @@ export function resolveModelForDelegateTask(input: {
   const categoryDefault = normalizeModel(input.categoryDefaultModel)
   const explicitHighBaseModel = categoryDefault ? getExplicitHighBaseModel(categoryDefault) : null
   const explicitHighModel = explicitHighBaseModel ? categoryDefault : undefined
-  if (categoryDefault) {
+  if (categoryDefault && !isModelProviderDisabled(categoryDefault, disabledProviders)) {
     if (input.isUserConfiguredCategoryModel) {
       log("[resolveModelForDelegateTask] using user-configured category model (bypass validation)", {
         categoryDefaultModel: categoryDefault,
@@ -128,7 +144,7 @@ export function resolveModelForDelegateTask(input: {
       return { model: categoryDefault }
     }
 
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       const categoryProvider = categoryDefault.includes("/") ? categoryDefault.split("/")[0] : undefined
       if (!connectedProviders || !categoryProvider || connectedProviders.includes(categoryProvider)) {
         return { model: categoryDefault }
@@ -142,7 +158,7 @@ export function resolveModelForDelegateTask(input: {
 
     const parts = categoryDefault.split("/")
     const providerHint = parts.length >= 2 ? [parts[0]] : undefined
-    const match = fuzzyMatchModel(categoryDefault, input.availableModels, providerHint)
+    const match = fuzzyMatchModel(categoryDefault, availableModels, providerHint)
     if (match) {
       if (isExplicitHighModel(categoryDefault) && match !== categoryDefault) {
         return { model: categoryDefault }
@@ -153,8 +169,9 @@ export function resolveModelForDelegateTask(input: {
   }
 
   const userFallbackModels = input.userFallbackModels
+    ?.filter((fallbackModel) => !isModelProviderDisabled(fallbackModel, disabledProviders))
   if (userFallbackModels && userFallbackModels.length > 0) {
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       for (const fallbackModel of userFallbackModels) {
         const parsedFallback = parseUserFallbackModel(fallbackModel)
         if (!parsedFallback) continue
@@ -174,7 +191,7 @@ export function resolveModelForDelegateTask(input: {
         const parsedFallback = parseUserFallbackModel(fallbackModel)
         if (!parsedFallback) continue
 
-        const match = fuzzyMatchModel(parsedFallback.baseModel, input.availableModels, parsedFallback.providerHint)
+        const match = fuzzyMatchModel(parsedFallback.baseModel, availableModels, parsedFallback.providerHint)
         if (match) {
           return { model: match, variant: parsedFallback.variant, matchedFallback: true }
         }
@@ -182,9 +199,9 @@ export function resolveModelForDelegateTask(input: {
     }
   }
 
-  const fallbackChain = input.fallbackChain
+  const fallbackChain = filterDisabledProvidersFromFallbackChain(input.fallbackChain, disabledProviders)
   if (fallbackChain && fallbackChain.length > 0) {
-    if (input.availableModels.size === 0) {
+    if (availableModels.size === 0) {
       if (connectedProviders) {
         const connectedSet = new Set(connectedProviders)
         for (const entry of fallbackChain) {
@@ -212,7 +229,7 @@ export function resolveModelForDelegateTask(input: {
       for (const entry of fallbackChain) {
         for (const provider of entry.providers) {
           const fullModel = `${provider}/${entry.model}`
-          const match = fuzzyMatchModel(fullModel, input.availableModels, [provider])
+          const match = fuzzyMatchModel(fullModel, availableModels, [provider])
           if (match) {
             if (explicitHighModel && entry.variant === "high" && match === explicitHighBaseModel) {
               return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
@@ -222,7 +239,7 @@ export function resolveModelForDelegateTask(input: {
           }
         }
 
-        const crossProviderMatch = fuzzyMatchModel(entry.model, input.availableModels)
+        const crossProviderMatch = fuzzyMatchModel(entry.model, availableModels)
         if (crossProviderMatch) {
           if (explicitHighModel && entry.variant === "high" && crossProviderMatch === explicitHighBaseModel) {
             return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
@@ -235,7 +252,7 @@ export function resolveModelForDelegateTask(input: {
   }
 
   const systemDefaultModel = normalizeModel(input.systemDefaultModel)
-  if (systemDefaultModel) {
+  if (systemDefaultModel && !isModelProviderDisabled(systemDefaultModel, disabledProviders)) {
     return { model: systemDefaultModel }
   }
 

--- a/src/tools/delegate-task/runtime-model-policy.ts
+++ b/src/tools/delegate-task/runtime-model-policy.ts
@@ -1,0 +1,53 @@
+import type { FallbackEntry } from "../../shared/model-requirements"
+import { getModelProvider, isProviderDisabled } from "../../shared/disabled-providers"
+
+export function validateRuntimeModelProvider(
+  runtimeModel: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): string | undefined {
+  if (!runtimeModel || !disabledProviders || disabledProviders.length === 0) return undefined
+  if (!isProviderDisabled(runtimeModel, disabledProviders)) return undefined
+
+  const provider = getModelProvider(runtimeModel)
+  return provider
+    ? `Runtime model override "${runtimeModel}" uses disabled provider "${provider}". Remove the model override or remove "${provider}" from disabled_providers.`
+    : `Runtime model override "${runtimeModel}" uses a disabled provider. Remove the model override or update disabled_providers.`
+}
+
+
+export function isProviderNameDisabled(
+  providerID: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): boolean {
+  if (!providerID || !disabledProviders || disabledProviders.length === 0) return false
+
+  const provider = providerID.trim().toLowerCase()
+  if (!provider) return false
+
+  return disabledProviders.some((entry) => entry.trim().toLowerCase() === provider)
+}
+
+export function isModelProviderDisabled(
+  model: string | undefined,
+  disabledProviders: readonly string[] | undefined,
+): boolean {
+  if (!model || !disabledProviders || disabledProviders.length === 0) return false
+  return isProviderDisabled(model, disabledProviders)
+}
+
+export function filterDisabledProvidersFromFallbackChain(
+  fallbackChain: readonly FallbackEntry[] | undefined,
+  disabledProviders: readonly string[] | undefined,
+): FallbackEntry[] | undefined {
+  if (!fallbackChain) return undefined
+  if (!disabledProviders || disabledProviders.length === 0) return [...fallbackChain]
+
+  const filteredChain = fallbackChain
+    .map((entry) => ({
+      ...entry,
+      providers: entry.providers.filter((provider) => !isProviderNameDisabled(provider, disabledProviders)),
+    }))
+    .filter((entry) => entry.providers.length > 0)
+
+  return filteredChain.length > 0 ? filteredChain : undefined
+}

--- a/src/tools/delegate-task/tool-argument-preparation.test.ts
+++ b/src/tools/delegate-task/tool-argument-preparation.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { prepareDelegateTaskArgs } from "./tool-argument-preparation"
+import type { ToolContextWithMetadata } from "./types"
+
+function createToolContext(): ToolContextWithMetadata {
+	return {
+		sessionID: "ses_test",
+		messageID: "msg_test",
+		agent: "sisyphus",
+		abort: new AbortController().signal,
+	}
+}
+
+describe("prepareDelegateTaskArgs", () => {
+	test("preserves runtime model and variant arguments", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			model: "openai/gpt-5.5",
+			variant: "xhigh",
+			prompt: "Implement the thing",
+			run_in_background: false,
+			load_skills: [],
+		}
+
+		//#when
+		const result = await prepareDelegateTaskArgs(args, createToolContext())
+
+		//#then
+		expect(result.model).toBe("openai/gpt-5.5")
+		expect(result.variant).toBe("xhigh")
+		expect(args.model).toBe("openai/gpt-5.5")
+		expect(args.variant).toBe("xhigh")
+	})
+})

--- a/src/tools/delegate-task/tool-argument-preparation.ts
+++ b/src/tools/delegate-task/tool-argument-preparation.ts
@@ -80,10 +80,14 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
 
   const taskID = typeof args.task_id === "string" ? args.task_id : undefined
   const command = typeof args.command === "string" ? args.command : undefined
+  const model = typeof args.model === "string" && args.model.trim() !== "" ? args.model.trim() : undefined
+  const variant = typeof args.variant === "string" && args.variant.trim() !== "" ? args.variant.trim() : undefined
 
   args.category = category
   args.subagent_type = subagentType
   args.requested_subagent_type = originalSubagentType
+  args.model = model
+  args.variant = variant
   args.description = description
   args.prompt = prompt
   args.run_in_background = runInBackground
@@ -95,6 +99,8 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
     category,
     subagent_type: subagentType,
     requested_subagent_type: originalSubagentType,
+    model,
+    variant,
     description,
     prompt,
     run_in_background: runInBackground === true,

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -47,6 +47,8 @@ const delegateTaskArgsSchema = {
     .describe("Optional; defaults to false (sync). true=async (returns background task ID `bg_...` for background_output), false=sync (waits). Use true ONLY for parallel exploration; otherwise omit or pass false for task delegation."),
   category: tool.schema.string().optional().describe("REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type."),
   subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type."),
+  model: tool.schema.string().optional().describe("Optional runtime model override for this delegated task, in provider/model format. Overrides category and agent config for this invocation only."),
+  variant: tool.schema.string().optional().describe("Optional runtime model variant for this delegated task, such as low, medium, high, xhigh, or max."),
   task_id: tool.schema
     .string()
     .optional()

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -15,6 +15,8 @@ export interface DelegateTaskArgs {
   category?: string
   subagent_type?: string
   requested_subagent_type?: string
+  model?: string
+  variant?: string
   run_in_background: boolean
   task_id?: string
   command?: string
@@ -66,6 +68,7 @@ export interface DelegateTaskToolOptions {
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]
   agentOverrides?: AgentOverrides
+  disabledProviders?: string[]
   sisyphusAgentConfig?: SisyphusAgentConfig
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>


### PR DESCRIPTION
## Summary

- Allow team member specs to preserve `model` and `variant` fields.
- Forward category member runtime model/variant through category resolution.
- Forward subagent member runtime model/variant through subagent resolution.
- Preserve `disabledProviders` while stripping only the global `sisyphusJuniorModel` override for category members.

## Why

Team members already accept model/variant-shaped config, but those fields were not forwarded into execution. This makes team specs behave like direct `task()` calls.

## Dependency

This is intended to stack after the runtime-model policy and delegate-task runtime model/variant PRs.

## Testing

- `bun test src/features/team-mode/types.test.ts src/features/team-mode/team-runtime/resolve-member.test.ts`
- `bun run typecheck`
- `bun run build`
- Manual driver for team schema model/variant preservation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward and preserve runtime model and variant across team members and delegate tasks. Normalize runtime model handling in the fallback pipeline to prevent redundant retries and respect disabled providers.

- **New Features**
  - Forward member and subagent runtime `model`/`variant` through resolution and execution.
  - Add `model` and `variant` to delegate-task: schema, types, argument prep, and selection.
  - Normalize event payloads into a single runtime model string (supports `providerID`/`modelID` plus `variant`).

- **Bug Fixes**
  - Preserve variants in `session.error`, `message.updated`, `session.status`, and the first-prompt watchdog.
  - Treat models as equivalent across string/object forms (including variants) to skip redundant fallbacks and clear pending state correctly.
  - Enforce disabled providers in model selection and fallback chains; trim whitespace in provider comparisons.

<sup>Written for commit 037504ae8ca430ea19bca9e668a81bffde96bda0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4342?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

