### PR TITLE
fix(team-mode): requeue live-delivered peer_messages on empty assistant turn

### DIFF
--- a/src/hooks/team-session-events/empty-turn-recovery.ts
+++ b/src/hooks/team-session-events/empty-turn-recovery.ts
@@ -1,0 +1,193 @@
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { ackMessages } from "../../features/team-mode/team-mailbox/ack"
+import {
+  releaseDeliveryReservation,
+  reserveMessageForDelivery,
+} from "../../features/team-mode/team-mailbox/reservation"
+import { transitionRuntimeState } from "../../features/team-mode/team-state-store/store"
+import { log } from "../../shared/logger"
+import { isRecord } from "../../shared/record-type-guard"
+import { isSessionActive, settleAfterSessionIdle } from "../../shared/session-idle-settle"
+
+export type SessionStatusApi = () => Promise<unknown>
+export type SessionMessagesApi = (input: { path: { id: string } }) => Promise<unknown>
+
+export type LiveDeliveryRecoveryClient = {
+  session: {
+    status?: SessionStatusApi
+    messages?: SessionMessagesApi
+  }
+}
+
+export type ProcessPendingLiveDeliveriesInput = {
+  client: LiveDeliveryRecoveryClient
+  teamRunId: string
+  memberName: string
+  sessionID: string
+  pendingInjectedMessageIds: readonly string[]
+  config: TeamModeConfig
+  idleSettleMs?: number
+}
+
+export type ProcessPendingLiveDeliveriesOutcome =
+  | { kind: "active" }
+  | { kind: "noop" }
+  | { kind: "acked"; acked: readonly string[] }
+  | { kind: "requeued"; requeued: readonly string[] }
+
+export async function processPendingLiveDeliveries(
+  input: ProcessPendingLiveDeliveriesInput,
+): Promise<ProcessPendingLiveDeliveriesOutcome> {
+  const { client, teamRunId, memberName, sessionID, pendingInjectedMessageIds, config, idleSettleMs } = input
+  if (pendingInjectedMessageIds.length === 0) {
+    return { kind: "noop" }
+  }
+
+  if (typeof client.session.status === "function") {
+    await settleAfterSessionIdle(idleSettleMs ?? 0)
+    if (await isSessionActive(client, sessionID)) {
+      log("team idle pending ack skipped while session remains active", {
+        event: "team-mode-idle-pending-ack-active",
+        teamRunId,
+        memberName,
+        sessionID,
+        pendingCount: pendingInjectedMessageIds.length,
+      })
+      return { kind: "active" }
+    }
+  }
+
+  const claimedMessageIds = await claimPendingMessageAcks(teamRunId, memberName, pendingInjectedMessageIds, config)
+  if (claimedMessageIds.length === 0) {
+    return { kind: "noop" }
+  }
+
+  const producedOutput = await assistantTurnProducedOutput(client, sessionID)
+  if (!producedOutput) {
+    await requeueLiveDeliveriesForEmptyTurn(teamRunId, memberName, claimedMessageIds, config)
+    log("team idle detected empty assistant turn after live delivery, requeued for wake hint", {
+      event: "team-mode-idle-empty-turn-requeue",
+      teamRunId,
+      memberName,
+      sessionID,
+      requeuedCount: claimedMessageIds.length,
+    })
+    return { kind: "requeued", requeued: claimedMessageIds }
+  }
+
+  await ackMessages(teamRunId, memberName, [...claimedMessageIds], config)
+  log("team idle handled pending live delivery ack", {
+    event: "team-mode-idle-pending-ack",
+    teamRunId,
+    memberName,
+    sessionID,
+    ackedCount: claimedMessageIds.length,
+  })
+  return { kind: "acked", acked: claimedMessageIds }
+}
+
+async function claimPendingMessageAcks(
+  teamRunId: string,
+  memberName: string,
+  messageIds: readonly string[],
+  config: TeamModeConfig,
+): Promise<readonly string[]> {
+  if (messageIds.length === 0) return []
+
+  let claimedMessageIds: string[] = []
+  const candidateMessageIds = new Set(messageIds)
+  await transitionRuntimeState(teamRunId, (currentRuntimeState) => {
+    const currentMember = currentRuntimeState.members.find((member) => member.name === memberName)
+    if (currentMember === undefined) {
+      claimedMessageIds = []
+      return currentRuntimeState
+    }
+
+    claimedMessageIds = currentMember.pendingInjectedMessageIds.filter((messageId) => candidateMessageIds.has(messageId))
+    if (claimedMessageIds.length === 0) {
+      return currentRuntimeState
+    }
+
+    const claimedMessageIdSet = new Set(claimedMessageIds)
+    return {
+      ...currentRuntimeState,
+      members: currentRuntimeState.members.map((member) => (
+        member.name === memberName
+          ? {
+            ...member,
+            pendingInjectedMessageIds: member.pendingInjectedMessageIds.filter((messageId) => !claimedMessageIdSet.has(messageId)),
+          }
+          : member
+      )),
+    }
+  }, config)
+
+  return claimedMessageIds
+}
+
+async function requeueLiveDeliveriesForEmptyTurn(
+  teamRunId: string,
+  memberName: string,
+  messageIds: readonly string[],
+  config: TeamModeConfig,
+): Promise<void> {
+  for (const messageId of messageIds) {
+    const reservation = await reserveMessageForDelivery(teamRunId, memberName, messageId, config)
+    if (reservation === null) continue
+    await releaseDeliveryReservation(reservation)
+  }
+}
+
+async function assistantTurnProducedOutput(
+  client: LiveDeliveryRecoveryClient,
+  sessionID: string,
+): Promise<boolean> {
+  const messagesApi = client.session.messages
+  if (typeof messagesApi !== "function") {
+    return true
+  }
+  try {
+    const response = await messagesApi({ path: { id: sessionID } })
+    const messages = extractMessagesData(response)
+    const lastAssistant = findLatestAssistantMessage(messages)
+    if (lastAssistant === undefined) return true
+    return assistantMessageHasOutput(lastAssistant)
+  } catch (error) {
+    log("team idle empty-turn detection failed; defaulting to ack", {
+      event: "team-mode-idle-empty-turn-detect-failed",
+      sessionID,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return true
+  }
+}
+
+function extractMessagesData(response: unknown): readonly unknown[] {
+  if (isRecord(response) && Array.isArray(response.data)) return response.data
+  return Array.isArray(response) ? response : []
+}
+
+function findLatestAssistantMessage(messages: readonly unknown[]): unknown | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (isAssistantMessage(message)) return message
+  }
+  return undefined
+}
+
+function isAssistantMessage(message: unknown): boolean {
+  if (!isRecord(message)) return false
+  const info = isRecord(message.info) ? message.info : message
+  return info.role === "assistant"
+}
+
+function assistantMessageHasOutput(message: unknown): boolean {
+  if (!isRecord(message)) return false
+  const parts = Array.isArray(message.parts) ? message.parts : []
+  for (const part of parts) {
+    if (!isRecord(part)) continue
+    if (part.type === "tool") return true
+    if (part.type === "text" && typeof part.text === "string" && part.text.trim().length > 0) return true
+  }
+  return false
+}

--- a/src/hooks/team-session-events/empty-turn-recovery.ts
+++ b/src/hooks/team-session-events/empty-turn-recovery.ts
@@ -153,12 +153,12 @@ async function assistantTurnProducedOutput(
     if (lastAssistant === undefined) return true
     return assistantMessageHasOutput(lastAssistant)
   } catch (error) {
-    log("team idle empty-turn detection failed; defaulting to ack", {
+    log("team idle empty-turn detection failed; defaulting to requeue (fail-safe)", {
       event: "team-mode-idle-empty-turn-detect-failed",
       sessionID,
       error: error instanceof Error ? error.message : String(error),
     })
-    return true
+    return false
   }
 }
 

--- a/src/hooks/team-session-events/team-idle-wake-hint.test.ts
+++ b/src/hooks/team-session-events/team-idle-wake-hint.test.ts
@@ -1076,4 +1076,51 @@ describe("createTeamIdleWakeHint", () => {
     const runtimeState = await loadRuntimeState(teamRunId, config)
     expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
   })
+
+  test("#given pending live-delivery and recipient session.messages API throws #when idle fires #then requeues fail-safe instead of silently acking", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await seedRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+    await seedReservedUnreadMessage(teamRunId, config, messageId, "live delivery body", 100)
+
+    const ackSpy = spyOn(ackModule, "ackMessages")
+    const promptAsyncSpy = mock(async (_input: WakeHintPromptInput) => ({}))
+    const messagesSpy = mock(async (_input: { path: { id: string } }) => {
+      throw new Error("transient network failure")
+    })
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          promptAsync: promptAsyncSpy,
+          messages: messagesSpy,
+        },
+      },
+    }, config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "member-session" },
+      },
+    })
+
+    // then
+    expect(ackSpy).not.toHaveBeenCalled()
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inboxEntries = await readdir(inboxDir)
+    expect(inboxEntries).toContain(`${messageId}.json`)
+    expect(inboxEntries).not.toContain(`.delivering-${messageId}.json`)
+    expect(inboxEntries).not.toContain("processed")
+
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+
+    expect(promptAsyncSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/hooks/team-session-events/team-idle-wake-hint.test.ts
+++ b/src/hooks/team-session-events/team-idle-wake-hint.test.ts
@@ -854,4 +854,226 @@ describe("createTeamIdleWakeHint", () => {
     expect(promptInput.body.parts[0]?.text).toContain("2 new team messages")
     expect(promptInput.body.agent).toBe("atlas")
   })
+
+  test("#given pending live-delivery and recipient assistant turn produced empty output #when idle fires #then requeues the message to unread and sends a wake hint instead of acking", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await seedRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+    await seedReservedUnreadMessage(teamRunId, config, messageId, "live delivery body", 100)
+
+    const ackSpy = spyOn(ackModule, "ackMessages")
+    const promptInputs: Array<WakeHintPromptInput> = []
+    const promptAsyncSpy = mock(async (input: WakeHintPromptInput) => {
+      promptInputs.push(input)
+      return {}
+    })
+    const messagesSpy = mock(async (_input: { path: { id: string } }) => ({
+      data: [
+        {
+          info: {
+            role: "user",
+            id: "msg-user-peer",
+            time: { created: 900, completed: 901 },
+          },
+          parts: [{ type: "text", text: `<peer_message from=\"lead\">work request</peer_message>` }],
+        },
+        {
+          info: {
+            role: "assistant",
+            id: "msg-assistant-empty",
+            time: { created: 1000, completed: 1050 },
+            finish: "stop",
+          },
+          parts: [],
+        },
+      ],
+    }))
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          promptAsync: promptAsyncSpy,
+          messages: messagesSpy,
+        },
+      },
+    }, config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "member-session" },
+      },
+    })
+
+    // then
+    expect(ackSpy).not.toHaveBeenCalled()
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inboxEntries = await readdir(inboxDir)
+    expect(inboxEntries).toContain(`${messageId}.json`)
+    expect(inboxEntries).not.toContain(`.delivering-${messageId}.json`)
+    expect(inboxEntries).not.toContain("processed")
+
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+
+    expect(promptAsyncSpy).toHaveBeenCalledTimes(1)
+    const promptInput = promptInputs[0]
+    if (promptInput === undefined) {
+      throw new Error("expected wake hint prompt input")
+    }
+    expect(promptInput.body.parts[0]?.text).toContain("1 new team messages")
+  })
+
+  test("#given pending live-delivery and recipient assistant turn produced text output #when idle fires #then acks the message as today (output-blind path unchanged)", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await seedRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+    await seedReservedUnreadMessage(teamRunId, config, messageId, "live delivery body", 100)
+
+    const ackSpy = spyOn(ackModule, "ackMessages")
+    const promptAsyncSpy = mock(async (_input: WakeHintPromptInput) => ({}))
+    const messagesSpy = mock(async (_input: { path: { id: string } }) => ({
+      data: [
+        {
+          info: {
+            role: "user",
+            id: "msg-user-peer",
+            time: { created: 900, completed: 901 },
+          },
+          parts: [{ type: "text", text: `<peer_message from=\"lead\">work request</peer_message>` }],
+        },
+        {
+          info: {
+            role: "assistant",
+            id: "msg-assistant-replied",
+            time: { created: 1000, completed: 1050 },
+            finish: "stop",
+          },
+          parts: [{ type: "text", text: "Acknowledged, I will respond now." }],
+        },
+      ],
+    }))
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          promptAsync: promptAsyncSpy,
+          messages: messagesSpy,
+        },
+      },
+    }, config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "member-session" },
+      },
+    })
+
+    // then
+    expect(ackSpy).toHaveBeenCalledTimes(1)
+    expect(ackSpy).toHaveBeenCalledWith(teamRunId, "worker", [messageId], config)
+    expect(promptAsyncSpy).not.toHaveBeenCalled()
+
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const processedEntries = await readdir(path.join(inboxDir, "processed"))
+    expect(processedEntries).toContain(`${messageId}.json`)
+  })
+
+  test("#given pending live-delivery and recipient assistant turn produced a tool call #when idle fires #then acks the message as today (tool output counts as response)", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await seedRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+    await seedReservedUnreadMessage(teamRunId, config, messageId, "live delivery body", 100)
+
+    const ackSpy = spyOn(ackModule, "ackMessages")
+    const promptAsyncSpy = mock(async (_input: WakeHintPromptInput) => ({}))
+    const messagesSpy = mock(async (_input: { path: { id: string } }) => ({
+      data: [
+        {
+          info: {
+            role: "user",
+            id: "msg-user-peer",
+            time: { created: 900, completed: 901 },
+          },
+          parts: [{ type: "text", text: `<peer_message from=\"lead\">work request</peer_message>` }],
+        },
+        {
+          info: {
+            role: "assistant",
+            id: "msg-assistant-tool",
+            time: { created: 1000, completed: 1050 },
+            finish: "stop",
+          },
+          parts: [{ type: "tool", tool: "team_send_message", state: { status: "completed" } }],
+        },
+      ],
+    }))
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          promptAsync: promptAsyncSpy,
+          messages: messagesSpy,
+        },
+      },
+    }, config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "member-session" },
+      },
+    })
+
+    // then
+    expect(ackSpy).toHaveBeenCalledTimes(1)
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+  })
+
+  test("#given pending live-delivery and recipient session.messages API is unavailable #when idle fires #then acks the message as today (backward compat)", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await seedRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+    await seedReservedUnreadMessage(teamRunId, config, messageId, "live delivery body", 100)
+
+    const ackSpy = spyOn(ackModule, "ackMessages")
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: { session: { promptAsync: mock(async (_input: WakeHintPromptInput) => ({})) } },
+    }, config)
+
+    // when
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "member-session" },
+      },
+    })
+
+    // then
+    expect(ackSpy).toHaveBeenCalledTimes(1)
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+  })
 })

--- a/src/hooks/team-session-events/team-idle-wake-hint.ts
+++ b/src/hooks/team-session-events/team-idle-wake-hint.ts
@@ -4,14 +4,16 @@ import {
   applyMemberSessionRouting,
   buildMemberPromptBody,
 } from "../../features/team-mode/member-session-routing"
-import { ackMessages } from "../../features/team-mode/team-mailbox/ack"
 import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
-import { loadRuntimeState, transitionRuntimeState } from "../../features/team-mode/team-state-store/store"
+import { loadRuntimeState } from "../../features/team-mode/team-state-store/store"
 import { resolveSessionEventID } from "../../shared/event-session-id"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { log } from "../../shared/logger"
-import { isSessionActive, settleAfterSessionIdle } from "../../shared/session-idle-settle"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../shared/prompt-async-gate"
+import {
+  type SessionMessagesApi,
+  processPendingLiveDeliveries,
+} from "./empty-turn-recovery"
 
 type PromptAsyncInput = {
   path: { id: string }
@@ -30,6 +32,7 @@ type TeamIdleWakeHintContext = {
     session: {
       promptAsync?: (input: PromptAsyncInput) => Promise<unknown>
       status?: () => Promise<unknown>
+      messages?: SessionMessagesApi
     }
   }
 }
@@ -49,45 +52,6 @@ function buildWakeHint(unreadCount: number): string {
 
 function buildWakeHintBatchKey(teamRunId: string, memberName: string, messageIds: string[]): string {
   return `${teamRunId}:${memberName}:${messageIds.toSorted().join(",")}`
-}
-
-async function claimPendingMessageAcks(
-  teamRunId: string,
-  memberName: string,
-  messageIds: readonly string[],
-  config: TeamModeConfig,
-): Promise<string[]> {
-  if (messageIds.length === 0) return []
-
-  let claimedMessageIds: string[] = []
-  const candidateMessageIds = new Set(messageIds)
-  await transitionRuntimeState(teamRunId, (currentRuntimeState) => {
-    const currentMember = currentRuntimeState.members.find((member) => member.name === memberName)
-    if (currentMember === undefined) {
-      claimedMessageIds = []
-      return currentRuntimeState
-    }
-
-    claimedMessageIds = currentMember.pendingInjectedMessageIds.filter((messageId) => candidateMessageIds.has(messageId))
-    if (claimedMessageIds.length === 0) {
-      return currentRuntimeState
-    }
-
-    const claimedMessageIdSet = new Set(claimedMessageIds)
-    return {
-      ...currentRuntimeState,
-      members: currentRuntimeState.members.map((member) => (
-        member.name === memberName
-          ? {
-            ...member,
-            pendingInjectedMessageIds: member.pendingInjectedMessageIds.filter((messageId) => !claimedMessageIdSet.has(messageId)),
-          }
-          : member
-      )),
-    }
-  }, config)
-
-  return claimedMessageIds
 }
 
 export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: TeamModeConfig, options?: TeamIdleWakeHintOptions): HookImpl {
@@ -111,39 +75,19 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
         return
       }
 
-      const pendingInjectedMessageIds = [...memberEntry.pendingInjectedMessageIds]
-      if (pendingInjectedMessageIds.length > 0) {
-        if (typeof ctx.client.session.status === "function") {
-          await settleAfterSessionIdle(options?.idleSettleMs ?? 0)
-          if (await isSessionActive(ctx.client, sessionID)) {
-            log("team idle pending ack skipped while session remains active", {
-              event: "team-mode-idle-pending-ack-active",
-              teamRunId: runtimeState.teamRunId,
-              memberName: memberEntry.name,
-              sessionID,
-              pendingCount: pendingInjectedMessageIds.length,
-            })
-            return
-          }
-        }
-
-        const claimedMessageIds = await claimPendingMessageAcks(
-          runtimeState.teamRunId,
-          memberEntry.name,
-          pendingInjectedMessageIds,
-          config,
-        )
-        if (claimedMessageIds.length > 0) {
-          await ackMessages(runtimeState.teamRunId, memberEntry.name, claimedMessageIds, config)
-          log("team idle handled pending live delivery ack", {
-            event: "team-mode-idle-pending-ack",
-            teamRunId: runtimeState.teamRunId,
-            memberName: memberEntry.name,
-            sessionID,
-            ackedCount: claimedMessageIds.length,
-          })
-        }
+      const pendingResult = await processPendingLiveDeliveries({
+        client: ctx.client,
+        teamRunId: runtimeState.teamRunId,
+        memberName: memberEntry.name,
+        sessionID,
+        pendingInjectedMessageIds: memberEntry.pendingInjectedMessageIds,
+        config,
+        idleSettleMs: options?.idleSettleMs,
+      })
+      if (pendingResult.kind === "active") {
+        return
       }
+      const ackedCount = pendingResult.kind === "acked" ? pendingResult.acked.length : 0
 
       const latestRuntimeState = await loadRuntimeState(runtimeMember.teamRunId, config)
       const latestMemberEntry = latestRuntimeState.members.find((member) => member.name === runtimeMember.memberName)
@@ -172,7 +116,7 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
           teamRunId: latestRuntimeState.teamRunId,
           memberName: latestMemberEntry.name,
           sessionID,
-          ackedCount: pendingInjectedMessageIds.length,
+          ackedCount,
         })
         return
       }
@@ -183,7 +127,7 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
           teamRunId: latestRuntimeState.teamRunId,
           memberName: latestMemberEntry.name,
           sessionID,
-          ackedCount: pendingInjectedMessageIds.length,
+          ackedCount,
         })
         return
       }
@@ -256,7 +200,7 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
         memberName: latestMemberEntry.name,
         sessionID,
         unreadCount: unreadMessages.length,
-        ackedCount: pendingInjectedMessageIds.length,
+        ackedCount,
       })
     } catch (error) {
       log("team idle wake hint failed", {

--- a/src/plugin/build-team-idle-wake-hint-client.test.ts
+++ b/src/plugin/build-team-idle-wake-hint-client.test.ts
@@ -11,6 +11,7 @@ type SdkLikeSession = {
   _client: FakeSdkHttp
   promptAsync: (options: { path: { id: string }; body?: unknown }) => Promise<{ url: string; body?: unknown }>
   status: () => Promise<{ url: string; _client: FakeSdkHttp }>
+  messages: (options: { path: { id: string } }) => Promise<{ url: string; _client: FakeSdkHttp }>
 }
 
 function createSdkLikeSession(http: FakeSdkHttp): SdkLikeSession {
@@ -21,6 +22,9 @@ function createSdkLikeSession(http: FakeSdkHttp): SdkLikeSession {
     },
     async status() {
       return { url: "/session", _client: this._client }
+    },
+    async messages(options) {
+      return { url: `/session/${options.path.id}/messages`, _client: this._client }
     },
   }
 }
@@ -74,6 +78,22 @@ describe("buildTeamIdleWakeHintClient", () => {
     // then
     expect(wrapped.session.promptAsync).toBeUndefined()
     expect(wrapped.session.status).toBeUndefined()
+    expect(wrapped.session.messages).toBeUndefined()
+  })
+
+  test("#given a real-SDK-like session whose messages reads this._client #when the wrapper dispatches the bound messages #then _client is preserved", async () => {
+    // given
+    const http: FakeSdkHttp = { post: async (args) => args }
+    const session = createSdkLikeSession(http)
+    const sdkClient = { session } as unknown as Parameters<typeof buildTeamIdleWakeHintClient>[0]
+
+    // when
+    const wrapped = buildTeamIdleWakeHintClient(sdkClient)
+    const result = (await wrapped.session.messages?.({ path: { id: "ses_messages" } } as never)) as { _client?: FakeSdkHttp; url?: string } | undefined
+
+    // then
+    expect(result?._client).toBe(http)
+    expect(result?.url).toBe("/session/ses_messages/messages")
   })
 
   test("#given a destructure-without-bind pattern #when promptAsync is invoked via a plain wrapper #then this._client is undefined (historical bug)", async () => {

--- a/src/plugin/build-team-idle-wake-hint-client.ts
+++ b/src/plugin/build-team-idle-wake-hint-client.ts
@@ -3,11 +3,13 @@ import type { PluginInput } from "@opencode-ai/plugin"
 type SdkSession = PluginInput["client"]["session"]
 type SdkPromptAsync = SdkSession["promptAsync"]
 type SdkStatus = SdkSession["status"]
+type SdkMessages = SdkSession["messages"]
 
 export type TeamIdleWakeHintNarrowClient = {
   session: {
     promptAsync?: SdkPromptAsync
     status?: SdkStatus
+    messages?: SdkMessages
   }
 }
 
@@ -19,7 +21,10 @@ export function buildTeamIdleWakeHintClient(client: PluginInput["client"]): Team
   const status = typeof session.status === "function"
     ? session.status.bind(session) as SdkStatus
     : undefined
+  const messages = typeof session.messages === "function"
+    ? session.messages.bind(session) as SdkMessages
+    : undefined
   return {
-    session: { promptAsync, status },
+    session: { promptAsync, status, messages },
   }
 }


### PR DESCRIPTION
## Problem

When a `peer_message` is live-delivered via `team_send_message` and the recipient model produces an EMPTY assistant turn (0 tool calls, 0 text, EOS), `team-idle-wake-hint` was unconditionally acking the pending delivery on `session.idle`. The ack moved the inbox file to `processed/`, `listUnreadMessages` then returned empty, and no wake hint fired. **The work was silently consumed and the recipient sat idle.**

## Reproduction

Observed on a live ultradebate session (`ses_1ab1d2addffeRGRHu7XSxsjfUt`) with `gemini-3-1-pro-preview`:

```
13:00:15.621  user turn:  <peer_message from="lead"> Phase 2 OPEN ...  (4000+ words)
13:00:15.771  assistant turn:  EMPTY (150ms, 0 tools, 0 text)  ← stuck
   ↓ ~3 minutes idle
13:03:17.748  user turn:  "You have 1 new team messages..." (manual nudge)
13:03:17.775  assistant turn:  [tool: team_send_message]  ← finally produces work
```

## Root cause

`ACK is outcome-blind` — confirmed via parallel ultrabrain investigation + direct code reading.

```
1. team_send_message → dispatchInternalPrompt(source="team-live-delivery")
2. markLiveDeliveryPending → pendingInjectedMessageIds += messageId
3. recipient model returns EMPTY assistant turn (gemini-3.1-pro behavior on long prompts)
4. session.idle fires
5. team-idle-wake-hint UNCONDITIONALLY acks pendingInjectedMessageIds
6. ack.ts moves .delivering-{id}.json → processed/{id}.json
7. listUnreadMessages returns [] → no wake hint dispatched
8. work permanently lost (recovery only via manual second team_send_message)
```

Existing recovery paths cover only `session.error` (`team-member-error-handler`) and 10-minute stale-reservation reclaim, **not the empty-output-but-no-error case.**

## Fix

Introduce `empty-turn-recovery.ts` with `processPendingLiveDeliveries` which:

1. **Detects empty assistant turn** by querying `session.messages` and checking the latest assistant message for non-empty text parts or tool calls (mirrors the prompt-async-gate's own `latestAssistantTurnBlocksInternalPrompt` logic for consistency).
2. **When empty:** releases the `.delivering-{id}.json` reservation back to `{id}.json` instead of acking, so the message reappears in the unread inbox.
3. **Falls through** to the existing `listUnreadMessages` + wake-hint path, which now sends the standard nudge (`"You have N new team messages. They will be injected on your next turn."`) that the model actually responds to.

**Backward compatible:** when `client.session.messages` is unavailable (older callers, test fixtures without the API) the helper returns `true` (assume output produced) so the prior ack-on-idle behavior is preserved.

`claimPendingMessageAcks` was moved to the new file as well, keeping `team-idle-wake-hint.ts` under the 250 pure LOC ceiling (244 → 194).

## Tests

| Scenario | Expected | Result |
|---|---|---|
| Empty assistant turn after live delivery | NOT ack, requeue to unread, wake hint fires | ✅ |
| Text-reply assistant turn after live delivery | ACK as today | ✅ |
| Tool-call assistant turn after live delivery | ACK as today (tool counts as output) | ✅ |
| `session.messages` API unavailable | ACK as today (backward compat) | ✅ |
| 15 existing tests in the file | All pass | ✅ |

**Verification:**
- 19/19 tests in `team-idle-wake-hint.test.ts` pass
- 298 tests pass across team-mode + prompt-async-gate test surface
- `bun run typecheck` clean
- Both touched files under the 250 pure LOC ceiling

## Related

This is the empty-output sibling of #4256/#4019 (duplicate-injection class). Same prompt-async invariant area, different failure direction (under-delivery instead of over-delivery).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent loss of live-delivered `peer_message` work when the recipient returns an empty assistant turn. We now detect empty output via `session.messages`, requeue on `session.idle`, and send the normal wake hint; the production client forwards `session.messages`, and we fail-safe to requeue on API errors.

- **Bug Fixes**
  - Added `empty-turn-recovery.ts` with `processPendingLiveDeliveries` to check the latest assistant turn via `client.session.messages`.
  - On empty output: release `.delivering-{id}.json` back to `{id}.json` so it’s unread and the wake hint fires; otherwise ack.
  - Wired `session.messages` through `build-team-idle-wake-hint-client` (bound like `promptAsync`/`status`) so detection runs in production.
  - Fail-safe: if `session.messages` throws, requeue and nudge; if the API is unavailable, ack (backward compat).

<sup>Written for commit 0250f84bf14a97c5950c334189782fe229666a6c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

