### PR TITLE
fix: raise EventEmitter max listeners to silence MaxListenersExceededWarning (#4334)

### DIFF
--- a/src/index.telemetry.test.ts
+++ b/src/index.telemetry.test.ts
@@ -61,6 +61,7 @@ function createTestPluginModule(): ReturnType<typeof createPluginModule> {
     })) as never,
     installAgentSortShim: mock(() => {}),
     setAgentSortOrder: mock(() => {}),
+    raiseEventEmitterLimit: mock(() => {}),
   })
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -48,6 +48,7 @@ const mockCreateFirstMessageVariantGate = mock(() => ({
   markSessionCreated: () => {},
   clear: () => {},
 }))
+const mockRaiseEventEmitterLimit = mock(() => {})
 
 let pluginModule: ReturnType<typeof createPluginModule>
 
@@ -73,6 +74,7 @@ function createTestPluginModule(): ReturnType<typeof createPluginModule> {
     log: mockLog,
     createModelCacheState: mockCreateModelCacheState as never,
     createFirstMessageVariantGate: mockCreateFirstMessageVariantGate as never,
+    raiseEventEmitterLimit: mockRaiseEventEmitterLimit,
   })
 }
 

--- a/src/shared/raise-event-emitter-limit.test.ts
+++ b/src/shared/raise-event-emitter-limit.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { EventEmitter } from "node:events"
+import { raiseEventEmitterLimit, __resetRaisedFlagForTests } from "./raise-event-emitter-limit"
+
+const ORIGINAL_DEFAULT = EventEmitter.defaultMaxListeners
+
+beforeEach(() => {
+  EventEmitter.defaultMaxListeners = ORIGINAL_DEFAULT
+  __resetRaisedFlagForTests()
+})
+
+afterEach(() => {
+  EventEmitter.defaultMaxListeners = ORIGINAL_DEFAULT
+  __resetRaisedFlagForTests()
+})
+
+describe("raiseEventEmitterLimit", () => {
+  test("raises EventEmitter.defaultMaxListeners when below target", () => {
+    //#given
+    EventEmitter.defaultMaxListeners = 10
+
+    //#when
+    raiseEventEmitterLimit(100)
+
+    //#then
+    expect(EventEmitter.defaultMaxListeners).toBe(100)
+  })
+
+  test("does not lower the default when already above target", () => {
+    //#given
+    EventEmitter.defaultMaxListeners = 200
+
+    //#when
+    raiseEventEmitterLimit(100)
+
+    //#then
+    expect(EventEmitter.defaultMaxListeners).toBe(200)
+  })
+
+  test("is idempotent across multiple calls", () => {
+    //#given
+    EventEmitter.defaultMaxListeners = 10
+
+    //#when
+    raiseEventEmitterLimit(100)
+    EventEmitter.defaultMaxListeners = 5
+    raiseEventEmitterLimit(100)
+
+    //#then
+    expect(EventEmitter.defaultMaxListeners).toBe(5)
+  })
+
+  test("defaults to 100 when no target is given", () => {
+    //#given
+    EventEmitter.defaultMaxListeners = 10
+
+    //#when
+    raiseEventEmitterLimit()
+
+    //#then
+    expect(EventEmitter.defaultMaxListeners).toBe(100)
+  })
+})

--- a/src/shared/raise-event-emitter-limit.test.ts
+++ b/src/shared/raise-event-emitter-limit.test.ts
@@ -3,14 +3,17 @@ import { EventEmitter } from "node:events"
 import { raiseEventEmitterLimit, __resetRaisedFlagForTests } from "./raise-event-emitter-limit"
 
 const ORIGINAL_DEFAULT = EventEmitter.defaultMaxListeners
+const ORIGINAL_PROCESS_MAX = process.getMaxListeners()
 
 beforeEach(() => {
   EventEmitter.defaultMaxListeners = ORIGINAL_DEFAULT
+  process.setMaxListeners(ORIGINAL_PROCESS_MAX)
   __resetRaisedFlagForTests()
 })
 
 afterEach(() => {
   EventEmitter.defaultMaxListeners = ORIGINAL_DEFAULT
+  process.setMaxListeners(ORIGINAL_PROCESS_MAX)
   __resetRaisedFlagForTests()
 })
 
@@ -35,6 +38,30 @@ describe("raiseEventEmitterLimit", () => {
 
     //#then
     expect(EventEmitter.defaultMaxListeners).toBe(200)
+  })
+
+  test("preserves EventEmitter.defaultMaxListeners === 0 (unlimited)", () => {
+    //#given a host that explicitly disabled the listener warning
+    EventEmitter.defaultMaxListeners = 0
+
+    //#when
+    raiseEventEmitterLimit(100)
+
+    //#then it stays unlimited; we do not silently downgrade to 100
+    expect(EventEmitter.defaultMaxListeners).toBe(0)
+  })
+
+  test("preserves process.getMaxListeners() === 0 (unlimited)", () => {
+    //#given
+    EventEmitter.defaultMaxListeners = 10
+    process.setMaxListeners(0)
+
+    //#when
+    raiseEventEmitterLimit(100)
+
+    //#then process stays unlimited; defaultMaxListeners still raises independently
+    expect(process.getMaxListeners()).toBe(0)
+    expect(EventEmitter.defaultMaxListeners).toBe(100)
   })
 
   test("is idempotent across multiple calls", () => {

--- a/src/shared/raise-event-emitter-limit.ts
+++ b/src/shared/raise-event-emitter-limit.ts
@@ -10,15 +10,23 @@ export function raiseEventEmitterLimit(target: number = TARGET_MAX_LISTENERS): v
   }
   raised = true
 
-  if (EventEmitter.defaultMaxListeners < target) {
+  // EventEmitter.defaultMaxListeners === 0 means "unlimited" in Node's API.
+  // Treat that as already-covered so a host that explicitly disabled the warning
+  // is not silently downgraded to `target`.
+  const currentDefault = EventEmitter.defaultMaxListeners
+  if (currentDefault !== 0 && currentDefault < target) {
     EventEmitter.defaultMaxListeners = target
   }
 
-  const proc = process as unknown as { setMaxListeners?: (n: number) => void; getMaxListeners?: () => number }
-  if (typeof proc.setMaxListeners === "function") {
-    const current = typeof proc.getMaxListeners === "function" ? proc.getMaxListeners() : 0
-    if (current < target) {
-      proc.setMaxListeners(target)
+  if (typeof process.setMaxListeners === "function") {
+    // Same "0 = unlimited" semantics on `process` itself. If `getMaxListeners`
+    // is unavailable, skip the raise rather than assume 0 and unconditionally
+    // overwrite the host's configuration.
+    if (typeof process.getMaxListeners === "function") {
+      const current = process.getMaxListeners()
+      if (current !== 0 && current < target) {
+        process.setMaxListeners(target)
+      }
     }
   }
 }

--- a/src/shared/raise-event-emitter-limit.ts
+++ b/src/shared/raise-event-emitter-limit.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from "node:events"
+
+const TARGET_MAX_LISTENERS = 100
+
+let raised = false
+
+export function raiseEventEmitterLimit(target: number = TARGET_MAX_LISTENERS): void {
+  if (raised) {
+    return
+  }
+  raised = true
+
+  if (EventEmitter.defaultMaxListeners < target) {
+    EventEmitter.defaultMaxListeners = target
+  }
+
+  const proc = process as unknown as { setMaxListeners?: (n: number) => void; getMaxListeners?: () => number }
+  if (typeof proc.setMaxListeners === "function") {
+    const current = typeof proc.getMaxListeners === "function" ? proc.getMaxListeners() : 0
+    if (current < target) {
+      proc.setMaxListeners(target)
+    }
+  }
+}
+
+export function __resetRaisedFlagForTests(): void {
+  raised = false
+}

--- a/src/testing/create-plugin-module.test.ts
+++ b/src/testing/create-plugin-module.test.ts
@@ -49,6 +49,7 @@ const mockCreateFirstMessageVariantGate = mock(() => ({
   markSessionCreated: () => {},
   clear: () => {},
 }))
+const mockRaiseEventEmitterLimit = mock(() => {})
 
 function createTestPluginModule(): ReturnType<typeof createPluginModule> {
   return createPluginModule({
@@ -72,6 +73,7 @@ function createTestPluginModule(): ReturnType<typeof createPluginModule> {
     log: mockLog,
     createModelCacheState: mockCreateModelCacheState as never,
     createFirstMessageVariantGate: mockCreateFirstMessageVariantGate as never,
+    raiseEventEmitterLimit: mockRaiseEventEmitterLimit,
   })
 }
 

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -21,6 +21,7 @@ import { createFirstMessageVariantGate } from "../shared/first-message-variant"
 import { initI18n } from "../shared/i18n"
 import { log } from "../shared/logger"
 import { logLegacyPluginStartupWarning } from "../shared/log-legacy-plugin-startup-warning"
+import { raiseEventEmitterLimit } from "../shared/raise-event-emitter-limit"
 import { migrateLegacyWorkspaceDirectory } from "../shared/legacy-workspace-migration"
 import { injectServerAuthIntoClient } from "../shared/opencode-server-auth"
 import { startBackgroundCheck as startTmuxCheck } from "../tools/interactive-bash"
@@ -36,6 +37,7 @@ export type PluginModuleDeps = {
   log: typeof log
   logLegacyPluginStartupWarning: typeof logLegacyPluginStartupWarning
   migrateLegacyWorkspaceDirectory: typeof migrateLegacyWorkspaceDirectory
+  raiseEventEmitterLimit: typeof raiseEventEmitterLimit
   detectExternalSkillPlugin: typeof detectExternalSkillPlugin
   getSkillPluginConflictWarning: typeof getSkillPluginConflictWarning
   injectServerAuthIntoClient: typeof injectServerAuthIntoClient
@@ -60,6 +62,7 @@ const defaultPluginModuleDeps: PluginModuleDeps = {
   log,
   logLegacyPluginStartupWarning,
   migrateLegacyWorkspaceDirectory,
+  raiseEventEmitterLimit,
   detectExternalSkillPlugin,
   getSkillPluginConflictWarning,
   injectServerAuthIntoClient,
@@ -80,6 +83,7 @@ const defaultPluginModuleDeps: PluginModuleDeps = {
 export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): PluginModule {
   const deps = { ...defaultPluginModuleDeps, ...overrides }
   const serverPlugin: Plugin = async (input, _options): Promise<Hooks> => {
+    deps.raiseEventEmitterLimit()
     deps.installAgentSortShim()
     deps.initConfigContext("opencode", null)
     deps.log("[oh-my-openagent] ENTRY - plugin loading", {


### PR DESCRIPTION
Closes #4334

## Root cause

The plugin registers ~58 hooks across 5 hook categories (`createSessionHooks`, `createToolGuardHooks`, `createTransformHooks`, `createContinuationHooks`, `createSkillHooks`). Each hook ultimately attaches a listener to the OpenCode effect runtime's internal EventTarget. Node's default `EventEmitter.defaultMaxListeners` is 10, so loading the plugin triggers a benign but noisy `MaxListenersExceededWarning` at startup.

We cannot reach the effect runtime's EventTarget directly from a plugin (it lives inside the bun-compiled OpenCode binary), but raising `EventEmitter.defaultMaxListeners` lifts the limit for emitters that don't override it — which is what the warning is about here.

## Fix

- New helper `src/shared/raise-event-emitter-limit.ts` raises `EventEmitter.defaultMaxListeners` (and `process.setMaxListeners`) to 100 the first time it's called. It only raises — it never lowers a higher limit set by a host.
- Called once at plugin entry in `createPluginModule`'s `serverPlugin`, before any hooks are registered.
- Idempotent across re-invocations.

## Verification

- npm run build: PASS
- npm test (relevant files: `raise-event-emitter-limit.test.ts`, `safe-create-hook.test.ts`, `create-plugin-module.test.ts`, `index.test.ts`, `index.telemetry.test.ts`): 23 pass, 0 fail
- New unit test covers: raises when below target, leaves higher limits alone, idempotent across calls, default target 100.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Node’s event listener limit to 100 at plugin startup to silence MaxListenersExceededWarning from ~58 plugin hooks. Preserves host configs, including unlimited (0), to avoid side effects.

- **Bug Fixes**
  - Added `raiseEventEmitterLimit` to raise `EventEmitter.defaultMaxListeners` and `process.setMaxListeners` to 100 only when below target; preserves 0 (unlimited) and is idempotent.
  - Call `raiseEventEmitterLimit()` in `createPluginModule`’s `serverPlugin` before hooks register; tests updated to mock it and new unit tests cover 0/unlimited and idempotency.

<sup>Written for commit 74ba09373aefc4c1a12fef725ef1bb0d35d2218b. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

