### PR TITLE
fix: trust user-configured multimodal-looker model for vision (#4209)

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -13,6 +13,18 @@ import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
+function collectTrustedVisionCapableModels(
+  pluginConfig: OhMyOpenCodeConfig,
+): string[] {
+  const trusted: string[] = []
+  const multimodalLookerOverride = pluginConfig.agents?.["multimodal-looker"]
+  const configuredModel = multimodalLookerOverride?.model
+  if (typeof configuredModel === "string" && configuredModel.includes("/")) {
+    trusted.push(configuredModel)
+  }
+  return trusted
+}
+
 export interface ConfigHandlerDeps {
   ctx: { directory: string; client?: any };
   pluginConfig: OhMyOpenCodeConfig;
@@ -26,7 +38,11 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     const formatterConfig = config.formatter;
 
     setAdditionalAllowedMcpEnvVars(pluginConfig.mcp_env_allowlist ?? [])
-    applyProviderConfig({ config, modelCacheState });
+    applyProviderConfig({
+      config,
+      modelCacheState,
+      trustedVisionCapableModels: collectTrustedVisionCapableModels(pluginConfig),
+    });
     clearFormatterCache()
 
     const pluginComponents = await loadPluginComponents({ pluginConfig });

--- a/src/plugin-handlers/provider-config-handler.test.ts
+++ b/src/plugin-handlers/provider-config-handler.test.ts
@@ -97,6 +97,92 @@ describe("applyProviderConfig", () => {
     ])
   })
 
+  test("trusts user-configured multimodal-looker model even when provider config omits modalities", () => {
+    // given - user configures glm-5.1 as multimodal-looker but provider model entry has no modalities/capabilities
+    const modelCacheState = createModelCacheState()
+    const visionCapableModelsCache = modelCacheState.visionCapableModelsCache
+    if (!visionCapableModelsCache) {
+      throw new Error("visionCapableModelsCache should be initialized")
+    }
+    const config = {
+      provider: {
+        "zhipuai-coding-plan": {
+          models: {
+            "glm-5.1": {
+              limit: { context: 200000 },
+            },
+          },
+        },
+      },
+    } satisfies Record<string, unknown>
+
+    // when
+    applyProviderConfig({
+      config,
+      modelCacheState,
+      trustedVisionCapableModels: ["zhipuai-coding-plan/glm-5.1"],
+    })
+
+    // then - trusted model is in cache even though provider config did not declare image support
+    expect(Array.from(visionCapableModelsCache.keys())).toEqual([
+      "zhipuai-coding-plan/glm-5.1",
+    ])
+    expect(readVisionCapableModelsCache()).toEqual([
+      { providerID: "zhipuai-coding-plan", modelID: "glm-5.1" },
+    ])
+  })
+
+  test("does not duplicate a trusted model already discovered via provider modalities", () => {
+    // given
+    const modelCacheState = createModelCacheState()
+    const visionCapableModelsCache = modelCacheState.visionCapableModelsCache
+    if (!visionCapableModelsCache) {
+      throw new Error("visionCapableModelsCache should be initialized")
+    }
+    const config = {
+      provider: {
+        google: {
+          models: {
+            "gemini-3-flash": {
+              modalities: { input: ["text", "image"] },
+            },
+          },
+        },
+      },
+    } satisfies Record<string, unknown>
+
+    // when
+    applyProviderConfig({
+      config,
+      modelCacheState,
+      trustedVisionCapableModels: ["google/gemini-3-flash"],
+    })
+
+    // then
+    expect(Array.from(visionCapableModelsCache.keys())).toEqual([
+      "google/gemini-3-flash",
+    ])
+  })
+
+  test("ignores malformed trusted vision-capable model strings", () => {
+    // given - entries missing provider or model are skipped silently
+    const modelCacheState = createModelCacheState()
+    const visionCapableModelsCache = modelCacheState.visionCapableModelsCache
+    if (!visionCapableModelsCache) {
+      throw new Error("visionCapableModelsCache should be initialized")
+    }
+
+    // when
+    applyProviderConfig({
+      config: { provider: {} },
+      modelCacheState,
+      trustedVisionCapableModels: ["no-slash", "/missing-provider", "provider-only/"],
+    })
+
+    // then
+    expect(visionCapableModelsCache.size).toBe(0)
+  })
+
   test("clears stale vision-capable models when provider config changes", () => {
     // given
     const modelCacheState = createModelCacheState()

--- a/src/plugin-handlers/provider-config-handler.ts
+++ b/src/plugin-handlers/provider-config-handler.ts
@@ -26,9 +26,19 @@ function supportsImageInput(modelConfig: ProviderModelConfig | undefined): boole
   return modelConfig?.capabilities?.input?.image === true
 }
 
+function parseTrustedModel(modelString: string): VisionCapableModel | undefined {
+  const [providerID, ...modelIDParts] = modelString.split("/")
+  const modelID = modelIDParts.join("/")
+  if (!providerID || modelID.length === 0) {
+    return undefined
+  }
+  return { providerID, modelID }
+}
+
 export function applyProviderConfig(params: {
   config: Record<string, unknown>;
   modelCacheState: ModelCacheState;
+  trustedVisionCapableModels?: string[];
 }): void {
   const providers = params.config.provider as
     | Record<string, ProviderConfig>
@@ -47,27 +57,35 @@ export function applyProviderConfig(params: {
   visionCapableModelsCache.clear()
   setVisionCapableModelsCache(visionCapableModelsCache)
 
-  if (!providers) return;
+  if (providers) {
+    for (const [providerID, providerConfig] of Object.entries(providers)) {
+      const models = providerConfig?.models;
+      if (!models) continue;
 
-  for (const [providerID, providerConfig] of Object.entries(providers)) {
-    const models = providerConfig?.models;
-    if (!models) continue;
+      for (const [modelID, modelConfig] of Object.entries(models)) {
+        if (supportsImageInput(modelConfig)) {
+          visionCapableModelsCache.set(
+            `${providerID}/${modelID}`,
+            { providerID, modelID },
+          )
+        }
 
-    for (const [modelID, modelConfig] of Object.entries(models)) {
-      if (supportsImageInput(modelConfig)) {
-        visionCapableModelsCache.set(
+        const contextLimit = modelConfig?.limit?.context;
+        if (!contextLimit) continue;
+
+        modelContextLimitsCache.set(
           `${providerID}/${modelID}`,
-          { providerID, modelID },
-        )
+          contextLimit,
+        );
       }
-
-      const contextLimit = modelConfig?.limit?.context;
-      if (!contextLimit) continue;
-
-      modelContextLimitsCache.set(
-        `${providerID}/${modelID}`,
-        contextLimit,
-      );
     }
+  }
+
+  for (const trustedModelString of params.trustedVisionCapableModels ?? []) {
+    const trustedModel = parseTrustedModel(trustedModelString)
+    if (!trustedModel) continue
+    const key = `${trustedModel.providerID}/${trustedModel.modelID}`
+    if (visionCapableModelsCache.has(key)) continue
+    visionCapableModelsCache.set(key, trustedModel)
   }
 }


### PR DESCRIPTION
Closes #4209

## Root cause

`applyProviderConfig` in `src/plugin-handlers/provider-config-handler.ts` populates the global vision-capable model cache by checking each provider's model entry for either `modalities.input: ["image"]` or `capabilities.input.image: true`. Users who configure providers such as `zhipuai-coding-plan/glm-5.1` typically rely on default provider metadata that does not surface those fields through `config.provider.<id>.models.<id>`, so the model never enters the cache. Downstream, multimodal-looker resolution and capability detection treat such models as text-only even though they support vision (the same model works in Claude Code).

## Fix

Trust the user's configured multimodal-looker agent model. `applyProviderConfig` now accepts an optional `trustedVisionCapableModels: string[]` and adds each `<provider>/<model>` entry to the vision-capable cache after walking the provider config, even when the provider entry omits modality/capability declarations. `createConfigHandler` collects the trusted list from `pluginConfig.agents["multimodal-looker"].model` and threads it through. This makes the user-configured vision model a first-class citizen of the cache so multimodal-looker selection, fallback chains, and image attachments pick it up.

Behavior is additive: existing detection via `modalities.input` and `capabilities.input.image` is unchanged; trusted entries that are already present are not duplicated; malformed entries (missing provider or model segment) are ignored.

## Verification

- npm run build: PASS
- bun test src/plugin-handlers/: 180 pass, 0 fail (includes 3 new tests covering the trust path, dedup, and malformed entries)
- The single pre-existing `agent-browser` failure in `src/tools/delegate-task/tools.test.ts` reproduces on the unmodified baseline and is unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trust the user-selected multimodal-looker agent model as vision-capable even when provider metadata lacks modality flags, so image attachments and model selection work as expected (e.g., `zhipuai-coding-plan/glm-5.1`).

- **Bug Fixes**
  - `applyProviderConfig` accepts `trustedVisionCapableModels: string[]` and seeds `<provider>/<model>` entries into the vision-capable cache.
  - `createConfigHandler` collects the trusted model from `pluginConfig.agents["multimodal-looker"].model` via `collectTrustedVisionCapableModels` and threads it through.
  - Additive behavior: existing `modalities.input`/`capabilities.input.image` detection unchanged; duplicates ignored; malformed entries skipped. Tests added for trust path, dedup, and malformed input.

<sup>Written for commit bfc507895b1c807dabddb7155d23a9fade996d89. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4348?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

