### PR TITLE
fix: TUI subagent session entry stuck spinning + unclickable (#4252)

### DIFF
--- a/src/tools/background-task/create-background-task.ts
+++ b/src/tools/background-task/create-background-task.ts
@@ -94,6 +94,13 @@ export function createBackgroundTask(
           await delay(WAIT_FOR_SESSION_INTERVAL_MS)
         }
 
+        // Capture late-arriving sessionId between the wait-loop exit and
+        // metadata publish so the OpenCode TUI subagent entry has a navigable
+        // target (issue #4252).
+        if (!sessionId) {
+          sessionId = manager.getTask(task.id)?.sessionId
+        }
+
         const bgMeta = {
           title: args.description,
           metadata: {

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -160,6 +160,15 @@ export async function executeBackgroundTask(
       return `Task failed to start (status: ${updatedTask.status}).\n\nTask ID: ${task.id}`
     }
 
+    // Capture late-arriving sessionId from the race window between wait-loop
+    // exit and metadata publish. Without this, a session that gets created
+    // moments after the wait loop returns leaves metadata.sessionId undefined,
+    // which makes the OpenCode TUI render the subagent entry as a perpetual
+    // spinner with no clickable navigation target (issue #4252).
+    if (!sessionId && updatedTask?.sessionId) {
+      sessionId = updatedTask.sessionId
+    }
+
     if (sessionId) {
       registerBackgroundSessionContext({
         sessionId,

--- a/src/tools/delegate-task/late-session-id-capture.test.ts
+++ b/src/tools/delegate-task/late-session-id-capture.test.ts
@@ -1,0 +1,70 @@
+const { describe, test, expect } = require("bun:test")
+
+import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+import type { ParentContext } from "./executor-types"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+
+const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-4-6" }
+
+function makeMockCtx(): ToolContextWithMetadata & { captured: any[] } {
+  const captured: any[] = []
+  return {
+    sessionID: "ses_parent",
+    messageID: "msg_parent",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+    callID: "call_001",
+    metadata: async (input: any) => { captured.push(input) },
+    captured,
+  }
+}
+
+const parentContext: ParentContext = {
+  sessionID: "ses_parent",
+  messageID: "msg_parent",
+  agent: "sisyphus",
+  model: MODEL,
+}
+
+describe("background-task late sessionId capture (issue #4252)", () => {
+  test("#given launch returns no sessionId and getTask returns one #when publishing metadata #then sessionId is captured so TUI entry is clickable", async () => {
+    const { executeBackgroundTask } = require("./background-task")
+    const ctx = makeMockCtx()
+    const args: DelegateTaskArgs = {
+      description: "deferred task",
+      prompt: "do it",
+      load_skills: [],
+      run_in_background: true,
+      subagent_type: "explore",
+    }
+
+    // launch returns a pending task with no sessionId; getTask returns the
+    // same task with sessionId populated *after* the wait loop exits. This
+    // simulates the race where the subagent session is created moments after
+    // we stop polling, and is the exact condition that left the OpenCode TUI
+    // session entry stuck spinning with no click target on v4.2.3.
+    await executeBackgroundTask(args, ctx, unsafeTestValue({
+      manager: {
+        launch: async () => ({
+          id: "bg_late",
+          description: "deferred task",
+          agent: "explore",
+          status: "pending",
+        }),
+        getTask: () => ({
+          id: "bg_late",
+          description: "deferred task",
+          agent: "explore",
+          status: "running",
+          sessionId: "ses_late",
+        }),
+      },
+    }), parentContext, "explore", MODEL, undefined)
+
+    const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+    expect(meta).toBeDefined()
+    expect(meta.metadata.sessionId).toBe("ses_late")
+    expect(meta.metadata.taskId).toBe("ses_late")
+    expect(meta.metadata.backgroundTaskId).toBe("bg_late")
+  })
+})


### PR DESCRIPTION
Closes #4252

## Summary

The OpenCode TUI renders background subagent session entries using `props.metadata.sessionId` as the navigation target. When the session ID arrived between the wait-loop exit and the metadata publish in `delegate_task` / `background_task`, the published metadata had `sessionId: undefined`, leaving the TUI entry stuck as a perpetual spinner with no clickable navigation target.

## Root cause

Both `src/tools/delegate-task/background-task.ts` and `src/tools/background-task/create-background-task.ts` poll `manager.getTask(task.id)` inside a wait loop until `sessionId` is populated or the timeout expires. If the loop exits because of timeout / abort, but the session is created moments later (still before metadata publish), the late `sessionId` was being ignored — even though `manager.getTask(...)` already returns the updated value.

## Fix

Add a single late-fallback before metadata publish in both paths:

```ts
if (!sessionId && updatedTask?.sessionId) {
  sessionId = updatedTask.sessionId
}
```

This closes the narrow race window without extending the wait timeout (which would unnecessarily block the LLM) and without depending on TUI changes. Matches the existing \"preserve late background session wiring on abort\" pattern from 291eeed8.

## Tests

New regression test `src/tools/delegate-task/late-session-id-capture.test.ts` mocks the exact race condition (`launch()` returns task with no sessionId; `getTask()` returns it after wait loop) and asserts the published metadata contains the late-arriving `sessionId`.

## Test plan

- [x] `npm run build` — PASS
- [x] `npm test` — exit code 0 (one unrelated pre-existing failure in `sisyphus-task > browserProvider propagation` re: agent-browser skill discovery, not touched by this PR)
- [x] Targeted: `bun test src/tools/delegate-task/late-session-id-capture.test.ts src/tools/delegate-task/metadata-task-id-consistency.test.ts src/tools/background-task/create-background-task.metadata.test.ts` — 18 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that left TUI background subagent entries stuck spinning and unclickable by capturing a late-arriving `sessionId` just before publishing metadata. Fixes #4252.

- **Bug Fixes**
  - Add a final pre-publish fallback to adopt a late `sessionId` in both paths: `src/tools/delegate-task/background-task.ts` (from `updatedTask?.sessionId`) and `src/tools/background-task/create-background-task.ts` (via `manager.getTask(task.id)?.sessionId`), closing the race without extending wait timeouts.
  - Add regression test `src/tools/delegate-task/late-session-id-capture.test.ts` that reproduces the timing window and verifies the published metadata includes the late `sessionId`.

<sup>Written for commit 779e2d2f1052163b1cfa5d8c718c20f1c921a132. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

