### PR TITLE
fix: Atlas agent honors config.agents.atlas.model override (#4255)

### DIFF
--- a/src/agents/builtin-agents/atlas-agent.ts
+++ b/src/agents/builtin-agents/atlas-agent.ts
@@ -38,13 +38,19 @@ export function maybeCreateAtlasConfig(input: {
   const orchestratorOverride = agentOverrides["atlas"]
   const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
 
-  const atlasResolution = applyModelResolution({
+  let atlasResolution = applyModelResolution({
     uiSelectedModel: orchestratorOverride?.model !== undefined ? undefined : uiSelectedModel,
     userModel: orchestratorOverride?.model,
     requirement: atlasRequirement,
     availableModels,
     systemDefaultModel,
   })
+
+  if (!atlasResolution && orchestratorOverride?.model) {
+    // User explicitly configured a model but resolution failed (e.g., cold cache, no system default).
+    // Honor the user's choice directly instead of dropping Atlas entirely.
+    atlasResolution = { model: orchestratorOverride.model, provenance: "override" as const }
+  }
 
   if (!atlasResolution) return undefined
   const { model: atlasModel, variant: atlasResolvedVariant } = atlasResolution

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -170,6 +170,30 @@ describe("createBuiltinAgents with model overrides", () => {
     }
   })
 
+  test("atlas honors user config model when resolution fails (no available models, no system default)", async () => {
+    // #given - regression for #4255: user sets agents.atlas.model but availableModels is empty
+    // and systemDefaultModel is undefined, so applyModelResolution returns undefined.
+    // Previous behavior: atlas was silently dropped, OpenCode used its built-in default.
+    // Expected behavior: honor the user's explicit model override.
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
+    const overrides = {
+      atlas: { model: "minimax-cn-coding-plan/MiniMax-M2.5-highspeed" },
+    }
+
+    try {
+      // #when - no systemDefaultModel, no availableModels, no cache
+      const agents = await createBuiltinAgents([], overrides, undefined, undefined)
+
+      // #then
+      expect(agents.atlas).toBeDefined()
+      expect(agents.atlas.model).toBe("minimax-cn-coding-plan/MiniMax-M2.5-highspeed")
+    } finally {
+      cacheSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("Sisyphus is created on first run when no availableModels or cache exist", async () => {
     // #given
     const systemDefaultModel = "anthropic/claude-opus-4-7"


### PR DESCRIPTION
Closes #4255

## Root cause

`maybeCreateAtlasConfig` in `src/agents/builtin-agents/atlas-agent.ts`
bails out early (returning `undefined`) whenever `applyModelResolution`
returns `undefined` — even when the user explicitly set
`agents.atlas.model` in `oh-my-opencode.json`. When Atlas is dropped,
OpenCode falls back to its built-in agent default, which surfaces as
the hardcoded `claude-sonnet-4-6` fallback from
`AGENT_MODEL_REQUIREMENTS["atlas"].fallbackChain[0]`.

The other agent builders already handle this scenario:

- `general-agents.ts` (lines 82–93): falls back to `override?.model`
  when resolution returns `undefined`.
- `sisyphus-agent.ts`: has an explicit `hasSisyphusExplicitConfig` check
  to keep flowing when the user has configured the agent.

Atlas had neither, so under edge cases (cold provider cache, no system
default, empty `availableModels`) the user's explicit model was
silently discarded.

## Fix

Mirror the defensive pattern from `general-agents.ts`: when
`applyModelResolution` returns `undefined` but the user has explicitly
set `orchestratorOverride.model`, honor that model directly instead of
dropping Atlas:

```ts
if (!atlasResolution && orchestratorOverride?.model) {
  atlasResolution = { model: orchestratorOverride.model, provenance: "override" as const }
}
```

Adds a regression test in `src/agents/utils.test.ts` covering the
scenario where:
- `agents.atlas.model` is set to `minimax-cn-coding-plan/MiniMax-M2.5-highspeed`
  (the exact model from the bug report)
- `availableModels` is empty
- `systemDefaultModel` is `undefined`
- no provider cache exists

## Verification

- `npm run build`: PASS
- `bun test src/agents/`: PASS (406 tests, including new regression test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4255 by making the Atlas agent honor `agents.atlas.model` when model resolution returns undefined, preventing an unintended fallback to `claude-sonnet-4-6`. Aligns Atlas with the defensive behavior used by other agents.

- **Bug Fixes**
  - In `src/agents/builtin-agents/atlas-agent.ts`, if `applyModelResolution` returns `undefined` and an override is set, use `{ model: override, provenance: "override" }` instead of dropping Atlas.
  - Added a regression test in `src/agents/utils.test.ts` for the cold-cache path: explicit `agents.atlas.model` (`minimax-cn-coding-plan/MiniMax-M2.5-highspeed`), empty `availableModels`, no `systemDefaultModel`, no provider cache.

<sup>Written for commit 7d444eed5e34445ca801d42a8ba4bcd996f0721c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4352?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

