### PR TITLE
fix(tmux-subagent): pane creation no longer silently fails (#3839)

### DIFF
--- a/src/features/tmux-subagent/attachable-session-status.ts
+++ b/src/features/tmux-subagent/attachable-session-status.ts
@@ -1,4 +1,4 @@
-const ATTACHABLE_SESSION_STATUSES = ["idle", "running", "busy"] as const
+const ATTACHABLE_SESSION_STATUSES = ["idle", "running", "busy", "retry"] as const
 
 export type AttachableSessionStatus = (typeof ATTACHABLE_SESSION_STATUSES)[number]
 

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -664,7 +664,7 @@ export class TmuxSessionManager {
   private async getSessionStatusType(sessionId: string): Promise<string | undefined> {
     try {
       const statusResult = await this.client.session.status({ path: undefined })
-      const allStatuses = parseSessionStatusMap(statusResult.data)
+      const allStatuses = parseSessionStatusMap(statusResult?.data ?? statusResult)
       return allStatuses[sessionId]?.type
     } catch (error) {
       this.deps.log("[tmux-session-manager] failed to read session status before spawn", {

--- a/src/features/tmux-subagent/polling.ts
+++ b/src/features/tmux-subagent/polling.ts
@@ -74,7 +74,7 @@ export function createSessionPollingController(params: {
 
     try {
       const statusResult = await params.client.session.status({ path: undefined })
-      const allStatuses = parseSessionStatusMap(statusResult.data)
+      const allStatuses = parseSessionStatusMap(statusResult?.data ?? statusResult)
 
       log("[tmux-session-manager] pollSessions", {
         trackedSessions: Array.from(params.sessions.keys()),
@@ -111,7 +111,7 @@ export function createSessionPollingController(params: {
 
               if (tracked.stableIdlePolls >= STABLE_POLLS_REQUIRED) {
                 const recheckResult = await params.client.session.status({ path: undefined })
-                const recheckStatuses = parseSessionStatusMap(recheckResult.data)
+                const recheckStatuses = parseSessionStatusMap(recheckResult?.data ?? recheckResult)
                 const recheckStatus = recheckStatuses[sessionId]
 
                 if (recheckStatus?.type === "idle") {

--- a/src/features/tmux-subagent/session-ready-waiter.test.ts
+++ b/src/features/tmux-subagent/session-ready-waiter.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, mock } from "bun:test"
+import { waitForSessionReady } from "./session-ready-waiter"
+
+// Regression for #3839: oh-my-openagent@4.0.0 read `statusResult.data` only,
+// but some OpenCode SDK/server versions return the status map at the top level
+// (no `.data` wrapper). With the original code, the parsed map was always
+// empty, `waitForSessionReady` timed out, and tmux panes were never spawned.
+describe("waitForSessionReady – #3839 SDK response shape", () => {
+  test("#given SDK returns wrapped { data: {...} } #when polled #then session is detected as ready", async () => {
+    const sessionId = "ses_wrapped"
+    const status = mock(async (_args: unknown) => ({
+      data: { [sessionId]: { type: "busy" } },
+    }))
+    const client = { session: { status } } as never
+
+    const ready = await waitForSessionReady({ client, sessionId })
+
+    expect(ready).toBe(true)
+    expect(status).toHaveBeenCalled()
+  })
+
+  test("#given SDK returns raw map (no .data wrapper) #when polled #then session is still detected as ready", async () => {
+    const sessionId = "ses_raw"
+    const status = mock(async (_args: unknown) => ({
+      [sessionId]: { type: "busy" },
+    }))
+    const client = { session: { status } } as never
+
+    const ready = await waitForSessionReady({ client, sessionId })
+
+    expect(ready).toBe(true)
+  })
+
+  test("#given SDK raw map omits the session #when polled #then nothing falsely reads from undefined", async () => {
+    const sessionId = "ses_absent"
+    const status = mock(async (_args: unknown) => ({
+      ses_other: { type: "busy" },
+    }))
+    const client = { session: { status } } as never
+
+    // Should NOT throw a TypeError on `undefined.type` access — proves the
+    // fallback expression is safely parsed by parseSessionStatusMap.
+    let threw: unknown
+    const racingTimeout = new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(false), 100)
+    })
+    const result = await Promise.race([
+      waitForSessionReady({ client, sessionId }).catch((err) => {
+        threw = err
+        return false
+      }),
+      racingTimeout,
+    ])
+
+    expect(threw).toBeUndefined()
+    expect(result).toBe(false)
+  })
+})

--- a/src/features/tmux-subagent/session-ready-waiter.ts
+++ b/src/features/tmux-subagent/session-ready-waiter.ts
@@ -18,7 +18,7 @@ export async function waitForSessionReady(params: {
   while (Date.now() - startTime < SESSION_READY_TIMEOUT_MS) {
     try {
       const statusResult = await params.client.session.status({ path: undefined })
-      const allStatuses = parseSessionStatusMap(statusResult.data)
+      const allStatuses = parseSessionStatusMap(statusResult?.data ?? statusResult)
       const sessionStatus = allStatuses[params.sessionId]?.type
 
       if (isAttachableSessionStatus(sessionStatus)) {


### PR DESCRIPTION
Fixes #3839

## Root cause

After upgrading to 4.0.0, tmux subagent panes silently fail to spawn. Two issues in `src/features/tmux-subagent/`:

1. **SDK response shape**: `waitForSessionReady` (and `manager.getSessionStatusType`, `polling.pollSessions`) call `parseSessionStatusMap(statusResult.data)`. Some OpenCode SDK/server versions return the status map at the top level, with no `.data` wrapper. The parsed map ends up empty, readiness times out at 10s, and the pane is never spawned — exactly the symptom in the issue log (`session readiness failed before spawn`).
2. **Missing attachable status**: `ATTACHABLE_SESSION_STATUSES = ["idle", "running", "busy"]` excludes `retry`, even though the background-agent classifier already treats `retry` as an active state. A child session that enters `retry` (e.g. transient API error) is treated as non-attachable.

## Fix

- `session-ready-waiter.ts`: `parseSessionStatusMap(statusResult?.data ?? statusResult)`.
- `manager.ts`: same fallback in `getSessionStatusType`.
- `polling.ts`: same fallback in both `pollSessions` and the stability recheck (`createSessionPollingController`).
- `attachable-session-status.ts`: add `"retry"` to `ATTACHABLE_SESSION_STATUSES`.

`polling-manager.ts` already used the `normalizeSDKResponse` helper, so it was already covered.

## Verification

- `npm run build`: PASS
- `npm test` for the affected module: `bun test src/features/tmux-subagent/` → 144 pass / 0 fail (was 141 pass before the regression test; new 3 tests added to `session-ready-waiter.test.ts` cover both wrapped and raw SDK response shapes).
- Pre-existing failure in `src/tools/delegate-task/tools.test.ts` (`agent-browser` skill resolution) is unrelated and reproduces on `dev` without these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores reliable tmux subagent pane creation in 4.0.0 by handling mixed SDK response shapes and accepting the "retry" status. Fixes #3839.

- **Bug Fixes**
  - Accept both wrapped and raw status maps in session-ready waiter, manager, and polling.
  - Treat "retry" as an attachable session status.
  - Add regression tests for both response shapes.

<sup>Written for commit c84844141c00d226e593bae18447b89e64a48999. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

