### PR TITLE
fix(grep): include OpenCode cache-backed bin in rg path resolution (#3805)

### DIFF
--- a/src/shared/ripgrep-cli.test.ts
+++ b/src/shared/ripgrep-cli.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+describe("resolveGrepCli OpenCode cache fallback (#3805)", () => {
+  let tempCache: string
+  let tempData: string
+  let originalCache: string | undefined
+  let originalData: string | undefined
+
+  beforeEach(() => {
+    const stamp = `omo-ripgrep-cli-${process.pid}-${Date.now()}`
+    tempCache = join(tmpdir(), `${stamp}-cache`)
+    tempData = join(tmpdir(), `${stamp}-data`)
+    mkdirSync(tempCache, { recursive: true })
+    mkdirSync(tempData, { recursive: true })
+    originalCache = process.env.XDG_CACHE_HOME
+    originalData = process.env.XDG_DATA_HOME
+    process.env.XDG_CACHE_HOME = tempCache
+    process.env.XDG_DATA_HOME = tempData
+  })
+
+  afterEach(() => {
+    if (originalCache === undefined) delete process.env.XDG_CACHE_HOME
+    else process.env.XDG_CACHE_HOME = originalCache
+    if (originalData === undefined) delete process.env.XDG_DATA_HOME
+    else process.env.XDG_DATA_HOME = originalData
+    try {
+      rmSync(tempCache, { recursive: true, force: true })
+      rmSync(tempData, { recursive: true, force: true })
+    } catch {
+      // best-effort cleanup
+    }
+  })
+
+  it("prefers ~/.cache/opencode/bin/rg over ~/.local/share/opencode/bin/rg", async () => {
+    const rgName = process.platform === "win32" ? "rg.exe" : "rg"
+    const cacheBinDir = join(tempCache, "opencode", "bin")
+    const dataBinDir = join(tempData, "opencode", "bin")
+    mkdirSync(cacheBinDir, { recursive: true })
+    mkdirSync(dataBinDir, { recursive: true })
+    const cacheRg = join(cacheBinDir, rgName)
+    const dataRg = join(dataBinDir, rgName)
+    writeFileSync(cacheRg, "")
+    writeFileSync(dataRg, "")
+
+    // Reset the module cache so the singleton cachedCli is fresh.
+    delete require.cache[require.resolve("./ripgrep-cli")]
+    const { resolveGrepCli } = await import("./ripgrep-cli")
+
+    const resolved = resolveGrepCli()
+    expect(resolved.backend).toBe("rg")
+    expect(resolved.path).toBe(cacheRg)
+  })
+})

--- a/src/shared/ripgrep-cli.ts
+++ b/src/shared/ripgrep-cli.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process"
 import { existsSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { downloadAndInstallRipgrep, getInstalledRipgrepPath } from "../tools/grep/downloader"
-import { getDataDir } from "./data-path"
+import { getDataDir, getOpenCodeCacheDir } from "./data-path"
 import { log } from "./logger"
 import { PUBLISHED_PACKAGE_NAME } from "./plugin-identity"
 
@@ -48,6 +48,10 @@ function getOpenCodeBundledRg(): string | null {
   const rgName = isWindows ? "rg.exe" : "rg"
 
   const candidates = [
+    // #3805: Upstream OpenCode's Global.Path.bin is cache-backed (~/.cache/opencode/bin),
+    // and its auto-downloaded ripgrep + LSP binaries live there. Probe it first so OMO
+    // reuses tools OpenCode already installed instead of triggering a duplicate download.
+    join(getOpenCodeCacheDir(), "bin", rgName),
     join(getDataDir(), "opencode", "bin", rgName),
     join(execDir, rgName),
     join(execDir, "bin", rgName),


### PR DESCRIPTION
Closes #3805

## Root cause

`src/shared/ripgrep-cli.ts`'s `getOpenCodeBundledRg()` only probed the
data-dir variant of OpenCode's managed bin directory
(`~/.local/share/opencode/bin`). Upstream OpenCode's `Global.Path.bin`
actually resolves to the **cache-backed** path
(`$XDG_CACHE_HOME/opencode/bin`, normally `~/.cache/opencode/bin`), and
that's where its built-in ripgrep auto-installer and many auto-installed
LSP server binaries land.

So when OpenCode had already auto-downloaded `rg`, OMO would miss it,
fall back to system `rg` if present, and otherwise trigger its own
duplicate ripgrep install into `~/.cache/oh-my-opencode/bin`.

## Fix

Add `getOpenCodeCacheDir()/bin/<rg>` as the first candidate in
`getOpenCodeBundledRg()`, ahead of the existing data-dir candidate.
`getOpenCodeCacheDir()` already exists in `src/shared/data-path.ts` and
mirrors upstream OpenCode's xdg-basedir behavior.

Added a unit test (`src/shared/ripgrep-cli.test.ts`) covering the
"cache vs data" preference: when both `~/.cache/opencode/bin/rg` and
`~/.local/share/opencode/bin/rg` exist, OMO must pick the cache one
(matching what OpenCode itself uses).

Scope note: the issue also calls out the LSP transport / server path
bases (`src/tools/lsp/server-path-bases.ts`, `lsp-client-transport.ts`)
upstream. Those files do not exist in this repo's `src/` tree — LSP is
served via the `packages/lsp-tools-mcp` submodule (empty here), so this
PR fixes only the grep path described in the same issue. If/when LSP
PATH plumbing lands in this repo, the same `getOpenCodeCacheDir()`
helper applies.

## Verification

- `npm run build`: PASS
- `npm test` (full suite via `bun test`): PASS for all touched areas
  - `bun test src/shared/`: 1021 pass / 0 fail
  - `bun test src/tools/grep/`: 12 pass / 0 fail
  - `bun test src/shared/ripgrep-cli.test.ts`: new test passes
- One pre-existing unrelated failure in `src/tools/delegate-task/tools.test.ts`
  (`browserProvider propagation > should resolve agent-browser skill...`) reproduces
  on unmodified `dev` — depends on an external `agent-browser` skill
  not installed in this sandbox. Bun reports exit 0; not introduced by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer OpenCode’s cache-backed `rg` when resolving ripgrep to reuse the editor’s auto-installed binary and avoid duplicate downloads (fixes #3805). Adds a focused test to confirm the cache path is chosen over the data-dir path.

- **Bug Fixes**
  - Grep path resolution: probe `~/.cache/opencode/bin` first; updated `getOpenCodeBundledRg()` and added `src/shared/ripgrep-cli.test.ts` to prefer cache over data.

<sup>Written for commit 6c691a1afa2bac18dbffd9f8ac38abbb7353bd99. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4356?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

