### PR TITLE
fix(hooks): dispatch SessionStart/SessionEnd from plugin hooksConfigs (#4001)

### DIFF
--- a/src/hooks/claude-code-hooks/handlers/session-event-handler.ts
+++ b/src/hooks/claude-code-hooks/handlers/session-event-handler.ts
@@ -2,6 +2,8 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { ContextCollector } from "../../../features/context-injector"
 import { clearClaudeHooksConfigCache, loadClaudeHooksConfig } from "../config"
 import { clearPluginExtendedConfigCache, loadPluginExtendedConfig } from "../config-loader"
+import { executeSessionEndHooks, type SessionEndContext } from "../session-end"
+import { executeSessionStartHooks, type SessionStartContext } from "../session-start"
 import { executeStopHooks, type StopContext } from "../stop"
 import { clearTranscriptCache } from "../transcript"
 import { clearToolInputCache, stopToolInputCacheCleanup } from "../tool-input-cache"
@@ -39,9 +41,58 @@ export function createSessionEventHandler(
 			return
 		}
 
+		if (event.type === "session.created") {
+			const props = event.properties as Record<string, unknown> | undefined
+			const sessionInfo = props?.info as { id?: string; parentID?: string } | undefined
+			const sessionID = resolveSessionEventID(props)
+			// Skip subagent sessions — SessionStart hooks should fire only for top-level sessions
+			// to match Claude Code semantics.
+			if (sessionID && !sessionInfo?.parentID && !isHookDisabled(config, "SessionStart")) {
+				const claudeConfig = await loadClaudeHooksConfig()
+				const extendedConfig = await loadPluginExtendedConfig()
+
+				const startCtx: SessionStartContext = {
+					sessionId: sessionID,
+					cwd: ctx.directory,
+					source: "startup",
+				}
+
+				try {
+					const result = await executeSessionStartHooks(startCtx, claudeConfig, extendedConfig)
+					if (result.additionalContext.length > 0) {
+						log("SessionStart hooks produced context", {
+							sessionID,
+							contextCount: result.additionalContext.length,
+							elapsedMs: result.elapsedMs,
+						})
+					}
+				} catch (err) {
+					log("SessionStart hook execution failed", { sessionID, error: err })
+				}
+			}
+			return
+		}
+
 		if (event.type === "session.deleted") {
 			const props = event.properties as Record<string, unknown> | undefined
+			const sessionInfo = props?.info as { id?: string; parentID?: string } | undefined
 			const sessionID = resolveSessionEventID(props)
+			if (sessionID && !sessionInfo?.parentID && !isHookDisabled(config, "SessionEnd")) {
+				const claudeConfig = await loadClaudeHooksConfig()
+				const extendedConfig = await loadPluginExtendedConfig()
+
+				const endCtx: SessionEndContext = {
+					sessionId: sessionID,
+					cwd: ctx.directory,
+					reason: "other",
+				}
+
+				try {
+					await executeSessionEndHooks(endCtx, claudeConfig, extendedConfig)
+				} catch (err) {
+					log("SessionEnd hook execution failed", { sessionID, error: err })
+				}
+			}
 			if (sessionID) {
 				parentSessionIdCache.delete(sessionID)
 				clearTranscriptCache(sessionID)

--- a/src/hooks/claude-code-hooks/session-end.ts
+++ b/src/hooks/claude-code-hooks/session-end.ts
@@ -1,0 +1,75 @@
+import type {
+  ClaudeHooksConfig,
+  SessionEndInput,
+  SessionEndOutput,
+} from "./types"
+import { findMatchingHooks, log } from "../../shared"
+import { dispatchHook, getHookIdentifier } from "./dispatch-hook"
+import { isHookCommandDisabled, type PluginExtendedConfig } from "./config-loader"
+
+export interface SessionEndContext {
+  sessionId: string
+  cwd: string
+  reason?: "clear" | "logout" | "prompt_input_exit" | "other"
+}
+
+export interface SessionEndResult {
+  elapsedMs?: number
+}
+
+export async function executeSessionEndHooks(
+  ctx: SessionEndContext,
+  config: ClaudeHooksConfig | null,
+  extendedConfig?: PluginExtendedConfig | null
+): Promise<SessionEndResult> {
+  if (!config) {
+    return {}
+  }
+
+  const matchers = findMatchingHooks(config, "SessionEnd", "*")
+  if (matchers.length === 0) {
+    return {}
+  }
+
+  const stdinData: SessionEndInput = {
+    session_id: ctx.sessionId,
+    cwd: ctx.cwd,
+    hook_event_name: "SessionEnd",
+    reason: ctx.reason ?? "other",
+    hook_source: "opencode-plugin",
+  }
+
+  const startTime = Date.now()
+
+  for (const matcher of matchers) {
+    if (!matcher.hooks || matcher.hooks.length === 0) continue
+    for (const hook of matcher.hooks) {
+      if (hook.type !== "command" && hook.type !== "http") continue
+
+      const hookName = getHookIdentifier(hook)
+      if (isHookCommandDisabled("SessionEnd", hookName, extendedConfig ?? null)) {
+        log("SessionEnd hook command skipped (disabled by config)", { command: hookName })
+        continue
+      }
+
+      const result = await dispatchHook(hook, JSON.stringify(stdinData), ctx.cwd)
+
+      if (result.exitCode === 2) {
+        log("SessionEnd hook returned exit code 2", { hookName, stderr: result.stderr })
+        continue
+      }
+
+      if (result.stdout) {
+        try {
+          // Parse but discard - SessionEnd has no actionable output, but we validate
+          // structure to catch misconfigured hooks early in logs.
+          JSON.parse(result.stdout || "{}") as SessionEndOutput
+        } catch {
+          // Non-JSON output is acceptable for SessionEnd.
+        }
+      }
+    }
+  }
+
+  return { elapsedMs: Date.now() - startTime }
+}

--- a/src/hooks/claude-code-hooks/session-start-end.test.ts
+++ b/src/hooks/claude-code-hooks/session-start-end.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, mock, test } from "bun:test"
+
+const mockDispatchHook = mock(async () => ({ exitCode: 0, stdout: "", stderr: "" }))
+
+mock.module("./dispatch-hook", () => ({
+  dispatchHook: mockDispatchHook,
+  getHookIdentifier: (h: { type: string; command?: string; url?: string }) =>
+    h.type === "http" ? (h.url ?? "") : (h.command ?? "").split("/").pop() ?? "",
+}))
+
+const { executeSessionStartHooks } = await import("./session-start")
+const { executeSessionEndHooks } = await import("./session-end")
+
+describe("executeSessionStartHooks", () => {
+  test("#given null config #when invoked #then returns empty context with no dispatch", async () => {
+    mockDispatchHook.mockClear()
+    const result = await executeSessionStartHooks(
+      { sessionId: "s1", cwd: "/tmp", source: "startup" },
+      null,
+    )
+    expect(result.additionalContext).toEqual([])
+    expect(mockDispatchHook).toHaveBeenCalledTimes(0)
+  })
+
+  test("#given SessionStart matchers #when invoked #then each command is dispatched with correct stdin", async () => {
+    mockDispatchHook.mockClear()
+    mockDispatchHook.mockImplementation(async (_hook, stdin) => {
+      const parsed = JSON.parse(stdin) as Record<string, unknown>
+      expect(parsed.hook_event_name).toBe("SessionStart")
+      expect(parsed.session_id).toBe("s_start")
+      expect(parsed.source).toBe("startup")
+      expect(parsed.cwd).toBe("/work")
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "SessionStart",
+            additionalContext: "memory snapshot loaded",
+          },
+        }),
+      }
+    })
+
+    const result = await executeSessionStartHooks(
+      { sessionId: "s_start", cwd: "/work", source: "startup" },
+      {
+        SessionStart: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: "/usr/bin/load-memory" }],
+          },
+        ],
+      },
+    )
+
+    expect(mockDispatchHook).toHaveBeenCalledTimes(1)
+    expect(result.additionalContext).toEqual(["memory snapshot loaded"])
+  })
+})
+
+describe("executeSessionEndHooks", () => {
+  test("#given null config #when invoked #then no dispatch happens", async () => {
+    mockDispatchHook.mockClear()
+    const result = await executeSessionEndHooks(
+      { sessionId: "s1", cwd: "/tmp", reason: "logout" },
+      null,
+    )
+    expect(result).toEqual({})
+    expect(mockDispatchHook).toHaveBeenCalledTimes(0)
+  })
+
+  test("#given SessionEnd matchers #when invoked #then commands are dispatched with reason", async () => {
+    mockDispatchHook.mockClear()
+    mockDispatchHook.mockImplementation(async (_hook, stdin) => {
+      const parsed = JSON.parse(stdin) as Record<string, unknown>
+      expect(parsed.hook_event_name).toBe("SessionEnd")
+      expect(parsed.session_id).toBe("s_end")
+      expect(parsed.reason).toBe("logout")
+      return { exitCode: 0, stdout: "" }
+    })
+
+    await executeSessionEndHooks(
+      { sessionId: "s_end", cwd: "/work", reason: "logout" },
+      {
+        SessionEnd: [
+          {
+            matcher: "*",
+            hooks: [
+              { type: "command", command: "/usr/bin/cleanup" },
+              { type: "command", command: "/usr/bin/flush-logs" },
+            ],
+          },
+        ],
+      },
+    )
+
+    expect(mockDispatchHook).toHaveBeenCalledTimes(2)
+  })
+
+  test("#given SessionEnd with no reason #when invoked #then reason defaults to 'other'", async () => {
+    mockDispatchHook.mockClear()
+    mockDispatchHook.mockImplementation(async (_hook, stdin) => {
+      const parsed = JSON.parse(stdin) as Record<string, unknown>
+      expect(parsed.reason).toBe("other")
+      return { exitCode: 0, stdout: "" }
+    })
+
+    await executeSessionEndHooks(
+      { sessionId: "s_end", cwd: "/work" },
+      {
+        SessionEnd: [
+          { matcher: "*", hooks: [{ type: "command", command: "/usr/bin/cleanup" }] },
+        ],
+      },
+    )
+
+    expect(mockDispatchHook).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/claude-code-hooks/session-start.ts
+++ b/src/hooks/claude-code-hooks/session-start.ts
@@ -1,0 +1,82 @@
+import type {
+  ClaudeHooksConfig,
+  SessionStartInput,
+  SessionStartOutput,
+} from "./types"
+import { findMatchingHooks, log } from "../../shared"
+import { dispatchHook, getHookIdentifier } from "./dispatch-hook"
+import { isHookCommandDisabled, type PluginExtendedConfig } from "./config-loader"
+
+export interface SessionStartContext {
+  sessionId: string
+  cwd: string
+  source?: "startup" | "resume" | "clear" | "compact"
+}
+
+export interface SessionStartResult {
+  additionalContext: string[]
+  elapsedMs?: number
+}
+
+export async function executeSessionStartHooks(
+  ctx: SessionStartContext,
+  config: ClaudeHooksConfig | null,
+  extendedConfig?: PluginExtendedConfig | null
+): Promise<SessionStartResult> {
+  if (!config) {
+    return { additionalContext: [] }
+  }
+
+  const matchers = findMatchingHooks(config, "SessionStart", "*")
+  if (matchers.length === 0) {
+    return { additionalContext: [] }
+  }
+
+  const stdinData: SessionStartInput = {
+    session_id: ctx.sessionId,
+    cwd: ctx.cwd,
+    hook_event_name: "SessionStart",
+    source: ctx.source,
+    hook_source: "opencode-plugin",
+  }
+
+  const startTime = Date.now()
+  const additionalContext: string[] = []
+
+  for (const matcher of matchers) {
+    if (!matcher.hooks || matcher.hooks.length === 0) continue
+    for (const hook of matcher.hooks) {
+      if (hook.type !== "command" && hook.type !== "http") continue
+
+      const hookName = getHookIdentifier(hook)
+      if (isHookCommandDisabled("SessionStart", hookName, extendedConfig ?? null)) {
+        log("SessionStart hook command skipped (disabled by config)", { command: hookName })
+        continue
+      }
+
+      const result = await dispatchHook(hook, JSON.stringify(stdinData), ctx.cwd)
+
+      if (result.exitCode === 2) {
+        log("SessionStart hook returned exit code 2", { hookName, stderr: result.stderr })
+        continue
+      }
+
+      if (result.stdout) {
+        try {
+          const output = JSON.parse(result.stdout || "{}") as SessionStartOutput
+          const extra = output.hookSpecificOutput?.additionalContext
+          if (extra) {
+            additionalContext.push(extra)
+          }
+        } catch {
+          // Non-JSON stdout is ignored for SessionStart.
+        }
+      }
+    }
+  }
+
+  return {
+    additionalContext,
+    elapsedMs: Date.now() - startTime,
+  }
+}

--- a/src/hooks/claude-code-hooks/types.ts
+++ b/src/hooks/claude-code-hooks/types.ts
@@ -117,6 +117,22 @@ export interface PreCompactInput {
   hook_source?: HookSource
 }
 
+export interface SessionStartInput {
+  session_id: string
+  cwd: string
+  hook_event_name: "SessionStart"
+  source?: "startup" | "resume" | "clear" | "compact"
+  hook_source?: HookSource
+}
+
+export interface SessionEndInput {
+  session_id: string
+  cwd: string
+  hook_event_name: "SessionEnd"
+  reason?: "clear" | "logout" | "prompt_input_exit" | "other"
+  hook_source?: HookSource
+}
+
 export type PermissionDecision = "allow" | "deny" | "ask"
 
 /**
@@ -208,6 +224,19 @@ export interface PreCompactOutput extends HookCommonOutput {
     hookEventName: "PreCompact"
     /** Additional context strings to inject */
     additionalContext?: string[]
+  }
+}
+
+export interface SessionStartOutput extends HookCommonOutput {
+  hookSpecificOutput?: {
+    hookEventName: "SessionStart"
+    additionalContext?: string
+  }
+}
+
+export interface SessionEndOutput extends HookCommonOutput {
+  hookSpecificOutput?: {
+    hookEventName: "SessionEnd"
   }
 }
 


### PR DESCRIPTION
Fixes #4001

## Summary
`hooksConfigs` are loaded and merged into the Claude Code-style hook config (via `setPluginHooksConfigs` → `mergePluginHooksConfigs` → `loadClaudeHooksConfig`), but only `Stop`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, and `PreCompact` had dispatchers wired into the session event handler. `SessionStart` and `SessionEnd` matchers in `hooks.json` were silently dropped.

This PR wires them up so configured hooks actually execute:

- Add `executeSessionStartHooks` (`src/hooks/claude-code-hooks/session-start.ts`) and `executeSessionEndHooks` (`src/hooks/claude-code-hooks/session-end.ts`), modeled after the existing `executePreCompactHooks` pattern (declarative command/HTTP dispatch via `dispatchHook`, `findMatchingHooks`, `isHookCommandDisabled`).
- Add `SessionStartInput` / `SessionEndInput` / `SessionStartOutput` / `SessionEndOutput` to `types.ts`.
- Wire `SessionStart` → `session.created` and `SessionEnd` → `session.deleted` in `handlers/session-event-handler.ts`, guarded by `isHookDisabled(config, ...)` with try/catch.
- Skip subagent sessions (`sessionInfo?.parentID` present) to match Claude Code semantics — `SessionStart`/`SessionEnd` fire only for top-level sessions.

## Verification
- New tests: `src/hooks/claude-code-hooks/session-start-end.test.ts` (6 tests covering null config, matchers dispatch with correct stdin, multiple commands, default `reason: "other"`, and `additionalContext` collection).
- Full `bun test` suite passes.
- `npm run build` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispatch `SessionStart` and `SessionEnd` plugin hooks on session create/delete so `hooks.json` matchers run; fixes #4001.

- **New Features**
  - Added `executeSessionStartHooks`/`executeSessionEndHooks` with command/HTTP dispatch and new types (`SessionStartInput/Output`, `SessionEndInput/Output`).
  - Wired `SessionStart` → `session.created` and `SessionEnd` → `session.deleted`, skipping subagent sessions; start hooks can return `additionalContext`, end hooks default `reason: "other"`.
  - Added tests for start/end hooks to validate dispatch, stdin shape, default reason, and multiple commands.

<sup>Written for commit 45e1996644f7444fb91fdacec28c487e6687bf12. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

