### PR TITLE
fix(process-cleanup): mock process.exit in SIGINT test so full file runs (#4058)

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -85,10 +85,16 @@ describe("#given process cleanup registration", () => {
       expect(shutdown).toHaveBeenCalledTimes(1)
     })
 
-    test("#when cleanup finishes after SIGINT #then the fallback exit timer is cleared", async () => {
+    test("#when cleanup finishes after SIGINT #then the fallback exit timer is cleared AND process.exit(0) is called", async () => {
+      // Regression guard for #4058: when scheduleForcedExit fires the real
+      // SIGINT path (exitAfterCleanup=true), the cleanup promise's .finally()
+      // calls process.exit(0). The test runner would otherwise terminate
+      // mid-file, producing a false-green (only 2 tests reported as passing
+      // when many more exist). process.exit MUST be mocked here.
       const sigintListenersBefore = process.listeners("SIGINT")
       const setTimeoutSpy = spyOn(globalThis, "setTimeout")
       const clearTimeoutSpy = spyOn(globalThis, "clearTimeout")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       // Re-enable forced exit so we can verify setTimeout/clearTimeout are called
       __enableScheduledForcedExitForTesting()
 
@@ -109,9 +115,11 @@ describe("#given process cleanup registration", () => {
 
         expect(setTimeoutSpy).toHaveBeenCalledTimes(1)
         expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledWith(0)
       } finally {
         setTimeoutSpy.mockRestore()
         clearTimeoutSpy.mockRestore()
+        exitSpy.mockRestore()
         __disableScheduledForcedExitForTesting()
         process.exitCode = 0
       }


### PR DESCRIPTION
## Summary
Re-open of #4359 which was auto-closed after a force-push accident made the branch identical to dev. Restored the original fix commit (fc3ee190) on the same branch.

Fixes #4058. The SIGINT/SIGTERM cleanup test was triggering a real process.exit during the test run, which aborted the rest of the file. Mocking process.exit in the test harness lets the full suite execute and exposes the underlying hang for the actual fix.

## Test plan
- [x] Test file now runs to completion
- [x] No regressions in existing cleanup tests

Refs #4359 (closed, restored here)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked `process.exit` in the SIGINT cleanup test to keep the runner alive and assert `exit(0)` after fast cleanup. This lets the full test file run and guards the regression in #4058.

- **Bug Fixes**
  - Spy on `process.exit` and expect it to be called with 0; keep forced-exit enabled to verify `setTimeout`/`clearTimeout` and timer cleanup; restore all spies.

<sup>Written for commit 3224f0bc7facb37417b5e2b96c800cbe4a631ad9. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4364?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

