### PR TITLE
feat: add config hot-reload for mid-session config changes

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5911,6 +5911,9 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 9007199254740991
+        },
+        "hot_reload": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/bun.lock
+++ b/bun.lock
@@ -41,17 +41,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.3.1",
-        "oh-my-opencode-darwin-x64": "4.3.1",
-        "oh-my-opencode-darwin-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-arm64": "4.3.1",
-        "oh-my-opencode-linux-arm64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64": "4.3.1",
-        "oh-my-opencode-linux-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-x64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.3.1",
-        "oh-my-opencode-windows-x64": "4.3.1",
-        "oh-my-opencode-windows-x64-baseline": "4.3.1",
+        "oh-my-opencode-darwin-arm64": "4.4.0",
+        "oh-my-opencode-darwin-x64": "4.4.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-arm64": "4.4.0",
+        "oh-my-opencode-linux-arm64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64": "4.4.0",
+        "oh-my-opencode-linux-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-x64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.4.0",
+        "oh-my-opencode-windows-x64": "4.4.0",
+        "oh-my-opencode-windows-x64-baseline": "4.4.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -399,27 +399,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wb+XTZ0Me3yBUejhhxXaiFpvZUmjT33EmgQPSrcwVIqpW4//DGpm4n9ptsSDm4ASaPaqG+v/dfNWmaXXS4FdqQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.4.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tGwtIIbxTDeeBqTkhBII4Mf/oBLavO1sSA2ZTlqNDY2srYu8677XRxq09+AF4aoexRB6JOyPOp3hpAwrRp+MHw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VnaFatAHVNpteFW/o/dHYVr6/NNDYnNnYgIupunUsO3J5beTFYJaPL5dq+1LRRQban9By9yMbOyXj7SGxGHmtQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VqqywGHjd5dLZEEYuqKJ2OiEK+NQFK5kskfnMsHaYf/sMlp7tv/RTDvtomtwk1KWXU3rW5acYSGxLxgMlpNBoA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Hd21GQR3pF5+4sTRSxypvQUUaSINke+fsbRtUWpun3uEDGpvpBfI3gcA+6ipM/VL0Qi35wvODU1W7Nl0welujA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tw4vJnLzbSPjdwYp+4vVnb/I2SysSptATylRmexiJGxAxpcAjqxk9yejzdHAhSALY/AlslKKzdpNJ7pGnFkiCA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-veU2mfOxDH11O+biZVahIF/Tlrp2cwvlmTpL0Cl8SHMBRUb8qhAHxN545e8Val3MSU6ydUXr0Ra5eAoazcAZ5g=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JWVfP9cze0y4eQZO9vs/5JQNmh6Bdfld0Vghwht75yQXTGIuzXw65ZjjB7/t5EMueVGt0xZJxFPGva1/Hk66Eg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rcuGLYeQ2uD60o5k54VCx/DiquIHxkACIK0KmK4IAjeNTfYpflfnEl/DfnsPpv7toWSI3XNOZwP4ig7ZfR72Pg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5ErkGwgH5o52mTZlwzc07pW7+0+S9hJXqeuqFZL5jAc8/UA0n+5pKOBT3tBF5CQdFFSNTX7FZeaCGaVQNtCvIg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dojsloeSYgu8wIZB2H7VoFDLm1sZvP+m00rWoQ6NqAW5/BlRfUtZql6JiVF31ofRzM8/UC0GJRwihtcg8piNLA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+eZA9R+zbFijTAknDT9wwR+JYCVUTVPdKnchTXLOhll+7Zyo9iVK/4Usa3s/UbWNXGz4fXbTk1ESiMQROF0Tlg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5lt3Rrkc3Y4idehke7JbMnawWZLZQjL5ghovjAlr9qsdgY5jsJEMAZW/TjgceAjTW0iAqSmtfVvVEtiPqLNk4w=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VhIsHJzVRsS+0jxY9e4ZCKvebcKIZj6Rw0pkxtYqm1xrZnPoiQzEkapoNJN2Jwr9ID2DubESl1ldOeqMhBRpSQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-26NV5DMaDETbecgw+LzjO/TpdzCnN0ZX/e74EQHFd0Z7ey7KK5p4x+dSBuY0F4NTZpFOQmbdZCJJOxyvDtUIHQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HltQLU4IGOuvVofESBLFxl6tfIkwuWWzPehoy6dkSE/OuqEzakTj85m7NDRIjmHyCLu2QVu/gKmf3wKoShEE4g=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-M+SJCWAc1QySELO3hmv3/vkRSfb7FPhUYVFi+34wBGFiywOK4jMOElyvCrEnxO3J1wGywEHgPWPaASs6f5ooIQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-baeGUFMCSFvBYjJsNY+bfu01AQdII9KG67LzgCCkFZKbARZJ6LR/1sGVNt4dxs3Bvdg3kYatpIvqozeiw1mYUA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-u38l63i/kq/vktaHsa7I+OBSoRXYWA8ExZ1tKv/d4adQuPzLfi9ruvTy+5fQ9GiDQZuRTlneenvrIYIfTJ4QYA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-MKjH5CIsMS8GDTimMpv9W+1SNgOaus9PeXC2H/hQd7BTkXZegN7JmH8mVJRLpHG4jDr432ky9O28ghRwqM76YQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-aeSyPkD/QDvc9x6l1q9VA4a1YwejefKzPPmuJKZAdWO6PSxdXN3nqx06+U2fR798KJbO4zNgg5vV331iMuvnqA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-VqVK+PK0dg0x+y1HxY2TVa13ulZbrYW4F2zA6JEV0nLNWRk0s7YnLQqXsm/bRNnfjsAFs+Frk5QS7mNorF79JQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/config-watcher.test.ts
+++ b/src/config-watcher.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import type { OhMyOpenCodeConfig } from "./config"
+
+const logCalls: Array<[string, unknown?]> = []
+let testConfigDir: string
+
+mock.module("./shared", () => ({
+  getOpenCodeConfigDir: (): string => testConfigDir,
+  detectConfigFile: (basePath: string): { format: string; path: string } => {
+    const jsoncPath = `${basePath}.jsonc`
+    const jsonPath = `${basePath}.json`
+    if (fs.existsSync(jsoncPath)) {
+      return { format: "jsonc", path: jsoncPath }
+    }
+    if (fs.existsSync(jsonPath)) {
+      return { format: "json", path: jsonPath }
+    }
+    return { format: "none", path: jsonPath }
+  },
+  log: (message: string, data?: unknown): void => {
+    logCalls.push([message, data])
+  },
+}))
+
+mock.module("./shared/plugin-identity", () => ({
+  CONFIG_BASENAME: "oh-my-openagent",
+  LEGACY_CONFIG_BASENAME: "oh-my-opencode",
+}))
+
+let mockLoadResult: OhMyOpenCodeConfig = {}
+let mockLoadShouldThrow = false
+
+mock.module("./plugin-config", () => ({
+  loadPluginConfig: (): OhMyOpenCodeConfig => {
+    if (mockLoadShouldThrow) {
+      throw new Error("Config parse error")
+    }
+    return mockLoadResult
+  },
+}))
+
+const { createConfigWatcher } = await import("./config-watcher")
+
+let testProjectDir: string
+
+beforeEach(() => {
+  logCalls.length = 0
+  mockLoadShouldThrow = false
+  mockLoadResult = {}
+
+  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-test-"))
+  testProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-project-"))
+
+  const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+  fs.writeFileSync(configFilePath, JSON.stringify({ agents: {} }))
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(testConfigDir, { recursive: true, force: true })
+  } catch {}
+  try {
+    fs.rmSync(testProjectDir, { recursive: true, force: true })
+  } catch {}
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("createConfigWatcher", () => {
+  test("#given hot_reload enabled and config file exists #when config file changes #then pluginConfig updates in place", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+    }
+
+    mockLoadResult = {
+      agents: {
+        build: { model: "openai/gpt-5.4" },
+      },
+    }
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, JSON.stringify({ agents: { build: { model: "openai/gpt-5.4" } } }))
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("openai/gpt-5.4")
+
+    dispose()
+  })
+
+  test("#given config file has parse errors #when config changes #then old config is preserved", async () => {
+    // given
+    const originalConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+    }
+    const pluginConfig: OhMyOpenCodeConfig = { ...originalConfig }
+
+    mockLoadShouldThrow = true
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, "{ invalid json }")
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("anthropic/claude-sonnet-4-20250514")
+
+    const errorLog = logCalls.find(([msg]) => msg.includes("reload failed"))
+    expect(errorLog).toBeDefined()
+
+    dispose()
+  })
+
+  test("#given watcher is active #when dispose is called #then watching stops and cleanup logged", () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    dispose()
+
+    // then
+    const disposeLog = logCalls.find(([msg]) => msg.includes("Disposed"))
+    expect(disposeLog).toBeDefined()
+  })
+
+  test("#given no config files exist #when createConfigWatcher called #then returns noop dispose", () => {
+    // given
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-empty-"))
+    const pluginConfig: OhMyOpenCodeConfig = {}
+
+    const savedDir = testConfigDir
+    testConfigDir = emptyDir
+
+    // when
+    const dispose = createConfigWatcher(emptyDir, {}, pluginConfig)
+
+    // then
+    const noFilesLog = logCalls.find(([msg]) => msg.includes("No config files found"))
+    expect(noFilesLog).toBeDefined()
+
+    dispose()
+
+    testConfigDir = savedDir
+    fs.rmSync(emptyDir, { recursive: true, force: true })
+  })
+
+  test("#given config section removed from file #when config reloads #then stale keys are deleted from pluginConfig", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+      categories: {
+        quick: { model: "openai/gpt-4.1-mini" },
+      },
+    }
+
+    mockLoadResult = {
+      agents: {
+        build: { model: "openai/gpt-5.4" },
+      },
+    }
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, JSON.stringify({ agents: { build: { model: "openai/gpt-5.4" } } }))
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("openai/gpt-5.4")
+    expect(pluginConfig.categories).toBeUndefined()
+    expect("categories" in pluginConfig).toBe(false)
+
+    dispose()
+  })
+
+  test("#given dispose already called #when dispose called again #then no errors", () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    dispose()
+
+    // then
+    expect(() => dispose()).not.toThrow()
+  })
+})

--- a/src/config-watcher.ts
+++ b/src/config-watcher.ts
@@ -1,0 +1,181 @@
+import * as fs from "fs"
+import * as path from "path"
+import type { OhMyOpenCodeConfig } from "./config"
+import { loadPluginConfig } from "./plugin-config"
+import { getOpenCodeConfigDir, detectConfigFile, log } from "./shared"
+import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "./shared/plugin-identity"
+
+const DEBOUNCE_MS = 300
+const REATTACH_DELAY_MS = 100
+const REATTACH_MAX_RETRIES = 5
+
+export interface ConfigWatcherDispose {
+  (): void
+}
+
+function resolveConfigPaths(directory: string): string[] {
+  const paths: string[] = []
+
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+
+  const canonicalUserPath = path.join(configDir, CONFIG_BASENAME)
+  const canonicalDetected = detectConfigFile(canonicalUserPath)
+  if (canonicalDetected.format !== "none") {
+    paths.push(canonicalDetected.path)
+  } else {
+    const legacyUserPath = path.join(configDir, LEGACY_CONFIG_BASENAME)
+    const legacyDetected = detectConfigFile(legacyUserPath)
+    if (legacyDetected.format !== "none") {
+      paths.push(legacyDetected.path)
+    }
+  }
+
+  const canonicalProjectPath = path.join(directory, ".opencode", CONFIG_BASENAME)
+  const canonicalProjectDetected = detectConfigFile(canonicalProjectPath)
+  if (canonicalProjectDetected.format !== "none") {
+    paths.push(canonicalProjectDetected.path)
+  } else {
+    const legacyProjectPath = path.join(directory, ".opencode", LEGACY_CONFIG_BASENAME)
+    const legacyProjectDetected = detectConfigFile(legacyProjectPath)
+    if (legacyProjectDetected.format !== "none") {
+      paths.push(legacyProjectDetected.path)
+    }
+  }
+
+  return paths
+}
+
+function applyConfigInPlace(
+  pluginConfig: OhMyOpenCodeConfig,
+  newConfig: OhMyOpenCodeConfig,
+): void {
+  for (const key of Object.keys(pluginConfig)) {
+    if (!(key in newConfig)) {
+      delete (pluginConfig as Record<string, unknown>)[key]
+    }
+  }
+  Object.assign(pluginConfig, newConfig)
+}
+
+/**
+ * Watches user and project config files, hot-reloading plugin config on change.
+ *
+ * Handles atomic saves (write-tmp → rename) by reattaching the watcher
+ * when a rename event is detected and the file reappears.
+ *
+ * Properties that won't hot-reload (startup-snapshotted by design):
+ * - disabled_hooks, tmuxConfig, safe_hook_creation
+ */
+export function createConfigWatcher(
+  directory: string,
+  ctx: unknown,
+  pluginConfig: OhMyOpenCodeConfig,
+): ConfigWatcherDispose {
+  const watchers: fs.FSWatcher[] = []
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const configPaths = resolveConfigPaths(directory)
+
+  if (configPaths.length === 0) {
+    log("[config-watcher] No config files found to watch")
+    return () => {}
+  }
+
+  const reloadConfig = (): void => {
+    try {
+      const newConfig = loadPluginConfig(directory, ctx)
+      applyConfigInPlace(pluginConfig, newConfig)
+      log("[config-watcher] Config hot-reloaded successfully", {
+        agents: newConfig.agents,
+        categories: newConfig.categories,
+      })
+    } catch (error) {
+      log("[config-watcher] Config reload failed, keeping previous config", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const debouncedReload = (): void => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+    }
+    debounceTimer = setTimeout(reloadConfig, DEBOUNCE_MS)
+  }
+
+  const attachWatcher = (configPath: string): void => {
+    if (disposed) return
+
+    try {
+      const watcher = fs.watch(configPath, (eventType) => {
+        if (disposed) return
+
+        if (eventType === "change") {
+          log("[config-watcher] Config file changed", { path: configPath, eventType })
+          debouncedReload()
+        } else if (eventType === "rename") {
+          log("[config-watcher] Config file renamed (atomic save detected)", { path: configPath })
+          watcher.close()
+          const idx = watchers.indexOf(watcher)
+          if (idx !== -1) watchers.splice(idx, 1)
+          reattachAfterRename(configPath, 0)
+        }
+      })
+
+      watcher.on("error", (error) => {
+        log("[config-watcher] Watcher error", {
+          path: configPath,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+
+      watchers.push(watcher)
+      log("[config-watcher] Watching config file", { path: configPath })
+    } catch (error) {
+      log("[config-watcher] Failed to watch config file", {
+        path: configPath,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const reattachAfterRename = (configPath: string, attempt: number): void => {
+    if (disposed) return
+    if (attempt >= REATTACH_MAX_RETRIES) {
+      log("[config-watcher] File did not reappear after rename, giving up", { path: configPath })
+      return
+    }
+
+    setTimeout(() => {
+      if (disposed) return
+      if (fs.existsSync(configPath)) {
+        debouncedReload()
+        attachWatcher(configPath)
+      } else {
+        reattachAfterRename(configPath, attempt + 1)
+      }
+    }, REATTACH_DELAY_MS)
+  }
+
+  for (const configPath of configPaths) {
+    attachWatcher(configPath)
+  }
+
+  return (): void => {
+    disposed = true
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    for (const watcher of watchers) {
+      try {
+        watcher.close()
+      } catch {
+        // ignore close errors during dispose
+      }
+    }
+    watchers.length = 0
+    log("[config-watcher] Disposed — stopped watching config files")
+  }
+}

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -22,6 +22,8 @@ export const ExperimentalConfigSchema = z.object({
   model_fallback_title: z.boolean().optional(),
   /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
   max_tools: z.number().int().min(1).optional(),
+  /** Enable config hot-reload: watches oh-my-opencode config files and applies changes mid-session without restart. Hot-reloads: agents, categories, experimental flags. Does NOT hot-reload: disabled_hooks, tmuxConfig, safe_hook_creation (startup-snapshotted). */
+  hot_reload: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/plugin-dispose.ts
+++ b/src/plugin-dispose.ts
@@ -10,8 +10,9 @@ export function createPluginDispose(args: {
     disconnectAll: () => Promise<void>
   }
   disposeHooks: () => void
+  configWatcherDispose?: () => void
 }): PluginDispose {
-  const { backgroundManager, skillMcpManager, disposeHooks } = args
+  const { backgroundManager, skillMcpManager, disposeHooks, configWatcherDispose } = args
   let disposePromise: Promise<void> | null = null
 
   return async (): Promise<void> => {
@@ -35,6 +36,13 @@ export function createPluginDispose(args: {
         disposeHooks()
       } catch (error) {
         log("[plugin-dispose] disposeHooks() error:", error)
+      }
+      if (configWatcherDispose) {
+        try {
+          configWatcherDispose()
+        } catch (error) {
+          log("[plugin-dispose] configWatcherDispose() error:", error)
+        }
       }
     })()
 

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -1,5 +1,6 @@
 import type { Hooks, Plugin, PluginModule } from "@opencode-ai/plugin"
 import type { HookName } from "../config"
+import { createConfigWatcher, type ConfigWatcherDispose } from "../config-watcher"
 import { initConfigContext } from "../cli/config-manager/config-context"
 
 import { createHooks } from "../create-hooks"
@@ -98,6 +99,12 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
     deps.initI18n(pluginConfig.i18n?.locale ? { locale: pluginConfig.i18n.locale } : undefined)
     deps.setAgentSortOrder(pluginConfig.agent_order)
+
+    let configWatcherDispose: ConfigWatcherDispose | undefined
+    if (pluginConfig.experimental?.hot_reload) {
+      configWatcherDispose = createConfigWatcher(input.directory, input, pluginConfig)
+      deps.log("[oh-my-openagent] Config hot-reload enabled")
+    }
 
     if (pluginConfig.openclaw) {
       await deps.initializeOpenClaw(pluginConfig.openclaw)


### PR DESCRIPTION
## Summary

Add `experimental.hot_reload` option that watches oh-my-openagent config files (user + project) and applies changes mid-session without restart.

**Hot-reloads:** agents, categories, experimental flags.
**Does NOT hot-reload:** disabled_hooks, tmuxConfig, safe_hook_creation (startup-snapshotted by design).

## Implementation

- `fs.watch`-based watcher with 300ms debounce
- Handles atomic saves (write-tmp → rename) via reattach with retry (5 attempts, 100ms delay)
- Proper cleanup on plugin dispose
- In-place config mutation preserves object references
- Schema updated: `experimental.hot_reload: boolean`

## Usage

```jsonc
// oh-my-openagent.json
{
  "experimental": {
    "hot_reload": true
  }
}
```

Then edit your config file while opencode is running — agent/category model changes take effect immediately.

## Testing

- 6 new tests covering: config change detection, parse error resilience, dispose cleanup, no-config-files noop, stale key deletion, double-dispose safety
- All 6 pass locally
- 21 pre-existing test failures (same on clean `upstream/dev`, unrelated to this PR)

## Prior Work

Builds on `feat/hot-reload-config` branch. This v2 rebases onto v4.4.0 and simplifies the approach.

cc @code-yeongyu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds config hot-reload so changes to user or project config take effect mid-session without a restart. Introduces `experimental.hot_reload` to watch `oh-my-openagent` (and legacy `oh-my-opencode`) files and apply updates on the fly.

- **New Features**
  - Added `experimental.hot_reload` flag to the schema.
  - Watches user and project config with a 300ms debounce and handles atomic saves.
  - Hot-reloads agents, categories, and experimental flags; does not reload `disabled_hooks`, `tmuxConfig`, or `safe_hook_creation`.
  - Updates config in place to preserve object references and cleans up on plugin dispose.

- **Migration**
  - Enable by setting `experimental.hot_reload: true` in your config.

<sup>Written for commit 77a9001aeb1ca0f0f1c2078cc5ece6dd0a187013. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

