### PR TITLE
feat(fallback-models): scoped fallback_models for ultrawork/compaction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,17 +41,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.3.1",
-        "oh-my-opencode-darwin-x64": "4.3.1",
-        "oh-my-opencode-darwin-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-arm64": "4.3.1",
-        "oh-my-opencode-linux-arm64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64": "4.3.1",
-        "oh-my-opencode-linux-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-x64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.3.1",
-        "oh-my-opencode-windows-x64": "4.3.1",
-        "oh-my-opencode-windows-x64-baseline": "4.3.1",
+        "oh-my-opencode-darwin-arm64": "4.4.0",
+        "oh-my-opencode-darwin-x64": "4.4.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-arm64": "4.4.0",
+        "oh-my-opencode-linux-arm64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64": "4.4.0",
+        "oh-my-opencode-linux-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-x64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.4.0",
+        "oh-my-opencode-windows-x64": "4.4.0",
+        "oh-my-opencode-windows-x64-baseline": "4.4.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -399,27 +399,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wb+XTZ0Me3yBUejhhxXaiFpvZUmjT33EmgQPSrcwVIqpW4//DGpm4n9ptsSDm4ASaPaqG+v/dfNWmaXXS4FdqQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.4.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tGwtIIbxTDeeBqTkhBII4Mf/oBLavO1sSA2ZTlqNDY2srYu8677XRxq09+AF4aoexRB6JOyPOp3hpAwrRp+MHw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VnaFatAHVNpteFW/o/dHYVr6/NNDYnNnYgIupunUsO3J5beTFYJaPL5dq+1LRRQban9By9yMbOyXj7SGxGHmtQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VqqywGHjd5dLZEEYuqKJ2OiEK+NQFK5kskfnMsHaYf/sMlp7tv/RTDvtomtwk1KWXU3rW5acYSGxLxgMlpNBoA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Hd21GQR3pF5+4sTRSxypvQUUaSINke+fsbRtUWpun3uEDGpvpBfI3gcA+6ipM/VL0Qi35wvODU1W7Nl0welujA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tw4vJnLzbSPjdwYp+4vVnb/I2SysSptATylRmexiJGxAxpcAjqxk9yejzdHAhSALY/AlslKKzdpNJ7pGnFkiCA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-veU2mfOxDH11O+biZVahIF/Tlrp2cwvlmTpL0Cl8SHMBRUb8qhAHxN545e8Val3MSU6ydUXr0Ra5eAoazcAZ5g=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JWVfP9cze0y4eQZO9vs/5JQNmh6Bdfld0Vghwht75yQXTGIuzXw65ZjjB7/t5EMueVGt0xZJxFPGva1/Hk66Eg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rcuGLYeQ2uD60o5k54VCx/DiquIHxkACIK0KmK4IAjeNTfYpflfnEl/DfnsPpv7toWSI3XNOZwP4ig7ZfR72Pg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5ErkGwgH5o52mTZlwzc07pW7+0+S9hJXqeuqFZL5jAc8/UA0n+5pKOBT3tBF5CQdFFSNTX7FZeaCGaVQNtCvIg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dojsloeSYgu8wIZB2H7VoFDLm1sZvP+m00rWoQ6NqAW5/BlRfUtZql6JiVF31ofRzM8/UC0GJRwihtcg8piNLA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+eZA9R+zbFijTAknDT9wwR+JYCVUTVPdKnchTXLOhll+7Zyo9iVK/4Usa3s/UbWNXGz4fXbTk1ESiMQROF0Tlg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5lt3Rrkc3Y4idehke7JbMnawWZLZQjL5ghovjAlr9qsdgY5jsJEMAZW/TjgceAjTW0iAqSmtfVvVEtiPqLNk4w=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VhIsHJzVRsS+0jxY9e4ZCKvebcKIZj6Rw0pkxtYqm1xrZnPoiQzEkapoNJN2Jwr9ID2DubESl1ldOeqMhBRpSQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-26NV5DMaDETbecgw+LzjO/TpdzCnN0ZX/e74EQHFd0Z7ey7KK5p4x+dSBuY0F4NTZpFOQmbdZCJJOxyvDtUIHQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HltQLU4IGOuvVofESBLFxl6tfIkwuWWzPehoy6dkSE/OuqEzakTj85m7NDRIjmHyCLu2QVu/gKmf3wKoShEE4g=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-M+SJCWAc1QySELO3hmv3/vkRSfb7FPhUYVFi+34wBGFiywOK4jMOElyvCrEnxO3J1wGywEHgPWPaASs6f5ooIQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-baeGUFMCSFvBYjJsNY+bfu01AQdII9KG67LzgCCkFZKbARZJ6LR/1sGVNt4dxs3Bvdg3kYatpIvqozeiw1mYUA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-u38l63i/kq/vktaHsa7I+OBSoRXYWA8ExZ1tKv/d4adQuPzLfi9ruvTy+5fQ9GiDQZuRTlneenvrIYIfTJ4QYA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-MKjH5CIsMS8GDTimMpv9W+1SNgOaus9PeXC2H/hQd7BTkXZegN7JmH8mVJRLpHG4jDr432ky9O28ghRwqM76YQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-aeSyPkD/QDvc9x6l1q9VA4a1YwejefKzPPmuJKZAdWO6PSxdXN3nqx06+U2fR798KJbO4zNgg5vV331iMuvnqA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-VqVK+PK0dg0x+y1HxY2TVa13ulZbrYW4F2zA6JEV0nLNWRk0s7YnLQqXsm/bRNnfjsAFs+Frk5QS7mNorF79JQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/config/schema/agent-overrides.test.ts
+++ b/src/config/schema/agent-overrides.test.ts
@@ -35,4 +35,58 @@ describe("AgentOverridesSchema", () => {
 
     expect(result.success).toBe(false)
   })
+
+test('validates fallback_models in ultrawork scope', () => {
+  const input = {
+    sisyphus: {
+      ultrawork: {
+        model: 'anthropic/claude-opus-4-7',
+        fallback_models: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+      },
+    },
+  }
+
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const uw = result.data.sisyphus?.ultrawork
+    expect(uw?.model).toBe('anthropic/claude-opus-4-7')
+    expect(uw?.fallback_models).toEqual(['openai/gpt-5.3', 'google/gemini-3.1-pro'])
+  }
+})
+
+test('validates fallback_models in compaction scope', () => {
+  const input = {
+    sisyphus: {
+      compaction: {
+        model: 'anthropic/claude-sonnet-4-6',
+        fallback_models: ['openai/gpt-5.4-mini'],
+      },
+    },
+  }
+
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const cp = result.data.sisyphus?.compaction
+    expect(cp?.model).toBe('anthropic/claude-sonnet-4-6')
+    expect(cp?.fallback_models).toEqual(['openai/gpt-5.4-mini'])
+  }
+})
+
+test('validates empty ultrawork scope without fallback_models', () => {
+  const input = {
+    sisyphus: {
+      ultrawork: {},
+    },
+  }
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const uw = result.data.sisyphus?.ultrawork
+    expect(uw?.model).toBeUndefined()
+    expect(uw?.variant).toBeUndefined()
+    expect(uw?.fallback_models).toBeUndefined()
+  }
+})
 })

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -47,12 +47,14 @@ export const AgentOverrideConfigSchema = z.object({
     .object({
       model: z.string().optional(),
       variant: z.string().optional(),
+      fallback_models: FallbackModelsSchema.optional(),
     })
     .optional(),
   compaction: z
     .object({
       model: z.string().optional(),
       variant: z.string().optional(),
+      fallback_models: FallbackModelsSchema.optional(),
     })
     .optional(),
 })

--- a/src/hooks/shared/compaction-model-resolver.ts
+++ b/src/hooks/shared/compaction-model-resolver.ts
@@ -7,7 +7,7 @@ export function resolveCompactionModel(
   sessionID: string,
   originalProviderID: string,
   originalModelID: string
-): { providerID: string; modelID: string } {
+): { providerID: string; modelID: string; fallbackModels?: unknown } {
   const sessionAgentName = getSessionAgent(sessionID)
   
   if (!sessionAgentName || !pluginConfig.agents) {
@@ -15,20 +15,29 @@ export function resolveCompactionModel(
   }
 
   const agentConfigKey = getAgentConfigKey(sessionAgentName)
-  const agentConfig = (pluginConfig.agents as Record<string, { compaction?: { model?: string } } | undefined>)[agentConfigKey]
+  const agentConfig = (pluginConfig.agents as Record<string, { compaction?: { model?: string; fallback_models?: unknown } } | undefined>)[agentConfigKey]
   const compactionConfig = agentConfig?.compaction
 
   if (!compactionConfig?.model) {
-    return { providerID: originalProviderID, modelID: originalModelID }
+    return {
+      providerID: originalProviderID,
+      modelID: originalModelID,
+      fallbackModels: compactionConfig?.fallback_models,
+    }
   }
 
   const modelParts = compactionConfig.model.split("/")
   if (modelParts.length < 2) {
-    return { providerID: originalProviderID, modelID: originalModelID }
+    return {
+      providerID: originalProviderID,
+      modelID: originalModelID,
+      fallbackModels: compactionConfig.fallback_models,
+    }
   }
 
   return {
     providerID: modelParts[0],
     modelID: modelParts.slice(1).join("/"),
+    fallbackModels: compactionConfig.fallback_models,
   }
 }

--- a/src/plugin/ultrawork-model-override.test.ts
+++ b/src/plugin/ultrawork-model-override.test.ts
@@ -235,6 +235,65 @@ describe("resolveUltraworkOverride", () => {
 
     getSessionAgentSpy.mockRestore()
   })
+
+  test('should return fallbackModels from ultrawork config when configured', () => {
+    //#given
+    const config = unsafeTestValue<Parameters<typeof resolveUltraworkOverride>[0]>({
+      agents: {
+        sisyphus: {
+          ultrawork: {
+            model: 'anthropic/claude-opus-4-7',
+            fallback_models: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+          },
+        },
+      },
+    })
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toEqual({
+      providerID: 'anthropic',
+      modelID: 'claude-opus-4-7',
+      fallbackModels: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+    })
+  })
+
+  test('should return fallbackModels without model/variant from ultrawork config', () => {
+    //#given
+    const config = unsafeTestValue<Parameters<typeof resolveUltraworkOverride>[0]>({
+      agents: {
+        sisyphus: {
+          ultrawork: {
+            fallback_models: ['openai/gpt-5.3'],
+          },
+        },
+      },
+    })
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toEqual({
+      fallbackModels: ['openai/gpt-5.3'],
+    })
+  })
+
+  test('should return null when ultrawork has no model, variant, or fallback_models', () => {
+    //#given
+    const config = createConfig('sisyphus', {})
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toBeNull()
+  })
 })
 
 describe("applyUltraworkModelOverrideOnMessage", () => {

--- a/src/plugin/ultrawork-model-override.ts
+++ b/src/plugin/ultrawork-model-override.ts
@@ -1,5 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { AgentOverrides } from "../config/schema/agent-overrides"
+import type { FallbackModels } from "../config/schema/fallback-models"
+
 import { getSessionAgent } from "../features/claude-code-session-state"
 import { log } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
@@ -35,6 +37,7 @@ export type UltraworkOverrideResult = {
   providerID?: string
   modelID?: string
   variant?: string
+  fallbackModels?: FallbackModels
 }
 
 type ModelDescriptor = {
@@ -78,10 +81,13 @@ export function resolveUltraworkOverride(
   const agentConfigKey = getAgentConfigKey(rawAgentName)
   const agentConfig = pluginConfig.agents[agentConfigKey as keyof AgentOverrides]
   const ultraworkConfig = agentConfig?.ultrawork
-  if (!ultraworkConfig?.model && !ultraworkConfig?.variant) return null
+  if (!ultraworkConfig?.model && !ultraworkConfig?.variant && !ultraworkConfig?.fallback_models) return null
 
   if (!ultraworkConfig.model) {
-    return { variant: ultraworkConfig.variant }
+    return {
+      variant: ultraworkConfig.variant,
+      fallbackModels: ultraworkConfig.fallback_models,
+    }
   }
 
   const modelParts = ultraworkConfig.model.split("/")
@@ -91,6 +97,7 @@ export function resolveUltraworkOverride(
     providerID: modelParts[0],
     modelID: modelParts.slice(1).join("/"),
     variant: ultraworkConfig.variant,
+    fallbackModels: ultraworkConfig.fallback_models,
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `fallback_models` support to ultrawork and compaction scope overrides in agent config. Previously, fallback_models could only be configured at the agent level — scoped overrides for ultrawork/compaction only supported `model` and `variant`.

## Changes

- **agent-overrides.ts**: Added `fallback_models: FallbackModelsSchema.optional()` to both `ultrawork` and `compaction` Zod objects
- **ultrawork-model-override.ts**: Extended `resolveUltraworkOverride()` to read and return `fallback_models` from ultrawork config
- **compaction-model-resolver.ts**: Updated to read and return `fallback_models` from compaction config
- **Tests**: 6 new tests covering schema validation and override resolution with fallback_models

## Usage

```jsonc
{
  "agents": {
    "sisyphus": {
      "ultrawork": {
        "model": "anthropic/claude-opus-4-7",
        "fallback_models": ["openai/gpt-5.3"]
      }
    }
  }
}
```

Closes #3779

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped `fallback_models` to `ultrawork` and `compaction` overrides so each scope can define its own fallback chain. Addresses Linear #3779 by enabling fallbacks when a primary model is unavailable.

- **New Features**
  - Added `fallback_models` to `ultrawork` and `compaction` in the agent overrides schema.
  - `resolveUltraworkOverride` and `resolveCompactionModel` now return `fallbackModels` (including when no model/variant is set); added tests for schema and resolution.

- **Dependencies**
  - Updated optional `oh-my-opencode-*` platform packages to `4.4.0` in `bun.lock`.

<sup>Written for commit c344112d466e400dfe770a21bab065ae103d5d71. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4373?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

