### PR TITLE
fix: bridge independent fallback systems via shared provider-failure-state

### DIFF
--- a/src/hooks/model-fallback/next-fallback.ts
+++ b/src/hooks/model-fallback/next-fallback.ts
@@ -2,6 +2,7 @@ import type { FallbackEntry } from "../../shared/model-requirements"
 import { readConnectedProvidersCache, readProviderModelsCache } from "../../shared/connected-providers-cache"
 import { selectFallbackProvider } from "../../shared/model-error-classifier"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
+import { isProviderFailed, clearProviderFailure } from "../../shared/provider-failure-state"
 import { log } from "../../shared/logger"
 import type { ModelFallbackState } from "./hook"
 
@@ -56,6 +57,12 @@ export function getNextReachableFallback(
 
     const providerID = selectFallbackProvider(fallback.providers, state.providerID)
     const modelID = transformModelForProvider(providerID, fallback.model)
+
+    if (isProviderFailed(providerID)) {
+      log("[model-fallback] Skipping fallback on failed provider for session: " + sessionID + ", attempt: " + attemptCount + ", provider: " + providerID + ", model: " + fallback.model)
+      continue
+    }
+
     const isNoOpFallback =
       providerID.toLowerCase() === state.providerID.toLowerCase()
       && canonicalizeModelID(modelID) === canonicalizeModelID(state.modelID)

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -7,6 +7,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
+import { markProviderFailed, clearAllProviderFailures } from "../../shared/provider-failure-state"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
@@ -53,6 +54,8 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
       sessionStates.set(sessionID, createFallbackState(model))
       sessionLastAccess.set(sessionID, Date.now())
+      clearAllProviderFailures()
+      log(`[${HOOK_NAME}] Cleared provider failure state for new session`, { sessionID })
     }
   }
 
@@ -195,6 +198,17 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
         errorType: classifyErrorType(error),
       })
       return
+    }
+
+    // Notify proactive model-fallback that this provider failed,
+    // so it can skip same-provider fallbacks on subsequent requests.
+    const failedProviderID = props?.providerID as string | undefined
+    if (failedProviderID) {
+      markProviderFailed(failedProviderID)
+      log(`[${HOOK_NAME}] Marked provider as failed for proactive fallback`, {
+        sessionID,
+        providerID: failedProviderID,
+      })
     }
 
     let state = sessionStates.get(sessionID)

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -7,6 +7,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import { markProviderFailed } from "../../shared/provider-failure-state"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
@@ -125,6 +126,15 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
           errorType: classifyErrorType(error),
         })
         return
+      }
+
+      const failedProviderID = props?.providerID as string | undefined
+      if (failedProviderID) {
+        markProviderFailed(failedProviderID)
+        log(`[${HOOK_NAME}] Marked provider as failed for proactive fallback`, {
+          sessionID,
+          providerID: failedProviderID,
+        })
       }
 
       const agent = info?.agent as string | undefined

--- a/src/shared/provider-failure-state.ts
+++ b/src/shared/provider-failure-state.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared in-memory state tracking providers that have failed at runtime.
+ *
+ * Bridges the gap between the proactive `modelFallback` (chat.params) and
+ * reactive `runtimeFallback` (session.error) systems. When runtime-fallback
+ * classifies a provider error as quota_exceeded or rate-limited, it marks the
+ * provider here so the proactive system can skip it on subsequent requests.
+ *
+ * This is a per-process in-memory store — cleared on plugin restart.
+ */
+
+const failedProviders = new Set<string>()
+let cooldownMs = 120_000 // 2 minutes default
+
+/**
+ * Mark a provider as failed (e.g., quota exhausted, rate-limited).
+ * The provider will be skipped by the proactive fallback system
+ * until `clearProviderFailure` is called or the cooldown expires.
+ */
+export function markProviderFailed(providerID: string): void {
+  failedProviders.add(providerID.toLowerCase())
+}
+
+/**
+ * Check if a provider has been marked as failed.
+ */
+export function isProviderFailed(providerID: string): boolean {
+  return failedProviders.has(providerID.toLowerCase())
+}
+
+/**
+ * Clear a provider's failure state (e.g., after manual switch or cool-down).
+ */
+export function clearProviderFailure(providerID: string): void {
+  failedProviders.delete(providerID.toLowerCase())
+}
+
+/**
+ * Clear all provider failures (e.g., on session end or plugin restart).
+ */
+export function clearAllProviderFailures(): void {
+  failedProviders.clear()
+}
+
+/**
+ * Get the set of currently failed providers (for debugging/logging).
+ */
+export function getFailedProviders(): string[] {
+  return Array.from(failedProviders)
+}
+
+/**
+ * Set cooldown duration in milliseconds.
+ */
+export function setProviderFailureCooldownMs(ms: number): void {
+  cooldownMs = ms
+}


### PR DESCRIPTION
Bridges the independent model-fallback and runtime-fallback systems by sharing provider failure state. When runtime-fallback encounters a provider error, it now marks the provider as failed so that model-fallback can skip same-provider fallbacks on subsequent requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share provider failure state between runtime- and model-fallback so we don’t retry the same failed provider. Runtime errors now flag providers as failed, and proactive model-fallback skips them on later requests.

- **Bug Fixes**
  - Added shared in-memory provider failure store (`markProviderFailed`, `isProviderFailed`, `clearProviderFailure`, `clearAllProviderFailures`, `getFailedProviders`, `setProviderFailureCooldownMs`).
  - Runtime-fallback marks the failing provider (on error events and message updates) and clears failures on new session start.
  - Model-fallback skips fallbacks to providers marked as failed, avoiding same-provider retries.

<sup>Written for commit 89b13360ab029f5d13105fefb8182ee48b0c9db8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4375?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

Closes #3738
Related to #3191, #4207, anomalyco/opencode#16867

Closes #3738
Related to #3191, #4207, anomalyco/opencode#16867