### PR TITLE
fix(runtime-fallback): skip equivalent fallback models with variant-only differences

### DIFF
--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -49,6 +49,11 @@ function parseCanonicalModel(model: string): { providerID: string; modelID: stri
   }
 }
 
+function stripVariant(modelID: string): string {
+  const idx = modelID.indexOf("::")
+  return idx >= 0 ? modelID.slice(0, idx) : modelID
+}
+
 function isEquivalentModel(candidate: string, current: string): boolean {
   const parsedCandidate = parseCanonicalModel(candidate)
   const parsedCurrent = parseCanonicalModel(current)
@@ -57,10 +62,16 @@ function isEquivalentModel(candidate: string, current: string): boolean {
     return candidate.toLowerCase() === current.toLowerCase()
   }
 
-  return (
-    parsedCandidate.providerID === parsedCurrent.providerID &&
-    parsedCandidate.modelID === parsedCurrent.modelID
-  )
+  if (parsedCandidate.providerID !== parsedCurrent.providerID) {
+    return false
+  }
+
+  // Compare base model IDs without variant — a model with variant "medium"
+  // is equivalent to the same model without variant or with a different variant.
+  const baseCandidate = stripVariant(parsedCandidate.modelID)
+  const baseCurrent = stripVariant(parsedCurrent.modelID)
+
+  return baseCandidate === baseCurrent
 }
 
 export function createFallbackState(originalModel: string): FallbackState {


### PR DESCRIPTION
When a model fails (e.g. openai/gpt-5.5) and a fallback entry exists with only a variant difference (e.g. openai/gpt-5.5(medium)), isEquivalentModel() now strips the variant before comparing. This prevents the runtime-fallback from retrying the same broken model with just a variant change, and correctly advances to the next distinct fallback model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips fallback entries that only differ by `::variant`, so runtime-fallback doesn’t retry the same failed model and moves to the next distinct one.

- **Bug Fixes**
  - Added `stripVariant()` and updated `isEquivalentModel()` to compare provider IDs and base model IDs without the `::variant`.

<sup>Written for commit 5ca638c69a4453c4aac0f706aad4cf54a7c10b5d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

