### PR TITLE
fix(background-agent): implement three-layer defense for silent empty outputs

### DIFF
--- a/packages/model-core/src/model-error-classifier.ts
+++ b/packages/model-core/src/model-error-classifier.ts
@@ -12,6 +12,7 @@ const RETRYABLE_ERROR_NAMES = new Set([
   "modelunavailableerror",
   "providerconnectionerror",
   "authenticationerror",
+  "emptyoutputerror",
 ])
 
 const STOP_ERROR_NAMES = new Set([

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -28,6 +28,7 @@ import {
   hasMoreFallbacks,
   shouldRetryError,
 } from "../../shared/model-error-classifier"
+import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
@@ -1081,6 +1082,24 @@ The fallback retry session is now created and can be inspected directly.
     return undefined
   }
 
+  /**
+   * Public hook for tool.execute.after detectors to retry a task on a fallback
+   * model when the current model returned empty output.
+   */
+  async retryTaskOnEmptyOutput(sessionID: string): Promise<boolean> {
+    const task = this.findBySession(sessionID)
+    if (!task) return false
+    return this.tryFallbackRetry(
+      task,
+      {
+        name: "EmptyOutputError",
+        message:
+          "Model returned no text output — may be rate-limited or returned an empty response",
+      },
+      "tool.execute.after (empty output)",
+    )
+  }
+
   private resolveTaskAttemptBySession(sessionID: string): { task: BackgroundTask; attemptID?: string; isCurrent: boolean } | undefined {
     const task = this.findBySession(sessionID)
     if (!task) {
@@ -1632,6 +1651,16 @@ The fallback retry session is now created and can be inspected directly.
         checkSessionTodos: (id) => this.checkSessionTodos(id),
         tryCompleteTask: (task, source) => this.tryCompleteTask(task, source),
         emitIdleEvent: (sessionID) => this.handleEvent({ type: "session.idle", properties: { sessionID } }),
+        onNoValidOutput: async (task, _sessionID) => {
+          const errorInfo = {
+            name: "EmptyOutputError",
+            message: `Model returned no text output — may be rate-limited or returned an empty response`,
+          }
+          const didFallback = await this.tryFallbackRetry(task, errorInfo, "session.idle (empty output)")
+          if (!didFallback) {
+            log("[background-agent] No fallback available for empty output, failing task:", task.id)
+          }
+        },
       })
     }
 
@@ -1834,6 +1863,21 @@ The fallback retry session is now created and can be inspected directly.
       const sessionFallbackChain = this.modelFallbackControllerAccessor?.getSessionFallbackChain(task.sessionId)
       if (sessionFallbackChain?.length) {
         task.fallbackChain = sessionFallbackChain
+      }
+    }
+
+    // When the category-resolver nullifies the fallback chain (explicit model,
+    // override, cold cache), use the requirement's hardcoded chain as a safety
+    // net so model-not-found / unavailable errors don't hang the task.
+    if (!task.fallbackChain && task.category) {
+      const requirement = CATEGORY_MODEL_REQUIREMENTS[task.category]
+      if (requirement?.fallbackChain?.length) {
+        task.fallbackChain = requirement.fallbackChain
+        this.logger("[background-agent] Populated fallback chain from category requirements:", {
+          taskId: task.id,
+          category: task.category,
+          chainLength: requirement.fallbackChain.length,
+        })
       }
     }
 
@@ -2082,6 +2126,30 @@ The task was re-queued on a fallback model after a retryable failure.
     }
   }
 
+  /**
+   * Checks whether the session produced actual text output (not just reasoning or tool calls).
+   * Stricter than validateSessionHasOutput — reasoning/thinking blocks alone don't count.
+   */
+  private async hasTextOutput(sessionID: string): Promise<boolean> {
+    try {
+      const response = await messagesInDirectory(this.client, {
+        path: { id: sessionID },
+      }, this.directory)
+
+      const messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, { preferResponseOnMissingData: true })
+
+      return messages.some((m: any) => {
+        if (m.info?.role !== "assistant") return false
+        const parts = m.parts ?? []
+        return parts.some((p: any) =>
+          p.type === "text" && p.text && p.text.trim().length > 0
+        )
+      })
+    } catch {
+      return true
+    }
+  }
+
   private clearNotificationsForTask(taskId: string): void {
     for (const [sessionID, tasks] of this.notifications.entries()) {
       const filtered = tasks.filter((t) => t.id !== taskId)
@@ -2311,6 +2379,61 @@ The task was re-queued on a fallback model after a retryable failure.
     if (task.status !== "running") {
       log("[background-agent] Task already completed, skipping:", { taskId: task.id, status: task.status, source })
       return false
+    }
+
+    // Before marking as completed, check if the session produced actual text output.
+    // Models can produce reasoning/thinking blocks but still return empty final text
+    // (e.g., rate-limited ChatGPT Plus via gpt-5.5, or misconfigured model variants).
+    // Catching this here covers all completion paths regardless of speed — the idle
+    // handler (Layer 2, 5s threshold) and tool.execute.after (Layer 3, launch message)
+    // both miss fast background task completions.
+    if (task.sessionId) {
+      const hasText = await this.hasTextOutput(task.sessionId)
+      if (!hasText) {
+        this.logger("[background-agent] Task completed with no text output, attempting fallback:", task.id)
+        const didFallback = await this.tryFallbackRetry(
+          task,
+          { name: "EmptyOutputError", message: "Model returned no text output — may be rate-limited or returned an empty response" },
+          `tryCompleteTask (empty output via ${source})`,
+        )
+        if (didFallback) {
+          // Fallback retry queued — don't mark this attempt as complete
+          return false
+        }
+        // No fallback available — mark as error so parent session knows it failed
+        this.logger("[background-agent] No fallback available for empty output, marking task as error:", task.id)
+        const errorMsg = "Model returned no text output and no fallback model is available"
+        if (task.currentAttemptID) {
+          finalizeAttempt(task, task.currentAttemptID, "error", errorMsg)
+        } else {
+          task.status = "error"
+          task.error = errorMsg
+          task.completedAt = new Date()
+        }
+        this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+        if (task.rootSessionId) this.unregisterRootDescendant(task.rootSessionId)
+        removeTaskToastTracking(task.id)
+        if (task.concurrencyKey) {
+          this.concurrencyManager.release(task.concurrencyKey)
+          task.concurrencyKey = undefined
+        }
+        this.markForNotification(task)
+        const timer = this.idleDeferralTimers.get(task.id)
+        if (timer) { clearTimeout(timer); this.idleDeferralTimers.delete(task.id) }
+        if (task.sessionId) {
+          await this.abortSessionWithLogging(task.sessionId, `task error (empty output via ${source})`)
+          clearDelegatedChildSessionBootstrap(task.sessionId)
+          SessionCategoryRegistry.remove(task.sessionId)
+        }
+        if (task.parentSessionId) this.updateBackgroundTaskMarker(task.parentSessionId)
+        try {
+          await this.enqueueNotificationForParent(task.parentSessionId, () => this.notifyParentSession(task))
+          log("[background-agent] Task errored (empty output):", { taskId: task.id, source })
+        } catch (err) {
+          log("[background-agent] Error in notifyParentSession for errored task:", { taskId: task.id, error: err })
+        }
+        return true
+      }
     }
 
     // Atomically mark as completed to prevent race conditions

--- a/src/features/background-agent/session-idle-event-handler.ts
+++ b/src/features/background-agent/session-idle-event-handler.ts
@@ -11,6 +11,12 @@ export function handleSessionIdleBackgroundEvent(args: {
   checkSessionTodos: (sessionID: string) => Promise<boolean>
   tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
   emitIdleEvent: (sessionID: string) => void
+  /**
+   * Called when the session is idle but has produced no valid output.
+   * This typically means the model returned an empty response (e.g. rate-limited).
+   * The callback should attempt a fallback retry or mark the task as error.
+   */
+  onNoValidOutput?: (task: BackgroundTask, sessionID: string) => Promise<void>
 }): void {
   const {
     properties,
@@ -20,6 +26,7 @@ export function handleSessionIdleBackgroundEvent(args: {
     checkSessionTodos,
     tryCompleteTask,
     emitIdleEvent,
+    onNoValidOutput,
   } = args
 
   const sessionID = resolveSessionEventID(properties)
@@ -62,7 +69,12 @@ export function handleSessionIdleBackgroundEvent(args: {
       }
 
       if (!hasValidOutput) {
-        log("[background-agent] Session.idle but no valid output yet, waiting:", task.id)
+        if (onNoValidOutput) {
+          log("[background-agent] Session.idle with no valid output, triggering fallback:", task.id)
+          await onNoValidOutput(task, sessionID)
+        } else {
+          log("[background-agent] Session.idle but no valid output yet, waiting:", task.id)
+        }
         return
       }
 

--- a/src/hooks/empty-task-response-detector.ts
+++ b/src/hooks/empty-task-response-detector.ts
@@ -1,4 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import type { BackgroundManager } from "../features/background-agent"
+import { extractTaskLink } from "../features/tool-metadata-store"
 
 const EMPTY_RESPONSE_WARNING = `[Task Empty Response Warning]
 
@@ -9,7 +11,10 @@ Task invocation completed but returned no response. This indicates the agent eit
 
 Note: The call has already completed - you are NOT waiting for a response. Proceed accordingly.`
 
-export function createEmptyTaskResponseDetectorHook(_ctx: PluginInput) {
+export function createEmptyTaskResponseDetectorHook(
+  _ctx: PluginInput,
+  backgroundManager?: BackgroundManager,
+) {
   return {
     "tool.execute.after": async (
       input: { tool: string; sessionID: string; callID: string },
@@ -19,9 +24,19 @@ export function createEmptyTaskResponseDetectorHook(_ctx: PluginInput) {
 
       const responseText = output.output?.trim() ?? ""
 
-      if (responseText === "") {
-        output.output = EMPTY_RESPONSE_WARNING
+      if (responseText !== "") return
+
+      if (backgroundManager) {
+        const link = extractTaskLink(output.metadata, "")
+        const sessionId = link.sessionId
+
+        if (sessionId) {
+          const didFallback = await backgroundManager.retryTaskOnEmptyOutput(sessionId)
+          if (didFallback) return
+        }
       }
+
+      output.output = EMPTY_RESPONSE_WARNING
     },
   }
 }

--- a/src/plugin/hooks/create-core-hooks.ts
+++ b/src/plugin/hooks/create-core-hooks.ts
@@ -33,6 +33,7 @@ export function createCoreHooks(args: {
     ctx,
     pluginConfig,
     modelCacheState,
+    backgroundManager,
     isHookEnabled,
     safeHookEnabled,
   })

--- a/src/plugin/hooks/create-tool-guard-hooks.test.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.test.ts
@@ -13,6 +13,11 @@ const mockModelCacheState = {
   modelContextLimitsCache: new Map(),
 } satisfies ModelCacheState
 
+const mockBackgroundManager = {
+  findBySession: () => undefined,
+  retryTaskOnEmptyOutput: async () => false,
+} as never
+
 describe("createToolGuardHooks", () => {
   let capturedOptions: { skipClaudeUserRules?: boolean } | undefined
 
@@ -40,6 +45,7 @@ describe("createToolGuardHooks", () => {
       ctx: mockContext,
       pluginConfig,
       modelCacheState: mockModelCacheState,
+      backgroundManager: mockBackgroundManager,
       isHookEnabled: (hookName: string) => hookName === "rules-injector",
       safeHookEnabled: true,
     })

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -1,6 +1,7 @@
 import type { HookName, OhMyOpenCodeConfig } from "../../config"
 import type { ModelCacheState } from "../../plugin-state"
 import type { PluginContext } from "../types"
+import type { BackgroundManager } from "../../features/background-agent"
 
 import {
   createCommentCheckerHooks,
@@ -55,10 +56,11 @@ export function createToolGuardHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
   modelCacheState: ModelCacheState
+  backgroundManager: BackgroundManager
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }): ToolGuardHooks {
-  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, backgroundManager, isHookEnabled, safeHookEnabled } = args
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
@@ -96,7 +98,7 @@ export function createToolGuardHooks(args: {
     : null
 
   const emptyTaskResponseDetector = isHookEnabled("empty-task-response-detector")
-    ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx))
+    ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx, backgroundManager))
     : null
 
   const cc = pluginConfig.claude_code


### PR DESCRIPTION
Implements a three-layer defense to prevent silent empty outputs from being reported as successful task completion:

1. **Binary layer** (task.ts): Fail-fast on empty output
2. **Plugin layer** (idle handler): Detects empty outputs after 5s+ idle
3. **Hook layer** (empty-task-response-detector): Catches empty task responses and triggers background manager retry

Prevents the '(No text output)' false-success path by making assistant-visible text the single success invariant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a three-layer defense so background tasks never report success with empty assistant output. If a model returns no text, we retry on a fallback model or clearly fail the task.

- **Bug Fixes**
  - Treat `EmptyOutputError` as retryable.
  - Background manager now verifies real assistant text (not just reasoning/tool calls) before completion; retries via `retryTaskOnEmptyOutput`, triggers fallback from `session.idle` through `onNoValidOutput`, backfills missing fallback chains from `CATEGORY_MODEL_REQUIREMENTS`, or marks error when no fallback exists.
  - `empty-task-response-detector` escalates empty outputs to the background manager using the task link; if no retry, emits a clear warning. `create-core-hooks` and `create-tool-guard-hooks` wire `backgroundManager`; tests updated.

<sup>Written for commit 88f2bd0ad1c80c15f8aa585fbffe39e84a2a9cbb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

