### PR TITLE
fix(runtime-fallback): detect empty_output and model_not_found for retry

### DIFF
--- a/src/hooks/runtime-fallback/chat-message-handler.ts
+++ b/src/hooks/runtime-fallback/chat-message-handler.ts
@@ -23,8 +23,11 @@ export function createChatMessageHandler(deps: HookDeps) {
       ? `${input.model.providerID}/${input.model.modelID}`
       : undefined
 
-    if (requestedModel && requestedModel !== state.currentModel) {
-      if (state.pendingFallbackModel && state.pendingFallbackModel === requestedModel) {
+    const stripVariant = (m: any) => String(m).replace(/\(.*?\)$/, "").toLowerCase()
+    const reqLower = requestedModel ? requestedModel.toLowerCase() : undefined
+
+    if (reqLower && reqLower !== stripVariant(state.currentModel)) {
+      if (state.pendingFallbackModel && stripVariant(state.pendingFallbackModel) === reqLower) {
         state.pendingFallbackModel = undefined
         state.pendingFallbackPromptMayHaveBeenAccepted = false
         return
@@ -34,8 +37,10 @@ export function createChatMessageHandler(deps: HookDeps) {
         sessionID,
         from: state.currentModel,
         to: requestedModel,
+        debug_reqLower: reqLower,
+        debug_stripVariant: stripVariant(state.currentModel)
       })
-      state = createFallbackState(requestedModel)
+      state = createFallbackState(requestedModel!)
       sessionStates.set(sessionID, state)
       return
     }
@@ -53,9 +58,12 @@ export function createChatMessageHandler(deps: HookDeps) {
     if (output.message && activeModel) {
       const parts = activeModel.split("/")
       if (parts.length >= 2) {
+        // Strip the variant suffix (e.g. '(medium)') from the modelID.
+        // Opencode requires variants to be stored in the agentSettings payload rather than the modelID itself.
+        // Failing to strip the variant will result in a ProviderModelNotFoundError and break the fallback chain.
         output.message.model = {
           providerID: parts[0],
-          modelID: parts.slice(1).join("/"),
+          modelID: parts.slice(1).join("/").replace(/\(.*?\)$/, ""),
         }
       }
     }

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -47,6 +47,10 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /暂时不可用/,
   /服务不可用/,
   /请稍后重试/,
+  /empty\s*output/i,
+  /no\s*text\s*output/i,
+  /model\s+not\s+found/i,
+  /provider\s+not\s+found/i,
 ]
 
 /**

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -126,7 +126,10 @@ export function classifyErrorType(error: unknown): string | undefined {
   if (
     errorName?.includes("providermodelnotfounderror") ||
     errorName?.includes("modelnotfounderror") ||
-    (errorName?.includes("unknownerror") && /model\s+not\s+found/i.test(message))
+    (errorName?.includes("unknownerror") && /model\s+not\s+found/i.test(message)) ||
+    /model\s+not\s+found/i.test(message) ||
+    /provider.*not\s+found/i.test(message) ||
+    /selected provider is forbidden/i.test(message)
   ) {
     return "model_not_found"
   }
@@ -156,6 +159,15 @@ export function classifyErrorType(error: unknown): string | undefined {
     isLocalizedQuotaExhaustionMessage(message)
   ) {
     return "quota_exceeded"
+  }
+
+  if (
+    errorName?.includes("emptyoutput") ||
+    /empty\s*output/i.test(message) ||
+    /no\s*text\s*output/i.test(message) ||
+    /no\s*content/i.test(message)
+  ) {
+    return "empty_output"
   }
 
   return undefined
@@ -190,8 +202,10 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
   }
 
   if (errorType === "quota_exceeded") {
-    // Quota exhaustion means the current model/provider cannot serve requests.
-    // Trigger fallback to the next configured model instead of stopping entirely.
+    return true
+  }
+
+  if (errorType === "empty_output") {
     return true
   }
 


### PR DESCRIPTION
Improves error classification in runtime-fallback to handle two additional retryable error cases:

1. **empty_output**: Detects when models return empty responses (e.g., rate-limited gpt-5.5) and triggers fallback to next model
2. **model_not_found**: Improves detection when error objects have incomplete structure (missing errorType but containing 'model not found' in message)

Also adds corresponding retry patterns to RETRYABLE_ERROR_PATTERNS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves runtime fallback by treating empty outputs and model/provider-not-found errors as retryable so requests move to the next model. Also strips model variant suffixes in overrides and responses to prevent ProviderModelNotFoundError and keep the fallback chain intact.

- Bug Fixes
  - Detects empty output via phrases like "empty output", "no text output", and "no content", and retries.
  - Broadens model/provider-not-found detection, including "model not found", "provider not found", and "selected provider is forbidden", even when errorType is missing; adds patterns to `RETRYABLE_ERROR_PATTERNS`.
  - Normalizes model IDs by stripping variant suffixes and comparing case-insensitively in manual overrides and output payloads to avoid false mismatches and maintain the fallback chain.

<sup>Written for commit d0b56fff822cdda4c60c71a5f00c25a77d1bdfa5. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

