### PR TITLE
feat(prompts-core): add packages/prompts-core foundation

### DIFF
--- a/.omo/evidence/pr1-prompts-core/loader.green.log
+++ b/.omo/evidence/pr1-prompts-core/loader.green.log
@@ -1,0 +1,14 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"Hello {PLACEHOLDER}, this is a test.\n","frontmatter":{"description":"test fixture"},"resolvedPath":"/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md"}
+S9 actual: Prompt not found at /Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/missing/default.md
+S10 actual: Hello Y, this is a test.
+
+S11 actual: HeLLo Y, this is a demo.
+
+
+ 4 pass
+ 0 fail
+ 5 expect() calls
+Ran 4 tests across 1 file. [43.00ms]

--- a/.omo/evidence/pr1-prompts-core/loader.red.log
+++ b/.omo/evidence/pr1-prompts-core/loader.red.log
@@ -1,0 +1,90 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"__red__","frontmatter":{},"resolvedPath":"__red__"}
+16 |       // when
+17 |       const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+18 | 
+19 |       // then
+20 |       console.info("S8 actual:", JSON.stringify(actual))
+21 |       expect(actual).toEqual({
+                          ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "body": 
+- "Hello {PLACEHOLDER}, this is a test.
+- "
+- ,
+-   "frontmatter": {
+-     "description": "test fixture",
+-   },
+-   "resolvedPath": "/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md",
++   "body": "__red__",
++   "frontmatter": {},
++   "resolvedPath": "__red__",
+  }
+
+- Expected  - 8
++ Received  + 3
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:21:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading an existing prompt #then returns body and frontmatter [0.52ms]
+S9 actual: no throw
+43 |         }
+44 |       }
+45 | 
+46 |       // then
+47 |       console.info("S9 actual:", actual)
+48 |       expect(thrown).toBeInstanceOf(PromptNotFoundError)
+                          ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class PromptNotFoundError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:48:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading a missing prompt #then throws path-aware error [0.13ms]
+S10 actual: __red__
+61 |       // when
+62 |       const actual = await loadPrompt(input)
+63 | 
+64 |       // then
+65 |       console.info("S10 actual:", actual.body)
+66 |       expect(actual.body).toBe("Hello Y, this is a test.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "Hello Y, this is a test.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:66:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when runtime injection is provided #then replaces placeholder [0.08ms]
+S11 actual: __red__
+83 |       // when
+84 |       const actual = await loadPrompt(input)
+85 | 
+86 |       // then
+87 |       console.info("S11 actual:", actual.body)
+88 |       expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "HeLLo Y, this is a demo.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:88:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when multiple injections are provided #then replaces all found values [0.14ms]
+
+ 0 pass
+ 4 fail
+ 4 expect() calls
+Ran 4 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s1.green.log
+++ b/.omo/evidence/pr1-prompts-core/s1.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s1.red.log
+++ b/.omo/evidence/pr1-prompts-core/s1.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s10.green.log
+++ b/.omo/evidence/pr1-prompts-core/s10.green.log
@@ -1,0 +1,14 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"Hello {PLACEHOLDER}, this is a test.\n","frontmatter":{"description":"test fixture"},"resolvedPath":"/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md"}
+S9 actual: Prompt not found at /Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/missing/default.md
+S10 actual: Hello Y, this is a test.
+
+S11 actual: HeLLo Y, this is a demo.
+
+
+ 4 pass
+ 0 fail
+ 5 expect() calls
+Ran 4 tests across 1 file. [43.00ms]

--- a/.omo/evidence/pr1-prompts-core/s10.red.log
+++ b/.omo/evidence/pr1-prompts-core/s10.red.log
@@ -1,0 +1,90 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"__red__","frontmatter":{},"resolvedPath":"__red__"}
+16 |       // when
+17 |       const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+18 | 
+19 |       // then
+20 |       console.info("S8 actual:", JSON.stringify(actual))
+21 |       expect(actual).toEqual({
+                          ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "body": 
+- "Hello {PLACEHOLDER}, this is a test.
+- "
+- ,
+-   "frontmatter": {
+-     "description": "test fixture",
+-   },
+-   "resolvedPath": "/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md",
++   "body": "__red__",
++   "frontmatter": {},
++   "resolvedPath": "__red__",
+  }
+
+- Expected  - 8
++ Received  + 3
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:21:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading an existing prompt #then returns body and frontmatter [0.52ms]
+S9 actual: no throw
+43 |         }
+44 |       }
+45 | 
+46 |       // then
+47 |       console.info("S9 actual:", actual)
+48 |       expect(thrown).toBeInstanceOf(PromptNotFoundError)
+                          ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class PromptNotFoundError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:48:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading a missing prompt #then throws path-aware error [0.13ms]
+S10 actual: __red__
+61 |       // when
+62 |       const actual = await loadPrompt(input)
+63 | 
+64 |       // then
+65 |       console.info("S10 actual:", actual.body)
+66 |       expect(actual.body).toBe("Hello Y, this is a test.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "Hello Y, this is a test.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:66:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when runtime injection is provided #then replaces placeholder [0.08ms]
+S11 actual: __red__
+83 |       // when
+84 |       const actual = await loadPrompt(input)
+85 | 
+86 |       // then
+87 |       console.info("S11 actual:", actual.body)
+88 |       expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "HeLLo Y, this is a demo.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:88:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when multiple injections are provided #then replaces all found values [0.14ms]
+
+ 0 pass
+ 4 fail
+ 4 expect() calls
+Ran 4 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s11.green.log
+++ b/.omo/evidence/pr1-prompts-core/s11.green.log
@@ -1,0 +1,14 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"Hello {PLACEHOLDER}, this is a test.\n","frontmatter":{"description":"test fixture"},"resolvedPath":"/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md"}
+S9 actual: Prompt not found at /Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/missing/default.md
+S10 actual: Hello Y, this is a test.
+
+S11 actual: HeLLo Y, this is a demo.
+
+
+ 4 pass
+ 0 fail
+ 5 expect() calls
+Ran 4 tests across 1 file. [43.00ms]

--- a/.omo/evidence/pr1-prompts-core/s11.red.log
+++ b/.omo/evidence/pr1-prompts-core/s11.red.log
@@ -1,0 +1,90 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"__red__","frontmatter":{},"resolvedPath":"__red__"}
+16 |       // when
+17 |       const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+18 | 
+19 |       // then
+20 |       console.info("S8 actual:", JSON.stringify(actual))
+21 |       expect(actual).toEqual({
+                          ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "body": 
+- "Hello {PLACEHOLDER}, this is a test.
+- "
+- ,
+-   "frontmatter": {
+-     "description": "test fixture",
+-   },
+-   "resolvedPath": "/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md",
++   "body": "__red__",
++   "frontmatter": {},
++   "resolvedPath": "__red__",
+  }
+
+- Expected  - 8
++ Received  + 3
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:21:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading an existing prompt #then returns body and frontmatter [0.52ms]
+S9 actual: no throw
+43 |         }
+44 |       }
+45 | 
+46 |       // then
+47 |       console.info("S9 actual:", actual)
+48 |       expect(thrown).toBeInstanceOf(PromptNotFoundError)
+                          ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class PromptNotFoundError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:48:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading a missing prompt #then throws path-aware error [0.13ms]
+S10 actual: __red__
+61 |       // when
+62 |       const actual = await loadPrompt(input)
+63 | 
+64 |       // then
+65 |       console.info("S10 actual:", actual.body)
+66 |       expect(actual.body).toBe("Hello Y, this is a test.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "Hello Y, this is a test.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:66:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when runtime injection is provided #then replaces placeholder [0.08ms]
+S11 actual: __red__
+83 |       // when
+84 |       const actual = await loadPrompt(input)
+85 | 
+86 |       // then
+87 |       console.info("S11 actual:", actual.body)
+88 |       expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "HeLLo Y, this is a demo.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:88:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when multiple injections are provided #then replaces all found values [0.14ms]
+
+ 0 pass
+ 4 fail
+ 4 expect() calls
+Ran 4 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s2.green.log
+++ b/.omo/evidence/pr1-prompts-core/s2.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s2.red.log
+++ b/.omo/evidence/pr1-prompts-core/s2.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s3.green.log
+++ b/.omo/evidence/pr1-prompts-core/s3.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s3.red.log
+++ b/.omo/evidence/pr1-prompts-core/s3.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s4.green.log
+++ b/.omo/evidence/pr1-prompts-core/s4.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s4.red.log
+++ b/.omo/evidence/pr1-prompts-core/s4.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s5.green.log
+++ b/.omo/evidence/pr1-prompts-core/s5.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s5.red.log
+++ b/.omo/evidence/pr1-prompts-core/s5.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s6.green.log
+++ b/.omo/evidence/pr1-prompts-core/s6.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s6.red.log
+++ b/.omo/evidence/pr1-prompts-core/s6.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s7.green.log
+++ b/.omo/evidence/pr1-prompts-core/s7.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/s7.red.log
+++ b/.omo/evidence/pr1-prompts-core/s7.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s8.green.log
+++ b/.omo/evidence/pr1-prompts-core/s8.green.log
@@ -1,0 +1,14 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"Hello {PLACEHOLDER}, this is a test.\n","frontmatter":{"description":"test fixture"},"resolvedPath":"/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md"}
+S9 actual: Prompt not found at /Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/missing/default.md
+S10 actual: Hello Y, this is a test.
+
+S11 actual: HeLLo Y, this is a demo.
+
+
+ 4 pass
+ 0 fail
+ 5 expect() calls
+Ran 4 tests across 1 file. [43.00ms]

--- a/.omo/evidence/pr1-prompts-core/s8.red.log
+++ b/.omo/evidence/pr1-prompts-core/s8.red.log
@@ -1,0 +1,90 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"__red__","frontmatter":{},"resolvedPath":"__red__"}
+16 |       // when
+17 |       const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+18 | 
+19 |       // then
+20 |       console.info("S8 actual:", JSON.stringify(actual))
+21 |       expect(actual).toEqual({
+                          ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "body": 
+- "Hello {PLACEHOLDER}, this is a test.
+- "
+- ,
+-   "frontmatter": {
+-     "description": "test fixture",
+-   },
+-   "resolvedPath": "/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md",
++   "body": "__red__",
++   "frontmatter": {},
++   "resolvedPath": "__red__",
+  }
+
+- Expected  - 8
++ Received  + 3
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:21:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading an existing prompt #then returns body and frontmatter [0.52ms]
+S9 actual: no throw
+43 |         }
+44 |       }
+45 | 
+46 |       // then
+47 |       console.info("S9 actual:", actual)
+48 |       expect(thrown).toBeInstanceOf(PromptNotFoundError)
+                          ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class PromptNotFoundError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:48:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading a missing prompt #then throws path-aware error [0.13ms]
+S10 actual: __red__
+61 |       // when
+62 |       const actual = await loadPrompt(input)
+63 | 
+64 |       // then
+65 |       console.info("S10 actual:", actual.body)
+66 |       expect(actual.body).toBe("Hello Y, this is a test.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "Hello Y, this is a test.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:66:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when runtime injection is provided #then replaces placeholder [0.08ms]
+S11 actual: __red__
+83 |       // when
+84 |       const actual = await loadPrompt(input)
+85 | 
+86 |       // then
+87 |       console.info("S11 actual:", actual.body)
+88 |       expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "HeLLo Y, this is a demo.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:88:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when multiple injections are provided #then replaces all found values [0.14ms]
+
+ 0 pass
+ 4 fail
+ 4 expect() calls
+Ran 4 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/s9.green.log
+++ b/.omo/evidence/pr1-prompts-core/s9.green.log
@@ -1,0 +1,14 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"Hello {PLACEHOLDER}, this is a test.\n","frontmatter":{"description":"test fixture"},"resolvedPath":"/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md"}
+S9 actual: Prompt not found at /Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/missing/default.md
+S10 actual: Hello Y, this is a test.
+
+S11 actual: HeLLo Y, this is a demo.
+
+
+ 4 pass
+ 0 fail
+ 5 expect() calls
+Ran 4 tests across 1 file. [43.00ms]

--- a/.omo/evidence/pr1-prompts-core/s9.red.log
+++ b/.omo/evidence/pr1-prompts-core/s9.red.log
@@ -1,0 +1,90 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/loader.test.ts:
+S8 actual: {"body":"__red__","frontmatter":{},"resolvedPath":"__red__"}
+16 |       // when
+17 |       const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+18 | 
+19 |       // then
+20 |       console.info("S8 actual:", JSON.stringify(actual))
+21 |       expect(actual).toEqual({
+                          ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "body": 
+- "Hello {PLACEHOLDER}, this is a test.
+- "
+- ,
+-   "frontmatter": {
+-     "description": "test fixture",
+-   },
+-   "resolvedPath": "/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/__fixtures__/demo/default.md",
++   "body": "__red__",
++   "frontmatter": {},
++   "resolvedPath": "__red__",
+  }
+
+- Expected  - 8
++ Received  + 3
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:21:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading an existing prompt #then returns body and frontmatter [0.52ms]
+S9 actual: no throw
+43 |         }
+44 |       }
+45 | 
+46 |       // then
+47 |       console.info("S9 actual:", actual)
+48 |       expect(thrown).toBeInstanceOf(PromptNotFoundError)
+                          ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class PromptNotFoundError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:48:22)
+(fail) loadPrompt > #given a markdown prompt fixture > #when loading a missing prompt #then throws path-aware error [0.13ms]
+S10 actual: __red__
+61 |       // when
+62 |       const actual = await loadPrompt(input)
+63 | 
+64 |       // then
+65 |       console.info("S10 actual:", actual.body)
+66 |       expect(actual.body).toBe("Hello Y, this is a test.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "Hello Y, this is a test.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:66:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when runtime injection is provided #then replaces placeholder [0.08ms]
+S11 actual: __red__
+83 |       // when
+84 |       const actual = await loadPrompt(input)
+85 | 
+86 |       // then
+87 |       console.info("S11 actual:", actual.body)
+88 |       expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+                               ^
+error: expect(received).toBe(expected)
+
+- "HeLLo Y, this is a demo.
+- "
++ "__red__"
+
+- Expected  - 2
++ Received  + 1
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/loader.test.ts:88:27)
+(fail) loadPrompt > #given a markdown prompt fixture > #when multiple injections are provided #then replaces all found values [0.14ms]
+
+ 0 pass
+ 4 fail
+ 4 expect() calls
+Ran 4 tests across 1 file. [74.00ms]

--- a/.omo/evidence/pr1-prompts-core/variant-resolver.green.log
+++ b/.omo/evidence/pr1-prompts-core/variant-resolver.green.log
@@ -1,0 +1,15 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: default
+S2 actual: gpt
+S3 actual: gemini
+S4 actual: planner
+S5 actual: default
+S6 actual: default
+S7 actual: NoMatchingVariantError
+
+ 7 pass
+ 0 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [75.00ms]

--- a/.omo/evidence/pr1-prompts-core/variant-resolver.red.log
+++ b/.omo/evidence/pr1-prompts-core/variant-resolver.red.log
@@ -1,0 +1,113 @@
+bun test v1.3.12 (700fc117)
+
+packages/prompts-core/src/variant-resolver.test.ts:
+S1 actual: __red__
+27 |       // when
+28 |       const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+29 | 
+30 |       // then
+31 |       console.info("S1 actual:", actual)
+32 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:32:22)
+(fail) resolveVariant > #given declared model variants > #when claude opus has no model match #then returns default fallback [0.39ms]
+S2 actual: __red__
+43 |       // when
+44 |       const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+45 | 
+46 |       // then
+47 |       console.info("S2 actual:", actual)
+48 |       expect(actual).toBe("gpt")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gpt"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:48:22)
+(fail) resolveVariant > #given declared model variants > #when openai gpt model matches #then returns gpt [0.10ms]
+S3 actual: __red__
+59 |       // when
+60 |       const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+61 | 
+62 |       // then
+63 |       console.info("S3 actual:", actual)
+64 |       expect(actual).toBe("gemini")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "gemini"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:64:22)
+(fail) resolveVariant > #given declared model variants > #when google gemini model matches #then returns gemini [0.04ms]
+S4 actual: __red__
+80 |         variants,
+81 |       })
+82 | 
+83 |       // then
+84 |       console.info("S4 actual:", actual)
+85 |       expect(actual).toBe("planner")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "planner"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:85:22)
+(fail) resolveVariant > #given agent and fallback variants > #when agent and model both match #then declared agent variant wins [0.12ms]
+S5 actual: __red__
+94 |       // when
+95 |       const actual = resolveVariant({ variants })
+96 | 
+97 |       // then
+98 |       console.info("S5 actual:", actual)
+99 |       expect(actual).toBe("default")
+                          ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:99:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no context is provided #then returns default fallback [0.08ms]
+S6 actual: __red__
+109 |       // when
+110 |       const actual = resolveVariant({ modelID: "unknown-model", variants })
+111 | 
+112 |       // then
+113 |       console.info("S6 actual:", actual)
+114 |       expect(actual).toBe("default")
+                           ^
+error: expect(received).toBe(expected)
+
+Expected: "default"
+Received: "__red__"
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:114:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant test matches #then returns fallback [0.07ms]
+S7 actual: __red__
+134 |         }
+135 |       }
+136 |       console.info("S7 actual:", actual)
+137 | 
+138 |       // then
+139 |       expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+                           ^
+error: expect(received).toBeInstanceOf(expected)
+
+Expected constructor: [class NoMatchingVariantError extends Error]
+Received value: undefined
+
+      at <anonymous> (/Users/yeongyu/local-workspaces/omo-wt/feat/prompts-core-foundation/packages/prompts-core/src/variant-resolver.test.ts:139:22)
+(fail) resolveVariant > #given agent and fallback variants > #when no variant matches and no fallback exists #then throws [0.09ms]
+
+ 0 pass
+ 7 fail
+ 7 expect() calls
+Ran 7 tests across 1 file. [74.00ms]

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@oh-my-opencode/comment-checker-core": "workspace:*",
         "@oh-my-opencode/hashline-core": "workspace:*",
         "@oh-my-opencode/model-core": "workspace:*",
+        "@oh-my-opencode/prompts-core": "workspace:*",
         "@oh-my-opencode/rules-engine": "workspace:*",
         "@oh-my-opencode/utils": "workspace:*",
         "@types/js-yaml": "^4.0.9",
@@ -103,6 +104,13 @@
     },
     "packages/model-core": {
       "name": "@oh-my-opencode/model-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@oh-my-opencode/utils": "workspace:*",
+      },
+    },
+    "packages/prompts-core": {
+      "name": "@oh-my-opencode/prompts-core",
       "version": "0.1.0",
       "dependencies": {
         "@oh-my-opencode/utils": "workspace:*",
@@ -208,6 +216,8 @@
     "@oh-my-opencode/hashline-core": ["@oh-my-opencode/hashline-core@workspace:packages/hashline-core"],
 
     "@oh-my-opencode/model-core": ["@oh-my-opencode/model-core@workspace:packages/model-core"],
+
+    "@oh-my-opencode/prompts-core": ["@oh-my-opencode/prompts-core@workspace:packages/prompts-core"],
 
     "@oh-my-opencode/rules-engine": ["@oh-my-opencode/rules-engine@workspace:packages/rules-engine"],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "packages/comment-checker-core",
     "packages/hashline-core",
     "packages/boulder-state",
-    "packages/agents-md-core"
+    "packages/agents-md-core",
+    "packages/prompts-core"
   ],
   "bin": {
     "oh-my-opencode": "bin/oh-my-opencode.js",
@@ -49,7 +50,7 @@
     "prepublishOnly": "bun run clean && bun run build:lsp-tools-mcp && bun run build",
     "test:model-capabilities": "bun test src/shared/model-capability-aliases.test.ts src/shared/model-capability-guardrails.test.ts src/shared/model-capabilities.test.ts src/cli/doctor/checks/model-resolution.test.ts --bail",
     "typecheck": "tsgo --noEmit && bun run typecheck:packages",
-    "typecheck:packages": "tsgo --noEmit -p packages/rules-engine/tsconfig.json && tsgo --noEmit -p packages/ast-grep-core/tsconfig.json && tsgo --noEmit -p packages/ast-grep-mcp/tsconfig.json && tsgo --noEmit -p packages/utils/tsconfig.json && tsgo --noEmit -p packages/model-core/tsconfig.json && tsgo --noEmit -p packages/comment-checker-core/tsconfig.json && tsgo --noEmit -p packages/hashline-core/tsconfig.json && tsgo --noEmit -p packages/boulder-state/tsconfig.json && tsgo --noEmit -p packages/agents-md-core/tsconfig.json",
+    "typecheck:packages": "tsgo --noEmit -p packages/rules-engine/tsconfig.json && tsgo --noEmit -p packages/ast-grep-core/tsconfig.json && tsgo --noEmit -p packages/ast-grep-mcp/tsconfig.json && tsgo --noEmit -p packages/utils/tsconfig.json && tsgo --noEmit -p packages/model-core/tsconfig.json && tsgo --noEmit -p packages/comment-checker-core/tsconfig.json && tsgo --noEmit -p packages/hashline-core/tsconfig.json && tsgo --noEmit -p packages/boulder-state/tsconfig.json && tsgo --noEmit -p packages/agents-md-core/tsconfig.json && tsgo --noEmit -p packages/prompts-core/tsconfig.json",
     "typecheck:script": "tsgo --noEmit -p script/tsconfig.json",
     "test": "bun test",
     "build:ast-grep-mcp": "bun run --cwd packages/ast-grep-mcp build"
@@ -100,6 +101,7 @@
     "@oh-my-opencode/comment-checker-core": "workspace:*",
     "@oh-my-opencode/hashline-core": "workspace:*",
     "@oh-my-opencode/model-core": "workspace:*",
+    "@oh-my-opencode/prompts-core": "workspace:*",
     "@oh-my-opencode/rules-engine": "workspace:*",
     "@oh-my-opencode/utils": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260518.1",

--- a/packages/prompts-core/package.json
+++ b/packages/prompts-core/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@oh-my-opencode/prompts-core",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Pure TypeScript prompt loading and variant resolution core for oh-my-opencode.",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "types": "./index.d.ts",
+  "scripts": {
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "test": "bun test src/*.test.ts test/*.test.ts"
+  },
+  "dependencies": {
+    "@oh-my-opencode/utils": "workspace:*"
+  }
+}

--- a/packages/prompts-core/src/__fixtures__/demo/default.md
+++ b/packages/prompts-core/src/__fixtures__/demo/default.md
@@ -1,0 +1,4 @@
+---
+description: test fixture
+---
+Hello {PLACEHOLDER}, this is a test.

--- a/packages/prompts-core/src/index.ts
+++ b/packages/prompts-core/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types"
+export * from "./variant-resolver"
+export * from "./loader"

--- a/packages/prompts-core/src/loader.test.ts
+++ b/packages/prompts-core/src/loader.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { loadPrompt } from "./loader"
+import { PromptNotFoundError } from "./types"
+
+const fixturesSource = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__")
+
+describe("loadPrompt", () => {
+  describe("#given a markdown prompt fixture", () => {
+    test("#when loading an existing prompt #then returns body and frontmatter", async () => {
+      // given
+      const expectedPath = join(fixturesSource, "demo", "default.md")
+
+      // when
+      const actual = await loadPrompt({ source: fixturesSource, name: "demo", variant: "default" })
+
+      // then
+      console.info("S8 actual:", JSON.stringify(actual))
+      expect(actual).toEqual({
+        body: "Hello {PLACEHOLDER}, this is a test.\n",
+        frontmatter: { description: "test fixture" },
+        resolvedPath: expectedPath,
+      })
+    })
+
+    test("#when loading a missing prompt #then throws path-aware error", async () => {
+      // given
+      const expectedPath = join(fixturesSource, "missing", "default.md")
+
+      // when
+      let actual = "no throw"
+      let thrown: unknown
+      try {
+        await loadPrompt({ source: fixturesSource, name: "missing", variant: "default" })
+      } catch (error) {
+        thrown = error
+        if (error instanceof Error) {
+          actual = error.message
+        } else {
+          throw error
+        }
+      }
+
+      // then
+      console.info("S9 actual:", actual)
+      expect(thrown).toBeInstanceOf(PromptNotFoundError)
+      expect(actual).toContain(expectedPath)
+    })
+
+    test("#when runtime injection is provided #then replaces placeholder", async () => {
+      // given
+      const input = {
+        source: fixturesSource,
+        name: "demo",
+        variant: "default",
+        inject: [{ placeholder: "{PLACEHOLDER}", resolver: () => "Y" }],
+      }
+
+      // when
+      const actual = await loadPrompt(input)
+
+      // then
+      console.info("S10 actual:", actual.body)
+      expect(actual.body).toBe("Hello Y, this is a test.\n")
+    })
+
+    test("#when multiple injections are provided #then replaces all found values", async () => {
+      // given
+      const input = {
+        source: fixturesSource,
+        name: "demo",
+        variant: "default",
+        inject: [
+          { placeholder: "{PLACEHOLDER}", resolver: () => "Y" },
+          { placeholder: "l", resolver: () => "L" },
+          { placeholder: "test", resolver: () => "demo" },
+          { placeholder: "{MISSING}", resolver: () => "ignored" },
+        ],
+      }
+
+      // when
+      const actual = await loadPrompt(input)
+
+      // then
+      console.info("S11 actual:", actual.body)
+      expect(actual.body).toBe("HeLLo Y, this is a demo.\n")
+    })
+  })
+})

--- a/packages/prompts-core/src/loader.ts
+++ b/packages/prompts-core/src/loader.ts
@@ -1,0 +1,9 @@
+import type { LoadedPrompt, LoadPromptInput } from "./types"
+
+export async function loadPrompt(_input: LoadPromptInput): Promise<LoadedPrompt> {
+  return {
+    body: "__red__",
+    frontmatter: {},
+    resolvedPath: "__red__",
+  }
+}

--- a/packages/prompts-core/src/loader.ts
+++ b/packages/prompts-core/src/loader.ts
@@ -1,9 +1,38 @@
-import type { LoadedPrompt, LoadPromptInput } from "./types"
+import { parseFrontmatter } from "@oh-my-opencode/utils"
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
 
-export async function loadPrompt(_input: LoadPromptInput): Promise<LoadedPrompt> {
+import { PromptNotFoundError, type LoadedPrompt, type LoadPromptInput } from "./types"
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  if (!(error instanceof Error)) return false
+  if (!("code" in error)) return false
+  return error.code === code
+}
+
+export async function loadPrompt(input: LoadPromptInput): Promise<LoadedPrompt> {
+  const resolvedPath = resolve(input.source, input.name, `${input.variant}.md`)
+  let content: string
+
+  try {
+    content = await readFile(resolvedPath, "utf8")
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) {
+      throw new PromptNotFoundError(`Prompt not found at ${resolvedPath}`)
+    }
+    throw error
+  }
+
+  const parsed = parseFrontmatter(content)
+  let body = parsed.body
+
+  for (const injection of input.inject ?? []) {
+    body = body.replaceAll(injection.placeholder, injection.resolver())
+  }
+
   return {
-    body: "__red__",
-    frontmatter: {},
-    resolvedPath: "__red__",
+    body,
+    frontmatter: parsed.data,
+    resolvedPath,
   }
 }

--- a/packages/prompts-core/src/types.ts
+++ b/packages/prompts-core/src/types.ts
@@ -1,0 +1,51 @@
+export interface VariantTest {
+  test: (input: { modelID?: string; agentName?: string }) => boolean
+}
+
+export interface VariantFallback {
+  fallback: true
+}
+
+export type VariantDefinition = VariantTest | VariantFallback
+
+export interface VariantTable {
+  [variantKey: string]: VariantDefinition
+}
+
+export interface ResolveVariantInput {
+  modelID?: string
+  agentName?: string
+  variants: VariantTable
+}
+
+export interface RuntimeInjection {
+  placeholder: string
+  resolver: () => string
+}
+
+export interface LoadPromptInput {
+  source: string
+  name: string
+  variant: string
+  inject?: readonly RuntimeInjection[]
+}
+
+export interface LoadedPrompt {
+  body: string
+  frontmatter: Record<string, unknown>
+  resolvedPath: string
+}
+
+export class PromptNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "PromptNotFoundError"
+  }
+}
+
+export class NoMatchingVariantError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "NoMatchingVariantError"
+  }
+}

--- a/packages/prompts-core/src/variant-resolver.test.ts
+++ b/packages/prompts-core/src/variant-resolver.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveVariant } from "./variant-resolver"
+import { NoMatchingVariantError, type VariantTable } from "./types"
+
+const isGpt = (input: { modelID?: string; agentName?: string }): boolean =>
+  input.modelID?.includes("gpt") ?? false
+
+const isGemini = (input: { modelID?: string; agentName?: string }): boolean =>
+  input.modelID?.includes("gemini") ?? false
+
+const isPlanner = (input: { modelID?: string; agentName?: string }): boolean =>
+  input.agentName === "prometheus"
+
+const alwaysFalse = (): boolean => false
+
+describe("resolveVariant", () => {
+  describe("#given declared model variants", () => {
+    test("#when claude opus has no model match #then returns default fallback", () => {
+      // given
+      const variants = {
+        gpt: { test: isGpt },
+        gemini: { test: isGemini },
+        default: { fallback: true },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({ modelID: "claude-opus-4-7", variants })
+
+      // then
+      console.info("S1 actual:", actual)
+      expect(actual).toBe("default")
+    })
+
+    test("#when openai gpt model matches #then returns gpt", () => {
+      // given
+      const variants = {
+        gpt: { test: isGpt },
+        gemini: { test: isGemini },
+        default: { fallback: true },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({ modelID: "openai/gpt-5.5", variants })
+
+      // then
+      console.info("S2 actual:", actual)
+      expect(actual).toBe("gpt")
+    })
+
+    test("#when google gemini model matches #then returns gemini", () => {
+      // given
+      const variants = {
+        gpt: { test: isGpt },
+        gemini: { test: isGemini },
+        default: { fallback: true },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({ modelID: "google/gemini-3-1-pro", variants })
+
+      // then
+      console.info("S3 actual:", actual)
+      expect(actual).toBe("gemini")
+    })
+  })
+
+  describe("#given agent and fallback variants", () => {
+    test("#when agent and model both match #then declared agent variant wins", () => {
+      // given
+      const variants = {
+        planner: { test: isPlanner },
+        gpt: { test: isGpt },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({
+        agentName: "prometheus",
+        modelID: "openai/gpt-5.5",
+        variants,
+      })
+
+      // then
+      console.info("S4 actual:", actual)
+      expect(actual).toBe("planner")
+    })
+
+    test("#when no context is provided #then returns default fallback", () => {
+      // given
+      const variants = {
+        default: { fallback: true },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({ variants })
+
+      // then
+      console.info("S5 actual:", actual)
+      expect(actual).toBe("default")
+    })
+
+    test("#when no variant test matches #then returns fallback", () => {
+      // given
+      const variants = {
+        gpt: { test: alwaysFalse },
+        default: { fallback: true },
+      } satisfies VariantTable
+
+      // when
+      const actual = resolveVariant({ modelID: "unknown-model", variants })
+
+      // then
+      console.info("S6 actual:", actual)
+      expect(actual).toBe("default")
+    })
+
+    test("#when no variant matches and no fallback exists #then throws", () => {
+      // given
+      const variants = {
+        a: { test: alwaysFalse },
+      } satisfies VariantTable
+
+      // when
+      let actual = "no throw"
+      let thrown: unknown
+      try {
+        actual = resolveVariant({ modelID: "x", variants })
+      } catch (error) {
+        thrown = error
+        if (error instanceof Error) {
+          actual = error.name
+        } else {
+          throw error
+        }
+      }
+      console.info("S7 actual:", actual)
+
+      // then
+      expect(thrown).toBeInstanceOf(NoMatchingVariantError)
+    })
+  })
+})

--- a/packages/prompts-core/src/variant-resolver.ts
+++ b/packages/prompts-core/src/variant-resolver.ts
@@ -1,0 +1,5 @@
+import type { ResolveVariantInput } from "./types"
+
+export function resolveVariant(_input: ResolveVariantInput): string {
+  return "__red__"
+}

--- a/packages/prompts-core/src/variant-resolver.ts
+++ b/packages/prompts-core/src/variant-resolver.ts
@@ -1,5 +1,29 @@
-import type { ResolveVariantInput } from "./types"
+import {
+  NoMatchingVariantError,
+  type ResolveVariantInput,
+  type VariantDefinition,
+  type VariantFallback,
+} from "./types"
 
-export function resolveVariant(_input: ResolveVariantInput): string {
-  return "__red__"
+function isVariantFallback(definition: VariantDefinition): definition is VariantFallback {
+  return "fallback" in definition && definition.fallback === true
+}
+
+export function resolveVariant(input: ResolveVariantInput): string {
+  const entries = Object.entries(input.variants)
+  const testInput = {
+    ...(input.modelID === undefined ? {} : { modelID: input.modelID }),
+    ...(input.agentName === undefined ? {} : { agentName: input.agentName }),
+  }
+
+  for (const [variantKey, definition] of entries) {
+    if (isVariantFallback(definition)) continue
+    if (definition.test(testInput)) return variantKey
+  }
+
+  const fallbackEntry = entries.find(([, definition]) => isVariantFallback(definition))
+  if (fallbackEntry !== undefined) return fallbackEntry[0]
+
+  const variantKeys = entries.map(([variantKey]) => variantKey).join(", ")
+  throw new NoMatchingVariantError(`No matching prompt variant found among: ${variantKeys}`)
 }

--- a/packages/prompts-core/test/opencode-coupling-audit.test.ts
+++ b/packages/prompts-core/test/opencode-coupling-audit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { readdir, readFile } from "node:fs/promises"
+import { dirname, extname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+type CouplingMatch = {
+  readonly filePath: string
+  readonly lineNumber: number
+  readonly line: string
+}
+
+const forbiddenImportPatterns = [/from\s+["']@opencode-ai\//, /from\s+["']\.\.\/opencode\//] as const
+
+async function collectTypeScriptFiles(directory: string): Promise<readonly string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const childPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectTypeScriptFiles(childPath)))
+      continue
+    }
+
+    if (entry.isFile() && extname(entry.name) === ".ts") {
+      files.push(childPath)
+    }
+  }
+
+  return files
+}
+
+function findForbiddenImports(filePath: string, content: string): readonly CouplingMatch[] {
+  const matches: CouplingMatch[] = []
+  const lines = content.split(/\r?\n/)
+
+  for (const [index, line] of lines.entries()) {
+    if (!forbiddenImportPatterns.some((pattern) => pattern.test(line))) continue
+    matches.push({ filePath, lineNumber: index + 1, line })
+  }
+
+  return matches
+}
+
+describe("opencode coupling audit", () => {
+  test("#given prompts-core source #when scanning imports #then no OpenCode adapter imports exist", async () => {
+    // given
+    const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+    const srcRoot = join(packageRoot, "src")
+    const sourceFiles = await collectTypeScriptFiles(srcRoot)
+    const matches: CouplingMatch[] = []
+
+    // when
+    for (const filePath of sourceFiles) {
+      const content = await readFile(filePath, "utf8")
+      matches.push(...findForbiddenImports(filePath, content))
+    }
+
+    // then
+    console.info("opencode coupling matches:", JSON.stringify(matches))
+    expect(matches).toEqual([])
+  })
+})

--- a/packages/prompts-core/tsconfig.json
+++ b/packages/prompts-core/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"],
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Summary
PR1 adds the foundation `packages/prompts-core/` package for the prompts-as-skills refactor. This PR intentionally ships only loader infrastructure, variant resolution, workspace wiring, tests, and evidence. It does not migrate ultrawork, Prometheus, Atlas, or mode prompt content.

## 5-PR plan
1. PR1: `packages/prompts-core/` foundation package, variant resolver, loader, tests.
2. PR2: Ultrawork prompt markdown migration.
3. PR3: Search, analyze, team, and hyperplan mode prompt migration.
4. PR4: Prometheus prompt migration.
5. PR5: Atlas prompt migration with runtime injection usage.

Plan reference: `.omo/plans/prompts-as-skills-refactor.md`

## Changes
- Added `@oh-my-opencode/prompts-core` workspace package.
- Added public types, `resolveVariant()`, `loadPrompt()`, and package barrel exports.
- Added markdown fixture and TDD tests for S1 through S11.
- Added OpenCode coupling audit for `packages/prompts-core/src/`.
- Registered the package in root workspaces, root typecheck, devDependencies, and `bun.lock`.

## Scenario coverage
- S1: Claude/default fallback variant.
- S2: GPT variant match.
- S3: Gemini variant match.
- S4: Declared agent variant wins before GPT model variant.
- S5: Missing model and agent context falls back.
- S6: Unknown model falls back when tests do not match.
- S7: No matching variant and no fallback throws `NoMatchingVariantError`.
- S8: Loader reads markdown, parses frontmatter, and returns resolved path.
- S9: Missing prompt throws `PromptNotFoundError` with path.
- S10: Runtime injection replaces `{PLACEHOLDER}`.
- S11: Multiple injections replace all occurrences and tolerate missing placeholders.
- S12: `bun test src/hooks/keyword-detector/` passes on current dev surface.
- S13: `bun test src/agents/` passes.

## Evidence paths
- `.omo/evidence/pr1-prompts-core/s1.red.log` through `.omo/evidence/pr1-prompts-core/s11.red.log`
- `.omo/evidence/pr1-prompts-core/s1.green.log` through `.omo/evidence/pr1-prompts-core/s11.green.log`
- `.omo/evidence/pr1-prompts-core/variant-resolver.red.log`
- `.omo/evidence/pr1-prompts-core/variant-resolver.green.log`
- `.omo/evidence/pr1-prompts-core/loader.red.log`
- `.omo/evidence/pr1-prompts-core/loader.green.log`

## Testing
- `bun install` passed.
- `bun run typecheck` passed.
- `bun test packages/prompts-core/` passed: 12 pass, 0 fail.
- `bun test src/hooks/keyword-detector/` passed: 88 pass, 0 fail on current dev.
- `bun test src/agents/` passed: 406 pass, 0 fail.
- `bun test` exited 0 on current Bun with no discovered root tests printed.
- `bun run build` passed.
- LSP diagnostics clean on changed files.
- grep guard found zero forbidden `@opencode-ai/*` or `../opencode/` imports in `packages/prompts-core/src/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `packages/prompts-core` foundation for prompts-as-skills: a TypeScript core to load Markdown prompts with runtime injection and resolve variants with fallbacks. Ships infrastructure and tests; prompt content migration will follow in later PRs.

- **New Features**
  - New workspace package `@oh-my-opencode/prompts-core`.
  - Public API: types, `resolveVariant()`, and `loadPrompt()`.
  - Loader parses frontmatter, supports runtime placeholder injection, returns resolved path; throws `PromptNotFoundError` if missing.
  - Variant resolver selects the first matching agent/model test, falls back when declared, throws `NoMatchingVariantError` otherwise.
  - Wired into root workspaces, `typecheck:packages`, and `bun.lock`; includes a coupling audit to prevent `@opencode-ai/*` and `../opencode/` imports.

<sup>Written for commit e37addd2ee24916063ab1813013a96bc8b901697. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4384?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

