### PR TITLE
feat(providers): AWS Bedrock support (#3803)

### DIFF
--- a/src/features/aws-bedrock-adapter.ts
+++ b/src/features/aws-bedrock-adapter.ts
@@ -1,0 +1,34 @@
+import { env } from "process"
+
+interface BedrockConfig {
+  region: string
+  accessKeyId?: string
+  secretAccessKey?: string
+  sessionToken?: string
+  modelId: string
+}
+
+export function createBedrockConfig(): BedrockConfig | null {
+  if (!env.AWS_BEDROCK_REGION) return null
+  return {
+    region: env.AWS_BEDROCK_REGION,
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: env.AWS_SESSION_TOKEN,
+    modelId: env.AWS_BEDROCK_MODEL_ID ?? "anthropic.claude-3-sonnet-20240229-v1:0",
+  }
+}
+
+export function isBedrockAvailable(): boolean {
+  return !!env.AWS_BEDROCK_REGION && !!(env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY)
+}
+
+export function getBedrockModelMapping(): Record<string, string> {
+  return {
+    "claude-3-sonnet": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "claude-3-haiku": "anthropic.claude-3-haiku-20240307-v1:0",
+    "claude-3-opus": "anthropic.claude-3-opus-20240229-v1:0",
+    "llama3-70b": "meta.llama3-70b-instruct-v1:0",
+    "mistral-7b": "mistral.mistral-7b-instruct-v0:2",
+  }
+}


### PR DESCRIPTION
AWS Bedrock as provider. Config from env vars. Model mapping for Claude/Llama/Mistral.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Bedrock provider support with env-based config, availability check, and model mapping for Claude 3, Llama 3, and Mistral. Defaults to Claude 3 Sonnet if no model is set.

- **New Features**
  - Bedrock adapter builds config from env and exposes an availability check.
  - Maps `claude-3-sonnet/haiku/opus`, `llama3-70b`, `mistral-7b` to Bedrock IDs: `anthropic.claude-3-sonnet-20240229-v1:0`, `anthropic.claude-3-haiku-20240307-v1:0`, `anthropic.claude-3-opus-20240229-v1:0`, `meta.llama3-70b-instruct-v1:0`, `mistral.mistral-7b-instruct-v0:2`.

- **Migration**
  - Required env vars: `AWS_BEDROCK_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
  - Optional: `AWS_SESSION_TOKEN`, `AWS_BEDROCK_MODEL_ID`.
  - Provider is available only when region and both credentials are set.

<sup>Written for commit 5a02834c0a44ef4491bcde1ec9fb51ca4d2473a8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4398?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

