### PR TITLE
feat(config): runtime config reload via PluginConfigStore (#4369)

### DIFF
--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -1,6 +1,7 @@
 import type { OhMyOpenCodeConfig } from "./config"
 import type { ModelCacheState } from "./plugin-state"
 import type { PluginContext, TmuxConfig } from "./plugin/types"
+import type { PluginConfigStore } from "./features/plugin-config-store"
 
 import type { SubagentSessionCreatedEvent } from "./features/background-agent"
 import { BackgroundManager } from "./features/background-agent"
@@ -45,6 +46,7 @@ export type Managers = {
   skillMcpManager: SkillMcpManager
   configHandler: ReturnType<typeof createConfigHandler>
   modelFallbackControllerAccessor: ModelFallbackControllerAccessor
+  configStore: PluginConfigStore
 }
 
 export function createManagers(args: {
@@ -156,6 +158,9 @@ export function createManagers(args: {
 
   const skillMcpManager = new deps.SkillMcpManagerClass()
 
+  const { PluginConfigStore } = require("./features/plugin-config-store")
+  const configStore = new PluginConfigStore(pluginConfig, ctx.directory ?? process.cwd())
+
   const configHandler = deps.createConfigHandlerFn({
     ctx: { directory: ctx.directory, client: ctx.client },
     pluginConfig,
@@ -168,5 +173,6 @@ export function createManagers(args: {
     skillMcpManager,
     configHandler,
     modelFallbackControllerAccessor,
+    configStore,
   }
 }

--- a/src/features/plugin-config-store/index.ts
+++ b/src/features/plugin-config-store/index.ts
@@ -1,0 +1,82 @@
+import { readFileSync, existsSync } from "fs"
+import { join, dirname } from "path"
+import { OhMyOpenCodeConfigSchema } from "../../config"
+import type { OhMyOpenCodeConfig } from "../../config"
+
+export class PluginConfigStore {
+  private current: OhMyOpenCodeConfig
+  private configPath: string
+
+  constructor(initial: OhMyOpenCodeConfig, configPath: string) {
+    this.current = { ...initial }
+    this.configPath = configPath
+  }
+
+  get(): OhMyOpenCodeConfig {
+    return this.current
+  }
+
+  async reload(): Promise<{ ok: boolean; errors?: string[] }> {
+    try {
+      const configDir = this.configPath.endsWith(".json") || this.configPath.endsWith(".jsonc")
+        ? dirname(this.configPath) : this.configPath
+      const candidates = [
+        join(configDir, "oh-my-opencode.jsonc"),
+        join(configDir, "oh-my-opencode.json"),
+        join(configDir, ".opencode/oh-my-opencode.jsonc"),
+      ]
+      let raw: string | null = null
+      for (const f of candidates) {
+        if (existsSync(f)) {
+          raw = readFileSync(f, "utf-8")
+          break
+        }
+      }
+      if (!raw) return { ok: false, errors: ["No config file found"] }
+      const parsed = JSON.parse(raw)
+      const result = OhMyOpenCodeConfigSchema.safeParse(parsed)
+      if (!result.success) {
+        return { ok: false, errors: result.error.issues.map(i => i.message) }
+      }
+      this.current = result.data
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, errors: [String(e)] }
+    }
+  }
+
+  getValue(path: string): unknown {
+    const parts = path.split(".")
+    let val: unknown = this.current
+    for (const p of parts) {
+      if (val && typeof val === "object" && p in (val as Record<string, unknown>)) {
+        val = (val as Record<string, unknown>)[p]
+      } else {
+        return undefined
+      }
+    }
+    return val
+  }
+
+  async setValue(path: string, value: string): Promise<{ ok: boolean; errors?: string[] }> {
+    const parts = path.split(".")
+    let obj: Record<string, unknown> = this.current as unknown as Record<string, unknown>
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!obj[parts[i]] || typeof obj[parts[i]] !== "object") {
+        obj[parts[i]] = {}
+      }
+      obj = obj[parts[i]] as Record<string, unknown>
+    }
+    const lastKey = parts[parts.length - 1]
+    // Try parsing as number or boolean
+    if (value === "true") obj[lastKey] = true
+    else if (value === "false") obj[lastKey] = false
+    else if (!isNaN(Number(value)) && value.trim() !== "") obj[lastKey] = Number(value)
+    else obj[lastKey] = value
+    return { ok: true }
+  }
+}
+
+export function createConfigStore(config: OhMyOpenCodeConfig, configPath: string): PluginConfigStore {
+  return new PluginConfigStore(config, configPath)
+}


### PR DESCRIPTION
## Feature #4369: Runtime Config Reload

Add PluginConfigStore for hot-swapping config without restart.

### Changes
-  — New PluginConfigStore class
  -  returns current config
  -  re-reads config file, parses with Zod, updates in-memory
  -  dot-notation access
  -  runtime override
- { is a shell keyword — Wire configStore into Managers type and return

### Usage


Closes #4369

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable runtime config reload without restarts via a new `PluginConfigStore` available as `managers.configStore`. Supports schema-validated reloads from JSON/JSONC and dot-path getters/setters to power the hot-reload flow in #4369.

- **New Features**
  - `PluginConfigStore` with `get()`, `reload()`, `getValue("a.b")`, `setValue("a.b", "…")`.
  - `reload()` searches `oh-my-opencode.jsonc`, `oh-my-opencode.json`, `.opencode/oh-my-opencode.jsonc` near the plugin directory and validates with the config schema.
  - Wired into `createManagers`; uses the initial config until reloaded or overridden.

<sup>Written for commit e3cf6dfdbb03d9f5d64f83678df2bbdb2ad6406c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

