### PR TITLE
feat(moderator-gate): ModeratorGate hook — deviation detection + user warnings

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -52,6 +52,7 @@ export const HookNameSchema = z.enum([
   "notepad-write-guard",
   "bash-file-read-guard",
   "anthropic-effort",
+  "moderator-gate",
   "hashline-read-enhancer",
   "read-image-resizer",
   "todo-description-override",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -68,3 +68,4 @@ export { createLegacyPluginToastHook } from "./legacy-plugin-toast"
 export { createFsyncSkipWarningHook } from "./fsync-skip-warning"
 export { createNotepadWriteGuardHook } from "./notepad-write-guard"
 export { createPlanFormatValidatorHook } from "./plan-format-validator"
+export { createModeratorGateHook, type ModeratorGateHook } from "./moderator-gate";

--- a/src/hooks/moderator-gate/decision-engine.ts
+++ b/src/hooks/moderator-gate/decision-engine.ts
@@ -1,0 +1,119 @@
+import type { Deviation } from "./deviation-detector"
+import { log } from "../../shared/logger"
+
+export type GateAction = "continue" | "warn" | "block"
+
+export interface GateDecision {
+  action: GateAction
+  deviations: Deviation[]
+  message: string
+  injectedWarning?: string
+}
+
+function getWorstSeverity(deviations: Deviation[]): "leve" | "media" | "grave" {
+  if (deviations.some((d) => d.severity === "grave")) return "grave"
+  if (deviations.some((d) => d.severity === "media")) return "media"
+  return "leve"
+}
+
+function buildDecisionMessage(deviations: Deviation[]): string {
+  const lines: string[] = []
+  lines.push("[Moderator Gate]")
+
+  const worst = getWorstSeverity(deviations)
+  if (worst === "grave") {
+    lines.push("Action: RECOMMENDED PAUSE")
+    lines.push("Detected potential architectural or dangerous change.")
+  } else if (worst === "media") {
+    lines.push("Action: FLAGGED FOR REVIEW")
+    lines.push("Detected notable change — review recommended before continuing.")
+  } else {
+    lines.push("Action: LOGGED")
+    lines.push("Minor deviation detected — no action needed.")
+  }
+
+  lines.push("")
+  for (const d of deviations) {
+    const icon = d.severity === "grave" ? "🔴" : d.severity === "media" ? "🟡" : "🟢"
+    lines.push(`${icon} [${d.severity.toUpperCase()}] ${d.category}: ${d.detail}`)
+  }
+
+  return lines.join("\n")
+}
+
+function buildWarningMessage(deviations: Deviation[]): string {
+  const worst = getWorstSeverity(deviations)
+
+  if (worst === "grave") {
+    return [
+      "",
+      "⚠️ [Moderator Gate] Se detectó un cambio potencialmente peligroso o arquitectónico.",
+      "Revisa el reporte de desviaciones arriba antes de continuar.",
+      "Si estás seguro, puedes ignorar esta advertencia y continuar.",
+      "",
+    ].join("\n")
+  }
+
+  if (worst === "media") {
+    return [
+      "",
+      "ℹ️ [Moderator Gate] Cambio notable detectado (ver reporte arriba).",
+      "Se recomienda revisión antes de continuar.",
+      "",
+    ].join("\n")
+  }
+
+  return ""
+}
+
+export function evaluateDeviations(deviations: Deviation[]): GateDecision {
+  if (deviations.length === 0) {
+    return {
+      action: "continue",
+      deviations: [],
+      message: "[Moderator Gate] No deviations detected. Continuing.",
+    }
+  }
+
+  const worst = getWorstSeverity(deviations)
+
+  log(`[moderator-gate] Evaluating ${deviations.length} deviation(s), worst=${worst}`, {
+    deviationCount: deviations.length,
+    worstSeverity: worst,
+    categories: [...new Set(deviations.map((d) => d.category))],
+  })
+
+  let action: GateAction
+  let injectedWarning: string | undefined
+
+  switch (worst) {
+    case "grave":
+      action = "warn"
+      injectedWarning = buildWarningMessage(deviations)
+      break
+    case "media":
+      action = "warn"
+      injectedWarning = buildWarningMessage(deviations)
+      break
+    case "leve":
+    default:
+      action = "continue"
+      break
+  }
+
+  // Grave deviations with config changes should block
+  const hasConfigChange = deviations.some(
+    (d) => d.category === "config-change" || d.category === "protected-area-write",
+  )
+  if (hasConfigChange) {
+    action = "warn"
+    injectedWarning = buildWarningMessage(deviations)
+  }
+
+  return {
+    action,
+    deviations,
+    message: buildDecisionMessage(deviations),
+    injectedWarning,
+  }
+}

--- a/src/hooks/moderator-gate/deviation-detector.ts
+++ b/src/hooks/moderator-gate/deviation-detector.ts
@@ -1,0 +1,206 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { basename, join } from "node:path"
+import { log } from "../../shared/logger"
+
+const BOULDER_DIR = ".omo"
+const BOULDER_FILE = "boulder.json"
+const PLANS_DIR = "plans"
+
+export interface ToolEvent {
+  tool: string
+  sessionID: string
+  callID: string
+  output: string
+  metadata: Record<string, unknown>
+}
+
+export interface Deviation {
+  severity: "leve" | "media" | "grave"
+  category: string
+  detail: string
+  filePath?: string
+}
+
+const WRITE_TOOLS = new Set(["write", "edit"])
+const DANGEROUS_COMMANDS = [
+  "git push", "git merge", "git rebase", "git reset",
+  "npm publish",
+  "rm -rf", "drop table", "alter table",
+  "npx", "bunx",
+] as const
+
+function getBoulderState(projectDir: string): Record<string, unknown> | null {
+  const filePath = join(projectDir, BOULDER_DIR, BOULDER_FILE)
+  if (!existsSync(filePath)) return null
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8"))
+  } catch {
+    return null
+  }
+}
+
+function getPlanProgressSum(projectDir: string): { total: number; completed: number } {
+  const plansDir = join(projectDir, BOULDER_DIR, PLANS_DIR)
+  if (!existsSync(plansDir)) return { total: 0, completed: 0 }
+
+  try {
+    const files = readdirSync(plansDir).filter((f) => f.endsWith(".md"))
+    let total = 0
+    let completed = 0
+
+    for (const file of files) {
+      const content = readFileSync(join(plansDir, file), "utf-8")
+      const unchecked = content.match(/\[ \]/g)
+      const checked = content.match(/\[x\]/gi)
+      const tasks = content.match(/[-*]\s+\[[\sx]\]/gi)
+      if (tasks) {
+        total += tasks.length
+        completed += checked?.length ?? 0
+      }
+    }
+
+    return { total, completed }
+  } catch {
+    return { total: 0, completed: 0 }
+  }
+}
+
+function getFileFromMeta(metadata: Record<string, unknown>): string | undefined {
+  return (metadata?.filePath as string) ?? (metadata?.file_path as string) ?? undefined
+}
+
+function detectFileDeviations(event: ToolEvent): Deviation[] {
+  const deviations: Deviation[] = []
+  if (!WRITE_TOOLS.has(event.tool.toLowerCase())) return deviations
+
+  const filePath = getFileFromMeta(event.metadata)
+  if (!filePath) return deviations
+
+  if (filePath.includes("node_modules")) {
+    deviations.push({
+      severity: "grave",
+      category: "protected-area-write",
+      detail: `Writing to node_modules: ${filePath}`,
+      filePath,
+    })
+  }
+
+  const configPatterns = ["tsconfig", "package.json", "bunfig", ".env", "docker"]
+  if (configPatterns.some((p) => filePath.toLowerCase().includes(p))) {
+    deviations.push({
+      severity: "grave",
+      category: "config-change",
+      detail: `Modifying configuration file: ${filePath}`,
+      filePath,
+    })
+  }
+
+  if (
+    filePath.includes("/src/features/")
+    && !filePath.endsWith(".test.ts")
+    && !filePath.includes("/test/")
+  ) {
+    deviations.push({
+      severity: "media",
+      category: "feature-change",
+      detail: `Modifying feature source: ${filePath}`,
+      filePath,
+    })
+  }
+
+  return deviations
+}
+
+function detectBashDeviations(event: ToolEvent): Deviation[] {
+  const deviations: Deviation[] = []
+  if (event.tool.toLowerCase() !== "bash") return deviations
+
+  const command = (event.metadata?.command as string) ?? event.output?.slice(0, 200) ?? ""
+
+  for (const dangerous of DANGEROUS_COMMANDS) {
+    if (command.toLowerCase().includes(dangerous)) {
+      deviations.push({
+        severity: "grave",
+        category: "dangerous-command",
+        detail: `Executing dangerous command pattern: ${dangerous}`,
+      })
+      break
+    }
+  }
+
+  if (
+    command.includes("npm install")
+    || command.includes("bun add")
+    || command.includes("pip install")
+    || command.includes("go get")
+  ) {
+    deviations.push({
+      severity: "media",
+      category: "dependency-add",
+      detail: `Adding new dependency: ${command.slice(0, 100)}`,
+    })
+  }
+
+  return deviations
+}
+
+function detectOutputDeviations(event: ToolEvent): Deviation[] {
+  const deviations: Deviation[] = []
+  const output = event.output ?? ""
+
+  const errorPatterns = [
+    /\bError:/, /\bfailed\b/i, /\bcannot find module\b/i,
+    /\bERR!\b/, /\bexit code 1\b/, /\bTypeError:/,
+  ]
+
+  for (const pattern of errorPatterns) {
+    if (pattern.test(output)) {
+      deviations.push({
+        severity: "media",
+        category: "error-in-output",
+        detail: `Error pattern detected in ${event.tool} output`,
+      })
+      break
+    }
+  }
+
+  return deviations
+}
+
+export function detectDeviations(
+  event: ToolEvent,
+  projectDir?: string,
+): Deviation[] {
+  const deviations: Deviation[] = [
+    ...detectFileDeviations(event),
+    ...detectBashDeviations(event),
+    ...detectOutputDeviations(event),
+  ]
+
+  if (projectDir && WRITE_TOOLS.has(event.tool.toLowerCase())) {
+    try {
+      const progress = getPlanProgressSum(projectDir)
+      if (progress.total > 0 && progress.completed === 0) {
+        deviations.push({
+          severity: "media",
+          category: "no-plan-progress",
+          detail: `Writing files but no plan steps completed (0/${progress.total})`,
+        })
+      }
+    } catch {
+      // Silently ignore plan read errors
+    }
+  }
+
+  return deviations
+}
+
+export function formatDeviations(deviations: Deviation[]): string {
+  if (deviations.length === 0) return ""
+  const parts = deviations.map((d) => {
+    const icon = d.severity === "grave" ? "🔴" : d.severity === "media" ? "🟡" : "🟢"
+    const path = d.filePath ? ` (${d.filePath})` : ""
+    return `${icon} [${d.severity.toUpperCase()}] ${d.category}${path}: ${d.detail}`
+  })
+  return ["", "---", "⚠️ Moderator Gate — Deviation Report:", ...parts, "---", ""].join("\n")
+}

--- a/src/hooks/moderator-gate/index.ts
+++ b/src/hooks/moderator-gate/index.ts
@@ -1,0 +1,143 @@
+import { log } from "../../shared/logger"
+import { detectDeviations, formatDeviations } from "./deviation-detector"
+import { evaluateDeviations } from "./decision-engine"
+import { recordDecision, type ModeratorRecord } from "./store"
+
+export type ModeratorGateHook = ReturnType<typeof createModeratorGateHook>
+
+function getProjectDir(): string | undefined {
+  try {
+    // Try to infer project dir from known workspace conventions
+    const possibleDirs = [
+      process.env.OMO_WORKSPACE_ROOT,
+      process.env.PROJECT_ROOT,
+      process.env.INIT_CWD,
+      process.cwd(),
+    ]
+    for (const dir of possibleDirs) {
+      if (dir && dir.length > 0) return dir
+    }
+  } catch {
+    // Fallback to undefined
+  }
+  return undefined
+}
+
+export function createModeratorGateHook() {
+  return {
+    "tool.execute.after": async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { title: string; output: string; metadata: Record<string, unknown> },
+    ): Promise<void> => {
+      const toolName = input.tool.toLowerCase()
+      const callId = input.callID
+
+      const outputLength = output.output?.length ?? 0
+      const metadataKeys = output.metadata ? Object.keys(output.metadata) : []
+
+      // Phase 1: Always log
+      log(`[moderator-gate] Tool executed: ${input.tool}`, {
+        sessionID: input.sessionID,
+        callID: callId,
+        outputLength,
+        metadataKeys: metadataKeys.length > 0 ? metadataKeys : undefined,
+      })
+
+      // Notable events logging
+      if (toolName === "write" || toolName === "edit") {
+        const filePath =
+          (output.metadata?.filePath as string) ??
+          (output.metadata?.file_path as string) ??
+          "unknown"
+        log(`[moderator-gate] File modification: ${filePath}`, {
+          sessionID: input.sessionID,
+          callID: callId,
+          filePath,
+        })
+      }
+
+      if (toolName === "bash") {
+        const commandPreview =
+          typeof output.metadata?.command === "string"
+            ? output.metadata.command.slice(0, 120)
+            : undefined
+        log(`[moderator-gate] Command executed: ${commandPreview ?? "unknown"}`, {
+          sessionID: input.sessionID,
+          callID: callId,
+        })
+      }
+
+      if (toolName === "task" || toolName === "delegate_task") {
+        const agentType = (output.metadata?.agent as string) ?? "unknown"
+        log(`[moderator-gate] Task delegation: ${agentType}`, {
+          sessionID: input.sessionID,
+          callID: callId,
+          agentType,
+        })
+      }
+
+      if (outputLength > 50000) {
+        log(`[moderator-gate] Large output warning: ${outputLength} bytes`, {
+          sessionID: input.sessionID,
+          callID: callId,
+          outputLength,
+        })
+      }
+
+      // Phase 2: Deviation detection
+      const deviations = detectDeviations(
+        {
+          tool: input.tool,
+          sessionID: input.sessionID,
+          callID: callId,
+          output: output.output ?? "",
+          metadata: output.metadata ?? {},
+        },
+        getProjectDir(),
+      )
+
+      // Phase 3: Decision engine
+      if (deviations.length > 0) {
+        const decision = evaluateDeviations(deviations)
+        log(`[moderator-gate] ${decision.message}`, {
+          sessionID: input.sessionID,
+          callID: callId,
+          deviationCount: deviations.length,
+          action: decision.action,
+        })
+
+        // Inject warning into output for user visibility
+        if (decision.injectedWarning) {
+          const header = [
+            "",
+            "---",
+            `[Moderator Gate] ${deviations.length} deviation(s) detected`,
+            `Worst severity: ${decision.action === 'warn' ? 'grave' : 'leve'}`, // from decision
+            "---",
+            "",
+          ].join("\n")
+
+          // Prepend warning to output
+          output.output = output.output
+            ? `${header}${decision.injectedWarning}\n${output.output}`
+            : `${header}${decision.injectedWarning}`
+          output.title = `⚠️ ${input.tool} (Moderator: ${deviations.length} deviation(s))`
+        }
+
+        // Phase 4: Record decision
+        const record: ModeratorRecord = {
+          timestamp: new Date().toISOString(),
+          tool: input.tool,
+          callID: callId,
+          sessionID: input.sessionID,
+          deviationCount: deviations.length,
+          severity: deviations.some((d) => d.severity === 'grave') ? 'grave'
+            : deviations.some((d) => d.severity === 'media') ? 'media' : 'leve',
+          action: decision.action,
+          categories: [...new Set(deviations.map((d) => d.category))],
+        }
+        await recordDecision(record)
+      }
+    },
+  }
+}

--- a/src/hooks/moderator-gate/store.ts
+++ b/src/hooks/moderator-gate/store.ts
@@ -1,0 +1,92 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { log } from "../../shared/logger"
+
+export type DeviationSeverity = "leve" | "media" | "grave"
+export type GateAction = "continue" | "warn" | "block"
+
+export interface ModeratorRecord {
+  timestamp: string
+  tool: string
+  callID: string
+  sessionID: string
+  deviationCount: number
+  severity: DeviationSeverity
+  action: GateAction
+  categories: string[]
+  filePath?: string
+  detail?: string
+}
+
+const RECORDS_DIR = ".omo"
+const RECORDS_FILE = "moderator-decisions.jsonl"
+const MAX_RECORDS = 1000
+
+function getRecordsPath(projectDir?: string): string | undefined {
+  const dir = projectDir ?? process.env.OMO_WORKSPACE_ROOT ?? process.cwd()
+  if (!dir) return undefined
+
+  const recordsDir = join(dir, RECORDS_DIR)
+  if (!existsSync(recordsDir)) {
+    try {
+      mkdirSync(recordsDir, { recursive: true })
+    } catch {
+      return undefined
+    }
+  }
+
+  return join(recordsDir, RECORDS_FILE)
+}
+
+export async function recordDecision(record: ModeratorRecord): Promise<void> {
+  const filePath = getRecordsPath()
+  if (!filePath) {
+    log("[moderator-gate] Could not determine records path", { record })
+    return
+  }
+
+  try {
+    appendFileSync(filePath, `${JSON.stringify(record)}\n`, "utf-8")
+
+    // Trim records if too many
+    const allRecords = readAllRecords()
+    if (allRecords.length > MAX_RECORDS) {
+      const trimmed = allRecords.slice(allRecords.length - MAX_RECORDS)
+      writeFileSync(filePath, trimmed.map((r) => JSON.stringify(r)).join("\n") + "\n", "utf-8")
+    }
+  } catch (err) {
+    log("[moderator-gate] Failed to save decision record", { error: err })
+  }
+}
+
+export function readAllRecords(projectDir?: string): ModeratorRecord[] {
+  const filePath = getRecordsPath(projectDir)
+  if (!filePath || !existsSync(filePath)) return []
+
+  try {
+    const content = readFileSync(filePath, "utf-8")
+    return content
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as ModeratorRecord
+        } catch {
+          return null
+        }
+      })
+      .filter((r): r is ModeratorRecord => r !== null)
+  } catch {
+    return []
+  }
+}
+
+export function getRecentDecisions(count = 10): ModeratorRecord[] {
+  const all = readAllRecords()
+  return all.slice(-count).reverse()
+}
+
+export function getWarningsCount(): number {
+  const all = readAllRecords()
+  return all.filter((r) => r.severity === "grave" || r.severity === "media").length
+}

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -21,6 +21,7 @@ import {
   createFsyncSkipWarningHook,
   createNotepadWriteGuardHook,
   createPlanFormatValidatorHook,
+  createModeratorGateHook,
 } from "../../hooks"
 import {
   getOpenCodeVersion,
@@ -45,6 +46,7 @@ export type ToolGuardHooks = {
   readImageResizer: ReturnType<typeof createReadImageResizerHook> | null
   todoDescriptionOverride: ReturnType<typeof createTodoDescriptionOverrideHook> | null
   webfetchRedirectGuard: ReturnType<typeof createWebFetchRedirectGuardHook> | null
+  moderatorGate: ReturnType<typeof createModeratorGateHook> | null
   fsyncSkipWarning: ReturnType<typeof createFsyncSkipWarningHook> | null
   teamToolGating: ReturnType<typeof createTeamToolGating> | null
   notepadWriteGuard: ReturnType<typeof createNotepadWriteGuardHook> | null
@@ -149,6 +151,9 @@ export function createToolGuardHooks(args: {
     ? safeHook("fsync-skip-warning", () => createFsyncSkipWarningHook())
     : null
 
+  const moderatorGate = isHookEnabled("moderator-gate")
+    ? safeHook("moderator-gate", () => createModeratorGateHook())
+    : null
   const planFormatValidator = isHookEnabled("plan-format-validator")
     ? safeHook("plan-format-validator", () => createPlanFormatValidatorHook(ctx))
     : null
@@ -176,5 +181,6 @@ export function createToolGuardHooks(args: {
     teamToolGating,
     notepadWriteGuard,
     planFormatValidator,
+    moderatorGate,
   }
 }

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -181,6 +181,7 @@ export function createToolExecuteAfterHandler(args: {
       await hooks.fsyncSkipWarning?.["tool.execute.after"]?.(hookInput, output)
       await hooks.jsonErrorRecovery?.["tool.execute.after"]?.(hookInput, output)
       await hooks.planFormatValidator?.["tool.execute.after"]?.(hookInput, output)
+      await hooks.moderatorGate?.["tool.execute.after"]?.(hookInput, output)
     }
 
     if (input.tool === "extract" || input.tool === "discard") {


### PR DESCRIPTION
## Summary

Adds **ModeratorGate**, a new ToolGuard hook (tier 2) that monitors `tool.execute.after` events for plan deviations and injects user warnings when significant changes are detected.

### Hook Files
| File | Purpose |
|------|---------|
| `src/hooks/moderator-gate/index.ts` | Hook principal — intercepta tool.execute.after |
| `src/hooks/moderator-gate/deviation-detector.ts` | Detecta desviaciones (writes, bash, outputs, plan context) |
| `src/hooks/moderator-gate/decision-engine.ts` | Evalúa gravedad y elige respuesta |
| `src/hooks/moderator-gate/store.ts` | Persiste decisiones para auditoría |

### Wiring
- Register in `create-tool-guard-hooks.ts` (ToolGuard tier)
- Wire into `tool-execute-after.ts` pipeline
- Register hook name in schema (`"moderator-gate"`)

### Clean version
Replaces contaminated PR #4372. 8 files, 569 lines, zero contamination. Refs #4372

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `moderator-gate`, a ToolGuard hook that watches `tool.execute.after` events, detects risky plan deviations, and injects user warnings when needed. Improves safety with clear alerts while allowing execution to continue.

- **New Features**
  - New `moderator-gate` hook (tier 2) with deviation detector and decision engine.
  - Injects warning headers and updates titles for medium/grave deviations; action is `warn` (non-blocking).
  - Detects: writes to `node_modules`, config changes (`package.json`, `tsconfig`, `bunfig`, `.env`, docker), feature source edits, dangerous bash (`git push`, `rm -rf`, `npm publish`, `npx`, `bunx`), dependency installs, error patterns in output, and writes with 0 completed plan tasks.
  - Persists decisions to `.omo/moderator-decisions.jsonl` (JSONL), auto-trim to 1000 records.
  - Registered in `HookNameSchema`, exported via `createModeratorGateHook`/`ModeratorGateHook`, and wired into `create-tool-guard-hooks.ts` and `tool-execute-after.ts`; enable via hook config.

<sup>Written for commit 092bd7de40c08ddf2c52ccd256ae985447ea567e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4405?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

