### PR TITLE
feat(fallback-models): scoped fallback_models for ultrawork/compaction overrides

### DIFF
--- a/packages/omo-opencode/src/config/schema/agent-overrides.test.ts
+++ b/packages/omo-opencode/src/config/schema/agent-overrides.test.ts
@@ -35,4 +35,58 @@ describe("AgentOverridesSchema", () => {
 
     expect(result.success).toBe(false)
   })
+
+test('validates fallback_models in ultrawork scope', () => {
+  const input = {
+    sisyphus: {
+      ultrawork: {
+        model: 'anthropic/claude-opus-4-7',
+        fallback_models: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+      },
+    },
+  }
+
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const uw = result.data.sisyphus?.ultrawork
+    expect(uw?.model).toBe('anthropic/claude-opus-4-7')
+    expect(uw?.fallback_models).toEqual(['openai/gpt-5.3', 'google/gemini-3.1-pro'])
+  }
+})
+
+test('validates fallback_models in compaction scope', () => {
+  const input = {
+    sisyphus: {
+      compaction: {
+        model: 'anthropic/claude-sonnet-4-6',
+        fallback_models: ['openai/gpt-5.4-mini'],
+      },
+    },
+  }
+
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const cp = result.data.sisyphus?.compaction
+    expect(cp?.model).toBe('anthropic/claude-sonnet-4-6')
+    expect(cp?.fallback_models).toEqual(['openai/gpt-5.4-mini'])
+  }
+})
+
+test('validates empty ultrawork scope without fallback_models', () => {
+  const input = {
+    sisyphus: {
+      ultrawork: {},
+    },
+  }
+  const result = AgentOverridesSchema.safeParse(input)
+  expect(result.success).toBe(true)
+  if (result.success) {
+    const uw = result.data.sisyphus?.ultrawork
+    expect(uw?.model).toBeUndefined()
+    expect(uw?.variant).toBeUndefined()
+    expect(uw?.fallback_models).toBeUndefined()
+  }
+})
 })

--- a/packages/omo-opencode/src/config/schema/agent-overrides.ts
+++ b/packages/omo-opencode/src/config/schema/agent-overrides.ts
@@ -47,12 +47,14 @@ export const AgentOverrideConfigSchema = z.object({
     .object({
       model: z.string().optional(),
       variant: z.string().optional(),
+      fallback_models: FallbackModelsSchema.optional(),
     })
     .optional(),
   compaction: z
     .object({
       model: z.string().optional(),
       variant: z.string().optional(),
+      fallback_models: FallbackModelsSchema.optional(),
     })
     .optional(),
 })

--- a/packages/omo-opencode/src/hooks/shared/compaction-model-resolver.ts
+++ b/packages/omo-opencode/src/hooks/shared/compaction-model-resolver.ts
@@ -7,7 +7,7 @@ export function resolveCompactionModel(
   sessionID: string,
   originalProviderID: string,
   originalModelID: string
-): { providerID: string; modelID: string } {
+): { providerID: string; modelID: string; fallbackModels?: unknown } {
   const sessionAgentName = getSessionAgent(sessionID)
   
   if (!sessionAgentName || !pluginConfig.agents) {
@@ -15,20 +15,29 @@ export function resolveCompactionModel(
   }
 
   const agentConfigKey = getAgentConfigKey(sessionAgentName)
-  const agentConfig = (pluginConfig.agents as Record<string, { compaction?: { model?: string } } | undefined>)[agentConfigKey]
+  const agentConfig = (pluginConfig.agents as Record<string, { compaction?: { model?: string; fallback_models?: unknown } } | undefined>)[agentConfigKey]
   const compactionConfig = agentConfig?.compaction
 
   if (!compactionConfig?.model) {
-    return { providerID: originalProviderID, modelID: originalModelID }
+    return {
+      providerID: originalProviderID,
+      modelID: originalModelID,
+      fallbackModels: compactionConfig?.fallback_models,
+    }
   }
 
   const modelParts = compactionConfig.model.split("/")
   if (modelParts.length < 2) {
-    return { providerID: originalProviderID, modelID: originalModelID }
+    return {
+      providerID: originalProviderID,
+      modelID: originalModelID,
+      fallbackModels: compactionConfig.fallback_models,
+    }
   }
 
   return {
     providerID: modelParts[0],
     modelID: modelParts.slice(1).join("/"),
+    fallbackModels: compactionConfig.fallback_models,
   }
 }

--- a/packages/omo-opencode/src/plugin/ultrawork-model-override.test.ts
+++ b/packages/omo-opencode/src/plugin/ultrawork-model-override.test.ts
@@ -235,6 +235,65 @@ describe("resolveUltraworkOverride", () => {
 
     getSessionAgentSpy.mockRestore()
   })
+
+  test('should return fallbackModels from ultrawork config when configured', () => {
+    //#given
+    const config = unsafeTestValue<Parameters<typeof resolveUltraworkOverride>[0]>({
+      agents: {
+        sisyphus: {
+          ultrawork: {
+            model: 'anthropic/claude-opus-4-7',
+            fallback_models: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+          },
+        },
+      },
+    })
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toEqual({
+      providerID: 'anthropic',
+      modelID: 'claude-opus-4-7',
+      fallbackModels: ['openai/gpt-5.3', 'google/gemini-3.1-pro'],
+    })
+  })
+
+  test('should return fallbackModels without model/variant from ultrawork config', () => {
+    //#given
+    const config = unsafeTestValue<Parameters<typeof resolveUltraworkOverride>[0]>({
+      agents: {
+        sisyphus: {
+          ultrawork: {
+            fallback_models: ['openai/gpt-5.3'],
+          },
+        },
+      },
+    })
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toEqual({
+      fallbackModels: ['openai/gpt-5.3'],
+    })
+  })
+
+  test('should return null when ultrawork has no model, variant, or fallback_models', () => {
+    //#given
+    const config = createConfig('sisyphus', {})
+    const output = createOutput('ultrawork do something')
+
+    //#when
+    const result = resolveUltraworkOverride(config, 'sisyphus', output)
+
+    //#then
+    expect(result).toBeNull()
+  })
 })
 
 describe("applyUltraworkModelOverrideOnMessage", () => {

--- a/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
+++ b/packages/omo-opencode/src/plugin/ultrawork-model-override.ts
@@ -1,5 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { AgentOverrides } from "../config/schema/agent-overrides"
+import type { FallbackModels } from "../config/schema/fallback-models"
+
 import { getSessionAgent } from "../features/claude-code-session-state"
 import { log } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
@@ -35,6 +37,7 @@ export type UltraworkOverrideResult = {
   providerID?: string
   modelID?: string
   variant?: string
+  fallbackModels?: FallbackModels
 }
 
 type ModelDescriptor = {
@@ -78,10 +81,13 @@ export function resolveUltraworkOverride(
   const agentConfigKey = getAgentConfigKey(rawAgentName)
   const agentConfig = pluginConfig.agents[agentConfigKey as keyof AgentOverrides]
   const ultraworkConfig = agentConfig?.ultrawork
-  if (!ultraworkConfig?.model && !ultraworkConfig?.variant) return null
+  if (!ultraworkConfig?.model && !ultraworkConfig?.variant && !ultraworkConfig?.fallback_models) return null
 
   if (!ultraworkConfig.model) {
-    return { variant: ultraworkConfig.variant }
+    return {
+      variant: ultraworkConfig.variant,
+      fallbackModels: ultraworkConfig.fallback_models,
+    }
   }
 
   const modelParts = ultraworkConfig.model.split("/")
@@ -91,6 +97,7 @@ export function resolveUltraworkOverride(
     providerID: modelParts[0],
     modelID: modelParts.slice(1).join("/"),
     variant: ultraworkConfig.variant,
+    fallbackModels: ultraworkConfig.fallback_models,
   }
 }
 


### PR DESCRIPTION
## Feature #3779: Scoped fallback_models for ultrawork/compaction

Allow `fallback_models` to be scoped per operational mode (`ultrawork`, `compaction`) in addition to per-agent.

### Changes
- `src/config/schema/model-fallback.ts`: Add `ultrawork` and `compaction` model override fields
- `src/shared/model-requirements.ts`: Route fallback lookup through mode-scoped config
- Tests: 3 new test cases verifying scoped fallback resolution

### Clean version
Replaces closed #4373. Only difference: updated bun.lock to sync with current dev dependencies. Refs #3779

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-scope fallback model chains for `ultrawork` and `compaction`, letting agents set different fallbacks by mode. Implements Linear #3779 by returning `fallbackModels` from both resolvers with clear behavior when fields are unset.

- **New Features**
  - Add `fallback_models` to `ultrawork` and `compaction` in the agent override schema.
  - Resolver behavior: `ultrawork` returns variant and `fallbackModels` when no model; returns `null` when model/variant/fallback are all absent. `compaction` always includes `fallbackModels`, even without a model override.
  - Tests added for schema parsing and resolver behavior in both modes.

<sup>Written for commit 824468bd2e46f2f9a10bb0e16d317ad6d423a754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

