### PR TITLE
fix(package): ship built-in plugin command and skill assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "bin",
     "postinstall.mjs",
     "packages/lsp-tools-mcp/dist",
-    "packages/ast-grep-mcp/dist"
+    "packages/ast-grep-mcp/dist",
+    ".agents/command",
+    ".agents/skills",
+    ".opencode/command",
+    ".opencode/skills"
   ],
   "exports": {
     ".": {

--- a/script/package-artifact.test.ts
+++ b/script/package-artifact.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="bun-types" />
+
+import { $ } from "bun"
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const temporaryDirectories: string[] = []
+
+function makeTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "omo-pack-"))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop()
+    if (directory) rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe("package artifact contents", () => {
+  test("ships project commands and skills from dot-directories", async () => {
+    // given
+    const destination = makeTemporaryDirectory()
+
+    // when
+    await $`bun pm pack --ignore-scripts --destination ${destination} --quiet`.quiet()
+    const tarball = readdirSync(destination).find((entry) => entry.endsWith(".tgz"))
+    expect(tarball).toBeDefined()
+    const entries = await $`tar -tzf ${join(destination, tarball ?? "missing.tgz")}`.text()
+
+    // then
+    expect(entries).toContain("package/.agents/command/security-research.md")
+    expect(entries).toContain("package/.agents/skills/security-research/SKILL.md")
+    expect(entries).toContain("package/.opencode/command/security-research.md")
+    expect(entries).toContain("package/.opencode/skills/hyperplan/SKILL.md")
+  })
+})


### PR DESCRIPTION
## Summary

- Include `.agents/command`, `.agents/skills`, `.opencode/command`, and `.opencode/skills` in the published package `files` whitelist.
- Add a package artifact regression test that runs `bun pm pack` and inspects the tarball for representative built-in command/skill assets.

## Why

The source tree and release notes advertise `/security-research`, but the npm artifact can drop the dot-directory command/skill assets because `package.json#files` only whitelisted build outputs and package metadata.

Closes #4379

## Verification

Local preflight was run on latest `upstream/dev` (`de7f1d887db6f274ae67075a360cd05d45f59179`) with CI-pinned Bun `1.3.12`:

```bash
git diff --check
npm --prefix packages/lsp-tools-mcp ci
npm --prefix packages/lsp-tools-mcp run build
BUN_INSTALL_ALLOW_SCRIPTS='@ast-grep/cli @ast-grep/napi' bun install --frozen-lockfile
bun test
bun run typecheck
bun run typecheck:script
bun run build
test -f dist/index.js
test -f dist/index.d.ts
bun test src/shared/dist-bundle-bun-globals.test.ts
```

All passed locally before publication.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship built-in plugin command and skill assets in the published package to restore plugin discovery. Adds a regression test that packs the tarball and verifies the assets are present; addresses #4379.

- Bug Fixes
  - Added `.agents/command`, `.agents/skills`, `.opencode/command`, `.opencode/skills` to `package.json#files` so the npm tarball includes discovery assets.
  - Added an artifact test using `bun pm pack` and `tar` to assert representative assets are included.

<sup>Written for commit f78f161e3985440eb748d2af22118ca6ea40a3a4. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4407?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

