### PR TITLE
fix(team-mode): preserve server auth for tmux pane attach

### DIFF
--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -12,6 +12,7 @@ let nextWindowNumber = 1
 let nextPaneNumber = 1
 let displaySessionId = "$7"
 let displaySuccess = true
+let originalServerPassword: string | undefined
 const panesByWindow = new Map<string, string[]>()
 
 function createTmuxCommandResult(output: string, success = true) {
@@ -113,9 +114,16 @@ function getCommands(): Array<Array<string>> {
 describe("team-layout-tmux", () => {
   afterEach(() => {
     mock.restore()
+    if (originalServerPassword === undefined) {
+      delete process.env.OPENCODE_SERVER_PASSWORD
+    } else {
+      process.env.OPENCODE_SERVER_PASSWORD = originalServerPassword
+    }
   })
 
   beforeEach(() => {
+    originalServerPassword = process.env.OPENCODE_SERVER_PASSWORD
+    delete process.env.OPENCODE_SERVER_PASSWORD
     runTmuxCommandMock.mockClear()
     isServerRunningMock.mockClear()
     isServerRunningMock.mockImplementation(async () => true)
@@ -191,6 +199,26 @@ describe("team-layout-tmux", () => {
     const literals = sendKeysCalls.map((args) => args.join(" "))
     expect(literals.some((s) => s.includes("--session 's-m1'"))).toBe(true)
     expect(literals.some((s) => s.includes("--session 's-m2'"))).toBe(true)
+  })
+
+  test("#given server password #when panes attach #then command carries auth env", async () => {
+    // given
+    process.env.OPENCODE_SERVER_PASSWORD = "secret with spaces'and-dollar$"
+    const { createTeamLayout } = await loadLayoutModule()
+
+    // when
+    await createTeamLayout(
+      "run-auth",
+      [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }],
+      tmuxMgr as never,
+    )
+
+    // then
+    const sendKeysCall = getCommands().find((args) => args[0] === "send-keys")
+    const attachCommand = sendKeysCall?.[3] ?? ""
+    expect(attachCommand).toContain("OPENCODE_SERVER_PASSWORD='secret with spaces'\\''and-dollar$'")
+    expect(attachCommand).toContain("opencode attach")
+    expect(attachCommand).toContain("--session 's-m1'")
   })
 
   test("uses caller window main-vertical layout with caller pane as primary", async () => {

--- a/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -13,6 +13,7 @@ let nextPaneNumber = 1
 let displaySessionId = "$7"
 let displaySuccess = true
 let originalServerPassword: string | undefined
+let originalServerUsername: string | undefined
 const panesByWindow = new Map<string, string[]>()
 
 function createTmuxCommandResult(output: string, success = true) {
@@ -119,11 +120,18 @@ describe("team-layout-tmux", () => {
     } else {
       process.env.OPENCODE_SERVER_PASSWORD = originalServerPassword
     }
+    if (originalServerUsername === undefined) {
+      delete process.env.OPENCODE_SERVER_USERNAME
+    } else {
+      process.env.OPENCODE_SERVER_USERNAME = originalServerUsername
+    }
   })
 
   beforeEach(() => {
     originalServerPassword = process.env.OPENCODE_SERVER_PASSWORD
+    originalServerUsername = process.env.OPENCODE_SERVER_USERNAME
     delete process.env.OPENCODE_SERVER_PASSWORD
+    delete process.env.OPENCODE_SERVER_USERNAME
     runTmuxCommandMock.mockClear()
     isServerRunningMock.mockClear()
     isServerRunningMock.mockImplementation(async () => true)
@@ -219,6 +227,50 @@ describe("team-layout-tmux", () => {
     expect(attachCommand).toContain("OPENCODE_SERVER_PASSWORD='secret with spaces'\\''and-dollar$'")
     expect(attachCommand).toContain("opencode attach")
     expect(attachCommand).toContain("--session 's-m1'")
+  })
+
+  test("#given password + username #when panes attach #then command carries both env vars", async () => {
+    // given — OPENCODE_SERVER_USERNAME is optional in opencode-server-auth
+    // (defaults to "opencode"), but when the caller sets it explicitly the
+    // pane must inherit the exact value, otherwise opencode attach falls back
+    // to the wrong default and the server rejects with 401.
+    process.env.OPENCODE_SERVER_PASSWORD = "pw"
+    process.env.OPENCODE_SERVER_USERNAME = "custom-user"
+    const { createTeamLayout } = await loadLayoutModule()
+
+    // when
+    await createTeamLayout(
+      "run-auth-username",
+      [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }],
+      tmuxMgr as never,
+    )
+
+    // then
+    const sendKeysCall = getCommands().find((args) => args[0] === "send-keys")
+    const attachCommand = sendKeysCall?.[3] ?? ""
+    expect(attachCommand).toContain("OPENCODE_SERVER_PASSWORD='pw'")
+    expect(attachCommand).toContain("OPENCODE_SERVER_USERNAME='custom-user'")
+    expect(attachCommand.indexOf("OPENCODE_SERVER_PASSWORD"))
+      .toBeLessThan(attachCommand.indexOf("opencode attach"))
+  })
+
+  test("#given only password (no username) #when panes attach #then USERNAME is omitted so child inherits default", async () => {
+    // given
+    process.env.OPENCODE_SERVER_PASSWORD = "pw"
+    const { createTeamLayout } = await loadLayoutModule()
+
+    // when
+    await createTeamLayout(
+      "run-auth-no-username",
+      [{ name: "m1", sessionId: "s-m1", worktreePath: "/tmp/m1" }],
+      tmuxMgr as never,
+    )
+
+    // then
+    const sendKeysCall = getCommands().find((args) => args[0] === "send-keys")
+    const attachCommand = sendKeysCall?.[3] ?? ""
+    expect(attachCommand).toContain("OPENCODE_SERVER_PASSWORD='pw'")
+    expect(attachCommand).not.toContain("OPENCODE_SERVER_USERNAME")
   })
 
   test("uses caller window main-vertical layout with caller pane as primary", async () => {

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -46,7 +46,19 @@ function getPaneWorkingDirectory(member: TeamLayoutMember): string {
 }
 
 function buildAttachCommand(member: TeamLayoutMember, serverUrl: string): string {
-  return `opencode attach ${shellSingleQuote(serverUrl)} --session ${shellSingleQuote(member.sessionId)} --dir ${shellSingleQuote(getPaneWorkingDirectory(member))}`
+  const serverPassword = process.env.OPENCODE_SERVER_PASSWORD
+  const passwordPrefix = serverPassword
+    ? `OPENCODE_SERVER_PASSWORD=${shellSingleQuote(serverPassword)} `
+    : ""
+  const attachArgs = [
+    "opencode attach",
+    shellSingleQuote(serverUrl),
+    "--session",
+    shellSingleQuote(member.sessionId),
+    "--dir",
+    shellSingleQuote(getPaneWorkingDirectory(member)),
+  ]
+  return `${passwordPrefix}${attachArgs.join(" ")}`
 }
 
 async function listPanesInWindow(tmuxPath: string, windowTarget: string, deps: TeamLayoutDeps): Promise<Array<string>> {

--- a/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/src/features/team-mode/team-layout-tmux/layout.ts
@@ -1,4 +1,5 @@
 import { log } from "../../../shared"
+import { getServerAuthEnvPrefix } from "../../../shared/opencode-server-auth"
 import { shellSingleQuote } from "../../../shared/shell-env"
 import * as sharedTmuxModule from "../../../shared/tmux"
 import * as tmuxPathResolverModule from "../../../tools/interactive-bash/tmux-path-resolver"
@@ -46,10 +47,6 @@ function getPaneWorkingDirectory(member: TeamLayoutMember): string {
 }
 
 function buildAttachCommand(member: TeamLayoutMember, serverUrl: string): string {
-  const serverPassword = process.env.OPENCODE_SERVER_PASSWORD
-  const passwordPrefix = serverPassword
-    ? `OPENCODE_SERVER_PASSWORD=${shellSingleQuote(serverPassword)} `
-    : ""
   const attachArgs = [
     "opencode attach",
     shellSingleQuote(serverUrl),
@@ -58,7 +55,7 @@ function buildAttachCommand(member: TeamLayoutMember, serverUrl: string): string
     "--dir",
     shellSingleQuote(getPaneWorkingDirectory(member)),
   ]
-  return `${passwordPrefix}${attachArgs.join(" ")}`
+  return `${getServerAuthEnvPrefix()}${attachArgs.join(" ")}`
 }
 
 async function listPanesInWindow(tmuxPath: string, windowTarget: string, deps: TeamLayoutDeps): Promise<Array<string>> {

--- a/src/shared/opencode-server-auth.test.ts
+++ b/src/shared/opencode-server-auth.test.ts
@@ -3,6 +3,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
 
 let getServerBasicAuthHeader: (typeof import("./opencode-server-auth"))["getServerBasicAuthHeader"]
+let getServerAuthEnvPrefix: (typeof import("./opencode-server-auth"))["getServerAuthEnvPrefix"]
 let injectServerAuthIntoClient: (typeof import("./opencode-server-auth"))["injectServerAuthIntoClient"]
 
 async function importFreshOpencodeServerAuthModule(): Promise<typeof import("./opencode-server-auth")> {
@@ -17,7 +18,9 @@ describe("opencode-server-auth", () => {
       OPENCODE_SERVER_PASSWORD: process.env.OPENCODE_SERVER_PASSWORD,
       OPENCODE_SERVER_USERNAME: process.env.OPENCODE_SERVER_USERNAME,
     }
-    ;({ getServerBasicAuthHeader, injectServerAuthIntoClient } = await importFreshOpencodeServerAuthModule())
+    delete process.env.OPENCODE_SERVER_PASSWORD
+    delete process.env.OPENCODE_SERVER_USERNAME
+    ;({ getServerBasicAuthHeader, getServerAuthEnvPrefix, injectServerAuthIntoClient } = await importFreshOpencodeServerAuthModule())
   })
 
   afterEach(() => {
@@ -267,5 +270,50 @@ describe("opencode-server-auth", () => {
     const client = {}
 
     expect(() => injectServerAuthIntoClient(client)).not.toThrow()
+  })
+
+  describe("getServerAuthEnvPrefix", () => {
+    test("#given no password #when building env prefix #then returns empty string", () => {
+      const result = getServerAuthEnvPrefix()
+      expect(result).toBe("")
+    })
+
+    test("#given password only #when building env prefix #then emits PASSWORD with trailing space and omits USERNAME", () => {
+      process.env.OPENCODE_SERVER_PASSWORD = "secret"
+
+      const result = getServerAuthEnvPrefix()
+
+      expect(result).toBe("OPENCODE_SERVER_PASSWORD='secret' ")
+      expect(result).not.toContain("OPENCODE_SERVER_USERNAME")
+    })
+
+    test("#given password and explicit username #when building env prefix #then emits both, USERNAME after PASSWORD", () => {
+      process.env.OPENCODE_SERVER_PASSWORD = "secret"
+      process.env.OPENCODE_SERVER_USERNAME = "alice"
+
+      const result = getServerAuthEnvPrefix()
+
+      expect(result).toBe("OPENCODE_SERVER_PASSWORD='secret' OPENCODE_SERVER_USERNAME='alice' ")
+    })
+
+    test("#given password with shell metacharacters #when building env prefix #then values are safely single-quoted", () => {
+      process.env.OPENCODE_SERVER_PASSWORD = "p w'$(echo pwn)`"
+      process.env.OPENCODE_SERVER_USERNAME = "u 'name"
+
+      const result = getServerAuthEnvPrefix()
+
+      // shellSingleQuote wraps in '...' and escapes inner ' as '\''.
+      expect(result).toBe("OPENCODE_SERVER_PASSWORD='p w'\\''$(echo pwn)`' OPENCODE_SERVER_USERNAME='u '\\''name' ")
+      expect(result).not.toMatch(/[^\\][^']\$\(/)
+    })
+
+    test("#given empty username string #when building env prefix #then emits USERNAME='' (explicit override is meaningful)", () => {
+      process.env.OPENCODE_SERVER_PASSWORD = "secret"
+      process.env.OPENCODE_SERVER_USERNAME = ""
+
+      const result = getServerAuthEnvPrefix()
+
+      expect(result).toBe("OPENCODE_SERVER_PASSWORD='secret' OPENCODE_SERVER_USERNAME='' ")
+    })
   })
 })

--- a/src/shared/opencode-server-auth.ts
+++ b/src/shared/opencode-server-auth.ts
@@ -1,4 +1,5 @@
 import { log } from "./logger"
+import { shellSingleQuote } from "./shell-env"
 
 /**
  * Builds HTTP Basic Auth header from environment variables.
@@ -15,6 +16,29 @@ export function getServerBasicAuthHeader(): string | undefined {
   const token = Buffer.from(`${username}:${password}`, "utf8").toString("base64")
 
   return `Basic ${token}`
+}
+
+/**
+ * Builds a shell-quoted env-var assignment prefix that propagates the opencode
+ * server auth secrets into a child process (e.g. `opencode attach` running
+ * inside a tmux pane). Returns an empty string when no auth is configured.
+ *
+ * The prefix has a trailing space so callers can concatenate directly:
+ *   `${getServerAuthEnvPrefix()}opencode attach ...`
+ *
+ * OPENCODE_SERVER_USERNAME is only emitted when it is explicitly set in the
+ * current process, so the child inherits the same default fallback behavior
+ * (`getServerBasicAuthHeader` defaults the username to `opencode`).
+ */
+export function getServerAuthEnvPrefix(): string {
+  const password = process.env.OPENCODE_SERVER_PASSWORD
+  if (!password) return ""
+  const username = process.env.OPENCODE_SERVER_USERNAME
+  const parts = [`OPENCODE_SERVER_PASSWORD=${shellSingleQuote(password)}`]
+  if (username !== undefined) {
+    parts.push(`OPENCODE_SERVER_USERNAME=${shellSingleQuote(username)}`)
+  }
+  return `${parts.join(" ")} `
 }
 
 type UnknownRecord = Record<string, unknown>

--- a/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./pane-command"
 
 describe("buildTmuxAttachCommand", () => {
+  let originalPassword: string | undefined
+  let originalUsername: string | undefined
+
+  beforeEach(() => {
+    originalPassword = process.env.OPENCODE_SERVER_PASSWORD
+    originalUsername = process.env.OPENCODE_SERVER_USERNAME
+    delete process.env.OPENCODE_SERVER_PASSWORD
+    delete process.env.OPENCODE_SERVER_USERNAME
+  })
+
+  afterEach(() => {
+    if (originalPassword === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+    else process.env.OPENCODE_SERVER_PASSWORD = originalPassword
+    if (originalUsername === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+    else process.env.OPENCODE_SERVER_USERNAME = originalUsername
+  })
+
   it("uses /bin/sh instead of inheriting SHELL", () => {
     const originalShell = process.env.SHELL
     process.env.SHELL = "/bin/tcsh"
@@ -13,6 +30,30 @@ describe("buildTmuxAttachCommand", () => {
     } finally {
       process.env.SHELL = originalShell
     }
+  })
+
+  it("propagates OPENCODE_SERVER_PASSWORD as an outer-shell env assignment when set", () => {
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
+    // Env prefix must appear before `/bin/sh -c` so the child shell inherits it.
+    expect(cmd.startsWith("OPENCODE_SERVER_PASSWORD='secret' /bin/sh -c \"")).toBe(true)
+  })
+
+  it("propagates both PASSWORD and USERNAME when username is set explicitly", () => {
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+    process.env.OPENCODE_SERVER_USERNAME = "alice"
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
+    expect(cmd).toContain("OPENCODE_SERVER_PASSWORD='secret'")
+    expect(cmd).toContain("OPENCODE_SERVER_USERNAME='alice'")
+    expect(cmd.indexOf("OPENCODE_SERVER_PASSWORD"))
+      .toBeLessThan(cmd.indexOf("/bin/sh -c"))
+  })
+
+  it("omits env prefix when no password is configured", () => {
+    const cmd = buildTmuxAttachCommand("http://localhost:3000", "ses_abc123")
+    expect(cmd.startsWith('/bin/sh -c "')).toBe(true)
+    expect(cmd).not.toContain("OPENCODE_SERVER_PASSWORD")
+    expect(cmd).not.toContain("OPENCODE_SERVER_USERNAME")
   })
 
   it("escapes serverUrl shell metacharacters", () => {

--- a/src/shared/tmux/tmux-utils/pane-command.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.ts
@@ -1,3 +1,4 @@
+import { getServerAuthEnvPrefix } from "../../opencode-server-auth"
 import { shellEscapeForDoubleQuotedCommand } from "../../shell-env"
 
 const TMUX_COMMAND_SHELL = "/bin/sh"
@@ -6,7 +7,7 @@ export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, dir
   const escapedUrl = shellEscapeForDoubleQuotedCommand(serverUrl)
   const escapedSessionId = shellEscapeForDoubleQuotedCommand(sessionId)
   const escapedDirectory = shellEscapeForDoubleQuotedCommand(directory || process.cwd())
-  return `${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
+  return `${getServerAuthEnvPrefix()}${TMUX_COMMAND_SHELL} -c "opencode attach ${escapedUrl} --session ${escapedSessionId} --dir ${escapedDirectory}"`
 }
 
 export function buildTmuxPlaceholderCommand(description: string): string {


### PR DESCRIPTION
## Summary

- Prefix generated Team Mode tmux `opencode attach` commands with `OPENCODE_SERVER_PASSWORD` when the leader process has it set.
- Keep the password shell-quoted so spaces, single quotes, and shell metacharacters are preserved safely.
- Add regression coverage for the attach command emitted to teammate panes.

## Why

Tmux visualization panes attach to the active opencode server. If that server requires `OPENCODE_SERVER_PASSWORD`, panes need the same auth secret as the leader process or attach can fail.

Closes #4409

Related to #3963 / #3966, but intentionally separated: this PR only handles auth propagation for panes that are created; #3966 handles skipped-layout diagnostics and port/server-url behavior.

## Verification

Local CI-equivalent preflight was run on latest `upstream/dev` (`de7f1d887db6f274ae67075a360cd05d45f59179`) with CI-pinned Bun `1.3.12`:

```bash
git diff --check
npm --prefix packages/lsp-tools-mcp ci
npm --prefix packages/lsp-tools-mcp run build
BUN_INSTALL_ALLOW_SCRIPTS='@ast-grep/cli @ast-grep/napi' bun install --frozen-lockfile
bun test
bun run typecheck
bun run typecheck:script
bun run build
test -f dist/index.js
test -f dist/index.d.ts
bun test src/shared/dist-bundle-bun-globals.test.ts
```

All passed locally before publication.