### PR TITLE
fix(team-mode): keep tmux rollback cleanup pane-scoped

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -380,6 +380,26 @@ describe("team-layout-tmux", () => {
     expect(commands.some((args) => args[0] === "kill-session")).toBe(false)
   })
 
+  test("#given ownedSession=false and paneIds #when removeTeamLayout runs #then it kills panes instead of the caller window", async () => {
+    // given
+    const { removeTeamLayout } = await loadLayoutModule()
+
+    // when
+    await removeTeamLayout("run-cleanup", {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "test-session:0",
+      paneIds: ["%10", "%11"],
+    }, tmuxMgr as never)
+
+    // then
+    const commands = getCommands()
+    expect(commands).toContainEqual(["kill-pane", "-t", "%10"])
+    expect(commands).toContainEqual(["kill-pane", "-t", "%11"])
+    expect(commands.some((args) => args[0] === "kill-window")).toBe(false)
+    expect(commands.some((args) => args[0] === "kill-session")).toBe(false)
+  })
+
   test("#given ownedSession=true, targetSessionId='omo-team-xyz' #when removeTeamLayout runs #then kill-session is called with -t omo-team-xyz (legacy behavior preserved)", async () => {
     // given
     const { removeTeamLayout } = await loadLayoutModule()

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/activate-team-layout.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/activate-team-layout.test.ts
@@ -126,6 +126,7 @@ describe("activateTeamLayout", () => {
       targetSessionId: "$caller",
       focusWindowId: "@10",
       gridWindowId: "@11",
+      paneIds: ["%11", "%21"],
     })
   })
 

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/activate-team-layout.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/activate-team-layout.ts
@@ -35,6 +35,10 @@ export async function activateTeamLayout(
   )
   if (!layout) return false
   const normalizedLayout = normalizeTeamLayout(runtimeState.teamRunId, layout)
+  const paneIds = [
+    ...Object.values(normalizedLayout.focusPanesByMember),
+    ...Object.values(normalizedLayout.gridPanesByMember),
+  ]
 
   await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
     ...currentState,
@@ -43,6 +47,7 @@ export async function activateTeamLayout(
       targetSessionId: normalizedLayout.targetSessionId,
       focusWindowId: normalizedLayout.focusWindowId,
       gridWindowId: normalizedLayout.gridWindowId,
+      ...(paneIds.length > 0 ? { paneIds } : {}),
     },
     members: currentState.members.map((member) => ({
       ...member,

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/cleanup-team-run-resources.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/cleanup-team-run-resources.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
@@ -8,6 +8,7 @@ import path from "node:path"
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import { TeamModeConfigSchema } from "../../../config/schema/team-mode"
 import type { BackgroundManager } from "../../background-agent/manager"
+import * as layoutModule from "../team-layout-tmux/layout"
 import {
   clearTeamSessionRegistry,
   lookupTeamSession,
@@ -49,6 +50,7 @@ function createStubBgMgr(): BackgroundManager {
 
 describe("cleanupTeamRunResources", () => {
   afterEach(async () => {
+    mock.restore()
     clearTeamSessionRegistry()
     await Promise.all(temporaryDirectories.splice(0).map(async (directoryPath) => rm(directoryPath, { recursive: true, force: true })))
   })
@@ -77,5 +79,80 @@ describe("cleanupTeamRunResources", () => {
     expect(lookupTeamSession("lead-session")).toBeUndefined()
     expect(lookupTeamSession("worker-session")).toBeUndefined()
     expect(lookupTeamSession("other-team-session")).toEqual({ teamRunId: "other-team", memberName: "solo", role: "member" })
+  })
+
+  test("uses persisted pane IDs for rollback layout cleanup so caller tmux windows are not killed", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "cleanup-team-run-layout-"))
+    temporaryDirectories.push(baseDir)
+    const teamRunId = "44444444-4444-4444-8444-444444444444"
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState({
+      ...createRuntimeState(teamRunId),
+      tmuxLayout: {
+        ownedSession: false,
+        targetSessionId: "$caller",
+        focusWindowId: "test-session:0",
+        paneIds: ["%10", "%11"],
+      },
+    }, createConfig(baseDir))
+    const removeTeamLayoutSpy = spyOn(layoutModule, "removeTeamLayout").mockResolvedValue(undefined)
+
+    // when
+    await cleanupTeamRunResources({
+      teamRunId,
+      config: createConfig(baseDir),
+      resources: [{}],
+      bgMgr: createStubBgMgr(),
+      tmuxMgr: { getServerUrl: () => "http://127.0.0.1:12345" } as never,
+      createdLayout: true,
+    })
+
+    // then
+    expect(removeTeamLayoutSpy).toHaveBeenCalledWith(teamRunId, {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "test-session:0",
+      paneIds: ["%10", "%11"],
+    }, expect.anything())
+  })
+
+  test("falls back to member pane IDs for rollback cleanup when older runtime state lacks layout paneIds", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "cleanup-team-run-layout-legacy-"))
+    temporaryDirectories.push(baseDir)
+    const teamRunId = "55555555-5555-4555-8555-555555555555"
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState({
+      ...createRuntimeState(teamRunId),
+      tmuxLayout: {
+        ownedSession: false,
+        targetSessionId: "$caller",
+        focusWindowId: "test-session:0",
+      },
+      members: [
+        { name: "lead", agentType: "leader", tmuxPaneId: "%0", status: "running", pendingInjectedMessageIds: [] },
+        { name: "worker-1", agentType: "general-purpose", tmuxPaneId: "%10", tmuxGridPaneId: "%11", status: "running", pendingInjectedMessageIds: [] },
+      ],
+    }, createConfig(baseDir))
+    const removeTeamLayoutSpy = spyOn(layoutModule, "removeTeamLayout").mockResolvedValue(undefined)
+
+    // when
+    await cleanupTeamRunResources({
+      teamRunId,
+      config: createConfig(baseDir),
+      resources: [{}],
+      bgMgr: createStubBgMgr(),
+      tmuxMgr: { getServerUrl: () => "http://127.0.0.1:12345" } as never,
+      createdLayout: true,
+    })
+
+    // then
+    expect(removeTeamLayoutSpy).toHaveBeenCalledWith(teamRunId, {
+      ownedSession: false,
+      targetSessionId: "$caller",
+      focusWindowId: "test-session:0",
+      paneIds: ["%10", "%11"],
+    }, expect.anything())
   })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/cleanup-team-run-resources.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/cleanup-team-run-resources.ts
@@ -18,6 +18,22 @@ function normalizeError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
 }
 
+function getLayoutCleanupTarget(runtimeState: Awaited<ReturnType<typeof loadRuntimeState>>) {
+  if (!runtimeState.tmuxLayout) return undefined
+  if (runtimeState.tmuxLayout.paneIds && runtimeState.tmuxLayout.paneIds.length > 0) {
+    return runtimeState.tmuxLayout
+  }
+
+  const paneIds = runtimeState.members.flatMap((member) => {
+    const ids = [member.tmuxPaneId, member.tmuxGridPaneId].filter((paneId): paneId is string => Boolean(paneId))
+    return member.agentType === "leader" ? [] : ids
+  })
+
+  return paneIds.length > 0
+    ? { ...runtimeState.tmuxLayout, paneIds }
+    : runtimeState.tmuxLayout
+}
+
 export async function cleanupTeamRunResources(args: {
   teamRunId: string
   config: TeamModeConfig
@@ -60,7 +76,7 @@ export async function cleanupTeamRunResources(args: {
   if (args.createdLayout && args.tmuxMgr) {
     try {
       const runtimeState = await loadRuntimeState(args.teamRunId, args.config)
-      await removeTeamLayout(args.teamRunId, runtimeState.tmuxLayout, args.tmuxMgr)
+      await removeTeamLayout(args.teamRunId, getLayoutCleanupTarget(runtimeState), args.tmuxMgr)
       cleanupReport.removedLayout = true
     } catch (layoutError) {
       cleanupReport.errors.push(`layout ${args.teamRunId}: ${normalizeError(layoutError).message}`)

--- a/packages/omo-opencode/src/features/team-mode/types.ts
+++ b/packages/omo-opencode/src/features/team-mode/types.ts
@@ -169,6 +169,7 @@ const RuntimeStateTmuxLayoutSchema = z.object({
   targetSessionId: z.string(),
   focusWindowId: z.string().optional(),
   gridWindowId: z.string().optional(),
+  paneIds: z.array(z.string()).optional(),
 }).strict()
 
 export const RuntimeStateSchema = z.object({


### PR DESCRIPTION
## Summary

- persist the tmux pane IDs created by team-mode visualization in `runtimeState.tmuxLayout`
- make team-create rollback cleanup pass pane IDs into `removeTeamLayout()` instead of only window IDs
- retain compatibility for older runtime state by deriving pane IDs from member `tmuxPaneId` / `tmuxGridPaneId`
- add regression coverage that `ownedSession: false` cleanup kills panes, not the caller tmux window

Fixes #4411.

## Related scan

This came from a fresh scan of open team/tmux issues and PRs. It is intentionally narrower than:

- #4035 / #4024: stale visible pane output and live-tail design
- #3963 / #3966: skipped tmux pane creation when the server URL is not reachable
- #3839 / #4353: silent pane creation failures
- #4213 / #4313: attach readiness / disappearing panes

This PR only addresses rollback cleanup safety for panes already created inside the caller tmux window.

## Root cause

Team-mode tmux visualization now uses the caller tmux window (`ownedSession: false`). Normal team deletion augments layout cleanup with member pane IDs, but create rollback passed `runtimeState.tmuxLayout` directly. Because that persisted layout did not include pane IDs, rollback cleanup could fall back to `kill-window -t <caller-window>` instead of killing only OMO-created teammate panes.

## Validation

- `bun test src/features/team-mode/team-runtime/activate-team-layout.test.ts src/features/team-mode/team-runtime/cleanup-team-run-resources.test.ts src/features/team-mode/team-layout-tmux/layout.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun run typecheck:script`
- `bun run build`
- `bun test`
- `npm --prefix packages/lsp-tools-mcp ci`
- `npm --prefix packages/lsp-tools-mcp run build`
- `test -f dist/index.js`
- `test -f dist/index.d.ts`
- `bun test src/shared/dist-bundle-bun-globals.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects caller tmux windows during team-mode rollback by scoping cleanup to OMO-created panes (`ownedSession: false`). We now persist pane IDs and prefer them during rollback; closes #4411.

- **Bug Fixes**
  - Persist `paneIds` in `runtimeState.tmuxLayout` (from focus and grid panes) during `activateTeamLayout`.
  - Pass `paneIds` to `removeTeamLayout` on rollback; if missing, derive from member `tmuxPaneId`/`tmuxGridPaneId` (excluding leader).
  - When `paneIds` are present, `removeTeamLayout` kills panes instead of the caller window; legacy `ownedSession: true` still `kill-session`.
  - Added tests for pane-scoped cleanup and the fallback path.

<sup>Written for commit 9339faafdb54eaf739aeada633bd5042ca81e14b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

