### PR TITLE
fix: 5 critical blockers from pre-publish ultradebate (v4.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           test -f dist/index.d.ts || (echo "ERROR: dist/index.d.ts not found!" && exit 1)
 
       - name: Verify dist bundle tests
-        run: bun test src/shared/dist-bundle-bun-globals.test.ts
+        run: bun test src/shared/dist-bundle-bun-globals.test.ts src/shared/dist-bundle-prompt-content.test.ts
 
       - name: Auto-commit schema changes
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -1,5 +1,8 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 import { ParentWakeNotifier } from "./parent-wake-notifier"
 
 type PromptAsyncCall = {
@@ -16,12 +19,11 @@ type PromptAsyncCall = {
 type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
 
 describe("ParentWakeNotifier — assistant turn blocking", () => {
-  test("#given stale unfinished assistant text turn blocks the parent #when flushing pending wake #then stale tool escape does not dispatch", async () => {
+  test("#given stale unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake dispatches after defer max", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
-    const promptAsyncCalls: PromptAsyncCall[] = []
-    const client: ParentWakeClient = {
+    const client = unsafeTestValue<ParentWakeClient>({
       session: {
         messages: async () => ({
           data: [
@@ -31,17 +33,16 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
                 finish: "unknown",
                 time: { created: 90_000 },
               },
-              parts: [{ type: "reasoning", text: "still streaming" }],
+              parts: [{ type: "text", text: "still streaming" }],
             },
           ],
         }),
-        status: async () => ({ data: { "parent-unfinished-text": { type: "idle" } } }),
-        promptAsync: async (call: PromptAsyncCall) => {
-          promptAsyncCalls.push(call)
+        status: async () => ({ data: { "parent-stale-text": { type: "idle" } } }),
+        promptAsync: async () => {
           return { data: {} }
         },
       },
-    }
+    })
     const notifier = new ParentWakeNotifier(
       {
         client,
@@ -59,12 +60,12 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       },
     )
     notifier.queuePendingParentWake(
-      "parent-unfinished-text",
+      "parent-stale-text",
       "task complete",
       { agent: "sisyphus" },
       true,
     )
-    const pendingWake = notifier.getPendingParentWakes().get("parent-unfinished-text")
+    const pendingWake = notifier.getPendingParentWakes().get("parent-stale-text")
     expect(pendingWake).toBeDefined()
     if (!pendingWake) {
       throw new Error("Missing pending parent wake")
@@ -73,11 +74,76 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
 
     try {
       // when
-      await notifier.flushPendingParentWake("parent-unfinished-text")
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-stale-text", pendingWake)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-unfinished-text")).toBe(true)
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given fresh unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake continues deferring", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "unknown",
+                time: { created: 99_000 },
+              },
+              parts: [{ type: "text", text: "still streaming" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-fresh-text": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-fresh-text",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 98_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-fresh-text", pendingWake)
+
+      // then
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -89,7 +155,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     // given
     const promptAsyncCalls: PromptAsyncCall[] = []
     let messageReads = 0
-    const client: ParentWakeClient = {
+    const client = unsafeTestValue<ParentWakeClient>({
       session: {
         messages: async () => {
           messageReads += 1
@@ -115,7 +181,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
           return { data: {} }
         },
       },
-    }
+    })
     const notifier = new ParentWakeNotifier(
       {
         client,

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -560,16 +560,24 @@ export class ParentWakeNotifier {
     const latestToolWaitAgeMs = toolWaitState.createdAt === undefined
       ? 0
       : now - toolWaitState.createdAt
+    const deferAge = now - wake.toolCallDeferralStartedAt
     if (
       wake.shouldReply
       && toolWaitState.waiting
-      && now - wake.toolCallDeferralStartedAt >= this.options.toolCallDeferMaxMs
+      && deferAge >= this.options.toolCallDeferMaxMs
       && latestToolWaitAgeMs >= this.options.toolCallDeferMaxMs
     ) {
       log("[background-agent] Sending parent wake after stale tool-call deferral window:", {
         sessionID,
       })
       return { defer: false, skipPromptGateToolStateCheck: true }
+    }
+    if (!toolWaitState.waiting && deferAge >= this.options.toolCallDeferMaxMs) {
+      log("[background-agent] Sending parent wake after stale assistant-text deferral window:", {
+        sessionID,
+        deferAgeMs: deferAge,
+      })
+      return { defer: false, skipPromptGateToolStateCheck: false }
     }
     log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
       sessionID,

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -45,6 +45,7 @@ export function createLoopStateController(options: {
 				completion_promise: initialCompletionPromise,
 				initial_completion_promise: initialCompletionPromise,
 				verification_attempt_id: undefined,
+				verification_attempt_started_at: undefined,
 				verification_session_id: undefined,
 				ultrawork: loopOptions?.ultrawork,
 				verification_pending: undefined,
@@ -139,6 +140,7 @@ export function createLoopStateController(options: {
 			state.verification_pending = true
 			state.completion_promise = ULTRAWORK_VERIFICATION_PROMISE
 			state.verification_attempt_id = undefined
+			state.verification_attempt_started_at = undefined
 			state.verification_session_id = undefined
 			state.initial_completion_promise ??= DEFAULT_COMPLETION_PROMISE
 
@@ -156,6 +158,7 @@ export function createLoopStateController(options: {
 			}
 
 			state.verification_session_id = verificationSessionID
+			state.verification_attempt_started_at = undefined
 
 			if (!writeState(directory, state, stateDir)) {
 				return null
@@ -175,6 +178,7 @@ export function createLoopStateController(options: {
 			state.completion_promise = state.initial_completion_promise ?? DEFAULT_COMPLETION_PROMISE
 			state.verification_pending = undefined
 			state.verification_attempt_id = undefined
+			state.verification_attempt_started_at = undefined
 			state.verification_session_id = undefined
 			if (typeof messageCountAtStart === "number") {
 				state.message_count_at_start = messageCountAtStart
@@ -197,6 +201,7 @@ export function createLoopStateController(options: {
 			state.completion_promise = state.initial_completion_promise ?? DEFAULT_COMPLETION_PROMISE
 			state.verification_pending = undefined
 			state.verification_attempt_id = undefined
+			state.verification_attempt_started_at = undefined
 			state.verification_session_id = undefined
 			if (typeof messageCountAtStart === "number") {
 				state.message_count_at_start = messageCountAtStart

--- a/src/hooks/ralph-loop/pending-verification-handler.ts
+++ b/src/hooks/ralph-loop/pending-verification-handler.ts
@@ -7,6 +7,8 @@ import { handleFailedVerification } from "./verification-failure-handler"
 import { withTimeout } from "./with-timeout"
 import type { IterationCommitExpectation } from "./types"
 
+export const STUCK_VERIFICATION_TIMEOUT_MS = 30 * 60 * 1000
+
 type OpenCodeSessionMessage = {
 	info?: { role?: string }
 	parts?: Array<{ type?: string; text?: string }>
@@ -138,12 +140,25 @@ export async function handlePendingVerification(
 		}
 
 		if (state.verification_attempt_id && !state.verification_session_id) {
-			log(`[${HOOK_NAME}] Skipped verification failure: oracle dispatch in flight`, {
-				sessionID,
-				verificationAttemptId: state.verification_attempt_id,
-				iteration: state.iteration,
-			})
-			return
+			const startedAt = state.verification_attempt_started_at
+			const attemptAgeMs = startedAt !== undefined ? Date.now() - startedAt : undefined
+			const isStuck = attemptAgeMs !== undefined && attemptAgeMs > STUCK_VERIFICATION_TIMEOUT_MS
+
+			if (isStuck) {
+				log(`[${HOOK_NAME}] Stuck oracle dispatch detected, proceeding to failure handler`, {
+					sessionID,
+					verificationAttemptId: state.verification_attempt_id,
+					attemptAgeMs,
+					iteration: state.iteration,
+				})
+			} else {
+				log(`[${HOOK_NAME}] Skipped verification failure: oracle dispatch in flight`, {
+					sessionID,
+					verificationAttemptId: state.verification_attempt_id,
+					iteration: state.iteration,
+				})
+				return
+			}
 		}
 
 		const restarted = await handleFailedVerification(ctx, {

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -41,6 +41,7 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
     }
 
     const ultrawork = data.ultrawork === true || data.ultrawork === "true" ? true : undefined
+    const verificationAttemptStartedAt = Number(data.verification_attempt_started_at)
     const maxIterations =
       data.max_iterations === undefined || data.max_iterations === ""
         ? ultrawork
@@ -65,6 +66,12 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
       verification_attempt_id: data.verification_attempt_id
         ? stripQuotes(data.verification_attempt_id)
         : undefined,
+      verification_attempt_started_at:
+        data.verification_attempt_started_at === undefined || data.verification_attempt_started_at === ""
+          ? undefined
+          : Number.isFinite(verificationAttemptStartedAt)
+            ? verificationAttemptStartedAt
+            : undefined,
       verification_session_id: data.verification_session_id
         ? stripQuotes(data.verification_session_id)
         : undefined,
@@ -106,8 +113,18 @@ export function writeState(
     const initialCompletionPromiseLine = state.initial_completion_promise
       ? `initial_completion_promise: "${state.initial_completion_promise}"\n`
       : ""
+    const existingState = readState(directory, customPath)
+    const verificationAttemptStartedAt = state.verification_session_id || !state.verification_attempt_id
+      ? undefined
+      : state.verification_attempt_started_at
+        ?? (existingState?.verification_attempt_id !== state.verification_attempt_id
+          ? Date.now()
+          : existingState.verification_attempt_started_at)
     const verificationAttemptLine = state.verification_attempt_id
       ? `verification_attempt_id: "${state.verification_attempt_id}"\n`
+      : ""
+    const verificationAttemptStartedAtLine = typeof verificationAttemptStartedAt === "number"
+      ? `verification_attempt_started_at: ${verificationAttemptStartedAt}\n`
       : ""
     const verificationSessionLine = state.verification_session_id
       ? `verification_session_id: "${state.verification_session_id}"\n`
@@ -124,7 +141,7 @@ export function writeState(
 active: ${state.active}
 iteration: ${state.iteration}
 ${maxIterationsLine}completion_promise: "${state.completion_promise}"
-${initialCompletionPromiseLine}${verificationAttemptLine}${verificationSessionLine}started_at: "${state.started_at}"
+${initialCompletionPromiseLine}${verificationAttemptLine}${verificationAttemptStartedAtLine}${verificationSessionLine}started_at: "${state.started_at}"
 ${sessionIdLine}${ultraworkLine}${verificationPendingLine}${strategyLine}${messageCountAtStartLine}---
 ${state.prompt}
 `

--- a/src/hooks/ralph-loop/stuck-oracle-dispatch-recovery.test.ts
+++ b/src/hooks/ralph-loop/stuck-oracle-dispatch-recovery.test.ts
@@ -1,0 +1,138 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { handlePendingVerification, STUCK_VERIFICATION_TIMEOUT_MS } from "./pending-verification-handler"
+import type { RalphLoopState } from "./types"
+
+const NOW_MS = 1_800_000_000_000
+
+type PendingVerificationInput = Parameters<typeof handlePendingVerification>[1]
+type LoopStateController = PendingVerificationInput["loopState"]
+
+function createState(verificationAttemptStartedAt?: number): RalphLoopState {
+	const state: RalphLoopState = {
+		active: true,
+		iteration: 2,
+		completion_promise: "<ulw-verification>",
+		initial_completion_promise: "<promise>DONE</promise>",
+		started_at: "2026-01-01T00:00:00.000Z",
+		prompt: "Ship release blockers",
+		session_id: "session-123",
+		ultrawork: true,
+		verification_pending: true,
+		verification_attempt_id: "attempt-123",
+	}
+
+	if (verificationAttemptStartedAt === undefined) {
+		return state
+	}
+
+	return {
+		...state,
+		verification_attempt_started_at: verificationAttemptStartedAt,
+	}
+}
+
+function createPluginInput(promptCalls: string[]): PluginInput {
+	return unsafeTestValue<PluginInput>({
+		client: {
+			session: {
+				messages: async () => ({ data: [] }),
+				promptAsync: async (input: unknown) => {
+					promptCalls.push(JSON.stringify(input) ?? "")
+					return {}
+				},
+				abort: async () => ({}),
+			},
+			tui: {
+				showToast: async () => ({}),
+			},
+		},
+		directory: "/tmp/ralph-loop-stuck-oracle-test",
+	})
+}
+
+function createLoopStateController(state: RalphLoopState) {
+	const clearVerificationState = mock<LoopStateController["clearVerificationState"]>(() => state)
+	const incrementIteration = mock<LoopStateController["incrementIteration"]>(() => state)
+	const loopState = {
+		restartAfterFailedVerification: mock<LoopStateController["restartAfterFailedVerification"]>(() => null),
+		clearVerificationState,
+		incrementIteration,
+		clear: mock<LoopStateController["clear"]>(() => true),
+		setVerificationSessionID: mock<LoopStateController["setVerificationSessionID"]>(() => null),
+	} satisfies LoopStateController
+
+	return { loopState, clearVerificationState, incrementIteration }
+}
+
+async function runPendingVerification(state: RalphLoopState, loopState: LoopStateController, promptCalls: string[]) {
+	await handlePendingVerification(createPluginInput(promptCalls), {
+		sessionID: "session-123",
+		state,
+		matchesParentSession: true,
+		matchesVerificationSession: false,
+		loopState,
+		directory: "/tmp/ralph-loop-stuck-oracle-test",
+		apiTimeoutMs: 100,
+	})
+}
+
+describe("ralph-loop stuck oracle dispatch recovery", () => {
+	const realDateNow = Date.now
+
+	beforeEach(() => {
+		Date.now = () => NOW_MS
+	})
+
+	afterEach(() => {
+		Date.now = realDateNow
+		releaseAllPromptAsyncReservationsForTesting()
+	})
+
+	test("#given verification attempt is recent and no verification session exists #when pending verification is handled #then handler returns early", async () => {
+		// given
+		const promptCalls: string[] = []
+		const state = createState(NOW_MS - 1_000)
+		const { loopState, clearVerificationState, incrementIteration } = createLoopStateController(state)
+
+		// when
+		await runPendingVerification(state, loopState, promptCalls)
+
+		// then
+		expect(promptCalls).toHaveLength(0)
+		expect(clearVerificationState).not.toHaveBeenCalled()
+		expect(incrementIteration).not.toHaveBeenCalled()
+	})
+
+	test("#given verification attempt is older than stuck timeout and no verification session exists #when pending verification is handled #then handler proceeds to failed verification recovery", async () => {
+		// given
+		const promptCalls: string[] = []
+		const state = createState(NOW_MS - STUCK_VERIFICATION_TIMEOUT_MS - 1)
+		const { loopState, clearVerificationState, incrementIteration } = createLoopStateController(state)
+
+		// when
+		await runPendingVerification(state, loopState, promptCalls)
+
+		// then
+		expect(promptCalls).toHaveLength(1)
+		expect(clearVerificationState).toHaveBeenCalledTimes(1)
+		expect(incrementIteration).toHaveBeenCalledTimes(1)
+	})
+
+	test("#given legacy verification attempt has no start timestamp and no verification session exists #when pending verification is handled #then handler returns early", async () => {
+		// given
+		const promptCalls: string[] = []
+		const state = createState()
+		const { loopState, clearVerificationState, incrementIteration } = createLoopStateController(state)
+
+		// when
+		await runPendingVerification(state, loopState, promptCalls)
+
+		// then
+		expect(promptCalls).toHaveLength(0)
+		expect(clearVerificationState).not.toHaveBeenCalled()
+		expect(incrementIteration).not.toHaveBeenCalled()
+	})
+})

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -8,6 +8,7 @@ export interface RalphLoopState {
   completion_promise: string
   initial_completion_promise?: string
   verification_attempt_id?: string
+  verification_attempt_started_at?: number
   verification_session_id?: string
   started_at: string
   prompt: string

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -111,6 +111,83 @@ describe("runtime-fallback error classifier", () => {
     expect(retryable).toBe(true)
   })
 
+  test("isRetryableError REJECTS isRetryable=true when status code is 401 Unauthorized", () => {
+    //#given
+    const error = { error: { statusCode: 401, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(false)
+  })
+
+  test("isRetryableError REJECTS isRetryable=true when status code is 403 Forbidden", () => {
+    //#given
+    const error = { error: { statusCode: 403, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(false)
+  })
+
+  test("isRetryableError REJECTS isRetryable=true when status code is 404 Not Found", () => {
+    //#given
+    const error = { error: { statusCode: 404, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(false)
+  })
+
+  test("isRetryableError HONORS isRetryable=true when status code is 429 (rate-limit)", () => {
+    //#given
+    const error = { error: { statusCode: 429, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("isRetryableError HONORS isRetryable=true when status code is 503 (service unavailable)", () => {
+    //#given
+    const error = { error: { statusCode: 503, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("isRetryableError HONORS isRetryable=true when no status code is present (pure network error)", () => {
+    //#given
+    const error = { error: { isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("isRetryableError HONORS isRetryable=true when status code is in retryOnErrors list", () => {
+    //#given
+    const error = { error: { statusCode: 400, isRetryable: true } }
+
+    //#when
+    const retryable = isRetryableError(error, [400, 429, 503, 529])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
   test("ignores malformed retryable flags on otherwise non-retryable errors", () => {
     //#given
     const error = {

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_CONFIG, RETRYABLE_ERROR_PATTERNS } from "./constants"
+import { DEFAULT_CONFIG, HOOK_NAME, RETRYABLE_ERROR_PATTERNS } from "./constants"
+import { log } from "../../shared/logger"
 
 export { extractAutoRetrySignal } from "./auto-retry-signal"
 
@@ -119,6 +120,10 @@ export function extractRetryableSignal(error: unknown): boolean | undefined {
   return undefined
 }
 
+function isStatusCodeRetrySafe(code: number, retryOnErrors: number[]): boolean {
+  return retryOnErrors.includes(code) || (code >= 500 && code < 600) || code === 408 || code === 425 || code === 429
+}
+
 function isLocalizedQuotaExhaustionMessage(message: string): boolean {
   return (
     (/预扣费额度失败/i.test(message) && /用户剩余额度/i.test(message)) ||
@@ -221,8 +226,16 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
     return true
   }
 
-  if (extractRetryableSignal(error) === true) {
-    return true
+  const retryableSignal = extractRetryableSignal(error)
+  if (retryableSignal === true) {
+    if (statusCode === undefined || isStatusCodeRetrySafe(statusCode, retryOnErrors)) {
+      return true
+    }
+
+    log(`[${HOOK_NAME}] Retryable signal rejected due to unsafe status code`, {
+      statusCode,
+      retryOnErrors,
+    })
   }
 
   return RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(message))

--- a/src/shared/dist-bundle-prompt-content.test.ts
+++ b/src/shared/dist-bundle-prompt-content.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+const DIST_INDEX = "dist/index.js"
+const SKIP_MESSAGE = "[skipped - dist not built]"
+
+const PROMPT_SIGNATURES = [
+  {
+    path: "packages/prompts-core/prompts/ultrawork/default.md",
+    label: "Ultrawork default",
+    signature: "ULTRAWORK MODE ENABLED!",
+  },
+  {
+    path: "packages/prompts-core/prompts/ultrawork/gemini.md",
+    label: "Ultrawork Gemini",
+    signature: "ULTRAWORK MODE ENABLED!",
+  },
+  {
+    path: "packages/prompts-core/prompts/ultrawork/gpt.md",
+    label: "Ultrawork GPT",
+    signature: "ULTRAWORK MODE ENABLED!",
+  },
+  {
+    path: "packages/prompts-core/prompts/atlas/default.md",
+    label: "Atlas default",
+    signature: "You are Atlas - the Master Orchestrator from OhMyOpenCode.",
+  },
+  {
+    path: "packages/prompts-core/prompts/atlas/gemini.md",
+    label: "Atlas Gemini",
+    signature: "Your value is ORCHESTRATION, not coding.",
+  },
+  {
+    path: "packages/prompts-core/prompts/atlas/gpt.md",
+    label: "Atlas GPT",
+    signature: "This prompt is outcome-first. Choose the most efficient path to the outcomes above.",
+  },
+  {
+    path: "packages/prompts-core/prompts/atlas/kimi.md",
+    label: "Atlas Kimi",
+    signature: "Trust the trained prior on the hard 30% (verification reasoning, failure diagnosis, dependency analysis).",
+  },
+  {
+    path: "packages/prompts-core/prompts/atlas/opus-4-7.md",
+    label: "Atlas Opus 4.7",
+    signature: "Opus 4.7 spawns fewer subagents than Opus 4.6 unless told otherwise.",
+  },
+  {
+    path: "packages/prompts-core/prompts/prometheus/default.md",
+    label: "Prometheus default",
+    signature: "YOU ARE A PLANNER. YOU ARE NOT AN IMPLEMENTER. YOU DO NOT WRITE CODE. YOU DO NOT EXECUTE TASKS.",
+  },
+  {
+    path: "packages/prompts-core/prompts/prometheus/gemini.md",
+    label: "Prometheus Gemini",
+    signature: "If you feel the urge to write code or implement something - STOP. That is NOT your job.",
+  },
+  {
+    path: "packages/prompts-core/prompts/prometheus/gpt.md",
+    label: "Prometheus GPT",
+    signature: "YOU ARE A PLANNER. NOT AN IMPLEMENTER. NOT A CODE WRITER.",
+  },
+  {
+    path: "packages/prompts-core/prompts/mode/search.md",
+    label: "Search mode",
+    signature: "MAXIMIZE SEARCH EFFORT. Launch multiple background agents IN PARALLEL:",
+  },
+  {
+    path: "packages/prompts-core/prompts/mode/analyze.md",
+    label: "Analyze mode",
+    signature: "IF COMPLEX - DO NOT STRUGGLE ALONE. Consult specialists:",
+  },
+  {
+    path: "packages/prompts-core/prompts/mode/team.md",
+    label: "Team mode",
+    signature: "Team-mode reference detected. Orchestrate via team_* tools",
+  },
+  {
+    path: "packages/prompts-core/prompts/mode/hyperplan.md",
+    label: "Hyperplan mode",
+    signature: "HYPERPLAN MODE ENABLED!",
+  },
+] as const
+
+describe("dist bundle prompt content", () => {
+  test("#given dist bundle #when scanned #then markdown prompt signatures are inlined", async () => {
+    const distIndex = Bun.file(DIST_INDEX)
+    if (!(await distIndex.exists())) {
+      console.info(SKIP_MESSAGE)
+      return
+    }
+
+    const bundle = await distIndex.text()
+
+    for (const prompt of PROMPT_SIGNATURES) {
+      expect(
+        bundle.includes(prompt.signature),
+        `${prompt.label} prompt content missing from dist/index.js (${prompt.path}): markdown inlining may have regressed`,
+      ).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes the 5 critical blockers surfaced by the 3-round adversarial pre-publish review of v4.4.0..HEAD. All 5 had unanimous **STANDS** verdicts from the surviving 3-member team (skeptic + validator + architect) and were rated as either CRITICAL (liveness/correctness) or HIGH (release-safety).

## The 5 blockers

### CRITICAL — liveness/correctness
- **V8** (commit f05e0cbe9): `extractRetryableSignal` would honor `isRetryable: true` from a provider's AI SDK error even for 401/403/422 etc., causing the runtime-fallback hook to burn every configured fallback model in an infinite loop. Now gated on a status-code allowlist (5xx, configured retry codes, 408/425/429, or absent status).
- **V11** (commit 69c955f61): `parent-wake-notifier` deferred forever when the assistant had unfinished text but no pending tool call (session crashed/abandoned mid-stream). The escape required `toolWaitState.waiting`. Added a parallel escape that fires after `toolCallDeferMaxMs` regardless of tool wait state.
- **V25** (commit 14b3523af): `pending-verification-handler` in ralph-loop returned early forever when `verification_attempt_id` was set but `verification_session_id` was never written by `tool-execute-after` (oracle hang/crash/external-kill). Tracks `verification_attempt_started_at`; falls through to `handleFailedVerification` after 30 minutes.

### HIGH — release safety net
- **V1 + V33** (commit 3e0a975d1): No CI test verified that the built `dist/index.js` actually contains the inlined markdown prompts. `bun test` runs from source; a future Bun upgrade that silently regresses `.md` inlining would pass source tests but produce a broken npm bundle with no fallback (TS prompts deleted in the migration). Added a smoke test that scans `dist/index.js` for 15 unique signature strings from each migrated prompt file (3 ultrawork + 5 atlas + 3 prometheus + 4 mode), wired into the existing `Verify dist bundle tests` step in CI.

### BLOCKING SEMVER — release-management decision
- **V29**: `package.json` is still `4.4.0`. **This release must be dispatched as `minor` (→ 4.5.0)** when publishing — 60 commits include `feat(ultrawork): enforce TDD…` and `feat(prompts-core): …` so `patch` (→ 4.4.1) would be semver-misleading. No code change; the publish workflow takes the bump type as a manual dispatch input. **Reminder for the release dispatcher: pick `minor`, not `patch`.**

## Per-commit changes

| Commit | Files | LOC |
|---|---|---|
| `f05e0cbe9` fix(runtime-fallback) | error-classifier.ts, error-classifier.test.ts | +93 −3 |
| `69c955f61` fix(parent-wake) | parent-wake-notifier.ts, parent-wake-assistant-blocking.test.ts | +90 −16 |
| `14b3523af` fix(ralph-loop) | types.ts, loop-state-controller.ts, storage.ts, pending-verification-handler.ts, stuck-oracle-dispatch-recovery.test.ts (NEW) | +183 −7 |
| `3e0a975d1` test(dist-bundle) | dist-bundle-prompt-content.test.ts (NEW), .github/workflows/ci.yml | +104 −1 |

## TDD evidence (per-fix RED → GREEN)

- **V8**: 3 RED cases (401/403/404 wrongly retryable) → 31/0 GREEN
- **V11**: 1 RED case (defers forever on unfinished text without tool wait) → 3/0 GREEN, 29/0 parent-wake regression
- **V25**: 1 RED case (stuck attempt returns early forever) → 3/0 GREEN new + 1/0 existing race-fix + 143/0 full ralph-loop regression
- **V1+V33**: Characterization test. Verified RED by temporarily breaking one signature, confirmed clear error message identifies the missing prompt file; restored. GREEN against real dist (6/0 across 2 dist bundle tests).

## Verification

- `bun run typecheck` — exit 0
- `bun run build` — succeeds; `dist/index.js` 2.41 MB
- Per-fix scoped test suites — 44/44 pass on changed areas
- Combined fix-area run — 44/44 pass
- Per-area regression check — runtime-fallback 65/65, ralph-loop 143/143, parent-wake 29/29
- LSP diagnostics clean on every changed file
- LOC ceiling — all NEW files ≤ 250 pure LOC. `parent-wake-notifier.ts` is 546 LOC pre-existing (intentionally not split as part of this fix; tracked separately as architectural debt AD-extracted into next release).

## Related

Findings from the pre-publish ultradebate session — 49 total findings across 3 surviving adversarial members (skeptic, validator, architect; researcher findings lost, creative errored at spawn). The 28 surviving insights after 3 rounds of defend/refine/concede identified these 5 as BLOCKING. Architectural debt items (7) recorded for next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five critical blockers for v4.5.0 to stop infinite fallback retries, unblock parent wake dispatch, and recover from stuck verifications. Adds a CI guard to ensure prompt markdown is bundled into `dist/index.js`.

- Bug Fixes
  - Runtime fallback: honor `isRetryable=true` only for 5xx, configured retry codes, or 408/425/429 (or no status). Prevents retry loops on 4xx like 401/403/404.
  - Parent wake: if unfinished assistant text has no pending tool call, send the wake after `toolCallDeferMaxMs` instead of deferring forever.
  - Ralph loop: track `verification_attempt_started_at`; if no verification session appears after 30 minutes, fail and recover the loop.
  - CI: add a test that scans `dist/index.js` for prompt signatures to verify markdown inlining; wired into the existing dist verification step.

- Migration
  - Publish as minor `4.5.0` in the release workflow (do not publish as a patch).

<sup>Written for commit 3e0a975d1ff209f2500f306237017cfa03ba12f0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4422?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

