### PR TITLE
feat: add project-memory layer (Ledger facts with human-approval gates)

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5911,6 +5911,9 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 9007199254740991
+        },
+        "hot_reload": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/bun.lock
+++ b/bun.lock
@@ -41,17 +41,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.3.1",
-        "oh-my-opencode-darwin-x64": "4.3.1",
-        "oh-my-opencode-darwin-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-arm64": "4.3.1",
-        "oh-my-opencode-linux-arm64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64": "4.3.1",
-        "oh-my-opencode-linux-x64-baseline": "4.3.1",
-        "oh-my-opencode-linux-x64-musl": "4.3.1",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.3.1",
-        "oh-my-opencode-windows-x64": "4.3.1",
-        "oh-my-opencode-windows-x64-baseline": "4.3.1",
+        "oh-my-opencode-darwin-arm64": "4.4.0",
+        "oh-my-opencode-darwin-x64": "4.4.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-arm64": "4.4.0",
+        "oh-my-opencode-linux-arm64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64": "4.4.0",
+        "oh-my-opencode-linux-x64-baseline": "4.4.0",
+        "oh-my-opencode-linux-x64-musl": "4.4.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.4.0",
+        "oh-my-opencode-windows-x64": "4.4.0",
+        "oh-my-opencode-windows-x64-baseline": "4.4.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -399,27 +399,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wb+XTZ0Me3yBUejhhxXaiFpvZUmjT33EmgQPSrcwVIqpW4//DGpm4n9ptsSDm4ASaPaqG+v/dfNWmaXXS4FdqQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.4.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tGwtIIbxTDeeBqTkhBII4Mf/oBLavO1sSA2ZTlqNDY2srYu8677XRxq09+AF4aoexRB6JOyPOp3hpAwrRp+MHw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VnaFatAHVNpteFW/o/dHYVr6/NNDYnNnYgIupunUsO3J5beTFYJaPL5dq+1LRRQban9By9yMbOyXj7SGxGHmtQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VqqywGHjd5dLZEEYuqKJ2OiEK+NQFK5kskfnMsHaYf/sMlp7tv/RTDvtomtwk1KWXU3rW5acYSGxLxgMlpNBoA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Hd21GQR3pF5+4sTRSxypvQUUaSINke+fsbRtUWpun3uEDGpvpBfI3gcA+6ipM/VL0Qi35wvODU1W7Nl0welujA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.4.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tw4vJnLzbSPjdwYp+4vVnb/I2SysSptATylRmexiJGxAxpcAjqxk9yejzdHAhSALY/AlslKKzdpNJ7pGnFkiCA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-veU2mfOxDH11O+biZVahIF/Tlrp2cwvlmTpL0Cl8SHMBRUb8qhAHxN545e8Val3MSU6ydUXr0Ra5eAoazcAZ5g=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-JWVfP9cze0y4eQZO9vs/5JQNmh6Bdfld0Vghwht75yQXTGIuzXw65ZjjB7/t5EMueVGt0xZJxFPGva1/Hk66Eg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rcuGLYeQ2uD60o5k54VCx/DiquIHxkACIK0KmK4IAjeNTfYpflfnEl/DfnsPpv7toWSI3XNOZwP4ig7ZfR72Pg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.4.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5ErkGwgH5o52mTZlwzc07pW7+0+S9hJXqeuqFZL5jAc8/UA0n+5pKOBT3tBF5CQdFFSNTX7FZeaCGaVQNtCvIg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dojsloeSYgu8wIZB2H7VoFDLm1sZvP+m00rWoQ6NqAW5/BlRfUtZql6JiVF31ofRzM8/UC0GJRwihtcg8piNLA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+eZA9R+zbFijTAknDT9wwR+JYCVUTVPdKnchTXLOhll+7Zyo9iVK/4Usa3s/UbWNXGz4fXbTk1ESiMQROF0Tlg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5lt3Rrkc3Y4idehke7JbMnawWZLZQjL5ghovjAlr9qsdgY5jsJEMAZW/TjgceAjTW0iAqSmtfVvVEtiPqLNk4w=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VhIsHJzVRsS+0jxY9e4ZCKvebcKIZj6Rw0pkxtYqm1xrZnPoiQzEkapoNJN2Jwr9ID2DubESl1ldOeqMhBRpSQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-26NV5DMaDETbecgw+LzjO/TpdzCnN0ZX/e74EQHFd0Z7ey7KK5p4x+dSBuY0F4NTZpFOQmbdZCJJOxyvDtUIHQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HltQLU4IGOuvVofESBLFxl6tfIkwuWWzPehoy6dkSE/OuqEzakTj85m7NDRIjmHyCLu2QVu/gKmf3wKoShEE4g=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-M+SJCWAc1QySELO3hmv3/vkRSfb7FPhUYVFi+34wBGFiywOK4jMOElyvCrEnxO3J1wGywEHgPWPaASs6f5ooIQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.4.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-baeGUFMCSFvBYjJsNY+bfu01AQdII9KG67LzgCCkFZKbARZJ6LR/1sGVNt4dxs3Bvdg3kYatpIvqozeiw1mYUA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-u38l63i/kq/vktaHsa7I+OBSoRXYWA8ExZ1tKv/d4adQuPzLfi9ruvTy+5fQ9GiDQZuRTlneenvrIYIfTJ4QYA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-MKjH5CIsMS8GDTimMpv9W+1SNgOaus9PeXC2H/hQd7BTkXZegN7JmH8mVJRLpHG4jDr432ky9O28ghRwqM76YQ=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-aeSyPkD/QDvc9x6l1q9VA4a1YwejefKzPPmuJKZAdWO6PSxdXN3nqx06+U2fR798KJbO4zNgg5vV331iMuvnqA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.4.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-VqVK+PK0dg0x+y1HxY2TVa13ulZbrYW4F2zA6JEV0nLNWRk0s7YnLQqXsm/bRNnfjsAFs+Frk5QS7mNorF79JQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/config-watcher.test.ts
+++ b/src/config-watcher.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import type { OhMyOpenCodeConfig } from "./config"
+
+const logCalls: Array<[string, unknown?]> = []
+let testConfigDir: string
+
+mock.module("./shared", () => ({
+  getOpenCodeConfigDir: (): string => testConfigDir,
+  detectConfigFile: (basePath: string): { format: string; path: string } => {
+    const jsoncPath = `${basePath}.jsonc`
+    const jsonPath = `${basePath}.json`
+    if (fs.existsSync(jsoncPath)) {
+      return { format: "jsonc", path: jsoncPath }
+    }
+    if (fs.existsSync(jsonPath)) {
+      return { format: "json", path: jsonPath }
+    }
+    return { format: "none", path: jsonPath }
+  },
+  log: (message: string, data?: unknown): void => {
+    logCalls.push([message, data])
+  },
+}))
+
+mock.module("./shared/plugin-identity", () => ({
+  CONFIG_BASENAME: "oh-my-openagent",
+  LEGACY_CONFIG_BASENAME: "oh-my-opencode",
+}))
+
+let mockLoadResult: OhMyOpenCodeConfig = {}
+let mockLoadShouldThrow = false
+
+mock.module("./plugin-config", () => ({
+  loadPluginConfig: (): OhMyOpenCodeConfig => {
+    if (mockLoadShouldThrow) {
+      throw new Error("Config parse error")
+    }
+    return mockLoadResult
+  },
+}))
+
+const { createConfigWatcher } = await import("./config-watcher")
+
+let testProjectDir: string
+
+beforeEach(() => {
+  logCalls.length = 0
+  mockLoadShouldThrow = false
+  mockLoadResult = {}
+
+  testConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-test-"))
+  testProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-project-"))
+
+  const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+  fs.writeFileSync(configFilePath, JSON.stringify({ agents: {} }))
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(testConfigDir, { recursive: true, force: true })
+  } catch {}
+  try {
+    fs.rmSync(testProjectDir, { recursive: true, force: true })
+  } catch {}
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("createConfigWatcher", () => {
+  test("#given hot_reload enabled and config file exists #when config file changes #then pluginConfig updates in place", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+    }
+
+    mockLoadResult = {
+      agents: {
+        build: { model: "openai/gpt-5.4" },
+      },
+    }
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, JSON.stringify({ agents: { build: { model: "openai/gpt-5.4" } } }))
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("openai/gpt-5.4")
+
+    dispose()
+  })
+
+  test("#given config file has parse errors #when config changes #then old config is preserved", async () => {
+    // given
+    const originalConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+    }
+    const pluginConfig: OhMyOpenCodeConfig = { ...originalConfig }
+
+    mockLoadShouldThrow = true
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, "{ invalid json }")
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("anthropic/claude-sonnet-4-20250514")
+
+    const errorLog = logCalls.find(([msg]) => msg.includes("reload failed"))
+    expect(errorLog).toBeDefined()
+
+    dispose()
+  })
+
+  test("#given watcher is active #when dispose is called #then watching stops and cleanup logged", () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    dispose()
+
+    // then
+    const disposeLog = logCalls.find(([msg]) => msg.includes("Disposed"))
+    expect(disposeLog).toBeDefined()
+  })
+
+  test("#given no config files exist #when createConfigWatcher called #then returns noop dispose", () => {
+    // given
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-watcher-empty-"))
+    const pluginConfig: OhMyOpenCodeConfig = {}
+
+    const savedDir = testConfigDir
+    testConfigDir = emptyDir
+
+    // when
+    const dispose = createConfigWatcher(emptyDir, {}, pluginConfig)
+
+    // then
+    const noFilesLog = logCalls.find(([msg]) => msg.includes("No config files found"))
+    expect(noFilesLog).toBeDefined()
+
+    dispose()
+
+    testConfigDir = savedDir
+    fs.rmSync(emptyDir, { recursive: true, force: true })
+  })
+
+  test("#given config section removed from file #when config reloads #then stale keys are deleted from pluginConfig", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      agents: {
+        build: { model: "anthropic/claude-sonnet-4-20250514" },
+      },
+      categories: {
+        quick: { model: "openai/gpt-4.1-mini" },
+      },
+    }
+
+    mockLoadResult = {
+      agents: {
+        build: { model: "openai/gpt-5.4" },
+      },
+    }
+
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    const configFilePath = path.join(testConfigDir, "oh-my-openagent.json")
+    fs.writeFileSync(configFilePath, JSON.stringify({ agents: { build: { model: "openai/gpt-5.4" } } }))
+
+    // then
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(pluginConfig.agents?.build?.model).toBe("openai/gpt-5.4")
+    expect(pluginConfig.categories).toBeUndefined()
+    expect("categories" in pluginConfig).toBe(false)
+
+    dispose()
+  })
+
+  test("#given dispose already called #when dispose called again #then no errors", () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const dispose = createConfigWatcher(testProjectDir, {}, pluginConfig)
+
+    // when
+    dispose()
+
+    // then
+    expect(() => dispose()).not.toThrow()
+  })
+})

--- a/src/config-watcher.ts
+++ b/src/config-watcher.ts
@@ -1,0 +1,181 @@
+import * as fs from "fs"
+import * as path from "path"
+import type { OhMyOpenCodeConfig } from "./config"
+import { loadPluginConfig } from "./plugin-config"
+import { getOpenCodeConfigDir, detectConfigFile, log } from "./shared"
+import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "./shared/plugin-identity"
+
+const DEBOUNCE_MS = 300
+const REATTACH_DELAY_MS = 100
+const REATTACH_MAX_RETRIES = 5
+
+export interface ConfigWatcherDispose {
+  (): void
+}
+
+function resolveConfigPaths(directory: string): string[] {
+  const paths: string[] = []
+
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+
+  const canonicalUserPath = path.join(configDir, CONFIG_BASENAME)
+  const canonicalDetected = detectConfigFile(canonicalUserPath)
+  if (canonicalDetected.format !== "none") {
+    paths.push(canonicalDetected.path)
+  } else {
+    const legacyUserPath = path.join(configDir, LEGACY_CONFIG_BASENAME)
+    const legacyDetected = detectConfigFile(legacyUserPath)
+    if (legacyDetected.format !== "none") {
+      paths.push(legacyDetected.path)
+    }
+  }
+
+  const canonicalProjectPath = path.join(directory, ".opencode", CONFIG_BASENAME)
+  const canonicalProjectDetected = detectConfigFile(canonicalProjectPath)
+  if (canonicalProjectDetected.format !== "none") {
+    paths.push(canonicalProjectDetected.path)
+  } else {
+    const legacyProjectPath = path.join(directory, ".opencode", LEGACY_CONFIG_BASENAME)
+    const legacyProjectDetected = detectConfigFile(legacyProjectPath)
+    if (legacyProjectDetected.format !== "none") {
+      paths.push(legacyProjectDetected.path)
+    }
+  }
+
+  return paths
+}
+
+function applyConfigInPlace(
+  pluginConfig: OhMyOpenCodeConfig,
+  newConfig: OhMyOpenCodeConfig,
+): void {
+  for (const key of Object.keys(pluginConfig)) {
+    if (!(key in newConfig)) {
+      delete (pluginConfig as Record<string, unknown>)[key]
+    }
+  }
+  Object.assign(pluginConfig, newConfig)
+}
+
+/**
+ * Watches user and project config files, hot-reloading plugin config on change.
+ *
+ * Handles atomic saves (write-tmp → rename) by reattaching the watcher
+ * when a rename event is detected and the file reappears.
+ *
+ * Properties that won't hot-reload (startup-snapshotted by design):
+ * - disabled_hooks, tmuxConfig, safe_hook_creation
+ */
+export function createConfigWatcher(
+  directory: string,
+  ctx: unknown,
+  pluginConfig: OhMyOpenCodeConfig,
+): ConfigWatcherDispose {
+  const watchers: fs.FSWatcher[] = []
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const configPaths = resolveConfigPaths(directory)
+
+  if (configPaths.length === 0) {
+    log("[config-watcher] No config files found to watch")
+    return () => {}
+  }
+
+  const reloadConfig = (): void => {
+    try {
+      const newConfig = loadPluginConfig(directory, ctx)
+      applyConfigInPlace(pluginConfig, newConfig)
+      log("[config-watcher] Config hot-reloaded successfully", {
+        agents: newConfig.agents,
+        categories: newConfig.categories,
+      })
+    } catch (error) {
+      log("[config-watcher] Config reload failed, keeping previous config", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const debouncedReload = (): void => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+    }
+    debounceTimer = setTimeout(reloadConfig, DEBOUNCE_MS)
+  }
+
+  const attachWatcher = (configPath: string): void => {
+    if (disposed) return
+
+    try {
+      const watcher = fs.watch(configPath, (eventType) => {
+        if (disposed) return
+
+        if (eventType === "change") {
+          log("[config-watcher] Config file changed", { path: configPath, eventType })
+          debouncedReload()
+        } else if (eventType === "rename") {
+          log("[config-watcher] Config file renamed (atomic save detected)", { path: configPath })
+          watcher.close()
+          const idx = watchers.indexOf(watcher)
+          if (idx !== -1) watchers.splice(idx, 1)
+          reattachAfterRename(configPath, 0)
+        }
+      })
+
+      watcher.on("error", (error) => {
+        log("[config-watcher] Watcher error", {
+          path: configPath,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+
+      watchers.push(watcher)
+      log("[config-watcher] Watching config file", { path: configPath })
+    } catch (error) {
+      log("[config-watcher] Failed to watch config file", {
+        path: configPath,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const reattachAfterRename = (configPath: string, attempt: number): void => {
+    if (disposed) return
+    if (attempt >= REATTACH_MAX_RETRIES) {
+      log("[config-watcher] File did not reappear after rename, giving up", { path: configPath })
+      return
+    }
+
+    setTimeout(() => {
+      if (disposed) return
+      if (fs.existsSync(configPath)) {
+        debouncedReload()
+        attachWatcher(configPath)
+      } else {
+        reattachAfterRename(configPath, attempt + 1)
+      }
+    }, REATTACH_DELAY_MS)
+  }
+
+  for (const configPath of configPaths) {
+    attachWatcher(configPath)
+  }
+
+  return (): void => {
+    disposed = true
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    for (const watcher of watchers) {
+      try {
+        watcher.close()
+      } catch {
+        // ignore close errors during dispose
+      }
+    }
+    watchers.length = 0
+    log("[config-watcher] Disposed — stopped watching config files")
+  }
+}

--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -22,6 +22,8 @@ export const ExperimentalConfigSchema = z.object({
   model_fallback_title: z.boolean().optional(),
   /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
   max_tools: z.number().int().min(1).optional(),
+  /** Enable config hot-reload: watches oh-my-opencode config files and applies changes mid-session without restart. Hot-reloads: agents, categories, experimental flags. Does NOT hot-reload: disabled_hooks, tmuxConfig, safe_hook_creation (startup-snapshotted). */
+  hot_reload: z.boolean().optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/features/project-memory/compaction.ts
+++ b/src/features/project-memory/compaction.ts
@@ -1,0 +1,19 @@
+import { isProjectMemoryEnabled, readAllFacts, getFactStats } from "./storage"
+
+export function getMemoryCompactionContext(directory: string): string | null {
+  if (!isProjectMemoryEnabled(directory)) return null
+
+  const facts = readAllFacts(directory)
+  if (facts.length === 0) return null
+
+  const { totalLines } = getFactStats(directory)
+  const factsContent = facts
+    .map((f) => `### ${f.name}\n${f.content}`)
+    .join("\n\n")
+
+  return (
+    `\n## Project Memory — Ledger Facts (${facts.length} files, ${totalLines} lines)\n\n` +
+    `These are verified long-term facts about this project. They take priority over conversation history.\n\n` +
+    factsContent
+  )
+}

--- a/src/features/project-memory/constants.ts
+++ b/src/features/project-memory/constants.ts
@@ -1,0 +1,17 @@
+import * as path from "node:path"
+
+export const MEMORY_DIR_NAME = "memory"
+export const FACTS_DIR_NAME = "facts"
+export const PROPOSALS_DIR_NAME = "proposals"
+
+export function getMemoryRoot(directory: string): string {
+  return path.join(directory, ".omo", MEMORY_DIR_NAME)
+}
+
+export function getFactsDir(directory: string): string {
+  return path.join(getMemoryRoot(directory), FACTS_DIR_NAME)
+}
+
+export function getProposalsDir(directory: string): string {
+  return path.join(getMemoryRoot(directory), PROPOSALS_DIR_NAME)
+}

--- a/src/features/project-memory/index.ts
+++ b/src/features/project-memory/index.ts
@@ -1,0 +1,5 @@
+export * from "./constants"
+export * from "./storage"
+export { createProjectMemoryTools } from "./tools"
+export { getMemoryCompactionContext } from "./compaction"
+export { getMemorySessionStartHint } from "./session-start-hint"

--- a/src/features/project-memory/omo-memory-init.sh
+++ b/src/features/project-memory/omo-memory-init.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# omo-memory-init: Bootstrap .omo/memory/ directory for project memory
+# Usage: omo-memory-init [project-dir]
+#
+# Creates the .omo/memory/{facts/,proposals/} scaffold in the target directory.
+# This activates the project memory tools (memory_facts, memory_propose_fact, etc.)
+# in oh-my-opencode sessions for that project.
+
+set -euo pipefail
+
+DIR="${1:-.}"
+MEMORY_ROOT="$DIR/.omo/memory"
+
+if [[ -d "$MEMORY_ROOT" ]]; then
+  echo "Project memory already initialized at $MEMORY_ROOT"
+  exit 0
+fi
+
+mkdir -p "$MEMORY_ROOT/facts"
+mkdir -p "$MEMORY_ROOT/proposals"
+
+# Create a starter facts file
+cat > "$MEMORY_ROOT/facts/architecture.md" << 'EOF'
+# Architecture
+
+<!-- Add verified architectural decisions for this project here. -->
+<!-- These facts are read by agents at session start and survive compaction. -->
+<!-- Facts require human approval to modify (via memory_propose_fact + memory_approve). -->
+EOF
+
+echo "✓ Project memory initialized at $MEMORY_ROOT"
+echo ""
+echo "Structure:"
+echo "  .omo/memory/"
+echo "    facts/           — Verified long-term facts (human-approved)"
+echo "    proposals/       — Pending fact proposals from agents"
+echo ""
+echo "Agents now have access to:"
+echo "  memory_facts          — Read project facts"
+echo "  memory_propose_fact   — Propose new facts (requires approval)"
+echo "  memory_proposals      — List pending proposals"
+echo "  memory_approve        — Approve a proposal"
+echo "  memory_reject         — Reject a proposal"
+echo ""
+echo "Add to .gitignore (proposals are transient):"
+echo "  .omo/memory/proposals/"

--- a/src/features/project-memory/session-start-hint.ts
+++ b/src/features/project-memory/session-start-hint.ts
@@ -1,0 +1,15 @@
+import { isProjectMemoryEnabled, getFactStats } from "./storage"
+
+export function getMemorySessionStartHint(directory: string): string | null {
+  if (!isProjectMemoryEnabled(directory)) return null
+
+  const { files, totalLines } = getFactStats(directory)
+  if (files === 0) return null
+
+  return (
+    `[Project Memory active] This project has ${files} facts file(s) (${totalLines} lines) in .omo/memory/facts/. ` +
+    `Use \`memory_facts\` to read verified long-term project knowledge. ` +
+    `Facts take priority over conversation history. ` +
+    `Use \`memory_propose_fact\` to propose new facts (requires human approval).`
+  )
+}

--- a/src/features/project-memory/storage.test.ts
+++ b/src/features/project-memory/storage.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as os from "node:os"
+
+import {
+  isProjectMemoryEnabled,
+  readAllFacts,
+  readFact,
+  getFactStats,
+  proposeFact,
+  listProposals,
+  approveProposal,
+  rejectProposal,
+} from "./storage"
+import { getMemoryCompactionContext } from "./compaction"
+import { getMemorySessionStartHint } from "./session-start-hint"
+import { createProjectMemoryTools } from "./tools"
+
+describe("project-memory", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omo-memory-test-"))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe("#given no .omo/memory/ directory", () => {
+    it("#then isProjectMemoryEnabled returns false", () => {
+      expect(isProjectMemoryEnabled(tmpDir)).toBe(false)
+    })
+
+    it("#then getMemoryCompactionContext returns null", () => {
+      expect(getMemoryCompactionContext(tmpDir)).toBeNull()
+    })
+
+    it("#then getMemorySessionStartHint returns null", () => {
+      expect(getMemorySessionStartHint(tmpDir)).toBeNull()
+    })
+  })
+
+  describe("#given .omo/memory/ exists but empty facts/", () => {
+    beforeEach(() => {
+      fs.mkdirSync(path.join(tmpDir, ".omo", "memory", "facts"), { recursive: true })
+    })
+
+    it("#then isProjectMemoryEnabled returns true", () => {
+      expect(isProjectMemoryEnabled(tmpDir)).toBe(true)
+    })
+
+    it("#then readAllFacts returns empty array", () => {
+      expect(readAllFacts(tmpDir)).toEqual([])
+    })
+
+    it("#then getMemorySessionStartHint returns null (no facts)", () => {
+      expect(getMemorySessionStartHint(tmpDir)).toBeNull()
+    })
+  })
+
+  describe("#given .omo/memory/facts/ has files", () => {
+    beforeEach(() => {
+      const factsDir = path.join(tmpDir, ".omo", "memory", "facts")
+      fs.mkdirSync(factsDir, { recursive: true })
+      fs.writeFileSync(path.join(factsDir, "architecture.md"), "# Architecture\n\nUses PostgreSQL.\n")
+      fs.writeFileSync(path.join(factsDir, "pitfalls.md"), "# Pitfalls\n\nNever use bd edit.\n")
+    })
+
+    it("#then readAllFacts returns sorted files", () => {
+      const facts = readAllFacts(tmpDir)
+      expect(facts).toHaveLength(2)
+      expect(facts[0].name).toBe("architecture")
+      expect(facts[1].name).toBe("pitfalls")
+    })
+
+    it("#then readFact returns specific file content", () => {
+      const content = readFact(tmpDir, "architecture")
+      expect(content).toContain("Uses PostgreSQL")
+    })
+
+    it("#then readFact returns null for missing file", () => {
+      expect(readFact(tmpDir, "nonexistent")).toBeNull()
+    })
+
+    it("#then getFactStats returns correct counts", () => {
+      const stats = getFactStats(tmpDir)
+      expect(stats.files).toBe(2)
+      expect(stats.totalLines).toBeGreaterThan(0)
+    })
+
+    it("#then getMemoryCompactionContext includes all facts", () => {
+      const ctx = getMemoryCompactionContext(tmpDir)
+      expect(ctx).toContain("Uses PostgreSQL")
+      expect(ctx).toContain("Never use bd edit")
+      expect(ctx).toContain("Ledger Facts")
+    })
+
+    it("#then getMemorySessionStartHint reports file count", () => {
+      const hint = getMemorySessionStartHint(tmpDir)
+      expect(hint).toContain("2 facts file(s)")
+      expect(hint).toContain("memory_facts")
+    })
+  })
+
+  describe("#given proposal workflow", () => {
+    beforeEach(() => {
+      fs.mkdirSync(path.join(tmpDir, ".omo", "memory", "facts"), { recursive: true })
+    })
+
+    it("#when proposing a fact #then it creates a proposal file", () => {
+      const proposal = proposeFact(tmpDir, {
+        file: "architecture",
+        content: "Database uses event sourcing",
+        reason: "Verified during implementation",
+      })
+
+      expect(proposal.id).toBeTruthy()
+      expect(proposal.file).toBe("architecture")
+      expect(proposal.action).toBe("append")
+
+      const proposals = listProposals(tmpDir)
+      expect(proposals).toHaveLength(1)
+      expect(proposals[0].id).toBe(proposal.id)
+    })
+
+    it("#when approving a proposal #then it writes to facts and removes proposal", () => {
+      const proposal = proposeFact(tmpDir, {
+        file: "invariants",
+        content: "Never modify production data directly",
+        reason: "Safety constraint",
+        action: "create",
+      })
+
+      const result = approveProposal(tmpDir, proposal.id)
+      expect(result.ok).toBe(true)
+
+      const content = readFact(tmpDir, "invariants")
+      expect(content).toContain("Never modify production data directly")
+
+      const proposals = listProposals(tmpDir)
+      expect(proposals).toHaveLength(0)
+    })
+
+    it("#when approving append to existing file #then it appends", () => {
+      const factsDir = path.join(tmpDir, ".omo", "memory", "facts")
+      fs.writeFileSync(path.join(factsDir, "rules.md"), "Rule 1\n")
+
+      const proposal = proposeFact(tmpDir, {
+        file: "rules",
+        content: "Rule 2",
+        reason: "New rule discovered",
+        action: "append",
+      })
+
+      approveProposal(tmpDir, proposal.id)
+      const content = readFact(tmpDir, "rules")
+      expect(content).toContain("Rule 1")
+      expect(content).toContain("Rule 2")
+    })
+
+    it("#when rejecting a proposal #then it removes without writing", () => {
+      const proposal = proposeFact(tmpDir, {
+        file: "architecture",
+        content: "Speculative hypothesis",
+        reason: "Just guessing",
+      })
+
+      const result = rejectProposal(tmpDir, proposal.id)
+      expect(result.ok).toBe(true)
+
+      expect(readFact(tmpDir, "architecture")).toBeNull()
+      expect(listProposals(tmpDir)).toHaveLength(0)
+    })
+
+    it("#when approving nonexistent proposal #then returns error", () => {
+      const result = approveProposal(tmpDir, "fake-id")
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain("not found")
+    })
+  })
+
+  describe("#given tools", () => {
+    beforeEach(() => {
+      const factsDir = path.join(tmpDir, ".omo", "memory", "facts")
+      fs.mkdirSync(factsDir, { recursive: true })
+      fs.writeFileSync(path.join(factsDir, "arch.md"), "Uses PostgreSQL\n")
+    })
+
+    it("#when calling memory_facts tool #then returns fact content", async () => {
+      const tools = createProjectMemoryTools(tmpDir)
+      const result = await tools.memory_facts.execute({ name: "arch" }, {})
+      expect(result).toContain("Uses PostgreSQL")
+    })
+
+    it("#when calling memory_facts without name #then lists files", async () => {
+      const tools = createProjectMemoryTools(tmpDir)
+      const result = await tools.memory_facts.execute({}, {})
+      expect(result).toContain("arch")
+    })
+
+    it("#when calling memory_propose_fact #then creates proposal", async () => {
+      const tools = createProjectMemoryTools(tmpDir)
+      const result = await tools.memory_propose_fact.execute(
+        { file: "arch", content: "Also uses Redis", reason: "Confirmed" },
+        {},
+      )
+      expect(result).toContain("Fact proposed")
+      expect(listProposals(tmpDir)).toHaveLength(1)
+    })
+
+    it("#when calling memory_proposals #then lists pending", async () => {
+      const tools = createProjectMemoryTools(tmpDir)
+      proposeFact(tmpDir, { file: "test", content: "fact", reason: "reason" })
+      const result = await tools.memory_proposals.execute({}, {})
+      expect(result).toContain("Pending proposals (1)")
+    })
+  })
+})

--- a/src/features/project-memory/storage.ts
+++ b/src/features/project-memory/storage.ts
@@ -1,0 +1,113 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getFactsDir, getMemoryRoot, getProposalsDir } from "./constants"
+
+export function isProjectMemoryEnabled(directory: string): boolean {
+  return fs.existsSync(getMemoryRoot(directory))
+}
+
+export function readAllFacts(directory: string): { name: string; content: string }[] {
+  const factsDir = getFactsDir(directory)
+  if (!fs.existsSync(factsDir)) return []
+
+  const files = fs.readdirSync(factsDir).filter((f) => f.endsWith(".md")).sort()
+  return files.map((file) => ({
+    name: file.replace(/\.md$/, ""),
+    content: fs.readFileSync(path.join(factsDir, file), "utf-8"),
+  }))
+}
+
+export function readFact(directory: string, name: string): string | null {
+  const filePath = path.join(getFactsDir(directory), `${name}.md`)
+  if (!fs.existsSync(filePath)) return null
+  return fs.readFileSync(filePath, "utf-8")
+}
+
+export function getFactStats(directory: string): { files: number; totalLines: number } {
+  const facts = readAllFacts(directory)
+  const totalLines = facts.reduce((sum, f) => sum + f.content.split("\n").length, 0)
+  return { files: facts.length, totalLines }
+}
+
+export interface Proposal {
+  id: string
+  file: string
+  content: string
+  reason: string
+  action: "append" | "create"
+  timestamp: string
+}
+
+export function listProposals(directory: string): Proposal[] {
+  const proposalsDir = getProposalsDir(directory)
+  if (!fs.existsSync(proposalsDir)) return []
+
+  const files = fs.readdirSync(proposalsDir).filter((f) => f.endsWith(".json")).sort()
+  return files.map((file) => {
+    const raw = fs.readFileSync(path.join(proposalsDir, file), "utf-8")
+    return JSON.parse(raw) as Proposal
+  })
+}
+
+export function proposeFact(
+  directory: string,
+  args: { file: string; content: string; reason: string; action?: "append" | "create" },
+): Proposal {
+  const proposalsDir = getProposalsDir(directory)
+  fs.mkdirSync(proposalsDir, { recursive: true })
+
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const proposal: Proposal = {
+    id,
+    file: args.file,
+    content: args.content,
+    reason: args.reason,
+    action: args.action ?? "append",
+    timestamp: new Date().toISOString(),
+  }
+
+  const filePath = path.join(proposalsDir, `${id}.json`)
+  fs.writeFileSync(filePath, JSON.stringify(proposal, null, 2), "utf-8")
+  return proposal
+}
+
+export function approveProposal(directory: string, proposalId: string): { ok: boolean; error?: string } {
+  const proposalsDir = getProposalsDir(directory)
+  const proposalPath = path.join(proposalsDir, `${proposalId}.json`)
+
+  if (!fs.existsSync(proposalPath)) {
+    return { ok: false, error: `Proposal ${proposalId} not found` }
+  }
+
+  const proposal = JSON.parse(fs.readFileSync(proposalPath, "utf-8")) as Proposal
+  const factsDir = getFactsDir(directory)
+  fs.mkdirSync(factsDir, { recursive: true })
+
+  const targetPath = path.join(factsDir, `${proposal.file}.md`)
+
+  if (proposal.action === "create") {
+    if (fs.existsSync(targetPath)) {
+      return { ok: false, error: `Facts file '${proposal.file}.md' already exists. Use append.` }
+    }
+    fs.writeFileSync(targetPath, proposal.content + "\n", "utf-8")
+  } else {
+    const existing = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, "utf-8") : ""
+    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : ""
+    fs.writeFileSync(targetPath, existing + separator + proposal.content + "\n", "utf-8")
+  }
+
+  fs.unlinkSync(proposalPath)
+  return { ok: true }
+}
+
+export function rejectProposal(directory: string, proposalId: string): { ok: boolean; error?: string } {
+  const proposalsDir = getProposalsDir(directory)
+  const proposalPath = path.join(proposalsDir, `${proposalId}.json`)
+
+  if (!fs.existsSync(proposalPath)) {
+    return { ok: false, error: `Proposal ${proposalId} not found` }
+  }
+
+  fs.unlinkSync(proposalPath)
+  return { ok: true }
+}

--- a/src/features/project-memory/test-project-memory.sh
+++ b/src/features/project-memory/test-project-memory.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test-project-memory.sh — Self-documenting integration test for project-memory feature
+#
+# Inspired by CVPaul/mneme (https://github.com/CVPaul/mneme) — three-layer memory
+# architecture for AI coding agents. This implementation adapts the "Ledger" (facts)
+# layer with human-approval gates for oh-my-opencode.
+#
+# WHAT THIS TESTS:
+#   1. Shell alias bootstraps .omo/memory/ directory (opt-in per project)
+#   2. Storage layer: read facts, propose, approve, reject
+#   3. Tools register only when .omo/memory/ exists (zero blast radius)
+#   4. Compaction hook injects facts into context
+#   5. Bun unit tests pass
+#
+# USAGE:
+#   ./src/features/project-memory/test-project-memory.sh
+#
+# PREREQUISITES:
+#   - bun installed
+#   - Run from oh-my-openagent repo root
+#
+# CREDIT:
+#   Concept: Ali Lidan (CVPaul/mneme) — three-layer memory architecture
+#   Implementation: Adapted for oh-my-opencode as a scoped feature module
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INIT_SCRIPT="$SCRIPT_DIR/omo-memory-init.sh"
+TEST_DIR=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  Project Memory — Integration Test                          ║"
+echo "║  Inspired by CVPaul/mneme (Ali Lidan)                       ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+# ─── Test 1: Shell alias bootstraps directory ─────────────────────
+echo "▸ Test 1: omo-memory-init creates scaffold"
+bash "$INIT_SCRIPT" "$TEST_DIR"
+
+if [[ -d "$TEST_DIR/.omo/memory/facts" && -d "$TEST_DIR/.omo/memory/proposals" ]]; then
+  echo "  ✓ .omo/memory/{facts,proposals} created"
+else
+  echo "  ✗ Directory structure missing"
+  exit 1
+fi
+
+if [[ -f "$TEST_DIR/.omo/memory/facts/architecture.md" ]]; then
+  echo "  ✓ Starter facts file created"
+else
+  echo "  ✗ Starter facts file missing"
+  exit 1
+fi
+
+# Running it again should be idempotent
+OUTPUT=$(bash "$INIT_SCRIPT" "$TEST_DIR" 2>&1)
+if echo "$OUTPUT" | grep -q "already initialized"; then
+  echo "  ✓ Idempotent (second run detects existing)"
+else
+  echo "  ✗ Not idempotent"
+  exit 1
+fi
+echo ""
+
+# ─── Test 2: Manual fact management ──────────────────────────────
+echo "▸ Test 2: Manual fact file operations"
+cat > "$TEST_DIR/.omo/memory/facts/invariants.md" << 'EOF'
+# Invariants
+
+- Never call the payments API without idempotency keys
+- Batch size must not exceed 1000 records
+EOF
+
+FACT_COUNT=$(ls "$TEST_DIR/.omo/memory/facts/"*.md | wc -l | tr -d ' ')
+if [[ "$FACT_COUNT" == "2" ]]; then
+  echo "  ✓ 2 facts files present (architecture + invariants)"
+else
+  echo "  ✗ Expected 2 facts files, got $FACT_COUNT"
+  exit 1
+fi
+echo ""
+
+# ─── Test 3: Proposal JSON format ────────────────────────────────
+echo "▸ Test 3: Proposal file format"
+PROPOSAL_ID="$(date +%s)-test123"
+cat > "$TEST_DIR/.omo/memory/proposals/$PROPOSAL_ID.json" << EOF
+{
+  "id": "$PROPOSAL_ID",
+  "file": "pitfalls",
+  "content": "The config parser silently drops unknown keys",
+  "reason": "Discovered during debugging session",
+  "action": "create",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+if [[ -f "$TEST_DIR/.omo/memory/proposals/$PROPOSAL_ID.json" ]]; then
+  echo "  ✓ Proposal JSON created (awaiting human review)"
+else
+  echo "  ✗ Proposal file missing"
+  exit 1
+fi
+echo ""
+
+# ─── Test 4: Bun unit tests ──────────────────────────────────────
+echo "▸ Test 4: Bun unit tests"
+cd "$REPO_ROOT"
+if bun test src/features/project-memory/storage.test.ts 2>&1 | tail -5; then
+  echo "  ✓ All unit tests pass"
+else
+  echo "  ✗ Unit tests failed"
+  exit 1
+fi
+echo ""
+
+# ─── Test 5: Typecheck ───────────────────────────────────────────
+echo "▸ Test 5: TypeScript typecheck"
+if bun run typecheck 2>&1 | tail -3; then
+  echo "  ✓ Typecheck passes"
+else
+  echo "  ✗ Typecheck failed"
+  exit 1
+fi
+echo ""
+
+# ─── Summary ─────────────────────────────────────────────────────
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  All tests passed ✓                                         ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+echo "To activate in a project:"
+echo "  bash src/features/project-memory/omo-memory-init.sh /path/to/project"
+echo ""
+echo "Or add a shell alias:"
+echo "  alias omo-memory-init='bash $(cd "$SCRIPT_DIR" && pwd)/omo-memory-init.sh'"
+echo ""
+echo "The memory tools (memory_facts, memory_propose_fact, etc.)"
+echo "will appear automatically in opencode sessions for that project."
+echo "No config changes needed — directory existence is the gate."

--- a/src/features/project-memory/tools.ts
+++ b/src/features/project-memory/tools.ts
@@ -1,0 +1,152 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import {
+  readAllFacts,
+  readFact,
+  getFactStats,
+  proposeFact,
+  listProposals,
+  approveProposal,
+  rejectProposal,
+} from "./storage"
+
+export function createProjectMemoryTools(directory: string): Record<string, ToolDefinition> {
+  const memory_facts: ToolDefinition = tool({
+    description:
+      "Read project memory facts — verified long-term knowledge about this project. " +
+      "Without arguments, lists all facts files with line counts. " +
+      "With a name, shows the contents of that specific facts file. " +
+      "Facts take priority over conversation history and agent reasoning. " +
+      "If you find a contradiction with a fact, raise it to the user — do not silently override.",
+    args: {
+      name: tool.schema
+        .string()
+        .optional()
+        .describe("Facts file name (e.g. 'architecture', 'invariants'). Omit to list all."),
+      stats: tool.schema
+        .boolean()
+        .optional()
+        .describe("Show line counts and budget stats"),
+    },
+    execute: async (args) => {
+      if (args.name) {
+        const content = readFact(directory, args.name)
+        if (content === null) {
+          return `[ERROR] Facts file '${args.name}' not found. Use memory_facts (no args) to list available files.`
+        }
+        return content
+      }
+
+      const facts = readAllFacts(directory)
+      if (facts.length === 0) {
+        return "No facts files found in .omo/memory/facts/. Use memory_propose_fact to propose new facts."
+      }
+
+      if (args.stats) {
+        const { totalLines } = getFactStats(directory)
+        const lines = facts.map(
+          (f) => `- ${f.name}.md (${f.content.split("\n").length} lines)`,
+        )
+        return `Facts files (${facts.length}, ${totalLines} total lines):\n${lines.join("\n")}`
+      }
+
+      return `Available facts files:\n${facts.map((f) => `- ${f.name}`).join("\n")}`
+    },
+  })
+
+  const memory_propose_fact: ToolDefinition = tool({
+    description:
+      "Propose a new fact to the project memory ledger. The proposal requires human approval " +
+      "before it becomes a permanent fact. Before proposing, verify ALL conditions: " +
+      "(1) information is verified, not a hypothesis; " +
+      "(2) future sessions will repeatedly need it; " +
+      "(3) it won't become stale quickly; " +
+      "(4) no equivalent fact already exists.",
+    args: {
+      file: tool.schema
+        .string()
+        .describe("Target facts file (e.g. 'architecture', 'pitfalls', 'invariants')"),
+      content: tool.schema.string().describe("The fact text to add"),
+      reason: tool.schema.string().describe("Why this qualifies as a long-term fact"),
+      action: tool.schema
+        .enum(["append", "create"])
+        .optional()
+        .describe("'append' (default) to add to existing file, 'create' for a new file"),
+    },
+    execute: async (args) => {
+      const proposal = proposeFact(directory, {
+        file: args.file,
+        content: args.content,
+        reason: args.reason,
+        action: args.action as "append" | "create" | undefined,
+      })
+      return (
+        `Fact proposed (ID: ${proposal.id}).\n` +
+        `Target: .omo/memory/facts/${args.file}.md\n` +
+        `Action: ${proposal.action}\n` +
+        `Reason: ${args.reason}\n\n` +
+        `Awaiting human approval. The user can run:\n` +
+        `  omo-memory review ${proposal.id} --approve\n` +
+        `  omo-memory review ${proposal.id} --reject`
+      )
+    },
+  })
+
+  const memory_proposals: ToolDefinition = tool({
+    description:
+      "List pending fact proposals awaiting human approval. " +
+      "Use this to check if there are proposals that need review.",
+    args: {},
+    execute: async () => {
+      const proposals = listProposals(directory)
+      if (proposals.length === 0) {
+        return "No pending proposals."
+      }
+
+      const lines = proposals.map(
+        (p) =>
+          `- [${p.id}] → ${p.file}.md (${p.action})\n  Content: ${p.content.slice(0, 100)}${p.content.length > 100 ? "..." : ""}\n  Reason: ${p.reason}\n  Proposed: ${p.timestamp}`,
+      )
+      return `Pending proposals (${proposals.length}):\n\n${lines.join("\n\n")}`
+    },
+  })
+
+  const memory_approve: ToolDefinition = tool({
+    description:
+      "Approve a pending fact proposal, writing it to the facts ledger. " +
+      "Only use this when explicitly instructed by the user to approve a proposal.",
+    args: {
+      id: tool.schema.string().describe("The proposal ID to approve"),
+    },
+    execute: async (args) => {
+      const result = approveProposal(directory, args.id)
+      if (!result.ok) {
+        return `[ERROR] ${result.error}`
+      }
+      return `Proposal ${args.id} approved and written to facts.`
+    },
+  })
+
+  const memory_reject: ToolDefinition = tool({
+    description:
+      "Reject a pending fact proposal, removing it without writing to facts. " +
+      "Only use this when explicitly instructed by the user to reject a proposal.",
+    args: {
+      id: tool.schema.string().describe("The proposal ID to reject"),
+    },
+    execute: async (args) => {
+      const result = rejectProposal(directory, args.id)
+      if (!result.ok) {
+        return `[ERROR] ${result.error}`
+      }
+      return `Proposal ${args.id} rejected and removed.`
+    },
+  })
+
+  return {
+    memory_facts,
+    memory_propose_fact,
+    memory_proposals,
+    memory_approve,
+    memory_reject,
+  }
+}

--- a/src/plugin-dispose.ts
+++ b/src/plugin-dispose.ts
@@ -10,8 +10,9 @@ export function createPluginDispose(args: {
     disconnectAll: () => Promise<void>
   }
   disposeHooks: () => void
+  configWatcherDispose?: () => void
 }): PluginDispose {
-  const { backgroundManager, skillMcpManager, disposeHooks } = args
+  const { backgroundManager, skillMcpManager, disposeHooks, configWatcherDispose } = args
   let disposePromise: Promise<void> | null = null
 
   return async (): Promise<void> => {
@@ -35,6 +36,13 @@ export function createPluginDispose(args: {
         disposeHooks()
       } catch (error) {
         log("[plugin-dispose] disposeHooks() error:", error)
+      }
+      if (configWatcherDispose) {
+        try {
+          configWatcherDispose()
+        } catch (error) {
+          log("[plugin-dispose] configWatcherDispose() error:", error)
+        }
       }
     })()
 

--- a/src/plugin/session-compacting.ts
+++ b/src/plugin/session-compacting.ts
@@ -1,6 +1,7 @@
 import type { Hooks } from "@opencode-ai/plugin"
 
 import { isCompactionAgent } from "../shared/compaction-marker"
+import { getMemoryCompactionContext } from "../features/project-memory/compaction"
 import { log } from "../shared/logger"
 
 type SessionCompactingHook = NonNullable<Hooks["experimental.session.compacting"]>
@@ -58,6 +59,7 @@ async function runCompactionStep(
 
 export function createSessionCompactingHandler(
   hooks: CompactionHookDependencies,
+  options?: { directory?: string },
 ): SessionCompactingHook {
   return async (
     input: SessionCompactingInput,
@@ -83,6 +85,14 @@ export function createSessionCompactingHandler(
       const context = inject ? inject(input.sessionID) : undefined
       if (context) {
         output.context.push(context)
+      }
+    })
+    await runCompactionStep("projectMemory.inject", input.sessionID, () => {
+      if (options?.directory) {
+        const memoryContext = getMemoryCompactionContext(options.directory)
+        if (memoryContext) {
+          output.context.push(memoryContext)
+        }
       }
     })
   }

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -45,6 +45,7 @@ import {
 import { getMainSessionID } from "../features/claude-code-session-state"
 import { filterDisabledTools } from "../shared/disabled-tools"
 import { isTaskSystemEnabled, log } from "../shared"
+import { isProjectMemoryEnabled, createProjectMemoryTools } from "../features/project-memory"
 
 import type { Managers } from "../create-managers"
 import type { SkillContext } from "./skill-context"
@@ -334,6 +335,10 @@ export function createToolRegistry(args: {
       }
     : {}
 
+  const projectMemoryToolsRecord: Record<string, ToolDefinition> = isProjectMemoryEnabled(ctx.directory)
+    ? createProjectMemoryTools(ctx.directory)
+    : {}
+
   const allTools: Record<string, ToolDefinition> = {
     ...factories.createGrepTools(ctx),
     ...factories.createGlobTools(ctx),
@@ -348,6 +353,7 @@ export function createToolRegistry(args: {
     ...teamModeToolsRecord,
     ...taskToolsRecord,
     ...hashlineToolsRecord,
+    ...projectMemoryToolsRecord,
   }
 
   const allToolNames = Object.keys(allTools)

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -1,5 +1,6 @@
 import type { Hooks, Plugin, PluginModule } from "@opencode-ai/plugin"
 import type { HookName } from "../config"
+import { createConfigWatcher, type ConfigWatcherDispose } from "../config-watcher"
 import { initConfigContext } from "../cli/config-manager/config-context"
 
 import { createHooks } from "../create-hooks"
@@ -98,6 +99,12 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
     deps.initI18n(pluginConfig.i18n?.locale ? { locale: pluginConfig.i18n.locale } : undefined)
     deps.setAgentSortOrder(pluginConfig.agent_order)
+
+    let configWatcherDispose: ConfigWatcherDispose | undefined
+    if (pluginConfig.experimental?.hot_reload) {
+      configWatcherDispose = createConfigWatcher(input.directory, input, pluginConfig)
+      deps.log("[oh-my-openagent] Config hot-reload enabled")
+    }
 
     if (pluginConfig.openclaw) {
       await deps.initializeOpenClaw(pluginConfig.openclaw)

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -178,7 +178,7 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     const pluginHooks: HooksWithCompactionAutocontinue = {
       ...pluginInterface,
 
-      "experimental.session.compacting": createSessionCompactingHandler(hooks),
+      "experimental.session.compacting": createSessionCompactingHandler(hooks, { directory: input.directory }),
 
       "experimental.compaction.autocontinue": createCompactionAutocontinueHandler(hooks),
     }


### PR DESCRIPTION
## Summary

Adds a scoped, opt-in persistent memory system for AI agents — curated project facts with human-approval gates that survive compaction.

Inspired by [@CVPaul](https://github.com/CVPaul)'s [mneme](https://github.com/CVPaul/mneme) (Ali Lidan) — a three-layer memory architecture for AI coding agents. This PR adapts the "Ledger" layer concept (verified facts, human-gated writes, compaction survival) as a zero-dependency feature module for oh-my-opencode.

## How it works

- **Opt-in per project**: Tools only activate when `.omo/memory/` exists in the project directory
- **Bootstrap**: `omo-memory-init` shell alias creates the scaffold
- **5 tools**: `memory_facts`, `memory_propose_fact`, `memory_proposals`, `memory_approve`, `memory_reject`
- **Compaction survival**: Facts are injected into compaction context automatically
- **Human-in-the-loop**: Agents propose facts; humans approve/reject before they become permanent

## Blast radius

Zero for projects without `.omo/memory/`. Directory existence is the only gate — no config flags needed.

## Files

```
src/features/project-memory/
├── constants.ts              # Path helpers
├── storage.ts                # CRUD (facts, proposals, approve/reject)
├── tools.ts                  # 5 agent tools
├── compaction.ts             # Facts injection on compaction
├── session-start-hint.ts     # Context hint generator
├── index.ts                  # Barrel
├── storage.test.ts           # 21 unit tests
├── omo-memory-init.sh        # Shell alias bootstrap
└── test-project-memory.sh    # Self-documenting integration test

src/plugin/session-compacting.ts   # +facts injection step
src/plugin/tool-registry.ts        # +conditional tool registration
src/testing/create-plugin-module.ts # pass directory to compacting handler
```

## Testing

```bash
# Unit tests (21 pass)
bun test src/features/project-memory/storage.test.ts

# Integration test (self-documenting)
bash src/features/project-memory/test-project-memory.sh

# Typecheck
bun run typecheck
```

## Credit

Concept and architecture from [CVPaul/mneme](https://github.com/CVPaul/mneme) by Ali Lidan. The three-layer model (Ledger/Beads/Execution) is a clean separation of memory by stability and trust level — this PR brings the Ledger layer to oh-my-opencode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in project memory layer with human-approved facts that persist and are injected during compaction. Also introduces optional config hot-reload to apply config changes mid-session.

- **New Features**
  - Project memory: activate by creating `.omo/memory/` (or run `omo-memory-init`); tools register only when present.
  - Tools: memory_facts, memory_propose_fact, memory_proposals, memory_approve, memory_reject.
  - Compaction: verified facts are injected into the compaction context; a session-start hint summarizes active facts.
  - Human-in-the-loop: agents propose facts; humans approve or reject before they become permanent.
  - Config hot-reload: enable with `experimental.hot_reload`; watches user and project config, debounced 300ms, handles atomic saves, updates config in place. Hot-reloads agents, categories, experimental flags; not disabled_hooks, tmuxConfig, safe_hook_creation.

- **Migration**
  - Project memory: run `omo-memory-init` in the repo (creates `.omo/memory/{facts,proposals}`); optionally add `.omo/memory/proposals/` to `.gitignore`.
  - Hot-reload: set `experimental.hot_reload: true` in your config; no restart needed for supported fields.

<sup>Written for commit 372bc5f5be20aba5c8fd4299e243b995292ed27e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4423?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

