### PR TITLE
fix(runtime-fallback): handle OpenCode Go/Zen error structures and reasoning-only output

### DIFF
--- a/packages/model-core/src/model-error-classifier.ts
+++ b/packages/model-core/src/model-error-classifier.ts
@@ -12,6 +12,7 @@ const RETRYABLE_ERROR_NAMES = new Set([
   "modelunavailableerror",
   "providerconnectionerror",
   "authenticationerror",
+  "emptyoutputerror",
 ])
 
 const STOP_ERROR_NAMES = new Set([

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -28,6 +28,7 @@ import {
   hasMoreFallbacks,
   shouldRetryError,
 } from "../../shared/model-error-classifier"
+import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
@@ -1081,6 +1082,24 @@ The fallback retry session is now created and can be inspected directly.
     return undefined
   }
 
+  /**
+   * Public hook for tool.execute.after detectors to retry a task on a fallback
+   * model when the current model returned empty output.
+   */
+  async retryTaskOnEmptyOutput(sessionID: string): Promise<boolean> {
+    const task = this.findBySession(sessionID)
+    if (!task) return false
+    return this.tryFallbackRetry(
+      task,
+      {
+        name: "EmptyOutputError",
+        message:
+          "Model returned no text output — may be rate-limited or returned an empty response",
+      },
+      "tool.execute.after (empty output)",
+    )
+  }
+
   private resolveTaskAttemptBySession(sessionID: string): { task: BackgroundTask; attemptID?: string; isCurrent: boolean } | undefined {
     const task = this.findBySession(sessionID)
     if (!task) {
@@ -1632,6 +1651,16 @@ The fallback retry session is now created and can be inspected directly.
         checkSessionTodos: (id) => this.checkSessionTodos(id),
         tryCompleteTask: (task, source) => this.tryCompleteTask(task, source),
         emitIdleEvent: (sessionID) => this.handleEvent({ type: "session.idle", properties: { sessionID } }),
+        onNoValidOutput: async (task, _sessionID) => {
+          const errorInfo = {
+            name: "EmptyOutputError",
+            message: `Model returned no text output — may be rate-limited or returned an empty response`,
+          }
+          const didFallback = await this.tryFallbackRetry(task, errorInfo, "session.idle (empty output)")
+          if (!didFallback) {
+            log("[background-agent] No fallback available for empty output, failing task:", task.id)
+          }
+        },
       })
     }
 
@@ -1834,6 +1863,21 @@ The fallback retry session is now created and can be inspected directly.
       const sessionFallbackChain = this.modelFallbackControllerAccessor?.getSessionFallbackChain(task.sessionId)
       if (sessionFallbackChain?.length) {
         task.fallbackChain = sessionFallbackChain
+      }
+    }
+
+    // When the category-resolver nullifies the fallback chain (explicit model,
+    // override, cold cache), use the requirement's hardcoded chain as a safety
+    // net so model-not-found / unavailable errors don't hang the task.
+    if (!task.fallbackChain && task.category) {
+      const requirement = CATEGORY_MODEL_REQUIREMENTS[task.category]
+      if (requirement?.fallbackChain?.length) {
+        task.fallbackChain = requirement.fallbackChain
+        this.logger("[background-agent] Populated fallback chain from category requirements:", {
+          taskId: task.id,
+          category: task.category,
+          chainLength: requirement.fallbackChain.length,
+        })
       }
     }
 
@@ -2082,6 +2126,30 @@ The task was re-queued on a fallback model after a retryable failure.
     }
   }
 
+  /**
+   * Checks whether the session produced actual text output (not just reasoning or tool calls).
+   * Stricter than validateSessionHasOutput — reasoning/thinking blocks alone don't count.
+   */
+  private async hasTextOutput(sessionID: string): Promise<boolean> {
+    try {
+      const response = await messagesInDirectory(this.client, {
+        path: { id: sessionID },
+      }, this.directory)
+
+      const messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, { preferResponseOnMissingData: true })
+
+      return messages.some((m: any) => {
+        if (m.info?.role !== "assistant") return false
+        const parts = m.parts ?? []
+        return parts.some((p: any) =>
+          p.type === "text" && p.text && p.text.trim().length > 0
+        )
+      })
+    } catch {
+      return true
+    }
+  }
+
   private clearNotificationsForTask(taskId: string): void {
     for (const [sessionID, tasks] of this.notifications.entries()) {
       const filtered = tasks.filter((t) => t.id !== taskId)
@@ -2311,6 +2379,61 @@ The task was re-queued on a fallback model after a retryable failure.
     if (task.status !== "running") {
       log("[background-agent] Task already completed, skipping:", { taskId: task.id, status: task.status, source })
       return false
+    }
+
+    // Before marking as completed, check if the session produced actual text output.
+    // Models can produce reasoning/thinking blocks but still return empty final text
+    // (e.g., rate-limited ChatGPT Plus via gpt-5.5, or misconfigured model variants).
+    // Catching this here covers all completion paths regardless of speed — the idle
+    // handler (Layer 2, 5s threshold) and tool.execute.after (Layer 3, launch message)
+    // both miss fast background task completions.
+    if (task.sessionId) {
+      const hasText = await this.hasTextOutput(task.sessionId)
+      if (!hasText) {
+        this.logger("[background-agent] Task completed with no text output, attempting fallback:", task.id)
+        const didFallback = await this.tryFallbackRetry(
+          task,
+          { name: "EmptyOutputError", message: "Model returned no text output — may be rate-limited or returned an empty response" },
+          `tryCompleteTask (empty output via ${source})`,
+        )
+        if (didFallback) {
+          // Fallback retry queued — don't mark this attempt as complete
+          return false
+        }
+        // No fallback available — mark as error so parent session knows it failed
+        this.logger("[background-agent] No fallback available for empty output, marking task as error:", task.id)
+        const errorMsg = "Model returned no text output and no fallback model is available"
+        if (task.currentAttemptID) {
+          finalizeAttempt(task, task.currentAttemptID, "error", errorMsg)
+        } else {
+          task.status = "error"
+          task.error = errorMsg
+          task.completedAt = new Date()
+        }
+        this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+        if (task.rootSessionId) this.unregisterRootDescendant(task.rootSessionId)
+        removeTaskToastTracking(task.id)
+        if (task.concurrencyKey) {
+          this.concurrencyManager.release(task.concurrencyKey)
+          task.concurrencyKey = undefined
+        }
+        this.markForNotification(task)
+        const timer = this.idleDeferralTimers.get(task.id)
+        if (timer) { clearTimeout(timer); this.idleDeferralTimers.delete(task.id) }
+        if (task.sessionId) {
+          await this.abortSessionWithLogging(task.sessionId, `task error (empty output via ${source})`)
+          clearDelegatedChildSessionBootstrap(task.sessionId)
+          SessionCategoryRegistry.remove(task.sessionId)
+        }
+        if (task.parentSessionId) this.updateBackgroundTaskMarker(task.parentSessionId)
+        try {
+          await this.enqueueNotificationForParent(task.parentSessionId, () => this.notifyParentSession(task))
+          log("[background-agent] Task errored (empty output):", { taskId: task.id, source })
+        } catch (err) {
+          log("[background-agent] Error in notifyParentSession for errored task:", { taskId: task.id, error: err })
+        }
+        return true
+      }
     }
 
     // Atomically mark as completed to prevent race conditions

--- a/src/features/background-agent/session-idle-event-handler.ts
+++ b/src/features/background-agent/session-idle-event-handler.ts
@@ -11,6 +11,12 @@ export function handleSessionIdleBackgroundEvent(args: {
   checkSessionTodos: (sessionID: string) => Promise<boolean>
   tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
   emitIdleEvent: (sessionID: string) => void
+  /**
+   * Called when the session is idle but has produced no valid output.
+   * This typically means the model returned an empty response (e.g. rate-limited).
+   * The callback should attempt a fallback retry or mark the task as error.
+   */
+  onNoValidOutput?: (task: BackgroundTask, sessionID: string) => Promise<void>
 }): void {
   const {
     properties,
@@ -20,6 +26,7 @@ export function handleSessionIdleBackgroundEvent(args: {
     checkSessionTodos,
     tryCompleteTask,
     emitIdleEvent,
+    onNoValidOutput,
   } = args
 
   const sessionID = resolveSessionEventID(properties)
@@ -62,7 +69,12 @@ export function handleSessionIdleBackgroundEvent(args: {
       }
 
       if (!hasValidOutput) {
-        log("[background-agent] Session.idle but no valid output yet, waiting:", task.id)
+        if (onNoValidOutput) {
+          log("[background-agent] Session.idle with no valid output, triggering fallback:", task.id)
+          await onNoValidOutput(task, sessionID)
+        } else {
+          log("[background-agent] Session.idle but no valid output yet, waiting:", task.id)
+        }
         return
       }
 

--- a/src/hooks/empty-task-response-detector.ts
+++ b/src/hooks/empty-task-response-detector.ts
@@ -1,4 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import type { BackgroundManager } from "../features/background-agent"
+import { extractTaskLink } from "../features/tool-metadata-store"
 
 const EMPTY_RESPONSE_WARNING = `[Task Empty Response Warning]
 
@@ -9,7 +11,10 @@ Task invocation completed but returned no response. This indicates the agent eit
 
 Note: The call has already completed - you are NOT waiting for a response. Proceed accordingly.`
 
-export function createEmptyTaskResponseDetectorHook(_ctx: PluginInput) {
+export function createEmptyTaskResponseDetectorHook(
+  _ctx: PluginInput,
+  backgroundManager?: BackgroundManager,
+) {
   return {
     "tool.execute.after": async (
       input: { tool: string; sessionID: string; callID: string },
@@ -19,9 +24,19 @@ export function createEmptyTaskResponseDetectorHook(_ctx: PluginInput) {
 
       const responseText = output.output?.trim() ?? ""
 
-      if (responseText === "") {
-        output.output = EMPTY_RESPONSE_WARNING
+      if (responseText !== "") return
+
+      if (backgroundManager) {
+        const link = extractTaskLink(output.metadata, "")
+        const sessionId = link.sessionId
+
+        if (sessionId) {
+          const didFallback = await backgroundManager.retryTaskOnEmptyOutput(sessionId)
+          if (didFallback) return
+        }
       }
+
+      output.output = EMPTY_RESPONSE_WARNING
     },
   }
 }

--- a/src/hooks/model-fallback/next-fallback.ts
+++ b/src/hooks/model-fallback/next-fallback.ts
@@ -2,6 +2,7 @@ import type { FallbackEntry } from "../../shared/model-requirements"
 import { readConnectedProvidersCache, readProviderModelsCache } from "../../shared/connected-providers-cache"
 import { selectFallbackProvider } from "../../shared/model-error-classifier"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
+import { isProviderFailed, clearProviderFailure } from "../../shared/provider-failure-state"
 import { log } from "../../shared/logger"
 import type { ModelFallbackState } from "./hook"
 
@@ -56,6 +57,12 @@ export function getNextReachableFallback(
 
     const providerID = selectFallbackProvider(fallback.providers, state.providerID)
     const modelID = transformModelForProvider(providerID, fallback.model)
+
+    if (isProviderFailed(providerID)) {
+      log("[model-fallback] Skipping fallback on failed provider for session: " + sessionID + ", attempt: " + attemptCount + ", provider: " + providerID + ", model: " + fallback.model)
+      continue
+    }
+
     const isNoOpFallback =
       providerID.toLowerCase() === state.providerID.toLowerCase()
       && canonicalizeModelID(modelID) === canonicalizeModelID(state.modelID)

--- a/src/hooks/runtime-fallback/AGENTS.md
+++ b/src/hooks/runtime-fallback/AGENTS.md
@@ -28,14 +28,25 @@ Default retry codes: `429, 500, 502, 503, 504`
 /rate.?limit/i, /too.?many.?requests/i, /quota.*reset.*after/i,
 /exhausted.*capacity/i, /all.*credentials.*for.*model/i,
 /cool(?:ing)?.?down/i, /model.*not.*supported/i,
-/service.?unavailable/i, /overloaded/i, /temporarily.?unavailable/i
+/service.?unavailable/i, /overloaded/i, /temporarily.?unavailable/i,
+/creditserror/i, /insufficient\s+balance/i, /free\s+promotion\s+has\s+ended/i,
+/authentication\s+error/i, /invalid\s+authentication/i
 ```
 
 ### Error Type Classification (error-classifier.ts)
-- `missing_api_key` — provider rejects auth
-- `model_not_found` — model unavailable
-- `quota_exceeded` — billing/quota hit
+- `missing_api_key` — provider rejects auth (checks name, code, and type fields)
+- `model_not_found` — model unavailable (checks name, code, and type fields)
+- `quota_exceeded` — billing/quota hit (checks name, code, and type fields)
+- `empty_output` — model returned no visible content
 - Auto-retry signal detection via `auto-retry-signal.ts` — extracts "retrying in ~2 weeks" style signals, triggers immediate fallback
+
+**Error Field Extraction:**
+The classifier reads error identifiers from multiple fields to support different provider APIs:
+- `name` field — Standard error name (e.g., `InsufficientQuotaError`)
+- `code` field — OpenCode Go style (e.g., `{ error: { code: "insufficient_quota" } }`)
+- `type` field — OpenCode Zen style (e.g., `{ type: "error", error: { type: "CreditsError" } }`)
+
+All three extractors are normalized (lowercased, underscores/dashes stripped) and combined for classification.
 
 ## FALLBACK STATE MACHINE
 
@@ -98,5 +109,5 @@ Failed models enter 60s cooldown. `findNextAvailableFallback()` skips models in 
 ## NOTES
 
 - Cooldown and failure tracking are **per-session** — concurrent sessions don't share state
-- `visible-assistant-response.ts` prevents retry if the assistant already produced a partial valid response
+- `visible-assistant-response.ts` prevents retry if the assistant already produced a partial valid response (including reasoning content)
 - Runtime-fallback is registered in the Session Tier via `create-session-hooks.ts`

--- a/src/hooks/runtime-fallback/chat-message-handler.ts
+++ b/src/hooks/runtime-fallback/chat-message-handler.ts
@@ -23,8 +23,11 @@ export function createChatMessageHandler(deps: HookDeps) {
       ? `${input.model.providerID}/${input.model.modelID}`
       : undefined
 
-    if (requestedModel && requestedModel !== state.currentModel) {
-      if (state.pendingFallbackModel && state.pendingFallbackModel === requestedModel) {
+    const stripVariant = (m: any) => String(m).replace(/\(.*?\)$/, "").toLowerCase()
+    const reqLower = requestedModel ? requestedModel.toLowerCase() : undefined
+
+    if (reqLower && reqLower !== stripVariant(state.currentModel)) {
+      if (state.pendingFallbackModel && stripVariant(state.pendingFallbackModel) === reqLower) {
         state.pendingFallbackModel = undefined
         state.pendingFallbackPromptMayHaveBeenAccepted = false
         return
@@ -34,8 +37,10 @@ export function createChatMessageHandler(deps: HookDeps) {
         sessionID,
         from: state.currentModel,
         to: requestedModel,
+        debug_reqLower: reqLower,
+        debug_stripVariant: stripVariant(state.currentModel)
       })
-      state = createFallbackState(requestedModel)
+      state = createFallbackState(requestedModel!)
       sessionStates.set(sessionID, state)
       return
     }
@@ -53,9 +58,12 @@ export function createChatMessageHandler(deps: HookDeps) {
     if (output.message && activeModel) {
       const parts = activeModel.split("/")
       if (parts.length >= 2) {
+        // Strip the variant suffix (e.g. '(medium)') from the modelID.
+        // Opencode requires variants to be stored in the agentSettings payload rather than the modelID itself.
+        // Failing to strip the variant will result in a ProviderModelNotFoundError and break the fallback chain.
         output.message.model = {
           providerID: parts[0],
-          modelID: parts.slice(1).join("/"),
+          modelID: parts.slice(1).join("/").replace(/\(.*?\)$/, ""),
         }
       }
     }

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -47,6 +47,10 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /暂时不可用/,
   /服务不可用/,
   /请稍后重试/,
+  /empty\s*output/i,
+  /no\s*text\s*output/i,
+  /model\s+not\s+found/i,
+  /provider\s+not\s+found/i,
 ]
 
 /**

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -51,6 +51,11 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /no\s*text\s*output/i,
   /model\s+not\s+found/i,
   /provider\s+not\s+found/i,
+  /creditserror/i,
+  /insufficient\s+balance/i,
+  /free\s+promotion\s+has\s+ended/i,
+  /authentication\s+error/i,
+  /invalid\s+authentication/i,
 ]
 
 /**

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -237,3 +237,23 @@ describe("model support fallback", () => {
     expect(retryable3).toBe(true)
   })
 })
+
+describe("empty output fallback", () => {
+  test("detects empty_output errors as retryable for fallback chain", () => {
+    //#given
+    const error1 = { message: "empty output" }
+    const error2 = { name: "EmptyOutputError", message: "no text output" }
+
+    //#when
+    const type1 = classifyErrorType(error1)
+    const type2 = classifyErrorType(error2)
+    const retryable1 = isRetryableError(error1, [])
+    const retryable2 = isRetryableError(error2, [])
+
+    //#then
+    expect(type1).toBe("empty_output")
+    expect(type2).toBe("empty_output")
+    expect(retryable1).toBe(true)
+    expect(retryable2).toBe(true)
+  })
+})

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -257,3 +257,76 @@ describe("empty output fallback", () => {
     expect(retryable2).toBe(true)
   })
 })
+
+describe("OpenCode Go/Zen error classification", () => {
+  test("classifies insufficient_quota via code field as quota_exceeded", () => {
+    //#given
+    const error = {
+      error: {
+        code: "insufficient_quota",
+        type: "insufficient_quota",
+        message: "You exceeded your current quota, please check your plan and billing details."
+      }
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies Zen CreditsError via type field as quota_exceeded", () => {
+    //#given
+    const error = {
+      type: "error",
+      error: {
+        type: "CreditsError",
+        message: "Insufficient balance. Manage your billing here: https://opencode.ai/workspace/..."
+      }
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(errorType).toBe("quota_exceeded")
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies Zen ModelError (free promotion ended) as retryable via pattern", () => {
+    //#given
+    const error = {
+      type: "error",
+      error: {
+        type: "ModelError",
+        message: "Free promotion has ended for Qwen3.6 Plus Free. You can continue using the model by subscribing to OpenCode Go."
+      }
+    }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies authentication_error as retryable", () => {
+    //#given
+    const error = {
+      error: {
+        type: "authentication_error",
+        message: "Invalid Authentication"
+      }
+    }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+})

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -126,7 +126,10 @@ export function classifyErrorType(error: unknown): string | undefined {
   if (
     errorName?.includes("providermodelnotfounderror") ||
     errorName?.includes("modelnotfounderror") ||
-    (errorName?.includes("unknownerror") && /model\s+not\s+found/i.test(message))
+    (errorName?.includes("unknownerror") && /model\s+not\s+found/i.test(message)) ||
+    /model\s+not\s+found/i.test(message) ||
+    /provider.*not\s+found/i.test(message) ||
+    /selected provider is forbidden/i.test(message)
   ) {
     return "model_not_found"
   }
@@ -156,6 +159,15 @@ export function classifyErrorType(error: unknown): string | undefined {
     isLocalizedQuotaExhaustionMessage(message)
   ) {
     return "quota_exceeded"
+  }
+
+  if (
+    errorName?.includes("emptyoutput") ||
+    /empty\s*output/i.test(message) ||
+    /no\s*text\s*output/i.test(message) ||
+    /no\s*content/i.test(message)
+  ) {
+    return "empty_output"
   }
 
   return undefined
@@ -190,8 +202,10 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
   }
 
   if (errorType === "quota_exceeded") {
-    // Quota exhaustion means the current model/provider cannot serve requests.
-    // Trigger fallback to the next configured model instead of stopping entirely.
+    return true
+  }
+
+  if (errorType === "empty_output") {
     return true
   }
 

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -97,6 +97,56 @@ export function extractErrorName(error: unknown): string | undefined {
   return undefined
 }
 
+export function extractErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+
+  const errorObj = error as Record<string, unknown>
+  
+  const directCode = errorObj.code
+  if (typeof directCode === "string" && directCode.length > 0) {
+    return directCode
+  }
+
+  const nestedError = errorObj.error as Record<string, unknown> | undefined
+  const nestedCode = nestedError?.code
+  if (typeof nestedCode === "string" && nestedCode.length > 0) {
+    return nestedCode
+  }
+
+  const dataError = (errorObj.data as Record<string, unknown> | undefined)?.error as Record<string, unknown> | undefined
+  const dataErrorCode = dataError?.code
+  if (typeof dataErrorCode === "string" && dataErrorCode.length > 0) {
+    return dataErrorCode
+  }
+
+  return undefined
+}
+
+export function extractErrorType(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+
+  const errorObj = error as Record<string, unknown>
+  
+  const directType = errorObj.type
+  if (typeof directType === "string" && directType.length > 0 && directType !== "error") {
+    return directType
+  }
+
+  const nestedError = errorObj.error as Record<string, unknown> | undefined
+  const nestedType = nestedError?.type
+  if (typeof nestedType === "string" && nestedType.length > 0) {
+    return nestedType
+  }
+
+  const dataError = (errorObj.data as Record<string, unknown> | undefined)?.error as Record<string, unknown> | undefined
+  const dataErrorType = dataError?.type
+  if (typeof dataErrorType === "string" && dataErrorType.length > 0) {
+    return dataErrorType
+  }
+
+  return undefined
+}
+
 function isLocalizedQuotaExhaustionMessage(message: string): boolean {
   return (
     (/预扣费额度失败/i.test(message) && /用户剩余额度/i.test(message)) ||
@@ -106,14 +156,17 @@ function isLocalizedQuotaExhaustionMessage(message: string): boolean {
 
 export function classifyErrorType(error: unknown): string | undefined {
   const message = getErrorMessage(error)
-  // Normalize by stripping underscores and dashes so snake_case / kebab-case
-  // provider error names (e.g. "insufficient_quota", "RESOURCE_EXHAUSTED")
-  // match the existing alphanumeric .includes() checks below.
   const errorName = extractErrorName(error)?.toLowerCase()?.replace(/[_-]/g, "")
+  const errorCode = extractErrorCode(error)?.toLowerCase()?.replace(/[_-]/g, "")
+  const errorType = extractErrorType(error)?.toLowerCase()?.replace(/[_-]/g, "")
+
+  const combinedErrorIdentifier = `${errorName || ""}${errorCode || ""}${errorType || ""}`
 
   if (
     errorName?.includes("ailoadapikeyerror") ||
     errorName?.includes("loadapi") ||
+    errorCode?.includes("invalidapikey") ||
+    errorType?.includes("authenticationerror") ||
     (/api.?key.?is.?missing/i.test(message) && /environment variable/i.test(message))
   ) {
     return "missing_api_key"
@@ -139,6 +192,9 @@ export function classifyErrorType(error: unknown): string | undefined {
     errorName?.includes("insufficientquota") ||
     errorName?.includes("billingerror") ||
     errorName?.includes("resourceexhausted") ||
+    errorCode?.includes("insufficientquota") ||
+    errorType?.includes("creditserror") ||
+    errorType?.includes("billingerror") ||
     /quota.?exceeded/i.test(message) ||
     /exceeded.*quota/i.test(message) ||
     /usage\s*quota/i.test(message) ||

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -7,6 +7,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { isAbortError } from "../../shared/is-abort-error"
+import { markProviderFailed, clearAllProviderFailures } from "../../shared/provider-failure-state"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
@@ -53,6 +54,8 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
       sessionStates.set(sessionID, createFallbackState(model))
       sessionLastAccess.set(sessionID, Date.now())
+      clearAllProviderFailures()
+      log(`[${HOOK_NAME}] Cleared provider failure state for new session`, { sessionID })
     }
   }
 
@@ -195,6 +198,17 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
         errorType: classifyErrorType(error),
       })
       return
+    }
+
+    // Notify proactive model-fallback that this provider failed,
+    // so it can skip same-provider fallbacks on subsequent requests.
+    const failedProviderID = props?.providerID as string | undefined
+    if (failedProviderID) {
+      markProviderFailed(failedProviderID)
+      log(`[${HOOK_NAME}] Marked provider as failed for proactive fallback`, {
+        sessionID,
+        providerID: failedProviderID,
+      })
     }
 
     let state = sessionStates.get(sessionID)

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -49,6 +49,11 @@ function parseCanonicalModel(model: string): { providerID: string; modelID: stri
   }
 }
 
+function stripVariant(modelID: string): string {
+  const idx = modelID.indexOf("::")
+  return idx >= 0 ? modelID.slice(0, idx) : modelID
+}
+
 function isEquivalentModel(candidate: string, current: string): boolean {
   const parsedCandidate = parseCanonicalModel(candidate)
   const parsedCurrent = parseCanonicalModel(current)
@@ -57,10 +62,16 @@ function isEquivalentModel(candidate: string, current: string): boolean {
     return candidate.toLowerCase() === current.toLowerCase()
   }
 
-  return (
-    parsedCandidate.providerID === parsedCurrent.providerID &&
-    parsedCandidate.modelID === parsedCurrent.modelID
-  )
+  if (parsedCandidate.providerID !== parsedCurrent.providerID) {
+    return false
+  }
+
+  // Compare base model IDs without variant — a model with variant "medium"
+  // is equivalent to the same model without variant or with a different variant.
+  const baseCandidate = stripVariant(parsedCandidate.modelID)
+  const baseCurrent = stripVariant(parsedCurrent.modelID)
+
+  return baseCandidate === baseCurrent
 }
 
 export function createFallbackState(originalModel: string): FallbackState {

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -7,6 +7,7 @@ import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
+import { markProviderFailed } from "../../shared/provider-failure-state"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
@@ -125,6 +126,15 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
           errorType: classifyErrorType(error),
         })
         return
+      }
+
+      const failedProviderID = props?.providerID as string | undefined
+      if (failedProviderID) {
+        markProviderFailed(failedProviderID)
+        log(`[${HOOK_NAME}] Marked provider as failed for proactive fallback`, {
+          sessionID,
+          providerID: failedProviderID,
+        })
       }
 
       const agent = info?.agent as string | undefined

--- a/src/hooks/runtime-fallback/visible-assistant-response.ts
+++ b/src/hooks/runtime-fallback/visible-assistant-response.ts
@@ -26,6 +26,23 @@ function getAssistantText(parts: SessionMessagePart[] | undefined): string {
     .join("\n")
 }
 
+function hasAssistantContent(parts: SessionMessagePart[] | undefined): boolean {
+  if (!parts || parts.length === 0) return false
+
+  return parts.some((part) => {
+    if (part.type === "text") {
+      const text = typeof part.text === "string" ? part.text.trim() : ""
+      return text.length > 0
+    }
+
+    if (typeof part.type === "string" && part.type !== "error") {
+      return true
+    }
+
+    return false
+  })
+}
+
 export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof extractAutoRetrySignal) {
   return async (
     ctx: HookDeps["ctx"],
@@ -60,12 +77,13 @@ export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof ext
         const parts = message.parts && message.parts.length > 0
           ? message.parts
           : infoMessageParts
-        const assistantText = getAssistantText(parts)
-        if (!assistantText) {
+        const hasContent = hasAssistantContent(parts)
+        if (!hasContent) {
           continue
         }
 
-        if (extractAutoRetrySignalFn({ message: assistantText })) {
+        const assistantText = getAssistantText(parts)
+        if (assistantText && extractAutoRetrySignalFn({ message: assistantText })) {
           continue
         }
 

--- a/src/plugin/hooks/create-core-hooks.ts
+++ b/src/plugin/hooks/create-core-hooks.ts
@@ -33,6 +33,7 @@ export function createCoreHooks(args: {
     ctx,
     pluginConfig,
     modelCacheState,
+    backgroundManager,
     isHookEnabled,
     safeHookEnabled,
   })

--- a/src/plugin/hooks/create-tool-guard-hooks.test.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.test.ts
@@ -13,6 +13,11 @@ const mockModelCacheState = {
   modelContextLimitsCache: new Map(),
 } satisfies ModelCacheState
 
+const mockBackgroundManager = {
+  findBySession: () => undefined,
+  retryTaskOnEmptyOutput: async () => false,
+} as never
+
 describe("createToolGuardHooks", () => {
   let capturedOptions: { skipClaudeUserRules?: boolean } | undefined
 
@@ -40,6 +45,7 @@ describe("createToolGuardHooks", () => {
       ctx: mockContext,
       pluginConfig,
       modelCacheState: mockModelCacheState,
+      backgroundManager: mockBackgroundManager,
       isHookEnabled: (hookName: string) => hookName === "rules-injector",
       safeHookEnabled: true,
     })

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -1,6 +1,7 @@
 import type { HookName, OhMyOpenCodeConfig } from "../../config"
 import type { ModelCacheState } from "../../plugin-state"
 import type { PluginContext } from "../types"
+import type { BackgroundManager } from "../../features/background-agent"
 
 import {
   createCommentCheckerHooks,
@@ -55,10 +56,11 @@ export function createToolGuardHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
   modelCacheState: ModelCacheState
+  backgroundManager: BackgroundManager
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }): ToolGuardHooks {
-  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, backgroundManager, isHookEnabled, safeHookEnabled } = args
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
@@ -96,7 +98,7 @@ export function createToolGuardHooks(args: {
     : null
 
   const emptyTaskResponseDetector = isHookEnabled("empty-task-response-detector")
-    ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx))
+    ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx, backgroundManager))
     : null
 
   const cc = pluginConfig.claude_code

--- a/src/shared/provider-failure-state.ts
+++ b/src/shared/provider-failure-state.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared in-memory state tracking providers that have failed at runtime.
+ *
+ * Bridges the gap between the proactive `modelFallback` (chat.params) and
+ * reactive `runtimeFallback` (session.error) systems. When runtime-fallback
+ * classifies a provider error as quota_exceeded or rate-limited, it marks the
+ * provider here so the proactive system can skip it on subsequent requests.
+ *
+ * This is a per-process in-memory store — cleared on plugin restart.
+ */
+
+const failedProviders = new Set<string>()
+let cooldownMs = 120_000 // 2 minutes default
+
+/**
+ * Mark a provider as failed (e.g., quota exhausted, rate-limited).
+ * The provider will be skipped by the proactive fallback system
+ * until `clearProviderFailure` is called or the cooldown expires.
+ */
+export function markProviderFailed(providerID: string): void {
+  failedProviders.add(providerID.toLowerCase())
+}
+
+/**
+ * Check if a provider has been marked as failed.
+ */
+export function isProviderFailed(providerID: string): boolean {
+  return failedProviders.has(providerID.toLowerCase())
+}
+
+/**
+ * Clear a provider's failure state (e.g., after manual switch or cool-down).
+ */
+export function clearProviderFailure(providerID: string): void {
+  failedProviders.delete(providerID.toLowerCase())
+}
+
+/**
+ * Clear all provider failures (e.g., on session end or plugin restart).
+ */
+export function clearAllProviderFailures(): void {
+  failedProviders.clear()
+}
+
+/**
+ * Get the set of currently failed providers (for debugging/logging).
+ */
+export function getFailedProviders(): string[] {
+  return Array.from(failedProviders)
+}
+
+/**
+ * Set cooldown duration in milliseconds.
+ */
+export function setProviderFailureCooldownMs(ms: number): void {
+  cooldownMs = ms
+}


### PR DESCRIPTION
## Summary

Fixes runtime fallback chain hanging when using OpenCode Go/Zen providers by improving error classification and visible output detection.

## Changes

### 1. Error Classification (error-classifier.ts)
- Added `extractErrorCode()` to read `code` field from errors (OpenCode Go style: `{ error: { code: "insufficient_quota" } }`)
- Added `extractErrorType()` to read `type` field from errors (Zen style: `{ type: "error", error: { type: "CreditsError" } }`)
- Updated `classifyErrorType()` to use all three extractors (name, code, type) for proper error identification

### 2. Retryable Patterns (constants.ts)
Added new patterns to `RETRYABLE_ERROR_PATTERNS`:
- `/creditserror/i` - Matches Zen CreditsError
- `/insufficient balance/i` - Matches balance errors  
- `/free promotion has ended/i` - Matches expired free models
- `/authentication error/i` - Matches auth errors
- `/invalid authentication/i` - Matches invalid auth

### 3. Visible Output Detection (visible-assistant-response.ts)
- Added `hasAssistantContent()` that treats any non-error part type as valid content
- Prevents false "empty response" detection when models return reasoning without visible text (e.g., GLM-5)

## Test Coverage

Added tests for:
- OpenCode Go `insufficient_quota` via code field
- Zen `CreditsError` via type field
- Zen `ModelError` (free promotion ended)
- Authentication errors

## Related Issues

Builds on top of previous fallback fixes:
- #4378 - Detect empty_output and model_not_found
- #4377 - Three-layer defense for silent empty outputs
- #4376 - Skip equivalent fallback models
- #4375 - Bridge independent fallback systems

Fixes the remaining issues where fallback chain hangs due to:
1. Errors using `code`/`type` fields instead of `name`
2. Missing retryable patterns for Zen-specific errors
3. GLM-5 returning reasoning but no text content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime fallback hangs with OpenCode Go/Zen by classifying errors via code/type, retrying on empty or model-not-found responses, and treating reasoning-only outputs correctly. Adds a three-layer empty-output defense, strips variant suffixes, and bridges proactive/runtime fallback so failed providers are skipped automatically.

- Bug Fixes
  - Detect and retry `empty_output` and `model_not_found`; add patterns for empty/no-text/provider-not-found/auth/credits/balance/promo-ended.
  - Classify OpenCode Go/Zen errors via `code`/`type` (e.g., `insufficient_quota`, `CreditsError`, `authentication_error`) to trigger fallback.
  - Treat reasoning-only parts as content; require final text and retry on no text across idle, completion, and tool hooks.
  - Strip variant suffixes from model IDs in requests/outputs; skip variant-only fallbacks to avoid no-op retries and `ProviderModelNotFoundError`.
  - Mark `EmptyOutputError` as retryable in `packages/model-core`; tests cover empty-output and OpenCode Go/Zen cases.

- Refactors
  - Bridge proactive `modelFallback` and runtime fallback via shared `provider-failure-state`; mark failed providers, skip them in proactive selection, and clear on new session.
  - Background agent: add `retryTaskOnEmptyOutput`, an idle fallback callback, a completion gate that falls back on no text, and populate missing chains from `CATEGORY_MODEL_REQUIREMENTS`.

<sup>Written for commit b6ca15a1cb00db32514f95882392813029cba1b1. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4424?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

