### PR TITLE
chore(gitignore): ignore .dev/, .omc/, and per-user .opencode/oh-my-openagent.jsonc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ oauth-success.html
 .debug-journal*.md
 session-ses_*.md
 plans/
+
+# Local dev harness + plugin runtime state (per-user, never committed)
+.dev/
+.omc/
+# .opencode/ tracks project assets (AGENTS.md, background-tasks.json, command/, skills/),
+# but oh-my-openagent.jsonc is per-user plugin config and must not be committed.
+.opencode/oh-my-openagent.jsonc


### PR DESCRIPTION
## Summary

Three per-user / per-machine artifacts have been observed leaking into PRs (e.g. PR #4421 originally carried a SQLite opencode harness DB and a 44-line user jsonc config alongside its real fix). Add explicit ignores so the same pollution can't recur on anyone's branch.

## Entries

| Pattern | Why |
|---|---|
| \`.dev/\` | opencode test harness sandbox (xdg cache, scratch DBs, per-user \`models.json\`). \`git ls-tree upstream/dev .dev/\` is empty — no project file lives here. |
| \`.omc/\` | runtime state from the oh-my-claudecode plugin suite (\`sessions/\`, \`state/\`, \`notepad\`). Mirrors the existing \`.omx/\` ignore that's already in the file. |
| \`.opencode/oh-my-openagent.jsonc\` | per-user plugin config. The rest of \`.opencode/\` (\`AGENTS.md\`, \`background-tasks.json\`, \`command/\`, \`skills/\`) is project source and **stays tracked** — only this one file is excluded. |

## Diff

\`.gitignore\` only: +7 lines (one section header + three entries + one explanatory comment).

## Test plan

- [x] \`git check-ignore .dev/opencode-harness/opencode.db\` → match
- [x] \`git check-ignore .omc/state/foo\` → match
- [x] \`git check-ignore .opencode/oh-my-openagent.jsonc\` → match
- [x] \`git ls-files .opencode/\` still shows \`AGENTS.md\`, \`background-tasks.json\`, \`command/*\`, \`skills/*\` — not affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ignores to `.gitignore` for `.dev/`, `.omc/`, and `.opencode/oh-my-openagent.jsonc` to stop per-user dev harness and plugin state from being committed. Project assets under `.opencode/` (e.g., `AGENTS.md`, `background-tasks.json`, `command/`, `skills/`) remain tracked.

<sup>Written for commit e7f4de7bbc443f34ed81c6437f2ef1e1e9943674. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

