### PR TITLE
fix(tmux-subagent): stop tracking team-mode member sessions in the subagent panel

### DIFF
--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -6,6 +6,7 @@ import type { SubagentSessionCreatedEvent } from "./features/background-agent"
 import { BackgroundManager } from "./features/background-agent"
 import { SkillMcpManager } from "./features/skill-mcp-manager"
 import { cleanupSessionTeamRuns } from "./features/team-mode/team-runtime/session-cleanup"
+import { lookupTeamSession } from "./features/team-mode/team-session-registry"
 import { createModelFallbackControllerAccessor } from "./hooks/model-fallback"
 import { initTaskToastManager } from "./features/task-toast-manager"
 import { TmuxSessionManager } from "./features/tmux-subagent"
@@ -68,7 +69,14 @@ export function createManagers(args: {
   if (tmuxConfig.enabled && ctx.serverUrl) {
     deps.markServerRunningInProcessFn()
   }
-  const tmuxSessionManager = new deps.TmuxSessionManagerClass(ctx, tmuxConfig)
+  const tmuxSessionManager = new deps.TmuxSessionManagerClass(ctx, tmuxConfig, undefined, {
+    // Team-mode members get their tmux panes from team-layout-tmux, which
+    // owns the lifecycle via runtimeState.tmuxLayout. Telling the subagent
+    // manager to ignore those sessions prevents the polling loop from racing
+    // pane closes against team-layout and stops them from being surfaced
+    // twice in the subagent panel.
+    shouldSkipSession: (sessionId) => lookupTeamSession(sessionId) !== undefined,
+  })
   const modelFallbackControllerAccessor = createModelFallbackControllerAccessor()
   let backgroundManager: BackgroundManager | undefined
 

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -617,6 +617,46 @@ describe('TmuxSessionManager', () => {
       }
     })
 
+    test('shouldSkipSession short-circuits the flow so team-mode sessions are not tracked twice', async () => {
+      // given - the host wires `shouldSkipSession` to lookupTeamSession so the
+      // subagent manager ignores sessions that team-layout-tmux already owns.
+      // Without this guard, polling and team-layout race over the same pane.
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config = createTmuxConfig({ enabled: true,
+      layout: 'main-vertical',
+      main_pane_size: 60,
+      main_pane_min_width: 80,
+      agent_pane_min_width: 40, })
+      const skippedSessionIds: string[] = []
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps, {
+        shouldSkipSession: (sessionId) => {
+          skippedSessionIds.push(sessionId)
+          return sessionId === 'ses_team_member'
+        },
+      })
+
+      // when - a team-member session.created fires
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_team_member', 'ses_parent', 'team member task'),
+      )
+
+      // then - the manager exits early; no window query, no spawn action.
+      expect(skippedSessionIds).toEqual(['ses_team_member'])
+      expect(mockQueryWindowState).not.toHaveBeenCalled()
+      expect(mockExecuteActions).not.toHaveBeenCalled()
+
+      // and - an ordinary subagent on the same manager still spawns normally.
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_plain_subagent', 'ses_parent', 'plain task'),
+      )
+      expect(skippedSessionIds).toEqual(['ses_team_member', 'ses_plain_subagent'])
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+    })
+
     test('second agent spawns with correct split direction', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -61,6 +61,25 @@ export interface TmuxUtilDeps {
   log: typeof sharedModule.log
 }
 
+/**
+ * Options passed to TmuxSessionManager at construction time.
+ *
+ * Distinct from `TmuxUtilDeps` (low-level tmux util injection): these are
+ * external policy hooks the manager defers to without owning the policy.
+ */
+export interface TmuxSessionManagerOptions {
+  /**
+   * Predicate the manager calls in `onSessionCreated` to decide whether this
+   * session should be ignored entirely. Used to keep team-mode member sessions
+   * out of the subagent pane tracking, since team-layout-tmux owns their pane
+   * lifecycle separately and double-tracking causes pane double-close races
+   * and stale entries in the subagent panel.
+   *
+   * Defaults to `() => false` (track everything).
+   */
+  shouldSkipSession?: (sessionId: string) => boolean
+}
+
 const defaultTmuxDeps: TmuxUtilDeps = {
   isInsideTmux: defaultIsInsideTmux,
   getCurrentPaneId: defaultGetCurrentPaneId,
@@ -104,6 +123,7 @@ export class TmuxSessionManager {
   private deferredAttachTickScheduled = false
   private nullStateCount = 0
   private deps: TmuxUtilDeps
+  private shouldSkipSession: (sessionId: string) => boolean
   private pollingManager: TmuxPollingManager
   private isolatedContainerPaneId: string | undefined
   private isolatedWindowPaneId: string | undefined
@@ -111,11 +131,17 @@ export class TmuxSessionManager {
   private staleSweepCompleted = false
   private staleSweepInProgress = false
   private isolatedSessionManagerId = createIsolatedSessionManagerId()
-  constructor(ctx: PluginInput, tmuxConfig: TmuxConfig, deps: Partial<TmuxUtilDeps> = {}) {
+  constructor(
+    ctx: PluginInput,
+    tmuxConfig: TmuxConfig,
+    deps: Partial<TmuxUtilDeps> = {},
+    options: TmuxSessionManagerOptions = {},
+  ) {
     this.client = ctx.client
     this.tmuxConfig = tmuxConfig
     this.projectDirectory = ctx.directory || process.cwd()
     this.deps = { ...defaultTmuxDeps, ...deps }
+    this.shouldSkipSession = options.shouldSkipSession ?? (() => false)
     const configuredPort = process.env.OPENCODE_PORT
     const parsedPort = configuredPort ? Number(configuredPort) : 4096
     const defaultPort = Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535
@@ -1151,6 +1177,19 @@ export class TmuxSessionManager {
     const info = event.properties?.info
     const sessionId = resolveSessionEventID(event.properties)
     if (!sessionId || !info?.parentID) return
+
+    // Team-mode members live in `team-layout-tmux` (which owns the pane
+    // lifecycle via runtimeState.tmuxLayout). Tracking them here as well
+    // produces two managers fighting over the same pane: polling can close a
+    // pane while team-layout is still rendering into it, and the subagent
+    // panel surfaces a duplicate row that's already represented in team_status.
+    if (this.shouldSkipSession(sessionId)) {
+      this.deps.log("[tmux-session-manager] onSessionCreated skipped via shouldSkipSession", {
+        sessionId,
+        parentID: info.parentID,
+      })
+      return
+    }
 
     const title = info.title ?? "Subagent"
 


### PR DESCRIPTION
## Symptom

Two complaints from the field that share a root cause:

1. **Team members surface inside the subagent panel** alongside the dedicated team_status view (same session shown twice).
2. **Team-member panes go missing / get closed underneath team-layout-tmux** during normal team operation — the polling loop in TmuxSessionManager decides the pane is idle and closes it while team-layout-tmux is still rendering into it.

## Root cause

Team-mode members are launched with \`bgMgr.launch({ suppressTmuxSpawn: true })\` to defer pane creation to \`createTeamLayout()\`. But \`suppressTmuxSpawn\` only blocks the explicit \`onSubagentSessionCreated\` callback wired in \`src/create-managers.ts\`. The team-member session still emits \`session.created\` through other paths, and \`TmuxSessionManager.onSessionCreated\` adds it to \`this.sessions\` regardless. Now two managers own the same pane:

- \`team-layout-tmux\` owns it via \`runtimeState.tmuxLayout\`
- \`TmuxSessionManager.sessions\` parallel-tracks it and polls for idle

The polling loop's close decision races team-layout's render and cleanup, producing the visible \"pane disappeared\" / \"member errored\" symptoms users report.

## Fix

Inject a \`shouldSkipSession\` predicate into TmuxSessionManager (a 4th optional constructor arg). The manager defaults to \`() => false\` — no behavior change for existing callers. \`create-managers.ts\` wires the predicate to \`lookupTeamSession\`, so any session already known to the team-session registry returns from \`onSessionCreated\` before \`spawnPendingSession\` runs.

## Layering

- \`tmux-subagent\` stays unaware of \`team-mode\` — no new imports across the boundary.
- The host (\`create-managers.ts\`) injects the team-side policy at construction time.
- Dependency direction remains \`team-mode → tmux-subagent\` only.

## Diff

| File | Change |
|---|---|
| \`src/features/tmux-subagent/manager.ts\` | +\`TmuxSessionManagerOptions\` type, +4th constructor arg, +1 field + 1 init line, +early-exit branch in \`onSessionCreated\` |
| \`src/create-managers.ts\` | +1 import, +wire \`shouldSkipSession\` to \`lookupTeamSession\` |
| \`src/features/tmux-subagent/manager.test.ts\` | +1 test verifying the early-exit fires for team-member sessionId AND ordinary subagents still spawn |

**3 files / +89 / −2** — minimal, reviewable.

## Related

- #4035 (team-mode tmux panes stay on first message) — partially helps; removes one race
- #4411 / PR #4412 (rollback tmux cleanup) — orthogonal, my prior fix
- #4420 / PR #4421 (fallback retry race) — orthogonal, my prior fix

## Test plan

- [x] \`bun test src/features/tmux-subagent/manager.test.ts src/create-managers.test.ts\` — 67 pass
- [x] \`bun test src/features/tmux-subagent/ src/features/team-mode/ src/hooks/team-session-events/\` — 436 pass / 0 fail
- [x] \`bun run typecheck\` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop tracking team‑mode member sessions in the tmux subagent to eliminate duplicate entries and prevent polling from closing team panes. This fixes subagent panel duplicates and the “pane disappeared” race under `team-layout-tmux`.

- **Bug Fixes**
  - Added optional `shouldSkipSession` to `TmuxSessionManager` (defaults to track all) and early‑exit in `onSessionCreated`.
  - Wired `create-managers.ts` to `lookupTeamSession` so team-member sessions are skipped before spawn/tracking.

<sup>Written for commit 12d4d775b02a7db4a6cd272650b44e7d36bc16a0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

