### PR TITLE
fix(tmux-subagent): close placeholder panes that exceed PLACEHOLDER_PANE_TIMEOUT_MS

### DIFF
--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager.test.ts
@@ -455,6 +455,91 @@ describe("TmuxPollingManager overlap", () => {
     }
   })
 
+  test("closes placeholder panes that exceed PLACEHOLDER_PANE_TIMEOUT_MS without ever activating or returning status", async () => {
+    //#given - a placeholder pane older than the grace cap (30 min) that has
+    // never been focused (attachActivated=false) and the server never replied
+    // with a status. Before this guard, polling skipped every close check
+    // indefinitely and the pane accumulated forever.
+    const { PLACEHOLDER_PANE_TIMEOUT_MS } = await import("../../shared/tmux")
+    const sessions = new Map<string, TrackedSession>()
+    sessions.set("ses-zombie", {
+      sessionId: "ses-zombie",
+      paneId: "%9",
+      description: "abandoned subagent pane",
+      attachActivated: false,
+      createdAt: new Date(Date.now() - (PLACEHOLDER_PANE_TIMEOUT_MS + 60_000)),
+      lastSeenAt: new Date(Date.now() - (PLACEHOLDER_PANE_TIMEOUT_MS + 60_000)),
+      closePending: false,
+      closeRetryCount: 0,
+      activityVersion: 0,
+    })
+
+    const closedSessionIds: string[] = []
+    const client = {
+      session: {
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    const manager = new TmuxPollingManager(
+      unsafeTestValue<import("../../tools/delegate-task/types").OpencodeClient>(client),
+      sessions,
+      async (sessionId) => {
+        closedSessionIds.push(sessionId)
+      },
+    )
+    const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+    //#when
+    await pollSessions.call(manager)
+
+    //#then
+    expect(closedSessionIds).toEqual(["ses-zombie"])
+    expect(sessions.get("ses-zombie")?.closePending).toBe(true)
+  })
+
+  test("still defers closure for placeholder panes within the grace window", async () => {
+    //#given - same pane shape, but only 5 minutes old (well under the 30 min cap).
+    // Existing behavior must be preserved: legitimate placeholder still gets time.
+    const { PLACEHOLDER_PANE_TIMEOUT_MS } = await import("../../shared/tmux")
+    const sessions = new Map<string, TrackedSession>()
+    sessions.set("ses-young", {
+      sessionId: "ses-young",
+      paneId: "%2",
+      description: "still setting up",
+      attachActivated: false,
+      createdAt: new Date(Date.now() - 5 * 60 * 1000),
+      lastSeenAt: new Date(),
+      closePending: false,
+      closeRetryCount: 0,
+      activityVersion: 0,
+    })
+
+    const closedSessionIds: string[] = []
+    const client = {
+      session: {
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    const manager = new TmuxPollingManager(
+      unsafeTestValue<import("../../tools/delegate-task/types").OpencodeClient>(client),
+      sessions,
+      async (sessionId) => {
+        closedSessionIds.push(sessionId)
+      },
+    )
+    const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+    //#when
+    await pollSessions.call(manager)
+
+    //#then
+    expect(PLACEHOLDER_PANE_TIMEOUT_MS).toBeGreaterThan(5 * 60 * 1000)
+    expect(closedSessionIds).toEqual([])
+    expect(sessions.get("ses-young")?.closePending).toBe(false)
+  })
+
   test("can still close non-activated sessions once status is idle and stable", async () => {
     //#given
     const sessions = new Map<string, TrackedSession>()

--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
@@ -1,5 +1,6 @@
 import type { OpencodeClient } from "../../tools/delegate-task/types"
 import {
+  PLACEHOLDER_PANE_TIMEOUT_MS,
   POLL_INTERVAL_BACKGROUND_MS,
   SESSION_MISSING_GRACE_MS,
   SESSION_READY_TIMEOUT_MS,
@@ -81,11 +82,31 @@ export class TmuxPollingManager {
         const status = allStatuses[sessionId]
         const elapsedMs = now - tracked.createdAt.getTime()
         if (!tracked.attachActivated && !status) {
-          log("[tmux-session-manager] placeholder pane has not been activated yet; skipping close checks", {
+          // Bounded grace: a placeholder pane the user never focuses + that
+          // never returns a server status would otherwise sit in the map
+          // forever, which is the primary source of pane accumulation across
+          // a long parent session. Fall through to the normal close path once
+          // it has clearly been a zombie for too long.
+          if (elapsedMs < PLACEHOLDER_PANE_TIMEOUT_MS) {
+            log("[tmux-session-manager] placeholder pane has not been activated yet; skipping close checks", {
+              sessionId,
+              paneId: tracked.paneId,
+              elapsedMs,
+              graceMs: PLACEHOLDER_PANE_TIMEOUT_MS,
+            })
+            continue
+          }
+
+          log("[tmux-session-manager] placeholder pane exceeded grace; queuing for close", {
             sessionId,
             paneId: tracked.paneId,
             elapsedMs,
+            graceMs: PLACEHOLDER_PANE_TIMEOUT_MS,
           })
+          if (!tracked.closePending) {
+            tracked.closePending = true
+            sessionsToClose.push(sessionId)
+          }
           continue
         }
 

--- a/packages/omo-opencode/src/shared/tmux/constants.ts
+++ b/packages/omo-opencode/src/shared/tmux/constants.ts
@@ -14,3 +14,12 @@ export const SESSION_MISSING_GRACE_MS = 30 * 1000  // 30 seconds
 // Session readiness polling config
 export const SESSION_READY_POLL_INTERVAL_MS = 500
 export const SESSION_READY_TIMEOUT_MS = 10_000  // 10 seconds max wait
+
+// Cap on how long a placeholder pane (never activated, no server status reply)
+// is allowed to linger before polling treats it as a zombie and queues it for
+// close. Generous because legitimate setup may take a while (slow attach,
+// deferred spawn, etc.) — significantly longer than SESSION_TIMEOUT_MS so
+// panes the user is about to attach to don't get killed under them. Without
+// this guard, panes that the user never focuses accumulate indefinitely
+// because polling skips every close check while attachActivated stays false.
+export const PLACEHOLDER_PANE_TIMEOUT_MS = 30 * 60 * 1000


### PR DESCRIPTION
## Symptom

Tmux subagent panes accumulate over a long parent session and are never cleaned up. Closing the parent OpenCode session GCs them, but during a single long-lived session the count keeps growing.

## Root cause

\`TmuxPollingManager.pollSessions\` (src/features/tmux-subagent/polling-manager.ts:83) skips every close check for any tracked session whose \`attachActivated\` is \`false\` AND whose server status query returns nothing:

\`\`\`ts
if (!tracked.attachActivated && !status) {
  log("placeholder pane has not been activated yet; skipping close checks", {...})
  continue  // ← unbounded
}
\`\`\`

The skip is correct for the few seconds between spawn and first status, but for any pane the user never focuses (background subagent panes the user doesn't look at, panes whose server never returns status because the session was DOA, etc.) the session never produces status AND never flips activated. The entry stays in \`this.sessions\` forever — neither \`missingTooLong\`, \`isTimedOut\`, nor the stability path get a chance to run.

## Fix

Cap the skip with a generous grace, \`PLACEHOLDER_PANE_TIMEOUT_MS = 30 min\`, added to \`src/shared/tmux/constants.ts\` next to the other session timeouts. Once a placeholder pane exceeds the cap, queue it for the normal close path (same as \`missingTooLong\` / \`isTimedOut\`).

The cap is **intentionally generous** — much longer than the brief few-seconds setup window so panes the user is genuinely about to attach to don't get killed under them. But it's finite, so the leak stops.

## Diff

| File | Change |
|---|---|
| \`src/shared/tmux/constants.ts\` | +\`PLACEHOLDER_PANE_TIMEOUT_MS = 30 * 60 * 1000\` (with comment) |
| \`src/features/tmux-subagent/polling-manager.ts\` | +1 import, +13 lines (cap check + structured log + close queueing) |
| \`src/features/tmux-subagent/polling-manager.test.ts\` | +2 tests |

**3 files / +116 / −1**, narrow and reviewable.

## Test plan

- [x] New: zombie placeholder pane (>30 min, never activated, no status) → queued for close + \`closePending: true\`
- [x] New: young placeholder pane (5 min old) → NOT closed (preserves existing setup-grace behavior)
- [x] \`bun test src/features/tmux-subagent/polling-manager.test.ts\` — 11 pass
- [x] \`bun test src/features/tmux-subagent/ src/shared/tmux/\` — 225 pass / 0 fail
- [x] \`bun run typecheck\` — clean

## Related

- Companion PR #4430 (\`fix(tmux-subagent): stop tracking team-mode member sessions in the subagent panel\`) addresses double-tracking specifically for team members.
- Together these two fixes address both halves of the user-reported issue: "Why are team members visible in the subagent panel AND why do subagents under a same session grow and never get deleted."
- The earlier investigation also identified zombie panes after max close-retries (Gap B) and lack of LRU eviction (Gap E) as additional structural concerns; both are out of scope here and likely warrant a separate maintainer discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes never-activated, no-status tmux subagent placeholder panes after 30 minutes to stop pane leaks during long sessions.

- **Bug Fixes**
  - Added `PLACEHOLDER_PANE_TIMEOUT_MS` (30 min) in `src/shared/tmux/constants.ts`.
  - Bounded the skip in `TmuxPollingManager.pollSessions`; after timeout, mark `closePending` and queue for normal close while keeping short setup grace.
  - Added tests for timed-out and young placeholder panes.

<sup>Written for commit 4388335a0424b7c5f358f1b162a4267a3f50ed20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

