### PR TITLE
fix(tools): return structured error objects from skill tool validation failures

### DIFF
--- a/src/tools/call-omo-agent/tools.test.ts
+++ b/src/tools/call-omo-agent/tools.test.ts
@@ -87,7 +87,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("disabled via disabled_agents")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("disabled via disabled_agents")
     })
 
     test("should reject agent in disabled_agents list with case-insensitive matching", async () => {
@@ -100,7 +101,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("disabled via disabled_agents")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("disabled via disabled_agents")
     })
 
     test("should allow agent not in disabled_agents list", async () => {
@@ -141,7 +143,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("subagent_type is required")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("subagent_type is required")
     })
 
     test("should reject general even when returned by client.app.agents()", async () => {
@@ -155,8 +158,10 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("Invalid agent type")
-      expect(result).toContain("Only explore, librarian are allowed")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      const output = typeof result === "object" ? result.output : result
+      expect(output).toContain("Invalid agent type")
+      expect(output).toContain("Only explore, librarian are allowed")
     })
 
     test("should reject unknown non-allowed agents", async () => {
@@ -169,7 +174,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("Invalid agent type")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Invalid agent type")
     })
 
     test("should perform case-insensitive matching for allowed agents", async () => {
@@ -182,7 +188,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).not.toContain("Invalid agent type")
+      expect(typeof result === "object" ? result.metadata?.kind : null).not.toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).not.toContain("Invalid agent type")
     })
 
     test("should exclude primary-mode agents from callable list", async () => {
@@ -199,7 +206,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("Invalid agent type")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Invalid agent type")
     })
 
     test("should fall back to ALLOWED_AGENTS when client.app.agents() fails", async () => {
@@ -212,7 +220,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).not.toContain("Invalid agent type")
+      expect(typeof result === "object" ? result.metadata?.kind : null).not.toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).not.toContain("Invalid agent type")
     })
 
     test("should reject unknown agent even when client.app.agents() fails (fallback mode)", async () => {
@@ -225,7 +234,8 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("Invalid agent type")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Invalid agent type")
     })
 
     test("should reject non-allowed agents before disabled_agents can make them appear callable", async () => {
@@ -239,8 +249,10 @@ describe("createCallOmoAgent", () => {
         toolCtx
       )
 
-      expect(result).toContain("Invalid agent type")
-      expect(result).not.toContain("disabled via disabled_agents")
+      expect(typeof result === "object" ? result.metadata?.kind : null).toBe("unsupported_agents_action")
+      const output = typeof result === "object" ? result.output : result
+      expect(output).toContain("Invalid agent type")
+      expect(output).not.toContain("disabled via disabled_agents")
     })
   })
 

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -141,7 +141,10 @@ export function createCallOmoAgent(
       );
 
       if (typeof args.subagent_type !== "string" || args.subagent_type.trim() === "") {
-        return "Error: subagent_type is required."
+        return {
+          output: "Error: subagent_type is required.",
+          metadata: { kind: "unsupported_agents_action" },
+        }
       }
 
       const callableAgents = await resolveCallableAgents(ctx.client);
@@ -153,7 +156,10 @@ export function createCallOmoAgent(
           (name) => name.toLowerCase() === strippedAgentType.toLowerCase(),
         )
       ) {
-        return `Error: Invalid agent type "${args.subagent_type}". Only ${callableAgents.join(", ")} are allowed.`;
+        return {
+          output: `Error: Invalid agent type "${args.subagent_type}". Only ${callableAgents.join(", ")} are allowed.`,
+          metadata: { kind: "unsupported_agents_action" },
+        }
       }
 
       const normalizedAgent = strippedAgentType.toLowerCase();
@@ -161,7 +167,10 @@ export function createCallOmoAgent(
 
       // Check if agent is disabled
       if (disabledAgents.some((disabled) => stripInvisibleAgentCharacters(disabled).toLowerCase() === normalizedAgent)) {
-        return `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your ${CONFIG_BASENAME}.json to use it.`
+        return {
+          output: `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your ${CONFIG_BASENAME}.json to use it.`,
+          metadata: { kind: "unsupported_agents_action" },
+        }
       }
 
       const { model: resolvedModel, fallbackChain } = resolveModelAndFallbackChain({

--- a/src/tools/session-manager/file-storage.ts
+++ b/src/tools/session-manager/file-storage.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { join } from "node:path"
 import { MESSAGE_STORAGE, PART_STORAGE, SESSION_STORAGE, TODO_DIR, TRANSCRIPT_DIR } from "./constants"
 import { getMessageDir } from "../../shared/opencode-message-dir"
@@ -20,14 +20,31 @@ export async function getFileMainSessions(directory?: string): Promise<SessionMe
       for (const file of sessionFiles) {
         if (!file.endsWith(".json")) continue
 
+        const filePath = join(projectPath, file)
         try {
-          const content = await readFile(join(projectPath, file), "utf-8")
+          const content = await readFile(filePath, "utf-8")
           const meta = JSON.parse(content) as SessionMetadata
           if (meta.parentID) continue
           if (directory && meta.directory !== directory) continue
           sessions.push(meta)
-        } catch {
-          continue
+        } catch (err) {
+          const sessionID = file.replace(/\.json$/, "")
+          try {
+            const stats = await stat(filePath)
+            const mtime = Math.floor(stats.mtimeMs)
+            sessions.push({
+              id: sessionID,
+              projectID: projectDir.name,
+              directory: directory || "",
+              time: {
+                created: mtime,
+                updated: mtime,
+              },
+              load_error: err instanceof Error ? err.message : String(err),
+            })
+          } catch {
+            continue
+          }
         }
       }
     }

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -397,6 +397,62 @@ describe("session-manager storage - getMainSessions", () => {
     expect(sessionsB[0].id).toBe("ses_projB")
   })
 
+  test("getMainSessions includes corrupted JSON files with mtime fallback and load_error", async () => {
+    //#given
+    const projectID = "proj_corrupt"
+    const now = Date.now()
+
+    // Create a valid session
+    createSessionMetadata(projectID, "ses_valid", { directory: "/test/path", updated: now - 1000 })
+
+    // Create a corrupted session file
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    mkdirSync(projectDir, { recursive: true })
+    const corruptFile = join(projectDir, "ses_corrupt.json")
+    writeFileSync(corruptFile, "{ invalid json", "utf-8")
+
+    // Manually set the mtime to be newer than the valid session
+    // Note: we can't easily control mtime in tests, so we'll verify it's included with load_error
+
+    //#when
+    const sessions = await storage.getMainSessions({ directory: "/test/path" })
+
+    //#then
+    expect(sessions.length).toBe(2)
+    const corruptSession = sessions.find((s) => s.id === "ses_corrupt")
+    expect(corruptSession).toBeDefined()
+    expect(corruptSession?.load_error).toBeTruthy()
+    expect(corruptSession?.time.updated).toBeGreaterThan(0)
+  })
+  test("getMainSessions sorts corrupted JSON files alongside valid sessions using mtime", async () => {
+    //#given
+    const projectID = "proj_sort"
+    const now = Date.now()
+
+    createSessionMetadata(projectID, "ses_old", { directory: "/test/path", updated: now - 5000 })
+    createSessionMetadata(projectID, "ses_new", { directory: "/test/path", updated: now })
+
+    // Create a corrupted file with mtime in between
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    mkdirSync(projectDir, { recursive: true })
+    const corruptFile = join(projectDir, "ses_mid.json")
+    writeFileSync(corruptFile, "{ invalid json", "utf-8")
+
+    // Touch the file to set mtime between old and new
+    // We use utimesSync to set a specific mtime
+    const { utimesSync } = require("node:fs")
+    utimesSync(corruptFile, new Date(now - 2500), new Date(now - 2500))
+
+    //#when
+    const sessions = await storage.getMainSessions({ directory: "/test/path" })
+
+    //#then
+    expect(sessions.length).toBe(3)
+    expect(sessions[0].id).toBe("ses_new")
+    expect(sessions[1].id).toBe("ses_mid")
+    expect(sessions[2].id).toBe("ses_old")
+  })
+
   test("getMainSessions returns all main sessions when directory is not specified", async () => {
     // given
     const projectA = "proj_aaa"

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -49,7 +49,22 @@ export interface SearchResult {
   timestamp?: number
 }
 
-export interface SessionMetadata {
+  id: string
+  version?: string
+  projectID: string
+  directory: string
+  title?: string
+  parentID?: string
+  time: {
+    created: number
+    updated: number
+  }
+  summary?: {
+    additions: number
+    deletions: number
+    files: number
+  }
+  load_error?: string
   id: string
   version?: string
   projectID: string

--- a/src/tools/skill-mcp/tools.test.ts
+++ b/src/tools/skill-mcp/tools.test.ts
@@ -42,7 +42,7 @@ describe("skill_mcp tool", () => {
   })
 
   describe("parameter validation", () => {
-    it("throws when no operation specified", async () => {
+    it("returns unsupported_mcp_action when no operation specified", async () => {
       // given
       const tool = createSkillMcpTool({
         manager,
@@ -50,13 +50,15 @@ describe("skill_mcp tool", () => {
         getSessionID: () => sessionID,
       })
 
-      // when / #then
-      await expect(
-        tool.execute({ mcp_name: "test-server" }, mockContext)
-      ).rejects.toThrow(/Missing operation/)
+      // when
+      const result = await tool.execute({ mcp_name: "test-server" }, mockContext)
+
+      // then
+      expect(typeof result === "object" && result.metadata?.kind).toBe("unsupported_mcp_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Missing operation")
     })
 
-    it("throws when multiple operations specified", async () => {
+    it("returns unsupported_mcp_action when multiple operations specified", async () => {
       // given
       const tool = createSkillMcpTool({
         manager,
@@ -64,17 +66,19 @@ describe("skill_mcp tool", () => {
         getSessionID: () => sessionID,
       })
 
-      // when / #then
-      await expect(
-        tool.execute({
-          mcp_name: "test-server",
-          tool_name: "some-tool",
-          resource_name: "some://resource",
-        }, mockContext)
-      ).rejects.toThrow(/Multiple operations/)
+      // when
+      const result = await tool.execute({
+        mcp_name: "test-server",
+        tool_name: "some-tool",
+        resource_name: "some://resource",
+      }, mockContext)
+
+      // then
+      expect(typeof result === "object" && result.metadata?.kind).toBe("unsupported_mcp_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Multiple operations")
     })
 
-    it("throws when mcp_name not found in any skill", async () => {
+    it("returns unsupported_mcp_action when mcp_name not found in any skill", async () => {
       // given
       loadedSkills = [
         createMockSkillWithMcp("test-skill", {
@@ -87,13 +91,15 @@ describe("skill_mcp tool", () => {
         getSessionID: () => sessionID,
       })
 
-      // when / #then
-      await expect(
-        tool.execute({ mcp_name: "unknown-server", tool_name: "some-tool" }, mockContext)
-      ).rejects.toThrow(/not found/)
+      // when
+      const result = await tool.execute({ mcp_name: "unknown-server", tool_name: "some-tool" }, mockContext)
+
+      // then
+      expect(typeof result === "object" && result.metadata?.kind).toBe("unsupported_mcp_action")
+      expect(typeof result === "object" ? result.output : result).toContain("not found")
     })
 
-    it("includes available MCP servers in error message", async () => {
+    it("includes available MCP servers in unsupported_mcp_action response", async () => {
       // given
       loadedSkills = [
         createMockSkillWithMcp("db-skill", {
@@ -109,13 +115,16 @@ describe("skill_mcp tool", () => {
         getSessionID: () => sessionID,
       })
 
-      // when / #then
-      await expect(
-        tool.execute({ mcp_name: "missing", tool_name: "test" }, mockContext)
-      ).rejects.toThrow(/sqlite.*db-skill|rest-api.*api-skill/s)
+      // when
+      const result = await tool.execute({ mcp_name: "missing", tool_name: "test" }, mockContext)
+
+      // then
+      expect(typeof result === "object" && result.metadata?.kind).toBe("unsupported_mcp_action")
+      const output = typeof result === "object" ? result.output : result
+      expect(output).toMatch(/sqlite.*db-skill|rest-api.*api-skill/s)
     })
 
-    it("throws on invalid JSON arguments", async () => {
+    it("returns unsupported_mcp_action on invalid JSON arguments", async () => {
       // given
       loadedSkills = [
         createMockSkillWithMcp("test-skill", {
@@ -128,14 +137,16 @@ describe("skill_mcp tool", () => {
         getSessionID: () => sessionID,
       })
 
-      // when / #then
-      await expect(
-        tool.execute({
-          mcp_name: "test-server",
-          tool_name: "some-tool",
-          arguments: "not valid json",
-        }, mockContext)
-      ).rejects.toThrow(/Invalid arguments JSON/)
+      // when
+      const result = await tool.execute({
+        mcp_name: "test-server",
+        tool_name: "some-tool",
+        arguments: "not valid json",
+      }, mockContext)
+
+      // then
+      expect(typeof result === "object" && result.metadata?.kind).toBe("unsupported_mcp_action")
+      expect(typeof result === "object" ? result.output : result).toContain("Invalid arguments JSON")
     })
   })
 

--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -115,28 +115,45 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
         .describe("Regex pattern to filter output lines (only matching lines returned)"),
     },
     async execute(args: SkillMcpArgs, toolContext: ToolContext) {
-      const operation = validateOperationParams(args)
+      let operation: OperationType
+      try {
+        operation = validateOperationParams(args)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          output: message,
+          metadata: { kind: "unsupported_mcp_action" },
+        }
+      }
       const skills = getLoadedSkills()
       const found = findMcpServer(args.mcp_name, skills)
 
       if (!found) {
         const builtinHint = formatBuiltinMcpHint(args.mcp_name)
         if (builtinHint) {
-          throw new Error(builtinHint)
+          return {
+            output: builtinHint,
+            metadata: { kind: "unsupported_mcp_action" },
+          }
         }
 
-        throw new Error(
-          `MCP server "${args.mcp_name}" not found.\n\n` +
+        return {
+          output:
+            `MCP server "${args.mcp_name}" not found.\n\n` +
             `Available MCP servers in loaded skills:\n` +
             formatAvailableMcps(skills) +
             `\n\n` +
             `Hint: Load the skill first using the 'skill' tool, then call skill_mcp.`,
-        )
+          metadata: { kind: "unsupported_mcp_action" },
+        }
       }
 
       const sessionID = toolContext.sessionID || getSessionID?.()
       if (!sessionID) {
-        throw new Error("No active session available for skill MCP call.")
+        return {
+          output: "No active session available for skill MCP call.",
+          metadata: { kind: "unsupported_mcp_action" },
+        }
       }
 
       const info: SkillMcpClientInfo = {
@@ -152,28 +169,45 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
         skillName: found.skill.name,
       }
 
-      const parsedArgs = parseSkillMcpArguments(args.arguments)
+      let parsedArgs: Record<string, unknown>
+      try {
+        parsedArgs = parseSkillMcpArguments(args.arguments)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          output: message,
+          metadata: { kind: "unsupported_mcp_action" },
+        }
+      }
 
       let output: string
-      switch (operation.type) {
-        case "tool": {
-          const result = await manager.callTool(info, context, operation.name, parsedArgs)
-          output = JSON.stringify(result, null, 2)
-          break
-        }
-        case "resource": {
-          const result = await manager.readResource(info, context, operation.name)
-          output = JSON.stringify(result, null, 2)
-          break
-        }
-        case "prompt": {
-          const stringArgs: Record<string, string> = {}
-          for (const [key, value] of Object.entries(parsedArgs)) {
-            stringArgs[key] = String(value)
+      try {
+        switch (operation.type) {
+          case "tool": {
+            const result = await manager.callTool(info, context, operation.name, parsedArgs)
+            output = JSON.stringify(result, null, 2)
+            break
           }
-          const result = await manager.getPrompt(info, context, operation.name, stringArgs)
-          output = JSON.stringify(result, null, 2)
-          break
+          case "resource": {
+            const result = await manager.readResource(info, context, operation.name)
+            output = JSON.stringify(result, null, 2)
+            break
+          }
+          case "prompt": {
+            const stringArgs: Record<string, string> = {}
+            for (const [key, value] of Object.entries(parsedArgs)) {
+              stringArgs[key] = String(value)
+            }
+            const result = await manager.getPrompt(info, context, operation.name, stringArgs)
+            output = JSON.stringify(result, null, 2)
+            break
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          output: message,
+          metadata: { kind: "unsupported_mcp_action" },
         }
       }
       return applyGrepFilter(output, args.grep)


### PR DESCRIPTION
## Summary

Convert Error throws and plain-string returns in call-omo-agent and skill-mcp tools into structured objects with { output, metadata: { kind } }.

- call-omo-agent: uses unsupported_agents_action kind for agent validation errors
- skill-mcp: uses unsupported_mcp_action kind for MCP operation validation errors

## Changes
- 4 files changed, 139 insertions(+), 73 deletions(-)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns structured error objects from `call-omo-agent` and `skill-mcp` validation, and fixes session list sorting by including corrupted session files using mtime. This stops hidden sessions and lets callers reliably detect validation failures.

- **Bug Fixes**
  - Session manager: `getFileMainSessions()` now includes corrupted JSON files using file mtime for `time.created`/`time.updated`, sets `load_error`, and preserves chronological sort.
  - Tools: validation failures return `{ output, metadata: { kind } }` instead of throws/plain strings. Kinds: `unsupported_agents_action` (agent checks) and `unsupported_mcp_action` (MCP op checks).

- **Migration**
  - For tool results, check `metadata.kind` to detect validation errors instead of parsing strings or relying on thrown errors.

<sup>Written for commit 19ed1b9b831ece285dc317722c4beff02acd15d2. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4432?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

