### PR TITLE
feat(help): #689 acp help JSON schema

### DIFF
--- a/assets/help/acp.schema.json
+++ b/assets/help/acp.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/acp.schema.json",
+  "title": "ACP Server Status",
+  "description": "JSON schema for oh-my-openagent Agent Control Protocol server output",
+  "type": "object",
+  "properties": {
+    "server": {
+      "type": "object",
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Server hostname"
+        },
+        "port": {
+          "type": "number",
+          "description": "Server port"
+        },
+        "running": {
+          "type": "boolean",
+          "description": "Whether the ACP server is running"
+        },
+        "uptime": {
+          "type": "number",
+          "description": "Server uptime in seconds"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Agent identifier"
+              },
+              "name": {
+                "type": "string",
+                "description": "Agent display name"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Agent version"
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Capability name"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "Capability version"
+                    },
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "Whether the capability is enabled"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "version",
+                    "enabled"
+                  ],
+                  "additionalProperties": false,
+                  "ref": "AcpCapability"
+                },
+                "description": "Agent capabilities"
+              },
+              "description": {
+                "description": "Agent description",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "version",
+              "capabilities"
+            ],
+            "additionalProperties": false,
+            "ref": "AcpAgent"
+          },
+          "description": "Registered agents"
+        },
+        "connections": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Connection ID"
+              },
+              "agentId": {
+                "type": "string",
+                "description": "Connected agent ID"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "connected",
+                  "disconnected",
+                  "error"
+                ],
+                "description": "Connection state"
+              },
+              "startedAt": {
+                "type": "number",
+                "description": "Connection start timestamp (epoch ms)"
+              },
+              "messagesSent": {
+                "type": "number",
+                "description": "Messages sent over this connection"
+              },
+              "messagesReceived": {
+                "type": "number",
+                "description": "Messages received over this connection"
+              }
+            },
+            "required": [
+              "id",
+              "agentId",
+              "state",
+              "startedAt",
+              "messagesSent",
+              "messagesReceived"
+            ],
+            "additionalProperties": false,
+            "ref": "AcpConnection"
+          },
+          "description": "Active connections"
+        }
+      },
+      "required": [
+        "hostname",
+        "port",
+        "running",
+        "uptime",
+        "agents",
+        "connections"
+      ],
+      "additionalProperties": false,
+      "ref": "AcpServer",
+      "description": "ACP server status"
+    },
+    "timestamp": {
+      "type": "number",
+      "description": "Snapshot timestamp (epoch ms)"
+    }
+  },
+  "required": [
+    "server",
+    "timestamp"
+  ],
+  "additionalProperties": false,
+  "ref": "AcpResult"
+}

--- a/script/build-help-schemas.ts
+++ b/script/build-help-schemas.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 import { DoctorResultSchema as DoctorSchema } from "../src/help/schema/doctor"
 import { StatusResultSchema as StatusSchema } from "../src/help/schema/status"
 import { SandboxResultSchema as SandboxSchema } from "../src/help/schema/sandbox"
+import { AcpResultSchema as AcpSchema } from "../src/help/schema/acp"
+
 const SCHEMA_OUTPUT_DIR = "assets/help"
 
 interface SchemaEntry {
@@ -53,6 +55,13 @@ const SCHEMAS: SchemaEntry[] = [
     title: "Sandbox Environment",
     description: "JSON schema for oh-my-openagent sandbox execution environment output",
     id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/sandbox.schema.json",
+  },
+  {
+    name: "acp",
+    schema: AcpSchema,
+    title: "ACP Server Status",
+    description: "JSON schema for oh-my-openagent Agent Control Protocol server output",
+    id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/acp.schema.json",
   },
 ]
 

--- a/src/help/schema/acp.ts
+++ b/src/help/schema/acp.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+
+export const AcpCapabilitySchema = z.object({
+  name: z.string().describe("Capability name"),
+  version: z.string().describe("Capability version"),
+  enabled: z.boolean().describe("Whether the capability is enabled"),
+}).meta({ ref: "AcpCapability" })
+
+export const AcpAgentSchema = z.object({
+  id: z.string().describe("Agent identifier"),
+  name: z.string().describe("Agent display name"),
+  version: z.string().nullable().describe("Agent version"),
+  capabilities: z.array(AcpCapabilitySchema).describe("Agent capabilities"),
+  description: z.string().optional().describe("Agent description"),
+}).meta({ ref: "AcpAgent" })
+
+export const AcpConnectionSchema = z.object({
+  id: z.string().describe("Connection ID"),
+  agentId: z.string().describe("Connected agent ID"),
+  state: z.enum(["connected", "disconnected", "error"]).describe("Connection state"),
+  startedAt: z.number().describe("Connection start timestamp (epoch ms)"),
+  messagesSent: z.number().describe("Messages sent over this connection"),
+  messagesReceived: z.number().describe("Messages received over this connection"),
+}).meta({ ref: "AcpConnection" })
+
+export const AcpServerSchema = z.object({
+  hostname: z.string().describe("Server hostname"),
+  port: z.number().describe("Server port"),
+  running: z.boolean().describe("Whether the ACP server is running"),
+  uptime: z.number().describe("Server uptime in seconds"),
+  agents: z.array(AcpAgentSchema).describe("Registered agents"),
+  connections: z.array(AcpConnectionSchema).describe("Active connections"),
+}).meta({ ref: "AcpServer" })
+
+export const AcpResultSchema = z.object({
+  server: AcpServerSchema.describe("ACP server status"),
+  timestamp: z.number().describe("Snapshot timestamp (epoch ms)"),
+}).meta({ ref: "AcpResult" })
+
+export type AcpCapability = z.infer<typeof AcpCapabilitySchema>
+export type AcpAgent = z.infer<typeof AcpAgentSchema>
+export type AcpConnection = z.infer<typeof AcpConnectionSchema>
+export type AcpServer = z.infer<typeof AcpServerSchema>
+export type AcpResult = z.infer<typeof AcpResultSchema>


### PR DESCRIPTION
## Summary
Add JSON schema for the `acp` CLI surface.

## Changes
- `src/help/schema/acp.ts`: Zod schemas (`AcpResult`, `AcpServer`, `AcpAgent`, `AcpCapability`, `AcpConnection`)
- `assets/help/acp.schema.json`: Generated JSON Schema (draft-7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JSON Schema and `zod` types for the `acp` CLI help output to enable validation and tooling. Addresses Linear #689 by defining server status, agents, and connections.

- **New Features**
  - Added `zod` schemas: `AcpResult`, `AcpServer`, `AcpAgent`, `AcpCapability`, `AcpConnection`.
  - Generated `assets/help/acp.schema.json` (draft-07).
  - Updated `script/build-help-schemas.ts` to include `acp` in the schema build.

<sup>Written for commit eed88e418112cc56397234c5ddaaa99386a1555d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

