### PR TITLE
feat(help): #690 bootstrap-plan help JSON schema

### DIFF
--- a/assets/help/bootstrap-plan.schema.json
+++ b/assets/help/bootstrap-plan.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/bootstrap-plan.schema.json",
+  "title": "Bootstrap Plan",
+  "description": "JSON schema for oh-my-openagent bootstrap plan output",
+  "type": "object",
+  "properties": {
+    "plan": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Plan version"
+        },
+        "createdAt": {
+          "type": "number",
+          "description": "Plan creation timestamp (epoch ms)"
+        },
+        "completedAt": {
+          "description": "Completion timestamp (epoch ms)",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "totalSteps": {
+          "type": "number",
+          "description": "Total number of steps"
+        },
+        "completedSteps": {
+          "type": "number",
+          "description": "Number of completed steps"
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Step identifier"
+              },
+              "title": {
+                "type": "string",
+                "description": "Step display title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Step description"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "in_progress",
+                  "completed",
+                  "skipped",
+                  "failed"
+                ],
+                "description": "Step execution status"
+              },
+              "duration": {
+                "description": "Step execution duration in ms",
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "error": {
+                "description": "Error message if failed",
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "description",
+              "status"
+            ],
+            "additionalProperties": false,
+            "ref": "BootstrapStep"
+          },
+          "description": "Bootstrap steps"
+        },
+        "summary": {
+          "description": "Overall summary of the bootstrap plan",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "createdAt",
+        "totalSteps",
+        "completedSteps",
+        "steps"
+      ],
+      "additionalProperties": false,
+      "ref": "BootstrapPlan",
+      "description": "The bootstrap plan"
+    },
+    "timestamp": {
+      "type": "number",
+      "description": "Snapshot timestamp (epoch ms)"
+    }
+  },
+  "required": [
+    "plan",
+    "timestamp"
+  ],
+  "additionalProperties": false,
+  "ref": "BootstrapPlanResult"
+}

--- a/script/build-help-schemas.ts
+++ b/script/build-help-schemas.ts
@@ -4,6 +4,7 @@ import { DoctorResultSchema as DoctorSchema } from "../src/help/schema/doctor"
 import { StatusResultSchema as StatusSchema } from "../src/help/schema/status"
 import { SandboxResultSchema as SandboxSchema } from "../src/help/schema/sandbox"
 import { AcpResultSchema as AcpSchema } from "../src/help/schema/acp"
+import { BootstrapPlanResultSchema as BootstrapPlanSchema } from "../src/help/schema/bootstrap-plan"
 
 const SCHEMA_OUTPUT_DIR = "assets/help"
 
@@ -62,6 +63,14 @@ const SCHEMAS: SchemaEntry[] = [
     title: "ACP Server Status",
     description: "JSON schema for oh-my-openagent Agent Control Protocol server output",
     id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/acp.schema.json",
+    id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/acp.schema.json",
+  },
+  {
+    name: "bootstrap-plan",
+    schema: BootstrapPlanSchema,
+    title: "Bootstrap Plan",
+    description: "JSON schema for oh-my-openagent bootstrap plan output",
+    id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/help/bootstrap-plan.schema.json",
   },
 ]
 

--- a/src/help/schema/bootstrap-plan.ts
+++ b/src/help/schema/bootstrap-plan.ts
@@ -1,0 +1,29 @@
+import { z } from "zod"
+
+export const BootstrapStepSchema = z.object({
+  id: z.string().describe("Step identifier"),
+  title: z.string().describe("Step display title"),
+  description: z.string().describe("Step description"),
+  status: z.enum(["pending", "in_progress", "completed", "skipped", "failed"]).describe("Step execution status"),
+  duration: z.number().nullable().optional().describe("Step execution duration in ms"),
+  error: z.string().nullable().optional().describe("Error message if failed"),
+}).meta({ ref: "BootstrapStep" })
+
+export const BootstrapPlanSchema = z.object({
+  version: z.string().describe("Plan version"),
+  createdAt: z.number().describe("Plan creation timestamp (epoch ms)"),
+  completedAt: z.number().nullable().optional().describe("Completion timestamp (epoch ms)"),
+  totalSteps: z.number().describe("Total number of steps"),
+  completedSteps: z.number().describe("Number of completed steps"),
+  steps: z.array(BootstrapStepSchema).describe("Bootstrap steps"),
+  summary: z.string().optional().describe("Overall summary of the bootstrap plan"),
+}).meta({ ref: "BootstrapPlan" })
+
+export const BootstrapPlanResultSchema = z.object({
+  plan: BootstrapPlanSchema.describe("The bootstrap plan"),
+  timestamp: z.number().describe("Snapshot timestamp (epoch ms)"),
+}).meta({ ref: "BootstrapPlanResult" })
+
+export type BootstrapStep = z.infer<typeof BootstrapStepSchema>
+export type BootstrapPlan = z.infer<typeof BootstrapPlanSchema>
+export type BootstrapPlanResult = z.infer<typeof BootstrapPlanResultSchema>


### PR DESCRIPTION
## Summary
Add JSON schema for the `bootstrap-plan` CLI surface.

## Changes
- `src/help/schema/bootstrap-plan.ts`: Zod schemas (`BootstrapPlanResult`, `BootstrapPlan`, `BootstrapStep`)
- `assets/help/bootstrap-plan.schema.json`: Generated JSON Schema (draft-7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JSON Schema (draft-07) for the `bootstrap-plan` CLI help output and integrates it into the schema build pipeline. This addresses Linear #690 by enabling tools to validate and parse bootstrap plans.

- **New Features**
  - Added `zod` schemas: `BootstrapStep`, `BootstrapPlan`, `BootstrapPlanResult` (src/help/schema/bootstrap-plan.ts).
  - Generated `assets/help/bootstrap-plan.schema.json` and registered it in `script/build-help-schemas.ts`.

<sup>Written for commit 69460564cf0481fbae1f671419943dea5a30cc1a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

