### PR TITLE
fix(tmux-subagent): break the zombie-pane wedge via close-retry cooldown

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -2594,6 +2594,132 @@ describe('TmuxSessionManager', () => {
     })
   })
 
+  describe('retryPendingCloses zombie pane recovery via cooldown', () => {
+    test('stamps a close-retry cooldown on the tracked session when the pane refuses to die after max retries', async () => {
+      // given - direct-seed the zombie state: pending close, retries
+      // already at MAX, pane still visible in window state. The maintainer
+      // explicitly chose to keep the session in `this.sessions` here for
+      // operator visibility (zombie-pane.test.ts: "stays tracked for
+      // manual intervention"). Before this change there was no way out —
+      // polling skipped the entry via `!closePending`, retryPendingCloses
+      // skipped via `>= MAX`, so the entry stayed wedged forever and
+      // panes accumulated across long parent sessions.
+      //
+      // After this change: the entry stays in the map AND finalize stamps
+      // `closeRetryCooldownUntil` so a future pass can reset state and
+      // let polling re-queue the close.
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState({
+        agentPanes: [
+          { paneId: '%stuck', width: 40, height: 44, left: 110, top: 0, title: 'omo-subagent-zombie', isActive: false },
+        ],
+      }))
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({ enabled: true }), mockTmuxDeps)
+
+      const internalSessions = Reflect.get(manager, 'sessions') as Map<string, Record<string, unknown>>
+      internalSessions.set('ses_zombie', {
+        sessionId: 'ses_zombie',
+        paneId: '%stuck',
+        description: 'zombie',
+        closePending: true,
+        closeRetryCount: 3, // MAX_CLOSE_RETRY_COUNT
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+        activityVersion: 0,
+        attachActivated: false,
+      })
+
+      // when
+      const retryPendingCloses = Reflect.get(manager, 'retryPendingCloses') as () => Promise<void>
+      await retryPendingCloses.call(manager)
+
+      // then - session stays tracked (maintainer's intent), cooldown is set.
+      expect(internalSessions.has('ses_zombie')).toBe(true)
+      const stamped = internalSessions.get('ses_zombie')
+      expect(stamped?.closeRetryCooldownUntil).toBeInstanceOf(Date)
+      const cooldownMs = (stamped?.closeRetryCooldownUntil as Date).getTime() - Date.now()
+      expect(cooldownMs).toBeGreaterThan(0)
+    })
+
+    test('resets retry state once the cooldown elapses so polling can re-queue the close', async () => {
+      // given - same setup, but cooldown stamped in the past.
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState({
+        agentPanes: [
+          { paneId: '%stuck', width: 40, height: 44, left: 110, top: 0, title: 'omo-subagent-zombie', isActive: false },
+        ],
+      }))
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({ enabled: true }), mockTmuxDeps)
+
+      const internalSessions = Reflect.get(manager, 'sessions') as Map<string, Record<string, unknown>>
+      internalSessions.set('ses_zombie', {
+        sessionId: 'ses_zombie',
+        paneId: '%stuck',
+        description: 'zombie',
+        closePending: true,
+        closeRetryCount: 3,
+        closeRetryCooldownUntil: new Date(Date.now() - 1_000), // already elapsed
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+        activityVersion: 0,
+        attachActivated: false,
+      })
+
+      // when
+      const retryPendingCloses = Reflect.get(manager, 'retryPendingCloses') as () => Promise<void>
+      await retryPendingCloses.call(manager)
+
+      // then - retry state reset; polling's next pass can re-queue
+      // (closePending=false, counter back at 0, cooldown cleared).
+      const refreshed = internalSessions.get('ses_zombie')
+      expect(refreshed?.closePending).toBe(false)
+      expect(refreshed?.closeRetryCount).toBe(0)
+      expect(refreshed?.closeRetryCooldownUntil).toBeUndefined()
+    })
+
+    test('does not reset retry state while the cooldown is still active', async () => {
+      // given - cooldown stamped in the future.
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState({
+        agentPanes: [
+          { paneId: '%stuck', width: 40, height: 44, left: 110, top: 0, title: 'omo-subagent-zombie', isActive: false },
+        ],
+      }))
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({ enabled: true }), mockTmuxDeps)
+
+      const futureCooldown = new Date(Date.now() + 10 * 60 * 1000)
+      const internalSessions = Reflect.get(manager, 'sessions') as Map<string, Record<string, unknown>>
+      internalSessions.set('ses_zombie', {
+        sessionId: 'ses_zombie',
+        paneId: '%stuck',
+        description: 'zombie',
+        closePending: true,
+        closeRetryCount: 3,
+        closeRetryCooldownUntil: futureCooldown,
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+        activityVersion: 0,
+        attachActivated: false,
+      })
+
+      // when
+      const retryPendingCloses = Reflect.get(manager, 'retryPendingCloses') as () => Promise<void>
+      await retryPendingCloses.call(manager)
+
+      // then - state unchanged; we wait for the cooldown.
+      const same = internalSessions.get('ses_zombie')
+      expect(same?.closePending).toBe(true)
+      expect(same?.closeRetryCount).toBe(3)
+      expect(same?.closeRetryCooldownUntil).toBe(futureCooldown)
+    })
+  })
+
 })
 
 describe('DecisionEngine', () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -76,6 +76,13 @@ const FAILED_READINESS_SESSION_TTL_MS = 5 * 60 * 1000
 const FAILED_READINESS_SWEEP_INTERVAL_MS = 60 * 1000
 const MAX_DEFERRED_QUEUE_SIZE = 20
 const MAX_CLOSE_RETRY_COUNT = 3
+// After MAX_CLOSE_RETRY_COUNT failed close attempts with the pane still
+// visible, finalizeForceRemoveCandidate stamps a cooldown on the tracked
+// session. retryPendingCloses checks the stamp on subsequent passes:
+// once elapsed, the retry counter and closePending reset so polling /
+// retry can attempt the close again. Without this, a wedged pane stays
+// in `this.sessions` for the rest of the parent session's lifetime.
+const CLOSE_RETRY_COOLDOWN_MS = 15 * 60 * 1000
 const MAX_ISOLATED_CONTAINER_NULL_STATE_COUNT = 2
 let nextIsolatedSessionManagerId = 1
 
@@ -398,11 +405,32 @@ export class TmuxSessionManager {
     }
 
     if (this.windowStateContainsPane(state, tracked.paneId)) {
-      this.deps.log("[tmux-session-manager] pane still exists after max close retries; manual intervention required", {
+      // The session is kept in `this.sessions` for operator visibility
+      // ("manual intervention required" was the maintainer's explicit
+      // intent in zombie-pane.test.ts), but before this change there was
+      // no way out: polling skipped it via `!closePending`,
+      // retryPendingCloses skipped it via `closeRetryCount >= MAX`, so the
+      // entry stayed wedged forever and panes accumulated across long
+      // parent sessions.
+      //
+      // Stamp a cooldown timestamp. retryPendingCloses checks it on
+      // subsequent passes — once elapsed, the retry counter and
+      // `closePending` reset, polling can re-queue the session, and the
+      // close path gets another shot. A pane that becomes responsive
+      // later eventually cleans up naturally; a permanently wedged pane
+      // retries every CLOSE_RETRY_COOLDOWN_MS instead of leaking memory
+      // for the rest of the parent session's lifetime.
+      this.deps.log("[tmux-session-manager] pane still exists after max close retries; arming retry cooldown for next attempt", {
         sessionId: tracked.sessionId,
         paneId: tracked.paneId,
+        closeRetryCount: tracked.closeRetryCount,
+        cooldownMs: CLOSE_RETRY_COOLDOWN_MS,
         source,
       })
+      const currentTracked = this.sessions.get(tracked.sessionId)
+      if (currentTracked) {
+        currentTracked.closeRetryCooldownUntil = new Date(Date.now() + CLOSE_RETRY_COOLDOWN_MS)
+      }
       return false
     }
 
@@ -493,6 +521,23 @@ export class TmuxSessionManager {
       if (!this.sessions.has(tracked.sessionId)) continue
 
       if (tracked.closeRetryCount >= MAX_CLOSE_RETRY_COUNT) {
+        if (tracked.closeRetryCooldownUntil) {
+          if (Date.now() >= tracked.closeRetryCooldownUntil.getTime()) {
+            this.deps.log("[tmux-session-manager] close-retry cooldown elapsed; resetting retry state so polling can re-attempt", {
+              sessionId: tracked.sessionId,
+              paneId: tracked.paneId,
+            })
+            const fresh = this.sessions.get(tracked.sessionId)
+            if (fresh) {
+              fresh.closeRetryCount = 0
+              fresh.closePending = false
+              fresh.closeRetryCooldownUntil = undefined
+            }
+            continue
+          }
+          // Cooldown still active — skip and let next pass check again.
+          continue
+        }
         await this.finalizeForceRemoveCandidate(tracked, "retryPendingCloses.max-retries")
         continue
       }
@@ -514,7 +559,16 @@ export class TmuxSessionManager {
 
       const nextRetryCount = currentTracked.closeRetryCount + 1
       if (nextRetryCount >= MAX_CLOSE_RETRY_COUNT) {
-        await this.finalizeForceRemoveCandidate(currentTracked, "retryPendingCloses.failed-retry")
+        // Bump the persisted counter to MAX BEFORE handing off to finalize.
+        // Without this, finalize sets the cooldown but the next pass sees
+        // counter < MAX and tries close again, re-stamping cooldown in a
+        // loop with no progress.
+        this.sessions.set(currentTracked.sessionId, {
+          ...currentTracked,
+          closeRetryCount: nextRetryCount,
+        })
+        const refreshed = this.sessions.get(currentTracked.sessionId)
+        await this.finalizeForceRemoveCandidate(refreshed ?? currentTracked, "retryPendingCloses.failed-retry")
         continue
       }
 

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -8,6 +8,13 @@ export interface TrackedSession {
   lastSeenAt: Date
   closePending: boolean
   closeRetryCount: number
+  // Set by `finalizeForceRemoveCandidate` when MAX_CLOSE_RETRY_COUNT
+  // is reached with the pane still visible. `retryPendingCloses` checks
+  // this on subsequent passes: once `Date.now() >= cooldownUntil`, the
+  // retry counter and `closePending` reset so polling and retry can
+  // attempt the close again. Without this, a wedged pane stays in the
+  // tracked sessions map for the rest of the parent session's lifetime.
+  closeRetryCooldownUntil?: Date
   // Stability detection fields (prevents premature closure)
   lastMessageCount?: number
   stableIdlePolls?: number


### PR DESCRIPTION
## Symptom

Subagent panes accumulate under a single parent session over a long lifetime — confirmed by maintainer's own \`zombie-pane.test.ts:278\` ("stays tracked for manual intervention" path).

## Root cause

\`finalizeForceRemoveCandidate\` deliberately keeps the tracked session in \`this.sessions\` when the pane is still visible after MAX_CLOSE_RETRY_COUNT failed attempts — that's the maintainer's encoded "manual intervention" contract and **this PR preserves it**.

What was missing was a way out. Once a session was past max retries with the pane still visible:

- polling skipped it via \`!closePending\`
- \`retryPendingCloses\` skipped it via \`closeRetryCount >= MAX\`
- nothing else ever drove a re-attempt

The entry stayed wedged for the rest of the parent session's life. Over a few hours users observed "panes accumulating" — exactly the structural leak called out in the investigation accompanying PR #4430 and PR #4431.

## Fix: cooldown-based retry recovery

The session **stays tracked** (maintainer contract preserved), but \`finalizeForceRemoveCandidate\` now stamps a \`closeRetryCooldownUntil\` timestamp instead of permanently wedging the entry. \`retryPendingCloses\` checks it on subsequent passes:

| State | Behavior |
|---|---|
| No cooldown stamped yet, \`>= MAX\` | Existing path: call finalize (which now stamps a cooldown if pane still visible) |
| Cooldown still active | Skip — no extra finalize calls, no thrash |
| Cooldown elapsed | Reset \`closeRetryCount = 0\`, \`closePending = false\`, clear the stamp; polling re-queues on its next cycle |

\`CLOSE_RETRY_COOLDOWN_MS = 15 * 60 * 1000\` — generous enough that a permanently wedged pane retries roughly 4x/hour (not thrashing) but short enough that a transiently stuck pane recovers within a reasonable window.

## Subtle bug also fixed

The \`failed-retry\` branch in \`retryPendingCloses\` previously did not persist the incremented \`closeRetryCount\` to the map before handing off to finalize. With the cooldown design that would have meant the next pass saw counter < MAX and re-entered the close path immediately, re-stamping cooldown in a tight loop. Now the counter is persisted to MAX before finalize.

## Diff

| File | Change |
|---|---|
| \`src/features/tmux-subagent/types.ts\` | +1 optional field on TrackedSession (\`closeRetryCooldownUntil?: Date\`) |
| \`src/features/tmux-subagent/manager.ts\` | +\`CLOSE_RETRY_COOLDOWN_MS\` constant; \`finalizeForceRemoveCandidate\` stamps cooldown instead of leaving wedged; \`retryPendingCloses\` checks cooldown + persists incremented counter before finalize |
| \`src/features/tmux-subagent/manager.test.ts\` | +3 regression tests (cooldown stamping, cooldown reset on elapsed, no reset while still active) |

**3 files / +189 / −2.**

## Test plan

- [x] \`bun test src/features/tmux-subagent/zombie-pane.test.ts src/features/tmux-subagent/manager.test.ts\` — 70/70 (maintainer's \`zombie-pane.test.ts:278\` still passes — contract preserved)
- [x] \`bun test src/features/tmux-subagent/ src/features/team-mode/ src/hooks/team-session-events/ src/shared/tmux/\` — 520 pass / 0 fail
- [x] \`bun run typecheck\` — clean

## Related

Sibling fixes from the same investigation (each independent and reviewable separately):
- PR #4430: stop tracking team-mode member sessions in the subagent panel
- PR #4431: close placeholder panes that exceed \`PLACEHOLDER_PANE_TIMEOUT_MS\`

Together these three fixes address both halves of the user-reported issue: "Why are team members in the subagent panel AND why do subagent panes accumulate forever under a single parent session."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zombie subagent panes from piling up by adding a cooldown-based retry after max close attempts. Sessions stay tracked for visibility, but the system now re-attempts cleanly and stops wedging.

- **Bug Fixes**
  - After `MAX_CLOSE_RETRY_COUNT`, `finalizeForceRemoveCandidate` stamps `closeRetryCooldownUntil`; `retryPendingCloses` resets retries once elapsed, otherwise skips.
  - Persist `closeRetryCount` to MAX before finalize to avoid immediate re-entry and cooldown restamping loops.
  - Add `closeRetryCooldownUntil?: Date` to `TrackedSession`; set `CLOSE_RETRY_COOLDOWN_MS` to 15 minutes.
  - Add regression tests for cooldown stamping, cooldown-elapsed reset, and no reset while cooldown is active.

<sup>Written for commit 1e6dac7ee9e9772b5b14bb3678a94cd906ee56ab. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4440?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

