### PR TITLE
feat(tmux-subagent): soft-cap warning when tracked-sessions count exceeds threshold

### DIFF
--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { TmuxPollingManager } from "./polling-manager"
+import { TRACKED_SESSIONS_WARN_THRESHOLD, TmuxPollingManager } from "./polling-manager"
 import type { TrackedSession, WindowState } from "./types"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
@@ -500,5 +500,113 @@ describe("TmuxPollingManager overlap", () => {
 
     //#then
     expect(closedSessionIds).toEqual(["ses-1"])
+  })
+
+  describe("warnIfTrackedSessionsExceedThreshold (soft-cap observability)", () => {
+    function seedSessions(sessions: Map<string, TrackedSession>, count: number): void {
+      const now = Date.now()
+      for (let index = 0; index < count; index += 1) {
+        sessions.set(`ses-${index}`, {
+          sessionId: `ses-${index}`,
+          paneId: `%${index}`,
+          description: "seeded",
+          attachActivated: true,
+          createdAt: new Date(now),
+          lastSeenAt: new Date(now),
+          closePending: false,
+          closeRetryCount: 0,
+          activityVersion: 0,
+        })
+      }
+    }
+
+    function makeManager(sessions: Map<string, TrackedSession>): TmuxPollingManager {
+      // Use a status client whose `data` mirrors the seeded sessions so
+      // none get marked missing during the test — we only care about the
+      // soft-cap warning state transitions.
+      const client = {
+        session: {
+          status: async () => {
+            const data: Record<string, { type: string }> = {}
+            for (const id of sessions.keys()) {
+              data[id] = { type: "running" }
+            }
+            return { data }
+          },
+          messages: async () => ({ data: [] }),
+        },
+      }
+      return new TmuxPollingManager(
+        unsafeTestValue<import("../../tools/delegate-task/types").OpencodeClient>(client),
+        sessions,
+        async () => {},
+      )
+    }
+
+    function getLastWarnedSize(manager: TmuxPollingManager): number | undefined {
+      return Reflect.get(manager, "lastWarnedTrackedSize") as number | undefined
+    }
+
+    test("does not warn while session count is below the threshold", async () => {
+      const sessions = new Map<string, TrackedSession>()
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD - 1)
+      const manager = makeManager(sessions)
+      const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+      await pollSessions.call(manager)
+
+      expect(getLastWarnedSize(manager)).toBeUndefined()
+    })
+
+    test("warns once when the count first crosses the threshold and records the size", async () => {
+      const sessions = new Map<string, TrackedSession>()
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD)
+      const manager = makeManager(sessions)
+      const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD)
+
+      // Same size on the next pass → no re-warn (dedup), state unchanged.
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD)
+
+      // Small growth (under 2x of the last-warned size) → still no re-warn.
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD + 10)
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD)
+    })
+
+    test("re-warns when the count doubles past the last-warned size", async () => {
+      const sessions = new Map<string, TrackedSession>()
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD)
+      const manager = makeManager(sessions)
+      const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD)
+
+      // Grow to 2x the previous warn point.
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD * 2)
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD * 2)
+    })
+
+    test("resets the last-warned size once the count drops back below the threshold", async () => {
+      const sessions = new Map<string, TrackedSession>()
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD)
+      const manager = makeManager(sessions)
+      const pollSessions = unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions
+
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBe(TRACKED_SESSIONS_WARN_THRESHOLD)
+
+      // Drop below threshold: forget the previous warn so a fresh climb
+      // back over re-warns.
+      sessions.clear()
+      seedSessions(sessions, TRACKED_SESSIONS_WARN_THRESHOLD - 10)
+      await pollSessions.call(manager)
+      expect(getLastWarnedSize(manager)).toBeUndefined()
+    })
   })
 })

--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
@@ -13,9 +13,18 @@ import { parseSessionStatusResponse } from "./session-status-parser"
 const MIN_STABILITY_TIME_MS = 10 * 1000
 const STABLE_POLLS_REQUIRED = 3
 
+// Soft cap on `this.sessions` size. Reaching this threshold means either a
+// genuine high-workload run OR a leak the existing close paths failed to
+// catch. We do NOT auto-evict — silent eviction could kill panes the user
+// is actively using. Instead we log loudly so the operator can investigate.
+// Warnings are deduped by doubling (50 → 100 → 200 → ...) to keep logs
+// readable while still surfacing growth that's worth attention.
+export const TRACKED_SESSIONS_WARN_THRESHOLD = 50
+
 export class TmuxPollingManager {
   private pollInterval?: ReturnType<typeof setInterval>
   private pollingInFlight = false
+  private lastWarnedTrackedSize?: number
 
   constructor(
     private client: OpencodeClient,
@@ -26,6 +35,27 @@ export class TmuxPollingManager {
     private activateSessionPane?: (tracked: TrackedSession) => Promise<boolean>,
     private canActivatePane: (state: WindowState) => boolean = (state) => state.windowActive !== false && state.sessionAttached !== false,
   ) {}
+
+  private warnIfTrackedSessionsExceedThreshold(): void {
+    const size = this.sessions.size
+    if (size < TRACKED_SESSIONS_WARN_THRESHOLD) {
+      // Reset so a fresh climb past the threshold logs again.
+      this.lastWarnedTrackedSize = undefined
+      return
+    }
+    // Re-emit only when size has doubled relative to the last warning (or
+    // on the first crossing of the threshold). Prevents log spam while
+    // still surfacing real growth.
+    if (this.lastWarnedTrackedSize !== undefined && size < this.lastWarnedTrackedSize * 2) {
+      return
+    }
+    log("[tmux-session-manager] tracked-sessions count exceeded soft cap; investigate for leak or runaway spawn", {
+      count: size,
+      threshold: TRACKED_SESSIONS_WARN_THRESHOLD,
+      previousWarnAt: this.lastWarnedTrackedSize,
+    })
+    this.lastWarnedTrackedSize = size
+  }
 
   handleEvent(event: { type: string; properties?: Record<string, unknown> }): void {
     const sessionId = this.getEventSessionId(event)
@@ -63,6 +93,8 @@ export class TmuxPollingManager {
         this.stopPolling()
         return
       }
+
+      this.warnIfTrackedSessionsExceedThreshold()
 
       await this.activateFocusedPanes()
 


### PR DESCRIPTION
## Why

\`TmuxPollingManager.sessions\` is a bare \`Map\` with no size cap. Even with the recent placeholder-timeout (PR #4431) and zombie-pane cooldown (PR #4440) fixes, an unanticipated leak path or a runaway spawn could still grow the map unbounded across a long parent session — and today there is no signal to the operator until they notice the symptom.

This PR adds the missing observability without changing close behavior.

## What

Surface a structured log line from inside \`pollSessions\` when \`this.sessions.size\` crosses \`TRACKED_SESSIONS_WARN_THRESHOLD\` (50). Dedup by doubling: re-emit at 100, 200, 400, ... so logs stay readable but real growth keeps being surfaced. Dropping back below the threshold clears the dedup state so a fresh climb is reported again.

## Why not auto-evict

Silent eviction would close panes the user is actively using. At this scale the cause is almost always **a leak somewhere we haven't found yet OR a runaway spawn** — both deserve the operator's attention, not a silent fix. A log line is the right primitive; eviction policy can be a follow-up if the operator-feedback signal proves insufficient.

## Diff

| File | Change |
|---|---|
| \`src/features/tmux-subagent/polling-manager.ts\` | +\`TRACKED_SESSIONS_WARN_THRESHOLD\` constant, +1 private field, +1 helper method, +1-line call from \`pollSessions\` |
| \`src/features/tmux-subagent/polling-manager.test.ts\` | +4 regression tests covering all dedup transitions |

**2 files / +141 / −1.**

## Test plan

- [x] below threshold → no warn (dedup state undefined)
- [x] first crossing → warn (dedup state records size)
- [x] small growth (≥ threshold but < 2× last warn) → no re-warn
- [x] doubling growth → re-warn (dedup state updated)
- [x] drop below threshold → dedup state cleared
- [x] \`bun test src/features/tmux-subagent/polling-manager.test.ts\` — 13/13
- [x] \`bun test src/features/tmux-subagent/ src/shared/tmux/\` — 227 pass / 0 fail
- [x] \`bun run typecheck\` — clean

## Related

Closing the last "Gap E" from the investigation that produced PR #4430, PR #4431, and PR #4440:

| Gap | PR | Status |
|---|---|---|
| Team-mode members tracked in subagent panel | #4430 | open |
| Placeholder panes never timed out | #4431 | open |
| Zombie pane wedged after max close retries | #4440 | open |
| **No observability for tracked-sessions growth** | **this PR** | open |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a soft-cap warning in the tmux subagent to alert when tracked sessions exceed a safe threshold. Improves observability for leaks or runaway spawns without changing close behavior.

- New Features
  - Emit a structured warn log from `pollSessions` when `this.sessions.size` ≥ `TRACKED_SESSIONS_WARN_THRESHOLD` (50).
  - Deduplicate warnings by doubling (50 → 100 → 200...) and reset once the count drops below the threshold.
  - Export `TRACKED_SESSIONS_WARN_THRESHOLD` and track the last warned size internally; no auto-eviction.

<sup>Written for commit 1b7a5f6f70d90d12e8d50939f5a9913b0cafb207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

