### PR TITLE
fix(runtime-fallback): handle object-shaped model preventing toLowerCase crash

### DIFF
--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -18,6 +18,27 @@ function resolveEventModel(props: Record<string, unknown> | undefined): string |
     return model
   }
 
+  if (model && typeof model === "object") {
+    const modelRecord = model as Record<string, unknown>
+    const provider = modelRecord.provider
+    const providerID = modelRecord.providerID
+    const modelName = modelRecord.model
+    const modelID = modelRecord.modelID
+    const id = modelRecord.id
+
+    if (typeof provider === "string" && typeof modelName === "string") {
+      return `${provider}/${modelName}`
+    }
+
+    if (typeof providerID === "string" && typeof modelID === "string") {
+      return `${providerID}/${modelID}`
+    }
+
+    if (typeof id === "string") {
+      return id
+    }
+  }
+
   const providerID = props?.providerID
   const modelID = props?.modelID
   if (typeof providerID === "string" && typeof modelID === "string") {
@@ -45,9 +66,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = props?.info as Record<string, unknown> | undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = resolveEventModel(sessionInfo)
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -209,7 +230,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: resolveEventModel(props),
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -50,6 +50,8 @@ function parseCanonicalModel(model: string): { providerID: string; modelID: stri
 }
 
 function isEquivalentModel(candidate: string, current: string): boolean {
+  if (typeof current !== "string") return false
+
   const parsedCandidate = parseCanonicalModel(candidate)
   const parsedCurrent = parseCanonicalModel(current)
 

--- a/src/hooks/runtime-fallback/index.test.ts
+++ b/src/hooks/runtime-fallback/index.test.ts
@@ -1024,6 +1024,50 @@ describe("runtime-fallback", () => {
       expect(createLog?.data).toMatchObject({ sessionID, model })
     })
 
+    test("#given session.created carries an object-shaped model #when fallback is prepared #then it does not crash", async () => {
+      //#given
+      const promptCalls: unknown[] = []
+      const sessionID = "test-session-object-model"
+      const hook = createRuntimeFallbackHook(
+        createMockPluginInput({
+          session: {
+            messages: async () => ({
+              data: [{ info: { role: "user" }, parts: [{ type: "text", text: "continue" }] }],
+            }),
+            promptAsync: async (args: unknown) => {
+              promptCalls.push(args)
+              return {}
+            },
+          },
+        }),
+        {
+          config: createMockConfig({ notify_on_fallback: false }),
+          pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+        },
+      )
+      SessionCategoryRegistry.register(sessionID, "test")
+
+      await hook.event({
+        event: {
+          type: "session.created",
+          properties: { info: { id: sessionID, model: { provider: "openai", model: "gpt-5.5-fast" } } },
+        },
+      })
+
+      //#when
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: { sessionID, error: { statusCode: 429, message: "Rate limit" } },
+        },
+      })
+
+      //#then
+      expect(promptCalls).toHaveLength(1)
+      const createLog = logCalls.find((c) => c.msg.includes("Session created with model"))
+      expect(createLog?.data).toMatchObject({ sessionID, model: "openai/gpt-5.5-fast" })
+    })
+
     test("should cleanup state on session.deleted", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), { config: createMockConfig() })
       const sessionID = "test-session-delete"


### PR DESCRIPTION
Fixes #4315

## Problem
`runtime-fallback` crashes with `current.toLowerCase is not a function` when OpenCode passes an object-shaped model config (e.g. `{provider, model}`) instead of a plain string.

## Root Cause
- `resolveEventModel()` only handled string model or providerID/modelID pair — object models fell through as undefined
- `isEquivalentModel()` in `fallback-state.ts` called `current.toLowerCase()` without type guard

## Fix
- Extended `resolveEventModel()` to extract string from object-shaped models
- Added `typeof current === 'string'` guard in `isEquivalentModel()` before `.toLowerCase()`
- Added regression test reproducing the crash with object model

## Tests
- Targeted tests pass
- Typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the runtime fallback when the model is passed as an object (e.g., { provider, model }). Prevents toLowerCase errors and ensures the correct model is used during fallback.

- **Bug Fixes**
  - Resolve object-shaped models from events into a canonical string (`provider/model`, `providerID/modelID`, or `id`)
  - Add a string type guard before calling `toLowerCase()` in model comparison
  - Add a regression test for `session.created` with object-shaped model

<sup>Written for commit df087d230a5c18b4616b487980a2367ef7182feb. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

