### PR TITLE
fix(plugin-handlers): explicit task deny for read-only subagents to prevent UI freeze (#4447)

### DIFF
--- a/src/plugin-handlers/tool-config-handler-task-deny.test.ts
+++ b/src/plugin-handlers/tool-config-handler-task-deny.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import type { OhMyOpenCodeConfig } from "../config"
+import { OhMyOpenCodeConfigSchema } from "../config"
+import { applyToolConfig } from "./tool-config-handler"
+
+type TestAgent = {
+  permission?: Record<string, unknown>
+}
+
+const TASK_DENIED_SUBAGENTS = [
+  "librarian",
+  "explore",
+  "oracle",
+  "multimodal-looker",
+  "metis",
+  "momus",
+] as const
+
+const TASK_ALLOWED_AGENT_NAMES = [
+  "sisyphus",
+  "atlas",
+  "hephaestus",
+  "sisyphus-junior",
+] as const
+
+function createParams(agentNames: readonly string[]): {
+  readonly config: Record<string, unknown>
+  readonly pluginConfig: OhMyOpenCodeConfig
+  readonly agentResult: Record<string, TestAgent>
+} {
+  const agentResult: Record<string, TestAgent> = {}
+  for (const agentName of agentNames) {
+    agentResult[agentName] = { permission: {} }
+  }
+
+  return {
+    config: { tools: {}, permission: {} },
+    pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+    agentResult,
+  }
+}
+
+function requirePermission(
+  agentResult: Record<string, TestAgent>,
+  agentName: string,
+): Record<string, unknown> {
+  const permission = agentResult[agentName]?.permission
+  if (!permission) {
+    throw new Error(`Missing permission for ${agentName}`)
+  }
+  return permission
+}
+
+describe("applyToolConfig task permission hard denials", () => {
+  describe("#given read-only and specialist subagents", () => {
+    describe("#when applying tool config", () => {
+      for (const agentName of TASK_DENIED_SUBAGENTS) {
+        it(`#then should explicitly deny task for ${agentName}`, () => {
+          const params = createParams([agentName])
+
+          applyToolConfig(params)
+
+          const permission = requirePermission(params.agentResult, agentName)
+          expect(permission.task).toBe("deny")
+        })
+      }
+    })
+  })
+
+  describe("#given librarian search permissions", () => {
+    describe("#when applying tool config", () => {
+      it("#then should keep grep_app allowed while task is denied", () => {
+        const params = createParams(["librarian"])
+
+        applyToolConfig(params)
+
+        const permission = requirePermission(params.agentResult, "librarian")
+        expect(permission["grep_app_*"]).toBe("allow")
+        expect(permission.task).toBe("deny")
+      })
+    })
+  })
+
+  describe("#given primary and executor agents", () => {
+    describe("#when applying tool config", () => {
+      for (const agentName of TASK_ALLOWED_AGENT_NAMES) {
+        it(`#then should keep task allowed for ${agentName}`, () => {
+          const params = createParams([agentName])
+
+          applyToolConfig(params)
+
+          const permission = requirePermission(params.agentResult, agentName)
+          expect(permission.task).toBe("allow")
+        })
+      }
+    })
+  })
+})

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -4,6 +4,15 @@ import { isTaskSystemEnabled } from "../shared";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
+const TASK_DENIED_SUBAGENT_KEYS = [
+  "librarian",
+  "explore",
+  "oracle",
+  "multimodal-looker",
+  "metis",
+  "momus",
+] as const;
+
 function getConfigQuestionPermission(): string | null {
   const configContent = process.env.OPENCODE_CONFIG_CONTENT;
   if (!configContent) return null;
@@ -19,6 +28,12 @@ function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWit
   return (agentResult[getAgentListDisplayName(key)] ?? agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
     | AgentWithPermission
     | undefined;
+}
+
+function denyTaskForAgent(agentResult: Record<string, unknown>, key: string): void {
+  const agent = agentByKey(agentResult, key);
+  if (!agent) return;
+  agent.permission = { ...agent.permission, task: "deny" };
 }
 
 export function applyToolConfig(params: {
@@ -58,6 +73,10 @@ export function applyToolConfig(params: {
     configQuestionPermission === "deny" ? "deny" :
     isCliRunMode ? "deny" :
     "allow";
+
+  for (const agentKey of TASK_DENIED_SUBAGENT_KEYS) {
+    denyTaskForAgent(params.agentResult, agentKey);
+  }
 
   const librarian = agentByKey(params.agentResult, "librarian");
   if (librarian) {


### PR DESCRIPTION
## Summary
Fixes #4447 by adding explicit `task: "deny"` permissions for read-only and specialist subagents that must not delegate further work. This prevents OpenCode from opening a permission prompt for background subagent `task` attempts.

## Changes
- Adds a shared task-deny pass for librarian, explore, oracle, multimodal-looker, metis, and momus in `applyToolConfig`.
- Preserves existing librarian `grep_app_*` allow and primary/executor `task` allow permissions.
- Adds regression coverage for explicit denial and unaffected delegating agents.

## Testing
- `bun test src/plugin-handlers/tool-config-handler-task-deny.test.ts`
- `bun test src/plugin-handlers/tool-config-handler.test.ts`
- `lsp_diagnostics` on changed TypeScript files
- `bun test && bun run typecheck && bun run build`

## Related Issues
Fixes #4447

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly denies task delegation for read-only and specialist subagents to stop background permission prompts that freeze the UI (fixes #4447). Keeps task delegation for primary/executor agents and preserves librarian search permissions.

- **Bug Fixes**
  - Added shared `task: "deny"` for `librarian`, `explore`, `oracle`, `multimodal-looker`, `metis`, `momus` in applyToolConfig.
  - Kept `librarian` `grep_app_*: "allow"` and preserved `task: "allow"` for `sisyphus`, `atlas`, `hephaestus`, `sisyphus-junior`.
  - Added tests to cover explicit denials and unaffected delegating agents.

<sup>Written for commit 75d1ff4c87b86d8f52b7bb57a1543394ec48f451. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

