### PR TITLE
fix(tool-execute-after): prevent session stall on metadata recovery failure (#4449)

### DIFF
--- a/src/plugin/tool-execute-after-metadata-recovery.test.ts
+++ b/src/plugin/tool-execute-after-metadata-recovery.test.ts
@@ -1,0 +1,83 @@
+/// <reference types="bun-types" />
+
+import { beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { clearPendingStore } from "../features/tool-metadata-store"
+import { _flushForTesting, _resetLoggerForTesting, _setLoggerForTesting } from "../shared/logger"
+import { createToolExecuteAfterHandler } from "./tool-execute-after"
+
+function readLogIfPresent(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+describe("createToolExecuteAfterHandler metadata recovery", () => {
+  beforeEach(() => {
+    clearPendingStore()
+    _resetLoggerForTesting()
+  })
+
+  it("#given builtin tool has no recoverable metadata #when tool.execute.after runs #then it fails open without warning spam", async () => {
+    // given
+    const logDir = mkdtempSync(join(tmpdir(), "omo-tool-after-"))
+    const logPath = join(logDir, "omo.log")
+    _setLoggerForTesting({ filePath: logPath })
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const output = { title: "result", output: "read output", metadata: {} }
+
+    try {
+      // when
+      await handler(
+        { tool: "read", sessionID: "ses_parent", callID: "call_read" },
+        output,
+      )
+      _flushForTesting()
+
+      // then
+      expect(output).toEqual({ title: "result", output: "read output", metadata: {} })
+      expect(readLogIfPresent(logPath)).not.toContain("Unable to recover stored metadata")
+    } finally {
+      _resetLoggerForTesting()
+      rmSync(logDir, { force: true, recursive: true })
+    }
+  })
+
+  it("#given metadata-linked tool has stale metadata #when tool.execute.after runs #then it warns and still completes hooks", async () => {
+    // given
+    const logDir = mkdtempSync(join(tmpdir(), "omo-tool-after-"))
+    const logPath = join(logDir, "omo.log")
+    _setLoggerForTesting({ filePath: logPath })
+    let hookRan = false
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {
+        categorySkillReminder: {
+          "tool.execute.after": async () => {
+            hookRan = true
+          },
+        },
+      } as never,
+    })
+
+    try {
+      // when
+      await handler(
+        { tool: "task", sessionID: "ses_parent", callID: "call_missing" },
+        { title: "result", output: "task output", metadata: {} },
+      )
+      _flushForTesting()
+
+      // then
+      expect(hookRan).toBe(true)
+      expect(readLogIfPresent(logPath)).toContain("Unable to recover stored metadata")
+    } finally {
+      _resetLoggerForTesting()
+      rmSync(logDir, { force: true, recursive: true })
+    }
+  })
+})

--- a/src/plugin/tool-execute-after-metadata-recovery.test.ts
+++ b/src/plugin/tool-execute-after-metadata-recovery.test.ts
@@ -47,6 +47,34 @@ describe("createToolExecuteAfterHandler metadata recovery", () => {
     }
   })
 
+  it("#given call_omo_agent has no recoverable store entry #when tool.execute.after runs #then it fails open without warning spam", async () => {
+    // given
+    const logDir = mkdtempSync(join(tmpdir(), "omo-tool-after-"))
+    const logPath = join(logDir, "omo.log")
+    _setLoggerForTesting({ filePath: logPath })
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const output = { title: "result", output: "agent output", metadata: {} }
+
+    try {
+      // when
+      await handler(
+        { tool: "call_omo_agent", sessionID: "ses_parent", callID: "call_agent" },
+        output,
+      )
+      _flushForTesting()
+
+      // then
+      expect(output).toEqual({ title: "result", output: "agent output", metadata: {} })
+      expect(readLogIfPresent(logPath)).not.toContain("Unable to recover stored metadata")
+    } finally {
+      _resetLoggerForTesting()
+      rmSync(logDir, { force: true, recursive: true })
+    }
+  })
+
   it("#given metadata-linked tool has stale metadata #when tool.execute.after runs #then it warns and still completes hooks", async () => {
     // given
     const logDir = mkdtempSync(join(tmpdir(), "omo-tool-after-"))

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -6,6 +6,15 @@ import type { PluginContext } from "./types"
 
 const VERIFICATION_ATTEMPT_PATTERN = /<ulw_verification_attempt_id>(.*?)<\/ulw_verification_attempt_id>/i
 
+const METADATA_LINKED_TOOLS = new Set([
+  "background_output",
+  "background_task",
+  "call_omo_agent",
+  "edit",
+  "hashline_edit",
+  "task",
+])
+
 type ToolExecuteAfterInput = {
   readonly tool: string
   readonly sessionID: string
@@ -38,6 +47,10 @@ function getPluginDirectory(ctx: PluginContext): string | null {
   }
 
   return null
+}
+
+function expectsRecoverableMetadata(tool: string): boolean {
+  return METADATA_LINKED_TOOLS.has(tool)
 }
 
 export function createToolExecuteAfterHandler(args: {
@@ -84,7 +97,7 @@ export function createToolExecuteAfterHandler(args: {
           output.metadata = { ...output.metadata, ...stored.metadata }
         }
       }
-    } else if (!nativeSessionId) {
+    } else if (!nativeSessionId && expectsRecoverableMetadata(input.tool)) {
       log("[tool-execute-after] Unable to recover stored metadata and no native session linkage was present", {
         tool: input.tool,
         sessionID: input.sessionID,

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -8,10 +8,7 @@ const VERIFICATION_ATTEMPT_PATTERN = /<ulw_verification_attempt_id>(.*?)<\/ulw_v
 
 const METADATA_LINKED_TOOLS = new Set([
   "background_output",
-  "background_task",
-  "call_omo_agent",
   "edit",
-  "hashline_edit",
   "task",
 ])
 


### PR DESCRIPTION
## Summary
- Gate metadata recovery warnings to tools that are expected to publish recoverable OMO metadata
- Keep ordinary built-in tools fail-open when OpenCode supplies no native session linkage
- Add regression tests for missing built-in metadata and stale metadata-linked task calls

## Root cause
The after-hook attempted metadata recovery for every tool call. Built-in tools such as read, bash, glob, grep, todowrite, LSP, and apply_patch do not publish OMO fallback metadata, and OpenCode may also provide no native session linkage. On Windows this produced repeated recovery warnings across normal tool calls and amplified the stalled busy-session diagnostics. The metadata store itself is keyed by sessionID/callID and is not path-based, so Windows path separators were not the cause; TTL eviction was also unlikely because cleanup only runs on store.

## Verification
- Red test confirmed: bun test v1.3.12 (700fc117) failed before fix because read logged the recovery warning
- bun test v1.3.12 (700fc117)
- 
- Bundled 18 modules in 5ms

  cli.js  30.59 KB  (entry point)

Bundled 1393 modules in 56ms

  index.js  4.68 MB  (entry point)

Patched Node/Electron require shim in dist/index.js
Bundled 614 modules in 31ms

  index.js  2.41 MB  (entry point)

Generating JSON Schema...
✓ JSON Schema generated: assets/oh-my-opencode.schema.json
- LSP diagnostics clean for 

Fixes #4449

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents warning spam and possible session stalls by gating metadata recovery warnings in `tool.execute.after` to store-backed tools only (`background_output`, `edit`, `task`); all other tools, including built-ins and `call_omo_agent`, now fail open without warnings. Fixes #4449.

- **Bug Fixes**
  - Limit recovery warnings to `background_output`, `edit`, `task`; remove `call_omo_agent` and dead aliases from the gate.
  - Keep built-in tools fail-open when native session ID is missing.
  - Add regression tests for built-ins without metadata and stale `task` metadata.

<sup>Written for commit f57532cbdb9797c3ab9c7329bd0c199201ec4865. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

