### PR TITLE
feat(team-mode): live-tail foundation modules + Python tailer (1/2 for #4035)

### DIFF
--- a/script/team-pane-live-tail.py
+++ b/script/team-pane-live-tail.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Live-tail an OpenCode session for tmux team-mode worker panes.
+
+OpenCode TUI's `attach --session <child>` enters a static subagent-detail
+view (the `session.child.promptDisabled` mode) for any session with a
+parentID. That view shows only the kickoff prompt and never streams.
+
+This tailer subscribes to /event SSE and renders updates as plain text in
+the companion live-tail tmux window while the main team window keeps attach.
+
+Usage: team-pane-live-tail.py <server-url> <session-id> [--no-clear] [--history N] [--insecure]
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+DIM = "\033[2m"
+RST = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+YEL = "\033[33m"
+GRN = "\033[32m"
+RED = "\033[31m"
+MAG = "\033[35m"
+BLU = "\033[34m"
+
+# Per-pane accent colour ramp; deterministic by session id so each worker
+# pane keeps its own colour across reconnects.
+ACCENT_COLOURS = ["\033[38;5;39m", "\033[38;5;208m", "\033[38;5;41m", "\033[38;5;213m", "\033[38;5;220m", "\033[38;5;81m"]
+
+
+def short(s: str, n: int = 100) -> str:
+    s = s.replace("\n", " ⏎ ").replace("\r", "")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def fmt_ts(ms: int | None) -> str:
+    if not ms:
+        return "        "
+    return time.strftime("%H:%M:%S", time.localtime(ms / 1000))
+
+
+def accent_for(session_id: str) -> str:
+    return ACCENT_COLOURS[sum(ord(c) for c in session_id) % len(ACCENT_COLOURS)]
+
+
+def summarize_peer_message(text: str) -> str | None:
+    """Compress a verbose <peer_message ...>...</peer_message> blob into one line."""
+    m = re.match(r'^\s*<peer_message\s+from="([^"]+)"[^>]*>(.*?)</peer_message>', text, re.DOTALL)
+    if not m:
+        return None
+    sender = m.group(1)
+    body = m.group(2).strip()
+    return f"⇠ peer from {sender}: {short(body, 70)}"
+
+
+class SessionState:
+    """Holds session metadata + role lookup so SSE part-updates render with
+    the correct USER/ASSISTANT label without re-fetching per event."""
+
+    def __init__(self, url: str, session_id: str, insecure: bool = False) -> None:
+        # OmO's tmuxMgr.getServerUrl() emits the URL with a trailing slash,
+        # so naive `f"{url}/session/..."` concatenation produces `//session`
+        # which OpenCode rejects with an empty body. Normalise once.
+        self.url = url.rstrip("/")
+        self.session_id = session_id
+        self.member_name = "unknown"
+        self.team_name = ""
+        self.task_line = ""
+        self.agent = ""
+        self.model = ""
+        self.role_by_message: dict[str, str] = {}
+        self.ssl_context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
+        self.footer: StatusFooter | None = None
+
+    def auth_headers(self) -> dict[str, str]:
+        password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+        if not password:
+            return {}
+        username = os.environ.get("OPENCODE_SERVER_USERNAME") or "opencode"
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
+    def open_url(
+        self,
+        url: str,
+        timeout: float | None = 5,
+        headers: dict[str, str] | None = None,
+    ):
+        merged_headers = {**self.auth_headers(), **(headers or {})}
+        request = urllib.request.Request(url, headers=merged_headers) if merged_headers else url
+        return urllib.request.urlopen(request, timeout=timeout, context=self.ssl_context)
+
+    def fetch(self) -> None:
+        try:
+            with self.open_url(f"{self.url}/session/{self.session_id}", timeout=5) as r:
+                info = json.load(r)
+        except (urllib.error.URLError, json.JSONDecodeError):
+            return
+        title = info.get("title", "") or ""
+        # Title shape: "Create team member <team>/<member> (@<agent> subagent)"
+        m = re.match(r"Create team member ([^/]+)/([^\s(]+)\s*\(@([^\s)]+)", title)
+        if m:
+            self.team_name = m.group(1)
+            self.member_name = m.group(2)
+            self.agent = m.group(3)
+        else:
+            self.member_name = title[:48]
+
+
+class StatusFooter:
+    """Daemon thread that prints a status line at the last terminal row every 10s."""
+
+    _INTERVAL = 10.0
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._connected = False
+        self._last_error: str | None = None
+        self._events_seen: int = 0
+        self._last_event_ts: float | None = None
+        self._capable = self._detect_capability()
+        self._thread: threading.Thread | None = None
+
+    def _detect_capability(self) -> bool:
+        term = os.environ.get("TERM", "")
+        if term in ("dumb", ""):
+            return False
+        try:
+            result = subprocess.run(["tput", "sc"], capture_output=True)
+            return result.returncode == 0
+        except (OSError, FileNotFoundError):
+            return False
+
+    def note_event(self) -> None:
+        with self._lock:
+            self._events_seen += 1
+            self._last_event_ts = time.time()
+            self._connected = True
+            self._last_error = None
+
+    def note_disconnect(self, err: str) -> None:
+        with self._lock:
+            self._connected = False
+            self._last_error = err
+
+    def note_reconnect(self, url: str) -> None:
+        with self._lock:
+            self._url = url
+            self._connected = True
+            self._last_error = None
+
+    def _render(self) -> str:
+        with self._lock:
+            if self._connected:
+                last_str = (
+                    time.strftime("%H:%M:%S", time.localtime(self._last_event_ts))
+                    if self._last_event_ts is not None
+                    else "--:--:--"
+                )
+                text = f"[connected → {self._url} | events: {self._events_seen} | last: {last_str}]"
+            else:
+                err_str = f" ({self._last_error})" if self._last_error else ""
+                text = f"[disconnected ✗{err_str}]"
+        return f"\x1b[s\x1b[999;1H\x1b[2K{DIM}{text}{RST}\x1b[u"
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._INTERVAL):
+            try:
+                sys.stdout.write(self._render())
+                sys.stdout.flush()
+            except (OSError, ValueError):
+                break
+
+    def start(self) -> None:
+        if not self._capable:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self._capable:
+            try:
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+            except (OSError, ValueError):
+                pass
+
+
+def render_banner(state: SessionState) -> None:
+    accent = accent_for(state.session_id)
+    print(f"{accent}{BOLD}▣ {state.member_name}{RST}", end="")
+    if state.agent:
+        print(f"  {DIM}{state.agent}{RST}", end="")
+    if state.team_name:
+        print(f"  {DIM}team={state.team_name}{RST}", end="")
+    print()
+    print(f"{DIM}session {state.session_id[:24]}…{RST}")
+
+
+def render_message(m: dict, state: SessionState) -> None:
+    info = m.get("info", {})
+    role = info.get("role", "?").upper()
+    msg_id = info.get("id")
+    if msg_id:
+        state.role_by_message[msg_id] = role
+    ts = fmt_ts(info.get("time", {}).get("created"))
+    parts = m.get("parts", [])
+    for p in parts:
+        ptype = p.get("type")
+        if ptype == "text" and p.get("text"):
+            text = p["text"]
+            peer = summarize_peer_message(text)
+            label, text = ("PEER", peer) if peer else (role, text)
+            colour = CYAN if label == "ASSISTANT" else (BLU if label == "PEER" else GRN)
+            print(f"{ts} {colour}{label:9s}{RST} {short(text)}")
+        elif ptype == "tool":
+            tool = p.get("tool", "?")
+            status = (p.get("state") or {}).get("status", "?")
+            colour = YEL if status != "error" else RED
+            print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+        elif ptype == "reasoning" and p.get("text"):
+            print(f"{ts} {MAG}REASONING{RST} {short(p['text'], 80)}")
+
+
+_KICKOFF_META_PREFIXES = ("Team:", "TeamRunId:", "Member:")
+
+
+def extract_task_line(kickoff_text: str) -> str:
+    """Return the task description line from a team-kickoff prompt body.
+
+    The kickoff begins with metadata headers (`Team:`, `TeamRunId:`, `Member:`)
+    that the OpenCode TUI's static subagent-detail view also surfaces — so
+    showing the first non-empty line of the prompt would just duplicate that
+    static header. The real differentiator (and what users want at a glance)
+    is the task body that follows the headers.
+    """
+    for line in kickoff_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(_KICKOFF_META_PREFIXES):
+            continue
+        if stripped.startswith("# ") or stripped.startswith("## "):
+            # The kickoff template ends with `# Team Communication` boilerplate.
+            return ""
+        return stripped
+    return ""
+
+
+def fetch_history(state: SessionState, n: int) -> int:
+    try:
+        with state.open_url(f"{state.url}/session/{state.session_id}/message", timeout=5) as r:
+            msgs = json.load(r)
+    except (urllib.error.URLError, json.JSONDecodeError) as e:
+        print(f"{RED}history fetch failed: {e}{RST}")
+        return 0
+    # Populate role lookup from full history so SSE renders correctly.
+    for m in msgs:
+        info = m.get("info", {})
+        if info.get("id") and info.get("role"):
+            state.role_by_message[info["id"]] = info["role"].upper()
+    # Find the kickoff prompt's task body (skip metadata headers).
+    for m in msgs:
+        info = m.get("info", {})
+        if info.get("role") != "user":
+            continue
+        for p in m.get("parts", []):
+            if p.get("type") != "text" or not p.get("text"):
+                continue
+            text = p["text"]
+            if "OMO_INTERNAL_INITIATOR" not in text:
+                continue
+            state.task_line = short(extract_task_line(text), 90)
+            break
+        if state.task_line:
+            break
+    if state.task_line:
+        print(f"{DIM}task: {state.task_line}{RST}")
+    print(f"{DIM}── {len(msgs)} messages, last {min(n, len(msgs))} ──{RST}")
+    for m in msgs[-n:]:
+        render_message(m, state)
+    return len(msgs)
+
+
+class _PollOpts:
+    """Options for poll_session_messages()."""
+
+    def __init__(
+        self,
+        poll_interval_seconds: float = 1.0,
+        max_reconnect_wallclock_seconds: int = 90,
+    ) -> None:
+        self.poll_interval_seconds = poll_interval_seconds
+        self.max_reconnect_wallclock_seconds = max_reconnect_wallclock_seconds
+
+
+_BACKOFF_SEQUENCE = (2, 5, 10, 15, 30)
+
+
+def poll_session_messages(state: SessionState, opts: _PollOpts | None = None) -> int:
+    """Tail the session by polling /session/<id>/message at a steady cadence.
+
+    Replaces the prior `/event` SSE flow. opencode 1.14.48's SSE endpoint
+    accepts subscribers but stops delivering events shortly after the
+    initial `server.connected` handshake (verified via 20s curl: 0 data
+    frames received while the bus published >140 message.part.delta
+    events). The opencode TUI itself uses /session/<id>/message polling
+    for the same reason — we match that strategy here.
+    """
+    if opts is None:
+        opts = _PollOpts()
+    interval = max(0.25, opts.poll_interval_seconds)
+    print(f"{DIM}── live tail (polling every {interval:.1f}s, Ctrl-C to exit) ──{RST}")
+    seen_parts: dict[str, int] = {}
+    seen_status: dict[str, str] = {}
+    seen_finish: set[str] = set()
+    failure_wallclock: float = 0.0
+    attempt: int = 0
+
+    while True:
+        try:
+            with state.open_url(
+                f"{state.url}/session/{state.session_id}/message",
+                timeout=10,
+            ) as r:
+                msgs = json.load(r)
+            # Reset failure tracking on a successful poll.
+            failure_wallclock = 0.0
+            attempt = 0
+            if state.footer is not None:
+                state.footer.note_reconnect(state.url)
+            rendered_any = _render_polled_messages(msgs, state, seen_parts, seen_status, seen_finish)
+            if rendered_any and state.footer is not None:
+                state.footer.note_event()
+            time.sleep(interval)
+        except (TimeoutError, socket.timeout):
+            if state.footer is not None:
+                state.footer.note_disconnect("poll timeout — retrying")
+            time.sleep(interval)
+        except (urllib.error.URLError, ConnectionResetError, OSError, ssl.SSLError) as e:
+            if state.footer is not None:
+                state.footer.note_disconnect(str(e))
+            delay = _BACKOFF_SEQUENCE[min(attempt, len(_BACKOFF_SEQUENCE) - 1)]
+            failure_wallclock += delay
+            if failure_wallclock >= opts.max_reconnect_wallclock_seconds:
+                print(
+                    f"[live-tail exited: server unreachable for "
+                    f"{opts.max_reconnect_wallclock_seconds}s. "
+                    f"Run team_refresh_panes to re-attach.]"
+                )
+                return 1
+            print(f"{DIM}poll interrupted ({e}); retrying in {delay}s{RST}")
+            attempt += 1
+            time.sleep(delay)
+
+
+def _render_polled_messages(
+    msgs: list,
+    state: SessionState,
+    seen_parts: dict[str, int],
+    seen_status: dict[str, str],
+    seen_finish: set[str],
+) -> bool:
+    """Render newly-grown content from a /session/<id>/message snapshot.
+
+    Returns True iff at least one line was printed this tick.
+    """
+    rendered = False
+    for m in msgs:
+        info = m.get("info") or {}
+        msg_id = info.get("id") or ""
+        role = (info.get("role") or "ASSISTANT").upper()
+        if msg_id:
+            state.role_by_message[msg_id] = role
+        ts = fmt_ts(int(time.time() * 1000))
+        finish = info.get("finish")
+        if msg_id and finish and msg_id not in seen_finish:
+            seen_finish.add(msg_id)
+            print(f"{ts} {DIM}{role} finish={finish}{RST}")
+            rendered = True
+        for part in (m.get("parts") or []):
+            pid = part.get("id") or ""
+            ptype = part.get("type")
+            parent_msg = part.get("messageID") or msg_id
+            prole = state.role_by_message.get(parent_msg, role)
+            text = part.get("text") or ""
+            prev_len = seen_parts.get(pid, 0)
+            if ptype == "text" and text and len(text) > prev_len:
+                seen_parts[pid] = len(text)
+                # On first sighting of a peer-coordination text, fold the
+                # boilerplate down to a one-line summary (matches the SSE
+                # path's behaviour at handle_event:419-421).
+                if prev_len == 0:
+                    peer = summarize_peer_message(text)
+                    if peer:
+                        print(f"{ts} {BLU}PEER     {RST} {peer}")
+                        rendered = True
+                        continue
+                colour = CYAN if prole == "ASSISTANT" else GRN
+                new_chunk = text[prev_len:]
+                print(f"{ts} {colour}{prole:9s}{RST} {short(new_chunk)}")
+                rendered = True
+            elif ptype == "tool":
+                status = (part.get("state") or {}).get("status", "?")
+                if status != seen_status.get(pid):
+                    seen_status[pid] = status
+                    colour = YEL if status != "error" else RED
+                    tool = part.get("tool", "?")
+                    print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+                    rendered = True
+            elif ptype == "reasoning" and text and len(text) > prev_len:
+                seen_parts[pid] = len(text)
+                new_chunk = text[prev_len:]
+                print(f"{ts} {MAG}REASONING{RST} {short(new_chunk, 80)}")
+                rendered = True
+    return rendered
+
+
+def match_session(ev: dict, session_id: str) -> bool:
+    props = ev.get("properties", {}) or {}
+    candidates = (
+        props.get("sessionID"),
+        props.get("sessionId"),
+        (props.get("info") or {}).get("sessionID"),
+        (props.get("info") or {}).get("sessionId"),
+        (props.get("part") or {}).get("sessionID"),
+        (props.get("part") or {}).get("sessionId"),
+    )
+    return any(c == session_id for c in candidates if c)
+
+
+def handle_event(ev: dict, state: SessionState, seen: dict[str, int]) -> None:
+    etype = ev.get("type", "")
+    props = ev.get("properties", {}) or {}
+    ts = fmt_ts(int(time.time() * 1000))
+    if etype == "message.updated":
+        info = props.get("info", {}) or {}
+        msg_id = info.get("id")
+        role = info.get("role", "?").upper()
+        if msg_id:
+            state.role_by_message[msg_id] = role
+        finish = info.get("finish")
+        if finish:
+            print(f"{ts} {DIM}{role} finish={finish}{RST}")
+        return
+    if etype == "message.part.delta":
+        message_id = props.get("messageID") or props.get("messageId")
+        role = state.role_by_message.get(message_id, "ASSISTANT")
+        field = props.get("field")
+        delta = props.get("delta") or ""
+        if field == "text" and delta:
+            colour = CYAN if role == "ASSISTANT" else GRN
+            print(f"{ts} {colour}{role:9s}{RST} {short(delta)}")
+        return
+    if etype != "message.part.updated":
+        return
+    part = props.get("part", {}) or {}
+    pid = part.get("id") or ""
+    parent_msg = part.get("messageID") or ""
+    role = state.role_by_message.get(parent_msg, "ASSISTANT")
+    ptype = part.get("type")
+    text = part.get("text") or ""
+    # Dedup growing-text streams: print only when the visible prefix grew.
+    prev_len = seen.get(pid, 0)
+    if ptype == "text" and text and len(text) > prev_len:
+        seen[pid] = len(text)
+        peer = summarize_peer_message(text)
+        if peer:
+            print(f"{ts} {BLU}PEER     {RST} {peer}")
+        else:
+            colour = CYAN if role == "ASSISTANT" else GRN
+            print(f"{ts} {colour}{role:9s}{RST} {short(text)}")
+    elif ptype == "tool":
+        # Tool events fire on every status transition; only print on terminal states.
+        status = (part.get("state") or {}).get("status", "?")
+        prev_status = seen.get(f"{pid}:status")
+        if status != prev_status:
+            seen[f"{pid}:status"] = status  # type: ignore[assignment]
+            colour = YEL if status != "error" else RED
+            tool = part.get("tool", "?")
+            print(f"{ts} {colour}TOOL     {RST} {tool} → {status}")
+    elif ptype == "reasoning" and text and len(text) > prev_len:
+        seen[pid] = len(text)
+        print(f"{ts} {MAG}REASONING{RST} {short(text, 80)}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("url")
+    p.add_argument("session_id")
+    p.add_argument("--no-clear", action="store_true")
+    p.add_argument("--history", type=int, default=4)
+    p.add_argument("--insecure", action="store_true", help="Disable TLS certificate verification (local/dev only).")
+    p.add_argument("--poll-interval-seconds", type=float, default=1.0, metavar="N",
+                   help="How often to poll /session/<id>/message (default 1.0s).")
+    # Back-compat: kept so older team_refresh_panes invocations don't crash on
+    # the unknown flag. Value is ignored — SSE has been replaced by polling.
+    p.add_argument("--idle-heartbeat-seconds", type=int, default=30, metavar="N",
+                   help="Deprecated, ignored (SSE replaced by polling).")
+    p.add_argument("--max-reconnect-wallclock-seconds", type=int, default=90, metavar="N")
+    p.add_argument("--no-footer", action="store_true")
+    args = p.parse_args()
+
+    if not args.no_clear:
+        print("\033[2J\033[H", end="")
+    state = SessionState(args.url, args.session_id, insecure=args.insecure)
+    state.fetch()
+    render_banner(state)
+    if args.insecure:
+        print(f"{YEL}{DIM}TLS verify disabled (--insecure). Local/dev use only.{RST}")
+
+    if not args.no_footer:
+        state.footer = StatusFooter(state.url)
+        state.footer.start()
+
+    fetch_history(state, args.history)
+    opts = _PollOpts(
+        poll_interval_seconds=args.poll_interval_seconds,
+        max_reconnect_wallclock_seconds=args.max_reconnect_wallclock_seconds,
+    )
+    result = poll_session_messages(state, opts)
+
+    if state.footer is not None:
+        state.footer.stop()
+
+    return result
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print(f"\n{DIM}interrupted{RST}")
+        sys.exit(130)

--- a/script/test_team_pane_live_tail.py
+++ b/script/test_team_pane_live_tail.py
@@ -1,0 +1,377 @@
+"""Unit tests for team-pane-live-tail.py renderer helpers.
+
+Run: python3 -m unittest script/test_team_pane_live_tail.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE / "team-pane-live-tail.py"
+
+spec = importlib.util.spec_from_file_location("team_pane_live_tail", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+sys.modules["team_pane_live_tail"] = mod
+spec.loader.exec_module(mod)
+
+
+class ExtractTaskLineTests(unittest.TestCase):
+    def test_skips_kickoff_metadata_headers(self) -> None:
+        text = (
+            "Team: omc-enhancement-team\n"
+            "TeamRunId: 59704820-c9d5-4ff9-8490-81f17040a982\n"
+            "Member: docs-auditor\n"
+            "Audit all AGENTS.md files for alignment with hooks.\n\n"
+            "# Team Communication\n\n"
+            "You are running as a team member..."
+        )
+        self.assertEqual(
+            mod.extract_task_line(text),
+            "Audit all AGENTS.md files for alignment with hooks.",
+        )
+
+    def test_returns_first_real_body_line_when_no_metadata(self) -> None:
+        self.assertEqual(
+            mod.extract_task_line("Just a single task description"),
+            "Just a single task description",
+        )
+
+    def test_returns_empty_when_only_metadata_and_section_headers(self) -> None:
+        text = (
+            "Team: x\n"
+            "TeamRunId: y\n"
+            "Member: z\n"
+            "# Team Communication\n"
+            "boilerplate"
+        )
+        self.assertEqual(mod.extract_task_line(text), "")
+
+    def test_strips_leading_whitespace(self) -> None:
+        self.assertEqual(mod.extract_task_line("    indented task"), "indented task")
+
+
+class SummarizePeerMessageTests(unittest.TestCase):
+    def test_compresses_full_peer_message(self) -> None:
+        text = (
+            '<peer_message from="lead" timestamp="123" messageId="abc">'
+            "Status check please.\nMore detail here.</peer_message>"
+        )
+        result = mod.summarize_peer_message(text)
+        self.assertIsNotNone(result)
+        self.assertIn("⇠ peer from lead:", result)
+        self.assertIn("Status check please", result)
+
+    def test_returns_none_for_non_peer_text(self) -> None:
+        self.assertIsNone(mod.summarize_peer_message("regular assistant output"))
+
+    def test_returns_none_for_malformed_xml(self) -> None:
+        self.assertIsNone(mod.summarize_peer_message('<peer_message from="lead">unclosed'))
+
+
+class AccentForTests(unittest.TestCase):
+    def test_deterministic_per_session(self) -> None:
+        a1 = mod.accent_for("ses_abc")
+        a2 = mod.accent_for("ses_abc")
+        self.assertEqual(a1, a2)
+
+    def test_different_sessions_can_get_different_colours(self) -> None:
+        # Picks two ids that differ in their character-sum modulo the ramp.
+        first = mod.accent_for("ses_aaaaa")
+        second = mod.accent_for("ses_aaaab")
+        self.assertNotEqual(first, second)
+
+
+class SessionStateUrlNormalizationTests(unittest.TestCase):
+    """OmO's tmuxMgr.getServerUrl() emits trailing-slash URLs; without
+    normalisation the script issues `http://.../4096//session/...` which
+    OpenCode rejects with an empty body. Regression test for that bug."""
+
+    def test_strips_single_trailing_slash(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096/", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_strips_multiple_trailing_slashes(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096///", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_leaves_url_without_trailing_slash_alone(self) -> None:
+        s = mod.SessionState("http://127.0.0.1:4096", "ses_x")
+        self.assertEqual(s.url, "http://127.0.0.1:4096")
+
+    def test_uses_unverified_context_only_when_insecure_enabled(self) -> None:
+        strict = mod.SessionState("https://127.0.0.1:4096", "ses_strict")
+        insecure = mod.SessionState("https://127.0.0.1:4096", "ses_insecure", insecure=True)
+        self.assertEqual(strict.ssl_context.verify_mode, mod.ssl.CERT_REQUIRED)
+        self.assertEqual(insecure.ssl_context.verify_mode, mod.ssl.CERT_NONE)
+
+    def test_open_url_merges_basic_auth_with_existing_headers(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with patch.dict(mod.os.environ, {"OPENCODE_SERVER_PASSWORD": "secret"}, clear=False):
+            with patch.object(mod.urllib.request, "urlopen") as urlopen:
+                state.open_url("http://x/event", headers={"Accept": "text/event-stream"})
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.headers["Accept"], "text/event-stream")
+        self.assertTrue(request.headers["Authorization"].startswith("Basic "))
+
+
+class SessionStateFetchTests(unittest.TestCase):
+    def _mock_session_response(self, payload: dict) -> patch:
+        body = json.dumps(payload).encode("utf-8")
+
+        class _Resp:
+            def __init__(self, b: bytes) -> None:
+                self._b = b
+
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *a: object) -> None:
+                pass
+
+            def read(self) -> bytes:
+                return self._b
+
+        return patch.object(mod.urllib.request, "urlopen", return_value=_Resp(body))
+
+    def test_parses_team_member_agent_from_title(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with self._mock_session_response({
+            "title": "Create team member omc-team/docs-auditor (@Sisyphus-Junior subagent)",
+        }):
+            # Wrap urlopen so json.load works on a file-like; patch json.load to
+            # decode bytes directly.
+            with patch.object(mod.json, "load", side_effect=lambda r: json.loads(r.read())):
+                state.fetch()
+        self.assertEqual(state.team_name, "omc-team")
+        self.assertEqual(state.member_name, "docs-auditor")
+        self.assertEqual(state.agent, "Sisyphus-Junior")
+
+    def test_falls_back_to_truncated_title_when_pattern_misses(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        with self._mock_session_response({"title": "ad-hoc title not matching pattern"}):
+            with patch.object(mod.json, "load", side_effect=lambda r: json.loads(r.read())):
+                state.fetch()
+        self.assertEqual(state.member_name, "ad-hoc title not matching pattern")
+        self.assertEqual(state.team_name, "")
+
+
+class HandleEventTests(unittest.TestCase):
+    def test_user_role_text_renders_as_user(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        state.role_by_message["msg1"] = "USER"
+        seen: dict = {}
+        ev = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "text",
+                    "id": "p1",
+                    "messageID": "msg1",
+                    "text": "Hello there",
+                },
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("USER", fake.getvalue())
+        self.assertNotIn("ASSISTANT", fake.getvalue())
+
+    def test_assistant_role_default_when_unknown(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        seen: dict = {}
+        ev = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "text",
+                    "id": "p1",
+                    "messageID": "unknown",
+                    "text": "Streaming response",
+                },
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("ASSISTANT", fake.getvalue())
+
+    def test_dedupes_growing_text_streams(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        seen: dict = {}
+        first = {
+            "type": "message.part.updated",
+            "properties": {"part": {"type": "text", "id": "p1", "messageID": "m", "text": "Hello"}},
+        }
+        same_size = {
+            "type": "message.part.updated",
+            "properties": {"part": {"type": "text", "id": "p1", "messageID": "m", "text": "Hello"}},
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(first, state, seen)
+            mod.handle_event(same_size, state, seen)
+        # Only one render despite two events of the same length.
+        self.assertEqual(fake.getvalue().count("Hello"), 1)
+
+    def test_text_delta_renders_live_increment(self) -> None:
+        state = mod.SessionState("http://x", "ses_y")
+        state.role_by_message["msg1"] = "ASSISTANT"
+        seen: dict = {}
+        ev = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionId": "ses_y",
+                "messageID": "msg1",
+                "partID": "part1",
+                "field": "text",
+                "delta": "streaming chunk",
+            },
+        }
+        with patch("sys.stdout", new=StringIO()) as fake:
+            mod.handle_event(ev, state, seen)
+        self.assertIn("ASSISTANT", fake.getvalue())
+        self.assertIn("streaming chunk", fake.getvalue())
+
+
+class MatchSessionTests(unittest.TestCase):
+    def test_matches_via_top_level_sessionId(self) -> None:
+        ev = {"properties": {"sessionId": "ses_abc"}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_part_sessionID(self) -> None:
+        ev = {"properties": {"part": {"sessionID": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_part_sessionId(self) -> None:
+        ev = {"properties": {"part": {"sessionId": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_info_sessionID(self) -> None:
+        ev = {"properties": {"info": {"sessionID": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_matches_via_info_sessionId(self) -> None:
+        ev = {"properties": {"info": {"sessionId": "ses_abc"}}}
+        self.assertTrue(mod.match_session(ev, "ses_abc"))
+
+    def test_does_not_match_message_id_as_session_id(self) -> None:
+        ev = {"properties": {"info": {"id": "ses_abc"}}}
+        self.assertFalse(mod.match_session(ev, "ses_abc"))
+
+    def test_rejects_other_session(self) -> None:
+        ev = {"properties": {"info": {"sessionID": "ses_other"}}}
+        self.assertFalse(mod.match_session(ev, "ses_abc"))
+
+
+class PolledMessageRendererTests(unittest.TestCase):
+    """Validate the /session/<id>/message polling renderer that replaced SSE."""
+
+    def _render(self, msgs: list) -> tuple[str, dict, dict, set]:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_parts: dict = {}
+        seen_status: dict = {}
+        seen_finish: set = set()
+        out = StringIO()
+        with patch("sys.stdout", out):
+            mod._render_polled_messages(msgs, state, seen_parts, seen_status, seen_finish)
+        return out.getvalue(), seen_parts, seen_status, seen_finish
+
+    def test_renders_text_growth_as_delta(self) -> None:
+        # First poll sees "Hello"; second poll sees "Hello world".
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_parts: dict = {}
+        out = StringIO()
+        with patch("sys.stdout", out):
+            mod._render_polled_messages(
+                [{"info": {"id": "m1", "role": "assistant"}, "parts": [{"id": "p1", "type": "text", "messageID": "m1", "text": "Hello"}]}],
+                state, seen_parts, {}, set(),
+            )
+            mod._render_polled_messages(
+                [{"info": {"id": "m1", "role": "assistant"}, "parts": [{"id": "p1", "type": "text", "messageID": "m1", "text": "Hello world"}]}],
+                state, seen_parts, {}, set(),
+            )
+        text = out.getvalue()
+        self.assertIn("Hello", text)
+        # The second render should only print " world" (the new tail), not "Hello" again.
+        # Strip ANSI to count substrings reliably.
+        import re as _re
+        plain = _re.sub(r"\x1b\[[0-9;]*m", "", text)
+        self.assertEqual(plain.count("Hello"), 1, f"expected one 'Hello' print, got: {plain!r}")
+        self.assertIn(" world", plain)
+
+    def test_renders_tool_status_transition_once(self) -> None:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_status: dict = {}
+        out = StringIO()
+        msg = {
+            "info": {"id": "m1", "role": "assistant"},
+            "parts": [{"id": "p1", "type": "tool", "messageID": "m1", "tool": "grep", "state": {"status": "running"}}],
+        }
+        with patch("sys.stdout", out):
+            # Two polls with the same running status — only first should print.
+            mod._render_polled_messages([msg], state, {}, seen_status, set())
+            mod._render_polled_messages([msg], state, {}, seen_status, set())
+        plain = out.getvalue()
+        self.assertEqual(plain.count("grep → running"), 1)
+
+    def test_renders_finish_once(self) -> None:
+        state = mod.SessionState("http://x", "ses_poll")
+        seen_finish: set = set()
+        out = StringIO()
+        msg = {"info": {"id": "m1", "role": "assistant", "finish": "stop"}, "parts": []}
+        with patch("sys.stdout", out):
+            mod._render_polled_messages([msg], state, {}, {}, seen_finish)
+            mod._render_polled_messages([msg], state, {}, {}, seen_finish)
+        plain = out.getvalue()
+        self.assertEqual(plain.count("finish=stop"), 1)
+
+
+class ReconnectWallclockBudgetTests(unittest.TestCase):
+    def test_reconnect_exits_after_wallclock_budget(self) -> None:
+        import time as _time
+
+        state = mod.SessionState("http://127.0.0.1:19999", "ses_test_budget")
+
+        # Patch open_url to always raise ConnectionRefusedError (subclass of OSError).
+        def always_fail(url: str, timeout=None, headers=None):  # type: ignore[override]
+            raise ConnectionRefusedError("refused")
+
+        state.open_url = always_fail  # type: ignore[method-assign]
+
+        opts = mod._PollOpts(
+            poll_interval_seconds=1.0,
+            max_reconnect_wallclock_seconds=2,
+        )
+
+        start = _time.monotonic()
+        result = mod.poll_session_messages(state, opts)
+        elapsed = _time.monotonic() - start
+
+        self.assertEqual(result, 1, "poll_session_messages should return 1 after budget exhaustion")
+        # Budget is 2s; the first backoff delay is 2s so it fires after one sleep.
+        self.assertLess(elapsed, 10.0, f"poll_session_messages took too long: {elapsed:.1f}s")
+
+
+class StatusFooterEventCountTests(unittest.TestCase):
+    def test_status_footer_persists_events_across_reconnect(self) -> None:
+        footer = mod.StatusFooter("http://127.0.0.1:19999")
+
+        # 3 events, then a disconnect, then 2 more events.
+        footer.note_event()
+        footer.note_event()
+        footer.note_event()
+        footer.note_disconnect("boom")
+        footer.note_event()
+        footer.note_event()
+
+        rendered = footer._render()
+        self.assertIn("events: 5", rendered, f"Expected 'events: 5' in footer render, got: {rendered!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/features/team-mode/team-layout-tmux/live-tail.test.ts
+++ b/src/features/team-mode/team-layout-tmux/live-tail.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach } from "bun:test"
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { _resetCacheForTests, buildLiveTailCommand, materializeLiveTailScript } from "./live-tail"
+
+describe("buildLiveTailCommand", () => {
+  beforeEach(() => {
+    _resetCacheForTests()
+  })
+
+  test("emits a python invocation with shell-quoted args", () => {
+    const cmd = buildLiveTailCommand("http://127.0.0.1:4096", "ses_abc123")
+    expect(cmd).toContain("python3 -u ")
+    expect(cmd).toContain("'http://127.0.0.1:4096'")
+    expect(cmd).toContain("'ses_abc123'")
+    expect(cmd).not.toContain("opencode attach")
+  })
+
+  test("escapes single quotes in url and session id", () => {
+    const cmd = buildLiveTailCommand("http://x.test/'evil", "ses_'evil")
+    expect(cmd).not.toMatch(/'\s'evil/)
+    expect(cmd.split("'").length).toBeGreaterThan(4)
+  })
+
+  test("appends --insecure only when explicitly enabled", () => {
+    const strictCmd = buildLiveTailCommand("https://127.0.0.1:4096", "ses_strict")
+    const insecureCmd = buildLiveTailCommand("https://127.0.0.1:4096", "ses_insecure", { allowInsecureTls: true })
+    expect(strictCmd).not.toContain(" --insecure")
+    expect(insecureCmd).toContain(" --insecure")
+  })
+
+  test("appends --no-footer when disableStatusFooter is true", () => {
+    const cmd = buildLiveTailCommand("http://x", "ses_y", { disableStatusFooter: true })
+    expect(cmd).toContain(" --no-footer")
+  })
+
+  test("omits --no-footer when disableStatusFooter is false or absent", () => {
+    const cmdDefault = buildLiveTailCommand("http://x", "ses_y")
+    const cmdFalse = buildLiveTailCommand("http://x", "ses_y", { disableStatusFooter: false })
+    expect(cmdDefault).not.toContain("--no-footer")
+    expect(cmdFalse).not.toContain("--no-footer")
+  })
+
+  test("references a file that materialize wrote with python content", () => {
+    const cmd = buildLiveTailCommand("http://127.0.0.1:4096", "ses_abc123")
+    const match = cmd.match(/python3 -u '([^']+)'/)
+    expect(match).not.toBeNull()
+    const path = match![1]!
+    expect(existsSync(path)).toBe(true)
+    const contents = readFileSync(path, "utf8")
+    expect(contents).toContain("Live-tail an OpenCode session")
+    expect(contents).toContain("/event")
+  })
+
+  test("materializeLiveTailScript writes 0700 mode and is idempotent", () => {
+    const path1 = materializeLiveTailScript()
+    const path2 = materializeLiveTailScript()
+    expect(path1).toBe(path2)
+    const mode = statSync(path1).mode & 0o777
+    expect(mode).toBe(0o700)
+  })
+
+  test("materialized script ends with a newline so python parses it cleanly", () => {
+    const path = materializeLiveTailScript()
+    const contents = readFileSync(path, "utf8")
+    expect(contents.endsWith("\n")).toBe(true)
+  })
+
+  test("materialized script declares the expected helper functions for renderer logic", () => {
+    // Smoke check that protects against accidentally bundling a stale script.
+    const path = materializeLiveTailScript()
+    const contents = readFileSync(path, "utf8")
+    for (const symbol of [
+      "def extract_task_line(",
+      "def summarize_peer_message(",
+      "class SessionState",
+      "def render_banner(",
+      "_KICKOFF_META_PREFIXES",
+    ]) {
+      expect(contents).toContain(symbol)
+    }
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/live-tail.ts
+++ b/src/features/team-mode/team-layout-tmux/live-tail.ts
@@ -1,0 +1,43 @@
+// Live-tail command builder for team-mode worker tmux panes.
+//
+// OpenCode TUI's `attach --session <child>` enters a static subagent-detail
+// view (see binary string "session.child.promptDisabled") for any session
+// that has a parentID. Team workers always carry parentID=lead, so team mode
+// now keeps the attach view in the main window and runs this Python tailer in
+// a companion window for the streaming feed.
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { shellSingleQuote } from "../../../shared/shell-env"
+import liveTailScript from "../../../../script/team-pane-live-tail.py" with { type: "text" }
+
+const SCRIPT_FILENAME = "omo-team-pane-live-tail.py"
+
+let cachedPath: string | null = null
+
+export function materializeLiveTailScript(): string {
+  if (cachedPath !== null) return cachedPath
+  const dir = join(tmpdir(), `omo-team-${process.pid}`)
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const path = join(dir, SCRIPT_FILENAME)
+  writeFileSync(path, liveTailScript, { mode: 0o700 })
+  cachedPath = path
+  return path
+}
+
+type LiveTailCommandOptions = {
+  allowInsecureTls?: boolean
+  disableStatusFooter?: boolean
+}
+
+export function buildLiveTailCommand(serverUrl: string, sessionId: string, options?: LiveTailCommandOptions): string {
+  const scriptPath = materializeLiveTailScript()
+  const insecureFlag = options?.allowInsecureTls ? " --insecure" : ""
+  const noFooterFlag = options?.disableStatusFooter ? " --no-footer" : ""
+  return `python3 -u ${shellSingleQuote(scriptPath)} ${shellSingleQuote(serverUrl)} ${shellSingleQuote(sessionId)}${insecureFlag}${noFooterFlag}`
+}
+
+export function _resetCacheForTests(): void {
+  cachedPath = null
+}

--- a/src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts
+++ b/src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it, mock } from "bun:test"
+
+import { reapStaleTailers, type ReapDeps } from "./reap-stale-tailers"
+
+describe("reapStaleTailers", () => {
+  it("#given mixed reachable and unreachable URLs #when reap #then dispatches SIGTERM only to PIDs whose URL is unreachable", async () => {
+    const killed: number[] = []
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 1, url: "http://A:4096" },
+        { pid: 2, url: "http://B:4096" },
+      ],
+      probeUrl: async (url) => url === "http://A:4096",
+      killPid: (pid) => {
+        killed.push(pid)
+      },
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(killed).toEqual([2])
+    expect(result.reapedPids).toEqual([2])
+    expect(result.livePids).toEqual([1])
+    expect(result.unreachableUrls).toEqual(["http://B:4096"])
+  })
+
+  it("#given multiple PIDs sharing the same URL #when reap #then probeUrl is invoked exactly once for that URL", async () => {
+    const probeUrlMock = mock(async (_url: string, _timeoutMs: number) => false)
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 10, url: "http://X:4096" },
+        { pid: 11, url: "http://X:4096" },
+        { pid: 12, url: "http://X:4096" },
+      ],
+      probeUrl: probeUrlMock,
+      killPid: () => {},
+    }
+
+    await reapStaleTailers({ deps })
+
+    expect(probeUrlMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given killPid throws for first PID #when reap #then resolves and reapedPids contains second PID only", async () => {
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [
+        { pid: 100, url: "http://dead:4096" },
+        { pid: 101, url: "http://dead:4096" },
+      ],
+      probeUrl: async () => false,
+      killPid: (pid) => {
+        if (pid === 100) throw new Error("ESRCH")
+      },
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(result.reapedPids).toEqual([101])
+    expect(result.unreachableUrls).toEqual(["http://dead:4096"])
+  })
+
+  it("#given empty process list #when reap #then returns all-empty result", async () => {
+    const deps: ReapDeps = {
+      listTailerProcesses: async () => [],
+      probeUrl: async () => true,
+      killPid: () => {},
+    }
+
+    const result = await reapStaleTailers({ deps })
+
+    expect(result).toEqual({ reapedPids: [], livePids: [], unreachableUrls: [] })
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts
+++ b/src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts
@@ -1,0 +1,152 @@
+import { log } from "../../../shared"
+
+export type ReapResult = {
+  reapedPids: number[]
+  livePids: number[]
+  unreachableUrls: string[]
+}
+
+export type ReapDeps = {
+  listTailerProcesses: () => Promise<Array<{ pid: number; url: string }>>
+  probeUrl: (url: string, timeoutMs: number) => Promise<boolean>
+  killPid: (pid: number) => void
+}
+
+const TAILER_SCRIPT_NAME = "omo-team-pane-live-tail.py"
+
+async function listTailerProcessesLinux(): Promise<Array<{ pid: number; url: string }>> {
+  const { readdirSync, readFileSync } = await import("node:fs")
+  const results: Array<{ pid: number; url: string }> = []
+
+  let entries: string[]
+  try {
+    entries = readdirSync("/proc")
+  } catch {
+    return results
+  }
+
+  for (const entry of entries) {
+    const pid = parseInt(entry, 10)
+    if (isNaN(pid)) continue
+
+    try {
+      const cmdlineRaw = readFileSync(`/proc/${pid}/cmdline`, "utf8")
+      const args = cmdlineRaw.split("\0").filter((a) => a.length > 0)
+      const scriptIndex = args.findIndex((a) => a.endsWith(TAILER_SCRIPT_NAME))
+      if (scriptIndex === -1) continue
+      const url = args[scriptIndex + 1]
+      if (!url) continue
+      results.push({ pid, url })
+    } catch {
+      // process may have exited or no permission
+    }
+  }
+
+  return results
+}
+
+async function listTailerProcessesDarwin(): Promise<Array<{ pid: number; url: string }>> {
+  const { spawn } = await import("node:child_process")
+  return new Promise((resolve) => {
+    const results: Array<{ pid: number; url: string }> = []
+    const proc = spawn("ps", ["-axo", "pid=,command="])
+    let stdout = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+
+    proc.on("close", () => {
+      for (const line of stdout.split("\n")) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        const spaceIdx = trimmed.indexOf(" ")
+        if (spaceIdx === -1) continue
+        const pidStr = trimmed.slice(0, spaceIdx).trim()
+        const command = trimmed.slice(spaceIdx + 1).trim()
+        const pid = parseInt(pidStr, 10)
+        if (isNaN(pid)) continue
+        const args = command.split(" ")
+        const scriptIndex = args.findIndex((a) => a.endsWith(TAILER_SCRIPT_NAME))
+        if (scriptIndex === -1) continue
+        const url = args[scriptIndex + 1]
+        if (!url) continue
+        results.push({ pid, url })
+      }
+      resolve(results)
+    })
+
+    proc.on("error", () => resolve(results))
+  })
+}
+
+async function listTailerProcesses(): Promise<Array<{ pid: number; url: string }>> {
+  if (process.platform === "linux") {
+    return listTailerProcessesLinux()
+  }
+  if (process.platform === "darwin") {
+    return listTailerProcessesDarwin()
+  }
+  log(`[team-mode] reap-stale-tailers: unsupported platform '${process.platform}', skipping reap`)
+  return []
+}
+
+async function probeUrl(url: string, timeoutMs: number): Promise<boolean> {
+  const base = url.replace(/\/+$/, "")
+  try {
+    await fetch(`${base}/path`, { method: "HEAD", signal: AbortSignal.timeout(timeoutMs) })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function killPid(pid: number): void {
+  process.kill(pid, "SIGTERM")
+}
+
+export const defaultDeps: ReapDeps = {
+  listTailerProcesses,
+  probeUrl,
+  killPid,
+}
+
+export async function reapStaleTailers(opts?: {
+  probeTimeoutMs?: number
+  deps?: ReapDeps
+}): Promise<ReapResult> {
+  const deps = opts?.deps ?? defaultDeps
+  const procs = await deps.listTailerProcesses()
+  const byUrl = new Map<string, number[]>()
+  for (const p of procs) {
+    const arr = byUrl.get(p.url) ?? []
+    arr.push(p.pid)
+    byUrl.set(p.url, arr)
+  }
+
+  const reaped: number[] = []
+  const live: number[] = []
+  const unreachable: string[] = []
+
+  await Promise.all(
+    [...byUrl.entries()].map(async ([url, pids]) => {
+      const ok = await deps.probeUrl(url, opts?.probeTimeoutMs ?? 1500)
+      if (ok) {
+        live.push(...pids)
+        return
+      }
+      unreachable.push(url)
+      for (const pid of pids) {
+        try {
+          deps.killPid(pid)
+          reaped.push(pid)
+        } catch (e) {
+          log("[team-mode] reap-stale-tailers SIGTERM failed", { pid, url, error: String(e) })
+        }
+      }
+    }),
+  )
+
+  log("[team-mode] reap-stale-tailers complete", { reaped, live, unreachable })
+  return { reapedPids: reaped, livePids: live, unreachableUrls: unreachable }
+}

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { detectServerPortOwnership, type ServerPortOwnershipDeps } from "./server-port-ownership"
+
+// /proc/net/tcp header line
+const TCP_HEADER =
+  "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+
+// Build a single /proc/net/tcp row. state defaults to "0A" (LISTEN).
+function tcpRow(localAddr: string, state = "0A"): string {
+  return `   0: ${localAddr} 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000 1000        0 12345 1 0000000000000000 100 0 0 10 0\n`
+}
+
+function makeDeps(files: Record<string, string>): ServerPortOwnershipDeps {
+  return {
+    readFile: async (path: string) => {
+      if (Object.prototype.hasOwnProperty.call(files, path)) {
+        return files[path]!
+      }
+      const err = Object.assign(new Error(`ENOENT: no such file or directory, open '${path}'`), {
+        code: "ENOENT",
+      })
+      throw err
+    },
+  }
+}
+
+describe("detectServerPortOwnership", () => {
+  const pid = 99999
+
+  it("returns hasOwnPort:true with decoded port when one LISTEN socket exists on 127.0.0.1", async () => {
+    // 0100007F:1F90 → 127.0.0.1:8080 (0x1F90 = 8080)
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x1f90) // 8080
+  })
+
+  it("returns hasOwnPort:false with reason when no LISTEN socket exists", async () => {
+    // state 01 = ESTABLISHED, not a LISTEN socket
+    const content = TCP_HEADER + tcpRow("0100007F:1F90", "01")
+    const deps = makeDeps({
+      [`/proc/${pid}/net/tcp`]: content,
+      [`/proc/${pid}/net/tcp6`]: TCP_HEADER, // empty — no rows
+    })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toContain("no LISTEN socket")
+  })
+
+  it("returns hasOwnPort:true with a port when multiple LISTEN sockets exist", async () => {
+    // Two LISTEN sockets: 0100007F:1F90 (8080) and 00000000:2000 (8192)
+    const content =
+      TCP_HEADER + tcpRow("0100007F:1F90") + "   1: 00000000:2000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000        0 12346 1 0000000000000000 100 0 0 10 0\n"
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    // Must return one of the two ports (cast away undefined to satisfy toContain overload)
+    expect([0x1f90, 0x2000]).toContain(result.port as number)
+  })
+
+  it("returns hasOwnPort:false with path-specific reason when /proc tcp file is not found", async () => {
+    // No files → readFile throws ENOENT for every path
+    const deps = makeDeps({})
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toMatch(/\/proc\/\d+\/net\/tcp not found/)
+  })
+
+  // #4071 finding 1: simulate macOS from a Linux runner via injected platform dep.
+  // With injected readFile present, the deps path must be consulted BEFORE the
+  // platform fallback so the parsing path is exercisable on any host.
+  it("on simulated darwin with injected readFile → parses normally (does NOT short-circuit to 'assume ownership')", async () => {
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps: ServerPortOwnershipDeps = {
+      readFile: async (path: string) => {
+        if (path === `/proc/${pid}/net/tcp`) return content
+        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+        throw err
+      },
+      getPlatform: () => "darwin",
+    }
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x1f90)
+    expect(result.reason).toBeUndefined()
+  })
+
+  it("on simulated darwin when injected readFile raises ENOENT → falls back to 'assume ownership'", async () => {
+    const deps: ServerPortOwnershipDeps = {
+      readFile: async () => {
+        const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+        throw err
+      },
+      getPlatform: () => "darwin",
+    }
+
+    const result = await detectServerPortOwnership({ pid, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.reason).toMatch(/platform unsupported/)
+  })
+
+  // #4071 finding 2: ownership anchored to the actual OpenCode server URL port.
+  it("with expectedPort matching a parsed LISTEN port → returns hasOwnPort:true with that port", async () => {
+    const content =
+      TCP_HEADER +
+      tcpRow("0100007F:1F90") +
+      "   1: 00000000:2000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000        0 12346 1 0000000000000000 100 0 0 10 0\n"
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, expectedPort: 0x2000, deps })
+
+    expect(result.hasOwnPort).toBe(true)
+    expect(result.port).toBe(0x2000)
+  })
+
+  it("with expectedPort NOT matching any parsed LISTEN port → returns hasOwnPort:false naming the expected port", async () => {
+    const content = TCP_HEADER + tcpRow("0100007F:1F90")
+    const deps = makeDeps({ [`/proc/${pid}/net/tcp`]: content })
+
+    const result = await detectServerPortOwnership({ pid, expectedPort: 9999, deps })
+
+    expect(result.hasOwnPort).toBe(false)
+    expect(result.reason).toContain("9999")
+  })
+})

--- a/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
+++ b/src/features/team-mode/team-layout-tmux/server-port-ownership.ts
@@ -1,0 +1,163 @@
+// Detects whether the current process owns a local LISTEN socket on a
+// specific port (when expectedPort is provided) or any local LISTEN socket
+// (when expectedPort is omitted).
+//
+// On Linux, reads /proc/<pid>/net/tcp (and tcp6) to find sockets in state 0A
+// (LISTEN) bound to a local interface (127.0.0.1 / 0.0.0.0 / :: / ::1). On
+// non-Linux platforms, the real /proc filesystem doesn't exist; readFile
+// throws ENOENT and the function falls through to a platform-aware path
+// that "assumes ownership" (so macOS/Windows users aren't blocked).
+//
+// IMPORTANT (#4071 review): tests inject `readFile` via deps to exercise
+// the parsing path on any host. The function MUST honor injected deps
+// before short-circuiting on platform — otherwise tests on Linux runners
+// that simulate macOS by mocking `os.platform()` would never reach the
+// parsing logic, and the no-ownership path would never be testable on
+// non-Linux CI hosts. The deps-injected readFile is consulted first; only
+// when it raises ENOENT (i.e. the real fs has no /proc) does the platform
+// fallback trigger.
+
+import { readFile as fsReadFile } from "node:fs/promises"
+import { log } from "../../../shared"
+
+export type ServerPortOwnership = {
+  hasOwnPort: boolean
+  port?: number   // present when hasOwnPort
+  reason?: string // present when !hasOwnPort
+}
+
+export type ServerPortOwnershipDeps = {
+  readFile: (path: string) => Promise<string>
+  // Injected so tests can simulate non-Linux platforms without an actual
+  // macOS host. Defaults to () => process.platform.
+  getPlatform?: () => NodeJS.Platform | string
+}
+
+const LISTEN_STATE = "0A"
+
+// IPv4 local addresses in /proc/net/tcp little-endian hex format
+const IPV4_LOOPBACK_HEX = "0100007F" // 127.0.0.1
+const IPV4_WILDCARD_HEX = "00000000" // 0.0.0.0
+
+// IPv6 local addresses in /proc/net/tcp6 little-endian 128-bit hex format
+const IPV6_WILDCARD_HEX = "00000000000000000000000000000000" // ::
+const IPV6_LOOPBACK_HEX = "00000000000000000000000001000000" // ::1
+const IPV6_MAPPED_LOOPBACK_HEX = "0000000000000000FFFF00000100007F" // ::ffff:127.0.0.1
+
+function isLocalAddress(hexIp: string): boolean {
+  return (
+    hexIp === IPV4_LOOPBACK_HEX ||
+    hexIp === IPV4_WILDCARD_HEX ||
+    hexIp === IPV6_WILDCARD_HEX ||
+    hexIp === IPV6_LOOPBACK_HEX ||
+    hexIp === IPV6_MAPPED_LOOPBACK_HEX
+  )
+}
+
+function parseTcpListenPorts(content: string): number[] {
+  const ports: number[] = []
+  const lines = content.split("\n")
+  // Skip header line (index 0)
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]?.trim()
+    if (!line) continue
+    const fields = line.split(/\s+/)
+    // field[1] = local_address (HEXIP:HEXPORT), field[3] = state
+    const localAddr = fields[1]
+    const state = fields[3]
+    if (!localAddr || !state) continue
+    if (state !== LISTEN_STATE) continue
+    const colonIdx = localAddr.indexOf(":")
+    if (colonIdx === -1) continue
+    const hexIp = localAddr.slice(0, colonIdx)
+    const hexPort = localAddr.slice(colonIdx + 1)
+    if (!isLocalAddress(hexIp)) continue
+    const parsed = parseInt(hexPort, 16)
+    if (Number.isFinite(parsed)) ports.push(parsed)
+  }
+  return ports
+}
+
+function selectPort(ports: number[], expectedPort?: number): number | null {
+  if (ports.length === 0) return null
+  if (expectedPort === undefined) return ports[0] ?? null
+  return ports.includes(expectedPort) ? expectedPort : null
+}
+
+let _platformWarned = false
+
+export const defaultDeps: ServerPortOwnershipDeps = {
+  readFile: (path: string) => fsReadFile(path, "utf8"),
+  getPlatform: () => process.platform,
+}
+
+export async function detectServerPortOwnership(opts?: {
+  pid?: number
+  // When provided, ownership is only reported as true if the pid owns a
+  // LISTEN socket on this exact port. Required (#4071 finding 2) so the
+  // function is anchored to the actual OpenCode server URL, not just any
+  // local listener.
+  expectedPort?: number
+  deps?: ServerPortOwnershipDeps
+}): Promise<ServerPortOwnership> {
+  const pid = opts?.pid ?? process.pid
+  const deps = opts?.deps ?? defaultDeps
+  const platform = (deps.getPlatform ?? defaultDeps.getPlatform!)()
+
+  // NOTE: /proc/<pid>/net/tcp shows sockets in the process's network namespace,
+  // not necessarily sockets owned exclusively by this process. In containerized
+  // or shared-namespace environments, this can produce false positives.
+  // For the team-mode use case (tmux server on localhost), this heuristic is
+  // sufficient because the tmux server process typically owns its listening socket.
+  const tcpPath = `/proc/${pid}/net/tcp`
+  // Consult injected/real readFile FIRST so test scaffolding can exercise
+  // the parsing path on any host. On non-Linux real fs this raises ENOENT
+  // and we fall through to the platform-assume branch below.
+  let tcpContent: string | null = null
+  try {
+    tcpContent = await deps.readFile(tcpPath)
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== "ENOENT") throw err
+    // ENOENT — fall through to platform handling.
+    if (platform !== "linux") {
+      if (!_platformWarned) {
+        _platformWarned = true
+        log("[server-port-ownership] platform unsupported (real fs has no /proc), assuming port ownership")
+      }
+      return { hasOwnPort: true, reason: "platform unsupported, assuming ownership" }
+    }
+    return { hasOwnPort: false, reason: `${tcpPath} not found` }
+  }
+
+  const tcpPorts = parseTcpListenPorts(tcpContent)
+  const tcpMatch = selectPort(tcpPorts, opts?.expectedPort)
+  if (tcpMatch !== null) {
+    return { hasOwnPort: true, port: tcpMatch }
+  }
+
+  // Try tcp6; ENOENT is non-fatal on kernels that omit it
+  const tcp6Path = `/proc/${pid}/net/tcp6`
+  try {
+    const tcp6Content = await deps.readFile(tcp6Path)
+    const tcp6Ports = parseTcpListenPorts(tcp6Content)
+    const tcp6Match = selectPort(tcp6Ports, opts?.expectedPort)
+    if (tcp6Match !== null) {
+      return { hasOwnPort: true, port: tcp6Match }
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err
+    }
+    // ENOENT on tcp6 is expected on some kernels — continue
+  }
+
+  const expectedSuffix = opts?.expectedPort !== undefined
+    ? ` matching expected port ${opts.expectedPort}`
+    : ""
+  return { hasOwnPort: false, reason: `no LISTEN socket${expectedSuffix} on ${tcpPath}` }
+}
+
+export function _resetPlatformWarnForTests(): void {
+  _platformWarned = false
+}

--- a/src/types/bun-text-imports.d.ts
+++ b/src/types/bun-text-imports.d.ts
@@ -1,0 +1,10 @@
+// Project-local ambient type for Bun text imports of file extensions
+// not covered by `bun-types/extensions.d.ts` (which declares .txt/.toml/
+// .yaml/.yml/.jsonc/.json5/.html but omits .py).
+//
+// `import script from "./foo.py" with { type: "text" }` returns the
+// file contents as a string at module load (bundle) time.
+declare module "*.py" {
+  const contents: string
+  export default contents
+}


### PR DESCRIPTION
## Summary

Replacement for #4024 (closed: 17 files, 2020/-57 diff was reviewer-hostile).

This is **1 of 2 PRs** that together fix #4035 (team-mode tmux member panes stay on first message while members keep running). This PR ships **only the new modules** — all new files, no modifications to existing upstream code. Reviewer can evaluate each module on its own merits before reviewing the integration PR.

## Why split

OpenCode TUI's \`attach --session <child>\` enters a static subagent-detail view for any session with \`parentID\`. Team workers always carry \`parentID=lead\`, so attach alone produces no streaming feed for worker panes (#4035). The fix needs:

1. A poller that streams \`/session/<id>/message\` deltas to a tmux pane.
2. A gate so only the process that owns the opencode server port runs tailers (multi-instance hygiene).
3. A reaper for tailer processes from aborted runs.

Each piece is independently reviewable. PR-2 wires them together.

## Modules (all new files)

| File | Lines | Purpose |
|---|---|---|
| \`script/team-pane-live-tail.py\` | 550 | Python tailer — polls \`/session/<id>/message\` and prints deltas. \`urllib.request\` only, no third-party deps. |
| \`script/test_team_pane_live_tail.py\` | 377 | Python tests (32 passing under pytest) |
| \`src/features/team-mode/team-layout-tmux/live-tail.ts\` | 43 | Materializes the script to per-process tmpdir; builds \`send-keys\` invocation |
| \`src/features/team-mode/team-layout-tmux/live-tail.test.ts\` | 84 | TS tests for materialization + command shape |
| \`src/features/team-mode/team-layout-tmux/server-port-ownership.ts\` | 163 | Linux: parse \`/proc/<pid>/net/tcp{,6}\` for LISTEN sockets on local interfaces. Non-Linux: assume ownership. Tests inject \`readFile\` via deps. |
| \`src/features/team-mode/team-layout-tmux/server-port-ownership.test.ts\` | 139 | 8 tests covering parse, IPv4/IPv6, deps-injection |
| \`src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts\` | 152 | Locates leftover tailer PIDs from aborted runs, signals cleanup |
| \`src/features/team-mode/team-layout-tmux/reap-stale-tailers.test.ts\` | 75 | Tests for reaper logic |
| \`src/types/bun-text-imports.d.ts\` | 10 | Ambient declaration: \`import \"./*.py\" with { type: \"text\" }\` |

## Verification

\`\`\`
bun test src/features/team-mode/team-layout-tmux/
# 55 pass, 1 skip, 0 fail

bun run typecheck
# clean

python3 -m pytest script/test_team_pane_live_tail.py
# 32 passed
\`\`\`

## Related

- Closes #4035 (jointly with PR-2)
- Replaces #4024 (closed)
- PR-2 will modify \`layout.ts\` / \`activate-team-layout.ts\` / team teardown paths to wire these in

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the live-tail foundation for team-mode so worker panes stream output instead of freezing on the first message. Part 1 of 2 toward #4035; wiring into the layout will land in the follow-up.

- New Features
  - `script/team-pane-live-tail.py`: Python tailer that polls `/session/<id>/message`, prints incremental deltas, supports Basic Auth (`OPENCODE_SERVER_*`), `--insecure`, and a periodic status footer.
  - `src/features/team-mode/team-layout-tmux/live-tail.ts`: Materializes the script to a tmpdir and builds the `python3 -u` command for tmux panes.
  - `src/features/team-mode/team-layout-tmux/server-port-ownership.ts`: Detects if this process owns the OpenCode server port (Linux: parse `/proc/<pid>/net/tcp{,6}`; non-Linux: assume ownership). Used to gate tailer spawns.
  - `src/features/team-mode/team-layout-tmux/reap-stale-tailers.ts`: Reaps leftover tailer PIDs when the server URL is unreachable.
  - `src/types/bun-text-imports.d.ts`: Enables `import "./*.py" with { type: "text" }` for Bun bundling.

<sup>Written for commit 52cbc1ec61fa39cefd37f64be3063c387b30f67e. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4456?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

