### PR TITLE
fix(shared): trim disabled provider comparisons

### DIFF
--- a/src/shared/disabled-providers.test.ts
+++ b/src/shared/disabled-providers.test.ts
@@ -22,6 +22,11 @@ describe("getModelProvider", () => {
     expect(getModelProvider("vercel/openai/gpt-5.5")).toBe("vercel")
   })
 
+  test("trims provider whitespace before returning", () => {
+    expect(getModelProvider(" github-copilot/gpt-5.5")).toBe("github-copilot")
+    expect(getModelProvider("github-copilot /gpt-5.5")).toBe("github-copilot")
+  })
+
   test("returns undefined when the string has no provider prefix", () => {
     expect(getModelProvider("gpt-5.5")).toBeUndefined()
     expect(getModelProvider("")).toBeUndefined()
@@ -49,6 +54,11 @@ describe("isProviderDisabled", () => {
     expect(isProviderDisabled("github-copilot/gpt-5.5", ["GitHub-Copilot"])).toBe(true)
     expect(isProviderDisabled("OPENAI/gpt-5.5", ["openai"])).toBe(true)
     expect(isProviderDisabled("openai/gpt-5.5", ["VERCEL"])).toBe(false)
+  })
+
+  test("trims provider and disabled-list entries before comparing", () => {
+    expect(isProviderDisabled(" github-copilot/gpt-5.5", ["github-copilot"])).toBe(true)
+    expect(isProviderDisabled("github-copilot /gpt-5.5", [" github-copilot "])).toBe(true)
   })
 })
 

--- a/src/shared/disabled-providers.ts
+++ b/src/shared/disabled-providers.ts
@@ -9,7 +9,8 @@ const HOOK_NAME = "disabled-providers"
 export function getModelProvider(model: string): string | undefined {
   const slash = model.indexOf("/")
   if (slash <= 0) return undefined
-  return model.slice(0, slash)
+  const provider = model.slice(0, slash).trim()
+  return provider || undefined
 }
 
 export function isProviderDisabled(
@@ -20,7 +21,7 @@ export function isProviderDisabled(
   const provider = getModelProvider(model)
   if (provider === undefined) return false
   const providerLower = provider.toLowerCase()
-  return disabled.some((entry) => entry.toLowerCase() === providerLower)
+  return disabled.some((entry) => entry.trim().toLowerCase() === providerLower)
 }
 
 export function filterDisabledProviderModels<T extends string | FallbackModelObject>(


### PR DESCRIPTION
## Summary

Surgical replacement for #4461 (closed: 879 lines mixed delegate-task + team-mode + plugin + disabled-providers concerns).

This PR carries **just one commit, 2 files, +13/-2** — the smallest standalone fix from that bundle: whitespace-tolerant comparison in \`isProviderNameDisabled\`.

## Fix

\`isProviderNameDisabled\` previously did literal equality on the configured provider names. JSONC config entries with stray whitespace (e.g. \`\"  openrouter  \"\`) silently failed to match, leaving disabled providers active.

| File | Change |
|---|---|
| \`src/shared/disabled-providers.ts\` | Trim both sides of the comparison |
| \`src/shared/disabled-providers.test.ts\` | Coverage for whitespace tolerance |

## Verification

\`\`\`
bun test src/shared/disabled-providers.test.ts
# 15 pass, 0 fail, 38 expect()

bun run typecheck
# clean
\`\`\`

## Related

- Replaces #4461 (closed). The rest of #4461 (runtime model threading, team-mode tie-in, plugin glue) was feature work, not a bug fix, and is deferred until the maintainer signals interest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix disabled-provider matching by trimming whitespace when parsing the provider and when comparing against the disabled list. Prevents configs with stray spaces (e.g., " github-copilot ") from leaving providers active.

- Bug Fixes
  - `getModelProvider` now trims the provider segment and returns `undefined` if empty.
  - `isProviderDisabled` trims each disabled entry before case-insensitive compare.
  - Added tests covering whitespace tolerance for both functions.

<sup>Written for commit 20a1df108f90decb0de29b513cfae99f6abb991a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4463?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

