### PR TITLE
fix(atlas): repair task() path crash and start-work agent resolution (#4417)

### DIFF
--- a/src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts
@@ -1,0 +1,47 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import {
+  _resetForTesting,
+  registerAgentName,
+} from "../../features/claude-code-session-state"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { injectContinuationPrompt } from "./continuation-prompt-injector"
+
+describe("ralph-loop continuation prompt agent resolution", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+    _resetForTesting()
+  })
+
+  test("#given OpenCode registered Atlas under legacy display name #when inherited agent is config key #then prompt uses registered name", async () => {
+    // given
+    registerAgentName("Atlas (Plan Executor)")
+    let capturedAgent: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      client: {
+        session: {
+          messages: async () => ({ data: [{ info: { agent: "atlas" } }] }),
+          promptAsync: async (input: { readonly body: { readonly agent?: string } }) => {
+            capturedAgent = input.body.agent
+            return {}
+          },
+        },
+      },
+    })
+
+    // when
+    await injectContinuationPrompt(ctx, {
+      sessionID: "ses_ralph_registered_atlas",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(capturedAgent).toBe("Atlas (Plan Executor)")
+  })
+})

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -10,7 +10,8 @@ import {
 	normalizeSDKResponse,
 	resolveInheritedPromptTools,
 } from "../../shared"
-import { normalizeAgentForPrompt, stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import { resolveRegisteredAgentName } from "../../features/claude-code-session-state"
+import { normalizeAgentForPromptKey, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { dispatchInternalPrompt } from "../shared/prompt-async-gate"
 
 type MessageInfo = {
@@ -62,20 +63,10 @@ function createPromptAsyncError(prefix: string, error: unknown): Error {
 }
 
 function normalizeInheritedAgentForPrompt(agent: string | undefined): string | undefined {
-	if (typeof agent !== "string") {
-		return undefined
-	}
-
-	const inheritedAgent = stripAgentListSortPrefix(agent).trim()
-	if (!inheritedAgent) {
-		return undefined
-	}
-
-	if (inheritedAgent.includes(" - ")) {
-		return inheritedAgent
-	}
-
-	return normalizeAgentForPrompt(inheritedAgent)
+	const resolvedAgent = resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)
+	if (typeof resolvedAgent !== "string") return undefined
+	const cleanAgent = stripAgentListSortPrefix(resolvedAgent).trim()
+	return cleanAgent || undefined
 }
 
 export async function injectContinuationPrompt(

--- a/src/hooks/todo-continuation-enforcer/continuation-injection-agent-resolution.test.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection-agent-resolution.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import {
+  _resetForTesting,
+  registerAgentName,
+} from "../../features/claude-code-session-state"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { injectContinuation } from "./continuation-injection"
+
+describe("todo continuation registered agent resolution", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+    _resetForTesting()
+  })
+
+  test("#given OpenCode registered Atlas under legacy display name #when continuation inherits config key #then prompt uses registered name", async () => {
+    // given
+    registerAgentName("Atlas (Plan Executor)")
+    let capturedAgent: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      directory: "/tmp/test",
+      client: {
+        session: {
+          todo: async () => ({ data: [{ id: "1", content: "todo", status: "pending", priority: "high" }] }),
+          promptAsync: async (input: { readonly body: { readonly agent?: string } }) => {
+            capturedAgent = input.body.agent
+            return {}
+          },
+        },
+      },
+    })
+    const sessionStateStore = {
+      getExistingState: () => ({ inFlight: false, lastInjectedAt: 0, consecutiveFailures: 0 }),
+    }
+
+    // when
+    await injectContinuation({
+      ctx,
+      sessionID: "ses_todo_registered_atlas",
+      resolvedInfo: {
+        agent: "atlas",
+        model: { providerID: "openai", modelID: "gpt-5.5" },
+      },
+      sessionStateStore: unsafeTestValue(sessionStateStore),
+    })
+
+    // then
+    expect(capturedAgent).toBe("Atlas (Plan Executor)")
+  })
+})

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -20,8 +20,8 @@ import { log } from "../../shared/logger"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   getAgentConfigKey,
-  normalizeAgentForPrompt,
   normalizeAgentForPromptKey,
+  stripAgentListSortPrefix,
 } from "../../shared/agent-display-names"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../shared/prompt-async-gate"
 
@@ -132,9 +132,8 @@ export async function injectContinuation(args: {
     tools = tools ?? previousMessage?.tools
   }
 
-  const promptAgent = normalizeAgentForPromptKey(agentName)
-  const resolvedAgent = resolveRegisteredAgentName(agentName)
-  const launchAgent = normalizeAgentForPrompt(resolvedAgent ?? agentName)
+  const promptAgent = resolveRegisteredAgentName(agentName) ?? normalizeAgentForPromptKey(agentName)
+  const launchAgent = promptAgent ? stripAgentListSortPrefix(promptAgent).trim() || undefined : undefined
 
   if (promptAgent && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: agentName })

--- a/src/shared/prompt-async-gate-path-compat.test.ts
+++ b/src/shared/prompt-async-gate-path-compat.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, mock, test } from "bun:test"
+
+import {
+  dispatchInternalPrompt,
+  releaseAllPromptAsyncReservationsForTesting,
+} from "./prompt-async-gate"
+
+type CompatPromptInput = {
+  readonly path: { readonly id: string } | string
+  readonly body: {
+    readonly parts: readonly []
+  }
+}
+
+function createPathSensitivePrompt() {
+  const calls: CompatPromptInput[] = []
+  const prompt = mock(async (input: CompatPromptInput) => {
+    calls.push(input)
+    if (typeof input.path !== "string") {
+      throw new TypeError('The "path" property must be of type string, got object')
+    }
+    return { ok: true }
+  })
+
+  return { calls, prompt }
+}
+
+describe("dispatchInternalPrompt path compatibility", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
+  test("#given sync prompt rejects object-form session path #when dispatching #then it retries with string-form path", async () => {
+    // given
+    const { calls, prompt } = createPathSensitivePrompt()
+    const client = { session: { prompt } }
+
+    // when
+    const result = await dispatchInternalPrompt<CompatPromptInput>({
+      mode: "sync",
+      client,
+      sessionID: "ses_sync_path_compat",
+      source: "test:path-compat:sync",
+      settleMs: 0,
+      checkStatus: false,
+      checkToolState: false,
+      queueBehavior: "defer",
+      input: {
+        path: { id: "ses_sync_path_compat" },
+        body: { parts: [] },
+      },
+    })
+
+    // then
+    expect(result.status).toBe("dispatched")
+    expect(calls.map((call) => call.path)).toEqual([
+      { id: "ses_sync_path_compat" },
+      "ses_sync_path_compat",
+    ])
+  })
+
+  test("#given async prompt rejects object-form session path #when dispatching #then it retries with string-form path", async () => {
+    // given
+    const { calls, prompt } = createPathSensitivePrompt()
+    const client = { session: { promptAsync: prompt } }
+
+    // when
+    const result = await dispatchInternalPrompt<CompatPromptInput>({
+      mode: "async",
+      client,
+      sessionID: "ses_async_path_compat",
+      source: "test:path-compat:async",
+      settleMs: 0,
+      checkStatus: false,
+      checkToolState: false,
+      queueBehavior: "defer",
+      input: {
+        path: { id: "ses_async_path_compat" },
+        body: { parts: [] },
+      },
+    })
+
+    // then
+    expect(result.status).toBe("dispatched")
+    expect(calls.map((call) => call.path)).toEqual([
+      { id: "ses_async_path_compat" },
+      "ses_async_path_compat",
+    ])
+  })
+})

--- a/src/shared/prompt-async-gate.ts
+++ b/src/shared/prompt-async-gate.ts
@@ -68,6 +68,47 @@ function createDefaultDedupeKey(source: string, input: unknown): string {
   return `${source}:${fingerprint.length}:${fingerprint.slice(0, 8192)}`
 }
 
+type ObjectPathPromptInput = {
+  readonly path?: { readonly id?: string } | string
+  readonly [key: string]: unknown
+}
+
+function hasObjectSessionPath(input: unknown): input is ObjectPathPromptInput & { readonly path: { readonly id: string } } {
+  return typeof input === "object"
+    && input !== null
+    && "path" in input
+    && typeof input.path === "object"
+    && input.path !== null
+    && "id" in input.path
+    && typeof input.path.id === "string"
+}
+
+function isObjectPathTypeError(error: unknown): boolean {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === "string" ? error : ""
+  return message.includes('The "path" property must be of type string') && message.includes("got object")
+}
+
+async function dispatchWithPathCompatibility<TInput>(
+  dispatch: (dispatchInput: TInput) => Promise<unknown>,
+  input: TInput,
+): Promise<unknown> {
+  try {
+    return await dispatch(input)
+  } catch (error) {
+    if (!isObjectPathTypeError(error) || !hasObjectSessionPath(input)) {
+      throw error
+    }
+
+    const retryInput = {
+      ...input,
+      path: input.path.id,
+    } as TInput
+    return dispatch(retryInput)
+  }
+}
+
 export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
   args: InternalPromptDispatchArgs<TInput>,
 ): Promise<InternalPromptDispatchResult> {
@@ -131,7 +172,7 @@ export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
       dispatchTimeoutMs,
       checkStatus: args.checkStatus !== false,
       checkToolState: args.checkToolState !== false,
-      dispatch,
+      dispatch: (dispatchInput) => dispatchWithPathCompatibility(dispatch, dispatchInput),
     })
   }
 
@@ -150,7 +191,7 @@ export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
       queueRetryMs,
       checkStatus: args.checkStatus !== false,
       checkToolState: args.checkToolState !== false,
-      dispatch: async (_dispatchInput: unknown) => dispatch(input),
+      dispatch: async (_dispatchInput: unknown) => dispatchWithPathCompatibility(dispatch, input),
     })
   }
 
@@ -166,7 +207,7 @@ export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
     dispatchTimeoutMs,
     checkStatus: args.checkStatus !== false,
     checkToolState: args.checkToolState !== false,
-    dispatch,
+    dispatch: (dispatchInput) => dispatchWithPathCompatibility(dispatch, dispatchInput),
   })
 }
 

--- a/src/shared/prompt-async-gate/types.ts
+++ b/src/shared/prompt-async-gate/types.ts
@@ -1,5 +1,7 @@
+export type PromptSessionPath = { readonly id?: string } | string
+
 export type PromptAsyncInput = {
-  readonly path?: { readonly id?: string }
+  readonly path?: PromptSessionPath
   readonly body?: unknown
   readonly query?: unknown
   readonly signal?: unknown


### PR DESCRIPTION
## Summary

Fixes #4417 — two related Atlas-mode bugs:

1. **Bug 1**: `task()` with `run_in_background=false` crashed with `The "path" property must be of type string, got object` originating from Node's `path.isAbsolute()` upstream of the OpenCode SDK.
2. **Bug 2**: `/start-work` was unresponsive under Atlas because ralph-loop and todo-continuation-enforcer passed the agent config key (`atlas`) instead of the registered display name (`Atlas (Plan Executor)`), producing `Agent not found` on dispatch.

## Bug 1 — Centralized path compatibility in `prompt-async-gate`

Per `AGENTS.md` "Internal message injection is dangerous": every prompt write must flow through `dispatchInternalPrompt`. All Bug 1 callsites the issue listed (`sync-prompt-sender.ts:84`, `boulder-continuation-injector.ts:105`, `idle-event.ts:320`, `session-route.ts`, and `model-suggestion-retry.ts`) already route through the gate, so wrapping the dispatch with a one-shot retry (object-path → string-path) covers them all without touching individual hooks.

- `src/shared/prompt-async-gate.ts` adds `dispatchWithPathCompatibility()` that catches the runtime `TypeError` matching the exact error signature, and retries once with `path` collapsed to `path.id`.
- `src/shared/prompt-async-gate/types.ts` broadens `PromptSessionPath` to `string | { id: string }` so the broadened input is type-safe.
- Regression test `src/shared/prompt-async-gate-path-compat.test.ts` (2 cases, sync + async) pins the retry behavior end-to-end.

## Bug 2 — Resolve registered agent name before dispatch

Adopts the issue's recommended pattern (same fix `start-work-hook` uses):

```ts
const promptAgent = resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)
```

- `src/hooks/ralph-loop/continuation-prompt-injector.ts` — `normalizeInheritedAgentForPrompt` now prefers the registered name, then strips invisible/sort-prefix characters.
- `src/hooks/todo-continuation-enforcer/continuation-injection.ts` — same resolution chain; collapses two stale `normalizeAgentForPrompt` helpers into one branded resolution path.
- Two regression tests (`continuation-prompt-injector-agent-resolution.test.ts`, `continuation-injection-agent-resolution.test.ts`) pin that the dispatched `body.agent` is the registered display name when the inherited agent is its config key — exact reproduction of the Atlas hang scenario described in #4417.

## Architectural invariants

Both meta-audits still pass:

- `src/shared/prompt-async-route-audit.test.ts` — confirms no new raw `session.promptAsync` route was introduced.
- `src/shared/mock-module-lifecycle-audit.test.ts` — confirms no orphaned `mock.module()` calls were added.

## Testing

- `bun test src/shared/prompt-async-gate-path-compat.test.ts` → 2 pass
- `bun test src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts` → 1 pass
- `bun test src/hooks/todo-continuation-enforcer/continuation-injection-agent-resolution.test.ts` → 1 pass
- `bun test src/shared/prompt-async-route-audit.test.ts` → 10 pass
- `bun test src/shared/mock-module-lifecycle-audit.test.ts` → 1 pass
- `bunx tsc --noEmit` → clean on changed files

Closes #4417


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Atlas-mode issues: prevents task() crashes from object-form session paths and makes /start-work use the correct agent, restoring Atlas prompts.

- **Bug Fixes**
  - Centralized path compatibility in `src/shared/prompt-async-gate.ts`: on the Node error The "path" property must be of type string, got object, retry once with `path` set to `path.id`. Broadened `PromptSessionPath` and added regression tests.
  - Resolved agent naming before dispatch in ralph-loop and todo-continuation-enforcer: use `resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)`, then strip sort-prefix characters. Ensures prompts use the registered display name (e.g., "Atlas (Plan Executor)") and added regression tests.

<sup>Written for commit 28efc4e81f70dfe729a92c69e101261c17159d2c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4465?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

