### PR TITLE
fix: make all-optional tool args schemas compatible with OpenAI strict function calling

### DIFF
--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -188,14 +188,14 @@ export function createTeamCreateTool(
   return tool({
     description: "Create a team run from a named or inline team spec.",
     args: {
+      leadSessionId: tool.schema.string().describe("Optional non-empty session ID override. Pass empty string \"\" to use the current session (recommended)."),
       teamName: tool.schema.string().optional().describe("Named team spec to load. Provide exactly one of teamName or inline_spec."),
       inline_spec: tool.schema.unknown().optional().describe("Inline team spec object or JSON string. Provide exactly one of teamName or inline_spec."),
-      leadSessionId: tool.schema.string().optional().describe("Optional non-empty session ID override. Usually omit this and let team_create use the current session."),
     },
     async execute(rawArgs, toolContext) {
       const args = parseTeamCreateArgs(rawArgs)
       const runtimeContext = toolContext as TeamLifecycleToolContext
-      const leadSessionId = args.leadSessionId ?? runtimeContext.sessionID
+      const leadSessionId = (args.leadSessionId && args.leadSessionId.length > 0 ? args.leadSessionId : undefined) ?? runtimeContext.sessionID
       if (!leadSessionId) throw new Error("team_create requires leadSessionId or tool context sessionID")
       const projectRoot = typeof runtimeContext.directory === "string" ? runtimeContext.directory : process.cwd()
       const callerTeamLead = resolveCallerTeamLead(runtimeContext.agent)

--- a/src/features/team-mode/tools/query.ts
+++ b/src/features/team-mode/tools/query.ts
@@ -58,10 +58,10 @@ export function createTeamListTool(config: TeamModeConfig, client: OpencodeClien
         tool.schema.literal("user"),
         tool.schema.literal("project"),
         tool.schema.literal("all"),
-      ]).optional().describe("Team scope filter"),
+      ]).describe("Team scope filter"),
     },
-    execute: async (args: { scope?: TeamListScope }) => {
-      const scope = args.scope ?? "all"
+    execute: async (args: { scope: TeamListScope }) => {
+      const scope = args.scope
       const projectRoot = process.cwd()
       const declaredTeamSpecs = await deps.discoverTeamSpecs(config, projectRoot)
       const activeTeams = await deps.listActiveTeams(config)

--- a/src/tools/background-task/create-background-cancel.ts
+++ b/src/tools/background-task/create-background-cancel.ts
@@ -8,8 +8,8 @@ export function createBackgroundCancel(manager: BackgroundManager, _client: Back
   return tool({
     description: BACKGROUND_CANCEL_DESCRIPTION,
     args: {
+      all: tool.schema.boolean().describe("Cancel all running background tasks. Set true to cancel all; false to cancel a specific taskId."),
       taskId: tool.schema.string().optional().describe("Task ID to cancel (required if all=false)"),
-      all: tool.schema.boolean().optional().describe("Cancel all running background tasks (default: false)"),
     },
     async execute(args: BackgroundCancelArgs, toolContext) {
       try {

--- a/src/tools/background-task/types.ts
+++ b/src/tools/background-task/types.ts
@@ -17,8 +17,8 @@ export interface BackgroundOutputArgs {
 }
 
 export interface BackgroundCancelArgs {
+  all: boolean
   taskId?: string
-  all?: boolean
 }
 
 export type BackgroundOutputMessage = {

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -73,7 +73,7 @@ export function createSessionManagerTools(
   const session_list: ToolDefinition = tool({
     description: SESSION_LIST_DESCRIPTION,
     args: {
-      limit: tool.schema.number().optional().describe("Maximum number of sessions to return"),
+      limit: tool.schema.number().describe("Maximum number of sessions to return. Pass 0 for no limit."),
       from_date: tool.schema.string().optional().describe("Filter sessions from this date (ISO 8601 format)"),
       to_date: tool.schema.string().optional().describe("Filter sessions until this date (ISO 8601 format)"),
       project_path: tool.schema.string().optional().describe("Filter sessions by project path (default: current working directory)"),

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -68,7 +68,7 @@ export interface SessionMetadata {
 }
 
 export interface SessionListArgs {
-  limit?: number
+  limit: number
   offset?: number
   from_date?: string
   to_date?: string


### PR DESCRIPTION
## Summary
- OpenAI-compatible providers (and proxies) reject MCP tool schemas where **all parameters are optional**, emitting a 500 error: `"None is not of type 'array'"` — the JSON Schema serializer outputs `required: null` instead of `required: []` for such tools.
- Promotes one semantically appropriate parameter to `required` in each of the 4 affected tools so the schema always has a valid `required` array.
- Runtime behavior is fully preserved via fallback logic where needed.
## Changes
- **`background_cancel`**: `all` (boolean) promoted to required; moved before `taskId`. Callers must now explicitly pass `all=false` when cancelling by ID. Updated `BackgroundCancelArgs` interface to match.
- **`session_list`**: `limit` promoted to required. Pass `0` to mean "no limit". Updated description and `SessionListArgs` interface to match.
- **`team_create`**: `leadSessionId` promoted to required and moved first. Pass `""` to use the current session. Added empty-string fallback in `execute`: `(leadSessionId && leadSessionId.length > 0 ? leadSessionId : undefined) ?? runtimeContext.sessionID`.
- **`team_list`**: `scope` promoted to required. Callers must now pass `"user"`, `"project"`, or `"all"` explicitly. Removed `?? "all"` fallback from `execute` since the value is always present.
## Testing
Verified by running against an OpenAI-compatible proxy (`new-api/gpt-5.5`, `github-copilot/gpt-5.2-codex`) that previously rejected these tool schemas with the `None is not of type 'array'` error. All 4 tools now pass schema validation and execute correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema incompatibility with OpenAI strict function calling by ensuring tool arg schemas never have all-optional parameters. One parameter is now required in `background_cancel`, `session_list`, `team_create`, and `team_list`, while preserving runtime behavior via fallbacks.

- **Migration**
  - `background_cancel`: `all` is required. Set true to cancel all tasks; set false and provide `taskId` to cancel one.
  - `session_list`: `limit` is required. Use 0 for no limit.
  - `team_create`: `leadSessionId` is required. Pass "" to use the current session.
  - `team_list`: `scope` is required. Pass `user`, `project`, or `all`.

<sup>Written for commit 40cb2833d02808a241a52e29a1f4af01cff14f9a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4467?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

