### PR TITLE
Add support for OpenCode 1.15 DB

### DIFF
--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -21,6 +21,7 @@ type TestPart = {
   content?: string | Array<{ type: "text"; text: string }>
   text?: string
   synthetic?: boolean
+  state?: { status?: string; output?: string }
 }
 
 type TestMessage = {
@@ -54,6 +55,35 @@ describe("createToolPairValidatorHook", () => {
     expect(messages).toEqual([
       { info: { role: "assistant" }, parts: [{ type: "tool", callID: "call_1" }] },
       { info: { role: "user" }, parts: [{ type: "tool_result", tool_use_id: "call_1", content: "done" }] },
+    ])
+  })
+
+  it("leaves terminal OpenCode tool parts unchanged", async () => {
+    //#given
+    const messages = [
+      {
+        info: { role: "assistant" },
+        parts: [
+          { type: "tool", callID: "call_completed", state: { status: "completed", output: "OK" } },
+          { type: "tool", callID: "call_error", state: { status: "error", output: "File not found" } },
+        ],
+      },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "final answer" }] },
+    ] satisfies TestMessage[]
+
+    //#when
+    await runTransform(messages)
+
+    //#then
+    expect(messages).toEqual([
+      {
+        info: { role: "assistant" },
+        parts: [
+          { type: "tool", callID: "call_completed", state: { status: "completed", output: "OK" } },
+          { type: "tool", callID: "call_error", state: { status: "error", output: "File not found" } },
+        ],
+      },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "final answer" }] },
     ])
   })
 

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -5,6 +5,7 @@ import { log } from "../../shared/logger"
 
 const TOOL_RESULT_PLACEHOLDER = "Tool output unavailable (context compacted)"
 const TOOL_RESULT_RECOVERY_CONTINUATION = "Recovered missing tool results. Continue from the repaired tool output."
+const TERMINAL_OPENCODE_TOOL_STATUSES = new Set(["completed", "error"])
 
 type ToolUsePart = {
   type: "tool_use"
@@ -46,6 +47,24 @@ type MessagesTransformHook = {
   ) => Promise<void>
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isTerminalOpenCodeToolPart(part: TransformPart): boolean {
+  const candidate = part as { type?: unknown; callID?: unknown; state?: unknown }
+  if (candidate.type !== "tool" || typeof candidate.callID !== "string" || candidate.callID.length === 0) {
+    return false
+  }
+
+  if (!isRecord(candidate.state)) {
+    return false
+  }
+
+  const status = candidate.state["status"]
+  return typeof status === "string" && TERMINAL_OPENCODE_TOOL_STATUSES.has(status)
+}
+
 function getToolUseID(part: TransformPart): string | null {
   const candidate = part as { type?: unknown; id?: unknown; callID?: unknown }
 
@@ -54,7 +73,7 @@ function getToolUseID(part: TransformPart): string | null {
   }
 
   if (candidate.type === "tool" && typeof candidate.callID === "string" && candidate.callID.length > 0) {
-    return candidate.callID
+    return isTerminalOpenCodeToolPart(part) ? null : candidate.callID
   }
 
   return null


### PR DESCRIPTION
## Summary

- Fixes false `tool-pair-validator` repairs for OpenCode 1.15 terminal tool parts.
- Preserves existing `tool_use` / `tool_result` recovery behavior for compacted or malformed histories.

## Changes

- Treats `type: "tool"` parts with terminal `state.status` values (`completed` or `error`) as already paired tool results.
- Prevents synthetic `tool_result` injection for normal OpenCode 1.15 tool executions.
- Adds a regression test covering completed and errored OpenCode tool parts.
- Rebuilds the plugin bundle so the local runtime uses the updated validator logic.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OpenCode 1.15 by treating terminal `tool` parts as real results, preventing false repairs and synthetic `tool_result` injection. Keeps existing recovery for compacted or malformed histories.

- **Bug Fixes**
  - Detect terminal OpenCode `tool` parts via `state.status` (`completed`/`error`) and exclude them from pairing.
  - Skip synthetic `tool_result` creation for these parts to avoid double results.
  - Add regression test for completed and errored cases and rebuild the plugin bundle.

<sup>Written for commit aa97341cc90eca0aa88b2eebe4c0615046268df1. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4469?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

