### PR TITLE
fix(docs): use portable markdown links

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,7 +6,7 @@
 
 Project-scope skills + slash commands under the new `.agents/` directory name. During the `oh-my-opencode` → `oh-my-openagent` rename transition, this directory is the **target** of the migration from `.opencode/`. It is a strict SUPERSET of `.opencode/` (5 -> 10 skills; 5 commands).
 
-Loaded alongside `.opencode/` by [`src/features/opencode-skill-loader/`](file:///Users/yeongyu/local-workspaces/omo/src/features/opencode-skill-loader/). When both directories declare the same skill or command name, the higher-priority scope wins per the loader's deduplication rules.
+Loaded alongside `.opencode/` by [`src/features/opencode-skill-loader/`](../src/features/opencode-skill-loader). When both directories declare the same skill or command name, the higher-priority scope wins per the loader's deduplication rules.
 
 ## SKILLS (10, superset of `.opencode/`)
 
@@ -45,7 +45,7 @@ Identical set to `.opencode/command/`:
 | Concern | Plan |
 |---------|------|
 | Why TWO directories? | `.opencode/` is the legacy layout. `.agents/` is the future-proof name after the harness rename. |
-| When does `.opencode/` go away? | After the multi-harness refactor lands and existing users have re-installed. Tracked in [ROADMAP](file:///Users/yeongyu/local-workspaces/omo/ROADMAP.md). |
+| When does `.opencode/` go away? | After the multi-harness refactor lands and existing users have re-installed. Tracked in [ROADMAP](../ROADMAP.md). |
 | What if both exist with conflicting skills? | The skill-loader dedupes by name. Higher-priority scope wins. The 5 shared skills (`work-with-pr`, `hyperplan`, etc.) are byte-identical between the two dirs today; if they diverge, fix here first. |
 | Where do NEW skills go? | `.agents/` only. Do NOT add new entries to `.opencode/`. |
 

--- a/.agents/skills/work-with-pr-workspace/iteration-1/eval-5/with_skill/outputs/execution-plan.md
+++ b/.agents/skills/work-with-pr-workspace/iteration-1/eval-5/with_skill/outputs/execution-plan.md
@@ -107,6 +107,6 @@ gh pr create --base dev \
 ```bash
 gh pr merge --squash --auto
 # Cleanup worktree
-cd /Users/yeongyu/local-workspaces/omo
+cd <repo-root>
 git worktree remove ../omo-wt/fix/comment-checker-note-false-positive
 ```

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-Project-scope OpenCode configuration: 5 skills and 5 slash commands committed alongside the source. Picked up by [`src/features/opencode-skill-loader/`](file:///Users/yeongyu/local-workspaces/omo/src/features/opencode-skill-loader/) and the slash-command discovery pipeline.
+Project-scope OpenCode configuration: 5 skills and 5 slash commands committed alongside the source. Picked up by [`src/features/opencode-skill-loader/`](../src/features/opencode-skill-loader) and the slash-command discovery pipeline.
 
 **Relationship to `.agents/`:** `.agents/` is the migration target during the `oh-my-opencode` → `oh-my-openagent` rename. It is a SUPERSET of `.opencode/` (mirrors all 5 skills + adds 5 more, mirrors the 5 commands). Both directories load during the transition; consumers should prefer `.agents/`.
 
@@ -38,7 +38,7 @@ Each skill follows the standard layout (`SKILL.md` + optional `scripts/`, `refer
 
 ## CONVENTIONS
 
-- **Skill YAML frontmatter is mandatory.** [`opencode-skill-loader`](file:///Users/yeongyu/local-workspaces/omo/src/features/opencode-skill-loader/) rejects skills without `name` + `description`.
+- **Skill YAML frontmatter is mandatory.** [`opencode-skill-loader`](../src/features/opencode-skill-loader) rejects skills without `name` + `description`.
 - **Project-scope > user-scope.** A skill at `.opencode/skills/X/` overrides `~/.config/opencode/skills/X/` of the same name.
 - **Trigger words** in the skill description determine when OpenCode loads the skill. Be specific.
 - **Commands are user-visible.** Name them with a leading `/` (the loader normalizes filename → command).

--- a/.opencode/skills/work-with-pr-workspace/iteration-1/eval-5/with_skill/outputs/execution-plan.md
+++ b/.opencode/skills/work-with-pr-workspace/iteration-1/eval-5/with_skill/outputs/execution-plan.md
@@ -107,6 +107,6 @@ gh pr create --base dev \
 ```bash
 gh pr merge --squash --auto
 # Cleanup worktree
-cd /Users/yeongyu/local-workspaces/omo
+cd <repo-root>
 git worktree remove ../omo-wt/fix/comment-checker-note-false-positive
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@
 
 ## OVERVIEW
 
-OpenCode plugin (npm: `oh-my-opencode`, dual-published as `oh-my-openagent` during the rename transition) extending OpenCode with 11 agents, 54-61 lifecycle hooks (base / +team-mode) across 57 dirs, 20-39 tools (gated by config flags including team-mode), 3-tier MCP system (built-in + .mcp.json + skill-embedded), Hashline LINE#ID edit tool, IntentGate keyword detector, Team Mode (parallel multi-agent coordination, OFF by default), Boulder feature (boulder-state work tracking + cli/boulder subcommand), configurable agent ordering, and Claude Code compatibility. **Repository contains ~2167 TypeScript files across `src/`, `script/`, `test-support/`, and `packages/web/`, ~313k LOC; `src/` itself has 120 barrel `index.ts` files.** Entry: `src/index.ts` is an 18-line wrapper that delegates to `src/testing/create-plugin-module.ts` `createPluginModule()` → staged plugin init (see INITIALIZATION FLOW). Ships in two editions of one product: **Ultimate** (omo for OpenCode, this plugin) and **Light** (omo for Codex CLI = [`packages/omo-codex/`](file:///Users/yeongyu/local-workspaces/omo/packages/omo-codex/AGENTS.md), distributed as the `lazycodex` alias; see CODEX LIGHT EDITION below).
+OpenCode plugin (npm: `oh-my-opencode`, dual-published as `oh-my-openagent` during the rename transition) extending OpenCode with 11 agents, 54-61 lifecycle hooks (base / +team-mode) across 57 dirs, 20-39 tools (gated by config flags including team-mode), 3-tier MCP system (built-in + .mcp.json + skill-embedded), Hashline LINE#ID edit tool, IntentGate keyword detector, Team Mode (parallel multi-agent coordination, OFF by default), Boulder feature (boulder-state work tracking + cli/boulder subcommand), configurable agent ordering, and Claude Code compatibility. **Repository contains ~2167 TypeScript files across `src/`, `script/`, `test-support/`, and `packages/web/`, ~313k LOC; `src/` itself has 120 barrel `index.ts` files.** Entry: `src/index.ts` is an 18-line wrapper that delegates to `src/testing/create-plugin-module.ts` `createPluginModule()` → staged plugin init (see INITIALIZATION FLOW). Ships in two editions of one product: **Ultimate** (omo for OpenCode, this plugin) and **Light** (omo for Codex CLI = [`packages/omo-codex/`](./packages/omo-codex/AGENTS.md), distributed as the `lazycodex` alias; see CODEX LIGHT EDITION below).
 
 ## STRUCTURE
 
-```
+```text
 oh-my-opencode/
 ├── src/
 │   ├── index.ts              # Plugin entry; thin wrapper that re-exports `createPluginModule()` from `src/testing/`
@@ -65,7 +65,7 @@ oh-my-opencode/
 
 ## INITIALIZATION FLOW
 
-```
+```text
 pluginModule.server(input, options)   # serverPlugin() in src/testing/create-plugin-module.ts
   ├─→ installAgentSortShim()          # patches Array.prototype.{toSorted,sort} for canonical agent ordering
   ├─→ initConfigContext()             # opencode-vs-openagent layout flag
@@ -90,7 +90,7 @@ pluginModule.server(input, options)   # serverPlugin() in src/testing/create-plu
 
 ## 14 OPENCODE HOOK HANDLERS
 
-12 wired in [`src/plugin-interface.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-interface.ts) + 2 wired directly in [`src/testing/create-plugin-module.ts`](file:///Users/yeongyu/local-workspaces/omo/src/testing/create-plugin-module.ts) (`experimental.session.compacting` + `experimental.compaction.autocontinue`).
+12 wired in [`src/plugin-interface.ts`](./src/plugin-interface.ts) + 2 wired directly in [`src/testing/create-plugin-module.ts`](./src/testing/create-plugin-module.ts) (`experimental.session.compacting` + `experimental.compaction.autocontinue`).
 
 | Handler | OpenCode Hook | Purpose |
 |---------|---------------|---------|
@@ -121,7 +121,7 @@ pluginModule.server(input, options)   # serverPlugin() in src/testing/create-plu
 
 OFF by default. Parallel multi-agent coordination, modeled after Claude Code Agent Teams. Enable via `team_mode.enabled` in `.opencode/oh-my-opencode.jsonc` or user config; restart OpenCode after change.
 
-Full schema in [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/team-mode.ts) (11 fields):
+Full schema in [`src/config/schema/team-mode.ts`](./src/config/schema/team-mode.ts) (11 fields):
 
 ```jsonc
 {
@@ -143,34 +143,34 @@ Full schema in [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-wo
 
 Teams live as directories under `~/.omo/teams/{name}/config.json` (user) or `<project>/.omo/teams/{name}/config.json` (project; project beats user on collisions). Members declared as `kind: "subagent_type"` (direct agent) or `kind: "category"` (routed through `sisyphus-junior`).
 
-**Member eligibility** (from [`AGENT_ELIGIBILITY_REGISTRY`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/types.ts)):
+**Member eligibility** (from [`AGENT_ELIGIBILITY_REGISTRY`](./src/features/team-mode/types.ts)):
 - `eligible`: sisyphus, atlas, sisyphus-junior
 - `conditional`: hephaestus (lacks `teammate: "allow"` permission by default — apply D-36 in `tool-config-handler.ts` or use `subagent_type: "sisyphus"` instead)
 - `hard-reject`: oracle, librarian, explore, multimodal-looker, metis, momus, prometheus (rejected at parse — use `task`/delegate-task)
 
 **Storage layout** (`~/.omo/teams/{name}/`): `config.json` (spec), `state.json` (runtime), `mailbox/` (messages), `tasklist.jsonl` (tasks), `worktrees/` (per-member git worktrees).
 
-**Implementation:** [`src/features/team-mode/`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/AGENTS.md). User docs: [`docs/guide/team-mode.md`](file:///Users/yeongyu/local-workspaces/omo/docs/guide/team-mode.md).
+**Implementation:** [`src/features/team-mode/`](./src/features/team-mode/AGENTS.md). User docs: [`docs/guide/team-mode.md`](./docs/guide/team-mode.md).
 
 ## CODEX LIGHT EDITION (omo-codex / lazycodex)
 
-oh-my-openagent ships in two editions of one product. **Ultimate** = this OpenCode plugin (omo for OpenCode). **Light** = omo for the OpenAI Codex CLI, vendored under [`packages/omo-codex/`](file:///Users/yeongyu/local-workspaces/omo/packages/omo-codex/AGENTS.md). "omo in Codex" / "omo for Codex" = **lazycodex**, and the public GitHub repo [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) IS this: a thin distribution layer over `omo-codex` (site lazycodex.ai; "Codex for no-brainers, just prompt with `ultrawork`"; Codex edition "coming June 2026", currently OpenCode-only).
+oh-my-openagent ships in two editions of one product. **Ultimate** = this OpenCode plugin (omo for OpenCode). **Light** = omo for the OpenAI Codex CLI, vendored under [`packages/omo-codex/`](./packages/omo-codex/AGENTS.md). "omo in Codex" / "omo for Codex" = **lazycodex**, and the public GitHub repo [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) IS this: a thin distribution layer over `omo-codex` (site lazycodex.ai; "Codex for no-brainers, just prompt with `ultrawork`"; Codex edition "coming June 2026", currently OpenCode-only).
 
 - **Package:** `@oh-my-opencode/omo-codex` (private, v0.1.0): "Codex harness adapter. Vendored Codex plugin namespace `omo` + TypeScript installer + telemetry." Plugin bundle pkg = `@sisyphuslabs/omo-codex-plugin`. Reuses `@oh-my-opencode/utils` + `@oh-my-opencode/shared-skills`.
 - **Marketplace identity (precision):** Codex sees marketplace `sisyphuslabs`, plugin `omo`, enabled as `omo@sisyphuslabs`. `lazycodex` is ONLY the repo/npm/bin alias, never the marketplace name.
 - **Alias mechanics:** root `package.json` maps `lazycodex-ai` to `bin/oh-my-opencode.js` (1 of 5 bin aliases: `oh-my-opencode`, `oh-my-openagent`, `omo`, `lazycodex`, `lazycodex-ai`, all the same compiled CLI). `bunx lazycodex-ai install` is exactly `bunx oh-my-openagent install --platform=codex`. Routing: `src/cli/cli-program.ts` (`lazycodex`/`lazycodex-ai` default platform to codex), `bin/platform.js` (both resolve the `oh-my-openagent` platform family). `src/cli/star-request.ts` stars both repos. The bare `lazycodex` npm name was unpublished 2026-05-30; the live npm package is `lazycodex-ai`.
 - **Disambiguation:** `publish.yml` republishes this repo's CLI under the npm name `lazycodex-ai` (name/version rewrite). The bare `lazycodex` npm name was unpublished 2026-05-30 and is no longer installable. `lazycodex` (without `-ai`) now refers only to the `code-yeongyu/lazycodex` GitHub repository that hosts the marketplace bundle, not an npm package. Both this repo's publish target and the `code-yeongyu/lazycodex` repo's package resolve to `lazycodex-ai` on npm, so their release versions must stay coordinated.
 - **Components (8):** `comment-checker`, `git-bash`, `lsp`, `rules`, `start-work-continuation`, `telemetry`, `ultrawork`, `ulw-loop`, wired to Codex events `SessionStart`/`UserPromptSubmit`/`PreToolUse`/`PostToolUse`/`PostCompact`/`Stop`/`SubagentStop`. No agent orchestration, no `team_*`, no built-in MCPs beyond LSP, no hashline.
-- **Install:** `bunx oh-my-openagent install --platform=codex` (or `bunx lazycodex-ai install`, or `--platform=both`) copies the plugin to `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/`, writes a local marketplace snapshot under `~/.codex/.tmp/marketplaces/sisyphuslabs/plugins/omo/`, copies bundled agent TOMLs into `~/.codex/agents/`, enables `omo@sisyphuslabs` in `~/.codex/config.toml`, links component CLIs into `~/.local/bin`. Windows: Git Bash preflight (`winget install --id Git.Git`). Installer: [`src/cli/install-codex/`](file:///Users/yeongyu/local-workspaces/omo/src/cli/install-codex/) + `packages/omo-codex/scripts/install*.mjs`.
-- **Deploy / publish** ([`.github/workflows/publish.yml`](file:///Users/yeongyu/local-workspaces/omo/.github/workflows/publish.yml), manual dispatch):
+- **Install:** `bunx oh-my-openagent install --platform=codex` (or `bunx lazycodex-ai install`, or `--platform=both`) copies the plugin to `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/`, writes a local marketplace snapshot under `~/.codex/.tmp/marketplaces/sisyphuslabs/plugins/omo/`, copies bundled agent TOMLs into `~/.codex/agents/`, enables `omo@sisyphuslabs` in `~/.codex/config.toml`, links component CLIs into `~/.local/bin`. Windows: Git Bash preflight (`winget install --id Git.Git`). Installer: [`src/cli/install-codex/`](./src/cli/install-codex/) + `packages/omo-codex/scripts/install*.mjs`.
+- **Deploy / publish** ([`.github/workflows/publish.yml`](./.github/workflows/publish.yml), manual dispatch):
   - `publish_lazycodex` (default **true**) publishes the npm alias `lazycodex-ai`: rewrites root `package.json` name to `lazycodex-ai` + version to the release + optionalDeps `oh-my-opencode-*` to `oh-my-openagent-*`, skips when `registry.npmjs.org/lazycodex-ai/${VERSION}` exists, publishes `--access public --provenance --tag latest`, then restores `package.json`. (The bare `lazycodex` npm name was unpublished 2026-05-30; `lazycodex-ai` is the live package.)
-  - `sync_lazycodex_marketplace` (default **false**, needs secret `LAZYCODEX_SYNC_TOKEN`) checks out `code-yeongyu/lazycodex`, builds the plugin + ast-grep-mcp + lsp-tools-mcp, runs [`script/sync-lazycodex-marketplace.ts`](file:///Users/yeongyu/local-workspaces/omo/script/sync-lazycodex-marketplace.ts) `<source-root> <lazycodex-root>`, then `git push origin HEAD:main`.
-  - **Sync mechanism is file copy + commit push, NOT a git subtree:** `marketplace.json` to `.agents/plugins/marketplace.json`; `plugin/` to `plugins/omo/`; bundles `ast-grep-mcp` + `lsp-tools-mcp` `dist/cli.js` to `plugins/omo/components/*/dist/`; rewrites `.mcp.json` paths; validates via `script/lazycodex-marketplace-validation.ts`. Root `package.json` `files` ships `packages/omo-codex/{marketplace.json,plugin,plugin/.codex-plugin,scripts}`. First-publish playbook: [`docs/reference/lazycodex-npm-reservation.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/lazycodex-npm-reservation.md). CI gate: `bun run test:codex` (ci.yml `codex-compatibility`, ubuntu/macos/windows).
-- **Telemetry:** event `omo_codex_daily_active` (once per UTC day per machine, id `sha256("omo-codex:"+hostname)`); opt-out `OMO_CODEX_DISABLE_POSTHOG=1` / `OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0` (global flags also disable). Full internals: [`packages/omo-codex/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/packages/omo-codex/AGENTS.md).
+  - `sync_lazycodex_marketplace` (default **false**, needs secret `LAZYCODEX_SYNC_TOKEN`) checks out `code-yeongyu/lazycodex`, builds the plugin + ast-grep-mcp + lsp-tools-mcp, runs [`script/sync-lazycodex-marketplace.ts`](./script/sync-lazycodex-marketplace.ts) `<source-root> <lazycodex-root>`, then `git push origin HEAD:main`.
+  - **Sync mechanism is file copy + commit push, NOT a git subtree:** `marketplace.json` to `.agents/plugins/marketplace.json`; `plugin/` to `plugins/omo/`; bundles `ast-grep-mcp` + `lsp-tools-mcp` `dist/cli.js` to `plugins/omo/components/*/dist/`; rewrites `.mcp.json` paths; validates via `script/lazycodex-marketplace-validation.ts`. Root `package.json` `files` ships `packages/omo-codex/{marketplace.json,plugin,plugin/.codex-plugin,scripts}`. First-publish playbook: [`docs/reference/lazycodex-npm-reservation.md`](./docs/reference/lazycodex-npm-reservation.md). CI gate: `bun run test:codex` (ci.yml `codex-compatibility`, ubuntu/macos/windows).
+- **Telemetry:** event `omo_codex_daily_active` (once per UTC day per machine, id `sha256("omo-codex:"+hostname)`); opt-out `OMO_CODEX_DISABLE_POSTHOG=1` / `OMO_CODEX_SEND_ANONYMOUS_TELEMETRY=0` (global flags also disable). Full internals: [`packages/omo-codex/AGENTS.md`](./packages/omo-codex/AGENTS.md).
 
 ## MULTI-LEVEL CONFIG
 
-```
+```text
 Walked configs (closer wins): <pwd up to $HOME>/.opencode/oh-my-openagent.json[c]   (legacy: oh-my-opencode.json[c])
                             ↓ merged onto
 User config:               ~/.config/opencode/oh-my-openagent.json[c]   (Windows: %APPDATA%\opencode\)
@@ -217,7 +217,7 @@ Schema autocomplete: `"$schema": "https://raw.githubusercontent.com/code-yeongyu
 
 ## ARCHITECTURE INVARIANTS
 
-- **Canonical agent order:** Sisyphus → Hephaestus → Prometheus → Atlas. Enforced by `installAgentSortShim()` (patches `Array.prototype.toSorted`/`.sort` narrowly when the array contains ≥2 canonical core agents). See [`src/plugin-handlers/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-handlers/AGENTS.md) for the full history of why this exists.
+- **Canonical agent order:** Sisyphus → Hephaestus → Prometheus → Atlas. Enforced by `installAgentSortShim()` (patches `Array.prototype.toSorted`/`.sort` narrowly when the array contains ≥2 canonical core agents). See [`src/plugin-handlers/AGENTS.md`](./src/plugin-handlers/AGENTS.md) for the full history of why this exists.
 - **Hashline edit + read pairing:** Every `Read` tool output is tagged with `LINE#ID` content hashes; `hashline_edit` validates the hash before applying. Stale hash → reject.
 - **5-tier hook composition:** Session (24) + ToolGuard (16) + Transform (5) + Continuation (7) + Skill (2) = 54 base. With `team_mode.enabled`: +1 ToolGuard (`team-tool-gating`), +2 Transform (`team-mode-status-injector`, `team-mailbox-injector`), +4 direct event handlers in `src/plugin/event.ts` (`team-session-events/*`) = 61 total. Composed by `createCoreHooks()` + `createContinuationHooks()` + `createSkillHooks()`.
 - **Per-session MCP isolation:** Tier-3 MCP clients keyed by `${sessionID}:${skillName}:${serverName}` so the same skill in two sessions does not share state.
@@ -322,8 +322,8 @@ bunx oh-my-opencode mcp-oauth login <server-url>  # Tier-3 MCP OAuth (PKCE + DCR
 - **Hashline edit:** every `Read` output tagged with `LINE#ID` content hashes (chars from `ZPMQVRWSNKTXJBYH`); edits reject on hash mismatch.
 - **zauc-mocks pattern:** 9 directories named `zauc-mocks-*` (5 in `src/hooks/`, 2 in `src/tools/`, 1 each in `src/mcp/` and `src/shared/`) hold `mock.module()` setup that must load alphabetically before the tests that consume those mocked modules. The `zauc-` prefix is purely a sort-order hack for `bun:test` discovery; these are NOT hooks/tools.
 - **Test discipline meta-audits:** two files (`src/shared/mock-module-lifecycle-audit.test.ts` and `src/shared/prompt-async-route-audit.test.ts`) parse the entire codebase via the TS compiler API and FAIL the suite when an architectural invariant is violated (`mock.module()` without restore, raw `session.promptAsync` outside the gate).
-- **Docs:** see [`docs/guide/`](file:///Users/yeongyu/local-workspaces/omo/docs/guide/) for user-facing guides (overview, installation, orchestration, agent-model-matching, team-mode), [`docs/reference/`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/) for CLI/configuration/features reference. v4.2.0+ adds [`CHANGELOG.md`](file:///Users/yeongyu/local-workspaces/omo/CHANGELOG.md), [`docs/reference/known-issues.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/known-issues.md), [`docs/reference/prompt-async-gate-rfc.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/prompt-async-gate-rfc.md), and [`docs/reference/release-process.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/release-process.md).
-- **Rules files** (auto-injected by `rules-injector` hook): [`.omo/rules/modular-code-enforcement.md`](file:///Users/yeongyu/local-workspaces/omo/.omo/rules/modular-code-enforcement.md) + [`.omo/rules/test-discipline.md`](file:///Users/yeongyu/local-workspaces/omo/.omo/rules/test-discipline.md) (forbids `setTimeout(resolve, N)` / `await sleep(N)` in tests unless time IS the SUT). Scans `.omo/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, plus `.github/copilot-instructions.md` and `.mdc` files.
+- **Docs:** see [`docs/guide/`](./docs/guide) for user-facing guides (overview, installation, orchestration, agent-model-matching, team-mode), [`docs/reference/`](./docs/reference) for CLI/configuration/features reference. v4.2.0+ adds [`CHANGELOG.md`](./CHANGELOG.md), [`docs/reference/known-issues.md`](./docs/reference/known-issues.md), [`docs/reference/prompt-async-gate-rfc.md`](./docs/reference/prompt-async-gate-rfc.md), and [`docs/reference/release-process.md`](./docs/reference/release-process.md).
+- **Rules files** (auto-injected by `rules-injector` hook): [`.omo/rules/test-discipline.md`](.omo/rules/test-discipline.md) (forbids `setTimeout(resolve, N)` / `await sleep(N)` in tests unless time IS the SUT). Scans `.omo/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, plus `.github/copilot-instructions.md` and `.mdc` files.
 - **Process cleanup:** Background-agent error handlers are now log-only — no force-exit on transient errors. Opt out entirely via `OMO_DISABLE_PROCESS_CLEANUP=1` env var.
 - **First-prompt watchdog:** `src/hooks/runtime-fallback/first-prompt-watchdog.ts` (206 LOC) detects subagent sessions producing no progress within 90s and triggers fallback / abort.
 - **ParentWakeNotifier:** Background-agent parent-wake state extracted to `src/features/background-agent/parent-wake-notifier.ts` (587 LOC) with dependency-injected client and enqueue callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `rules-core` **security**: project rule files and directories can no longer escape the workspace via symlinks. `findRuleFilesRecursive` and the project-single-file path now require every realpath to remain within the scan boundary, blocking attacks where a hostile repo points `.github/copilot-instructions.md` (or any `.omo/rules` entry) at host secrets such as `~/.ssh/id_rsa`. Tests track the boundary contract in [`packages/rules-core/src/index.test.ts`](packages/rules-core/src/index.test.ts).
+- `rules-core` **security**: project rule files and directories can no longer escape the workspace via symlinks. `findRuleFilesRecursive` and the project-single-file path now require every realpath to remain within the scan boundary, blocking attacks where a hostile repo points `.github/copilot-instructions.md` (or any `.omo/rules` entry) at host secrets such as `~/.ssh/id_rsa`. Tests track the boundary contract in [`packages/rules-engine/src/index.test.ts`](packages/rules-engine/src/index.test.ts).
 - `test-isolation`: rules-injector storage and fixture home isolated per-test; cross-suite leak diagnostic regression test added.
 - `ast-grep-mcp`: absolute paths whose `realpath` stays inside the workspace are now accepted (covered by red test); `path` entries are normalized via `resolve` + `realpath` and rejected for null bytes, leading `-`, and out-of-workspace traversal.
 - `runtime-fallback`: completion progress events (`message.part.updated`, deltas, finished markers) now correctly recognized, preventing false-negative retry triggers on sessions that are actually making progress.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ After making changes, you can test your local build in OpenCode:
    }
    ```
 
-   For example, if your project is at `/Users/yourname/projects/oh-my-opencode`:
+   For example, if your project is at `<local-checkout>/oh-my-opencode`:
 
    ```json
    {
-     "plugin": ["file:///Users/yourname/projects/oh-my-opencode/dist/index.js"]
+     "plugin": ["file://<local-checkout>/oh-my-opencode/dist/index.js"]
    }
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,15 +86,15 @@ After making changes, you can test your local build in OpenCode:
 
    ```json
    {
-     "plugin": ["file:///absolute/path/to/oh-my-opencode/dist/index.js"]
+     "plugin": ["file://./oh-my-opencode/dist/index.js"]
    }
    ```
 
-   For example, if your project is at `<local-checkout>/oh-my-opencode`:
+   For example, if your config is in the parent directory of `oh-my-opencode`:
 
    ```json
    {
-     "plugin": ["file://<local-checkout>/oh-my-opencode/dist/index.js"]
+     "plugin": ["file://./oh-my-opencode/dist/index.js"]
    }
    ```
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,35 +4,35 @@
 
 ## OVERVIEW
 
-19 Markdown files across 6 subdirectories + 2 root files. Categorized by audience: user-facing guides + reference, internal design docs (superpowers/), troubleshooting, legal. The web site at [packages/web/](file:///Users/yeongyu/local-workspaces/omo/packages/web/) consumes some of these (via `web-deploy.yml` triggers).
+19 Markdown files across 6 subdirectories + 2 root files. Categorized by audience: user-facing guides + reference, internal design docs (superpowers/), troubleshooting, legal. The web site at [packages/web/](../packages/web) consumes some of these (via `web-deploy.yml` triggers).
 
 ## WHERE TO LOOK
 
 | Audience / Task | Location |
 |------|----------|
-| New users — what is this? | [docs/guide/overview.md](file:///Users/yeongyu/local-workspaces/omo/docs/guide/overview.md) |
-| Installing the plugin | [docs/guide/installation.md](file:///Users/yeongyu/local-workspaces/omo/docs/guide/installation.md) |
-| How agents collaborate | [docs/guide/orchestration.md](file:///Users/yeongyu/local-workspaces/omo/docs/guide/orchestration.md) |
-| Picking the right model per agent | [docs/guide/agent-model-matching.md](file:///Users/yeongyu/local-workspaces/omo/docs/guide/agent-model-matching.md) |
-| Team Mode (opt-in multi-agent) | [docs/guide/team-mode.md](file:///Users/yeongyu/local-workspaces/omo/docs/guide/team-mode.md) |
-| Configuration field reference | [docs/reference/configuration.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/configuration.md) |
-| Feature-by-feature reference | [docs/reference/features.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/features.md) |
-| CLI command reference | [docs/reference/cli.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/cli.md) |
-| Known issues & workarounds | [docs/reference/known-issues.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/known-issues.md) |
-| `prompt_async_gate` deep-dive | [docs/reference/prompt-async-gate-rfc.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/prompt-async-gate-rfc.md) |
-| Shared core multi-PR extraction QA | [docs/reference/shared-core-multi-pr.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/shared-core-multi-pr.md) |
-| Release process | [docs/reference/release-process.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/release-process.md) |
-| Claiming the lazycodex npm name | [docs/reference/lazycodex-npm-reservation.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/lazycodex-npm-reservation.md) |
-| Rules-injector cross-module comparison | [docs/reference/rules-injection-cross-module-comparison.md](file:///Users/yeongyu/local-workspaces/omo/docs/reference/rules-injection-cross-module-comparison.md) |
-| Sample configs | [docs/examples/](file:///Users/yeongyu/local-workspaces/omo/docs/examples/) (default, coding-focused, planning-focused) |
-| Privacy & ToS | [docs/legal/](file:///Users/yeongyu/local-workspaces/omo/docs/legal/) |
-| Manifesto | [docs/manifesto.md](file:///Users/yeongyu/local-workspaces/omo/docs/manifesto.md) |
-| Ollama troubleshooting | [docs/troubleshooting/ollama.md](file:///Users/yeongyu/local-workspaces/omo/docs/troubleshooting/ollama.md) |
-| Internal design plans/specs | [docs/superpowers/plans/](file:///Users/yeongyu/local-workspaces/omo/docs/superpowers/plans/) + [docs/superpowers/specs/](file:///Users/yeongyu/local-workspaces/omo/docs/superpowers/specs/) |
+| New users — what is this? | [docs/guide/overview.md](./guide/overview.md) |
+| Installing the plugin | [docs/guide/installation.md](./guide/installation.md) |
+| How agents collaborate | [docs/guide/orchestration.md](./guide/orchestration.md) |
+| Picking the right model per agent | [docs/guide/agent-model-matching.md](./guide/agent-model-matching.md) |
+| Team Mode (opt-in multi-agent) | [docs/guide/team-mode.md](./guide/team-mode.md) |
+| Configuration field reference | [docs/reference/configuration.md](./reference/configuration.md) |
+| Feature-by-feature reference | [docs/reference/features.md](./reference/features.md) |
+| CLI command reference | [docs/reference/cli.md](./reference/cli.md) |
+| Known issues & workarounds | [docs/reference/known-issues.md](./reference/known-issues.md) |
+| `prompt_async_gate` deep-dive | [docs/reference/prompt-async-gate-rfc.md](./reference/prompt-async-gate-rfc.md) |
+| Shared core multi-PR extraction QA | [docs/reference/shared-core-multi-pr.md](./reference/shared-core-multi-pr.md) |
+| Release process | [docs/reference/release-process.md](./reference/release-process.md) |
+| Claiming the lazycodex npm name | [docs/reference/lazycodex-npm-reservation.md](./reference/lazycodex-npm-reservation.md) |
+| Rules-injector cross-module comparison | [docs/reference/rules-injection-cross-module-comparison.md](./reference/rules-injection-cross-module-comparison.md) |
+| Sample configs | [docs/examples/](./examples) (default, coding-focused, planning-focused) |
+| Privacy & ToS | [docs/legal/](./legal) |
+| Manifesto | [docs/manifesto.md](./manifesto.md) |
+| Ollama troubleshooting | [docs/troubleshooting/ollama.md](./troubleshooting/ollama.md) |
+| Internal design plans/specs | [docs/superpowers/plans/](./superpowers/plans) + [docs/superpowers/specs/](./superpowers/specs) |
 
 ## STRUCTURE
 
-```
+```text
 docs/
 ├── manifesto.md                              # The "why" — referenced from README
 ├── model-capabilities-maintenance.md         # How model-capabilities cache is refreshed
@@ -51,13 +51,13 @@ docs/
 
 - **User-facing language only in `guide/` and `reference/`.** No `OmO` internal jargon without explanation.
 - **`superpowers/` is internal.** Design docs, plans, RFCs. Outside readers should not be expected to follow these.
-- **Path links** use the `file://` scheme so OpenCode renders them in TUI. Use absolute paths.
+- **Path links** in checked-in docs use repository-relative Markdown links.
 - **No HTML.** Markdown only. No `<details>` / `<summary>` (causes rendering issues in some terminals).
 - **Code blocks** use language fences. Use `jsonc` for config snippets to preserve comments.
-- **Docs touching `packages/web/` re-trigger the web CI** via [`web-ci.yml`](file:///Users/yeongyu/local-workspaces/omo/.github/workflows/web-ci.yml).
+- **Docs touching `packages/web/` re-trigger the web CI** via [`web-ci.yml`](../.github/workflows/web-ci.yml).
 
 ## ANTI-PATTERNS
 
 - Never add a doc to `guide/` or `reference/` without a `WHERE TO LOOK` entry above.
-- Never paste agent-facing system prompts here. Those live in [`src/agents/`](file:///Users/yeongyu/local-workspaces/omo/src/agents/) or [`src/features/builtin-skills/`](file:///Users/yeongyu/local-workspaces/omo/src/features/builtin-skills/).
-- Never document changing config keys without also updating [`src/config/schema/`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/) and re-running `bun run build:schema`.
+- Never paste agent-facing system prompts here. Those live in [`src/agents/`](../src/agents) or [`src/features/builtin-skills/`](../src/features/builtin-skills).
+- Never document changing config keys without also updating [`src/config/schema/`](../src/config/schema) and re-running `bun run build:schema`.

--- a/docs/reference/rules-injection-cross-module-comparison.md
+++ b/docs/reference/rules-injection-cross-module-comparison.md
@@ -1,7 +1,7 @@
 # Rules Injection Modules — Cross-Module Comparison Report
 
 Comparison and porting record for the three rule injection implementations
-maintained out of `/Users/yeongyu/local-workspaces`:
+tracked during cross-repository development:
 
 - **codex-rules** — Codex hook plugin now bundled under the OMO Codex marketplace plugin (`packages/omo-codex/plugin/components/rules`, marketplace `sisyphuslabs`, plugin `omo`). The original standalone repo was `code-yeongyu/codex-rules`, branch `main`.
 - **pi-rules** — pi-mono extension (`pi-extensions/pi-rules`, repo `code-yeongyu/pi-rules`, branch `main`).

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -13,7 +13,7 @@
 | **Platform binaries** | 11 | One per (OS × arch × variant). Uniform layout: `bin/` + `package.json` only. Selected at install time by `bin/` shim + `postinstall.mjs`. |
 | **MCP packages** | 3 | `lsp-tools-mcp`, `ast-grep-mcp`, `git-bash-mcp` |
 | **Core packages** | 9 | `utils`, `model-core`, `prompts-core`, `rules-engine` (was `rules-core`), `agents-md-core`, `ast-grep-core`, `comment-checker-core`, `hashline-core`, `boulder-state` |
-| **Codex adapter** | 1 | `omo-codex` (Codex CLI Light edition; npm/bin alias `lazycodex`; Codex marketplace `sisyphuslabs` / plugin `omo`). See [`packages/omo-codex/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/packages/omo-codex/AGENTS.md) |
+| **Codex adapter** | 1 | `omo-codex` (Codex CLI Light edition; npm/bin alias `lazycodex`; Codex marketplace `sisyphuslabs` / plugin `omo`). See [`packages/omo-codex/AGENTS.md`](./omo-codex/AGENTS.md) |
 | **Skills** | 1 | `shared-skills` (cross-harness SKILL.md bundle shared between OMO and Codex; shipped via root `files` array) |
 | **Web** | 1 | `web` |
 
@@ -21,7 +21,7 @@
 
 `oh-my-opencode-darwin-arm64`, `oh-my-opencode-darwin-x64`, `oh-my-opencode-darwin-x64-baseline`, `oh-my-opencode-linux-arm64`, `oh-my-opencode-linux-arm64-musl`, `oh-my-opencode-linux-x64`, `oh-my-opencode-linux-x64-baseline`, `oh-my-opencode-linux-x64-musl`, `oh-my-opencode-linux-x64-musl-baseline`, `oh-my-opencode-windows-x64`, `oh-my-opencode-windows-x64-baseline`.
 
-Each contains only a `bin/<binary>` and a `package.json`. Built by [`script/build-binaries.ts`](file:///Users/yeongyu/local-workspaces/omo/script/build-binaries.ts) via `bun compile`. Published by the `publish-platform.yml` workflow.
+Each contains only a `bin/<binary>` and a `package.json`. Built by [`script/build-binaries.ts`](../script/build-binaries.ts) via `bun compile`. Published by the `publish-platform.yml` workflow.
 
 `-baseline` variants are pure x86_64 (no AVX2) for older CPUs. `-musl` variants link against musl libc for Alpine. Runtime selection happens in `bin/` and `postinstall.mjs`.
 
@@ -29,7 +29,7 @@ Each contains only a `bin/<binary>` and a `package.json`. Built by [`script/buil
 
 | Package | Layout | Purpose |
 |---------|--------|---------|
-| `lsp-tools-mcp/` | Vendored standalone project (`.github/`, `CHANGELOG.md`, `LICENSE`, `src/`, `test/`, `biome.json`, `vitest.config.ts`) | Serves `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_prepare_rename`, `lsp_rename`, `lsp_status` tools via stdio MCP. Registered as tier-1 MCP `lsp` in [`src/mcp/`](file:///Users/yeongyu/local-workspaces/omo/src/mcp/). |
+| `lsp-tools-mcp/` | Vendored standalone project (`.github/`, `CHANGELOG.md`, `LICENSE`, `src/`, `test/`, `biome.json`, `vitest.config.ts`) | Serves `lsp_diagnostics`, `lsp_goto_definition`, `lsp_find_references`, `lsp_symbols`, `lsp_prepare_rename`, `lsp_rename`, `lsp_status` tools via stdio MCP. Registered as tier-1 MCP `lsp` in [`src/mcp/`](../src/mcp). |
 | `ast-grep-mcp/` | Internal package (`src/`, `dist/`, `tsconfig.json`) | Serves `ast_grep_search` + `ast_grep_replace` tools via stdio MCP. Registered as tier-1 MCP `ast_grep`. |
 | `git-bash-mcp/` | Internal package (`src/`, `dist/`, `tsconfig.json`) | stdio MCP serving the Windows-only `git_bash` tool for the Codex edition. Tier-1 MCP. |
 
@@ -51,18 +51,18 @@ Each contains only a `bin/<binary>` and a `package.json`. Built by [`script/buil
 
 | Package | Sub-AGENTS.md | Purpose |
 |---------|---------------|---------|
-| `web/` | yes ([packages/web/AGENTS.md](file:///Users/yeongyu/local-workspaces/omo/packages/web/AGENTS.md)) | Marketing site. Next.js 15 + Cloudflare Workers via `@opennextjs/cloudflare`. Independent `bun.lock` + `tsconfig.json`. Only place in the repo where `@/*` path aliases are allowed. |
+| `web/` | yes ([packages/web/AGENTS.md](./web/AGENTS.md)) | Marketing site. Next.js 15 + Cloudflare Workers via `@opennextjs/cloudflare`. Independent `bun.lock` + `tsconfig.json`. Only place in the repo where `@/*` path aliases are allowed. |
 
 ## CODEX ADAPTER
 
-`omo-codex` is the Codex CLI Light edition (vendored Codex plugin namespace `omo` + TS installer + telemetry); its public distribution is the `lazycodex` bin/npm alias and the `code-yeongyu/lazycodex` marketplace repo; full layout in [`packages/omo-codex/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/packages/omo-codex/AGENTS.md) and the publish/deploy pipeline in the root [`AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/AGENTS.md).
+`omo-codex` is the Codex CLI Light edition (vendored Codex plugin namespace `omo` + TS installer + telemetry); its public distribution is the `lazycodex` bin/npm alias and the `code-yeongyu/lazycodex` marketplace repo; full layout in [`packages/omo-codex/AGENTS.md`](./omo-codex/AGENTS.md) and the publish/deploy pipeline in the root [`AGENTS.md`](../AGENTS.md).
 
 ## CONVENTIONS
 
 - **No new package without explicit need.** Adding a sibling package complicates publish + CI. Justify the boundary first.
-- **Platform binaries** are generated. Do NOT edit by hand. Modify [`script/build-binaries.ts`](file:///Users/yeongyu/local-workspaces/omo/script/build-binaries.ts).
+- **Platform binaries** are generated. Do NOT edit by hand. Modify [`script/build-binaries.ts`](../script/build-binaries.ts).
 - **`lsp-tools-mcp` is vendored source.** Build it with `bun run build:lsp-tools-mcp` before workflows or package tasks that need `packages/lsp-tools-mcp/dist`.
-- **`packages/web/` is excluded from root `bun test`** via `bunfig.toml`. It has its own [`web-ci.yml`](file:///Users/yeongyu/local-workspaces/omo/.github/workflows/web-ci.yml) workflow.
+- **`packages/web/` is excluded from root `bun test`** via `bunfig.toml`. It has its own [`web-ci.yml`](../.github/workflows/web-ci.yml) workflow.
 - **CI builds** for non-platform packages run as part of the root `ci.yml`. Platform binaries build only via `publish-platform.yml` when triggered by `publish.yml`.
 
 ## ANTI-PATTERNS

--- a/packages/omo-codex/AGENTS.md
+++ b/packages/omo-codex/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-`@oh-my-opencode/omo-codex` (private, v0.1.0): the Codex harness adapter = the **Light Edition** (omo for the OpenAI Codex CLI). Vendors a Codex plugin namespace `omo` + a TypeScript installer + telemetry. Public distribution = the `lazycodex` bin/npm alias and the [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) marketplace repo. Codex marketplace identity = `sisyphuslabs` / plugin `omo` (`omo@sisyphuslabs`); `lazycodex` is the alias only. Full identity + the publish/deploy pipeline live in the root [`AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/AGENTS.md) "CODEX LIGHT EDITION" section.
+`@oh-my-opencode/omo-codex` (private, v0.1.0): the Codex harness adapter = the **Light Edition** (omo for the OpenAI Codex CLI). Vendors a Codex plugin namespace `omo` + a TypeScript installer + telemetry. Public distribution = the `lazycodex` bin/npm alias and the [`code-yeongyu/lazycodex`](https://github.com/code-yeongyu/lazycodex) marketplace repo. Codex marketplace identity = `sisyphuslabs` / plugin `omo` (`omo@sisyphuslabs`); `lazycodex` is the alias only. Full identity + the publish/deploy pipeline live in the root [`AGENTS.md`](../../AGENTS.md) "CODEX LIGHT EDITION" section.
 
 ## LAYOUT
 

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -9,13 +9,13 @@ description: Developer reference for all 11 Oh My OpenAgent agent definitions, f
 
 ## OVERVIEW
 
-11 built-in agents. Type enum: [`src/config/schema/agent-names.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/agent-names.ts) `BuiltinAgentNameSchema`. 10 of them register via [`builtin-agents.ts`](file:///Users/yeongyu/local-workspaces/omo/src/agents/builtin-agents.ts) `agentSources` record (factory functions). **Prometheus is special-cased** — it has no `createPrometheusAgent` factory; instead [`prometheus-agent-config-builder.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-handlers/prometheus-agent-config-builder.ts) constructs its config directly during `agent-config-handler` Phase 3.
+11 built-in agents. Type enum: [`src/config/schema/agent-names.ts`](../config/schema/agent-names.ts) `BuiltinAgentNameSchema`. 10 of them register via [`builtin-agents.ts`](./builtin-agents.ts) `agentSources` record (factory functions). **Prometheus is special-cased** — it has no `createPrometheusAgent` factory; instead [`prometheus-agent-config-builder.ts`](../plugin-handlers/prometheus-agent-config-builder.ts) constructs its config directly during `agent-config-handler` Phase 3.
 
-All factories follow `createXXXAgent(model) → AgentConfig`. Each carries a static `mode` property (`AgentFactory` type in [`src/agents/types.ts`](file:///Users/yeongyu/local-workspaces/omo/src/agents/types.ts)). Composed via `buildAgent()`.
+All factories follow `createXXXAgent(model) → AgentConfig`. Each carries a static `mode` property (`AgentFactory` type in [`src/agents/types.ts`](./types.ts)). Composed via `buildAgent()`.
 
 ## AGENT INVENTORY
 
-Modes verified from each agent file's `const MODE: AgentMode = ...` and (for Prometheus) [`prometheus-agent-config-builder.ts:100`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-handlers/prometheus-agent-config-builder.ts#L100). Chains verified from [`src/shared/model-requirements.ts`](file:///Users/yeongyu/local-workspaces/omo/src/shared/model-requirements.ts).
+Modes verified from each agent file's `const MODE: AgentMode = ...` and (for Prometheus) [`prometheus-agent-config-builder.ts:100`](../plugin-handlers/prometheus-agent-config-builder.ts#L100). Chains verified from [`src/shared/model-requirements.ts`](../shared/model-requirements.ts).
 
 | Agent | Default Model | Temp | Mode | Fallback (after default) | Purpose |
 |-------|---------------|------|------|--------------------------|---------|
@@ -33,7 +33,7 @@ Modes verified from each agent file's `const MODE: AgentMode = ...` and (for Pro
 
 ## TOOL RESTRICTIONS
 
-Defined in [`src/shared/agent-tool-restrictions.ts`](file:///Users/yeongyu/local-workspaces/omo/src/shared/agent-tool-restrictions.ts).
+Defined in [`src/shared/agent-tool-restrictions.ts`](../shared/agent-tool-restrictions.ts).
 
 | Agent | Denied Tools |
 |-------|-------------|
@@ -47,7 +47,7 @@ Defined in [`src/shared/agent-tool-restrictions.ts`](file:///Users/yeongyu/local
 
 ## TEAM-MODE ELIGIBILITY
 
-Authoritative registry: [`AGENT_ELIGIBILITY_REGISTRY`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/types.ts) in `team-mode/types.ts`. Three verdict tiers:
+Authoritative registry: [`AGENT_ELIGIBILITY_REGISTRY`](../features/team-mode/types.ts) in `team-mode/types.ts`. Three verdict tiers:
 
 | Verdict | Agents |
 |---------|--------|
@@ -55,11 +55,11 @@ Authoritative registry: [`AGENT_ELIGIBILITY_REGISTRY`](file:///Users/yeongyu/loc
 | `conditional` | hephaestus (lacks `teammate: "allow"` permission by default — see D-36 / `tool-config-handler.ts`; use `subagent_type: "sisyphus"` instead) |
 | `hard-reject` | oracle, librarian, explore, multimodal-looker, metis, momus, prometheus (each with a specific rejection message) |
 
-Read-only agents are rejected at TeamSpec parse time. For those, the lead delegates via `task` (delegate-task) instead. See [`team-mode/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/AGENTS.md).
+Read-only agents are rejected at TeamSpec parse time. For those, the lead delegates via `task` (delegate-task) instead. See [`team-mode/AGENTS.md`](../features/team-mode/AGENTS.md).
 
 ## STRUCTURE
 
-```
+```text
 agents/
 ├── sisyphus.ts                                # Main orchestrator router
 ├── sisyphus/                                  # Model-specific variant prompts
@@ -99,11 +99,11 @@ const createXXXAgent: AgentFactory = (model: string) => ({
 createXXXAgent.mode = "subagent" // or "primary" or "all"
 ```
 
-Model resolution: 4-step pipeline → override → category-default → provider-fallback → system-default. Defined in [`shared/model-resolution-pipeline.ts`](file:///Users/yeongyu/local-workspaces/omo/src/shared/model-resolution-pipeline.ts).
+Model resolution: 4-step pipeline → override → category-default → provider-fallback → system-default. Defined in [`shared/model-resolution-pipeline.ts`](../shared/model-resolution-pipeline.ts).
 
 ## MODES
 
-Definition (from [`src/agents/types.ts`](file:///Users/yeongyu/local-workspaces/omo/src/agents/types.ts)):
+Definition (from [`src/agents/types.ts`](./types.ts)):
 
 - **`primary`** — respects user's UI-selected model. Used by: sisyphus, hephaestus, atlas, prometheus.
 - **`subagent`** — uses own fallback chain, ignores UI selection. Used by: oracle, librarian, explore, multimodal-looker, metis, momus, sisyphus-junior.
@@ -111,7 +111,7 @@ Definition (from [`src/agents/types.ts`](file:///Users/yeongyu/local-workspaces/
 
 ## CANONICAL ORDER
 
-`Sisyphus → Hephaestus → Prometheus → Atlas` (primary core agents) then alphabetical for the rest. Enforced by [`installAgentSortShim()`](file:///Users/yeongyu/local-workspaces/omo/src/shared/agent-sort-shim.ts) — patches `Array.prototype.{toSorted,sort}` narrowly when ≥2 canonical core agents are in the array. See [`src/plugin-handlers/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-handlers/AGENTS.md) for the full history.
+`Sisyphus → Hephaestus → Prometheus → Atlas` (primary core agents) then alphabetical for the rest. Enforced by [`installAgentSortShim()`](../shared/agent-sort-shim.ts) — patches `Array.prototype.{toSorted,sort}` narrowly when ≥2 canonical core agents are in the array. See [`src/plugin-handlers/AGENTS.md`](../plugin-handlers/AGENTS.md) for the full history.
 
 ## DYNAMIC PROMPT BUILDER
 

--- a/src/agents/prometheus/AGENTS.md
+++ b/src/agents/prometheus/AGENTS.md
@@ -9,9 +9,9 @@ description: Developer reference for the Prometheus strategic planner agent prom
 
 ## OVERVIEW
 
-3 TypeScript files plus 3 markdown prompt variants in [`packages/prompts-core/prompts/prometheus/`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/prometheus/). Prometheus remains the interview-mode strategic planner, but this directory is now a thin adapter layer. Prompt content lives in `packages/prompts-core`; `src/agents/prometheus/` routes model variants and applies runtime tool gating.
+3 TypeScript files plus 3 markdown prompt variants in [`packages/prompts-core/prompts/prometheus/`](../../../packages/prompts-core/prompts/prometheus). Prometheus remains the interview-mode strategic planner, but this directory is now a thin adapter layer. Prompt content lives in `packages/prompts-core`; `src/agents/prometheus/` routes model variants and applies runtime tool gating.
 
-This shape follows the package layering refactor in [`ROADMAP.md`](file:///Users/yeongyu/local-workspaces/omo/ROADMAP.md): prompts are harness-neutral core assets, while the OpenCode adapter keeps only model routing and runtime integration.
+This shape follows the package layering refactor in [`ROADMAP.md`](../../../ROADMAP.md): prompts are harness-neutral core assets, while the OpenCode adapter keeps only model routing and runtime integration.
 
 ## FILES
 
@@ -27,7 +27,7 @@ This shape follows the package layering refactor in [`ROADMAP.md`](file:///Users
 
 ## MODEL VARIANT ROUTING
 
-[`system-prompt.ts`](file:///Users/yeongyu/local-workspaces/omo/src/agents/prometheus/system-prompt.ts) exposes `getPrometheusPromptSource(model)`:
+[`system-prompt.ts`](./system-prompt.ts) exposes `getPrometheusPromptSource(model)`:
 
 - GPT family models, as detected by `isGptModel(model)`, route to `"gpt"`.
 - Gemini family models, as detected by `isGeminiModel(model)`, route to `"gemini"`.
@@ -48,7 +48,7 @@ This filtering is runtime adapter behavior. Do not duplicate stripped markdown v
 - Must explore codebase before planning (NEVER plan blind)
 - Plans saved to `.omo/plans/`
 - Acceptance criteria requiring "user manually tests" are FORBIDDEN
-- Prompt edits belong in [`packages/prompts-core/prompts/prometheus/`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/prometheus/), not in TypeScript section files
+- Prompt edits belong in [`packages/prompts-core/prompts/prometheus/`](../../../packages/prompts-core/prompts/prometheus), not in TypeScript section files
 
 ## PLAN OUTPUT FORMAT
 

--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -421,11 +421,11 @@ ${taskManagementSection}
 <file_links>
 **ALWAYS link files** when mentioning them by name. Use FLUENT format - URL hidden in link text.
 
-Format: \`[display text](file:///absolute/path/to/file.ts)\`
-Line range: \`[auth logic](file:///abs/path/auth.ts#L15-L23)\`
+Format: \`[display text](/absolute/path/to/file.ts)\`
+Line reference: \`[auth logic](/abs/path/auth.ts:42)\`
 URL-encode special chars: spaces → \`%20\`, \`(\` → \`%28\`, \`)\` → \`%29\`
 
-Example: \`The [auth handler](file:///abs/path/auth.ts#L42) validates via [token check](file:///abs/path/token.ts#L15-L23).\`
+Example: \`The [auth handler](/abs/path/auth.ts:42) validates via [token check](/abs/path/token.ts:15).\`
 
 NEVER show raw URL inline. ALWAYS embed in link text.
 </file_links>

--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -425,7 +425,7 @@ Format: \`[display text](file:///absolute/path/to/file.ts)\`
 Line range: \`[auth logic](file:///abs/path/auth.ts#L15-L23)\`
 URL-encode special chars: spaces → \`%20\`, \`(\` → \`%28\`, \`)\` → \`%29\`
 
-Example: \`The [auth handler](file:///Users/yeongyu/src/auth.ts#L42) validates via [token check](file:///Users/yeongyu/src/token.ts#L15-L23).\`
+Example: \`The [auth handler](file:///abs/path/auth.ts#L42) validates via [token check](file:///abs/path/token.ts#L15-L23).\`
 
 NEVER show raw URL inline. ALWAYS embed in link text.
 </file_links>

--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -421,11 +421,11 @@ ${taskManagementSection}
 <file_links>
 **ALWAYS link files** when mentioning them by name. Use FLUENT format - URL hidden in link text.
 
-Format: \`[display text](/absolute/path/to/file.ts)\`
-Line reference: \`[auth logic](/abs/path/auth.ts:42)\`
+Format: \`[display text](relative/path/to/file.ts)\`
+Line reference: \`[auth logic](src/auth.ts:42)\`
 URL-encode special chars: spaces → \`%20\`, \`(\` → \`%28\`, \`)\` → \`%29\`
 
-Example: \`The [auth handler](/abs/path/auth.ts:42) validates via [token check](/abs/path/token.ts:15).\`
+Example: \`The [auth handler](src/auth.ts:42) validates via [token check](src/token.ts:15).\`
 
 NEVER show raw URL inline. ALWAYS embed in link text.
 </file_links>

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -214,7 +214,7 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
   it("mirrors an existing source plugin entry into profile configs", async () => {
     // given
-    const sourcePlugin = "file:///Users/yeongyu/local-workspaces/omo/src/index.ts"
+    const sourcePlugin = "file:///Users/dev/local-workspaces/omo/src/index.ts"
     writeFileSync(testConfigPath, JSON.stringify({ plugin: [sourcePlugin] }, null, 2) + "\n", "utf-8")
 
     const profileDir = join(testConfigDir, "profiles", "today")
@@ -239,7 +239,7 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
   it("uses the parent source plugin entry when OPENCODE_CONFIG_DIR points at a profile", async () => {
     // given
-    const sourcePlugin = "file:///Users/yeongyu/local-workspaces/omo/src/index.ts"
+    const sourcePlugin = "file:///Users/dev/local-workspaces/omo/src/index.ts"
     writeFileSync(testConfigPath, JSON.stringify({ plugin: [sourcePlugin] }, null, 2) + "\n", "utf-8")
 
     const profileDir = join(testConfigDir, "profiles", "today")

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -9,6 +9,8 @@ import { detectCurrentConfig } from "./detect-current-config"
 import { addPluginToOpenCodeConfig } from "./add-plugin-to-opencode-config"
 import * as pluginNameWithVersion from "./plugin-name-with-version"
 
+const sourcePlugin = new URL("../../index.ts", import.meta.url).href
+
 describe("detectCurrentConfig - single package detection", () => {
   let testConfigDir = ""
   let testConfigPath = ""
@@ -214,7 +216,6 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
   it("mirrors an existing source plugin entry into profile configs", async () => {
     // given
-    const sourcePlugin = "file:///Users/dev/local-workspaces/omo/src/index.ts"
     writeFileSync(testConfigPath, JSON.stringify({ plugin: [sourcePlugin] }, null, 2) + "\n", "utf-8")
 
     const profileDir = join(testConfigDir, "profiles", "today")
@@ -239,7 +240,6 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
   it("uses the parent source plugin entry when OPENCODE_CONFIG_DIR points at a profile", async () => {
     // given
-    const sourcePlugin = "file:///Users/dev/local-workspaces/omo/src/index.ts"
     writeFileSync(testConfigPath, JSON.stringify({ plugin: [sourcePlugin] }, null, 2) + "\n", "utf-8")
 
     const profileDir = join(testConfigDir, "profiles", "today")

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -57,7 +57,7 @@ Parallel multi-agent coordination, OFF by default. Subdirs:
 - `team-layout-tmux/` — optional tmux pane visualization
 - `tools/` — 12 `team_*` tool implementations
 
-Eligible members: sisyphus, atlas, sisyphus-junior, hephaestus only. See [`team-mode/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/AGENTS.md).
+Eligible members: sisyphus, atlas, sisyphus-junior, hephaestus only. See [`team-mode/AGENTS.md`](./team-mode/AGENTS.md).
 
 ### opencode-skill-loader (~2.8k LOC)
 

--- a/src/features/boulder-state/AGENTS.md
+++ b/src/features/boulder-state/AGENTS.md
@@ -6,7 +6,7 @@
 
 10 files (~1k LOC excl. tests). Tracks Sisyphus's "boulder" — the active work plan being rolled across sessions, worktrees, and subagent task delegations. Named after the Sisyphus myth: the boulder must keep rolling until the plan is complete.
 
-Inspected interactively via `bunx oh-my-opencode boulder` (see [`src/cli/boulder/`](file:///Users/yeongyu/local-workspaces/omo/src/cli/boulder/)).
+Inspected interactively via `bunx oh-my-opencode boulder` (see [`src/cli/boulder/`](../../cli/boulder)).
 
 ## SCHEMA (v2)
 
@@ -42,7 +42,7 @@ interface BoulderState {
 
 ## LIFECYCLE
 
-```
+```text
 session.startWork(plan)
   → BoulderState created with active_plan, started_at, plan_name
   → atlas-hook reads BoulderState on session.idle for boulder continuation
@@ -58,15 +58,15 @@ session.completed
 
 | Where | What |
 |-------|------|
-| [`src/cli/boulder/`](file:///Users/yeongyu/local-workspaces/omo/src/cli/boulder/) | CLI inspector formats this state |
-| [`src/hooks/atlas/`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/atlas/) | Reads work state, drives boulder-complete and parallel-delegation prompts |
-| [`src/hooks/ralph-loop/`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/ralph-loop/) | Resumes subagent task sessions via `task_sessions` |
-| [`src/hooks/start-work/`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/start-work/) | Creates the BoulderState on `/start-work` invocation |
-| [`src/hooks/todo-continuation-enforcer/`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/todo-continuation-enforcer/) | Session-idle continuation when boulder incomplete |
+| [`src/cli/boulder/`](../../cli/boulder) | CLI inspector formats this state |
+| [`src/hooks/atlas/`](../../hooks/atlas) | Reads work state, drives boulder-complete and parallel-delegation prompts |
+| [`src/hooks/ralph-loop/`](../../hooks/ralph-loop) | Resumes subagent task sessions via `task_sessions` |
+| [`src/hooks/start-work/`](../../hooks/start-work) | Creates the BoulderState on `/start-work` invocation |
+| [`src/hooks/todo-continuation-enforcer/`](../../hooks/todo-continuation-enforcer) | Session-idle continuation when boulder incomplete |
 
 ## STORAGE
 
-```
+```text
 <worktree-root>/.omo/boulder.json   # gitignored; one file per worktree
 ```
 

--- a/src/features/team-mode/AGENTS.md
+++ b/src/features/team-mode/AGENTS.md
@@ -6,11 +6,11 @@
 
 Spawns coordinated agent teams with shared mailbox, task list, optional tmux layout, and graceful lifecycle. Modeled after Claude Code Agent Teams. **OFF by default.** Enable via `team_mode.enabled` in `oh-my-opencode.jsonc`; restart OpenCode after enabling.
 
-User docs: [`docs/guide/team-mode.md`](file:///Users/yeongyu/local-workspaces/omo/docs/guide/team-mode.md).
+User docs: [`docs/guide/team-mode.md`](../../../docs/guide/team-mode.md).
 
 ## CONFIG
 
-Full schema: [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/team-mode.ts).
+Full schema: [`src/config/schema/team-mode.ts`](../../config/schema/team-mode.ts).
 
 ```jsonc
 {
@@ -32,7 +32,7 @@ Full schema: [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-work
 
 ## 12 TEAM_* TOOLS
 
-Registered via [`src/plugin/tool-registry.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/tool-registry.ts) `teamModeToolsRecord` only when enabled.
+Registered via [`src/plugin/tool-registry.ts`](../../plugin/tool-registry.ts) `teamModeToolsRecord` only when enabled.
 
 | Tool | Source File | Purpose |
 |------|-------------|---------|
@@ -51,7 +51,7 @@ Registered via [`src/plugin/tool-registry.ts`](file:///Users/yeongyu/local-works
 
 ## ELIGIBLE AGENTS
 
-[`AGENT_ELIGIBILITY_REGISTRY`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/types.ts) in `types.ts` — three verdict tiers, each with its own rejection message:
+[`AGENT_ELIGIBILITY_REGISTRY`](./types.ts) in `types.ts` — three verdict tiers, each with its own rejection message:
 
 | Verdict | Agents | Notes |
 |---------|--------|-------|
@@ -77,7 +77,7 @@ Hard-reject agents throw at TeamSpec parse with a specific message ("Agent 'X' i
 
 ## MODULE LAYOUT
 
-```
+```text
 team-mode/
 ├── index.ts                    # barrel
 ├── types.ts                    # Zod schemas: TeamSpec, Member, Message, Task, RuntimeState; AGENT_ELIGIBILITY_REGISTRY
@@ -103,7 +103,7 @@ team-mode/
 
 ## STORAGE LAYOUT
 
-```
+```text
 ~/.omo/teams/{name}/                       # user scope
 <project>/.omo/teams/{name}/               # project scope (wins on collision)
   ├── config.json                          # TeamSpec
@@ -115,7 +115,7 @@ team-mode/
 
 ## LIFECYCLE
 
-```
+```text
 1. team_create
    → load TeamSpec → validate eligibility → spawn member sessions
    → init mailbox + tasklist + worktrees → optional tmux layout
@@ -138,19 +138,19 @@ team-mode/
 
 | Where | What |
 |-------|------|
-| [`src/index.ts`](file:///Users/yeongyu/local-workspaces/omo/src/index.ts) (entry) | `checkTeamModeDependencies()` + `ensureBaseDirs()` if `team_mode.enabled` |
-| [`src/plugin/tool-registry.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/tool-registry.ts) `teamModeToolsRecord` | Registers 12 `team_*` tools |
-| [`create-transform-hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/hooks/create-transform-hooks.ts) | Conditionally builds `teamModeStatusInjector` (`team-mode-status-injector` hook) and `teamMailboxInjector` (`team-mailbox-injector` hook) — both Transform tier |
-| [`create-tool-guard-hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/hooks/create-tool-guard-hooks.ts) | Conditionally builds `teamToolGating` (`team-tool-gating` hook) — Tool Guard tier |
-| [`src/plugin/event.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/event.ts) | Registers 4 team-session-event handlers from `src/hooks/team-session-events/`: `team-idle-wake-hint`, `team-lead-orphan-handler`, `team-member-error-handler`, `team-member-status-handler` |
-| [`src/cli/doctor/checks/team-mode.ts`](file:///Users/yeongyu/local-workspaces/omo/src/cli/doctor/checks/team-mode.ts) | Doctor check for team-mode prerequisites |
-| [`src/features/builtin-skills/skills/team-mode.ts`](file:///Users/yeongyu/local-workspaces/omo/src/features/builtin-skills/skills/team-mode.ts) | Built-in skill documenting the 12 tools — gated on `team_mode.enabled` |
+| [`src/index.ts`](../../index.ts) (entry) | `checkTeamModeDependencies()` + `ensureBaseDirs()` if `team_mode.enabled` |
+| [`src/plugin/tool-registry.ts`](../../plugin/tool-registry.ts) `teamModeToolsRecord` | Registers 12 `team_*` tools |
+| [`create-transform-hooks.ts`](../../plugin/hooks/create-transform-hooks.ts) | Conditionally builds `teamModeStatusInjector` (`team-mode-status-injector` hook) and `teamMailboxInjector` (`team-mailbox-injector` hook) — both Transform tier |
+| [`create-tool-guard-hooks.ts`](../../plugin/hooks/create-tool-guard-hooks.ts) | Conditionally builds `teamToolGating` (`team-tool-gating` hook) — Tool Guard tier |
+| [`src/plugin/event.ts`](../../plugin/event.ts) | Registers 4 team-session-event handlers from `src/hooks/team-session-events/`: `team-idle-wake-hint`, `team-lead-orphan-handler`, `team-member-error-handler`, `team-member-status-handler` |
+| [`src/cli/doctor/checks/team-mode.ts`](../../cli/doctor/checks/team-mode.ts) | Doctor check for team-mode prerequisites |
+| [`src/features/builtin-skills/skills/team-mode.ts`](../builtin-skills/skills/team-mode.ts) | Built-in skill documenting the 12 tools — gated on `team_mode.enabled` |
 
 ## WHERE TO LOOK
 
 | Task | Location |
 |------|----------|
-| Add new team tool | `tools/` + register in [`src/plugin/tool-registry.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/tool-registry.ts) `teamModeToolsRecord` |
+| Add new team tool | `tools/` + register in [`src/plugin/tool-registry.ts`](../../plugin/tool-registry.ts) `teamModeToolsRecord` |
 | Modify member eligibility | `types.ts` `AGENT_ELIGIBILITY_REGISTRY` |
 | Change storage format | `types.ts` Zod schemas |
 | Add worktree behavior | `team-worktree/manager.ts` |

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -21,7 +21,7 @@
 
 Total exposed hooks: **53 base, 60 with team-mode** (counts the 4 team-session-events handlers individually).
 
-Hook name allowlist for `disabled_hooks`: all configurable hook names enumerated in [`src/config/schema/hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/hooks.ts) `HookNameSchema`. Team-session-event sub-hooks are not individually listed in the schema — they activate together with `team_mode.enabled`.
+Hook name allowlist for `disabled_hooks`: all configurable hook names enumerated in [`src/config/schema/hooks.ts`](../config/schema/hooks.ts) `HookNameSchema`. Team-session-event sub-hooks are not individually listed in the schema — they activate together with `team_mode.enabled`.
 
 ### Tier 1: Session Hooks (23)
 
@@ -104,19 +104,19 @@ Hook name allowlist for `disabled_hooks`: all configurable hook names enumerated
 
 | Hook | Tier | Registered In | Purpose |
 |------|------|---------------|---------|
-| `team-mode-status-injector` | Transform | [`create-transform-hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/hooks/create-transform-hooks.ts) | Inject `<team_mode_status>` block into messages |
-| `team-mailbox-injector` | Transform | [`create-transform-hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/hooks/create-transform-hooks.ts) | Pull pending team mailbox messages into agent context |
-| `team-tool-gating` | Tool Guard | [`create-tool-guard-hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/hooks/create-tool-guard-hooks.ts) | Restrict `team_*` tools based on member role + permissions |
-| `team-idle-wake-hint` | event handler | [`src/plugin/event.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/event.ts) | Nudge idle team members back to work |
-| `team-lead-orphan-handler` | event handler | [`src/plugin/event.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/event.ts) | Detect lead departure → orphan members |
-| `team-member-error-handler` | event handler | [`src/plugin/event.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/event.ts) | React to member session errors |
-| `team-member-status-handler` | event handler | [`src/plugin/event.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/event.ts) | Track member status transitions |
+| `team-mode-status-injector` | Transform | [`create-transform-hooks.ts`](../plugin/hooks/create-transform-hooks.ts) | Inject `<team_mode_status>` block into messages |
+| `team-mailbox-injector` | Transform | [`create-transform-hooks.ts`](../plugin/hooks/create-transform-hooks.ts) | Pull pending team mailbox messages into agent context |
+| `team-tool-gating` | Tool Guard | [`create-tool-guard-hooks.ts`](../plugin/hooks/create-tool-guard-hooks.ts) | Restrict `team_*` tools based on member role + permissions |
+| `team-idle-wake-hint` | event handler | [`src/plugin/event.ts`](../plugin/event.ts) | Nudge idle team members back to work |
+| `team-lead-orphan-handler` | event handler | [`src/plugin/event.ts`](../plugin/event.ts) | Detect lead departure → orphan members |
+| `team-member-error-handler` | event handler | [`src/plugin/event.ts`](../plugin/event.ts) | React to member session errors |
+| `team-member-status-handler` | event handler | [`src/plugin/event.ts`](../plugin/event.ts) | Track member status transitions |
 
 The 4 `team-session-events/` handlers live in `src/hooks/team-session-events/` (separate files: `team-idle-wake-hint.ts`, `team-lead-orphan-handler.ts`, `team-member-error-handler.ts`, `team-member-status-handler.ts`) and are wired into `src/plugin/event.ts` directly, not through a tier composer.
 
 ## STRUCTURE
 
-```
+```text
 hooks/
 ├── shared/                                  # Cross-hook helpers (timing, prompt builders, etc.)
 ├── (52 hook directories — see tier tables above)
@@ -137,7 +137,7 @@ hooks/
    - Continuation/idle? → `create-continuation-hooks.ts`
    - Skill awareness? → `create-skill-hooks.ts`
    - Team-mode-only? → register inside the team-mode conditional block
-3. Add hook name to [`config/schema/hooks.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/hooks.ts) `HookNameSchema`
+3. Add hook name to [`config/schema/hooks.ts`](../config/schema/hooks.ts) `HookNameSchema`
 4. Cover with co-located `*.test.ts` (given/when/then style)
 
 ## NOTES

--- a/src/hooks/auto-update-checker/AGENTS.md
+++ b/src/hooks/auto-update-checker/AGENTS.md
@@ -47,5 +47,5 @@ Three `zauc-mocks-*` directories in `src/hooks/` exist specifically to test this
 
 ## CROSS-REFERENCES
 
-- Parent: [`src/hooks/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/AGENTS.md) -- Session Tier hook list
-- [`src/cli/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/cli/AGENTS.md) -- CLI uses the same npm dist-tag helpers
+- Parent: [`src/hooks/AGENTS.md`](../AGENTS.md) -- Session Tier hook list
+- [`src/cli/AGENTS.md`](../../cli/AGENTS.md) -- CLI uses the same npm dist-tag helpers

--- a/src/hooks/keyword-detector/AGENTS.md
+++ b/src/hooks/keyword-detector/AGENTS.md
@@ -4,9 +4,9 @@
 
 ## OVERVIEW
 
-Transform Tier hook on `messages.transform`. Scans the first user message for mode keywords and injects mode-specific system prompts. The detector and routing logic stay in `src/hooks/keyword-detector/`; prompt bodies now live in [`packages/prompts-core/prompts/`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/) so they can be shared by future harness adapters.
+Transform Tier hook on `messages.transform`. Scans the first user message for mode keywords and injects mode-specific system prompts. The detector and routing logic stay in `src/hooks/keyword-detector/`; prompt bodies now live in [`packages/prompts-core/prompts/`](../../../packages/prompts-core/prompts) so they can be shared by future harness adapters.
 
-This matches the package layering direction in [`ROADMAP.md`](file:///Users/yeongyu/local-workspaces/omo/ROADMAP.md): `packages/prompts-core` owns static prompt content, while this OpenCode hook owns keyword detection, model routing, and message injection.
+This matches the package layering direction in [`ROADMAP.md`](../../../ROADMAP.md): `packages/prompts-core` owns static prompt content, while this OpenCode hook owns keyword detection, model routing, and message injection.
 
 ## KEYWORDS
 
@@ -21,7 +21,7 @@ This matches the package layering direction in [`ROADMAP.md`](file:///Users/yeon
 
 ## STRUCTURE
 
-```
+```text
 keyword-detector/
 ├── index.ts           # Barrel export
 ├── hook.ts            # createKeywordDetectorHook() chat.message handler
@@ -53,31 +53,31 @@ keyword-detector/
 
 | Prompt family | Markdown source |
 |---------------|-----------------|
-| Ultrawork default | [`packages/prompts-core/prompts/ultrawork/default.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/ultrawork/default.md) |
-| Ultrawork GPT | [`packages/prompts-core/prompts/ultrawork/gpt.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/ultrawork/gpt.md) |
-| Ultrawork Gemini | [`packages/prompts-core/prompts/ultrawork/gemini.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/ultrawork/gemini.md) |
-| Ultrawork planner | [`packages/prompts-core/prompts/ultrawork/planner.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/ultrawork/planner.md) |
-| Search mode | [`packages/prompts-core/prompts/mode/search.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/mode/search.md) |
-| Analyze mode | [`packages/prompts-core/prompts/mode/analyze.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/mode/analyze.md) |
-| Team mode | [`packages/prompts-core/prompts/mode/team.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/mode/team.md) |
-| Hyperplan mode | [`packages/prompts-core/prompts/mode/hyperplan.md`](file:///Users/yeongyu/local-workspaces/omo/packages/prompts-core/prompts/mode/hyperplan.md) |
+| Ultrawork default | [`packages/prompts-core/prompts/ultrawork/default.md`](../../../packages/prompts-core/prompts/ultrawork/default.md) |
+| Ultrawork GPT | [`packages/prompts-core/prompts/ultrawork/gpt.md`](../../../packages/prompts-core/prompts/ultrawork/gpt.md) |
+| Ultrawork Gemini | [`packages/prompts-core/prompts/ultrawork/gemini.md`](../../../packages/prompts-core/prompts/ultrawork/gemini.md) |
+| Ultrawork planner | [`packages/prompts-core/prompts/ultrawork/planner.md`](../../../packages/prompts-core/prompts/ultrawork/planner.md) |
+| Search mode | [`packages/prompts-core/prompts/mode/search.md`](../../../packages/prompts-core/prompts/mode/search.md) |
+| Analyze mode | [`packages/prompts-core/prompts/mode/analyze.md`](../../../packages/prompts-core/prompts/mode/analyze.md) |
+| Team mode | [`packages/prompts-core/prompts/mode/team.md`](../../../packages/prompts-core/prompts/mode/team.md) |
+| Hyperplan mode | [`packages/prompts-core/prompts/mode/hyperplan.md`](../../../packages/prompts-core/prompts/mode/hyperplan.md) |
 
 The `src/hooks/keyword-detector/{search,analyze,team,hyperplan}/default.ts` files keep the regex triggers in the hook layer and import the markdown-backed constants from `@oh-my-opencode/prompts-core`. The ultrawork files import markdown with Bun's `.md` text loader so the exact prompt bytes are bundled into `dist/index.js`.
 
 ## ULTRAWORK VARIANT ROUTING
 
-[`ultrawork/source-detector.ts`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/keyword-detector/ultrawork/source-detector.ts) decides the ultrawork source in priority order:
+[`ultrawork/source-detector.ts`](./ultrawork/source-detector.ts) decides the ultrawork source in priority order:
 
 1. Planner agents (`prometheus`, `planner`, or normalized `plan`) route to `planner.md`.
 2. GPT family models, as detected by `isGptModel(modelID)`, route to `gpt.md`.
 3. Gemini family models, as detected by `isGeminiModel(modelID)`, route to `gemini.md`.
 4. Everything else routes to `default.md`.
 
-[`ultrawork/index.ts`](file:///Users/yeongyu/local-workspaces/omo/src/hooks/keyword-detector/ultrawork/index.ts) exposes `getUltraworkMessage(agentName, modelID)`, switches on that source, and returns the loaded markdown body.
+[`ultrawork/index.ts`](./ultrawork/index.ts) exposes `getUltraworkMessage(agentName, modelID)`, switches on that source, and returns the loaded markdown body.
 
 ## DETECTION LOGIC
 
-```
+```text
 chat.message (user input)
   -> extractPromptText(parts)
   -> isSystemDirective? skip
@@ -100,7 +100,7 @@ chat.message (user input)
 }
 ```
 
-Default: empty/missing means every detector is active. Schema lives at [`src/config/schema/keyword-detector.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/keyword-detector.ts).
+Default: empty/missing means every detector is active. Schema lives at [`src/config/schema/keyword-detector.ts`](../../config/schema/keyword-detector.ts).
 
 ## GUARDS
 

--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -499,7 +499,7 @@ describe("external-plugin-detector", () => {
       fs.mkdirSync(profileConfigDir, { recursive: true })
       fs.writeFileSync(
         path.join(projectConfigDir, "opencode.json"),
-        JSON.stringify({ plugin: ["file:///Users/yeongyu/local-workspaces/omo/src/index.ts"] }),
+        JSON.stringify({ plugin: ["file:///Users/dev/local-workspaces/omo/src/index.ts"] }),
       )
       fs.writeFileSync(
         path.join(profileConfigDir, "opencode.json"),
@@ -521,7 +521,7 @@ describe("external-plugin-detector", () => {
       expect(result.detected).toBe(true)
       expect(result.pluginName).toBe("oh-my-openagent")
       expect(result.duplicatePlugins).toEqual([
-        "file:///Users/yeongyu/local-workspaces/omo/src/index.ts",
+        "file:///Users/dev/local-workspaces/omo/src/index.ts",
         "oh-my-openagent@latest",
       ])
     })
@@ -567,7 +567,7 @@ describe("external-plugin-detector", () => {
     test("#given duplicate OMO entries #when generating a warning #then it tells the user startup is disabled", () => {
       // when
       const warning = getDuplicateOmoPluginWarning([
-        "file:///Users/yeongyu/local-workspaces/omo/src/index.ts",
+        "file:///Users/dev/local-workspaces/omo/src/index.ts",
         "oh-my-openagent@latest",
       ])
 

--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -10,6 +10,8 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import * as os from "node:os"
 
+const sourcePlugin = new URL("../index.ts", import.meta.url).href
+
 async function importFreshExternalPluginDetectorModule(): Promise<typeof import("./external-plugin-detector")> {
   return import(`./external-plugin-detector?test=${Date.now()}-${Math.random()}`)
 }
@@ -303,13 +305,13 @@ describe("external-plugin-detector", () => {
       expect(result.pluginName).toBe("opencode-notifier")
     })
 
-    test("should match file:///path/to/opencode-notifier (file path)", () => {
+    test("should match relative file path to opencode-notifier", () => {
       // given - file path
       const opencodeDir = path.join(tempDir, ".opencode")
       fs.mkdirSync(opencodeDir, { recursive: true })
       fs.writeFileSync(
         path.join(opencodeDir, "opencode.json"),
-        JSON.stringify({ plugin: ["file:///home/user/plugins/opencode-notifier"] })
+        JSON.stringify({ plugin: ["file://./plugins/opencode-notifier"] })
       )
 
       // when
@@ -430,13 +432,13 @@ describe("external-plugin-detector", () => {
       expect(result.pluginName).toBe("opencode-skills")
     })
 
-    test("should detect file:///path/to/opencode-skills", () => {
+    test("should detect relative file path to opencode-skills", () => {
       // given - file path
       const opencodeDir = path.join(tempDir, ".opencode")
       fs.mkdirSync(opencodeDir, { recursive: true })
       fs.writeFileSync(
         path.join(opencodeDir, "opencode.json"),
-        JSON.stringify({ plugin: ["file:///home/user/plugins/opencode-skills"] })
+        JSON.stringify({ plugin: ["file://./plugins/opencode-skills"] })
       )
 
       // when
@@ -499,7 +501,7 @@ describe("external-plugin-detector", () => {
       fs.mkdirSync(profileConfigDir, { recursive: true })
       fs.writeFileSync(
         path.join(projectConfigDir, "opencode.json"),
-        JSON.stringify({ plugin: ["file:///Users/dev/local-workspaces/omo/src/index.ts"] }),
+        JSON.stringify({ plugin: [sourcePlugin] }),
       )
       fs.writeFileSync(
         path.join(profileConfigDir, "opencode.json"),
@@ -521,7 +523,7 @@ describe("external-plugin-detector", () => {
       expect(result.detected).toBe(true)
       expect(result.pluginName).toBe("oh-my-openagent")
       expect(result.duplicatePlugins).toEqual([
-        "file:///Users/dev/local-workspaces/omo/src/index.ts",
+        sourcePlugin,
         "oh-my-openagent@latest",
       ])
     })
@@ -567,7 +569,7 @@ describe("external-plugin-detector", () => {
     test("#given duplicate OMO entries #when generating a warning #then it tells the user startup is disabled", () => {
       // when
       const warning = getDuplicateOmoPluginWarning([
-        "file:///Users/dev/local-workspaces/omo/src/index.ts",
+        sourcePlugin,
         "oh-my-openagent@latest",
       ])
 

--- a/src/shared/markdown-link-audit.test.ts
+++ b/src/shared/markdown-link-audit.test.ts
@@ -90,6 +90,17 @@ function readMarkdownTarget(line: string, index: number, depth = 0, target = "")
   return readMarkdownTarget(line, index + 1, nextDepth, `${target}${char}`)
 }
 
+function readAngleBracketTarget(line: string, index: number, target = ""): string | undefined {
+  const char = line[index]
+  if (!char) {
+    return undefined
+  }
+  if (char === ">" && !isEscaped(line, index)) {
+    return target || undefined
+  }
+  return readAngleBracketTarget(line, index + 1, `${target}${char}`)
+}
+
 function collectInlineTargets(line: string, lineNumber: number, index = 0): Array<{ line: number; target: string }> {
   if (index >= line.length) {
     return []
@@ -103,7 +114,9 @@ function collectInlineTargets(line: string, lineNumber: number, index = 0): Arra
     return collectInlineTargets(line, lineNumber, index + 1)
   }
   const nestedTargets = collectInlineTargets(line.slice(labelStart + 1, labelEnd), lineNumber)
-  const target = line[labelEnd + 1] === "(" ? readMarkdownTarget(line, labelEnd + 2) : undefined
+  const target = line[labelEnd + 1] === "("
+    ? line[labelEnd + 2] === "<" ? readAngleBracketTarget(line, labelEnd + 3) : readMarkdownTarget(line, labelEnd + 2)
+    : undefined
   const currentTargets = target ? [...nestedTargets, { line: lineNumber, target }] : nestedTargets
   return [...currentTargets, ...collectInlineTargets(line, lineNumber, labelEnd + 1)]
 }
@@ -190,6 +203,12 @@ describe("markdown local link audit", () => {
   test("#given inline code spans #when collecting targets #then links inside code spans are ignored", () => {
     expect(collectLinkedTargets("Use `create_memory_object_stream[T](max_buffer_size=N)` then [Guide](./guide/overview.md)")).toEqual([
       { line: 1, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given angle-bracket-wrapped destination with spaces #when collecting targets #then the spaced target is audited", () => {
+    expect(collectLinkedTargets("[Release notes](<./docs/release notes.md>)")).toEqual([
+      { line: 1, target: "./docs/release notes.md" },
     ])
   })
 

--- a/src/shared/markdown-link-audit.test.ts
+++ b/src/shared/markdown-link-audit.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { dirname, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const WORKSPACE_ROOT = resolve(import.meta.dir, "../..")
+const MARKDOWN_LINK_RE = /(?<!!)\[[^\]\n]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+const MARKDOWN_REFERENCE_DEFINITION_RE = /^ {0,3}\[([^\]\n]+)\]:\s+(\S+)/
+
+function collectMarkdownFiles(): string[] {
+  const output = Bun.spawnSync(["git", "ls-files", "*.md"], { cwd: WORKSPACE_ROOT, stdout: "pipe" })
+  expect(output.exitCode).toBe(0)
+  return output.stdout.toString("utf-8").trim().split("\n").filter(Boolean).map((filePath) => resolve(WORKSPACE_ROOT, filePath))
+}
+
+function stripFencedCodeBlocks(markdown: string): string {
+  return markdown.replace(/(^|\n) {0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n {0,3}\2(?=\n|$)/g, (match) => match.replace(/[^\n]/g, ""))
+}
+
+function stripIndentedCodeBlocks(markdown: string): string {
+  return markdown.replace(/(^|\n)(?: {4}|\t)[^\n]*/g, (match) => match.replace(/[^\n]/g, ""))
+}
+
+function isExternalLink(target: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target) && !target.startsWith("file://")
+}
+
+function resolveMarkdownTarget(filePath: string, target: string): string | undefined {
+  if (target.startsWith("#") || isExternalLink(target)) {
+    return undefined
+  }
+  const targetUrl = target.split("#", 1)[0]?.split("?", 1)[0]
+  if (!targetUrl) {
+    return undefined
+  }
+  if (targetUrl.startsWith("file://")) {
+    const fileTarget = targetUrl.slice("file://".length)
+    if (fileTarget.startsWith("./") || fileTarget.startsWith("../")) {
+      return resolve(dirname(filePath), decodeURIComponent(fileTarget))
+    }
+    return fileURLToPath(targetUrl)
+  }
+  return resolve(dirname(filePath), decodeURIComponent(targetUrl))
+}
+
+function relativeWorkspacePath(filePath: string): string {
+  return relative(WORKSPACE_ROOT, filePath)
+}
+
+function collectLinkedTargets(markdown: string): Array<{ line: number; target: string }> {
+  return stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown)).split("\n").flatMap((line, lineIndex) => {
+    const linkTargets = Array.from(line.matchAll(MARKDOWN_LINK_RE), (match) => match[1])
+      .filter((target): target is string => Boolean(target))
+      .map((target) => ({ line: lineIndex + 1, target }))
+    const referenceTarget = MARKDOWN_REFERENCE_DEFINITION_RE.exec(line)?.[2]
+    return referenceTarget ? [...linkTargets, { line: lineIndex + 1, target: referenceTarget }] : linkTargets
+  })
+}
+
+describe("markdown local link audit", () => {
+  test("#given external markdown links #when resolving targets #then http and https links are ignored", () => {
+    expect(resolveMarkdownTarget("docs/AGENTS.md", "http://example.com/readme.md")).toBeUndefined()
+    expect(resolveMarkdownTarget("docs/AGENTS.md", "https://example.com/readme.md")).toBeUndefined()
+  })
+
+  test("#given relative file uri markdown link #when resolving target #then it resolves from the markdown file", () => {
+    expect(resolveMarkdownTarget("docs/AGENTS.md", "file://./guide/overview.md")).toBe(resolve("docs/guide/overview.md"))
+  })
+
+  test("#given reference-style markdown links #when collecting targets #then link definitions are audited", () => {
+    expect(collectLinkedTargets("[Guide][guide]\n\n[guide]: ./guide/overview.md")).toEqual([
+      { line: 3, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given indented fenced code block #when collecting targets #then links inside the fence are ignored", () => {
+    expect(collectLinkedTargets("   ```markdown\n[Missing](./missing.md)\n   ```\n[Guide](./guide/overview.md)")).toEqual([
+      { line: 4, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given indented code block #when collecting targets #then links inside the code block are ignored", () => {
+    expect(collectLinkedTargets("    [Missing](./missing.md)\n\t[AlsoMissing](./also-missing.md)\n[Guide](./guide/overview.md)")).toEqual([
+      { line: 3, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given checked-in markdown #when local links are audited #then every local target exists", async () => {
+    const offenders = (await Promise.all(collectMarkdownFiles().map(async (filePath) => {
+      return collectLinkedTargets(await readFile(filePath, "utf-8")).flatMap((linkedTarget) => {
+        const targetPath = resolveMarkdownTarget(filePath, linkedTarget.target)
+        return targetPath && !existsSync(targetPath) ? [`${relativeWorkspacePath(filePath)}:${linkedTarget.line} missing ${linkedTarget.target}`] : []
+      })
+    }))).flat()
+    expect(offenders.sort()).toEqual([])
+  }, 20_000)
+})

--- a/src/shared/markdown-link-audit.test.ts
+++ b/src/shared/markdown-link-audit.test.ts
@@ -24,6 +24,10 @@ function stripIndentedCodeBlocks(markdown: string): string {
   return markdown.replace(/(^|\n)(?: {4}|\t)[^\n]*/g, (match) => match.replace(/[^\n]/g, ""))
 }
 
+function stripInlineCodeSpans(markdown: string): string {
+  return markdown.replace(/`[^`\n]*`/g, (match) => match.replace(/[^\n]/g, ""))
+}
+
 function isExternalLink(target: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(target) && !target.startsWith("file://")
 }
@@ -105,7 +109,7 @@ function collectInlineTargets(line: string, lineNumber: number, index = 0): Arra
 }
 
 function collectLinkedTargets(markdown: string): Array<{ line: number; target: string }> {
-  return stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown)).split("\n").flatMap((line, lineIndex) => {
+  return stripInlineCodeSpans(stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown))).split("\n").flatMap((line, lineIndex) => {
     const referenceTarget = MARKDOWN_REFERENCE_DEFINITION_RE.exec(line)?.[2]
     const targets = collectInlineTargets(line, lineIndex + 1)
     return referenceTarget ? [...targets, { line: lineIndex + 1, target: referenceTarget }] : targets
@@ -113,7 +117,7 @@ function collectLinkedTargets(markdown: string): Array<{ line: number; target: s
 }
 
 function collectMaintainerLocalPathLines(markdown: string): number[] {
-  return stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown)).split("\n").flatMap((line, lineIndex) => (
+  return stripInlineCodeSpans(stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown))).split("\n").flatMap((line, lineIndex) => (
     MAINTAINER_LOCAL_PATH_RE.test(line) ? [lineIndex + 1] : []
   ))
 }
@@ -180,6 +184,12 @@ describe("markdown local link audit", () => {
   test("#given indented code block #when collecting targets #then links inside the code block are ignored", () => {
     expect(collectLinkedTargets("    [Missing](./missing.md)\n\t[AlsoMissing](./also-missing.md)\n[Guide](./guide/overview.md)")).toEqual([
       { line: 3, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given inline code spans #when collecting targets #then links inside code spans are ignored", () => {
+    expect(collectLinkedTargets("Use `create_memory_object_stream[T](max_buffer_size=N)` then [Guide](./guide/overview.md)")).toEqual([
+      { line: 1, target: "./guide/overview.md" },
     ])
   })
 

--- a/src/shared/markdown-link-audit.test.ts
+++ b/src/shared/markdown-link-audit.test.ts
@@ -7,8 +7,8 @@ import { dirname, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const WORKSPACE_ROOT = resolve(import.meta.dir, "../..")
-const MARKDOWN_LINK_RE = /(?<!!)\[[^\]\n]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
 const MARKDOWN_REFERENCE_DEFINITION_RE = /^ {0,3}\[([^\]\n]+)\]:\s+(\S+)/
+const MAINTAINER_LOCAL_PATH_RE = /file:\/\/\/(?:Users|home)\/|(?:^|[\s(`'"])(?:\/Users|\/home)\//
 
 function collectMarkdownFiles(): string[] {
   const output = Bun.spawnSync(["git", "ls-files", "*.md"], { cwd: WORKSPACE_ROOT, stdout: "pipe" })
@@ -50,14 +50,72 @@ function relativeWorkspacePath(filePath: string): string {
   return relative(WORKSPACE_ROOT, filePath)
 }
 
+function countPrecedingBackslashes(line: string, index: number, count = 0): number {
+  return line[index - count - 1] === "\\" ? countPrecedingBackslashes(line, index, count + 1) : count
+}
+
+function isEscaped(line: string, index: number): boolean {
+  return countPrecedingBackslashes(line, index) % 2 === 1
+}
+
+function findClosingBracket(line: string, openIndex: number, index = openIndex, depth = 0): number {
+  if (index >= line.length) {
+    return -1
+  }
+  const char = line[index]
+  const isUnescaped = !isEscaped(line, index)
+  const nextDepth = char === "[" && isUnescaped ? depth + 1 : char === "]" && isUnescaped ? depth - 1 : depth
+  return char === "]" && isUnescaped && nextDepth === 0
+    ? index
+    : findClosingBracket(line, openIndex, index + 1, nextDepth)
+}
+
+function readMarkdownTarget(line: string, index: number, depth = 0, target = ""): string | undefined {
+  const char = line[index]
+  if (!char) {
+    return undefined
+  }
+  const isUnescaped = !isEscaped(line, index)
+  if (char === ")" && isUnescaped && depth === 0) {
+    return target || undefined
+  }
+  if (/\s/.test(char) && depth === 0) {
+    return target || undefined
+  }
+  const nextDepth = char === "(" && isUnescaped ? depth + 1 : char === ")" && isUnescaped ? depth - 1 : depth
+  return readMarkdownTarget(line, index + 1, nextDepth, `${target}${char}`)
+}
+
+function collectInlineTargets(line: string, lineNumber: number, index = 0): Array<{ line: number; target: string }> {
+  if (index >= line.length) {
+    return []
+  }
+  const labelStart = line[index] === "!" && line[index + 1] === "[" ? index + 1 : line[index] === "[" ? index : -1
+  if (labelStart === -1 || isEscaped(line, labelStart)) {
+    return collectInlineTargets(line, lineNumber, index + 1)
+  }
+  const labelEnd = findClosingBracket(line, labelStart)
+  if (labelEnd === -1) {
+    return collectInlineTargets(line, lineNumber, index + 1)
+  }
+  const nestedTargets = collectInlineTargets(line.slice(labelStart + 1, labelEnd), lineNumber)
+  const target = line[labelEnd + 1] === "(" ? readMarkdownTarget(line, labelEnd + 2) : undefined
+  const currentTargets = target ? [...nestedTargets, { line: lineNumber, target }] : nestedTargets
+  return [...currentTargets, ...collectInlineTargets(line, lineNumber, labelEnd + 1)]
+}
+
 function collectLinkedTargets(markdown: string): Array<{ line: number; target: string }> {
   return stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown)).split("\n").flatMap((line, lineIndex) => {
-    const linkTargets = Array.from(line.matchAll(MARKDOWN_LINK_RE), (match) => match[1])
-      .filter((target): target is string => Boolean(target))
-      .map((target) => ({ line: lineIndex + 1, target }))
     const referenceTarget = MARKDOWN_REFERENCE_DEFINITION_RE.exec(line)?.[2]
-    return referenceTarget ? [...linkTargets, { line: lineIndex + 1, target: referenceTarget }] : linkTargets
+    const targets = collectInlineTargets(line, lineIndex + 1)
+    return referenceTarget ? [...targets, { line: lineIndex + 1, target: referenceTarget }] : targets
   })
+}
+
+function collectMaintainerLocalPathLines(markdown: string): number[] {
+  return stripIndentedCodeBlocks(stripFencedCodeBlocks(markdown)).split("\n").flatMap((line, lineIndex) => (
+    MAINTAINER_LOCAL_PATH_RE.test(line) ? [lineIndex + 1] : []
+  ))
 }
 
 describe("markdown local link audit", () => {
@@ -73,6 +131,43 @@ describe("markdown local link audit", () => {
   test("#given reference-style markdown links #when collecting targets #then link definitions are audited", () => {
     expect(collectLinkedTargets("[Guide][guide]\n\n[guide]: ./guide/overview.md")).toEqual([
       { line: 3, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given separated reference-style markdown links #when collecting targets #then each definition target is audited", () => {
+    expect(collectLinkedTargets("[Guide][guide] and [Docs][]\n\n[guide]: ./guide/overview.md\n[Docs]: docs/AGENTS.md")).toEqual([
+      { line: 3, target: "./guide/overview.md" },
+      { line: 4, target: "docs/AGENTS.md" },
+    ])
+  })
+
+  test("#given image-wrapped markdown link #when collecting targets #then wrapper target is audited", () => {
+    expect(collectLinkedTargets("[![License](https://img.shields.io/badge/license-SUL--1.0-white)](LICENSE.md)")).toEqual([
+      { line: 1, target: "https://img.shields.io/badge/license-SUL--1.0-white" },
+      { line: 1, target: "LICENSE.md" },
+    ])
+  })
+
+  test("#given nested markdown links #when collecting targets #then each nested target is audited", () => {
+    expect(collectLinkedTargets("[[Guide](./guide/overview.md)](README.md)")).toEqual([
+      { line: 1, target: "./guide/overview.md" },
+      { line: 1, target: "README.md" },
+    ])
+  })
+
+  test("#given escaped label brackets #when collecting targets #then odd escapes block closing and even escapes allow closing", () => {
+    expect(collectLinkedTargets("[Guide\\](./guide/overview.md)")).toEqual([])
+    expect(collectLinkedTargets("[Guide\\\\](./guide/overview.md)")).toEqual([
+      { line: 1, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given escaped target parentheses #when collecting targets #then odd escapes keep reading and even escapes close target", () => {
+    expect(collectLinkedTargets("[Guide](docs/foo\\).md)")).toEqual([
+      { line: 1, target: "docs/foo\\).md" },
+    ])
+    expect(collectLinkedTargets("[Guide](docs/foo\\\\).md)")).toEqual([
+      { line: 1, target: "docs/foo\\\\" },
     ])
   })
 
@@ -94,6 +189,13 @@ describe("markdown local link audit", () => {
         const targetPath = resolveMarkdownTarget(filePath, linkedTarget.target)
         return targetPath && !existsSync(targetPath) ? [`${relativeWorkspacePath(filePath)}:${linkedTarget.line} missing ${linkedTarget.target}`] : []
       })
+    }))).flat()
+    expect(offenders.sort()).toEqual([])
+  }, 20_000)
+
+  test("#given checked-in markdown #when maintainer-local paths are audited #then none are present", async () => {
+    const offenders = (await Promise.all(collectMarkdownFiles().map(async (filePath) => {
+      return collectMaintainerLocalPathLines(await readFile(filePath, "utf-8")).map((line) => `${relativeWorkspacePath(filePath)}:${line}`)
     }))).flat()
     expect(offenders.sort()).toEqual([])
   }, 20_000)

--- a/src/shared/markdown-link-audit.test.ts
+++ b/src/shared/markdown-link-audit.test.ts
@@ -101,6 +101,11 @@ function readAngleBracketTarget(line: string, index: number, target = ""): strin
   return readAngleBracketTarget(line, index + 1, `${target}${char}`)
 }
 
+function skipLeadingWhitespace(line: string, index: number): number {
+  const char = line[index]
+  return char && /\s/.test(char) ? skipLeadingWhitespace(line, index + 1) : index
+}
+
 function collectInlineTargets(line: string, lineNumber: number, index = 0): Array<{ line: number; target: string }> {
   if (index >= line.length) {
     return []
@@ -114,9 +119,10 @@ function collectInlineTargets(line: string, lineNumber: number, index = 0): Arra
     return collectInlineTargets(line, lineNumber, index + 1)
   }
   const nestedTargets = collectInlineTargets(line.slice(labelStart + 1, labelEnd), lineNumber)
-  const target = line[labelEnd + 1] === "("
-    ? line[labelEnd + 2] === "<" ? readAngleBracketTarget(line, labelEnd + 3) : readMarkdownTarget(line, labelEnd + 2)
-    : undefined
+  const destStart = line[labelEnd + 1] === "(" ? skipLeadingWhitespace(line, labelEnd + 2) : -1
+  const target = destStart === -1
+    ? undefined
+    : line[destStart] === "<" ? readAngleBracketTarget(line, destStart + 1) : readMarkdownTarget(line, destStart)
   const currentTargets = target ? [...nestedTargets, { line: lineNumber, target }] : nestedTargets
   return [...currentTargets, ...collectInlineTargets(line, lineNumber, labelEnd + 1)]
 }
@@ -208,6 +214,18 @@ describe("markdown local link audit", () => {
 
   test("#given angle-bracket-wrapped destination with spaces #when collecting targets #then the spaced target is audited", () => {
     expect(collectLinkedTargets("[Release notes](<./docs/release notes.md>)")).toEqual([
+      { line: 1, target: "./docs/release notes.md" },
+    ])
+  })
+
+  test("#given whitespace-padded inline destination #when collecting targets #then leading whitespace after the paren is skipped", () => {
+    expect(collectLinkedTargets("[Guide]( ./guide/overview.md )")).toEqual([
+      { line: 1, target: "./guide/overview.md" },
+    ])
+  })
+
+  test("#given whitespace-padded angle-bracket destination #when collecting targets #then the spaced target is audited", () => {
+    expect(collectLinkedTargets("[Release notes]( <./docs/release notes.md> )")).toEqual([
       { line: 1, target: "./docs/release notes.md" },
     ])
   })

--- a/src/testing/create-plugin-module.test.ts
+++ b/src/testing/create-plugin-module.test.ts
@@ -233,7 +233,7 @@ describe("createPluginModule()", () => {
       // given
       const pluginModule = createTestPluginModule()
       const duplicatePlugins = [
-        "file:///Users/yeongyu/local-workspaces/omo/src/index.ts",
+        "file:///Users/dev/local-workspaces/omo/src/index.ts",
         "oh-my-openagent@latest",
       ]
       mockDetectDuplicateOmoPlugin.mockReturnValue({

--- a/src/testing/create-plugin-module.test.ts
+++ b/src/testing/create-plugin-module.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, mock } from "bun:test"
 import { getLocale, initI18n, t } from "../shared/i18n"
 import { createPluginModule } from "./create-plugin-module"
 
+const sourcePlugin = new URL("../index.ts", import.meta.url).href
+
 const mockInitConfigContext = mock(() => {})
 const mockDetectExternalSkillPlugin = mock(() => ({ detected: false, pluginName: null, allPlugins: [] }))
 const mockGetSkillPluginConflictWarning = mock(() => "")
@@ -233,7 +235,7 @@ describe("createPluginModule()", () => {
       // given
       const pluginModule = createTestPluginModule()
       const duplicatePlugins = [
-        "file:///Users/dev/local-workspaces/omo/src/index.ts",
+        sourcePlugin,
         "oh-my-openagent@latest",
       ]
       mockDetectDuplicateOmoPlugin.mockReturnValue({

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-Tools registered via [`createToolRegistry()`](file:///Users/yeongyu/local-workspaces/omo/src/plugin/tool-registry.ts) in `src/plugin/`. Native tools are factory-based (`createXXXTool`) except `interactive_bash` (`ToolDefinition`). LSP and AST-grep tools are no longer native `src/tools/` implementations; they are served by Tier-1 built-in MCPs `lsp` and `ast_grep` and keep the same exposed names (`lsp_diagnostics`, `ast_grep_search`, etc.).
+Tools registered via [`createToolRegistry()`](../plugin/tool-registry.ts) in `src/plugin/`. Native tools are factory-based (`createXXXTool`) except `interactive_bash` (`ToolDefinition`). LSP and AST-grep tools are no longer native `src/tools/` implementations; they are served by Tier-1 built-in MCPs `lsp` and `ast_grep` and keep the same exposed names (`lsp_diagnostics`, `ast_grep_search`, etc.).
 
 ## TOOL CATALOG
 
@@ -49,7 +49,7 @@ Tools registered via [`createToolRegistry()`](file:///Users/yeongyu/local-worksp
 
 ## DELEGATION CATEGORIES (built-in 8)
 
-`task` (delegate) selects model by category. Default category models live in provider-specific files under `src/tools/delegate-task/` and aggregate via `BUILTIN_CATEGORIES` in `builtin-categories.ts`. Authoritative fallback chains in [`src/shared/model-requirements.ts`](file:///Users/yeongyu/local-workspaces/omo/src/shared/model-requirements.ts) `CATEGORY_MODEL_REQUIREMENTS`.
+`task` (delegate) selects model by category. Default category models live in provider-specific files under `src/tools/delegate-task/` and aggregate via `BUILTIN_CATEGORIES` in `builtin-categories.ts`. Authoritative fallback chains in [`src/shared/model-requirements.ts`](../shared/model-requirements.ts) `CATEGORY_MODEL_REQUIREMENTS`.
 
 | Category | Default Model | Source File | Domain |
 |----------|---------------|-------------|--------|
@@ -66,7 +66,7 @@ User-defined categories declared in `categories: { ... }` config override and ex
 
 ## TOOL DIR LAYOUT
 
-```
+```text
 tools/
 ├── background-task/      # background_output, background_cancel (LLM interface; engine in features/background-agent)
 ├── call-omo-agent/       # call_omo_agent (explore + librarian only)


### PR DESCRIPTION
## Summary

Replace maintainer-local `file://` Markdown links in checked-in docs with repository-relative links and add a regression audit to keep local Markdown targets portable.

## Changes

- Converted `file:///Users/yeongyu/local-workspaces/omo/...` Markdown links in AGENTS docs to repository-relative Markdown links.
- Updated `docs/AGENTS.md` guidance to require repository-relative path links in checked-in docs.
- Added `src/shared/markdown-link-audit.test.ts` to audit checked-in Markdown local links while ignoring external URLs and code blocks.
- Fixed a stale `CHANGELOG.md` link from `packages/rules-core` to `packages/rules-engine`.

## Testing

- `bun test src/shared/markdown-link-audit.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

## Related Issues

Fixes #4468

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted docs and examples to portable, repository‑relative Markdown links and added a strict audit that blocks maintainer‑local paths and missing files. This makes links render consistently across machines and prevents regressions.

- **New Features**
  - Markdown link audit (`src/shared/markdown-link-audit.test.ts`) scans git‑tracked `*.md`, resolves repo‑relative and `file://` links (including `file://./..`), ignores code blocks/spans, and fails on missing files or maintainer‑local paths.
  - Hardened parsing supports `<...>` destinations with spaces, skips whitespace after `(`, handles nested/image and reference‑style links, and respects escapes.

- **Bug Fixes**
  - Replaced maintainer‑local `file:///...` paths with repo‑relative links across docs and AGENTS pages; updated docs guidance to require repo‑relative links.
  - Updated examples and tests to prefer relative links: prompt examples now use `src/*.ts:line` format; fixtures compute plugin URLs via `import.meta.url`; config snippets use `file://./...`; normalized worktree examples to `<repo-root>`.
  - Fixed `CHANGELOG.md` reference from `packages/rules-core` to `packages/rules-engine`.

<sup>Written for commit 4516175d603401060451b38b5d354191ffecede1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

