### PR TITLE
fix(skills): preserve external provider-named skills

### DIFF
--- a/src/features/opencode-skill-loader/skill-content.test.ts
+++ b/src/features/opencode-skill-loader/skill-content.test.ts
@@ -547,6 +547,31 @@ describe("resolveMultipleSkills with browserProvider", () => {
 })
 
 describe("resolveMultipleSkillsAsync with browserProvider filtering", () => {
+	it("should resolve discovered non-builtin agent-browser when browserProvider is playwright", async () => {
+		// given: an OpenCode user skill shares a name with a non-selected browser provider
+		const skillDir = join(testConfigDir, "skills", "agent-browser")
+		mkdirSync(skillDir, { recursive: true })
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			[
+				"---",
+				"name: agent-browser",
+				"description: External agent-browser skill",
+				"---",
+				"External agent-browser body.",
+				"",
+			].join("\n"),
+		)
+
+		// when: resolving the external skill with the default playwright provider
+		const result = await resolveMultipleSkillsAsync(["agent-browser"])
+
+		// then: provider gating does not hide user-defined skills
+		expect(result.resolved.has("agent-browser")).toBe(true)
+		expect(result.resolved.get("agent-browser")).toContain("External agent-browser body")
+		expect(result.notFound).not.toContain("agent-browser")
+	})
+
 	it("should exclude discovered agent-browser when browserProvider is playwright", async () => {
 		// given: playwright is the selected browserProvider (default)
 		const skillNames = ["playwright", "git-master"]

--- a/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/src/features/opencode-skill-loader/skill-discovery.ts
@@ -54,6 +54,10 @@ export async function getAllSkills(options?: SkillResolutionOptions): Promise<Lo
 
 	// Filter discovered skills to exclude provider-gated names that don't match the selected provider
 	const filteredDiscoveredSkills = discoveredSkills.filter((skill) => {
+		if (skill.scope !== "builtin") {
+			return true
+		}
+
 		if (!providerGatedSkillNames.has(skill.name)) {
 			return true
 		}

--- a/src/plugin/skill-context.test.ts
+++ b/src/plugin/skill-context.test.ts
@@ -19,7 +19,7 @@ describe("createSkillContext", () => {
     rmSync(testDirectory, { recursive: true, force: true })
   })
 
-  it("excludes discovered playwright skill when browser provider is agent-browser", async () => {
+  it("keeps discovered playwright skill when browser provider is agent-browser", async () => {
     // given
     const discoveredPlaywrightDir = join(testDirectory, ".claude", "skills", "playwright")
     mkdirSync(discoveredPlaywrightDir, { recursive: true })
@@ -74,8 +74,8 @@ describe("createSkillContext", () => {
       // then
       expect(result.browserProvider).toBe("agent-browser")
       expect(result.mergedSkills.some((skill) => skill.name === "agent-browser")).toBe(true)
-      expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(false)
-      expect(result.availableSkills.some((skill) => skill.name === "playwright")).toBe(false)
+      expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(true)
+      expect(result.availableSkills.some((skill) => skill.name === "playwright")).toBe(true)
     } finally {
       discoverConfigSourceSkillsSpy.mockRestore()
       discoverUserClaudeSkillsSpy.mockRestore()
@@ -86,7 +86,7 @@ describe("createSkillContext", () => {
     }
   })
 
-  it("excludes discovered dev-browser skill when browser provider is playwright", async () => {
+  it("keeps discovered dev-browser skill when browser provider is playwright", async () => {
     // given
     const discoveredDevBrowserSkill = {
       name: "dev-browser",
@@ -137,8 +137,8 @@ describe("createSkillContext", () => {
       // then
       expect(result.browserProvider).toBe("playwright")
       expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(true)
-      expect(result.mergedSkills.some((skill) => skill.name === "dev-browser")).toBe(false)
-      expect(result.availableSkills.some((skill) => skill.name === "dev-browser")).toBe(false)
+      expect(result.mergedSkills.some((skill) => skill.name === "dev-browser")).toBe(true)
+      expect(result.availableSkills.some((skill) => skill.name === "dev-browser")).toBe(true)
     } finally {
       discoverConfigSourceSkillsSpy.mockRestore()
       discoverUserClaudeSkillsSpy.mockRestore()

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -39,6 +39,10 @@ function filterProviderGatedSkills(
   browserProvider: BrowserAutomationProvider,
 ): LoadedSkill[] {
   return skills.filter((skill) => {
+    if (skill.scope !== "builtin") {
+      return true
+    }
+
     if (!PROVIDER_GATED_SKILL_NAMES.has(skill.name)) {
       return true
     }


### PR DESCRIPTION
## Summary
- apply browser provider gating only to builtin browser skills
- keep user/project skills named agent-browser, playwright, or dev-browser resolvable
- add regression coverage for external agent-browser resolution

## Context
Previous provider-gating work appears to have intentionally filtered discovered browser-provider skills across all sources, not only builtins. That behavior prevents discovered `agent-browser`, `playwright`, or `dev-browser` skills from overriding the configured `browser_automation_engine.provider`.

This PR intentionally narrows that behavior. The browser provider gate still applies to builtin browser variants, so agents only see the selected builtin browser automation implementation. However, higher-priority user/project/OpenCode skills can also intentionally use names like `agent-browser` or `playwright`. The skill loader documents that same-named higher-priority skills override lower-priority builtin/plugin skills, and `.agents/skills` paths are now part of native skill discovery.

Without the scope check, provider gating removes those user-defined skills before priority merging can preserve them. In practice, a user-installed `~/.agents/skills/agent-browser/SKILL.md` can disappear solely because the configured builtin provider is `playwright`.

## Prior behavior
- `browser_automation_engine.provider` selected the builtin browser skill.
- Discovered skills with provider-like names were also filtered before merge.
- This meant same-named user/project skills could not override builtin browser-provider choices.

## New behavior
- Builtin browser variants remain provider-gated.
- Non-builtin skills are left to normal scope priority and explicit skill resolution.
- User/project/OpenCode skills named `agent-browser`, `playwright`, or `dev-browser` remain resolvable.

## Testing
- bun run typecheck
- HOME="/var/folders/41/p190xfs12fb321fs2696lcp40000gn/T/opencode/omo-test-home" bun test src/plugin/skill-context.test.ts src/features/opencode-skill-loader/skill-content.test.ts