### PR TITLE
fix(team-mode): wake leader session on every member completion message (#4464)

### DIFF
--- a/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
+++ b/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
+import { saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import type { RuntimeState } from "../../features/team-mode/types"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../shared/prompt-async-gate"
+import { createTeamIdleWakeHint } from "./team-idle-wake-hint"
+
+type WakeHintPromptInput = {
+  readonly path: { readonly id: string }
+  readonly body: {
+    readonly parts: readonly { readonly type: "text"; readonly text: string }[]
+  }
+  readonly query: { readonly directory: string }
+}
+
+const temporaryDirectories: string[] = []
+const COMPLETION_CYCLE_COUNT = 6
+
+async function createTemporaryBaseDir(): Promise<string> {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "team-leader-wake-hint-"))
+  temporaryDirectories.push(baseDir)
+  return baseDir
+}
+
+function createConfig(baseDir: string): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+}
+
+function createLeaderRuntimeState(teamRunId: string): RuntimeState {
+  return {
+    version: 1,
+    teamRunId,
+    teamName: "team-alpha",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "lead",
+        sessionId: "lead-session",
+        agentType: "leader",
+        status: "idle",
+        pendingInjectedMessageIds: [],
+      },
+      {
+        name: "worker",
+        sessionId: "worker-session",
+        agentType: "general-purpose",
+        status: "idle",
+        pendingInjectedMessageIds: [],
+      },
+    ],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10_000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
+
+async function seedRuntimeState(runtimeState: RuntimeState, config: TeamModeConfig): Promise<void> {
+  await mkdir(path.join(config.base_dir ?? "", "runtime", runtimeState.teamRunId), { recursive: true })
+  await saveRuntimeState(runtimeState, config)
+}
+
+async function sendCompletionToLead(teamRunId: string, config: TeamModeConfig, body: string, timestamp: number): Promise<void> {
+  await sendMessage({
+    version: 1,
+    messageId: randomUUID(),
+    from: "worker",
+    to: "lead",
+    kind: "message",
+    body,
+    timestamp,
+  }, teamRunId, config, { isLead: false, activeMembers: ["lead"] })
+}
+
+afterEach(async () => {
+  releaseAllPromptAsyncReservationsForTesting()
+  await Promise.all(temporaryDirectories.splice(0).map(async (directoryPath) => {
+    await rm(directoryPath, { recursive: true, force: true })
+  }))
+})
+
+describe("createTeamIdleWakeHint leader delivery", () => {
+  test("#given repeated member completions to an idle leader #when each cycle idles after delivery #then every completion wakes the leader", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    const config = createConfig(baseDir)
+    const teamRunId = randomUUID()
+    await seedRuntimeState(createLeaderRuntimeState(teamRunId), config)
+
+    const promptInputs: WakeHintPromptInput[] = []
+    const promptAsyncSpy = mock(async (input: WakeHintPromptInput) => {
+      promptInputs.push(input)
+      return {}
+    })
+    const handler = createTeamIdleWakeHint({
+      directory: "/tmp/project",
+      client: { session: { promptAsync: promptAsyncSpy } },
+    }, config)
+
+    // when
+    const completionBodies = Array.from(
+      { length: COMPLETION_CYCLE_COUNT },
+      (_, index) => `completion ${index + 1}`,
+    )
+    for (const [index, body] of completionBodies.entries()) {
+      await sendCompletionToLead(teamRunId, config, body, 100 + index)
+      await handler({ event: { type: "session.idle", properties: { sessionID: "lead-session" } } })
+      releasePromptAsyncReservation("lead-session", "team-idle-wake-hint")
+    }
+
+    // then
+    expect(promptAsyncSpy).toHaveBeenCalledTimes(COMPLETION_CYCLE_COUNT)
+    expect(promptInputs.map((input) => input.path.id)).toEqual(Array(COMPLETION_CYCLE_COUNT).fill("lead-session"))
+    expect(promptInputs.at(-1)?.body.parts[0]?.text).toContain(`${COMPLETION_CYCLE_COUNT} new team messages`)
+
+    const unreadMessages = await listUnreadMessages(teamRunId, "lead", config)
+    expect(unreadMessages.map((message) => message.body)).toEqual(completionBodies)
+  })
+})

--- a/src/hooks/team-session-events/team-idle-wake-hint.ts
+++ b/src/hooks/team-session-events/team-idle-wake-hint.ts
@@ -177,17 +177,6 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
         return
       }
 
-      if (latestMemberEntry.agentType === "leader") {
-        log("team lead idle handled without wake hint", {
-          event: "team-mode-lead-idle-ack-only",
-          teamRunId: latestRuntimeState.teamRunId,
-          memberName: latestMemberEntry.name,
-          sessionID,
-          ackedCount: pendingInjectedMessageIds.length,
-        })
-        return
-      }
-
       if (typeof ctx.client.session.promptAsync !== "function") {
         log("team idle wake hint skipped without promptAsync", {
           event: "team-mode-idle-wake-hint-skipped",


### PR DESCRIPTION
## Summary
- Fixes #4464 by allowing the team idle wake hint hook to wake alive idle leaders when unread mailbox messages exist.
- Adds a regression test that simulates 6 member completion cycles to one leader and asserts every cycle dispatches a wake prompt while all messages remain delivered in the mailbox.
- Keeps the fix narrow to the leader wake path and does not touch PR #4472's inactive-member relaunch path.

## Testing
- \bun test v1.3.12 (700fc117) ✅
- \bun test v1.3.12 (700fc117) ✅
- \bun test v1.3.12 (700fc117) ✅
- \bun test v1.3.12 (700fc117)
Bundled 18 modules in 3ms

  cli.js  30.59 KB  (entry point)

Bundled 1393 modules in 45ms

  index.js  4.68 MB  (entry point)

Patched Node/Electron require shim in dist/index.js
Bundled 614 modules in 26ms

  index.js  2.41 MB  (entry point)

Generating JSON Schema...
✓ JSON Schema generated: assets/oh-my-opencode.schema.json ✅
- LSP diagnostics on changed files ✅

## Related Issues
Fixes #4464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wake idle leader sessions whenever unread team mailbox messages exist, so leaders are prompted on every member completion. Fixes #4464 and does not change the inactive-member relaunch path.

- **Bug Fixes**
  - Removed the leader-only early return in the idle wake hint so leaders receive a wake prompt when unread messages are present.
  - Added a regression test that simulates six member completion cycles and verifies a wake prompt per cycle, with all messages preserved in the mailbox.

<sup>Written for commit 58025f9ba44db2d24b5870422049b3d2888a0060. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

