### PR TITLE
fix(thinking-block-validator): prevent dual thinking streams after question tool response (#4374)

### DIFF
--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -78,14 +78,15 @@ function hasContentParts(parts: Part[]): boolean {
 }
 
 /**
- * Check if a message starts with a thinking/reasoning block
+ * Check if a message already carries a thinking/reasoning block anywhere.
  */
-function startsWithThinkingBlock(parts: Part[]): boolean {
+function hasThinkingBlock(parts: Part[]): boolean {
   if (!parts || parts.length === 0) return false
 
-  const firstPart = parts[0]
-  const type = firstPart.type as string
-  return type === "thinking" || type === "redacted_thinking" || type === "reasoning"
+  return parts.some((part) => {
+    const type = part.type as string
+    return type === "thinking" || type === "redacted_thinking" || type === "reasoning"
+  })
 }
 
 /**
@@ -160,8 +161,8 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
         // Only check assistant messages
         if (msg.info.role !== "assistant") continue
 
-        // Check if message has content parts but doesn't start with thinking
-        if (hasContentParts(msg.parts) && !startsWithThinkingBlock(msg.parts)) {
+        // Check if message has content parts but no thinking block yet.
+        if (hasContentParts(msg.parts) && !hasThinkingBlock(msg.parts)) {
           // Find the most recent real thinking part (with valid signature) from
           // previous turns.  If none exists we cannot safely inject a thinking
           // block - a synthetic block without a signature would cause the API

--- a/src/plugin/messages-transform-thinking-block.test.ts
+++ b/src/plugin/messages-transform-thinking-block.test.ts
@@ -1,0 +1,100 @@
+declare const describe: (name: string, fn: () => void) => void
+declare const it: (name: string, fn: () => void | Promise<void>) => void
+declare const expect: <T>(value: T) => {
+  toBe(expected: T): void
+}
+
+import type { CreatedHooks } from "../create-hooks"
+import { createThinkingBlockValidatorHook } from "../hooks/thinking-block-validator/hook"
+import { createToolPairValidatorHook } from "../hooks/tool-pair-validator/hook"
+import { createMessagesTransformHandler } from "./messages-transform"
+
+type TestPart = {
+  type: string
+  id?: string
+  toolUseId?: string
+  tool_use_id?: string
+  name?: string
+  content?: Array<{ type: "text"; text: string }>
+  text?: string
+  thinking?: string
+  signature?: string
+}
+
+type TestMessage = {
+  info: {
+    role: "assistant" | "user"
+    id?: string
+    sessionID?: string
+  }
+  parts: TestPart[]
+}
+
+function createTestHooks(): CreatedHooks {
+  return {
+    thinkingBlockValidator: createThinkingBlockValidatorHook(),
+    toolPairValidator: createToolPairValidatorHook(),
+  } as CreatedHooks
+}
+
+async function runMessagesTransform(messages: TestMessage[]): Promise<void> {
+  const handler = createMessagesTransformHandler({ hooks: createTestHooks() })
+  await handler({}, { messages: messages as never })
+}
+
+function countThinkingParts(parts: TestPart[]): number {
+  return parts.filter((part) => part.type === "thinking" || part.type === "redacted_thinking").length
+}
+
+describe("messages transform thinking block integration", () => {
+  it("#given a question tool answer and a resumed assistant turn with existing thinking #when messages transform runs #then it keeps one thinking block in that assistant turn", async () => {
+    //#given
+    const thinkingBeforeQuestion: TestPart = {
+      type: "thinking",
+      thinking: "ask a clarifying question",
+      signature: "sig-before-question",
+    }
+    const thinkingAfterAnswer: TestPart = {
+      type: "thinking",
+      thinking: "continue after answer",
+      signature: "sig-after-answer",
+    }
+    const messages = [
+      {
+        info: { id: "msg_user_prompt", role: "user", sessionID: "ses_question_thinking" },
+        parts: [{ type: "text", text: "think, then ask a question" }],
+      },
+      {
+        info: { id: "msg_question", role: "assistant", sessionID: "ses_question_thinking" },
+        parts: [thinkingBeforeQuestion, { type: "tool_use", id: "toolu_question", name: "question" }],
+      },
+      {
+        info: { id: "msg_question_answer", role: "user", sessionID: "ses_question_thinking" },
+        parts: [
+          {
+            type: "tool_result",
+            toolUseId: "toolu_question",
+            tool_use_id: "toolu_question",
+            content: [{ type: "text", text: "answer" }],
+          },
+        ],
+      },
+      {
+        info: { id: "msg_resumed", role: "assistant", sessionID: "ses_question_thinking" },
+        parts: [
+          { type: "text", text: "resuming" },
+          thinkingAfterAnswer,
+          { type: "tool_use", id: "toolu_after_answer", name: "bash" },
+        ],
+      },
+    ] satisfies TestMessage[]
+
+    //#when
+    await runMessagesTransform(messages)
+
+    //#then
+    const resumedMessage = messages.find((message) => message.info.id === "msg_resumed")
+    expect(resumedMessage?.parts[1]).toBe(thinkingAfterAnswer)
+    expect(countThinkingParts(resumedMessage?.parts ?? [])).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #4374 by making the proactive thinking block validator idempotent when an assistant message already contains a thinking part later in the part list. This prevents stale pre-question thinking from being prepended to the resumed assistant turn after a question tool answer.

## Changes
- Treat any existing thinking/reasoning part in an assistant message as sufficient, not only a leading thinking part.
- Add a messages-transform regression test covering question tool answer history with resumed thinking.

## Testing
- `bun test src/hooks/thinking-block-validator/hook.test.ts src/plugin/messages-transform-thinking-block.test.ts src/hooks/tool-pair-validator/hook.test.ts src/hooks/session-recovery/index.test.ts src/shared/prompt-async-route-audit.test.ts src/shared/mock-module-lifecycle-audit.test.ts` ✅
- `bun test` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- LSP diagnostics on changed files ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate thinking blocks when resuming an assistant turn after a question tool answer, keeping only the intended thinking stream. Fixes #4374 by skipping injection if any thinking/reasoning part already exists in the message.

- **Bug Fixes**
  - Detects thinking/reasoning anywhere in an assistant message (`thinking`, `redacted_thinking`, `reasoning`) and avoids prepending stale thinking.
  - Adds a `messages-transform` integration test for question tool answer history to ensure only one thinking block remains.

<sup>Written for commit e443e86d61500b491f533de3797c803c00c69043. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4477?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

