### PR TITLE
fix(parent-wake-notifier): deliver background completion reminders during active parent turn (#4164)

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -2449,8 +2449,14 @@ The task was re-queued on a fallback model after a retryable failure.
         const shouldDeferNotification = await this.isSessionActive(task.parentSessionId)
 
         if (shouldDeferNotification) {
-          this.queuePendingParentWake(task.parentSessionId, notification, parentPromptContext, shouldReply)
-          log("[background-agent] Deferred notification until parent session is idle:", {
+          this.queuePendingParentWake(
+            task.parentSessionId,
+            notification,
+            parentPromptContext,
+            shouldReply,
+            PENDING_PARENT_WAKE_DEBOUNCE_MS,
+          )
+          log("[background-agent] Queued notification while parent session is active:", {
             taskId: task.id,
             allComplete,
             isTaskFailure,

--- a/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -108,6 +108,61 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake active turn events", () => {
+  test("#when background task completes during active parent turn #then parent gets same-turn no-reply reminder", async () => {
+    // given
+    const sessionStatuses: Record<string, { type: string }> = {
+      "parent-1": { type: "busy" },
+    }
+    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
+    managerUnderTest = manager
+    const task = createTask({
+      id: "task-a",
+      parentSessionId: "parent-1",
+      description: "task A",
+      status: "completed",
+      completedAt: new Date("2026-05-20T14:19:14.625Z"),
+    })
+    getTasks(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+    // when
+    await notifyParentSessionForTest(manager, task)
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
+  })
+
+  test("#when background task fails during active parent turn #then parent wake stays deferred", async () => {
+    // given
+    const sessionStatuses: Record<string, { type: string }> = {
+      "parent-1": { type: "busy" },
+    }
+    const { manager, promptAsyncCalls } = createManager(sessionStatuses)
+    managerUnderTest = manager
+    const task = createTask({
+      id: "task-a",
+      parentSessionId: "parent-1",
+      description: "task A",
+      status: "error",
+      error: "UnknownError: UnknownError",
+      completedAt: new Date("2026-05-20T14:19:14.625Z"),
+    })
+    getTasks(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+    // when
+    await notifyParentSessionForTest(manager, task)
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(0)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+  })
+
   test("#when parent reasoning delta is newer than stale idle state #then background completion does not fork a reply", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -77,6 +77,19 @@ type ToolWaitDeferralDecision = {
 
 type Unrefable = ReturnType<typeof setTimeout> & { unref?: () => unknown }
 
+const ACTIVE_TURN_COMPLETION_NOTIFICATION_MARKERS = [
+  "[BACKGROUND TASK COMPLETED]",
+  "[ALL BACKGROUND TASKS COMPLETE]",
+] as const
+
+function notificationAllowsActiveTurnDelivery(notification: string): boolean {
+  return ACTIVE_TURN_COMPLETION_NOTIFICATION_MARKERS.some((marker) => notification.includes(marker))
+}
+
+function pendingWakeAllowsActiveTurnDelivery(wake: PendingParentWake): boolean {
+  return wake.notifications.length > 0 && wake.notifications.every(notificationAllowsActiveTurnDelivery)
+}
+
 function unrefTimerHandle(handle: ReturnType<typeof setTimeout>): void {
   const maybeUnref = (handle as Unrefable).unref
   if (typeof maybeUnref === "function") {
@@ -151,21 +164,24 @@ export class ParentWakeNotifier {
       return
     }
 
-    if (await this.isSessionActive(sessionID)) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      return
-    }
-
+    const sessionActive = await this.isSessionActive(sessionID)
     this.clearPendingParentWakeTimer(sessionID)
-    await settleAfterSessionIdle()
+    if (!sessionActive) {
+      await settleAfterSessionIdle()
 
-    if (await this.isSessionActive(sessionID)) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      return
+      if (await this.isSessionActive(sessionID)) {
+        this.schedulePendingParentWakeFlush(sessionID)
+        return
+      }
     }
 
     const latestWake = this.pendingParentWakes.get(sessionID)
     if (!latestWake) {
+      return
+    }
+    const canDeliverDuringActiveTurn = sessionActive && pendingWakeAllowsActiveTurnDelivery(latestWake)
+    if (sessionActive && !canDeliverDuringActiveTurn) {
+      this.schedulePendingParentWakeFlush(sessionID)
       return
     }
 
@@ -218,11 +234,12 @@ export class ParentWakeNotifier {
         source: "background-agent-parent-wake",
         settleMs: 0,
         queueBehavior: "defer",
+        checkStatus: !canDeliverDuringActiveTurn,
         checkToolState: !toolWaitDecision.skipPromptGateToolStateCheck,
         input: {
           path: { id: sessionID },
           body: {
-            noReply: !latestWake.shouldReply,
+            noReply: canDeliverDuringActiveTurn ? true : !latestWake.shouldReply,
             ...latestWake.promptContext,
             parts: [createInternalAgentTextPart(notificationContent)],
           },


### PR DESCRIPTION
## Summary
Fixes #4164 by allowing successful background completion reminders to dispatch during an active parent turn without forking a new reply.

## Changes
- Allows `[BACKGROUND TASK COMPLETED]` and `[ALL BACKGROUND TASKS COMPLETE]` parent wakes to bypass only the active-status gate while still routing through `dispatchInternalPrompt`.
- Forces active-turn completion delivery to `noReply: true` so it informs the current turn instead of starting an overlapping assistant reply.
- Keeps failed/cancelled/interrupted wakes deferred while active to avoid regressing #4470.
- Shortens active-session completion flush scheduling to the same debounce used for idle parents.

## Testing
- `bun test src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/task-completion-cleanup.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/parent-wake-assistant-blocking.test.ts src/features/background-agent/manager.test.ts` ✅
- `bun test src/shared/prompt-async-route-audit.test.ts src/shared/mock-module-lifecycle-audit.test.ts` ✅
- `bun run typecheck` ✅
- `bun test` ✅ (`BUN_TEST_EXIT=0`)
- `bun run build` ✅

## Notes
- `parent-wake-notifier.ts` and `manager.ts` are inherited oversized files; this PR keeps the #4164/#4470 overlap fix surgical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers background completion reminders during an active parent turn without spawning a new assistant reply. Addresses #4164 while keeping #4470 protections intact.

- **Bug Fixes**
  - Only completion wakes (marked “[BACKGROUND TASK COMPLETED]” / “[ALL BACKGROUND TASKS COMPLETE]”) bypass the active-session gate and are sent with `noReply` to update the current turn.
  - Failed/cancelled/interrupted wakes remain deferred while active; status/tool checks stay enabled.
  - Unified debounce for active-session flushes with the idle debounce by passing `PENDING_PARENT_WAKE_DEBOUNCE_MS` to `queuePendingParentWake`.
  - Added tests for active-turn success (same-turn, no-reply) and failure (deferred).

<sup>Written for commit ec7ce51ea63dad1089adcceea1a603caa6b448e3. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

