### PR TITLE
fix(atlas): add hard cap on total continuation injections per session

### DIFF
--- a/src/hooks/atlas/idle-event.ts
+++ b/src/hooks/atlas/idle-event.ts
@@ -27,6 +27,7 @@ import { HOOK_NAME } from "./hook-name"
 import { resolveActiveBoulderSession } from "./resolve-active-boulder-session"
 import { BOULDER_COMPLETE_PROMPT } from "./system-reminder-templates"
 import {
+  incrementAndCheckTotalInjectionCap,
   markContinuationStalled,
   resetStallStateForPlanChange,
   shouldAbortForNoToolProgress,
@@ -400,6 +401,32 @@ export async function handleAtlasSessionIdle(input: {
       noProgressIterations,
       reason: sessionState.stalledContinuationReason,
     })
+    return
+  }
+
+  // Hard-cap guard: absolute ceiling on continuation injections per session.
+  // This prevents infinite loops when the LLM makes qualifying tool calls
+  // (grep, read) that reset the no-tool-progress counter without actually
+  // resolving the underlying task.
+  if (incrementAndCheckTotalInjectionCap(sessionState)) {
+    markContinuationStalled(
+      sessionState,
+      boulderState.plan_name,
+      activePlanPath,
+    )
+    if (sessionState.pendingRetryTimer) {
+      clearTimeout(sessionState.pendingRetryTimer)
+      sessionState.pendingRetryTimer = undefined
+    }
+    log(
+      `[${HOOK_NAME}] Aborting boulder continuation: total injection count exceeded hard cap`,
+      {
+        sessionID,
+        plan: boulderState.plan_name,
+        totalInjections: sessionState.totalContinuationInjections,
+        reason: sessionState.stalledContinuationReason,
+      },
+    )
     return
   }
 

--- a/src/hooks/atlas/tool-progress.ts
+++ b/src/hooks/atlas/tool-progress.ts
@@ -11,6 +11,21 @@ const FAILURE_OUTPUT_PATTERN = /^\s*(?:error|failed|failure|denied|rejected)\b/i
 
 export const MAX_BOULDER_CONTINUATION_NO_TOOL_PROGRESS = 3
 
+/**
+ * Absolute ceiling on continuation injections per session, regardless of
+ * whether the agent produces "tangible" tool progress (bash/edit/write).
+ *
+ * Rationale: the no-tool-progress guard resets every time the LLM calls a
+ * qualifying tool (e.g. a simple `grep`), so a stuck agent that reads files
+ * but never actually resolves its tasks can loop indefinitely.  This hard
+ * cap guarantees the loop terminates.
+ *
+ * At ~11 s per injection cycle (5 s cooldown + 6 s retry delay), 50
+ * injections ≈ 9 minutes — generous enough for genuine work but short
+ * enough to prevent the 5+ hour infinite loops we have observed.
+ */
+export const MAX_TOTAL_CONTINUATION_INJECTIONS = 50
+
 export type ToolProgressOutput = {
   title?: string
   output?: string
@@ -74,4 +89,10 @@ export function shouldAbortForNoToolProgress(state: SessionState): boolean {
 export function markContinuationStalled(state: SessionState, planName: string, planPath: string): void {
   state.stalledContinuationReason = `Boulder continuation stalled for plan "${planName}": ${MAX_BOULDER_CONTINUATION_NO_TOOL_PROGRESS} consecutive continuation iterations produced no successful bash/edit/write tool progress.`
   state.stalledContinuationPlanPath = planPath
+}
+
+/** Increment the per-session injection counter and return whether the hard cap was hit. */
+export function incrementAndCheckTotalInjectionCap(state: SessionState): boolean {
+  state.totalContinuationInjections = (state.totalContinuationInjections ?? 0) + 1
+  return state.totalContinuationInjections >= MAX_TOTAL_CONTINUATION_INJECTIONS
 }

--- a/src/hooks/atlas/types.ts
+++ b/src/hooks/atlas/types.ts
@@ -56,4 +56,6 @@ export interface SessionState {
   stalledContinuationPlanPath?: string
   /** The plan path the in-progress no-tool-progress counter is keyed to. Changes here reset the counter. */
   activeContinuationPlanPath?: string
+  /** Total number of continuation injections for this session (used by hard-cap guard). */
+  totalContinuationInjections?: number
 }


### PR DESCRIPTION
## Problem

The atlas hook's `handleAtlasSessionIdle` can enter an infinite continuation loop when:

1. The plan has unchecked top-level checkboxes (`[ ]`) under `## TODOs` or `## Final Verification Wave`
2. All actual implementation work is already done, but the LLM fails to mark the checkboxes (plan file too large, nested format mismatch, etc.)
3. Each continuation injection causes the LLM to make "tangible" tool calls (`bash grep`, `Read`) that reset the `no-tool-progress` counter

**Observed in production**: 2,262 injection attempts over 5+ hours (~8 s per cycle) for a plan where all tasks were already implemented but checkboxes were not yet updated.

```
[2026-05-25T16:12:34Z] [atlas] Injecting boulder continuation { remaining: 9 }
[2026-05-25T16:12:40Z] [atlas] Injecting boulder continuation { remaining: 9 }
...2260 more times...
[2026-05-25T21:16:47Z] [atlas] Injecting boulder continuation { remaining: 9 }
```

### Why the existing guard fails

`MAX_BOULDER_CONTINUATION_NO_TOOL_PROGRESS = 3` only counts *consecutive* iterations where no `bash`/`edit`/`write` tool makes progress. But `bash grep ...` and `Read` qualify as tangible progress, so the counter resets to 0 every time the LLM reads a file or runs a grep — which is exactly what it does when checking whether a task is implemented.

## Solution

Add `MAX_TOTAL_CONTINUATION_INJECTIONS = 50` as an absolute ceiling on continuation injections per session, regardless of tool progress. When hit, the session is marked stalled (same mechanism as the existing no-tool-progress guard) and no further continuations are injected.

At ~11 s per injection cycle (5 s cooldown + 6 s retry delay), 50 injections ≈ 9 minutes — generous enough for genuine multi-task work but short enough to prevent the unbounded loops we observed.

## Changes

| File | Change |
|------|--------|
| `src/hooks/atlas/types.ts` | Add `totalContinuationInjections?: number` to `SessionState` |
| `src/hooks/atlas/tool-progress.ts` | Add `MAX_TOTAL_CONTINUATION_INJECTIONS` constant + `incrementAndCheckTotalInjectionCap()` helper |
| `src/hooks/atlas/idle-event.ts` | Call hard-cap check after the existing `shouldAbortForNoToolProgress` guard |

## Testing

The change is defensive — it only triggers after 50+ injections in a single session, which only happens in the stuck-loop scenario. Normal plan execution completes well within the cap.

Verified locally by patching the compiled `dist/index.js` with the equivalent logic and confirming that a previously stuck plan session terminates after 30 injections (our local patch used 30; this PR uses 50 to be more generous).

## Edge Cases

- **Plan changes mid-session**: The `totalContinuationInjections` counter is per-session, not per-plan. If the boulder switches plans, the counter continues. This is intentional — a session that has already consumed 50 injections without completing is likely stuck regardless of which plan it's working on.
- **Long-running legitimate work**: 50 injections × ~11 s = ~9 minutes of wall clock time. Plans that genuinely need more time will have their tasks completed and checkboxes marked, which triggers the `progress.isComplete` path and resets the session.
- **Interaction with stalled detection**: If `shouldAbortForNoToolProgress` fires first (3 consecutive no-progress iterations), it sets `stalledContinuationReason` which causes early return before the hard-cap check. The hard cap only fires when the no-progress guard is repeatedly defeated by trivial tool calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hard cap on continuation injections per Atlas session to stop infinite loops when trivial tool calls reset the no-progress counter. When the cap is hit (50), the session is marked stalled and no further continuations are injected (~9 minutes max loop time).

- **Bug Fixes**
  - Added `MAX_TOTAL_CONTINUATION_INJECTIONS = 50` and `incrementAndCheckTotalInjectionCap()`.
  - Tracked `totalContinuationInjections` in `SessionState`.
  - Applied the hard-cap check in `handleAtlasSessionIdle` after the existing no-tool-progress guard, clearing any pending retry timer and logging the stall reason.

<sup>Written for commit abc2644865cf4da2cb28c3deb7b83b7f7e2b92f0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

