### PR TITLE
fix(posthog): make OMO_DISABLE_POSTHOG env parsing case-insensitive and trim-tolerant (refs #4368)

### DIFF
--- a/src/shared/posthog.test.ts
+++ b/src/shared/posthog.test.ts
@@ -142,6 +142,68 @@ describe("posthog client creation", () => {
   })
 })
 
+describe("posthog disable env var parsing", () => {
+  beforeEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  afterEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  const disableValues = ["TRUE", "True", "Yes", "YES", " 1 ", " true "]
+
+  for (const value of disableValues) {
+    it(`treats OMO_DISABLE_POSTHOG=${JSON.stringify(value)} as disabled`, async () => {
+      // given
+      process.env.OMO_DISABLE_POSTHOG = value
+      process.env.POSTHOG_API_KEY = "test-api-key"
+      const captured: CapturedPostHogMessage[] = []
+      mockPostHogNode(captured)
+      const posthogModule = await importPostHogModule()
+      posthogModule.__setActivityStateProviderForTesting(() => ({
+        dayUTC: "2026-04-18",
+        captureDaily: true,
+      }))
+      const client = posthogModule.createCliPostHog()
+
+      // when
+      client.trackActive("distinct-cli", "run_started")
+
+      // then
+      expect(captured).toHaveLength(0)
+      posthogModule.__resetActivityStateProviderForTesting()
+    })
+  }
+
+  const sendFalsyValues = ["NO", "No", "FALSE", "False", " 0 "]
+
+  for (const value of sendFalsyValues) {
+    it(`treats OMO_SEND_ANONYMOUS_TELEMETRY=${JSON.stringify(value)} as disabled`, async () => {
+      // given
+      process.env.OMO_SEND_ANONYMOUS_TELEMETRY = value
+      process.env.POSTHOG_API_KEY = "test-api-key"
+      const captured: CapturedPostHogMessage[] = []
+      mockPostHogNode(captured)
+      const posthogModule = await importPostHogModule()
+      posthogModule.__setActivityStateProviderForTesting(() => ({
+        dayUTC: "2026-04-18",
+        captureDaily: true,
+      }))
+      const client = posthogModule.createCliPostHog()
+
+      // when
+      client.trackActive("distinct-cli", "run_started")
+
+      // then
+      expect(captured).toHaveLength(0)
+      posthogModule.__resetActivityStateProviderForTesting()
+    })
+  }
+})
+
 describe("posthog trackActive emission contract", () => {
   let resetActivityStateProvider: (() => void) | null = null
 

--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -61,8 +61,12 @@ function isFalsy(value: string | undefined): boolean {
   return value === "0" || value === "false" || value === "no"
 }
 
+function isTruthy(value: string | undefined): boolean {
+  return value === "1" || value === "true" || value === "yes"
+}
+
 function shouldDisablePostHog(): boolean {
-  if (process.env.OMO_DISABLE_POSTHOG === "true" || process.env.OMO_DISABLE_POSTHOG === "1") {
+  if (isTruthy(process.env.OMO_DISABLE_POSTHOG?.trim().toLowerCase())) {
     return true
   }
 


### PR DESCRIPTION
## Summary
Hardens telemetry env-var parsing so case-variant and whitespace-padded values are honored. The behavior change is strictly additive: every value already disabled today (`true`, `1`, `0`, `false`, `no`) is still disabled; only previously-ignored variants (`TRUE`, `Yes`, ` 1 `, ` true `, etc.) are now respected.

## Scope clarification (re: #4368)
Issue #4368 reports `OMO_DISABLE_POSTHOG=1` not disabling telemetry. The pre-fix code already strictly matched `=== "1"`, so this PR is **NOT a guaranteed fix for that specific reproduction** — the user's reported value already worked under the old code. A full codebase audit (every `new PostHog(...)`, every `capture()`, every `trackActive()`, every CLI entrypoint) confirmed there is **no telemetry capture path that bypasses `shouldDisablePostHog()`**, so the residual cause in #4368 is most likely environment-side (env var not propagated to the spawned bun process, or a broken plugin install — the `oh-my-openagent unknown` in their doctor output is consistent with a missing `~/.cache/opencode/node_modules/oh-my-openagent`).

Keeping `Refs #4368` rather than `Fixes #4368` so the issue stays open until the reporter's actual root cause is identified. The robustness improvement here closes the door on a *related* class of failures (case/whitespace mismatch on shell/CI env vars) that other users will eventually hit.

## Root Cause
`shouldDisablePostHog()` in `src/shared/posthog.ts` previously compared `OMO_DISABLE_POSTHOG` against the strict string literals `"true"` and `"1"`. Shell environments and config tooling frequently emit case-variant or padded values such as `TRUE`, `True`, `Yes`, ` 1 `, or ` true `; those values silently fell through to the default "capture telemetry" branch, even though the user clearly intended to opt out.

The companion var `OMO_SEND_ANONYMOUS_TELEMETRY` was already normalized via `.trim().toLowerCase()` before `isFalsy()` — the disable path just never received the same treatment.

## Changes
| File | Change |
|------|--------|
| `src/shared/posthog.ts` | Add symmetric `isTruthy()` helper; normalize `OMO_DISABLE_POSTHOG` with `.trim().toLowerCase()` before matching (mirror of the existing `OMO_SEND_ANONYMOUS_TELEMETRY` path) |
| `src/shared/posthog.test.ts` | 12 new given/when/then cases covering case-variant + whitespace inputs for both env vars |

Diff: +67 / −1 across 2 files. `fix()` only — no behavior change for values already handled (`true`, `1`, `0`, `false`, `no`).

## Reproduction (before fix)
```
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG="TRUE" as disabled
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG="True" as disabled
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG="Yes" as disabled
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG="YES" as disabled
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG=" 1 " as disabled
(fail) posthog disable env var parsing > treats OMO_DISABLE_POSTHOG=" true " as disabled

 10 pass
 6 fail
 32 expect() calls
```

## Verification (after fix)
```
bun test src/shared/posthog.test.ts
 16 pass
 0 fail
 32 expect() calls
Ran 16 tests across 1 file. [438.00ms]
```

## Test
- Regression test: `src/shared/posthog.test.ts` (12 new cases under `describe("posthog disable env var parsing")`)
- Related telemetry suite: `bun test src/shared/posthog{,-activity-state}.test.ts src/cli/cli-installer.telemetry.test.ts src/cli/run/runner.telemetry.test.ts src/index.telemetry.test.ts` — 25 pass
- Typecheck: `bun run typecheck` — clean

Refs #4368
