### PR TITLE
fix(start-work): substitute placeholders across all text parts + idempotent contextInfo append (#4480)

### DIFF
--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -1203,4 +1203,64 @@ You are starting a Sisyphus work session.
       }
     })
   })
+
+  // Regression coverage for #4480 — on an error-retry path OpenCode may
+  // re-issue the start-work template alongside the already-processed text,
+  // producing multiple text parts (or a second <session-context> block) with
+  // un-substituted $SESSION_ID / $TIMESTAMP literals. The hook must substitute
+  // across every text part, and must not stack a second contextInfo block.
+  describe("retry-path idempotence (#4480)", () => {
+    test("should substitute $SESSION_ID / $TIMESTAMP across all text parts", async () => {
+      // given - retry-style multi-part input where a second template was re-
+      // issued after the first part was already substituted by an earlier
+      // hook firing
+      const hook = createStartWorkHook(createMockPluginInput())
+      const output = {
+        parts: [
+          {
+            type: "text",
+            text: createStartWorkPrompt({ sessionContext: "Session: ses-abc123\nTimestamp: 2026-01-01T00:00:00Z" }),
+          },
+          {
+            type: "text",
+            text: createStartWorkPrompt({ sessionContext: "Session: $SESSION_ID\nTimestamp: $TIMESTAMP" }),
+          },
+        ],
+      }
+
+      // when
+      await hook["chat.message"](
+        { sessionID: "ses-retry-789" },
+        output
+      )
+
+      // then - both parts should have placeholders replaced
+      expect(output.parts[0].text).not.toContain("$SESSION_ID")
+      expect(output.parts[0].text).not.toContain("$TIMESTAMP")
+      expect(output.parts[1].text).not.toContain("$SESSION_ID")
+      expect(output.parts[1].text).not.toContain("$TIMESTAMP")
+      expect(output.parts[1].text).toContain("ses-retry-789")
+    })
+
+    test("should not append contextInfo twice when hook fires more than once", async () => {
+      // given - hook fires once
+      const hook = createStartWorkHook(createMockPluginInput())
+      const output = {
+        parts: [{ type: "text", text: createStartWorkPrompt() }],
+      }
+      await hook["chat.message"]({ sessionID: "session-double" }, output)
+      const firstRunText = output.parts[0].text ?? ""
+      const firstMarkerCount = (firstRunText.match(/<!-- omo-start-work-context -->/g) ?? []).length
+      expect(firstMarkerCount).toBe(1)
+
+      // when - the same output re-enters the hook (e.g. retry, or
+      // command.execute.before followed by chat.message)
+      await hook["chat.message"]({ sessionID: "session-double" }, output)
+
+      // then - the marker must still appear exactly once
+      const secondRunText = output.parts[0].text ?? ""
+      const secondMarkerCount = (secondRunText.match(/<!-- omo-start-work-context -->/g) ?? []).length
+      expect(secondMarkerCount).toBe(1)
+    })
+  })
 })

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -24,6 +24,7 @@ import { findRecentSessionPlanPath } from "./session-plan-affinity"
 
 export const HOOK_NAME = "start-work" as const
 const START_WORK_TEMPLATE_MARKER = "You are starting a Sisyphus work session."
+const CONTEXT_INFO_MARKER = "<!-- omo-start-work-context -->"
 
 interface StartWorkHookInput {
   sessionID: string
@@ -115,13 +116,29 @@ export function createStartWorkHook(ctx: PluginInput) {
       preferredPlanPath,
     })
 
-    const idx = output.parts.findIndex((p) => p.type === "text" && p.text)
-    if (idx >= 0 && output.parts[idx].text) {
-      output.parts[idx].text = output.parts[idx].text
+    // Substitute placeholders across every text part: on an error-retry path
+    // OpenCode may re-issue the original template alongside the already-
+    // processed text, leaving a second <session-context> block with un-
+    // substituted $SESSION_ID / $TIMESTAMP literals (#4480).
+    let firstTextIdx = -1
+    let contextAlreadyInjected = false
+    for (let i = 0; i < output.parts.length; i++) {
+      const part = output.parts[i]
+      if (part.type !== "text" || !part.text) continue
+      part.text = part.text
         .replace(/\$SESSION_ID/g, sessionId)
         .replace(/\$TIMESTAMP/g, timestamp)
+      if (part.text.includes(CONTEXT_INFO_MARKER)) {
+        contextAlreadyInjected = true
+      }
+      if (firstTextIdx < 0) firstTextIdx = i
+    }
 
-      output.parts[idx].text += `\n\n---\n${contextInfo}`
+    // Marker-guarded append: keeps the hook idempotent when it fires more than
+    // once for the same session (e.g. command.execute.before + chat.message,
+    // or retry-driven re-firings).
+    if (!contextAlreadyInjected && firstTextIdx >= 0) {
+      output.parts[firstTextIdx].text += `\n\n---\n${CONTEXT_INFO_MARKER}\n${contextInfo}`
     }
 
     log(`[${HOOK_NAME}] Context injected`, {


### PR DESCRIPTION
## Summary

Fixes #4480 (and addresses OmO-side contribution to #4481).

On an error-retry path OpenCode can re-issue the start-work template alongside the already-processed text. The hook only substituted `$SESSION_ID` / `$TIMESTAMP` in the first text part and appended `contextInfo` unconditionally, so a second `<session-context>` block kept the literal placeholders and re-firings stacked contextInfos.

## Changes

Two surgical changes in `src/hooks/start-work/start-work-hook.ts`:

- Substitute `$SESSION_ID` and `$TIMESTAMP` across **every** text part, not just the first one returned by `findIndex()`.
- Marker-guard the contextInfo append with an HTML comment so repeated firings (e.g. `command.execute.before` followed by `chat.message`, or a retry-driven re-fire) leave the appended block intact instead of stacking duplicates.

## Test plan

- [x] `bun test src/hooks/start-work/index.test.ts` (39 pass, +2 new)
- [x] New tests under `retry-path idempotence (#4480)`:
  - multi-part input keeps no literal placeholders after the hook runs
  - the contextInfo marker stays at count == 1 after the hook runs twice

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4480 by updating the start-work hook to replace placeholders in all text parts and to append context info only once. Prevents raw $SESSION_ID/$TIMESTAMP from leaking and avoids duplicate <session-context> blocks on retry paths.

- **Bug Fixes**
  - Replace $SESSION_ID and $TIMESTAMP across every text part, not just the first.
  - Append contextInfo once using an HTML marker <!-- omo-start-work-context --> to keep the hook idempotent across re-firings.

<sup>Written for commit 60a9f86cb6be71ba1cf1bb7353b298f178174b28. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

