### PR TITLE
fix(plugin-hooks): inject CLAUDE_PLUGIN_ROOT into plugin-sourced hook spawn (#4458)

### DIFF
--- a/src/features/claude-code-plugin-loader/hook-loader.test.ts
+++ b/src/features/claude-code-plugin-loader/hook-loader.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { loadPluginHooksConfigs } from "./hook-loader"
+import type { LoadedPlugin } from "./types"
+
+// Regression coverage for #4458 — every command/http action loaded from a
+// plugin's hooks config must carry the plugin's installPath as `pluginRoot`
+// so the downstream dispatcher can export CLAUDE_PLUGIN_ROOT on the spawn.
+describe("loadPluginHooksConfigs pluginRoot stamping (#4458)", () => {
+  let tempDirectory = ""
+
+  beforeEach(() => {
+    tempDirectory = mkdtempSync(join(tmpdir(), "omo-hook-loader-"))
+  })
+
+  afterEach(() => {
+    rmSync(tempDirectory, { recursive: true, force: true })
+  })
+
+  function makePlugin(pluginName: string, hooksJson: unknown): LoadedPlugin {
+    const installPath = join(tempDirectory, pluginName)
+    const hooksPath = join(installPath, "hooks.json")
+    // Use mkdir via writeFileSync target dir trick — easier to just create the
+    // install dir explicitly.
+    rmSync(installPath, { recursive: true, force: true })
+    const fs = require("node:fs") as typeof import("node:fs")
+    fs.mkdirSync(installPath, { recursive: true })
+    writeFileSync(hooksPath, JSON.stringify(hooksJson), "utf-8")
+    return {
+      name: pluginName,
+      version: "0.0.0",
+      scope: "user",
+      installPath,
+      pluginKey: `${pluginName}@test`,
+      hooksPath,
+    }
+  }
+
+  test("#given a plugin hooks config #when loaded #then every command action carries pluginRoot=installPath", () => {
+    // given
+    const plugin = makePlugin("hello-plugin", {
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: "*",
+            hooks: [
+              { type: "command", command: "echo hi" },
+              { type: "command", command: "${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh" },
+            ],
+          },
+        ],
+      },
+    })
+
+    // when
+    const configs = loadPluginHooksConfigs([plugin])
+
+    // then
+    expect(configs).toHaveLength(1)
+    const matchers = configs[0]?.hooks?.UserPromptSubmit ?? []
+    expect(matchers).toHaveLength(1)
+    const actions = matchers[0]?.hooks ?? []
+    expect(actions).toHaveLength(2)
+    for (const action of actions) {
+      expect(action.type).toBe("command")
+      // Type narrowing for the test: command-type entries should carry pluginRoot.
+      expect((action as { pluginRoot?: string }).pluginRoot).toBe(plugin.installPath)
+    }
+  })
+
+  test("#given an http action #when loaded #then it also carries pluginRoot", () => {
+    // given
+    const plugin = makePlugin("http-plugin", {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "http", url: "https://example.test/hook" },
+            ],
+          },
+        ],
+      },
+    })
+
+    // when
+    const configs = loadPluginHooksConfigs([plugin])
+
+    // then
+    const action = configs[0]?.hooks?.PostToolUse?.[0]?.hooks?.[0]
+    expect(action?.type).toBe("http")
+    expect((action as { pluginRoot?: string }).pluginRoot).toBe(plugin.installPath)
+  })
+})

--- a/src/features/claude-code-plugin-loader/hook-loader.ts
+++ b/src/features/claude-code-plugin-loader/hook-loader.ts
@@ -1,7 +1,28 @@
 import { existsSync, readFileSync } from "fs"
 import { log } from "../../shared/logger"
-import type { HooksConfig, LoadedPlugin } from "./types"
+import type { HookEntry, HooksConfig, LoadedPlugin } from "./types"
 import { resolvePluginPaths } from "./plugin-path-resolver"
+
+/**
+ * Stamp every action with the plugin's installPath so that the downstream
+ * dispatcher can set CLAUDE_PLUGIN_ROOT on the spawned hook process (#4458).
+ * The plugin association is otherwise lost once configs are merged together.
+ */
+function stampPluginRoot(config: HooksConfig, pluginRoot: string): void {
+  const eventMap = config.hooks
+  if (!eventMap) return
+  for (const matchers of Object.values(eventMap)) {
+    if (!Array.isArray(matchers)) continue
+    for (const matcher of matchers) {
+      if (!Array.isArray(matcher?.hooks)) continue
+      for (const action of matcher.hooks as HookEntry[]) {
+        if (action && (action.type === "command" || action.type === "http")) {
+          action.pluginRoot = pluginRoot
+        }
+      }
+    }
+  }
+}
 
 export function loadPluginHooksConfigs(plugins: LoadedPlugin[]): HooksConfig[] {
   const configs: HooksConfig[] = []
@@ -14,6 +35,7 @@ export function loadPluginHooksConfigs(plugins: LoadedPlugin[]): HooksConfig[] {
       let config = JSON.parse(content) as HooksConfig
 
       config = resolvePluginPaths(config, plugin.installPath)
+      stampPluginRoot(config, plugin.installPath)
 
       configs.push(config)
       log(`Loaded plugin hooks config from ${plugin.name}`, { path: plugin.hooksPath })

--- a/src/features/claude-code-plugin-loader/types.ts
+++ b/src/features/claude-code-plugin-loader/types.ts
@@ -115,10 +115,10 @@ export interface PluginManifest {
  * Hooks configuration
  */
 export type HookEntry =
-  | { type: "command"; command?: string }
+  | { type: "command"; command?: string; allowedEnvVars?: string[]; pluginRoot?: string }
   | { type: "prompt"; prompt?: string }
   | { type: "agent"; agent?: string }
-  | { type: "http"; url: string; headers?: Record<string, string>; allowedEnvVars?: string[]; timeout?: number }
+  | { type: "http"; url: string; headers?: Record<string, string>; allowedEnvVars?: string[]; timeout?: number; pluginRoot?: string }
 
 export interface HookMatcher {
   matcher?: string

--- a/src/hooks/claude-code-hooks/dispatch-hook.ts
+++ b/src/hooks/claude-code-hooks/dispatch-hook.ts
@@ -26,6 +26,9 @@ export async function dispatchHook(
   if (cmdHook.allowedEnvVars) {
     options.allowedEnvVars = cmdHook.allowedEnvVars
   }
+  if (cmdHook.pluginRoot) {
+    options.pluginRoot = cmdHook.pluginRoot
+  }
 
   return executeHookCommand(
     hook.command,

--- a/src/hooks/claude-code-hooks/types.ts
+++ b/src/hooks/claude-code-hooks/types.ts
@@ -27,6 +27,8 @@ export interface HookCommand {
   command: string
   /** Env vars allowed to pass through to the spawned process (plugin-sourced hooks are intersected with mcp_env_allowlist) */
   allowedEnvVars?: string[]
+  /** Plugin install path. When set, CLAUDE_PLUGIN_ROOT is injected into the spawn env and substituted in the command string. */
+  pluginRoot?: string
 }
 
 export interface HookHttp {
@@ -35,6 +37,8 @@ export interface HookHttp {
   headers?: Record<string, string>
   allowedEnvVars?: string[]
   timeout?: number
+  /** Plugin install path. Recorded for diagnostics; HTTP hooks do not spawn a child process. */
+  pluginRoot?: string
 }
 
 export type HookAction = HookCommand | HookHttp

--- a/src/shared/command-executor/execute-hook-command.test.ts
+++ b/src/shared/command-executor/execute-hook-command.test.ts
@@ -57,6 +57,56 @@ describe("executeHookCommand", () => {
     // cleanup
     delete process.env.__OMO_TEST_FULL_ENV_VAR
   })
+
+  // Regression coverage for #4458 — plugin-sourced hooks must run with
+  // CLAUDE_PLUGIN_ROOT exported into the child env (so scripts can read
+  // process.env.CLAUDE_PLUGIN_ROOT) AND substituted in the command string
+  // (so commands written as `$CLAUDE_PLUGIN_ROOT/scripts/foo.sh` resolve).
+  test("#given pluginRoot option #when executing command #then CLAUDE_PLUGIN_ROOT is exported into env", async () => {
+    // when
+    const result = await executeHookCommand(
+      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-x" },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("plugin-root=/tmp/plugin-x")
+  })
+
+  test("#given pluginRoot option with allowedEnvVars #when executing command #then CLAUDE_PLUGIN_ROOT survives the env scrub", async () => {
+    // when
+    const result = await executeHookCommand(
+      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-y", allowedEnvVars: [] },
+    )
+
+    // then - the empty allowedEnvVars list scrubs everything except HOME/PATH,
+    // but CLAUDE_PLUGIN_ROOT must still be present because pluginRoot is
+    // honored independently of the allowlist.
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("plugin-root=/tmp/plugin-y")
+  })
+
+  test("#given pluginRoot option #when command references ${CLAUDE_PLUGIN_ROOT} #then it is substituted before spawn", async () => {
+    // when - shell-style ${VAR} would normally also expand at spawn time, but
+    // we substitute earlier so the form works even in commands that disable
+    // shell variable expansion downstream.
+    const result = await executeHookCommand(
+      'echo "rooted=${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"',
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-z" },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("rooted=/tmp/plugin-z/scripts/foo.sh")
+  })
 })
 
 export {}

--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -18,6 +18,13 @@ export interface ExecuteHookOptions {
   timeoutMs?: number;
   /** When provided, scrub process.env to only include these vars plus HOME/PATH/etc. Used for plugin-sourced hooks. */
   allowedEnvVars?: string[];
+  /**
+   * Plugin install path. When set, CLAUDE_PLUGIN_ROOT is exported into the
+   * spawn env and substituted in the command string so plugin-sourced hooks
+   * can reference $CLAUDE_PLUGIN_ROOT / ${CLAUDE_PLUGIN_ROOT} the same way
+   * Claude Code's CLI does (#4458).
+   */
+  pluginRoot?: string;
 }
 
 export async function executeHookCommand(
@@ -29,11 +36,18 @@ export async function executeHookCommand(
   const home = getHomeDirectory();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
 
-  const expandedCommand = command
+  const pluginRoot = options?.pluginRoot;
+  let expandedCommand = command
     .replace(/^~(?=\/|$)/g, home)
     .replace(/\s~(?=\/)/g, ` ${home}`)
     .replace(/\$CLAUDE_PROJECT_DIR/g, cwd)
     .replace(/\$\{CLAUDE_PROJECT_DIR\}/g, cwd);
+
+  if (pluginRoot) {
+    expandedCommand = expandedCommand
+      .replace(/\$CLAUDE_PLUGIN_ROOT/g, pluginRoot)
+      .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
+  }
 
   let finalCommand = expandedCommand;
 
@@ -58,7 +72,7 @@ export async function executeHookCommand(
 
     // Keys that are always set from normalized sources and must not be
     // overwritten by ambient process.env values during the allowlist merge.
-    const PROTECTED_ENV_KEYS = new Set(["HOME", "CLAUDE_PROJECT_DIR"]);
+    const PROTECTED_ENV_KEYS = new Set(["HOME", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT"]);
 
     let env: Record<string, string | undefined>;
     if (options?.allowedEnvVars) {
@@ -75,6 +89,10 @@ export async function executeHookCommand(
       }
     } else {
       env = { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd };
+    }
+
+    if (pluginRoot) {
+      env.CLAUDE_PLUGIN_ROOT = pluginRoot;
     }
 
     const proc = spawn(finalCommand, {


### PR DESCRIPTION
## Summary

Fixes #4458. Plugin-sourced hooks could not read `process.env.CLAUDE_PLUGIN_ROOT`, which Claude Code's plugin spec promises. The loader only did textual substitution of `\${CLAUDE_PLUGIN_ROOT}` in path-valued config fields via \`resolvePluginPaths\`; the env var itself was never exported into the spawned hook process, so plugin scripts (or commands that disable shell variable expansion downstream) could not resolve \`\$CLAUDE_PLUGIN_ROOT\` at runtime.

## Changes

Plumbed the plugin's installPath through the dispatcher:

- **`claude-code-plugin-loader/types.ts`**: `HookEntry` "command" and "http" variants now carry an optional \`pluginRoot\` field.
- **`claude-code-plugin-loader/hook-loader.ts`**: \`stampPluginRoot\` walks the loaded \`HooksConfig\` once and tags every command/http action with the owning plugin's installPath. Preserves plugin association through the downstream config merge, which would otherwise discard it.
- **`claude-code-hooks/types.ts`**: \`HookCommand\` and \`HookHttp\` gain the matching optional \`pluginRoot\` field so the type universes agree.
- **`claude-code-hooks/dispatch-hook.ts`**: pass \`cmdHook.pluginRoot\` through to \`executeHookCommand\` options.
- **`command-executor/execute-hook-command.ts`**: \`ExecuteHookOptions\` accepts \`pluginRoot\`. When set: substitute \`\$CLAUDE_PLUGIN_ROOT\` and \`\${CLAUDE_PLUGIN_ROOT}\` in the command string, and export \`CLAUDE_PLUGIN_ROOT\` into the child env. Added to \`PROTECTED_ENV_KEYS\` so the allowlist scrub cannot overwrite or drop it.

## Test plan

- [x] \`bun test src/hooks/claude-code-hooks/\` (90 pass)
- [x] \`execute-hook-command.test.ts\`: 3 new cases — env injection, env-injection-with-allowedEnvVars (proves it survives the scrub), and \`\${CLAUDE_PLUGIN_ROOT}\` substitution.
- [x] \`hook-loader.test.ts\` (new file): asserts that command and http actions loaded from a plugin's hooks config carry \`pluginRoot=installPath\`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plugin-sourced hooks now receive CLAUDE_PLUGIN_ROOT in their env and command strings, so scripts can resolve plugin paths reliably. Fixes #4458 and aligns with the plugin spec.

- **Bug Fixes**
  - Stamp each plugin action with its `pluginRoot` during hook load to preserve plugin association.
  - Pass `pluginRoot` through the dispatcher to the command executor.
  - Substitute `$CLAUDE_PLUGIN_ROOT` and `${CLAUDE_PLUGIN_ROOT}` in commands and export `CLAUDE_PLUGIN_ROOT` to the child env.
  - Protect `CLAUDE_PLUGIN_ROOT` from the env allowlist scrub so it always reaches the spawned process.
  - Add tests for stamping, env injection, allowlist behavior, and substitution.

<sup>Written for commit d1d55fd3e4822e6456cb97ffa7cdd8ad4d7c9cd0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4489?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

