### PR TITLE
fix(agents): strip LSP tool references from agent prompts when LSP MCP is disabled

### DIFF
--- a/src/agents/builtin-agents/strip-lsp-references.test.ts
+++ b/src/agents/builtin-agents/strip-lsp-references.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect } from "bun:test"
+import { stripLspPromptReferences, removeLspLines } from "./strip-lsp-references"
+import type { AgentConfig } from "@opencode-ai/sdk"
+
+describe("strip-lsp-references", () => {
+  describe("#given stripLspPromptReferences", () => {
+    describe("#when lsp is in disabled_mcps", () => {
+      test("#then removes lines containing lsp_ from prompt", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: [
+            "## Verification",
+            "",
+            "Run `lsp_diagnostics` on changed files at:",
+            "- End of a logical task unit",
+            "- Before marking a todo item complete",
+            "",
+            "### Evidence Requirements",
+            "",
+            "- **File edit** → `lsp_diagnostics` clean on changed files",
+            "- **Build command** → Exit code 0",
+            "- **Test run** → Pass",
+          ].join("\n"),
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["lsp"])
+
+        // then
+        expect(result.prompt).not.toContain("lsp_diagnostics")
+        expect(result.prompt).toContain("## Verification")
+        expect(result.prompt).toContain("- End of a logical task unit")
+        expect(result.prompt).toContain("- **Build command** → Exit code 0")
+        expect(result.prompt).toContain("- **Test run** → Pass")
+      })
+
+      test("#then handles multiple lsp tool types", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: [
+            "Tools available:",
+            "- `lsp_find_references`: Map all usages before changes",
+            "- `lsp_rename` / `lsp_prepare_rename`: Safe symbol renames",
+            "- `grep`: Search files",
+            "- `glob`: Find files",
+          ].join("\n"),
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["lsp"])
+
+        // then
+        expect(result.prompt).not.toContain("lsp_find_references")
+        expect(result.prompt).not.toContain("lsp_rename")
+        expect(result.prompt).not.toContain("lsp_prepare_rename")
+        expect(result.prompt).toContain("- `grep`: Search files")
+        expect(result.prompt).toContain("- `glob`: Find files")
+      })
+
+      test("#then does not produce triple blank lines", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: [
+            "Section A",
+            "",
+            "Run `lsp_diagnostics` on files",
+            "",
+            "Section B",
+          ].join("\n"),
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["lsp"])
+
+        // then
+        expect(result.prompt).not.toContain("\n\n\n")
+        expect(result.prompt).toContain("Section A")
+        expect(result.prompt).toContain("Section B")
+      })
+
+      test("#then returns same reference if no lsp_ found in prompt", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: "No LSP references here at all.",
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["lsp"])
+
+        // then
+        expect(result).toBe(config)
+      })
+    })
+
+    describe("#when lsp is NOT in disabled_mcps", () => {
+      test("#then returns config unchanged", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: "Run `lsp_diagnostics` on changed files",
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, [])
+
+        // then
+        expect(result).toBe(config)
+        expect(result.prompt).toContain("lsp_diagnostics")
+      })
+
+      test("#then preserves prompt when other mcps are disabled", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+          prompt: "Run `lsp_diagnostics` on changed files",
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["playwright", "exa"])
+
+        // then
+        expect(result).toBe(config)
+        expect(result.prompt).toContain("lsp_diagnostics")
+      })
+    })
+
+    describe("#when config has no prompt", () => {
+      test("#then returns config unchanged", () => {
+        // given
+        const config: AgentConfig = {
+          model: "test-model",
+        }
+
+        // when
+        const result = stripLspPromptReferences(config, ["lsp"])
+
+        // then
+        expect(result).toBe(config)
+      })
+    })
+  })
+
+  describe("#given removeLspLines", () => {
+    test("#then removes only lines containing lsp_", () => {
+      // given
+      const input = [
+        "Line 1: normal",
+        "Line 2: has lsp_diagnostics reference",
+        "Line 3: normal",
+        "Line 4: has lsp_find_references too",
+        "Line 5: normal",
+      ].join("\n")
+
+      // when
+      const result = removeLspLines(input)
+
+      // then
+      expect(result).toBe(["Line 1: normal", "Line 3: normal", "Line 5: normal"].join("\n"))
+    })
+
+    test("#then collapses triple newlines to double", () => {
+      // given
+      const input = [
+        "Before",
+        "",
+        "lsp_diagnostics line",
+        "",
+        "After",
+      ].join("\n")
+
+      // when
+      const result = removeLspLines(input)
+
+      // then
+      expect(result).toBe(["Before", "", "After"].join("\n"))
+    })
+  })
+})

--- a/src/agents/builtin-agents/strip-lsp-references.ts
+++ b/src/agents/builtin-agents/strip-lsp-references.ts
@@ -1,0 +1,36 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+
+/**
+ * Strips lines containing `lsp_` tool references from agent prompts
+ * when the LSP MCP is disabled via `disabled_mcps`.
+ *
+ * This prevents agents from being instructed to call LSP tools
+ * (lsp_diagnostics, lsp_find_references, lsp_rename, etc.)
+ * that don't exist when the LSP MCP server is not registered.
+ *
+ * Follows the same post-processing pattern as `applyEnvironmentContext`.
+ */
+export function stripLspPromptReferences(
+  config: AgentConfig,
+  disabledMcps: string[],
+): AgentConfig {
+  if (!disabledMcps.includes("lsp")) return config
+  if (!config.prompt) return config
+
+  const stripped = removeLspLines(config.prompt)
+  if (stripped === config.prompt) return config
+
+  return { ...config, prompt: stripped }
+}
+
+/**
+ * Removes lines that reference `lsp_` tools from a prompt string.
+ * Handles both backtick-wrapped (`lsp_diagnostics`) and bare references.
+ * Also collapses resulting double-blank-lines into single blank lines.
+ */
+export function removeLspLines(prompt: string): string {
+  const lines = prompt.split("\n")
+  const filtered = lines.filter((line) => !line.includes("lsp_"))
+  const result = filtered.join("\n")
+  return result.replace(/\n{3,}/g, "\n\n")
+}

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -35,6 +35,7 @@ import {
   filterProtectedAgentOverrides,
 } from "./agent-override-protection";
 import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
+import { stripLspPromptReferences } from "../agents/builtin-agents/strip-lsp-references";
 import { buildPlanDemoteConfig } from "./plan-model-inheritance";
 import { adaptHostSkillConfig } from "../shared/host-skill-config";
 
@@ -183,6 +184,14 @@ export async function applyAgentConfig(params: {
     disableOmoEnv,
     params.pluginConfig.team_mode?.enabled ?? false,
   );
+
+  // Strip LSP tool references from agent prompts when LSP MCP is disabled (#4486)
+  const disabledMcps = params.pluginConfig.disabled_mcps ?? [];
+  if (disabledMcps.includes("lsp")) {
+    for (const agentName of Object.keys(builtinAgents)) {
+      builtinAgents[agentName] = stripLspPromptReferences(builtinAgents[agentName], disabledMcps);
+    }
+  }
 
   const disabledAgentNames = new Set(
     (migratedDisabledAgents ?? []).map(a => a.toLowerCase())


### PR DESCRIPTION
## Summary

When `disabled_mcps` includes `lsp`, agent prompts still contain hardcoded references to `lsp_diagnostics`, `lsp_find_references`, `lsp_rename`, and `lsp_prepare_rename`. This causes agents to attempt calling tools that don't exist.

## Changes

- Add `stripLspPromptReferences(config, disabledMcps)` utility in `src/agents/builtin-agents/strip-lsp-references.ts`
- Apply post-processing in `agent-config-handler.ts` after `createBuiltinAgents()` returns
- Lines containing `lsp_` tool references are removed from agent prompts when LSP MCP is disabled
- Collapses resulting triple blank lines to double

## Testing

- 9 unit tests covering all edge cases (strip when disabled, preserve when enabled, multiple tool types, no triple blanks)
- `bun run typecheck` passes
- `bun test` on affected file passes (9/9, 21 assertions)

Closes #4486

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip `lsp_` tool references from builtin agent prompts when the `lsp` MCP is disabled. Prevents calls to non-existent tools and aligns with `disabled_mcps` (closes #4486).

- **Bug Fixes**
  - Added `stripLspPromptReferences` to remove `lsp_` tool lines (e.g., `lsp_diagnostics`, `lsp_find_references`, `lsp_rename`) when `disabled_mcps` includes `lsp`; no-op otherwise.
  - Applied in `agent-config-handler` after `createBuiltinAgents()` so all builtin prompts are cleaned; collapses 3+ blank lines to 2.
  - Added unit tests for disabled/enabled cases and formatting.

<sup>Written for commit b961c623070ea0e9ce766039717d5ef1a336df64. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

