### PR TITLE
fix(keyword-detector): prevent duplicate mode injection on undo + resend

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -22,6 +22,7 @@ import type { DetectedKeyword } from "./detector"
 import { detectKeywordsWithType, extractPromptText, looksLikeSlashCommand } from "./detector"
 
 const defaultModeUltraworkInjectedSessions = new Set<string>()
+const injectedKeywordSessions = new Map<string, Set<string>>()
 
 function suppressComboStandalones(detected: DetectedKeyword[]): DetectedKeyword[] {
   const hasCombo = detected.some((k) => k.type === "hyperplan-ultrawork")
@@ -225,7 +226,28 @@ export function createKeywordDetectorHook(
       const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
-      output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
+      // Deduplication guard: skip injection if all detected keywords were already injected in this session
+      const sessionInjected = injectedKeywordSessions.get(input.sessionID)
+      const newKeywords = sessionInjected
+        ? detectedKeywords.filter((k) => !sessionInjected.has(k.type))
+        : detectedKeywords
+
+      if (newKeywords.length === 0) {
+        log(`[keyword-detector] All detected keywords already injected, skipping duplicate injection`, { sessionID: input.sessionID })
+        return
+      }
+
+      // Track injected keywords for this session
+      if (!sessionInjected) {
+        injectedKeywordSessions.set(input.sessionID, new Set(newKeywords.map((k) => k.type)))
+      } else {
+        for (const k of newKeywords) {
+          sessionInjected.add(k.type)
+        }
+      }
+
+      const newMessages = newKeywords.map((k) => k.message).join("\n\n")
+      output.parts[textPartIndex].text = `${newMessages}\n\n---\n\n${originalText}`
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {
         sessionID: input.sessionID,

--- a/src/hooks/keyword-detector/keyword-dedup.test.ts
+++ b/src/hooks/keyword-detector/keyword-dedup.test.ts
@@ -1,0 +1,152 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import * as sessionState from "../../features/claude-code-session-state"
+import { _resetForTesting } from "../../features/claude-code-session-state"
+import { ContextCollector } from "../../features/context-injector"
+import * as sharedModule from "../../shared"
+import { createKeywordDetectorHook } from "./index"
+
+type ToastOptions = { body: { title: string } }
+
+function createMockPluginInput(): PluginInput {
+  const client = {} as PluginInput["client"]
+  Object.assign(client, { tui: { showToast: async () => {} } })
+
+  return {
+    client,
+    project: {
+      id: "dedup-test-project",
+      worktree: "/tmp/dedup-test",
+      time: { created: 0 },
+    },
+    directory: "/tmp/dedup-test",
+    worktree: "/tmp/dedup-test",
+    serverUrl: new URL("http://localhost"),
+    $: {} as PluginInput["$"],
+  }
+}
+
+describe("keyword-detector deduplication", () => {
+  let logSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    _resetForTesting()
+    logSpy = spyOn(sharedModule, "log").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy?.mockRestore()
+    _resetForTesting()
+  })
+
+  describe("#given undo + resend scenario", () => {
+    test("#when same keyword detected twice in same session, #then second injection is skipped", async () => {
+      // given
+      const collector = new ContextCollector()
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+      const sessionID = "dedup-session-1"
+
+      const makeOutput = () => ({
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: "ultrawork do something" }],
+      })
+
+      // when - first call injects
+      const output1 = makeOutput()
+      await hook["chat.message"]({ sessionID }, output1)
+
+      // then - first call should inject
+      expect(output1.parts[0].text).toContain("---")
+      expect(output1.parts[0].text).toContain("do something")
+
+      // when - second call (undo + resend) with same session
+      const output2 = makeOutput()
+      await hook["chat.message"]({ sessionID }, output2)
+
+      // then - second call should NOT inject (text unchanged)
+      expect(output2.parts[0].text).toBe("ultrawork do something")
+    })
+
+    test("#when different keywords detected in same session, #then only new keywords are injected", async () => {
+      // given
+      const collector = new ContextCollector()
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+      const sessionID = "dedup-session-2"
+
+      // when - first message triggers ultrawork
+      const output1 = {
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: "ultrawork do something" }],
+      }
+      await hook["chat.message"]({ sessionID }, output1)
+
+      // then - ultrawork injected
+      expect(output1.parts[0].text).toContain("---")
+
+      // when - second message triggers search (different keyword, same session)
+      const output2 = {
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: "search for react hooks" }],
+      }
+      await hook["chat.message"]({ sessionID }, output2)
+
+      // then - search should be injected (it's a new keyword type)
+      expect(output2.parts[0].text).toContain("---")
+      expect(output2.parts[0].text).toContain("react hooks")
+    })
+
+    test("#when same keyword detected in different sessions, #then both sessions get injection", async () => {
+      // given
+      const collector = new ContextCollector()
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+
+      const makeOutput = () => ({
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: "ultrawork do something" }],
+      })
+
+      // when - session A gets injection
+      const outputA = makeOutput()
+      await hook["chat.message"]({ sessionID: "session-A" }, outputA)
+
+      // then - session A injected
+      expect(outputA.parts[0].text).toContain("---")
+
+      // when - session B (different session) sends same keyword
+      const outputB = makeOutput()
+      await hook["chat.message"]({ sessionID: "session-B" }, outputB)
+
+      // then - session B also gets injection (different session = no dedup)
+      expect(outputB.parts[0].text).toContain("---")
+    })
+
+    test("#when search keyword resent in same session, #then duplicate search injection is prevented", async () => {
+      // given
+      const collector = new ContextCollector()
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+      const sessionID = "dedup-search-session"
+
+      const makeSearchOutput = () => ({
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: "search for typescript patterns" }],
+      })
+
+      // when - first search
+      const output1 = makeSearchOutput()
+      await hook["chat.message"]({ sessionID }, output1)
+
+      // then - search injected
+      expect(output1.parts[0].text).toContain("---")
+      expect(output1.parts[0].text).toContain("typescript patterns")
+
+      // when - undo + resend same search
+      const output2 = makeSearchOutput()
+      await hook["chat.message"]({ sessionID }, output2)
+
+      // then - no duplicate injection
+      expect(output2.parts[0].text).toBe("search for typescript patterns")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes duplicate [search-mode] / <ultrawork-mode> / [analyze-mode] / [team-mode] / <hyperplan-mode> injection when user performs undo + resend.

## Problem

The keyword-detector hook fires on every chat.message event without tracking whether it already injected a mode prompt for the current session. When a user undoes and resends a message, the hook fires again and injects the same mode prompt a second time.

## Changes

- **src/hooks/keyword-detector/hook.ts**: Add injectedKeywordSessions Map that tracks which keyword types have been injected per session. On subsequent chat.message events, only new (not-yet-injected) keyword types are injected.
- **src/hooks/keyword-detector/keyword-dedup.test.ts**: 4 tests covering:
  - Same keyword in same session skipped on second call
  - Different keywords in same session still injected
  - Same keyword in different sessions both injected
  - Search keyword dedup specifically

## Testing

- `bun test src/hooks/keyword-detector/keyword-dedup.test.ts` — 4 pass
- `bun test src/hooks/keyword-detector/index.test.ts` — 47 pass (no regressions)
- `bun run typecheck` — clean

Closes #4251

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate mode prompt injections in keyword-detector on undo + resend by deduplicating per session. Applies to search, ultrawork, analyze, team, and hyperplan modes; fixes #4251.

- **Bug Fixes**
  - Track injected keyword types per session via `injectedKeywordSessions` and skip re-injection on repeat `chat.message` events.
  - Inject only new keyword types within a session; different sessions remain unaffected.
  - Added `keyword-dedup.test.ts` covering same-keyword skip, different-keyword inject, cross-session behavior, and search-specific dedup.

<sup>Written for commit 25df299a534ec2c02404df02bab7f85ef89c6802. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4493?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

