### PR TITLE
fix(hooks): avoid mutating frozen output.args on opencode >= 1.14

### DIFF
--- a/src/hooks/write-existing-file-guard/index.test.ts
+++ b/src/hooks/write-existing-file-guard/index.test.ts
@@ -561,3 +561,95 @@ describe("createWriteExistingFileGuardHook", () => {
     ).rejects.toThrow(BLOCK_MESSAGE)
   })
 })
+
+describe("frozen args handling (issue #3816)", () => {
+  let tempDir = ""
+  let hook: Hook
+  let callCounter = 0
+
+  const createFile = (relativePath: string, content = "existing content"): string => {
+    const absolutePath = join(tempDir, relativePath)
+    mkdirSync(dirname(absolutePath), { recursive: true })
+    writeFileSync(absolutePath, content)
+    return absolutePath
+  }
+
+  const invokeWithFrozenArgs = async (args: {
+    tool: string
+    sessionID?: string
+    outputArgs: Record<string, unknown>
+  }): Promise<{ args: Record<string, unknown> }> => {
+    callCounter += 1
+    const frozenArgs = Object.freeze({ ...args.outputArgs })
+    const output = { args: frozenArgs as Record<string, unknown> }
+
+    await hook["tool.execute.before"]?.(
+      {
+        tool: args.tool,
+        sessionID: args.sessionID ?? "ses_default",
+        callID: `call_${callCounter}`,
+      } as never,
+      output as never
+    )
+
+    return output
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "frozen-args-"))
+    hook = createWriteExistingFileGuardHook({ directory: tempDir })
+    callCounter = 0
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test("#given frozen args with overwrite #when write tool invoked #then does not throw TypeError", async () => {
+    // given
+    const existingFile = createFile("frozen-test.ts")
+    const sessionID = "ses_frozen"
+
+    // when - read first to grant permission
+    await invokeWithFrozenArgs({
+      tool: "read",
+      sessionID,
+      outputArgs: { filePath: existingFile },
+    })
+
+    // then - write with frozen args containing overwrite should not throw
+    const result = await invokeWithFrozenArgs({
+      tool: "write",
+      sessionID,
+      outputArgs: { filePath: existingFile, content: "new", overwrite: true },
+    })
+
+    // overwrite key should be removed from args
+    expect(result.args).not.toHaveProperty("overwrite")
+    expect(result.args).toHaveProperty("filePath")
+    expect(result.args).toHaveProperty("content")
+  })
+
+  test("#given frozen args without overwrite #when write tool invoked #then does not throw TypeError", async () => {
+    // given
+    const existingFile = createFile("frozen-no-overwrite.ts")
+    const sessionID = "ses_frozen2"
+
+    // when - read first
+    await invokeWithFrozenArgs({
+      tool: "read",
+      sessionID,
+      outputArgs: { filePath: existingFile },
+    })
+
+    // then - write with frozen args (no overwrite key) should work fine
+    const result = await invokeWithFrozenArgs({
+      tool: "write",
+      sessionID,
+      outputArgs: { filePath: existingFile, content: "new" },
+    })
+
+    expect(result.args).toHaveProperty("filePath")
+    expect(result.args).toHaveProperty("content")
+  })
+})

--- a/src/hooks/write-existing-file-guard/tool-execute-before-handler.ts
+++ b/src/hooks/write-existing-file-guard/tool-execute-before-handler.ts
@@ -146,7 +146,8 @@ export async function handleWriteExistingFileGuardToolExecuteBefore(params: {
 
   const overwriteEnabled = isOverwriteEnabled(args?.overwrite)
   if (argsRecord && "overwrite" in argsRecord) {
-    delete argsRecord.overwrite
+    const { overwrite: _, ...rest } = argsRecord
+    ;(output as { args: Record<string, unknown> }).args = rest
   }
 
   if (!existsSync(resolvedPath)) {

--- a/src/tools/delegate-task/tool-argument-preparation.ts
+++ b/src/tools/delegate-task/tool-argument-preparation.ts
@@ -81,15 +81,6 @@ export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx
   const taskID = typeof args.task_id === "string" ? args.task_id : undefined
   const command = typeof args.command === "string" ? args.command : undefined
 
-  args.category = category
-  args.subagent_type = subagentType
-  args.requested_subagent_type = originalSubagentType
-  args.description = description
-  args.prompt = prompt
-  args.run_in_background = runInBackground
-  args.task_id = taskID
-  args.command = command
-  args.load_skills = normalizedLoadSkills
 
   return {
     category,


### PR DESCRIPTION
## Summary

Fixes remaining frozen output.args mutation sites that cause TypeError: Attempted to assign to readonly property on opencode >= 1.14.34 with OPENCODE_EXPERIMENTAL=true.

## Changes

### src/hooks/write-existing-file-guard/tool-execute-before-handler.ts`n- Replace delete argsRecord.overwrite (direct mutation of potentially frozen object) with destructured spread that creates a new args object without the overwrite key

### src/tools/delegate-task/tool-argument-preparation.ts`n- Remove 9 dead write lines (84-92) that mutated rgs object directly. The function already returns a fresh object at line 94-104, making these writes both unnecessary and dangerous on frozen args.

### src/hooks/write-existing-file-guard/index.test.ts`n- Add 2 regression tests verifying frozen args don't throw TypeError

## Testing

- un run typecheck - clean
- un test src/hooks/write-existing-file-guard/ - 25 pass, 0 fail
- Existing tests unaffected

Closes #3816

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent TypeError crashes by avoiding mutations of frozen output.args on opencode >= 1.14. Fixes #3816.

- **Bug Fixes**
  - write-existing-file-guard: replaced in-place delete of overwrite with creating a new args object and reassigning to output.args.
  - delegate-task args prep: removed dead in-place mutations; the function already returns a fresh object.
  - Added regression tests to verify frozen args don’t throw and overwrite is stripped.

<sup>Written for commit a36dbad5d375201eac0d866f2685778f359f976f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4494?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

