### PR TITLE
fix(mcp): handle Windows .bat/.cmd wrapper scripts for LSP and ast-grep MCP startup

### DIFF
--- a/src/mcp/ast-grep.ts
+++ b/src/mcp/ast-grep.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { hasCliSuffix } from "./cli-suffix";
 import type { LocalMcpConfig } from "./lsp";
 import { resolveRuntimeExecutable, type RuntimeExecutable, type RuntimeExecutableResolver } from "./runtime-executable";
+import { wrapWindowsShellCommand } from "./windows-shell-command";
 
 const PACKAGE_REL = "packages/ast-grep-mcp";
 const DIST_CLI_REL = "dist/cli.js";
@@ -119,7 +120,7 @@ export function createAstGrepMcpConfig(options: AstGrepMcpConfigOptions = {}): L
   const resolvedCommand = resolveAstGrepCommand(options);
   return {
     type: "local",
-    command: resolvedCommand.command,
+    command: wrapWindowsShellCommand(resolvedCommand.command),
     enabled: resolvedCommand.exists,
     environment: {
       [WORKSPACE_ENV]: workspaceDirectory,

--- a/src/mcp/lsp.ts
+++ b/src/mcp/lsp.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { hasCliSuffix } from "./cli-suffix"
 import { resolveRuntimeExecutable, type RuntimeExecutable, type RuntimeExecutableResolver } from "./runtime-executable"
+import { wrapWindowsShellCommand } from "./windows-shell-command"
 
 const SUBMODULE_REL = "packages/lsp-tools-mcp"
 const DIST_CLI_REL = "dist/cli.js"
@@ -158,7 +159,7 @@ export function createLspMcpConfig(options: LspMcpConfigOptions = {}): LocalMcpC
 
   return {
     type: "local",
-    command: resolvedCommand.command,
+    command: wrapWindowsShellCommand(resolvedCommand.command),
     enabled: resolvedCommand.exists,
     environment: {
       LSP_TOOLS_MCP_PROJECT_CONFIG: PROJECT_LSP_CONFIG,

--- a/src/mcp/windows-shell-command.test.ts
+++ b/src/mcp/windows-shell-command.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+
+import { wrapWindowsShellCommand } from "./windows-shell-command"
+
+describe("wrapWindowsShellCommand", () => {
+  test("#given a .cmd command on Windows #when wrapped #then prepends cmd.exe /c", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "win32" })
+
+    // when
+    const result = wrapWindowsShellCommand(["C:\\Program Files\\nodejs\\npm.cmd", "install"])
+
+    // then
+    expect(result).toEqual(["cmd.exe", "/c", "C:\\Program Files\\nodejs\\npm.cmd", "install"])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+
+  test("#given a .bat command on Windows #when wrapped #then prepends cmd.exe /c", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "win32" })
+
+    // when
+    const result = wrapWindowsShellCommand(["C:\\tools\\jdtls.bat", "--data", "/tmp"])
+
+    // then
+    expect(result).toEqual(["cmd.exe", "/c", "C:\\tools\\jdtls.bat", "--data", "/tmp"])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+
+  test("#given a .exe command on Windows #when wrapped #then returns unchanged", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "win32" })
+
+    // when
+    const result = wrapWindowsShellCommand(["C:\\Program Files\\nodejs\\node.exe", "dist/cli.js", "mcp"])
+
+    // then
+    expect(result).toEqual(["C:\\Program Files\\nodejs\\node.exe", "dist/cli.js", "mcp"])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+
+  test("#given any command on non-Windows #when wrapped #then returns unchanged", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "linux" })
+
+    // when
+    const result = wrapWindowsShellCommand(["/usr/bin/node", "dist/cli.js", "mcp"])
+
+    // then
+    expect(result).toEqual(["/usr/bin/node", "dist/cli.js", "mcp"])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+
+  test("#given an empty command array #when wrapped #then returns empty array", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "win32" })
+
+    // when
+    const result = wrapWindowsShellCommand([])
+
+    // then
+    expect(result).toEqual([])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+
+  test("#given a .CMD uppercase extension on Windows #when wrapped #then prepends cmd.exe /c", () => {
+    // given
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", { value: "win32" })
+
+    // when
+    const result = wrapWindowsShellCommand(["C:\\tools\\NPM.CMD", "run", "build"])
+
+    // then
+    expect(result).toEqual(["cmd.exe", "/c", "C:\\tools\\NPM.CMD", "run", "build"])
+
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+  })
+})

--- a/src/mcp/windows-shell-command.ts
+++ b/src/mcp/windows-shell-command.ts
@@ -1,0 +1,16 @@
+const WINDOWS_SHELL_EXTENSIONS = [".cmd", ".bat"]
+
+function isWindowsShellScript(command: string): boolean {
+  const lower = command.toLowerCase()
+  return WINDOWS_SHELL_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function wrapWindowsShellCommand(command: string[]): string[] {
+  if (process.platform !== "win32") return command
+  if (command.length === 0) return command
+
+  const [executable, ...args] = command
+  if (!isWindowsShellScript(executable)) return command
+
+  return ["cmd.exe", "/c", executable, ...args]
+}

--- a/src/shared/bun-which-shim.ts
+++ b/src/shared/bun-which-shim.ts
@@ -32,7 +32,7 @@ function resolvePathValue(): string | undefined {
 function getWindowsCandidates(commandName: string): string[] {
   if (process.platform !== "win32") return [commandName]
 
-  return [commandName, `${commandName}.exe`, `${commandName}.cmd`, `${commandName}.bat`, `${commandName}.com`]
+  return [`${commandName}.exe`, `${commandName}.cmd`, `${commandName}.bat`, `${commandName}.com`, commandName]
 }
 
 export function bunWhich(commandName: string): string | null {


### PR DESCRIPTION
## Summary

Fixes LSP server failing to start on Windows when the language server binary is a .bat or .cmd wrapper script (e.g., jdtls.bat, npm.cmd).

## Changes

1. **src/shared/bun-which-shim.ts** - Reorder `getWindowsCandidates()` to match Windows PATHEXT priority: `.exe` > `.cmd` > `.bat` > `.com` > extensionless. Previously extensionless was checked first, causing Windows to try executing shebang scripts directly.

2. **src/mcp/windows-shell-command.ts** (new) - `wrapWindowsShellCommand()` utility that prepends `cmd.exe /c` when the resolved command ends in `.bat`/`.cmd` on Windows, ensuring proper shell interpretation.

3. **src/mcp/lsp.ts** + **src/mcp/ast-grep.ts** - Apply `wrapWindowsShellCommand()` to the resolved command arrays before returning `LocalMcpConfig`.

## Testing

- 6 new tests for `wrapWindowsShellCommand` (all pass)
- `bun run typecheck` passes
- Pre-existing test failures on Windows (CRLF in bun-which-shim.test.ts, node resolution in zauc-mocks) confirmed unrelated

Closes #4262

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows startup for LSP and `ast-grep` MCP when the executable is a `.bat`/`.cmd` wrapper by running via `cmd.exe /c` and aligning PATH resolution with PATHEXT. Closes #4262.

- **Bug Fixes**
  - Match Windows PATHEXT order in `getWindowsCandidates()` (`.exe` > `.cmd` > `.bat` > `.com` > extensionless).
  - Add `wrapWindowsShellCommand()` to prepend `cmd.exe /c` for `.bat`/`.cmd` commands on Windows.
  - Apply the wrapper in `src/mcp/lsp.ts` and `src/mcp/ast-grep.ts`.
  - Add 6 unit tests for the wrapper.

<sup>Written for commit 27207e6d215380773f108cbc6d12f16d49d0ee9f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4496?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

