### PR TITLE
fix(agents): strip lsp prompt guidance when disabled

### DIFF
--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -26,6 +26,7 @@ import { collectPendingBuiltinAgents } from "./builtin-agents/general-agents"
 import { maybeCreateSisyphusConfig } from "./builtin-agents/sisyphus-agent"
 import { maybeCreateHephaestusConfig } from "./builtin-agents/hephaestus-agent"
 import { maybeCreateAtlasConfig } from "./builtin-agents/atlas-agent"
+import { stripDisabledMcpReferencesFromAgents } from "./disabled-mcp-prompt-sanitizer"
 
 type AgentSource = AgentFactory | AgentConfig
 
@@ -73,6 +74,7 @@ export async function createBuiltinAgents(
   useTaskSystem = false,
   disableOmoEnv = false,
   teamModeEnabled = false,
+  disabledMcps: string[] = [],
 ): Promise<Record<string, AgentConfig>> {
 
   const connectedProviders = readConnectedProvidersCache()
@@ -178,5 +180,5 @@ export async function createBuiltinAgents(
     result["atlas"] = atlasConfig
   }
 
-  return result
+  return stripDisabledMcpReferencesFromAgents(result, disabledMcps)
 }

--- a/src/agents/disabled-mcp-prompt-sanitizer.test.ts
+++ b/src/agents/disabled-mcp-prompt-sanitizer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test"
+import { stripDisabledMcpPromptReferences } from "./disabled-mcp-prompt-sanitizer"
+
+describe("disabled MCP prompt sanitizer", () => {
+  it("#given lsp is enabled #when sanitizing #then preserves lsp guidance", () => {
+    // given
+    const prompt = "After every file edit, run `lsp_diagnostics` on every changed file.\nUse `lsp_*` tools.\n"
+
+    // when
+    const sanitized = stripDisabledMcpPromptReferences(prompt, [])
+
+    // then
+    expect(sanitized).toContain("lsp_diagnostics")
+    expect(sanitized).toContain("lsp_*")
+  })
+
+  it("#given lsp is disabled #when sanitizing #then removes lsp tool instructions", () => {
+    // given
+    const prompt = [
+      "Before edits, inspect the code.",
+      "After every file edit, run `lsp_diagnostics` on every changed file.",
+      "Semantic search (definitions, references): LSP tools",
+      "Use `lsp_*` for diagnostics.",
+      "Build after tests.",
+    ].join("\n")
+
+    // when
+    const sanitized = stripDisabledMcpPromptReferences(prompt, ["lsp"])
+
+    // then
+    expect(sanitized).toContain("Before edits")
+    expect(sanitized).toContain("Build after tests")
+    expect(sanitized).not.toContain("lsp_diagnostics")
+    expect(sanitized).not.toContain("lsp_*")
+    expect(sanitized).not.toContain("LSP tools")
+  })
+})

--- a/src/agents/disabled-mcp-prompt-sanitizer.ts
+++ b/src/agents/disabled-mcp-prompt-sanitizer.ts
@@ -1,0 +1,35 @@
+const LSP_PROMPT_MARKERS = [
+  "lsp_diagnostics",
+  "lsp_*",
+  "lsp tools",
+  "semantic search",
+]
+
+function referencesLspPromptTool(line: string): boolean {
+  const normalized = line.toLowerCase()
+  return LSP_PROMPT_MARKERS.some((marker) => normalized.includes(marker))
+}
+
+export function stripDisabledMcpPromptReferences(prompt: string, disabledMcps: readonly string[] = []): string {
+  if (!disabledMcps.includes("lsp")) return prompt
+
+  return prompt
+    .split("\n")
+    .filter((line) => !referencesLspPromptTool(line))
+    .join("\n")
+}
+
+export function stripDisabledMcpReferencesFromAgents<T extends Record<string, { prompt?: string }>>(
+  agents: T,
+  disabledMcps: readonly string[] = [],
+): T {
+  if (!disabledMcps.includes("lsp")) return agents
+
+  for (const agent of Object.values(agents)) {
+    if (typeof agent.prompt === "string") {
+      agent.prompt = stripDisabledMcpPromptReferences(agent.prompt, disabledMcps)
+    }
+  }
+
+  return agents
+}

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -1618,6 +1618,46 @@ describe("agent override tools migration", () => {
   })
 })
 
+describe("disabled MCP prompt references", () => {
+  test("#given lsp mcp is disabled #when builtin agents are created #then prompts omit lsp tool instructions", async () => {
+    // given
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
+
+    try {
+      // when
+      const agents = await createBuiltinAgents(
+        [],
+        {},
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+        ["lsp"],
+      )
+
+      // then
+      const prompts = Object.values(agents)
+        .map((agent) => agent.prompt ?? "")
+        .join("\n")
+      expect(prompts).not.toContain("lsp_diagnostics")
+      expect(prompts).not.toContain("lsp_*")
+      expect(prompts).not.toContain("LSP tools")
+    } finally {
+      connectedSpy.mockRestore()
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
 describe("Deadlock prevention - fetchAvailableModels must not receive client", () => {
    test("createBuiltinAgents should call fetchAvailableModels with undefined client to prevent deadlock", async () => {
      // #given - This test ensures we don't regress on issue #1301

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -182,6 +182,7 @@ export async function applyAgentConfig(params: {
     useTaskSystem,
     disableOmoEnv,
     params.pluginConfig.team_mode?.enabled ?? false,
+    params.pluginConfig.disabled_mcps ?? [],
   );
 
   const disabledAgentNames = new Set(


### PR DESCRIPTION
## Summary

- Fixes #4486 by removing static LSP tool guidance from built-in agent prompts when the `lsp` MCP is disabled.
- Adds a small prompt sanitizer plus direct and integration regression coverage.

## Changes

- Added `src/agents/disabled-mcp-prompt-sanitizer.ts` to strip `lsp_diagnostics`, `lsp_*`, `LSP tools`, and semantic-search prompt lines only when `disabled_mcps` includes `lsp`.
- Passed `disabled_mcps` from `applyAgentConfig()` into built-in agent creation.
- Added tests covering the sanitizer and generated built-in agent prompts.

## Testing

```bash
bun test src/agents/disabled-mcp-prompt-sanitizer.test.ts src/agents/utils.test.ts --bail
# 74 pass, 0 fail, 175 expect() calls

bun run typecheck
# passed: tsgo --noEmit and typecheck:packages completed with exit code 0

bun run build
# passed: build:ast-grep-mcp, plugin bundle, declaration emit, CLI bundle, schema generation completed with exit code 0

bun test --bail
# not fully passed in this Windows clean clone: script/package-layout.test.ts timed out after 5000ms.
# Re-run targeted test with a longer timeout also timed out after 20000ms:
# bun test script/package-layout.test.ts --timeout 20000
# This failure is isolated to the existing package packing test and is unrelated to the prompt sanitizer changes.
```

LSP diagnostics were run on all changed TypeScript files and reported no diagnostics:

- `src/agents/disabled-mcp-prompt-sanitizer.ts`
- `src/agents/disabled-mcp-prompt-sanitizer.test.ts`
- `src/agents/builtin-agents.ts`
- `src/agents/utils.test.ts`
- `src/plugin-handlers/agent-config-handler.ts`

## Community Rules Review

### CONTRIBUTING.md

- Followed Bun-only workflow: `bun install` was run before changes, and validation used `bun test`, `bun run typecheck`, and `bun run build`.
- Used English Conventional Commits.
- Did not modify `package.json` version or run publish commands.

### PR Template

- Used the repository PR template sections and added verification detail required for this issue.

### CI Requirements

- CI targets `dev` and blocks `master` PRs, so this PR targets `dev`.
- Relevant checks attempted locally: focused tests passed, typecheck passed, build passed, LSP diagnostics clean.
- Full `bun test --bail` was attempted but hit an unrelated existing `script/package-layout.test.ts` timeout on Windows.

### Base Branch

- Base branch is `dev`, matching the repository default branch and CI policy.

## Related Issues

Closes #4486


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes LSP tool guidance from built-in agent prompts when the `lsp` MCP is disabled, so agents don’t suggest unavailable tools. Addresses #4486.

- **Bug Fixes**
  - Added a prompt sanitizer that strips `lsp_diagnostics`, `lsp_*`, “LSP tools”, and semantic-search lines only when `lsp` is in `disabled_mcps`.
  - Passed `disabled_mcps` from `applyAgentConfig()` into `createBuiltinAgents()` and applied the sanitizer to generated prompts.
  - Added unit and integration tests to ensure prompts are cleaned when LSP is disabled and unchanged when enabled.

<sup>Written for commit 62abefecc9ab1eee21925ff77b1d4eb4568f4c3f. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4497?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

