### PR TITLE
fix(session-manager): correct corrupted types.ts in #4432 (session sort corruption)

### DIFF
--- a/src/tools/session-manager/file-storage.ts
+++ b/src/tools/session-manager/file-storage.ts
@@ -28,17 +28,22 @@ export async function getFileMainSessions(directory?: string): Promise<SessionMe
           if (directory && meta.directory !== directory) continue
           sessions.push(meta)
         } catch (error) {
-          const stats = await stat(filePath)
+          let created = Date.now()
+          let updated = Date.now()
+          try {
+            const stats = await stat(filePath)
+            created = stats.mtimeMs
+            updated = stats.mtimeMs
+          } catch {
+            // stat failed (file removed between readdir and stat), use fallback timestamps
+          }
           sessions.push({
             id: file.replace(/\.json$/, ""),
             projectID: projectDir.name,
             directory: directory ?? "",
-            time: {
-              created: stats.mtimeMs,
-              updated: stats.mtimeMs,
-            },
+            time: { created, updated },
             load_error: (error as Error).message,
-          } as SessionMetadata)
+          })
         }
       }
     }

--- a/src/tools/session-manager/file-storage.ts
+++ b/src/tools/session-manager/file-storage.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { join } from "node:path"
 import { MESSAGE_STORAGE, PART_STORAGE, SESSION_STORAGE, TODO_DIR, TRANSCRIPT_DIR } from "./constants"
 import { getMessageDir } from "../../shared/opencode-message-dir"
@@ -20,14 +20,25 @@ export async function getFileMainSessions(directory?: string): Promise<SessionMe
       for (const file of sessionFiles) {
         if (!file.endsWith(".json")) continue
 
+        const filePath = join(projectPath, file)
         try {
-          const content = await readFile(join(projectPath, file), "utf-8")
+          const content = await readFile(filePath, "utf-8")
           const meta = JSON.parse(content) as SessionMetadata
           if (meta.parentID) continue
           if (directory && meta.directory !== directory) continue
           sessions.push(meta)
-        } catch {
-          continue
+        } catch (error) {
+          const stats = await stat(filePath)
+          sessions.push({
+            id: file.replace(/\.json$/, ""),
+            projectID: projectDir.name,
+            directory: directory ?? "",
+            time: {
+              created: stats.mtimeMs,
+              updated: stats.mtimeMs,
+            },
+            load_error: (error as Error).message,
+          } as SessionMetadata)
         }
       }
     }

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -415,6 +415,35 @@ describe("session-manager storage - getMainSessions", () => {
     // then
     expect(sessions.length).toBe(2)
   })
+
+  test("getMainSessions handles corrupted session files with load_error instead of crashing", async () => {
+    // given
+    const projectID = "proj_corrupted"
+    const now = Date.now()
+
+    // valid session
+    createSessionMetadata(projectID, "ses_valid1", { directory: "/test", updated: now })
+
+    // corrupted session file (invalid JSON)
+    const projectDir = join(TEST_SESSION_STORAGE, projectID)
+    writeFileSync(join(projectDir, "ses_corrupted1.json"), "not valid json {{{")
+
+    createMessageForSession("ses_valid1", "msg_001", now)
+
+    // when
+    const sessions = await storage.getMainSessions({})
+
+    // then — corrupted file produces load_error entry, does not crash
+    const corrupted = sessions.find((s) => s.id === "ses_corrupted1")
+    expect(corrupted).toBeDefined()
+    expect(corrupted?.load_error).toBeDefined()
+    expect(typeof corrupted?.load_error).toBe("string")
+
+    // valid session is still returned
+    const valid = sessions.find((s) => s.id === "ses_valid1")
+    expect(valid).toBeDefined()
+    expect(valid?.load_error).toBeUndefined()
+  })
 })
 
 describe("session-manager storage - SDK path (beta mode)", () => {

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -65,6 +65,7 @@ export interface SessionMetadata {
     deletions: number
     files: number
   }
+  load_error?: string
 }
 
 export interface SessionListArgs {


### PR DESCRIPTION
## Problem

PR #4432 (commit 4906d920) introduced a corrupted diff to `src/tools/session-manager/types.ts` that replaced `export interface SessionMetadata {` with orphaned body fields. This broke both `test` and `typecheck` CI checks with:

```
53 |   version?: string
               ^
error: Unexpected :
```

## Solution

- Properly adds `load_error?: string` to `SessionMetadata` inside the existing interface
- Correctly applies the `file-storage.ts` changes from the original fix:
  - `stat` import from `node:fs/promises`
  - Uses `filePath` variable to avoid re-joining paths
  - On JSON parse failure: uses mtime fallback for timestamps, sets `load_error` field
  - Proper `catch (error) {` binding
- Original storage.test.ts tests remain unchanged and pass (56 pass, 0 fail)

## Verification

- `bun run typecheck`: clean
- `bun test src/tools/session-manager`: 56 pass, 0 fail

Closes #680 (session sort corruption)
Ref: PR #4432

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a corrupted change from #4432 that broke typecheck and tests, and makes session loading resilient to malformed JSON by falling back to file mtime and capturing a `load_error`. Closes #680.

- **Bug Fixes**
  - Restores `SessionMetadata` and adds `load_error?: string`.
  - In `file-storage.ts`: import `stat`, use `filePath`, on JSON parse failure return a fallback session with mtime and `load_error`; guard `stat` in try/catch; remove unsafe cast; correct `catch (error)` binding.
  - Adds a regression test for corrupted JSON; tests pass and typecheck is clean.

<sup>Written for commit 74563fd55edf8c83de9afe88a844af365dfa3f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

