### PR TITLE
fix(hooks): align plugin hooks state key with process.cwd() (#4001)

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -47,7 +47,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
 
     const pluginComponents = await loadPluginComponents({ pluginConfig });
 
-    applyHookConfig({ pluginComponents, ctx });
+    applyHookConfig({ pluginComponents });
 
     const agentResult = await applyAgentConfig({
       config,

--- a/src/plugin-handlers/hook-config-handler.test.ts
+++ b/src/plugin-handlers/hook-config-handler.test.ts
@@ -9,17 +9,22 @@ mock.module("../hooks/claude-code-hooks/config", () => ({
 const { applyHookConfig } = await import("./hook-config-handler")
 
 describe("applyHookConfig", () => {
+  let originalCwd = ""
+
   beforeEach(() => {
     mockSetPluginHooksConfigs.mockClear()
+    originalCwd = process.cwd()
   })
 
   afterEach(() => {
     mockSetPluginHooksConfigs.mockClear()
+    if (process.cwd() !== originalCwd) {
+      process.chdir(originalCwd)
+    }
   })
 
-  test("#given ctx.directory #when applyHookConfig called #then setPluginHooksConfigs receives ctx.directory", () => {
+  test("#given hooksConfigs #when applyHookConfig called #then setPluginHooksConfigs receives process.cwd() to align with loader", () => {
     // given
-    const testDirectory = "/test/dir"
     const pluginComponents = {
       commands: {},
       skills: {},
@@ -42,22 +47,18 @@ describe("applyHookConfig", () => {
     }
 
     // when
-    applyHookConfig({
-      pluginComponents,
-      ctx: { directory: testDirectory },
-    })
+    applyHookConfig({ pluginComponents })
 
     // then
     expect(mockSetPluginHooksConfigs).toHaveBeenCalledTimes(1)
     expect(mockSetPluginHooksConfigs).toHaveBeenCalledWith(
-      testDirectory,
+      process.cwd(),
       pluginComponents.hooksConfigs,
     )
   })
 
-  test("#given empty hooksConfigs #when applyHookConfig called #then setPluginHooksConfigs still called with empty array", () => {
+  test("#given empty hooksConfigs #when applyHookConfig called #then setPluginHooksConfigs still called with empty array under process.cwd()", () => {
     // given
-    const testDirectory = "/another/dir"
     const pluginComponents = {
       commands: {},
       skills: {},
@@ -69,14 +70,47 @@ describe("applyHookConfig", () => {
     }
 
     // when
-    applyHookConfig({
-      pluginComponents,
-      ctx: { directory: testDirectory },
-    })
+    applyHookConfig({ pluginComponents })
 
     // then
     expect(mockSetPluginHooksConfigs).toHaveBeenCalledTimes(1)
-    expect(mockSetPluginHooksConfigs).toHaveBeenCalledWith(testDirectory, [])
+    expect(mockSetPluginHooksConfigs).toHaveBeenCalledWith(process.cwd(), [])
+  })
+
+  test("#given process.cwd() changed before apply #when applyHookConfig called #then setPluginHooksConfigs receives the new cwd, never a stale ctx.directory (#4001)", () => {
+    // given
+    const pluginComponents = {
+      commands: {},
+      skills: {},
+      agents: {},
+      mcpServers: {},
+      hooksConfigs: [
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "*",
+                hooks: [{ type: "command", command: "echo pre" }],
+              },
+            ],
+          },
+        },
+      ],
+      plugins: [{ name: "worktree-plugin", version: "1.0.0" }],
+      errors: [],
+    }
+    process.chdir("/tmp")
+    const expectedCwd = process.cwd()
+
+    // when
+    applyHookConfig({ pluginComponents })
+
+    // then
+    expect(mockSetPluginHooksConfigs).toHaveBeenCalledTimes(1)
+    expect(mockSetPluginHooksConfigs).toHaveBeenCalledWith(
+      expectedCwd,
+      pluginComponents.hooksConfigs,
+    )
   })
 })
 

--- a/src/plugin-handlers/hook-config-handler.ts
+++ b/src/plugin-handlers/hook-config-handler.ts
@@ -4,9 +4,8 @@ import { log } from "../shared"
 
 export function applyHookConfig(params: {
   pluginComponents: PluginComponents;
-  ctx: { directory: string };
 }): void {
-  const { pluginComponents, ctx } = params
+  const { pluginComponents } = params
 
   if (pluginComponents.hooksConfigs.length > 0) {
     log("[hook-config-handler] Merging plugin hooks configs", {
@@ -15,5 +14,10 @@ export function applyHookConfig(params: {
     })
   }
 
-  setPluginHooksConfigs(ctx.directory, pluginComponents.hooksConfigs)
+  // `loadClaudeHooksConfig` reads `pluginHooksState` keyed by
+  // `process.cwd()`; the earlier wiring keyed the state by `ctx.directory`
+  // (the plugin host's project directory), so any setup where the two
+  // diverge — worktree, launcher chdir, dev sandbox — silently dropped
+  // every plugin hook even though `applyHookConfig` ran. See #4001 / #4179.
+  setPluginHooksConfigs(process.cwd(), pluginComponents.hooksConfigs)
 }


### PR DESCRIPTION
## Summary

`applyHookConfig` stored plugin hooks state keyed by **`ctx.directory`** (the plugin host's project directory), while the runtime loader `loadClaudeHooksConfig` retrieves the same state by **`process.cwd()`**. When the two diverge — worktree workflows, launcher chdir, dev sandbox, or anywhere OpenCode's plugin host hands a directory that differs from cwd — every plugin hook silently disappeared from the Claude Code dispatch path even though `applyHookConfig` logged success.

This PR drops the now-unused `ctx` parameter from `applyHookConfig` and writes under `process.cwd()`, aligning set and get on the same key. The `setPluginHooksConfigs(directory, ...)` API itself keeps its multi-project-keyed shape — the existing `setPluginHooksConfigs` tests in `claude-code-hooks/config.test.ts` (which exercise directory-keyed isolation between dirA and dirB) still hold.

A new regression test in `hook-config-handler.test.ts` chdirs before the call and asserts the **post-chdir cwd** is used as the state key, so a silent regression to the previous behavior would now fail loudly.

## Relationship to #4001 and #4179

The dispatch wiring itself was fixed by [4d105d05](https://github.com/code-yeongyu/oh-my-openagent/commit/4d105d05) (PR #4180), which closed #4179. #4001 is the same root cause reported from a Chinese-language angle and was not closed alongside. This PR addresses the residual `ctx.directory` vs `process.cwd()` key-mismatch hazard and is intended to **close #4001**.

## Files changed

- `src/plugin-handlers/hook-config-handler.ts` — write under `process.cwd()`, drop `ctx` param, add comment pointing to #4001/#4179
- `src/plugin-handlers/config-handler.ts` — caller no longer passes `ctx`
- `src/plugin-handlers/hook-config-handler.test.ts` — refresh existing two tests, add a chdir-based regression test

## Test plan

- [x] `bun test src/plugin-handlers/hook-config-handler.test.ts` — 3 pass
- [x] `bun test src/plugin-handlers/` — 48 pass (config-handler) + 3 pass (hook-config-handler) and adjacent
- [x] `bun test src/plugin-handlers/ src/hooks/claude-code-hooks/config.test.ts` — 203 pass / 0 fail
- [x] No new typecheck errors introduced (existing dev errors in `bun-file-shim.ts` / `process-cleanup.test-helpers.ts` are pre-existing and unrelated)

Closes #4001.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align plugin hooks state to `process.cwd()` so the setter and loader use the same key, fixing disappearing hooks when the host directory differs from the current working directory (closes #4001).

- **Bug Fixes**
  - Store via `setPluginHooksConfigs(process.cwd(), ...)` and remove `ctx` from `applyHookConfig` to match `loadClaudeHooksConfig`.
  - Add a chdir-based regression test to assert cwd is used as the key; refresh existing tests.

<sup>Written for commit 02405989d9ecae6953638288c8d83ae525229794. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4501?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

