### PR TITLE
fix(start-work): prevent duplicate command-instruction injection on error retry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { tmpdir } from "node:os"
 import { randomUUID } from "node:crypto"
-import { createStartWorkHook } from "./index"
+import { createStartWorkHook, _resetProcessedSessionsForTesting } from "./index"
 import { buildStartWorkContextInfo } from "./context-info-builder"
 import { createAtlasHook } from "../atlas"
 import {
@@ -50,6 +50,7 @@ You are starting a Sisyphus work session.
   }
 
   beforeEach(() => {
+    _resetProcessedSessionsForTesting()
     sessionState._resetForTesting()
     sessionState.registerAgentName("atlas")
     sessionState.registerAgentName("sisyphus")

--- a/src/hooks/start-work/index.ts
+++ b/src/hooks/start-work/index.ts
@@ -1,4 +1,4 @@
-export { HOOK_NAME, createStartWorkHook } from "./start-work-hook"
+export { HOOK_NAME, createStartWorkHook, _resetProcessedSessionsForTesting } from "./start-work-hook"
 export { detectWorktreePath, listWorktrees, parseWorktreeListPorcelain } from "./worktree-detector"
 export type { ParsedUserRequest } from "./parse-user-request"
 export { parseUserRequest } from "./parse-user-request"

--- a/src/hooks/start-work/start-work-dedup.test.ts
+++ b/src/hooks/start-work/start-work-dedup.test.ts
@@ -1,0 +1,114 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test, beforeEach } from "bun:test"
+import { mkdirSync, rmSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { randomUUID } from "node:crypto"
+import { createStartWorkHook, _resetProcessedSessionsForTesting } from "./start-work-hook"
+import * as sessionState from "../../features/claude-code-session-state"
+import { clearBoulderState } from "../../features/boulder-state"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+
+describe("start-work hook deduplication", () => {
+  let testDir: string
+
+  function createMockPluginInput() {
+    return {
+      directory: testDir,
+      client: {
+        session: {
+          messages: async () => ({ data: [] }),
+        },
+      },
+    } as Parameters<typeof createStartWorkHook>[0]
+  }
+
+  function createStartWorkOutput() {
+    return {
+      parts: [{
+        type: "text",
+        text: `<command-instruction>
+You are starting a Sisyphus work session.
+</command-instruction>
+
+<session-context>
+Session ID: $SESSION_ID
+Timestamp: $TIMESTAMP
+</session-context>`,
+      }],
+      message: { agent: "sisyphus" },
+    }
+  }
+
+  beforeEach(() => {
+    _resetProcessedSessionsForTesting()
+    sessionState._resetForTesting()
+    sessionState.registerAgentName("atlas")
+    sessionState.registerAgentName("sisyphus")
+    testDir = join(tmpdir(), `start-work-dedup-test-${randomUUID()}`)
+    mkdirSync(testDir, { recursive: true })
+    mkdirSync(join(testDir, ".omo"), { recursive: true })
+    clearBoulderState(testDir)
+  })
+
+  test("#given same session called twice #when error retry #then second call is skipped", async () => {
+    // given
+    const hook = createStartWorkHook(createMockPluginInput())
+    const sessionID = "session-dedup-test"
+    const output1 = createStartWorkOutput()
+    const output2 = createStartWorkOutput()
+
+    // when - first call processes normally
+    await hook["chat.message"]({ sessionID }, output1)
+
+    // then - first call should have injected context (replaced $SESSION_ID)
+    expect(output1.parts[0].text).not.toContain("$SESSION_ID")
+    expect(output1.parts[0].text).toContain(sessionID)
+
+    // when - second call (error retry) should be skipped
+    await hook["chat.message"]({ sessionID }, output2)
+
+    // then - second output should remain unchanged (still has $SESSION_ID literal)
+    expect(output2.parts[0].text).toContain("$SESSION_ID")
+    expect(output2.parts[0].text).not.toContain(sessionID)
+  })
+
+  test("#given different sessions #when both call hook #then both are processed", async () => {
+    // given
+    const hook = createStartWorkHook(createMockPluginInput())
+    const output1 = createStartWorkOutput()
+    const output2 = createStartWorkOutput()
+
+    // when
+    await hook["chat.message"]({ sessionID: "session-A" }, output1)
+    await hook["chat.message"]({ sessionID: "session-B" }, output2)
+
+    // then - both should have been processed (replaced $SESSION_ID)
+    expect(output1.parts[0].text).toContain("session-A")
+    expect(output2.parts[0].text).toContain("session-B")
+  })
+
+  test("#given command.execute.before handler #when same session retries #then second call is skipped", async () => {
+    // given
+    const hook = createStartWorkHook(createMockPluginInput())
+    const sessionID = "session-cmd-dedup"
+    const output1 = createStartWorkOutput()
+    const output2 = createStartWorkOutput()
+
+    // when - first call via command.execute.before
+    await hook["command.execute.before"](
+      { sessionID, command: "start-work", arguments: "" },
+      output1,
+    )
+
+    // then - first call processed
+    expect(output1.parts[0].text).toContain(sessionID)
+
+    // when - retry via chat.message (same session)
+    await hook["chat.message"]({ sessionID }, output2)
+
+    // then - second call skipped
+    expect(output2.parts[0].text).toContain("$SESSION_ID")
+  })
+})

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -25,6 +25,14 @@ import { findRecentSessionPlanPath } from "./session-plan-affinity"
 export const HOOK_NAME = "start-work" as const
 const START_WORK_TEMPLATE_MARKER = "You are starting a Sisyphus work session."
 
+/** Tracks sessions that have already been processed to prevent duplicate injection on error retry */
+const processedSessions = new Set<string>()
+
+/** @internal — test-only reset */
+export function _resetProcessedSessionsForTesting(): void {
+  processedSessions.clear()
+}
+
 interface StartWorkHookInput {
   sessionID: string
   messageID?: string
@@ -78,6 +86,12 @@ export function createStartWorkHook(ctx: PluginInput) {
     ) {
       return
     }
+
+    if (processedSessions.has(input.sessionID)) {
+      log(`[${HOOK_NAME}] Skipping duplicate injection for session`, { sessionID: input.sessionID })
+      return
+    }
+    processedSessions.add(input.sessionID)
 
     log(`[${HOOK_NAME}] Processing start-work command`, { sessionID: input.sessionID })
     const activeAgent = isAgentRegistered("atlas")


### PR DESCRIPTION
## Summary

Fixes #4481 — `<command-instruction>` gets duplicated when `/start-work` encounters an error and retries.

## Root Cause

The `start-work` hook fires on both `chat.message` and `command.execute.before` events. On error retry, OpenCode re-sends the command, causing the hook to process and inject context a second time into the same session.

## Changes

- Added a module-level `processedSessions` Set that tracks which sessions have already been processed
- On subsequent calls for the same session, the hook logs and returns early (skipping duplicate injection)
- Added `_resetProcessedSessionsForTesting()` export for test isolation
- Updated existing `index.test.ts` to reset the Set in `beforeEach`

## Testing

- `bun test src/hooks/start-work/start-work-dedup.test.ts` — 3 pass (dedup same session, different sessions both processed, cross-handler dedup)
- `bun test src/hooks/start-work/index.test.ts` — 37 pass (no regressions)
- `bun run typecheck` — clean

Closes #4481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate `<command-instruction>` injection when `/start-work` retries after an error. The hook now processes each session only once across `chat.message` and `command.execute.before`. Fixes #4481.

- **Bug Fixes**
  - Track processed sessions in a module-level `processedSessions` Set and skip repeats.
  - Export `_resetProcessedSessionsForTesting` from `start-work-hook` and re-export in `index.ts`; added `start-work-dedup.test.ts` and updated `index.test.ts`.

- **Dependencies**
  - Synced `bun.lock` platform binary optional dependencies (`oh-my-opencode-*`) to `4.5.1` to match `package.json`.

<sup>Written for commit 18f2f46d9653aaeac4f4143ce83ee8b10ba52d09. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4503?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

