### PR TITLE
fix(claude-code-hooks): inject CLAUDE_PLUGIN_ROOT env var for plugin-sourced hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/features/claude-code-plugin-loader/hook-loader.ts
+++ b/src/features/claude-code-plugin-loader/hook-loader.ts
@@ -15,6 +15,9 @@ export function loadPluginHooksConfigs(plugins: LoadedPlugin[]): HooksConfig[] {
 
       config = resolvePluginPaths(config, plugin.installPath)
 
+      // Attach the plugin root so command hooks can resolve paths via CLAUDE_PLUGIN_ROOT
+      config = { ...config, pluginRoot: plugin.installPath }
+
       configs.push(config)
       log(`Loaded plugin hooks config from ${plugin.name}`, { path: plugin.hooksPath })
     } catch (error) {

--- a/src/features/claude-code-plugin-loader/types.ts
+++ b/src/features/claude-code-plugin-loader/types.ts
@@ -140,6 +140,8 @@ export interface HooksConfig {
     SessionEnd?: HookMatcher[]
     PreCompact?: HookMatcher[]
   }
+  /** Plugin root path injected as CLAUDE_PLUGIN_ROOT for command hooks from this plugin */
+  pluginRoot?: string
 }
 
 /**

--- a/src/hooks/claude-code-hooks/config.test.ts
+++ b/src/hooks/claude-code-hooks/config.test.ts
@@ -244,6 +244,169 @@ describe("mergePluginHooksConfigs", () => {
     expect(result.Stop).toBeUndefined()
     expect(result.PreToolUse).toBeUndefined()
   })
+
+  test("#given plugin command hook with pluginRoot #when merged #then pluginRoot is attached to command hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      pluginRoot: "/opt/my-plugin",
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: "echo hello" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const stopHooks = result.Stop ?? []
+    expect(stopHooks.length).toBe(1)
+    const hook = stopHooks[0].hooks[0]
+    expect(hook.type).toBe("command")
+    if (hook.type === "command") {
+      expect(hook.pluginRoot).toBe("/opt/my-plugin")
+    }
+  })
+
+  test("#given plugin command hook without pluginRoot #when merged #then pluginRoot is not set on hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: "echo hello" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const stopHooks = result.Stop ?? []
+    expect(stopHooks.length).toBe(1)
+    const hook = stopHooks[0].hooks[0]
+    expect(hook.type).toBe("command")
+    if (hook.type === "command") {
+      expect(hook.pluginRoot).toBeUndefined()
+    }
+  })
+
+  test("#given plugin HTTP hook with pluginRoot #when merged #then pluginRoot is NOT attached to HTTP hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      pluginRoot: "/opt/my-plugin",
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "*",
+            hooks: [{ type: "http", url: "https://example.com/hook" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const preToolHooks = result.PreToolUse ?? []
+    expect(preToolHooks.length).toBe(1)
+    const hook = preToolHooks[0].hooks[0]
+    expect(hook.type).toBe("http")
+    // HTTP hooks don't get pluginRoot
+    expect((hook as Record<string, unknown>).pluginRoot).toBeUndefined()
+  })
+  test("#given plugin command hook with pluginRoot #when merged #then pluginRoot is attached to command hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      pluginRoot: "/opt/my-plugin",
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: "echo hello" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const stopHooks = result.Stop ?? []
+    expect(stopHooks.length).toBe(1)
+    const hook = stopHooks[0].hooks[0]
+    expect(hook.type).toBe("command")
+    if (hook.type === "command") {
+      expect(hook.pluginRoot).toBe("/opt/my-plugin")
+    }
+  })
+
+  test("#given plugin command hook without pluginRoot #when merged #then pluginRoot is not set on hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: "echo hello" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const stopHooks = result.Stop ?? []
+    expect(stopHooks.length).toBe(1)
+    const hook = stopHooks[0].hooks[0]
+    expect(hook.type).toBe("command")
+    if (hook.type === "command") {
+      expect(hook.pluginRoot).toBeUndefined()
+    }
+  })
+
+  test("#given plugin HTTP hook with pluginRoot #when merged #then pluginRoot is NOT attached to HTTP hook", () => {
+    // given
+    const base = {}
+    const pluginConfig = {
+      pluginRoot: "/opt/my-plugin",
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "*",
+            hooks: [{ type: "http", url: "https://example.com/hook" }],
+          },
+        ],
+      },
+    }
+
+    // when
+    const result = mergePluginHooksConfigs(base, [pluginConfig])
+
+    // then
+    const preToolHooks = result.PreToolUse ?? []
+    expect(preToolHooks.length).toBe(1)
+    const hook = preToolHooks[0].hooks[0]
+    expect(hook.type).toBe("http")
+    // HTTP hooks don't get pluginRoot
+    expect((hook as Record<string, unknown>).pluginRoot).toBeUndefined()
+  })
 })
 
 describe("setPluginHooksConfigs", () => {

--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -202,6 +202,7 @@ export function mergePluginHooksConfigs(
   for (const pluginConfig of pluginHooksConfigs) {
     if (!pluginConfig.hooks) continue
 
+    const pluginRoot = pluginConfig.pluginRoot
     const pluginOverrides: ClaudeHooksConfig = {}
     for (const eventType of ALL_HOOK_EVENT_TYPES) {
       const pluginMatchers = pluginConfig.hooks[eventType]
@@ -213,7 +214,13 @@ export function mergePluginHooksConfigs(
           matcher: m.matcher ?? m.pattern ?? "*",
           hooks: (m.hooks ?? [])
             .filter(isHookAction)
-            .map(applyMcpEnvAllowlist),
+            .map(applyMcpEnvAllowlist)
+            .map((action) => {
+              if (action.type === "command" && pluginRoot) {
+                return { ...action, pluginRoot }
+              }
+              return action
+            }),
         }))
         .filter((m) => m.hooks.length > 0)
 

--- a/src/hooks/claude-code-hooks/dispatch-hook.ts
+++ b/src/hooks/claude-code-hooks/dispatch-hook.ts
@@ -26,6 +26,9 @@ export async function dispatchHook(
   if (cmdHook.allowedEnvVars) {
     options.allowedEnvVars = cmdHook.allowedEnvVars
   }
+  if (cmdHook.pluginRoot) {
+    options.pluginRoot = cmdHook.pluginRoot
+  }
 
   return executeHookCommand(
     hook.command,

--- a/src/hooks/claude-code-hooks/types.ts
+++ b/src/hooks/claude-code-hooks/types.ts
@@ -27,6 +27,8 @@ export interface HookCommand {
   command: string
   /** Env vars allowed to pass through to the spawned process (plugin-sourced hooks are intersected with mcp_env_allowlist) */
   allowedEnvVars?: string[]
+  /** Plugin root path injected as CLAUDE_PLUGIN_ROOT env var for plugin-sourced hooks */
+  pluginRoot?: string
 }
 
 export interface HookHttp {
@@ -235,4 +237,6 @@ export interface PluginConfig {
  */
 export interface PluginHooksConfig {
   hooks?: Partial<Record<ClaudeHookEvent, unknown[]>>
+  /** Plugin root path — injected as CLAUDE_PLUGIN_ROOT into command hooks from this plugin */
+  pluginRoot?: string
 }

--- a/src/shared/command-executor/execute-hook-command.test.ts
+++ b/src/shared/command-executor/execute-hook-command.test.ts
@@ -23,7 +23,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      "echo $__OMO_TEST_ALLOWED_VAR $__OMO_TEST_SECRET_VAR",
+      "node -e \"console.log(process.env.__OMO_TEST_ALLOWED_VAR, process.env.__OMO_TEST_SECRET_VAR)\"",
       "",
       tempDirectory,
       { allowedEnvVars: ["__OMO_TEST_ALLOWED_VAR"] },
@@ -45,7 +45,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      "echo $__OMO_TEST_FULL_ENV_VAR",
+      "node -e \"console.log(process.env.__OMO_TEST_FULL_ENV_VAR)\"",
       "",
       tempDirectory,
     )
@@ -56,6 +56,48 @@ describe("executeHookCommand", () => {
 
     // cleanup
     delete process.env.__OMO_TEST_FULL_ENV_VAR
+  })
+
+  test("#given pluginRoot provided #when executing command #then CLAUDE_PLUGIN_ROOT is set in env", async () => {
+    // given
+    const pluginRoot = "/opt/my-plugin"
+
+    // when
+    const result = await executeHookCommand(
+      "node -e \"console.log(process.env.CLAUDE_PLUGIN_ROOT)\"",
+      "",
+      tempDirectory,
+      { pluginRoot },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(pluginRoot)
+  })
+
+  test("#given pluginRoot provided with allowedEnvVars #when executing command #then CLAUDE_PLUGIN_ROOT is set alongside restricted env", async () => {
+    // given
+    const pluginRoot = "/opt/my-plugin"
+    process.env.__OMO_TEST_ALLOWED_VAR2 = "allowed"
+    process.env.__OMO_TEST_SECRET_VAR2 = "secret"
+
+    // when
+    const result = await executeHookCommand(
+      "node -e \"console.log(process.env.CLAUDE_PLUGIN_ROOT, process.env.__OMO_TEST_ALLOWED_VAR2, process.env.__OMO_TEST_SECRET_VAR2)\"",
+      "",
+      tempDirectory,
+      { pluginRoot, allowedEnvVars: ["__OMO_TEST_ALLOWED_VAR2"] },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(pluginRoot)
+    expect(result.stdout).toContain("allowed")
+    expect(result.stdout).not.toContain("secret")
+
+    // cleanup
+    delete process.env.__OMO_TEST_ALLOWED_VAR2
+    delete process.env.__OMO_TEST_SECRET_VAR2
   })
 })
 

--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -18,6 +18,8 @@ export interface ExecuteHookOptions {
   timeoutMs?: number;
   /** When provided, scrub process.env to only include these vars plus HOME/PATH/etc. Used for plugin-sourced hooks. */
   allowedEnvVars?: string[];
+  /** When provided, inject as CLAUDE_PLUGIN_ROOT env var so plugin-sourced hooks can resolve relative paths. */
+  pluginRoot?: string;
 }
 
 export async function executeHookCommand(
@@ -75,6 +77,9 @@ export async function executeHookCommand(
       }
     } else {
       env = { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd };
+    }
+    if (options?.pluginRoot) {
+      env.CLAUDE_PLUGIN_ROOT = options.pluginRoot;
     }
 
     const proc = spawn(finalCommand, {


### PR DESCRIPTION
## Summary

Fixes #4458.

Plugin-sourced command hooks had no way to resolve paths relative to their plugin installation directory. CLAUDE_PLUGIN_ROOT was documented but never actually injected into the hook execution environment.

## Root Cause

The plugin root path (plugin.installPath) was available in loadPluginHooksConfigs() but was never threaded through to the command execution layer. executeHookCommand() had no mechanism to inject CLAUDE_PLUGIN_ROOT.

## Fix

Thread pluginRoot from HooksConfig through the merge pipeline and into executeHookCommand options, where it is set as CLAUDE_PLUGIN_ROOT in the spawned process environment.

## Changes

- src/features/claude-code-plugin-loader/types.ts: Add pluginRoot optional field to HooksConfig
- src/features/claude-code-plugin-loader/hook-loader.ts: Attach plugin.installPath as pluginRoot when loading plugin hooks
- src/hooks/claude-code-hooks/types.ts: Add pluginRoot optional field to HookCommand
- src/hooks/claude-code-hooks/config.ts: Propagate pluginRoot onto command hooks (not HTTP hooks) during merge
- src/hooks/claude-code-hooks/dispatch-hook.ts: Pass pluginRoot to executeHookCommand options
- src/shared/command-executor/execute-hook-command.ts: Set CLAUDE_PLUGIN_ROOT env var when pluginRoot provided
- src/hooks/claude-code-hooks/config.test.ts: 3 new tests for pluginRoot propagation
- src/shared/command-executor/execute-hook-command.test.ts: 2 new tests for CLAUDE_PLUGIN_ROOT injection

## Testing

bun test src/hooks/claude-code-hooks/config.test.ts src/shared/command-executor/execute-hook-command.test.ts
20 pass / 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects CLAUDE_PLUGIN_ROOT into plugin-sourced command hooks so they can resolve paths relative to the plugin install directory. Threads the plugin root from plugin load through config merge to command execution, with tests.

- **Bug Fixes**
  - Add `pluginRoot` to hooks config and command hooks; set from `plugin.installPath`.
  - Propagate `pluginRoot` only to command hooks; dispatch passes it to execution.
  - `executeHookCommand` sets `CLAUDE_PLUGIN_ROOT` and respects `allowedEnvVars`.
  - HTTP hooks are unchanged.

- **Dependencies**
  - Sync `bun.lock` platform binaries to `oh-my-opencode-*@4.5.1`.

<sup>Written for commit f85d769d232abb6e1ff94bcbb471f973d66de559. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

