### PR TITLE
Use managed exact plugin versions for auto updates

### DIFF
--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -6,7 +6,7 @@ export {
 } from "./config-manager/config-context"
 
 export { fetchNpmDistTags } from "./config-manager/npm-dist-tags"
-export { getPluginNameWithVersion } from "./config-manager/plugin-name-with-version"
+export { getPluginNameWithVersion, resolvePluginInstallReference } from "./config-manager/plugin-name-with-version"
 export { addPluginToOpenCodeConfig } from "./config-manager/add-plugin-to-opencode-config"
 
 export { generateOmoConfig } from "./config-manager/generate-omo-config"

--- a/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -1,14 +1,24 @@
 import { readFileSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
 import type { ConfigMergeResult } from "../types"
 import { PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../shared"
+import { writeManagedPluginState } from "../../shared/managed-plugin-state"
 import { backupConfigFile } from "./backup-config"
 import { getConfigDir } from "./config-context"
 import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists"
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
 import { detectConfigFormat } from "./opencode-config-format"
 import { parseOpenCodeConfigFileWithError, type OpenCodeConfig } from "./parse-opencode-config-file"
-import { getPluginNameWithVersion } from "./plugin-name-with-version"
+import { resolvePluginInstallReference } from "./plugin-name-with-version"
 import { checkVersionCompatibility, extractVersionFromPluginEntry } from "./version-compatibility"
+
+function finalizeSuccess(configPath: string, pluginEntry: string, channel: string): ConfigMergeResult {
+  writeManagedPluginState(dirname(configPath), {
+    entry: pluginEntry,
+    channel,
+  })
+  return { success: true, configPath }
+}
 
 export async function addPluginToOpenCodeConfig(currentVersion: string): Promise<ConfigMergeResult> {
   try {
@@ -22,13 +32,13 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
   }
 
   const { format, path } = detectConfigFormat()
-  const pluginEntry = await getPluginNameWithVersion(currentVersion, PLUGIN_NAME)
+  const { entry: pluginEntry, channel } = await resolvePluginInstallReference(currentVersion, PLUGIN_NAME)
 
   try {
     if (format === "none") {
       const config: OpenCodeConfig = { plugin: [pluginEntry] }
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
-      return { success: true, configPath: path }
+      return finalizeSuccess(path, pluginEntry, channel)
     }
 
     const parseResult = parseOpenCodeConfigFileWithError(path)
@@ -100,7 +110,7 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
     }
 
-    return { success: true, configPath: path }
+    return finalizeSuccess(path, pluginEntry, channel)
   } catch (err) {
     return {
       success: false,

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -8,6 +8,13 @@ import { detectCurrentConfig } from "./detect-current-config"
 import { addPluginToOpenCodeConfig } from "./add-plugin-to-opencode-config"
 import * as pluginNameWithVersion from "./plugin-name-with-version"
 
+function mockInstallReference(version: string) {
+  return spyOn(pluginNameWithVersion, "resolvePluginInstallReference").mockResolvedValue({
+    entry: `oh-my-openagent@${version}`,
+    channel: "latest",
+  })
+}
+
 describe("detectCurrentConfig - single package detection", () => {
   let testConfigDir = ""
   let testConfigPath = ""
@@ -86,6 +93,7 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
   it("writes canonical plugin entry for new installs", async () => {
     // given
+    const resolvePluginInstallReferenceSpy = mockInstallReference("3.11.0")
     writeFileSync(testConfigPath, JSON.stringify({}, null, 2) + "\n", "utf-8")
 
     // when
@@ -94,11 +102,13 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.11.0"])
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("upgrades a bare legacy plugin entry to canonical", async () => {
     // given
+    const resolvePluginInstallReferenceSpy = mockInstallReference("3.11.0")
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n", "utf-8")
 
     // when
@@ -107,12 +117,16 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.11.0"])
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("updates a version-pinned legacy entry to the requested version", async () => {
     // given
-    const getPluginNameWithVersionSpy = spyOn(pluginNameWithVersion, "getPluginNameWithVersion").mockResolvedValue("oh-my-openagent@3.16.0")
+    const resolvePluginInstallReferenceSpy = spyOn(pluginNameWithVersion, "resolvePluginInstallReference").mockResolvedValue({
+      entry: "oh-my-openagent@3.16.0",
+      channel: "latest",
+    })
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode@3.15.0"] }, null, 2) + "\n", "utf-8")
 
     // when
@@ -122,11 +136,12 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
     expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.16.0"])
-    getPluginNameWithVersionSpy.mockRestore()
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("removes stale legacy entry when canonical and legacy entries both exist", async () => {
     // given
+    const resolvePluginInstallReferenceSpy = mockInstallReference("3.11.0")
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent", "oh-my-opencode"] }, null, 2) + "\n", "utf-8")
 
     // when
@@ -135,12 +150,16 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.11.0"])
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("preserves a canonical entry when the same version is re-installed", async () => {
     // given
-    const getPluginNameWithVersionSpy = spyOn(pluginNameWithVersion, "getPluginNameWithVersion").mockResolvedValue("oh-my-openagent@3.10.0")
+    const resolvePluginInstallReferenceSpy = spyOn(pluginNameWithVersion, "resolvePluginInstallReference").mockResolvedValue({
+      entry: "oh-my-openagent@3.10.0",
+      channel: "latest",
+    })
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent@3.10.0"] }, null, 2) + "\n", "utf-8")
 
     // when
@@ -150,12 +169,15 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     expect(result.success).toBe(true)
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
     expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"])
-    getPluginNameWithVersionSpy.mockRestore()
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("blocks a downgrade for a version-pinned canonical entry", async () => {
     // given
-    const getPluginNameWithVersionSpy = spyOn(pluginNameWithVersion, "getPluginNameWithVersion").mockResolvedValue("oh-my-openagent@3.15.0")
+    const resolvePluginInstallReferenceSpy = spyOn(pluginNameWithVersion, "resolvePluginInstallReference").mockResolvedValue({
+      entry: "oh-my-openagent@3.15.0",
+      channel: "latest",
+    })
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent@3.16.0"] }, null, 2) + "\n", "utf-8")
 
     // when
@@ -167,11 +189,12 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
 
     const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
     expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.16.0"])
-    getPluginNameWithVersionSpy.mockRestore()
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 
   it("rewrites quoted jsonc plugin field in place", async () => {
     // given
+    const resolvePluginInstallReferenceSpy = mockInstallReference("3.11.0")
     testConfigPath = join(testConfigDir, "opencode.jsonc")
     writeFileSync(testConfigPath, '{\n  "plugin": ["oh-my-opencode"]\n}\n', "utf-8")
 
@@ -181,7 +204,8 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
     // then
     expect(result.success).toBe(true)
     const savedContent = readFileSync(testConfigPath, "utf-8")
-    expect(savedContent.includes('"plugin": [\n    "oh-my-openagent"\n  ]')).toBe(true)
+    expect(savedContent.includes('"plugin": [\n    "oh-my-openagent@3.11.0"\n  ]')).toBe(true)
     expect(savedContent.includes("oh-my-opencode")).toBe(false)
+    resolvePluginInstallReferenceSpy.mockRestore()
   })
 })

--- a/src/cli/config-manager/plugin-name-with-version.test.ts
+++ b/src/cli/config-manager/plugin-name-with-version.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test"
 
-import { getPluginNameWithVersion } from "../config-manager"
+import { getPluginNameWithVersion, resolvePluginInstallReference } from "../config-manager"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
 describe("getPluginNameWithVersion", () => {
@@ -12,7 +12,7 @@ describe("getPluginNameWithVersion", () => {
     globalThis.fetch = originalFetch
   })
 
-  test("returns the canonical latest tag when current version matches latest", async () => {
+  test("returns the exact versioned entry when current version matches latest", async () => {
     //#given
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() =>
       Promise.resolve({
@@ -25,10 +25,10 @@ describe("getPluginNameWithVersion", () => {
     const result = await getPluginNameWithVersion("3.13.1")
 
     //#then
-    expect(result).toBe("oh-my-openagent@latest")
+    expect(result).toBe("oh-my-openagent@3.13.1")
   })
 
-  test("preserves the canonical prerelease channel when fetch fails", async () => {
+  test("returns the exact prerelease version when fetch fails", async () => {
     //#given
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() => Promise.reject(new Error("Network error"))))
 
@@ -36,10 +36,10 @@ describe("getPluginNameWithVersion", () => {
     const result = await getPluginNameWithVersion("3.14.0-beta.1")
 
     //#then
-    expect(result).toBe("oh-my-openagent@beta")
+    expect(result).toBe("oh-my-openagent@3.14.0-beta.1")
   })
 
-  test("returns the canonical bare package name for stable fallback", async () => {
+  test("returns the exact stable version for fallback", async () => {
     //#given
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() =>
       Promise.resolve({
@@ -52,6 +52,47 @@ describe("getPluginNameWithVersion", () => {
     const result = await getPluginNameWithVersion("3.13.1")
 
     //#then
-    expect(result).toBe("oh-my-openagent")
+    expect(result).toBe("oh-my-openagent@3.13.1")
+  })
+})
+
+describe("resolvePluginInstallReference", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("returns the matching release channel when dist-tags resolve", async () => {
+    //#given
+    globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ latest: "3.13.1", beta: "3.14.0-beta.1" }),
+      } as Response)
+    ))
+
+    //#when
+    const result = await resolvePluginInstallReference("3.14.0-beta.1")
+
+    //#then
+    expect(result).toEqual({
+      entry: "oh-my-openagent@3.14.0-beta.1",
+      channel: "beta",
+    })
+  })
+
+  test("falls back to latest for stable releases without dist-tag metadata", async () => {
+    //#given
+    globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() => Promise.reject(new Error("Network error"))))
+
+    //#when
+    const result = await resolvePluginInstallReference("3.13.1")
+
+    //#then
+    expect(result).toEqual({
+      entry: "oh-my-openagent@3.13.1",
+      channel: "latest",
+    })
   })
 })

--- a/src/cli/config-manager/plugin-name-with-version.ts
+++ b/src/cli/config-manager/plugin-name-with-version.ts
@@ -4,30 +4,47 @@ import { fetchNpmDistTags } from "./npm-dist-tags"
 const DEFAULT_PACKAGE_NAME = PLUGIN_NAME
 const PRIORITIZED_TAGS = ["latest", "beta", "next"] as const
 
-function getFallbackEntry(version: string, packageName: string): string {
+export interface PluginInstallReference {
+  entry: string
+  channel: string
+}
+
+function getFallbackChannel(version: string): string {
   const prereleaseMatch = version.match(/-([a-zA-Z][a-zA-Z0-9-]*)(?:\.|$)/)
   if (prereleaseMatch) {
-    return `${packageName}@${prereleaseMatch[1]}`
+    return prereleaseMatch[1]
   }
 
-  return packageName
+  return "latest"
+}
+
+export async function resolvePluginInstallReference(
+  currentVersion: string,
+  packageName: string = DEFAULT_PACKAGE_NAME
+): Promise<PluginInstallReference> {
+  const distTags = await fetchNpmDistTags(packageName)
+  let channel = getFallbackChannel(currentVersion)
+
+  if (distTags) {
+    const allTags = new Set([...PRIORITIZED_TAGS, ...Object.keys(distTags)])
+    for (const tag of allTags) {
+      if (distTags[tag] === currentVersion) {
+        channel = tag
+        break
+      }
+    }
+  }
+
+  return {
+    entry: `${packageName}@${currentVersion}`,
+    channel,
+  }
 }
 
 export async function getPluginNameWithVersion(
   currentVersion: string,
   packageName: string = DEFAULT_PACKAGE_NAME
 ): Promise<string> {
-  const distTags = await fetchNpmDistTags(packageName)
-
-
-  if (distTags) {
-    const allTags = new Set([...PRIORITIZED_TAGS, ...Object.keys(distTags)])
-    for (const tag of allTags) {
-      if (distTags[tag] === currentVersion) {
-        return `${packageName}@${tag}`
-      }
-    }
-  }
-
-  return getFallbackEntry(currentVersion, packageName)
+  const { entry } = await resolvePluginInstallReference(currentVersion, packageName)
+  return entry
 }

--- a/src/hooks/auto-update-checker/checker/pinned-version-updater.test.ts
+++ b/src/hooks/auto-update-checker/checker/pinned-version-updater.test.ts
@@ -36,6 +36,23 @@ describe("pinned-version-updater", () => {
       expect(updated).not.toContain(`${PACKAGE_NAME}@3.1.8`)
     })
 
+    test("preserves canonical alias when updating version", () => {
+      //#given
+      const config = JSON.stringify({
+        plugin: ["oh-my-openagent@3.1.8"],
+      })
+      fs.writeFileSync(configPath, config)
+
+      //#when
+      const result = updatePinnedVersion(configPath, "oh-my-openagent@3.1.8", "3.4.0")
+
+      //#then
+      expect(result).toBe(true)
+      const updated = fs.readFileSync(configPath, "utf-8")
+      expect(updated).toContain("oh-my-openagent@3.4.0")
+      expect(updated).not.toContain("oh-my-opencode@3.4.0")
+    })
+
     test("returns false when entry not found", () => {
       //#given
       const config = JSON.stringify({
@@ -79,6 +96,23 @@ describe("pinned-version-updater", () => {
       const reverted = fs.readFileSync(configPath, "utf-8")
       expect(reverted).toContain(`${PACKAGE_NAME}@3.1.8`)
       expect(reverted).not.toContain(`${PACKAGE_NAME}@3.4.0`)
+    })
+
+    test("reverts canonical alias back to the original entry", () => {
+      //#given
+      const config = JSON.stringify({
+        plugin: ["oh-my-openagent@3.4.0"],
+      })
+      fs.writeFileSync(configPath, config)
+
+      //#when
+      const result = revertPinnedVersion(configPath, "3.4.0", "oh-my-openagent@3.1.8")
+
+      //#then
+      expect(result).toBe(true)
+      const reverted = fs.readFileSync(configPath, "utf-8")
+      expect(reverted).toContain("oh-my-openagent@3.1.8")
+      expect(reverted).not.toContain("oh-my-opencode@3.1.8")
     })
 
     test("reverts to unpinned entry", () => {

--- a/src/hooks/auto-update-checker/checker/pinned-version-updater.ts
+++ b/src/hooks/auto-update-checker/checker/pinned-version-updater.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs"
 import { log } from "../../../shared/logger"
-import { PACKAGE_NAME } from "../constants"
 
 function replacePluginEntry(configPath: string, oldEntry: string, newEntry: string): boolean {
   try {
@@ -51,12 +50,18 @@ function replacePluginEntry(configPath: string, oldEntry: string, newEntry: stri
   }
 }
 
+function buildVersionedEntry(entry: string, version: string): string {
+  const atIndex = entry.lastIndexOf("@")
+  const packageName = atIndex === -1 ? entry : entry.slice(0, atIndex)
+  return `${packageName}@${version}`
+}
+
 export function updatePinnedVersion(configPath: string, oldEntry: string, newVersion: string): boolean {
-  const newEntry = `${PACKAGE_NAME}@${newVersion}`
+  const newEntry = buildVersionedEntry(oldEntry, newVersion)
   return replacePluginEntry(configPath, oldEntry, newEntry)
 }
 
 export function revertPinnedVersion(configPath: string, failedVersion: string, originalEntry: string): boolean {
-  const failedEntry = `${PACKAGE_NAME}@${failedVersion}`
+  const failedEntry = buildVersionedEntry(originalEntry, failedVersion)
   return replacePluginEntry(configPath, failedEntry, originalEntry)
 }

--- a/src/hooks/auto-update-checker/hook/background-update-check.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.ts
@@ -2,12 +2,14 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { runBunInstallWithDetails } from "../../../cli/config-manager"
+import { getManagedPluginStatePath, readManagedPluginState, writeManagedPluginState } from "../../../shared/managed-plugin-state"
 import { log } from "../../../shared/logger"
 import { getOpenCodeCacheDir, getOpenCodeConfigPaths } from "../../../shared"
 import { invalidatePackage } from "../cache"
 import { PACKAGE_NAME } from "../constants"
 import { extractChannel } from "../version-channel"
 import { findPluginEntry, getCachedVersion, getLatestVersion, syncCachePackageJsonToIntent } from "../checker"
+import { revertPinnedVersion, updatePinnedVersion } from "../checker/pinned-version-updater"
 import { showAutoUpdatedToast, showUpdateAvailableToast } from "./update-toasts"
 
 type BackgroundUpdateCheckDeps = {
@@ -22,7 +24,11 @@ type BackgroundUpdateCheckDeps = {
   findPluginEntry: typeof findPluginEntry
   getCachedVersion: typeof getCachedVersion
   getLatestVersion: typeof getLatestVersion
+  readManagedPluginState: typeof readManagedPluginState
+  writeManagedPluginState: typeof writeManagedPluginState
   syncCachePackageJsonToIntent: typeof syncCachePackageJsonToIntent
+  updatePinnedVersion: typeof updatePinnedVersion
+  revertPinnedVersion: typeof revertPinnedVersion
   showUpdateAvailableToast: typeof showUpdateAvailableToast
   showAutoUpdatedToast: typeof showAutoUpdatedToast
 }
@@ -49,13 +55,23 @@ const defaultDeps: BackgroundUpdateCheckDeps = {
   findPluginEntry,
   getCachedVersion,
   getLatestVersion,
+  readManagedPluginState,
+  writeManagedPluginState,
   syncCachePackageJsonToIntent,
+  updatePinnedVersion,
+  revertPinnedVersion,
   showUpdateAvailableToast,
   showAutoUpdatedToast,
 }
 
 function getPinnedVersionToastMessage(latestVersion: string): string {
   return `Update available: ${latestVersion} (version pinned, update manually)`
+}
+
+function buildVersionedEntry(entry: string, version: string): string {
+  const atIndex = entry.lastIndexOf("@")
+  const packageName = atIndex === -1 ? entry : entry.slice(0, atIndex)
+  return `${packageName}@${version}`
 }
 
 /**
@@ -134,6 +150,8 @@ export function createBackgroundUpdateCheckRunner(
       return
     }
 
+    const configPaths = deps.getOpenCodeConfigPaths({ binary: "opencode" })
+    const managedState = deps.readManagedPluginState(configPaths.configDir)
     const cachedVersion = deps.getCachedVersion()
     const currentVersion = cachedVersion ?? pluginInfo.pinnedVersion
     if (!currentVersion) {
@@ -141,7 +159,15 @@ export function createBackgroundUpdateCheckRunner(
       return
     }
 
-    const channel = deps.extractChannel(pluginInfo.pinnedVersion ?? currentVersion)
+    const isManagedPinnedEntry =
+      pluginInfo.isPinned &&
+      managedState?.entry === pluginInfo.entry &&
+      managedState.channel.trim().length > 0
+
+    const channel = isManagedPinnedEntry
+      ? managedState.channel
+      : deps.extractChannel(pluginInfo.pinnedVersion ?? currentVersion)
+
     const latestVersion = await deps.getLatestVersion(channel)
     if (!latestVersion) {
       deps.log("[auto-update-checker] Failed to fetch latest version for channel:", channel)
@@ -149,6 +175,22 @@ export function createBackgroundUpdateCheckRunner(
     }
 
     if (currentVersion === latestVersion) {
+      if (!pluginInfo.isPinned) {
+        const updatedManagedEntry = buildVersionedEntry(pluginInfo.entry, currentVersion)
+        const migrated = deps.updatePinnedVersion(pluginInfo.configPath, pluginInfo.entry, currentVersion)
+        if (migrated) {
+          const wroteState = deps.writeManagedPluginState(configPaths.configDir, {
+            entry: updatedManagedEntry,
+            channel,
+          })
+          if (!wroteState) {
+            deps.log(`[auto-update-checker] Failed to persist managed plugin state: ${getManagedPluginStatePath(configPaths.configDir)}`)
+          }
+        } else {
+          deps.log(`[auto-update-checker] Failed to migrate dynamic plugin entry to managed exact version: ${pluginInfo.entry}`)
+        }
+      }
+
       deps.log("[auto-update-checker] Already on latest version for channel:", channel)
       return
     }
@@ -161,14 +203,45 @@ export function createBackgroundUpdateCheckRunner(
       return
     }
 
-    if (pluginInfo.isPinned) {
+    if (pluginInfo.isPinned && !isManagedPinnedEntry) {
       await deps.showUpdateAvailableToast(ctx, latestVersion, () => getPinnedVersionToastMessage(latestVersion))
       deps.log(`[auto-update-checker] User-pinned version detected (${pluginInfo.entry}), skipping auto-update. Notification only.`)
       return
     }
 
-    const syncResult = deps.syncCachePackageJsonToIntent(pluginInfo)
+    let intendedPluginInfo = pluginInfo
+    let updatedManagedEntry: string | null = null
+    const shouldManageEntry = !pluginInfo.isPinned || isManagedPinnedEntry
+
+    const revertManagedPinnedConfig = (): void => {
+      if (!updatedManagedEntry) {
+        return
+      }
+      const reverted = deps.revertPinnedVersion(pluginInfo.configPath, latestVersion, pluginInfo.entry)
+      if (!reverted) {
+        deps.log(`[auto-update-checker] Failed to revert managed pinned config after install failure: ${pluginInfo.configPath}`)
+      }
+    }
+
+    if (shouldManageEntry) {
+      const updated = deps.updatePinnedVersion(pluginInfo.configPath, pluginInfo.entry, latestVersion)
+      if (!updated) {
+        await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+        deps.log(`[auto-update-checker] Failed to update managed config entry: ${pluginInfo.entry}`)
+        return
+      }
+
+      updatedManagedEntry = buildVersionedEntry(pluginInfo.entry, latestVersion)
+      intendedPluginInfo = {
+        ...pluginInfo,
+        entry: updatedManagedEntry,
+        pinnedVersion: latestVersion,
+      }
+    }
+
+    const syncResult = deps.syncCachePackageJsonToIntent(intendedPluginInfo)
     if (syncResult.error) {
+      revertManagedPinnedConfig()
       deps.log(`[auto-update-checker] Sync failed with error: ${syncResult.error}`, syncResult.message)
       await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
       return
@@ -181,9 +254,20 @@ export function createBackgroundUpdateCheckRunner(
     if (installSuccess) {
       const cachePrimed = await primeCacheWorkspace(activeWorkspace, deps)
       if (!cachePrimed) {
+        revertManagedPinnedConfig()
         await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
         deps.log("[auto-update-checker] cache workspace priming failed after install")
         return
+      }
+
+      if (updatedManagedEntry) {
+        const wroteState = deps.writeManagedPluginState(configPaths.configDir, {
+          entry: updatedManagedEntry,
+          channel,
+        })
+        if (!wroteState) {
+          deps.log(`[auto-update-checker] Failed to persist managed plugin state: ${getManagedPluginStatePath(configPaths.configDir)}`)
+        }
       }
 
       await deps.showAutoUpdatedToast(ctx, currentVersion, latestVersion)
@@ -191,6 +275,7 @@ export function createBackgroundUpdateCheckRunner(
       return
     }
 
+    revertManagedPinnedConfig()
     await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
     deps.log("[auto-update-checker] bun install failed; update not installed (falling back to notification-only)")
   }

--- a/src/hooks/zauc-mocks-bg/background-update-check.test.ts
+++ b/src/hooks/zauc-mocks-bg/background-update-check.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test"
 
 import type { PluginEntryInfo } from "../auto-update-checker/checker"
 import type { SyncResult } from "../auto-update-checker/checker/sync-package-json"
+import type { ManagedPluginState } from "../../shared/managed-plugin-state"
 
 type ToastMessageGetter = (isUpdate: boolean, version?: string) => string
 let importCounter = 0
@@ -23,6 +24,10 @@ const mockGetLatestVersion = mock(async (): Promise<string | null> => "3.5.0")
 const mockExtractChannel = mock(() => "latest")
 const mockInvalidatePackage = mock(() => {})
 const mockRunBunInstallWithDetails = mock(async () => ({ success: true }))
+const mockReadManagedPluginState = mock((_configDir: string): ManagedPluginState | null => null)
+const mockWriteManagedPluginState = mock((_configDir: string, _state: ManagedPluginState): boolean => true)
+const mockUpdatePinnedVersion = mock((_configPath: string, _oldEntry: string, _newVersion: string): boolean => true)
+const mockRevertPinnedVersion = mock((_configPath: string, _failedVersion: string, _originalEntry: string): boolean => true)
 const mockShowUpdateAvailableToast = mock(
   async (_ctx: PluginInput, _latestVersion: string, _getToastMessage: ToastMessageGetter): Promise<void> => {},
 )
@@ -56,7 +61,11 @@ async function createRunner() {
     findPluginEntry: mockFindPluginEntry,
     getCachedVersion: mockGetCachedVersion,
     getLatestVersion: mockGetLatestVersion,
+    readManagedPluginState: mockReadManagedPluginState,
+    writeManagedPluginState: mockWriteManagedPluginState,
     syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
+    updatePinnedVersion: mockUpdatePinnedVersion,
+    revertPinnedVersion: mockRevertPinnedVersion,
     showUpdateAvailableToast: mockShowUpdateAvailableToast as never,
     showAutoUpdatedToast: mockShowAutoUpdatedToast as never,
   })
@@ -75,6 +84,10 @@ describe("runBackgroundUpdateCheck", () => {
     mockExtractChannel.mockReset()
     mockInvalidatePackage.mockReset()
     mockRunBunInstallWithDetails.mockReset()
+    mockReadManagedPluginState.mockReset()
+    mockWriteManagedPluginState.mockReset()
+    mockUpdatePinnedVersion.mockReset()
+    mockRevertPinnedVersion.mockReset()
     mockShowUpdateAvailableToast.mockReset()
     mockShowAutoUpdatedToast.mockReset()
     mockLog.mockReset()
@@ -85,6 +98,10 @@ describe("runBackgroundUpdateCheck", () => {
     mockGetLatestVersion.mockResolvedValue("3.5.0")
     mockExtractChannel.mockReturnValue("latest")
     mockRunBunInstallWithDetails.mockResolvedValue({ success: true })
+    mockReadManagedPluginState.mockReturnValue(null)
+    mockWriteManagedPluginState.mockReturnValue(true)
+    mockUpdatePinnedVersion.mockReturnValue(true)
+    mockRevertPinnedVersion.mockReturnValue(true)
     mockSyncCachePackageJsonToIntent.mockImplementation((_pluginInfo) => ({ synced: true, error: null }))
   })
 
@@ -138,6 +155,11 @@ describe("runBackgroundUpdateCheck", () => {
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
+    expect(mockUpdatePinnedVersion).toHaveBeenCalledWith("/test/opencode.json", "oh-my-opencode@3.4.0", "3.4.0")
+    expect(mockWriteManagedPluginState).toHaveBeenCalledWith("/config", {
+      entry: "oh-my-opencode@3.4.0",
+      channel: "latest",
+    })
     expect(mockRunBunInstallWithDetails).not.toHaveBeenCalled()
     expect(mockShowAutoUpdatedToast).not.toHaveBeenCalled()
   })
@@ -167,6 +189,35 @@ describe("runBackgroundUpdateCheck", () => {
     expect(mockRunBunInstallWithDetails).not.toHaveBeenCalled()
   })
 
+  it("#given managed pinned exact version #when checking in background #then it rewrites config and auto updates", async () => {
+    // #given
+    const runBackgroundUpdateCheck = await createRunner()
+    mockFindPluginEntry.mockReturnValue(createPluginEntry({
+      entry: "oh-my-opencode@3.4.0",
+      isPinned: true,
+      pinnedVersion: "3.4.0",
+    }))
+    mockReadManagedPluginState.mockReturnValue({
+      entry: "oh-my-opencode@3.4.0",
+      channel: "latest",
+    })
+
+    // #when
+    await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+
+    // #then
+    expect(mockUpdatePinnedVersion).toHaveBeenCalledWith("/test/opencode.json", "oh-my-opencode@3.4.0", "3.5.0")
+    expect(mockSyncCachePackageJsonToIntent).toHaveBeenCalledWith(expect.objectContaining({
+      entry: "oh-my-opencode@3.5.0",
+      pinnedVersion: "3.5.0",
+    }))
+    expect(mockWriteManagedPluginState).toHaveBeenCalledWith("/config", {
+      entry: "oh-my-opencode@3.5.0",
+      channel: "latest",
+    })
+    expect(mockShowAutoUpdatedToast).toHaveBeenCalledWith(mockCtx, "3.4.0", "3.5.0")
+  })
+
   it("#given unpinned update succeeds #when checking in background #then it syncs invalidates installs and toasts", async () => {
     // #given
     const runBackgroundUpdateCheck = await createRunner()
@@ -175,9 +226,14 @@ describe("runBackgroundUpdateCheck", () => {
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
+    expect(mockUpdatePinnedVersion).toHaveBeenCalledWith("/test/opencode.json", "oh-my-opencode@3.4.0", "3.5.0")
     expect(mockSyncCachePackageJsonToIntent).toHaveBeenCalledTimes(1)
     expect(mockInvalidatePackage).toHaveBeenCalledTimes(1)
     expect(mockRunBunInstallWithDetails).toHaveBeenCalledTimes(2)
+    expect(mockWriteManagedPluginState).toHaveBeenCalledWith("/config", {
+      entry: "oh-my-opencode@3.5.0",
+      channel: "latest",
+    })
     expect(mockShowAutoUpdatedToast).toHaveBeenCalledWith(mockCtx, "3.4.0", "3.5.0")
     expect(mockShowUpdateAvailableToast).not.toHaveBeenCalled()
   })
@@ -214,6 +270,29 @@ describe("runBackgroundUpdateCheck", () => {
     await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
 
     // #then
+    expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(mockCtx, "3.5.0", getToastMessage)
+    expect(mockShowAutoUpdatedToast).not.toHaveBeenCalled()
+  })
+
+  it("#given managed pinned install fails #when checking in background #then it reverts config and notifies only", async () => {
+    // #given
+    const runBackgroundUpdateCheck = await createRunner()
+    mockFindPluginEntry.mockReturnValue(createPluginEntry({
+      entry: "oh-my-opencode@3.4.0",
+      isPinned: true,
+      pinnedVersion: "3.4.0",
+    }))
+    mockReadManagedPluginState.mockReturnValue({
+      entry: "oh-my-opencode@3.4.0",
+      channel: "latest",
+    })
+    mockRunBunInstallWithDetails.mockResolvedValue({ success: false })
+
+    // #when
+    await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+
+    // #then
+    expect(mockRevertPinnedVersion).toHaveBeenCalledWith("/test/opencode.json", "3.5.0", "oh-my-opencode@3.4.0")
     expect(mockShowUpdateAvailableToast).toHaveBeenCalledWith(mockCtx, "3.5.0", getToastMessage)
     expect(mockShowAutoUpdatedToast).not.toHaveBeenCalled()
   })

--- a/src/hooks/zauc-mocks-ws/workspace-resolution.test.ts
+++ b/src/hooks/zauc-mocks-ws/workspace-resolution.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 import type { PluginEntryInfo } from "../auto-update-checker/checker"
 import type { SyncResult } from "../auto-update-checker/checker/sync-package-json"
+import type { ManagedPluginState } from "../../shared/managed-plugin-state"
 import { PACKAGE_NAME } from "../auto-update-checker/constants"
 
 type ToastMessageGetter = (isUpdate: boolean, version?: string) => string
@@ -30,6 +31,10 @@ const mockGetCachedVersion = mock((): string | null => "3.4.0")
 const mockGetLatestVersion = mock(async (): Promise<string | null> => "3.5.0")
 const mockExtractChannel = mock(() => "latest")
 const mockInvalidatePackage = mock(() => {})
+const mockReadManagedPluginState = mock((_configDir: string): ManagedPluginState | null => null)
+const mockWriteManagedPluginState = mock((_configDir: string, _state: ManagedPluginState): boolean => true)
+const mockUpdatePinnedVersion = mock((_configPath: string, _oldEntry: string, _newVersion: string): boolean => true)
+const mockRevertPinnedVersion = mock((_configPath: string, _failedVersion: string, _originalEntry: string): boolean => true)
 const mockShowUpdateAvailableToast = mock(
   async (_ctx: PluginInput, _latestVersion: string, _getToastMessage: ToastMessageGetter): Promise<void> => {},
 )
@@ -61,7 +66,11 @@ async function createRunner() {
     findPluginEntry: mockFindPluginEntry,
     getCachedVersion: mockGetCachedVersion,
     getLatestVersion: mockGetLatestVersion,
+    readManagedPluginState: mockReadManagedPluginState,
+    writeManagedPluginState: mockWriteManagedPluginState,
     syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
+    updatePinnedVersion: mockUpdatePinnedVersion,
+    revertPinnedVersion: mockRevertPinnedVersion,
     showUpdateAvailableToast: mockShowUpdateAvailableToast as never,
     showAutoUpdatedToast: mockShowAutoUpdatedToast as never,
   })
@@ -84,6 +93,10 @@ describe("workspace resolution", () => {
     mockGetLatestVersion.mockReset()
     mockExtractChannel.mockReset()
     mockInvalidatePackage.mockReset()
+    mockReadManagedPluginState.mockReset()
+    mockWriteManagedPluginState.mockReset()
+    mockUpdatePinnedVersion.mockReset()
+    mockRevertPinnedVersion.mockReset()
     mockRunBunInstallWithDetails.mockReset()
     mockShowUpdateAvailableToast.mockReset()
     mockShowAutoUpdatedToast.mockReset()
@@ -94,6 +107,10 @@ describe("workspace resolution", () => {
     mockGetCachedVersion.mockReturnValue("3.4.0")
     mockGetLatestVersion.mockResolvedValue("3.5.0")
     mockExtractChannel.mockReturnValue("latest")
+    mockReadManagedPluginState.mockReturnValue(null)
+    mockWriteManagedPluginState.mockReturnValue(true)
+    mockUpdatePinnedVersion.mockReturnValue(true)
+    mockRevertPinnedVersion.mockReturnValue(true)
     mockRunBunInstallWithDetails.mockResolvedValue({ success: true })
     mockSyncCachePackageJsonToIntent.mockReturnValue({ synced: true, error: null })
   })

--- a/src/shared/managed-plugin-state.ts
+++ b/src/shared/managed-plugin-state.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { CONFIG_BASENAME } from "./plugin-identity"
+
+export interface ManagedPluginState {
+  entry: string
+  channel: string
+}
+
+const MANAGED_PLUGIN_STATE_FILENAME = `${CONFIG_BASENAME}-plugin-state.json`
+
+export function getManagedPluginStatePath(configDir: string): string {
+  return join(configDir, MANAGED_PLUGIN_STATE_FILENAME)
+}
+
+export function readManagedPluginState(configDir: string): ManagedPluginState | null {
+  try {
+    const content = readFileSync(getManagedPluginStatePath(configDir), "utf-8")
+    const parsed = JSON.parse(content) as Partial<ManagedPluginState> | null
+    if (!parsed || typeof parsed !== "object") {
+      return null
+    }
+    if (typeof parsed.entry !== "string" || typeof parsed.channel !== "string") {
+      return null
+    }
+    return {
+      entry: parsed.entry,
+      channel: parsed.channel,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function writeManagedPluginState(configDir: string, state: ManagedPluginState): boolean {
+  try {
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(getManagedPluginStatePath(configDir), JSON.stringify(state, null, 2) + "\n")
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- install the plugin as a managed exact version instead of writing dynamic `@latest` entries
- persist channel metadata so auto-update can keep exact-version installs moving forward automatically
- migrate existing dynamic plugin entries to managed exact versions and roll config back if a background update install fails

## Why
`oh-my-openagent` currently writes dynamic plugin entries such as `@latest`, which keeps startup coupled to OpenCode's plugin resolution path. When that path is slow or unstable, users can get multi-minute stalls before the plugin even loads. This change does not fix OpenCode core's startup fallback, but it does remove `oh-my-openagent` from relying on that path after install.

## Testing
- `bun test src/cli/config-manager/plugin-name-with-version.test.ts`
- `bun test src/cli/config-manager/plugin-detection.test.ts`
- `bun test src/hooks/zauc-mocks-bg/background-update-check.test.ts`
- `bun test src/hooks/zauc-mocks-ws/workspace-resolution.test.ts`
- `bun test src/hooks/auto-update-checker/hook.test.ts`
- `bun test src/hooks/zauc-mocks-hook/hook.test.ts`
- `bun test src/hooks/auto-update-checker/checker/pinned-version-updater.test.ts`

## Notes
- I intentionally left unrelated generated files (`bun.lock`, `assets/oh-my-opencode.schema.json`) out of this PR.
- There is an existing unrelated Windows path assertion issue in `plugin-entry.test.ts`; it is not introduced by this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch plugin installs to managed exact versions with a persisted release channel. This removes `@latest` stalls at startup and lets auto‑update advance pinned installs safely.

- **New Features**
  - Installs `oh-my-openagent@<version>` via `resolvePluginInstallReference`, returning the exact entry and its channel.
  - Persists channel metadata in a config-scoped `...-plugin-state.json` so updates track the right channel.
  - Background updater migrates dynamic/unpinned entries to exact versions, writes state, and reverts the config on failure.
  - Version bumps preserve the canonical alias (e.g., keep `oh-my-openagent`, migrate legacy `oh-my-opencode` safely).

- **Migration**
  - No manual steps. Existing dynamic entries are converted to exact versions during install or the next background check.
  - If an update fails, the config entry is rolled back automatically.

<sup>Written for commit a186d12f328e79bbaa13cd0229020eeeff908674. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4513?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

