### PR TITLE
test(hooks): add test coverage for comment-checker hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/comment-checker/hook.test.ts
+++ b/src/hooks/comment-checker/hook.test.ts
@@ -1,0 +1,258 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+const processWithCliMock = mock(async () => {})
+const processApplyPatchEditsWithCliMock = mock(async () => {})
+const extractApplyPatchEditsMock = mock(() => [] as Array<{ filePath: string }>)
+
+mock.module("./cli-runner", () => ({
+  initializeCommentCheckerCli: () => {},
+  getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
+  isCliPathUsable: () => true,
+  processWithCli: processWithCliMock,
+  processApplyPatchEditsWithCli: processApplyPatchEditsWithCliMock,
+}))
+
+mock.module("@oh-my-opencode/comment-checker-core", () => ({
+  extractApplyPatchEdits: extractApplyPatchEditsMock,
+}))
+
+afterAll(() => {
+  mock.restore()
+})
+
+const { createCommentCheckerHooks } = await import("./hook")
+const { stopPendingCallCleanup } = await import("./pending-calls")
+const { _resetCommentCheckerInitializationForTesting } = await import("./initialization-gate")
+
+describe("comment-checker hook", () => {
+  beforeEach(() => {
+    processWithCliMock.mockClear()
+    processApplyPatchEditsWithCliMock.mockClear()
+    extractApplyPatchEditsMock.mockClear()
+    stopPendingCallCleanup()
+    _resetCommentCheckerInitializationForTesting()
+  })
+
+  afterEach(() => {
+    stopPendingCallCleanup()
+    _resetCommentCheckerInitializationForTesting()
+  })
+
+  describe("#given tool.execute.before", () => {
+    it("#when tool is write #then registers pending call with filePath and content", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "write", sessionID: "ses_1", callID: "call_1" }
+      const output = { args: { filePath: "/src/file.ts", content: "const x = 1\n" } }
+
+      // when
+      await hooks["tool.execute.before"](input, output)
+
+      // then - verify by running after hook which should pick up the pending call
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+      expect(processWithCliMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("#when tool is edit with file_path #then registers pending call", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "edit", sessionID: "ses_2", callID: "call_2" }
+      const output = {
+        args: {
+          file_path: "/src/edit.ts",
+          old_string: "const a = 1\n",
+          new_string: "// comment\nconst a = 1\n",
+        },
+      }
+
+      // when
+      await hooks["tool.execute.before"](input, output)
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(1)
+      expect(processWithCliMock).toHaveBeenCalledWith(
+        input,
+        expect.objectContaining({
+          filePath: "/src/edit.ts",
+          oldString: "const a = 1\n",
+          newString: "// comment\nconst a = 1\n",
+          tool: "edit",
+        }),
+        expect.any(Object),
+        "/tmp/fake-comment-checker",
+        undefined,
+        expect.any(Function),
+      )
+    })
+
+    it("#when tool is read #then does not register pending call", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "read", sessionID: "ses_3", callID: "call_3" }
+
+      // when
+      await hooks["tool.execute.before"](input, { args: { filePath: "/src/file.ts" } })
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when no filePath in args #then does not register pending call", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "write", sessionID: "ses_4", callID: "call_4" }
+
+      // when
+      await hooks["tool.execute.before"](input, { args: {} })
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when tool is multiedit with path #then registers pending call with edits", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "multiedit", sessionID: "ses_5", callID: "call_5" }
+      const edits = [{ old_string: "const b = 1\n", new_string: "// added\nconst b = 1\n" }]
+
+      // when
+      await hooks["tool.execute.before"](input, { args: { path: "/src/multi.ts", edits } })
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(1)
+      expect(processWithCliMock).toHaveBeenCalledWith(
+        input,
+        expect.objectContaining({
+          filePath: "/src/multi.ts",
+          edits,
+          tool: "multiedit",
+        }),
+        expect.any(Object),
+        "/tmp/fake-comment-checker",
+        undefined,
+        expect.any(Function),
+      )
+    })
+  })
+
+  describe("#given tool.execute.after", () => {
+    it("#when output indicates tool failure #then skips comment checking", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "write", sessionID: "ses_6", callID: "call_6" }
+      await hooks["tool.execute.before"](input, {
+        args: { filePath: "/src/file.ts", content: "// slop\nconst x = 1\n" },
+      })
+
+      // when - output contains error indicator
+      await hooks["tool.execute.after"](input, {
+        title: "error",
+        output: "Error: file not found",
+        metadata: {},
+      })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when output contains 'failed to' #then skips comment checking", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "write", sessionID: "ses_7", callID: "call_7" }
+      await hooks["tool.execute.before"](input, {
+        args: { filePath: "/src/file.ts", content: "const x = 1\n" },
+      })
+
+      // when
+      await hooks["tool.execute.after"](input, {
+        title: "fail",
+        output: "Failed to write file",
+        metadata: {},
+      })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when tool is apply_patch with edits #then processes with apply_patch handler", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "apply_patch", sessionID: "ses_8", callID: "call_8", args: {} }
+      const metadata = { files: [{ filePath: "/src/patch.ts" }] }
+      extractApplyPatchEditsMock.mockReturnValueOnce([{ filePath: "/src/patch.ts", newString: "// patched" }])
+
+      // when
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Applied", metadata })
+
+      // then
+      expect(extractApplyPatchEditsMock).toHaveBeenCalledTimes(1)
+      expect(processApplyPatchEditsWithCliMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("#when tool is apply_patch with no edits #then skips processing", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "apply_patch", sessionID: "ses_9", callID: "call_9", args: {} }
+      extractApplyPatchEditsMock.mockReturnValueOnce([])
+
+      // when
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Applied", metadata: {} })
+
+      // then
+      expect(processApplyPatchEditsWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when no pending call found for callID #then does nothing", async () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+      const input = { tool: "write", sessionID: "ses_10", callID: "call_unknown" }
+
+      // when - no before hook was called, so no pending call exists
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledTimes(0)
+    })
+
+    it("#when custom_prompt config is provided #then passes it to processWithCli", async () => {
+      // given
+      const hooks = createCommentCheckerHooks({ custom_prompt: "No AI comments allowed" })
+      const input = { tool: "write", sessionID: "ses_11", callID: "call_11" }
+      await hooks["tool.execute.before"](input, {
+        args: { filePath: "/src/file.ts", content: "// AI slop\nconst x = 1\n" },
+      })
+
+      // when
+      await hooks["tool.execute.after"](input, { title: "ok", output: "Success", metadata: {} })
+
+      // then
+      expect(processWithCliMock).toHaveBeenCalledWith(
+        input,
+        expect.any(Object),
+        expect.any(Object),
+        "/tmp/fake-comment-checker",
+        "No AI comments allowed",
+        expect.any(Function),
+      )
+    })
+  })
+
+  describe("#given dispose", () => {
+    it("#when called #then stops pending call cleanup", () => {
+      // given
+      const hooks = createCommentCheckerHooks()
+
+      // when - should not throw
+      hooks.dispose()
+
+      // then - no error means cleanup was stopped successfully
+      expect(true).toBe(true)
+    })
+  })
+})
+
+export {}


### PR DESCRIPTION
Add 12 tests for the comment-checker hook covering:

- 	ool.execute.before: write/edit/multiedit registration, non-mutation skip, missing filePath
- 	ool.execute.after: tool failure skip, apply_patch with/without edits, missing pending call, custom_prompt passthrough
- dispose: cleanup on session end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 12 tests for the comment-checker hook: pending-call registration, skip on non-mutations/failures, `apply_patch` edits, custom_prompt passthrough, and dispose cleanup. Also sync `bun.lock` platform binaries for `oh-my-opencode-*` to 4.5.1.

<sup>Written for commit c8492d6ab4f96aeb8331670922e5d1037352cd2a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4517?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

