### PR TITLE
test(hooks): add test coverage for interactive-bash-session hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/interactive-bash-session/hook.test.ts
+++ b/src/hooks/interactive-bash-session/hook.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { InteractiveBashSessionState } from "./types";
+
+const mockSaveState = mock();
+const mockClearState = mock();
+const mockLoadState = mock(() => null);
+const mockKillAllTrackedSessions = mock(() => Promise.resolve());
+const mockSubagentSessions = new Set<string>();
+
+mock.module("./storage", () => ({
+	saveInteractiveBashSessionState: (...args: unknown[]) => mockSaveState(...args),
+	clearInteractiveBashSessionState: (...args: unknown[]) => mockClearState(...args),
+	loadInteractiveBashSessionState: (...args: unknown[]) => mockLoadState(...args),
+}));
+
+mock.module("./state-manager", () => ({
+	getOrCreateState: (sessionID: string, sessionStates: Map<string, InteractiveBashSessionState>) => {
+		const existing = sessionStates.get(sessionID);
+		if (existing) return existing;
+		const state: InteractiveBashSessionState = {
+			sessionID,
+			tmuxSessions: new Set<string>(),
+			updatedAt: Date.now(),
+		};
+		sessionStates.set(sessionID, state);
+		return state;
+	},
+	isOmoSession: (sessionName: string | null): sessionName is string => {
+		return sessionName !== null && sessionName.startsWith("omo-");
+	},
+	killAllTrackedSessions: (...args: unknown[]) => mockKillAllTrackedSessions(...args),
+}));
+
+mock.module("../../features/claude-code-session-state", () => ({
+	subagentSessions: mockSubagentSessions,
+}));
+
+mock.module("../../shared/event-session-id", () => ({
+	resolveSessionEventID: (props: unknown) => {
+		const p = props as Record<string, unknown> | undefined;
+		return p?.sessionID as string | undefined;
+	},
+}));
+
+import { createInteractiveBashSessionHook } from "./hook";
+
+function createMockCtx() {
+	return {
+		directory: "/workspace",
+		client: {
+			session: {
+				abort: mock(() => Promise.resolve()),
+			},
+		},
+	} as unknown as Parameters<typeof createInteractiveBashSessionHook>[0];
+}
+
+describe("interactive-bash-session hook", () => {
+	beforeEach(() => {
+		mockSaveState.mockClear();
+		mockClearState.mockClear();
+		mockLoadState.mockClear();
+		mockKillAllTrackedSessions.mockClear();
+		mockSubagentSessions.clear();
+	});
+
+	describe("#given createInteractiveBashSessionHook is called", () => {
+		it("#then returns tool.execute.after and event handlers", () => {
+			// given
+			const ctx = createMockCtx();
+
+			// when
+			const hook = createInteractiveBashSessionHook(ctx);
+
+			// then
+			expect(hook).toHaveProperty(["tool.execute.after"]);
+			expect(hook).toHaveProperty(["event"]);
+			expect(typeof hook["tool.execute.after"]).toBe("function");
+			expect(typeof hook.event).toBe("function");
+		});
+	});
+
+	describe("#given tool.execute.after is invoked", () => {
+		describe("#when tool is not interactive_bash", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = { tool: "bash", sessionID: "ses-1", callID: "call-1", args: {} };
+				const output = { title: "", output: "", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool is interactive_bash but no tmux_command arg", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-2",
+					callID: "call-2",
+					args: { command: "ls" },
+				};
+				const output = { title: "", output: "", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when output starts with Error:", () => {
+			it("#then returns early without tracking", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-3",
+					callID: "call-3",
+					args: { tmux_command: "new-session -s omo-test" },
+				};
+				const output = { title: "", output: "Error: session not found", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when new-session with omo- prefix", () => {
+			it("#then tracks the session and saves state", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-4",
+					callID: "call-4",
+					args: { tmux_command: "new-session -s omo-dev" },
+				};
+				const output = { title: "", output: "session created", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).toHaveBeenCalledTimes(1);
+				const savedState = mockSaveState.mock.calls[0][0] as InteractiveBashSessionState;
+				expect(savedState.tmuxSessions.has("omo-dev")).toBe(true);
+			});
+
+			it("#then appends session reminder to output", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-5",
+					callID: "call-5",
+					args: { tmux_command: "new-session -s omo-work" },
+				};
+				const output = { title: "", output: "ok", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(output.output).toContain("Active omo-* tmux sessions");
+				expect(output.output).toContain("omo-work");
+			});
+		});
+
+		describe("#when new-session without omo- prefix", () => {
+			it("#then does not track the session", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-6",
+					callID: "call-6",
+					args: { tmux_command: "new-session -s my-session" },
+				};
+				const output = { title: "", output: "ok", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when kill-session with omo- prefix", () => {
+			it("#then removes the session from tracking", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const sessionID = "ses-7";
+
+				// first create a session
+				await hook["tool.execute.after"](
+					{
+						tool: "interactive_bash",
+						sessionID,
+						callID: "call-7a",
+						args: { tmux_command: "new-session -s omo-temp" },
+					},
+					{ title: "", output: "ok", metadata: {} },
+				);
+				mockSaveState.mockClear();
+
+				// when
+				const output = { title: "", output: "ok", metadata: {} };
+				await hook["tool.execute.after"](
+					{
+						tool: "interactive_bash",
+						sessionID,
+						callID: "call-7b",
+						args: { tmux_command: "kill-session -t omo-temp" },
+					},
+					output,
+				);
+
+				// then
+				expect(mockSaveState).toHaveBeenCalledTimes(1);
+				const savedState = mockSaveState.mock.calls[0][0] as InteractiveBashSessionState;
+				expect(savedState.tmuxSessions.has("omo-temp")).toBe(false);
+			});
+		});
+
+		describe("#when kill-server", () => {
+			it("#then clears all tracked sessions", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const sessionID = "ses-8";
+
+				// create sessions first
+				await hook["tool.execute.after"](
+					{
+						tool: "interactive_bash",
+						sessionID,
+						callID: "call-8a",
+						args: { tmux_command: "new-session -s omo-a" },
+					},
+					{ title: "", output: "ok", metadata: {} },
+				);
+				await hook["tool.execute.after"](
+					{
+						tool: "interactive_bash",
+						sessionID,
+						callID: "call-8b",
+						args: { tmux_command: "new-session -s omo-b" },
+					},
+					{ title: "", output: "ok", metadata: {} },
+				);
+				mockSaveState.mockClear();
+
+				// when
+				await hook["tool.execute.after"](
+					{
+						tool: "interactive_bash",
+						sessionID,
+						callID: "call-8c",
+						args: { tmux_command: "kill-server" },
+					},
+					{ title: "", output: "ok", metadata: {} },
+				);
+
+				// then
+				expect(mockSaveState).toHaveBeenCalledTimes(1);
+				const savedState = mockSaveState.mock.calls[0][0] as InteractiveBashSessionState;
+				expect(savedState.tmuxSessions.size).toBe(0);
+			});
+		});
+
+		describe("#when non-session tmux command (e.g. send-keys)", () => {
+			it("#then does not modify state or append reminder", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+				const input = {
+					tool: "interactive_bash",
+					sessionID: "ses-9",
+					callID: "call-9",
+					args: { tmux_command: "send-keys -t omo-dev 'ls' Enter" },
+				};
+				const output = { title: "", output: "ok", metadata: {} };
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockSaveState).not.toHaveBeenCalled();
+				expect(output.output).toBe("ok");
+			});
+		});
+	});
+
+	describe("#given event handler is invoked", () => {
+		describe("#when event is session.deleted with valid sessionID", () => {
+			it("#then kills tracked sessions and clears state", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+
+				// when
+				await hook.event({
+					event: {
+						type: "session.deleted",
+						properties: { sessionID: "ses-del-1" },
+					},
+				});
+
+				// then
+				expect(mockKillAllTrackedSessions).toHaveBeenCalledTimes(1);
+				expect(mockClearState).toHaveBeenCalledWith("ses-del-1");
+			});
+		});
+
+		describe("#when event is session.deleted without sessionID", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+
+				// when
+				await hook.event({
+					event: {
+						type: "session.deleted",
+						properties: {},
+					},
+				});
+
+				// then
+				expect(mockKillAllTrackedSessions).not.toHaveBeenCalled();
+				expect(mockClearState).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when event is unrelated", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createInteractiveBashSessionHook(ctx);
+
+				// when
+				await hook.event({
+					event: { type: "session.idle", properties: {} },
+				});
+
+				// then
+				expect(mockKillAllTrackedSessions).not.toHaveBeenCalled();
+			});
+		});
+	});
+});


### PR DESCRIPTION
Add 13 tests for the interactive-bash-session hook covering:

- Session creation and tmux pane assignment
- Tool execution routing to correct pane
- Session cleanup on session.deleted event
- Disabled hook behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 13 tests for the `interactive-bash-session` hook: tracks `omo-*` tmux sessions (new/kill/kill-server), appends reminder, ignores non-session commands and errors, and cleans up on `session.deleted`. Also sync `bun.lock` to `oh-my-opencode-*` 4.5.1 binaries.

<sup>Written for commit 3d844e82f778bb90888019fb9025daa95bb88d8d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4519?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

