### PR TITLE
test(hooks): add test coverage for model-fallback hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/model-fallback/fallback-state-controller.test.ts
+++ b/src/hooks/model-fallback/fallback-state-controller.test.ts
@@ -1,0 +1,293 @@
+import type { FallbackEntry } from "../../shared/model-requirements"
+
+declare const require: (name: string) => any
+const { describe, test, expect, beforeEach, afterAll, mock } = require("bun:test")
+
+const mockAgentModelRequirements: Record<string, { fallbackChain?: FallbackEntry[] }> = {}
+const mockGetAgentConfigKey = mock((name: string) => name.toLowerCase().replace(/ - /g, "-"))
+
+afterAll(() => {
+  mock.restore()
+})
+
+async function importFreshStateControllerModule() {
+  mock.module("../../shared/agent-display-names", () => ({
+    getAgentConfigKey: mockGetAgentConfigKey,
+  }))
+
+  mock.module("../../shared/model-requirements", () => ({
+    AGENT_MODEL_REQUIREMENTS: mockAgentModelRequirements,
+  }))
+
+  mock.module("../../shared/connected-providers-cache", () => ({
+    readConnectedProvidersCache: () => null,
+    readProviderModelsCache: () => null,
+  }))
+
+  mock.module("../../shared/model-error-classifier", () => ({
+    selectFallbackProvider: (providers: string[]) => providers[0] ?? "opencode",
+  }))
+
+  mock.module("../../shared/provider-model-id-transform", () => ({
+    transformModelForProvider: (_provider: string, model: string) => model,
+  }))
+
+  mock.module("../../shared/logger", () => ({
+    log: () => {},
+  }))
+
+  const module = await import(`./fallback-state-controller?test=${Date.now()}-${Math.random()}`)
+  mock.restore()
+  return module
+}
+
+const { createModelFallbackStateController } = await importFreshStateControllerModule()
+
+describe("fallback-state-controller", () => {
+  let controller: ReturnType<typeof createModelFallbackStateController>
+
+  beforeEach(() => {
+    controller = createModelFallbackStateController({
+      pendingModelFallbacks: new Map(),
+      lastToastKey: new Map(),
+      sessionFallbackChains: new Map(),
+    })
+
+    Object.keys(mockAgentModelRequirements).forEach((key) => {
+      delete mockAgentModelRequirements[key]
+    })
+  })
+
+  describe("#given setSessionFallbackChain", () => {
+    test("#when called with a valid chain #then stores a defensive copy", () => {
+      // given
+      const chain: FallbackEntry[] = [{ providers: ["anthropic"], model: "claude-opus-4-7" }]
+
+      // when
+      controller.setSessionFallbackChain("ses_1", chain)
+      chain.push({ providers: ["openai"], model: "gpt-5.5" })
+
+      // then
+      const stored = controller.getSessionFallbackChain("ses_1")
+      expect(stored).toEqual([{ providers: ["anthropic"], model: "claude-opus-4-7" }])
+    })
+
+    test("#when called with undefined #then stores empty array", () => {
+      // given
+      controller.setSessionFallbackChain("ses_2", [{ providers: ["a"], model: "m" }])
+
+      // when
+      controller.setSessionFallbackChain("ses_2", undefined)
+
+      // then the chain is stored as empty (not deleted)
+      const stored = controller.getSessionFallbackChain("ses_2")
+      expect(stored).toEqual([])
+    })
+
+    test("#when called with empty sessionID #then does nothing", () => {
+      // when
+      controller.setSessionFallbackChain("", [{ providers: ["a"], model: "m" }])
+
+      // then
+      expect(controller.getSessionFallbackChain("")).toBeUndefined()
+    })
+  })
+
+  describe("#given getSessionFallbackChain", () => {
+    test("#when chain exists #then returns a defensive copy", () => {
+      // given
+      controller.setSessionFallbackChain("ses_3", [{ providers: ["anthropic"], model: "opus" }])
+
+      // when
+      const first = controller.getSessionFallbackChain("ses_3")
+      first?.push({ providers: ["openai"], model: "gpt" })
+
+      // then subsequent get is unaffected
+      expect(controller.getSessionFallbackChain("ses_3")).toEqual([
+        { providers: ["anthropic"], model: "opus" },
+      ])
+    })
+
+    test("#when chain does not exist #then returns undefined", () => {
+      expect(controller.getSessionFallbackChain("nonexistent")).toBeUndefined()
+    })
+  })
+
+  describe("#given clearSessionFallbackChain", () => {
+    test("#when called #then removes the chain entirely", () => {
+      // given
+      controller.setSessionFallbackChain("ses_4", [{ providers: ["a"], model: "m" }])
+
+      // when
+      controller.clearSessionFallbackChain("ses_4")
+
+      // then
+      expect(controller.getSessionFallbackChain("ses_4")).toBeUndefined()
+    })
+  })
+
+  describe("#given setPendingModelFallback", () => {
+    test("#when no chain exists for agent #then returns false", () => {
+      // given no session chain and no agent requirements
+      // when
+      const result = controller.setPendingModelFallback("ses_5", "unknown-agent", "anthropic", "claude-opus-4-7")
+
+      // then
+      expect(result).toBe(false)
+    })
+
+    test("#when session chain is empty #then returns false", () => {
+      // given session chain explicitly set to empty
+      controller.setSessionFallbackChain("ses_6", undefined)
+
+      // when
+      const result = controller.setPendingModelFallback("ses_6", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // then
+      expect(result).toBe(false)
+    })
+
+    test("#when valid chain exists #then arms the fallback and returns true", () => {
+      // given
+      controller.setSessionFallbackChain("ses_7", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+
+      // when
+      const result = controller.setPendingModelFallback("ses_7", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // then
+      expect(result).toBe(true)
+      expect(controller.hasPendingModelFallback("ses_7")).toBe(true)
+    })
+
+    test("#when fallback already pending #then returns false", () => {
+      // given
+      controller.setSessionFallbackChain("ses_8", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+      controller.setPendingModelFallback("ses_8", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // when
+      const result = controller.setPendingModelFallback("ses_8", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // then
+      expect(result).toBe(false)
+    })
+
+    test("#when chain exhausted #then returns false on re-arm", () => {
+      // given a single-entry chain
+      controller.setSessionFallbackChain("ses_9", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+      controller.setPendingModelFallback("ses_9", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // consume the fallback
+      controller.getNextFallback("ses_9")
+
+      // when trying to re-arm with a different model after chain is exhausted
+      const result = controller.setPendingModelFallback("ses_9", "sisyphus", "openai", "gpt-5.5")
+
+      // then
+      expect(result).toBe(false)
+    })
+
+    test("#when uses agent requirements as fallback chain source", () => {
+      // given agent has requirements but no session chain
+      mockAgentModelRequirements["sisyphus"] = {
+        fallbackChain: [{ providers: ["openai"], model: "gpt-5.5" }],
+      }
+      mockGetAgentConfigKey.mockReturnValueOnce("sisyphus")
+
+      // when
+      const result = controller.setPendingModelFallback("ses_10", "Sisyphus", "anthropic", "claude-opus-4-7")
+
+      // then
+      expect(result).toBe(true)
+    })
+  })
+
+  describe("#given getNextFallback", () => {
+    test("#when no pending fallback #then returns null", () => {
+      expect(controller.getNextFallback("ses_11")).toBeNull()
+    })
+
+    test("#when pending fallback exists #then returns next entry", () => {
+      // given
+      controller.setSessionFallbackChain("ses_12", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+      controller.setPendingModelFallback("ses_12", "sisyphus", "anthropic", "claude-opus-4-7")
+
+      // when
+      const result = controller.getNextFallback("ses_12")
+
+      // then
+      expect(result).toEqual({
+        providerID: "openai",
+        modelID: "gpt-5.5",
+        variant: undefined,
+        reasoningEffort: undefined,
+        temperature: undefined,
+        top_p: undefined,
+        maxTokens: undefined,
+        thinking: undefined,
+      })
+    })
+
+    test("#when all entries exhausted #then returns null and cleans up state", () => {
+      // given single-entry chain, already consumed
+      controller.setSessionFallbackChain("ses_13", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+      controller.setPendingModelFallback("ses_13", "sisyphus", "anthropic", "claude-opus-4-7")
+      controller.getNextFallback("ses_13")
+
+      // re-arm
+      controller.setPendingModelFallback("ses_13", "sisyphus", "openai", "gpt-5.5")
+
+      // when
+      const result = controller.getNextFallback("ses_13")
+
+      // then
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("#given clearPendingModelFallback", () => {
+    test("#when called #then removes pending state and toast key", () => {
+      // given
+      controller.setSessionFallbackChain("ses_14", [
+        { providers: ["openai"], model: "gpt-5.5" },
+      ])
+      controller.setPendingModelFallback("ses_14", "sisyphus", "anthropic", "claude-opus-4-7")
+      controller.lastToastKey.set("ses_14", "some-key")
+
+      // when
+      controller.clearPendingModelFallback("ses_14")
+
+      // then
+      expect(controller.hasPendingModelFallback("ses_14")).toBe(false)
+      expect(controller.lastToastKey.has("ses_14")).toBe(false)
+    })
+  })
+
+  describe("#given reset", () => {
+    test("#when called #then clears all state", () => {
+      // given
+      controller.setSessionFallbackChain("ses_15", [{ providers: ["a"], model: "m" }])
+      controller.setPendingModelFallback("ses_15", "sisyphus", "a", "m-old")
+      controller.lastToastKey.set("ses_15", "key")
+
+      // when
+      controller.reset()
+
+      // then
+      expect(controller.getSessionFallbackChain("ses_15")).toBeUndefined()
+      expect(controller.hasPendingModelFallback("ses_15")).toBe(false)
+      expect(controller.lastToastKey.size).toBe(0)
+    })
+  })
+})
+
+export {}


### PR DESCRIPTION
Add 17 tests for the model-fallback hook's FallbackStateController covering:

- setSessionFallbackChain / getSessionFallbackChain (defensive copy, undefined, empty sessionID)
- clearSessionFallbackChain
- setPendingModelFallback (no chain, empty chain, valid chain, already pending, chain exhausted, agent requirements fallback)
- getNextFallback / clearPendingModelFallback
- reset

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 17 unit tests for the model-fallback `FallbackStateController` covering session chain I/O, pending fallback setup, next-fallback retrieval, and reset/cleanup, including undefined/empty chains, agent-derived chains, already-pending/exhausted chains, and defensive copies. Sync `bun.lock` platform binaries for `oh-my-opencode-*` to 4.5.1.

<sup>Written for commit 8c21c831806d109d63333ea57b4aa6b79db3e84d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4521?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

