### PR TITLE
test(hooks): add test coverage for plan-format-validator hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/plan-format-validator/hook.test.ts
+++ b/src/hooks/plan-format-validator/hook.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createPlanFormatValidatorHook } from "./hook"
+
+function createMockCtx(directory: string) {
+  return {
+    directory,
+    client: { tui: { showToast: () => Promise.resolve() } },
+  } as never
+}
+
+function createInput(tool: string, filePath: string) {
+  return {
+    tool,
+    sessionID: "test-session",
+    callID: "test-call",
+    args: { filePath },
+  }
+}
+
+function createOutput(outputText = "File written successfully") {
+  return {
+    title: "Write",
+    output: outputText,
+    metadata: {},
+  }
+}
+
+describe("createPlanFormatValidatorHook", () => {
+  let testDir: string
+  let plansDir: string
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `omo-plan-validator-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    plansDir = join(testDir, ".omo", "plans")
+    mkdirSync(plansDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  describe("#given a Write tool writes a valid plan with correct task labels", () => {
+    it("#then does not append a warning", async () => {
+      // given
+      const planContent = [
+        "# My Plan",
+        "",
+        "## TODOs",
+        "- [ ] 1. First task",
+        "- [ ] 2. Second task",
+        "",
+        "## Final Verification Wave",
+        "- [ ] F1. Verify first",
+      ].join("\n")
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given a Write tool writes a plan with malformed task labels", () => {
+    it("#then appends a plan-format-warning when some tasks are skipped", async () => {
+      // given - "T1." is not a valid label format (should be "1.")
+      const planContent = [
+        "# My Plan",
+        "",
+        "## TODOs",
+        "- [ ] T1. First task",
+        "- [ ] T2. Second task",
+        "- [ ] 3. Third task",
+        "",
+      ].join("\n")
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toContain("<plan-format-warning>")
+      expect(output.output).toContain("only parsed **1**")
+    })
+  })
+
+  describe("#given a Write tool writes a plan where all task labels are malformed", () => {
+    it("#then appends a warning indicating 0 tasks parsed", async () => {
+      // given
+      const planContent = [
+        "# My Plan",
+        "",
+        "## TODOs",
+        "- [ ] Task-1. First task",
+        "- [ ] Task-2. Second task",
+        "",
+      ].join("\n")
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toContain("<plan-format-warning>")
+      expect(output.output).toContain("parsed **0**")
+    })
+  })
+
+  describe("#given the tool is not a Write or Edit tool", () => {
+    it("#then does not check the file", async () => {
+      // given
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, "## TODOs\n- [ ] T1. Bad label\n")
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Read", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given the file is not in .omo/plans/", () => {
+    it("#then does not validate the file", async () => {
+      // given
+      const otherPath = join(testDir, "some-file.md")
+      writeFileSync(otherPath, "## TODOs\n- [ ] T1. Bad label\n")
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", otherPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given the file does not exist on disk", () => {
+    it("#then does not append a warning", async () => {
+      // given
+      const planPath = join(plansDir, "nonexistent.md")
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given the output already contains a plan-format-warning", () => {
+    it("#then does not append a duplicate warning", async () => {
+      // given
+      const planContent = [
+        "## TODOs",
+        "- [ ] T1. Bad label",
+      ].join("\n")
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput("File written\n<plan-format-warning>existing</plan-format-warning>")
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then - should still have only the original warning, not a second one
+      const matches = output.output.match(/<plan-format-warning>/g)
+      expect(matches?.length).toBe(1)
+    })
+  })
+
+  describe("#given the plan has no checkboxes", () => {
+    it("#then does not append a warning", async () => {
+      // given
+      const planContent = [
+        "# My Plan",
+        "",
+        "## TODOs",
+        "Just some text without checkboxes",
+      ].join("\n")
+      const planPath = join(plansDir, "test-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given the Edit tool writes a plan file", () => {
+    it("#then validates the plan format", async () => {
+      // given
+      const planContent = [
+        "## TODOs",
+        "- [ ] Phase 1: Bad label",
+        "- [ ] 1. Good label",
+      ].join("\n")
+      const planPath = join(plansDir, "edit-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("edit", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given args is undefined", () => {
+    it("#then does nothing", async () => {
+      // given
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = {
+        tool: "Write",
+        sessionID: "test-session",
+        callID: "test-call",
+        args: undefined,
+      }
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input as never, output)
+
+      // then
+      expect(output.output).not.toContain("<plan-format-warning>")
+    })
+  })
+
+  describe("#given Final Verification Wave has malformed labels", () => {
+    it("#then detects the mismatch", async () => {
+      // given
+      const planContent = [
+        "## TODOs",
+        "- [ ] 1. Good task",
+        "",
+        "## Final Verification Wave",
+        "- [ ] T-F1. Bad final label",
+        "- [ ] F1. Good final label",
+      ].join("\n")
+      const planPath = join(plansDir, "final-wave-plan.md")
+      writeFileSync(planPath, planContent)
+
+      const hook = createPlanFormatValidatorHook(createMockCtx(testDir))
+      const input = createInput("Write", planPath)
+      const output = createOutput()
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toContain("<plan-format-warning>")
+    })
+  })
+})


### PR DESCRIPTION
Add 11 tests for the plan-format-validator hook covering:

- Valid plan format passes through
- Missing required sections detected
- Malformed markdown handling
- Disabled hook behavior
- Non-plan tool calls skipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 11 tests for the `plan-format-validator` hook to confirm plan validation works and warnings show only when they should, covering valid plans, malformed task labels (including Final Verification Wave), Edit vs Write tool filtering, non-plan paths, missing files, pre-existing warnings, no checkboxes, and undefined args. Also sync `bun.lock` platform binaries (`oh-my-opencode-*`) to 4.5.1.

<sup>Written for commit 059e3f8e82a37e697a34b1a940dfec11cea5ad4c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4522?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

