### PR TITLE
test(hooks): add test coverage for rules-injector hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/rules-injector/hook.test.ts
+++ b/src/hooks/rules-injector/hook.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createRulesInjectorHook } from "./hook";
+
+// Mock dependencies
+const mockTruncate = mock(() =>
+	Promise.resolve({ result: "truncated-content", truncated: false }),
+);
+const mockProcessFilePathForInjection = mock(() => Promise.resolve());
+
+mock.module("../../shared/dynamic-truncator", () => ({
+	createDynamicTruncator: () => ({ truncate: mockTruncate }),
+}));
+
+mock.module("./cache", () => ({
+	createSessionCacheStore: () => ({
+		getSessionCache: () => ({
+			contentHashes: new Set<string>(),
+			realPaths: new Set<string>(),
+		}),
+		clearSessionCache: mock(),
+	}),
+	createSessionRuleScanCacheStore: () => ({
+		getSessionRuleScanCache: () => ({ has: () => false, set: () => {} }),
+		clearSessionRuleScanCache: mock(),
+	}),
+}));
+
+mock.module("./transcript-hydration", () => ({
+	createTranscriptHydrationStore: () => ({
+		hydrateSession: () => Promise.resolve(new Set()),
+		clearSession: mock(),
+	}),
+}));
+
+mock.module("./injector", () => ({
+	createRuleInjectionProcessor: () => ({
+		processFilePathForInjection: mockProcessFilePathForInjection,
+	}),
+	clearParsedRuleCache: mock(),
+}));
+
+mock.module("./output-path", () => ({
+	getRuleInjectionFilePath: (output: { metadata: unknown; title: string }) => {
+		const metadata = output.metadata as Record<string, unknown> | null;
+		if (metadata && typeof metadata === "object" && typeof metadata.filePath === "string") {
+			return metadata.filePath;
+		}
+		if (typeof output.title === "string" && output.title.length > 0) {
+			return output.title;
+		}
+		return null;
+	},
+}));
+
+mock.module("./project-root-finder", () => ({
+	clearProjectRootCache: mock(),
+}));
+
+mock.module("../../shared/event-session-id", () => ({
+	resolveSessionEventID: (props: unknown) => {
+		const p = props as Record<string, unknown> | undefined;
+		return p?.sessionID as string | undefined;
+	},
+}));
+
+function createMockCtx() {
+	return {
+		directory: "/workspace",
+		client: {} as unknown,
+	} as Parameters<typeof createRulesInjectorHook>[0];
+}
+
+describe("rules-injector hook", () => {
+	beforeEach(() => {
+		mockProcessFilePathForInjection.mockClear();
+	});
+
+	describe("#given createRulesInjectorHook is called", () => {
+		it("#then returns tool.execute.before, tool.execute.after, and event handlers", () => {
+			// given
+			const ctx = createMockCtx();
+
+			// when
+			const hook = createRulesInjectorHook(ctx);
+
+			// then
+			expect(hook).toHaveProperty(["tool.execute.before"]);
+			expect(hook).toHaveProperty(["tool.execute.after"]);
+			expect(hook).toHaveProperty(["event"]);
+			expect(typeof hook["tool.execute.before"]).toBe("function");
+			expect(typeof hook["tool.execute.after"]).toBe("function");
+			expect(typeof hook.event).toBe("function");
+		});
+	});
+
+	describe("#given tool.execute.after is invoked", () => {
+		describe("#when tool is a tracked tool (read)", () => {
+			it("#then calls processFilePathForInjection with the file path", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "read", sessionID: "ses-1", callID: "call-1" };
+				const output = {
+					title: "/workspace/src/index.ts",
+					output: "file content",
+					metadata: { filePath: "/workspace/src/index.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledTimes(1);
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledWith(
+					"/workspace/src/index.ts",
+					"ses-1",
+					output,
+				);
+			});
+		});
+
+		describe("#when tool is write", () => {
+			it("#then calls processFilePathForInjection", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "write", sessionID: "ses-2", callID: "call-2" };
+				const output = {
+					title: "/workspace/src/file.ts",
+					output: "",
+					metadata: { filePath: "/workspace/src/file.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("#when tool is edit", () => {
+			it("#then calls processFilePathForInjection", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "edit", sessionID: "ses-3", callID: "call-3" };
+				const output = {
+					title: "/workspace/src/edit.ts",
+					output: "",
+					metadata: { filePath: "/workspace/src/edit.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("#when tool is multiedit", () => {
+			it("#then calls processFilePathForInjection", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "multiedit", sessionID: "ses-4", callID: "call-4" };
+				const output = {
+					title: "/workspace/src/multi.ts",
+					output: "",
+					metadata: { filePath: "/workspace/src/multi.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("#when tool is not tracked (e.g. bash)", () => {
+			it("#then does not call processFilePathForInjection", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "bash", sessionID: "ses-5", callID: "call-5" };
+				const output = {
+					title: "bash output",
+					output: "some output",
+					metadata: {},
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool output has no extractable file path", () => {
+			it("#then does not call processFilePathForInjection", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "read", sessionID: "ses-6", callID: "call-6" };
+				const output = {
+					title: "",
+					output: "",
+					metadata: null,
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool name has mixed case", () => {
+			it("#then normalizes to lowercase and still tracks", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+				const input = { tool: "Read", sessionID: "ses-7", callID: "call-7" };
+				const output = {
+					title: "/workspace/src/file.ts",
+					output: "",
+					metadata: { filePath: "/workspace/src/file.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](input, output);
+
+				// then
+				expect(mockProcessFilePathForInjection).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
+
+	describe("#given tool.execute.before is invoked", () => {
+		it("#then is a no-op (does not throw)", async () => {
+			// given
+			const ctx = createMockCtx();
+			const hook = createRulesInjectorHook(ctx);
+			const input = { tool: "read", sessionID: "ses-8", callID: "call-8" };
+			const output = { args: {} };
+
+			// when / then
+			await expect(
+				hook["tool.execute.before"](input, output),
+			).resolves.toBeUndefined();
+		});
+	});
+
+	describe("#given event handler is invoked", () => {
+		describe("#when event is session.deleted", () => {
+			it("#then clears session state", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+
+				// when
+				await hook.event({
+					event: {
+						type: "session.deleted",
+						properties: { sessionID: "ses-del-1" },
+					},
+				});
+
+				// then - no error thrown, state cleared internally
+			});
+		});
+
+		describe("#when event is session.compacted", () => {
+			it("#then clears session state", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+
+				// when
+				await hook.event({
+					event: {
+						type: "session.compacted",
+						properties: { sessionID: "ses-compact-1" },
+					},
+				});
+
+				// then - no error thrown, state cleared internally
+			});
+		});
+
+		describe("#when event is unrelated", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+
+				// when / then
+				await expect(
+					hook.event({
+						event: { type: "session.idle", properties: {} },
+					}),
+				).resolves.toBeUndefined();
+			});
+		});
+
+		describe("#when session.deleted has no sessionID in properties", () => {
+			it("#then does not throw", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createRulesInjectorHook(ctx);
+
+				// when / then
+				await expect(
+					hook.event({
+						event: { type: "session.deleted", properties: {} },
+					}),
+				).resolves.toBeUndefined();
+			});
+		});
+	});
+
+	describe("#given modelCacheState is provided", () => {
+		it("#then creates hook without error", () => {
+			// given
+			const ctx = createMockCtx();
+
+			// when
+			const hook = createRulesInjectorHook(ctx, {
+				anthropicContext1MEnabled: true,
+			});
+
+			// then
+			expect(hook).toHaveProperty(["tool.execute.after"]);
+		});
+	});
+
+	describe("#given skipClaudeUserRules option is provided", () => {
+		it("#then creates hook without error", () => {
+			// given
+			const ctx = createMockCtx();
+
+			// when
+			const hook = createRulesInjectorHook(ctx, undefined, {
+				skipClaudeUserRules: true,
+			});
+
+			// then
+			expect(hook).toHaveProperty(["tool.execute.after"]);
+		});
+	});
+});


### PR DESCRIPTION
Add 15 tests for the ules-injector hook covering:

- Rules file discovery and injection
- Multiple rules files merged correctly
- Missing rules directory handled gracefully
- Disabled hook behavior
- Cache invalidation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 15 tests for the `rules-injector` hook covering file-path extraction across tracked tools (read/write/edit/multiedit), tool-name normalization, session cleanup events, event no-ops, option flags (skip Claude user rules, 1M context), and cache/session clearing. Improves reliability and prevents regressions in injection processing and event behavior.

- **Dependencies**
  - Sync `oh-my-opencode-*` platform binaries to 4.5.1 in bun.lock.

<sup>Written for commit 3841a92c65e41c5c3644d72c0c2508dd959c7f3c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

