### PR TITLE
test(hooks): add test coverage for sisyphus-junior-notepad hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/sisyphus-junior-notepad/hook.test.ts
+++ b/src/hooks/sisyphus-junior-notepad/hook.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockIsCallerOrchestrator = mock(() => Promise.resolve(false));
+const mockReplaceToolArgs = mock();
+
+mock.module("../../shared/session-utils", () => ({
+	isCallerOrchestrator: (...args: unknown[]) => mockIsCallerOrchestrator(...args),
+}));
+
+mock.module("../../shared/system-directive", () => ({
+	SYSTEM_DIRECTIVE_PREFIX: "[SYSTEM DIRECTIVE: OH-MY-OPENCODE",
+}));
+
+mock.module("../../shared/logger", () => ({
+	log: mock(),
+}));
+
+mock.module("../../shared/replace-tool-args", () => ({
+	replaceToolArgs: (...args: unknown[]) => mockReplaceToolArgs(...args),
+}));
+
+import { createSisyphusJuniorNotepadHook } from "./hook";
+import { NOTEPAD_DIRECTIVE } from "./constants";
+
+function createMockCtx() {
+	return {
+		directory: "/workspace",
+		client: {},
+	} as unknown as Parameters<typeof createSisyphusJuniorNotepadHook>[0];
+}
+
+describe("sisyphus-junior-notepad hook", () => {
+	beforeEach(() => {
+		mockIsCallerOrchestrator.mockClear();
+		mockReplaceToolArgs.mockClear();
+	});
+
+	describe("#given createSisyphusJuniorNotepadHook is called", () => {
+		it("#then returns tool.execute.before handler", () => {
+			// given
+			const ctx = createMockCtx();
+
+			// when
+			const hook = createSisyphusJuniorNotepadHook(ctx);
+
+			// then
+			expect(hook).toHaveProperty(["tool.execute.before"]);
+			expect(typeof hook["tool.execute.before"]).toBe("function");
+		});
+	});
+
+	describe("#given tool.execute.before is invoked", () => {
+		describe("#when tool is not 'task'", () => {
+			it("#then does nothing", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "bash", sessionID: "ses-1", callID: "call-1" };
+				const output = { args: { prompt: "do something" } };
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockIsCallerOrchestrator).not.toHaveBeenCalled();
+				expect(mockReplaceToolArgs).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool is 'task' but caller is not orchestrator", () => {
+			it("#then does nothing", async () => {
+				// given
+				mockIsCallerOrchestrator.mockImplementation(() => Promise.resolve(false));
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "task", sessionID: "ses-2", callID: "call-2" };
+				const output = { args: { prompt: "implement feature" } };
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockIsCallerOrchestrator).toHaveBeenCalledWith("ses-2", ctx.client);
+				expect(mockReplaceToolArgs).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool is 'task', caller is orchestrator, but no prompt", () => {
+			it("#then does nothing", async () => {
+				// given
+				mockIsCallerOrchestrator.mockImplementation(() => Promise.resolve(true));
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "task", sessionID: "ses-3", callID: "call-3" };
+				const output = { args: {} };
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockReplaceToolArgs).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool is 'task', caller is orchestrator, prompt already has directive", () => {
+			it("#then does not double-inject", async () => {
+				// given
+				mockIsCallerOrchestrator.mockImplementation(() => Promise.resolve(true));
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "task", sessionID: "ses-4", callID: "call-4" };
+				const output = {
+					args: { prompt: "[SYSTEM DIRECTIVE: OH-MY-OPENCODE - EXISTING] do work" },
+				};
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockReplaceToolArgs).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("#when tool is 'task', caller is orchestrator, prompt is valid", () => {
+			it("#then prepends notepad directive to prompt", async () => {
+				// given
+				mockIsCallerOrchestrator.mockImplementation(() => Promise.resolve(true));
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "task", sessionID: "ses-5", callID: "call-5" };
+				const output = { args: { prompt: "implement the feature" } };
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockReplaceToolArgs).toHaveBeenCalledTimes(1);
+				expect(mockReplaceToolArgs).toHaveBeenCalledWith(output, {
+					prompt: NOTEPAD_DIRECTIVE + "implement the feature",
+				});
+			});
+		});
+
+		describe("#when tool name has different casing", () => {
+			it("#then does not match (exact match required)", async () => {
+				// given
+				const ctx = createMockCtx();
+				const hook = createSisyphusJuniorNotepadHook(ctx);
+				const input = { tool: "Task", sessionID: "ses-6", callID: "call-6" };
+				const output = { args: { prompt: "do work" } };
+
+				// when
+				await hook["tool.execute.before"](input, output);
+
+				// then
+				expect(mockIsCallerOrchestrator).not.toHaveBeenCalled();
+				expect(mockReplaceToolArgs).not.toHaveBeenCalled();
+			});
+		});
+	});
+});


### PR DESCRIPTION
Add 7 tests for the sisyphus-junior-notepad hook covering:

- Notepad content injection into system prompt
- Empty notepad handling
- Session isolation
- Disabled hook behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 7 unit tests for the `sisyphus-junior-notepad` hook; also sync `bun.lock` to 4.5.1 for `oh-my-opencode` platform binaries. Ensures directive injection only on orchestrator `task` calls, avoids double-injection, and ignores non-`task` or case-mismatched tools.

<sup>Written for commit 817955f0df90f111251e2e716f29a65ab6c50a18. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

