### PR TITLE
Normalize plugin-entry path assertion across platforms

### DIFF
--- a/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -197,7 +197,7 @@ describe("findPluginEntry", () => {
     expect(execution.status).toBe(0)
     const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
     expect(pluginInfo).not.toBeNull()
-    expect(pluginInfo?.configPath).toEndWith("/profiles/today/opencode.json")
+    expect(path.normalize(pluginInfo?.configPath ?? "")).toBe(path.normalize(path.join(profileConfigDir, "opencode.json")))
     expect(pluginInfo?.pinnedVersion).toBe("beta")
   })
 })


### PR DESCRIPTION
## Summary
- normalize the `configPath` assertion in `plugin-entry.test.ts`
- compare against the expected joined path instead of a hard-coded POSIX suffix

## Why
This test currently hard-codes a `/profiles/today/opencode.json` suffix, so it fails on Windows even though the production behavior is correct. The issue is cross-platform and test-only.

## Testing
- `bun test src/hooks/auto-update-checker/checker/plugin-entry.test.ts`

## Notes
- I intentionally left unrelated working tree changes (`bun.lock`, `assets/oh-my-opencode.schema.json`) out of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-platform test by normalizing `configPath` assertion in `plugin-entry.test.ts`, replacing a hard-coded POSIX suffix with a normalized `path.join(profileConfigDir, "opencode.json")` comparison so tests pass on Windows.

<sup>Written for commit b131d4bc6041e61d6b9c94a82566cc890c3ad00b. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4526?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

