### PR TITLE
fix: normalize Windows where.exe output in ripgrep resolver

### DIFF
--- a/src/shared/ripgrep-cli.test.ts
+++ b/src/shared/ripgrep-cli.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -26,6 +26,7 @@ describe("resolveGrepCli OpenCode cache fallback (#3805)", () => {
     else process.env.XDG_CACHE_HOME = originalCache
     if (originalData === undefined) delete process.env.XDG_DATA_HOME
     else process.env.XDG_DATA_HOME = originalData
+    mock.restore()
     try {
       rmSync(tempCache, { recursive: true, force: true })
       rmSync(tempData, { recursive: true, force: true })
@@ -52,5 +53,32 @@ describe("resolveGrepCli OpenCode cache fallback (#3805)", () => {
     const resolved = resolveGrepCli()
     expect(resolved.backend).toBe("rg")
     expect(resolved.path).toBe(cacheRg)
+  })
+
+  it("strips Windows CRLF from where.exe output before spawning ripgrep (#4512)", async () => {
+    const rawRgPath = "C:\\Users\\tester\\.local\\bin\\rg.exe"
+
+    mock.module("node:child_process", () => ({
+      spawnSync: () => ({
+        status: 0,
+        stdout: `${rawRgPath}\r\nC:\\Windows\\System32\\rg.exe\r\n`,
+      }),
+    }))
+    mock.module("node:fs", () => ({
+      existsSync: () => false,
+    }))
+    mock.module("../tools/grep/downloader", () => ({
+      downloadAndInstallRipgrep: async () => rawRgPath,
+      getInstalledRipgrepPath: () => null,
+    }))
+
+    delete require.cache[require.resolve("./ripgrep-cli")]
+    const { resolveGrepCli } = await import("./ripgrep-cli")
+
+    const resolved = resolveGrepCli()
+
+    expect(resolved.backend).toBe("rg")
+    expect(resolved.path).toBe(rawRgPath)
+    expect(resolved.path.endsWith("\r")).toBe(false)
   })
 })

--- a/src/shared/ripgrep-cli.ts
+++ b/src/shared/ripgrep-cli.ts
@@ -18,6 +18,13 @@ export const DEFAULT_RG_THREADS = 4
 let cachedCli: ResolvedCli | null = null
 let autoInstallAttempted = false
 
+function getFirstExecutablePath(stdout: string): string | null {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? null
+}
+
 function findExecutable(name: string): string | null {
   const isWindows = process.platform === "win32"
   const cmd = isWindows ? "where.exe" : "which"
@@ -32,7 +39,7 @@ function findExecutable(name: string): string | null {
     })
     const stdout = result.stdout
     if (result.status === 0 && stdout.trim()) {
-      return stdout.trim().split("\n")[0]
+      return getFirstExecutablePath(stdout)
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary

Fix a remaining Windows-specific `rg`/`grep` resolver bug in `src/shared/ripgrep-cli.ts`.

`where.exe` returns CRLF-delimited output on Windows, but the current resolver takes the first line with `stdout.trim().split("\n")[0]`. That can leave a trailing `\r` on the selected executable path and later cause:

```text
spawn ... rg.exe\r ENOENT
```

This PR makes the resolver CRLF-safe by splitting on `/\r?\n/`, trimming each candidate, and taking the first non-empty entry.

## Why

Closes #4512.

Issue `#3919` / PR `#4300` fixed a separate Windows Desktop utility-process crash path. This patch covers a second remaining Windows-specific failure mode in the ripgrep executable resolver itself.

## Validation

- Added a regression test for CRLF-delimited `where.exe` output
- `bun test src/shared/ripgrep-cli.test.ts --bail`
- `bun test src/shared/mock-module-lifecycle-audit.test.ts --bail`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Windows `where.exe` output in the ripgrep resolver to strip CRLF and pick the correct path, preventing `ENOENT` when spawning `rg`. Fixes #4512.

- **Bug Fixes**
  - Split probe output on `/\r?\n/`, trim lines, and use the first non-empty entry.
  - Prevents selecting `rg.exe\r`; preserves resolver order and non-Windows behavior.
  - Adds a regression test for CRLF-delimited `where.exe` output.

<sup>Written for commit b49cd9f864a468467c17c127a61f3cda7534f3a8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4527?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

