### PR TITLE
Fix runtime fallback and background subagent stalls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,17 +42,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.0",
-        "oh-my-opencode-darwin-x64": "4.5.0",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-arm64": "4.5.0",
-        "oh-my-opencode-linux-arm64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64": "4.5.0",
-        "oh-my-opencode-linux-x64-baseline": "4.5.0",
-        "oh-my-opencode-linux-x64-musl": "4.5.0",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.0",
-        "oh-my-opencode-windows-x64": "4.5.0",
-        "oh-my-opencode-windows-x64-baseline": "4.5.0",
+        "oh-my-opencode-darwin-arm64": "4.5.1",
+        "oh-my-opencode-darwin-x64": "4.5.1",
+        "oh-my-opencode-darwin-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-arm64": "4.5.1",
+        "oh-my-opencode-linux-arm64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64": "4.5.1",
+        "oh-my-opencode-linux-x64-baseline": "4.5.1",
+        "oh-my-opencode-linux-x64-musl": "4.5.1",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.5.1",
+        "oh-my-opencode-windows-x64": "4.5.1",
+        "oh-my-opencode-windows-x64-baseline": "4.5.1",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -410,27 +410,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jMGHduiNLcunFOHCFs4s3h3QUF6melta+El5bRy13CfI59lxiHIyBhfESWnWrDWo0bLvMT79ptwM4oMtOH/O9A=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-eBpVUGaj4f8CrpETV3j5Uw184QUfSzr8skhTeCemygH8THnbbEQC5lj3KfpeDFD+iWyvG6dKXFgfD80dbFn/qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-0e7lZ/Q1Y+1ueEjAAKCJ6DoWG/L3lKyfe7tu+6gnMKP8yRVAKnqVKptcb0eizTkFwszS6LMXaZxXRxzDUM00+w=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/78kDxNiK4UxyNqm0sUWUvBkjlqT1b/XQ7acsR76wWxvcT/rMHOcYhbJCC9tmlfGsgiRj9mrUQQ4GyZ4AUflGQ=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OFXm5KtNvS0hmNTku/bh+9jgTWJXCPHeo9apYBCSp+WjoJaWNQgei96kVeEGX9lrTR0YqBpU5I9iJQtLOSfrYA=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H40//7oWAAE4/dos5bdaLvu1dZX22DIX8u8KfJnY7/bN/+bYO5WSXu7ANakEebkzVBBHqsMfK5G6GgdvEEcolg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7IUXBHIeMESfiFK9tdMmloFy01ZxxTB83sqDSfzrC496O76pGpP6L0HZ2U0qliGp4Ug0niH3E0adXsAeDtj/Yg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kY2z28+FXEzanYbAJNp6FuxLpr7A1nHywZMU8mQBeGT7evySHojBeAUcrCKAj+nswZkecebwTI+4Q+EfWCKwvQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pdNy9We2Z646LLQ0Q62BIuGMoJwLKBFXTQx94TtMgars7wCjgkJg6I/c21qvlSwILh7eUKwk57rhQUvOouBIug=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xHjRCECGzE4ZxlalBGAmptOal8+zY26RBcY0KSK81tZRs0NElEq4Oj+3tsWZXLHrdMeZJ+s2Z04//VpaQrgePA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UsbVr8OmE/eRk0AHgMOTCU12p/HMRzPEy89A71Fq1Qco3tJ+NiIqaaHs90CkHSFggTs+aaQedi8Mu9lOExa9Pg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-yNBVPT/v/QaAffmEOy8r4jyih0ebGC3E3pD3aZ7YSGJ6c4xbZCMCiSftCDE0XyDT7wSr/0HUzFOVvn+EfLkbzQ=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-h/WiF/PysX8IR6hYsyavMwSSkFyOewB/bOS0jvQCxJ/9X/q4ybdaNyZA8ASPBUhHCkvxZ9LVanvgc6VkcT499Q=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/zUu9Lwl3pj9LgP5v1AKsJeOio3ikSaI7WUCAGcnomuGmG0Lbn5RzaWVGxf6kVMOneBzAyQ3sKUde630TI4fzA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OkE2i6BK9fv9LQsLxFwbtstGZZijd30k/7Hr1fNuC3jDQysu2OtXwKFc73WrmKyRE5f75ME1VOXoTyk4mjGPhg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MxyxOZENSouJLinvNFK06eSRNIG4dq5Nh3Zct+dI48aveS/kn7IIDvUTlx5mgCFvGhMygtq/UYgT7n29GKAmpw=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lmd9ytyVrGJFGJw7/9QGqSpy9aksZrVtCA4cpIGPxiPKaQC5d8ABEQXx+MPe49+xp7XMGv97T879eQmsnHkr6g=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-g0gZUb9RAil2LH6QddDvhhEJGBa8w3NzFDBnfEJKRWnZwIs5Z0T4nfDtxvEDCUHXZ5q25DX/jdwTzgggIXiqlw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-XOLHHHb03Jz464K0/JaflfXT6bS+dIegVAgKs6jtBKRazYvWMo1G6y9qds/adHyt3K0GTmPGCNwM0xWfhnHZKw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JSQduUCWqHac9Sh78pqEPA3K7NCJt0TX4klUOOQbUKlbw1RIjKCh2i9zy7iW5oUGyH7vxXWWvaACSEUIaDD8HA=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-Hr22TnP7gQ9ORgi5+2CT/VgvkyO7gPNOffXnqzCzt+TW6WCU58sqQnPcUvuGmbB0P+C+IWYPYpJhOcxAq38oxQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-0u6GeWC9wUeC90dhyHw5W4DSlhAey6P4GRmWcNjnR0nStGnXlca3TOgpJHKEBZdt8tS2tosk9OfGeTZ+la+vZQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2337,7 +2337,7 @@ describe("BackgroundManager.tryCompleteTask", () => {
     expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
   })
 
-   test("should abort session on completion", async () => {
+   test("should abort active session on completion", async () => {
      // #given
      const abortedSessionIDs: string[] = []
      const client = {
@@ -2348,6 +2348,7 @@ describe("BackgroundManager.tryCompleteTask", () => {
            abortedSessionIDs.push(args.path.id)
            return {}
          },
+         status: async () => ({ data: { "session-1": { type: "busy" } } }),
          messages: async () => ({ data: [] }),
        },
      }
@@ -2372,6 +2373,45 @@ describe("BackgroundManager.tryCompleteTask", () => {
 
     // #then
     expect(abortedSessionIDs).toEqual(["session-1"])
+  })
+
+  test("should not abort idle completed session on completion", async () => {
+    // #given
+    const abortedSessionIDs: string[] = []
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (args: { path: { id: string } }) => {
+          abortedSessionIDs.push(args.path.id)
+          return {}
+        },
+        status: async () => ({ data: { "session-1": { type: "idle" } } }),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    manager.shutdown()
+    manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-1",
+      sessionId: "session-1",
+      parentSessionId: "session-parent",
+      parentMessageId: "msg-1",
+      description: "test task",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+
+    // #when
+    await tryCompleteTaskForTest(manager, task)
+
+    // #then
+    expect(abortedSessionIDs).toEqual([])
+    expect(task.status).toBe("completed")
   })
 
   test("should clean pendingByParent even when promptAsync notification fails", async () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -2343,8 +2343,18 @@ The task was re-queued on a fallback model after a retryable failure.
     }
 
     if (task.sessionId) {
-      // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT)
-      await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
+      // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT).
+      // Only abort sessions that are still actively streaming; aborting an
+      // already-idle completed child can create false "interrupted" markers.
+      if (await isOpenCodeSessionActive(this.client, task.sessionId)) {
+        await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
+      } else {
+        log("[background-agent] Skipping abort for completed idle task session:", {
+          taskId: task.id,
+          sessionId: task.sessionId,
+          source,
+        })
+      }
 
       clearDelegatedChildSessionBootstrap(task.sessionId)
       SessionCategoryRegistry.remove(task.sessionId)

--- a/src/hooks/atlas/background-launch-session-tracking.ts
+++ b/src/hooks/atlas/background-launch-session-tracking.ts
@@ -6,8 +6,8 @@ import {
   type BoulderState,
   resolveBoulderPlanPath,
   resolveBoulderPlanPathForWork,
+  startTaskTimer,
   upsertTaskSessionState,
-  upsertTaskSessionStateForWork,
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { HOOK_NAME } from "./hook-name"
@@ -65,7 +65,7 @@ export async function syncBackgroundLaunchSessionTracking(input: {
 
   if (currentTask && !shouldSkipTaskSessionUpdate) {
     if (trackedWork) {
-      upsertTaskSessionStateForWork(ctx.directory, trackedWork.work_id, {
+      startTaskTimer(ctx.directory, trackedWork.work_id, {
         taskKey: currentTask.key,
         taskLabel: currentTask.label,
         taskTitle: currentTask.title,

--- a/src/hooks/atlas/idle-event.ts
+++ b/src/hooks/atlas/idle-event.ts
@@ -47,7 +47,9 @@ function getTaskLabelSortValue(taskLabel: string): number {
 function hasRunningBackgroundTasks(sessionID: string, options?: AtlasHookOptions): boolean {
   const backgroundManager = options?.backgroundManager
   return backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) =>
+        task.status === "running" || task.status === "pending"
+      )
     : false
 }
 

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -147,9 +147,7 @@ export function createToolExecuteAfterHandler(input: {
       recordToolProgress(getState(toolInput.sessionID))
     }
 
-    if (!(await resolveIsCallerOrchestrator(toolInput.sessionID))) {
-      return
-    }
+    const callerIsOrchestrator = await resolveIsCallerOrchestrator(toolInput.sessionID)
 
     if (isWriteOrEditToolName(toolInput.tool)) {
       let filePath = toolInput.callID ? pendingFilePaths.get(toolInput.callID) : undefined
@@ -161,26 +159,55 @@ export function createToolExecuteAfterHandler(input: {
         pendingPlanSnapshots?.delete(toolInput.callID)
       }
       if (!filePath) {
-        filePath = toolOutput.metadata?.filePath as string | undefined
+        filePath = typeof toolOutput.metadata?.filePath === "string"
+          ? toolOutput.metadata.filePath
+          : typeof toolOutput.args?.filePath === "string"
+            ? toolOutput.args.filePath
+            : typeof toolOutput.args?.path === "string"
+              ? toolOutput.args.path
+              : typeof toolOutput.args?.file === "string"
+                ? toolOutput.args.file
+                : undefined
       }
 
       if (filePath && toolInput.sessionID) {
         const sessionWork = getWorkForSession(ctx.directory, toolInput.sessionID)
         if (sessionWork) {
           const planPath = resolveBoulderPlanPathForWork(ctx.directory, sessionWork)
-          if (resolve(filePath) === resolve(planPath) && planSnapshot !== undefined) {
-            const beforeCheckedKeys = parseCheckedTopLevelTaskKeys(planSnapshot)
+          if (resolve(filePath) === resolve(planPath)) {
             const afterCheckedKeys = readCheckedTaskKeysFromPlan(planPath)
-            for (const taskKey of afterCheckedKeys) {
-              if (!beforeCheckedKeys.has(taskKey)) {
-                endTaskTimer(ctx.directory, sessionWork.work_id, taskKey)
+            if (planSnapshot !== undefined) {
+              const beforeCheckedKeys = parseCheckedTopLevelTaskKeys(planSnapshot)
+              for (const taskKey of afterCheckedKeys) {
+                if (!beforeCheckedKeys.has(taskKey)) {
+                  endTaskTimer(ctx.directory, sessionWork.work_id, taskKey)
+                }
+              }
+            } else {
+              for (const taskKey of afterCheckedKeys) {
+                if (sessionWork.task_sessions?.[taskKey]) {
+                  endTaskTimer(ctx.directory, sessionWork.work_id, taskKey)
+                }
+              }
+            }
+          }
+        } else {
+          const boulderState = readBoulderState(ctx.directory)
+          if (boulderState?.active_work_id) {
+            const planPath = resolveBoulderPlanPath(ctx.directory, boulderState)
+            if (resolve(filePath) === resolve(planPath)) {
+              const afterCheckedKeys = readCheckedTaskKeysFromPlan(planPath)
+              for (const taskKey of afterCheckedKeys) {
+                if (boulderState.task_sessions?.[taskKey]) {
+                  endTaskTimer(ctx.directory, boulderState.active_work_id, taskKey)
+                }
               }
             }
           }
         }
       }
 
-      if (filePath && !isOmoPath(filePath)) {
+      if (callerIsOrchestrator && filePath && !isOmoPath(filePath)) {
         toolOutput.output = (toolOutput.output || "") + DIRECT_WORK_REMINDER
         log(`[${HOOK_NAME}] Direct work reminder appended`, {
           sessionID: toolInput.sessionID,
@@ -188,6 +215,10 @@ export function createToolExecuteAfterHandler(input: {
           filePath,
         })
       }
+      return
+    }
+
+    if (!callerIsOrchestrator) {
       return
     }
 

--- a/src/hooks/atlas/types.ts
+++ b/src/hooks/atlas/types.ts
@@ -28,6 +28,7 @@ export interface ToolExecuteAfterOutput {
   title: string
   output: string
   metadata: Record<string, unknown>
+  args?: Record<string, unknown>
 }
 
 export type TrackedTopLevelTaskRef = Pick<TopLevelTaskRef, "key" | "label" | "title">

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -39,7 +39,9 @@ function hasRunningBackgroundTasks(
 	sessionID: string,
 ): boolean {
 	return backgroundManager
-		? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+		? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) =>
+				task.status === "running" || task.status === "pending"
+			)
 		: false
 }
 

--- a/src/hooks/runtime-fallback/auto-retry.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry.test.ts
@@ -4,7 +4,12 @@ import { createAutoRetryHelpers } from "./auto-retry"
 import { createFallbackState } from "./fallback-state"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 
-function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInput {
+type PromptCallRecorder = {
+  count: number
+  bodies?: unknown[]
+}
+
+function createContext(promptCalls: PromptCallRecorder): RuntimeFallbackPluginInput {
   const session = {
     abort: async () => ({}),
     messages: async () => ({
@@ -15,8 +20,9 @@ function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInp
         },
       ],
     }),
-    promptAsync: async () => {
+    promptAsync: async (input: { body?: unknown }) => {
       promptCalls.count += 1
+      promptCalls.bodies?.push(input.body)
       return {}
     },
     status: async () => ({ data: { "session-auto-retry": { type: "busy" } } }),
@@ -32,7 +38,7 @@ function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInp
   }
 }
 
-function createDeps(promptCalls: { count: number }): HookDeps {
+function createDeps(promptCalls: PromptCallRecorder): HookDeps {
   return {
     ctx: createContext(promptCalls),
     config: {
@@ -98,5 +104,24 @@ describe("createAutoRetryHelpers", () => {
     expect(promptCalls.count).toBe(0)
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
     expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
+  })
+
+  test("#given a plugin display agent is resolved #when auto retry dispatches internally #then it omits the plugin agent from promptAsync", async () => {
+    // given
+    const promptCalls = { count: 0, bodies: [] as unknown[] }
+    const deps = createDeps(promptCalls)
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-auto-retry-plugin-agent"
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    deps.sessionStates.set(sessionID, state)
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", "Atlas - Plan Executor", "first-prompt-watchdog")
+
+    // then
+    expect(promptCalls.count).toBe(1)
+    expect(promptCalls.bodies).toHaveLength(1)
+    expect((promptCalls.bodies[0] as Record<string, unknown>).agent).toBeUndefined()
   })
 })

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -19,9 +19,41 @@ import {
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 
 const SESSION_TTL_MS = 30 * 60 * 1000
+const ZERO_WIDTH_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g
+const INTERNAL_PROMPT_AGENT_NAMES = new Set([
+  "build",
+  "explore",
+  "general",
+  "plan",
+])
 
 declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
 declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
+
+function normalizeInternalPromptAgentName(name: string): string {
+  return name.replace(ZERO_WIDTH_CHARACTERS_REGEX, "").toLowerCase()
+}
+
+function resolveInternalPromptAgentName(name: string | undefined): string | undefined {
+  if (typeof name !== "string") {
+    return undefined
+  }
+
+  const normalizedOriginalName = normalizeInternalPromptAgentName(name)
+  if (INTERNAL_PROMPT_AGENT_NAMES.has(normalizedOriginalName)) {
+    return name.replace(ZERO_WIDTH_CHARACTERS_REGEX, "")
+  }
+
+  const registeredName = resolveRegisteredAgentName(name)
+  const normalizedRegisteredName = registeredName
+    ? normalizeInternalPromptAgentName(registeredName)
+    : undefined
+  if (normalizedRegisteredName && INTERNAL_PROMPT_AGENT_NAMES.has(normalizedRegisteredName)) {
+    return registeredName
+  }
+
+  return undefined
+}
 
 export function createAutoRetryHelpers(deps: HookDeps) {
   const {
@@ -175,7 +207,14 @@ export function createAutoRetryHelpers(deps: HookDeps) {
       })
 
       const retryAgent = resolvedAgent ?? getSessionAgent(sessionID)
-      const launchAgent = resolveRegisteredAgentName(retryAgent)
+      const launchAgent = resolveInternalPromptAgentName(retryAgent)
+      if (!launchAgent && retryAgent) {
+        log(`[${HOOK_NAME}] Omitting plugin agent from internal fallback prompt`, {
+          sessionID,
+          agent: retryAgent,
+          source,
+        })
+      }
       if (!hadAwaitingFallbackResult) {
         sessionAwaitingFallbackResult.add(sessionID)
         scheduleSessionFallbackTimeout(sessionID, retryAgent)

--- a/src/hooks/runtime-fallback/chat-message-handler.ts
+++ b/src/hooks/runtime-fallback/chat-message-handler.ts
@@ -1,7 +1,7 @@
 import type { HookDeps } from "./types"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
-import { createFallbackState } from "./fallback-state"
+import { createFallbackState, isEquivalentModel } from "./fallback-state"
 
 export function createChatMessageHandler(deps: HookDeps) {
   const { config, sessionStates, sessionLastAccess } = deps
@@ -23,21 +23,29 @@ export function createChatMessageHandler(deps: HookDeps) {
       ? `${input.model.providerID}/${input.model.modelID}`
       : undefined
 
-    if (requestedModel && requestedModel !== state.currentModel) {
-      if (state.pendingFallbackModel && state.pendingFallbackModel === requestedModel) {
+    if (requestedModel && !isEquivalentModel(requestedModel, state.currentModel)) {
+      if (state.pendingFallbackModel && isEquivalentModel(requestedModel, state.pendingFallbackModel)) {
         state.pendingFallbackModel = undefined
         state.pendingFallbackPromptMayHaveBeenAccepted = false
         return
       }
 
-      log(`[${HOOK_NAME}] Detected manual model change, resetting fallback state`, {
-        sessionID,
-        from: state.currentModel,
-        to: requestedModel,
-      })
-      state = createFallbackState(requestedModel)
-      sessionStates.set(sessionID, state)
-      return
+      if (state.pendingFallbackModel) {
+        log(`[${HOOK_NAME}] Applying pending fallback over provider retry model`, {
+          sessionID,
+          requestedModel,
+          fallbackModel: state.currentModel,
+        })
+      } else {
+        log(`[${HOOK_NAME}] Detected manual model change, resetting fallback state`, {
+          sessionID,
+          from: state.currentModel,
+          to: requestedModel,
+        })
+        state = createFallbackState(requestedModel)
+        sessionStates.set(sessionID, state)
+        return
+      }
     }
 
     if (state.currentModel === state.originalModel) return

--- a/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
+++ b/src/hooks/runtime-fallback/fallback-bootstrap-model.ts
@@ -2,11 +2,12 @@ import type { OhMyOpenCodeConfig } from "../../config"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import { modelToFallbackString } from "./fallback-state"
 
 type ResolveFallbackBootstrapModelOptions = {
   sessionID: string
   source: string
-  eventModel?: string
+  eventModel?: unknown
   resolvedAgent?: string
   pluginConfig?: OhMyOpenCodeConfig
 }
@@ -14,8 +15,9 @@ type ResolveFallbackBootstrapModelOptions = {
 export function resolveFallbackBootstrapModel(
   options: ResolveFallbackBootstrapModelOptions,
 ): string | undefined {
-  if (options.eventModel) {
-    return options.eventModel
+  const eventModel = modelToFallbackString(options.eventModel)
+  if (eventModel) {
+    return eventModel
   }
 
   const agentConfigs = options.pluginConfig?.agents

--- a/src/hooks/runtime-fallback/fallback-state.test.ts
+++ b/src/hooks/runtime-fallback/fallback-state.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { createFallbackState, isEquivalentModel } from "./fallback-state"
+
+describe("runtime fallback state", () => {
+  test("#given OpenCode provides a model object #when fallback state is created #then model identity is normalized to a string", () => {
+    // given
+    const model = {
+      providerID: "anthropic",
+      modelID: "claude-opus-4-7",
+      variant: "max",
+    }
+
+    // when
+    const state = createFallbackState(model)
+
+    // then
+    expect(state.originalModel).toBe("anthropic/claude-opus-4-7(max)")
+    expect(state.currentModel).toBe("anthropic/claude-opus-4-7(max)")
+  })
+
+  test("#given fallback compares string and object forms of the same model #when checking equivalence #then it does not throw and treats them as equivalent", () => {
+    // expect
+    expect(isEquivalentModel(
+      "anthropic/claude-opus-4-7(max)",
+      { providerID: "anthropic", modelID: "claude-opus-4-7", variant: "max" },
+    )).toBe(true)
+  })
+})

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -4,6 +4,35 @@ import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
 import { parseModelString } from "../../tools/delegate-task/model-string-parser"
 
+export function modelToFallbackString(model: unknown): string {
+  if (typeof model === "string") {
+    return model
+  }
+
+  if (model && typeof model === "object") {
+    const record = model as Record<string, unknown>
+    const providerID = typeof record.providerID === "string"
+      ? record.providerID
+      : typeof record.provider === "string"
+        ? record.provider
+        : undefined
+    const modelID = typeof record.modelID === "string"
+      ? record.modelID
+      : typeof record.id === "string"
+        ? record.id
+        : typeof record.model === "string"
+          ? record.model
+          : undefined
+
+    if (providerID && modelID) {
+      const variant = typeof record.variant === "string" ? record.variant.trim() : ""
+      return variant ? `${providerID}/${modelID}(${variant})` : `${providerID}/${modelID}`
+    }
+  }
+
+  return ""
+}
+
 function canonicalizeModelID(modelID: string): string {
   const loweredModelID = modelID.toLowerCase()
   const dottedModelID = loweredModelID.replace(/\./g, "-")
@@ -49,12 +78,14 @@ function parseCanonicalModel(model: string): { providerID: string; modelID: stri
   }
 }
 
-function isEquivalentModel(candidate: string, current: string): boolean {
-  const parsedCandidate = parseCanonicalModel(candidate)
-  const parsedCurrent = parseCanonicalModel(current)
+export function isEquivalentModel(candidate: unknown, current: unknown): boolean {
+  const candidateText = modelToFallbackString(candidate)
+  const currentText = modelToFallbackString(current)
+  const parsedCandidate = parseCanonicalModel(candidateText)
+  const parsedCurrent = parseCanonicalModel(currentText)
 
   if (!parsedCandidate || !parsedCurrent) {
-    return candidate.toLowerCase() === current.toLowerCase()
+    return candidateText.toLowerCase() === currentText.toLowerCase()
   }
 
   return (
@@ -63,10 +94,11 @@ function isEquivalentModel(candidate: string, current: string): boolean {
   )
 }
 
-export function createFallbackState(originalModel: string): FallbackState {
+export function createFallbackState(originalModel: unknown): FallbackState {
+  const normalizedModel = modelToFallbackString(originalModel)
   return {
-    originalModel,
-    currentModel: originalModel,
+    originalModel: normalizedModel,
+    currentModel: normalizedModel,
     fallbackIndex: -1,
     failedModels: new Map<string, number>(),
     attemptCount: 0,

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -213,9 +213,9 @@ describe("first-prompt-watchdog", () => {
     watchdog.dispose()
   })
 
-  it("#given the session is not a subagent #when a user message is observed #then the watchdog never arms and nothing fires", async () => {
+  it("#given a main session stays silent past the threshold #when fallback is configured #then it queues fallback for the provider retry without aborting", async () => {
     // given
-    const sessionID = "session-not-a-subagent"
+    const sessionID = "session-main-silent"
     // NOT added to subagentSessions
     const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
     const calls: RecordedCalls = { abort: [], autoRetry: [] }
@@ -229,6 +229,9 @@ describe("first-prompt-watchdog", () => {
     // then
     expect(calls.abort).toEqual([])
     expect(calls.autoRetry).toEqual([])
+    const state = deps.sessionStates.get(sessionID)
+    expect(state?.currentModel).toBe(FALLBACK_MODEL)
+    expect(state?.pendingFallbackModel).toBe(FALLBACK_MODEL)
 
     watchdog.dispose()
   })

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -5,7 +5,7 @@ import { log } from "../../shared/logger"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import { isRecord } from "../../shared/record-type-guard"
-import { createFallbackState } from "./fallback-state"
+import { createFallbackState, prepareFallback } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
@@ -17,7 +17,7 @@ declare function setTimeout(callback: () => void | Promise<void>, delay?: number
 declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
 
 export interface FirstPromptWatchdog {
-  onUserMessage(sessionID: string, model?: string, agent?: string): void
+  onUserMessage(sessionID: string, model?: unknown, agent?: string): void
   onAssistantProgress(sessionID: string): void
   onSessionTerminal(sessionID: string): void
   dispose(): void
@@ -89,7 +89,7 @@ export function observeEventForWatchdog(
     if (!sessionID || !role) return
 
     if (role === "user") {
-      const model = info?.model as string | undefined
+      const model = info?.model
       const agent = info?.agent as string | undefined
       watchdog.onUserMessage(sessionID, model, agent)
       return
@@ -132,20 +132,15 @@ export function createFirstPromptWatchdog(
     armed.delete(sessionID)
   }
 
-  const fire = async (sessionID: string, model: string | undefined, agent: string | undefined): Promise<void> => {
+  const fire = async (sessionID: string, model: unknown, agent: string | undefined): Promise<void> => {
     timers.delete(sessionID)
     armed.delete(sessionID)
-
-    if (!subagentSessions.has(sessionID)) {
-      log(`[${HOOK_NAME}] ${SOURCE}: session no longer a subagent at fire time, skipping`, { sessionID })
-      return
-    }
 
     const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
     const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, deps.pluginConfig)
 
     if (fallbackModels.length === 0) {
-      log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms with no fallback configured`, {
+      log(`[${HOOK_NAME}] ${SOURCE}: session silent past ${watchdogMs}ms with no fallback configured`, {
         sessionID,
         model,
         agent: resolvedAgent,
@@ -169,9 +164,29 @@ export function createFirstPromptWatchdog(
       state = createFallbackState(initialModel)
       deps.sessionStates.set(sessionID, state)
       deps.sessionLastAccess.set(sessionID, Date.now())
+    } else {
+      deps.sessionLastAccess.set(sessionID, Date.now())
     }
 
-    log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms, dispatching fallback`, {
+    if (!subagentSessions.has(sessionID)) {
+      const result = prepareFallback(sessionID, state, fallbackModels, deps.config)
+      if (result.success && result.newModel) {
+        log(`[${HOOK_NAME}] ${SOURCE}: session silent past ${watchdogMs}ms, queued fallback for next provider retry`, {
+          sessionID,
+          model: result.newModel,
+          fallbackCount: fallbackModels.length,
+        })
+        return
+      }
+
+      log(`[${HOOK_NAME}] ${SOURCE}: fallback preparation failed`, {
+        sessionID,
+        error: result.error,
+      })
+      return
+    }
+
+    log(`[${HOOK_NAME}] ${SOURCE}: session silent past ${watchdogMs}ms, dispatching fallback`, {
       sessionID,
       model: state.currentModel,
       fallbackCount: fallbackModels.length,
@@ -195,7 +210,6 @@ export function createFirstPromptWatchdog(
   return {
     onUserMessage(sessionID, model, agent) {
       if (!sessionID) return
-      if (!subagentSessions.has(sessionID)) return
       if (armed.has(sessionID)) return
 
       armed.add(sessionID)
@@ -204,7 +218,7 @@ export function createFirstPromptWatchdog(
       }, watchdogMs)
       timers.set(sessionID, timer)
 
-      log(`[${HOOK_NAME}] ${SOURCE}: armed for subagent`, { sessionID, model, agent, watchdogMs })
+      log(`[${HOOK_NAME}] ${SOURCE}: armed for session`, { sessionID, model, agent, watchdogMs })
     },
     onAssistantProgress(sessionID) {
       if (!sessionID || !armed.has(sessionID)) return

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -1,6 +1,6 @@
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createChatMessageHandler } from "./chat-message-handler"
-import { DEFAULT_CONFIG } from "./constants"
+import { DEFAULT_CONFIG, DEFAULT_FIRST_PROMPT_WATCHDOG_MS } from "./constants"
 import { createEventHandler } from "./event-handler"
 import { createFirstPromptWatchdog, observeEventForWatchdog } from "./first-prompt-watchdog"
 import { createMessageUpdateHandler } from "./message-update-handler"
@@ -62,7 +62,10 @@ export function createRuntimeFallbackHook(
   const baseEventHandler = factories.createEventHandler(deps, helpers)
   const messageUpdateHandler = factories.createMessageUpdateHandler(deps, helpers)
   const chatMessageHandler = factories.createChatMessageHandler(deps)
-  const firstPromptWatchdog = factories.createFirstPromptWatchdog(deps, helpers)
+  const firstPromptWatchdogMs = config.timeout_seconds > 0
+    ? config.timeout_seconds * 1000
+    : DEFAULT_FIRST_PROMPT_WATCHDOG_MS
+  const firstPromptWatchdog = factories.createFirstPromptWatchdog(deps, helpers, firstPromptWatchdogMs)
 
   let cleanupInterval: RuntimeFallbackInterval | null = null
   let intervalStarted = false

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -46,6 +46,7 @@ function createDeps(): HookDeps {
     sessionAwaitingFallbackResult: new Set(),
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
   }
 }
 
@@ -104,7 +105,7 @@ describe("createSessionStatusHandler", () => {
     SessionCategoryRegistry.clear()
   })
 
-  it("#given a pending fallback model #when a new provider cooldown retry arrives #then the handler overrides the pending fallback and advances the chain", async () => {
+  it("#given a pending fallback model #when a new provider cooldown retry arrives #then the handler queues the next fallback for OpenCode's provider retry", async () => {
     // given
     SessionCategoryRegistry.clear()
     const sessionID = "session-status-pending-fallback"
@@ -135,16 +136,41 @@ describe("createSessionStatusHandler", () => {
     })
 
     // then
-    expect(abortCalls).toEqual([sessionID])
-    expect(retryCalls).toEqual([
-      {
-        sessionID,
-        model: "google/gemini-2.5-pro",
-        source: "session.status",
-      },
-    ])
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([])
     expect(state.currentModel).toBe("google/gemini-2.5-pro")
     expect(state.pendingFallbackModel).toBe("google/gemini-2.5-pro")
+    SessionCategoryRegistry.clear()
+  })
+
+  it("#given fallback retry is already in flight #when provider retry status arrives #then it does not abort the session", async () => {
+    // given
+    SessionCategoryRegistry.clear()
+    const sessionID = "session-status-retry-in-flight"
+    SessionCategoryRegistry.register(sessionID, "test")
+
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
+    deps.sessionRetryInFlight.add(sessionID)
+
+    const handler = createSessionStatusHandler(deps, createHelpers(abortCalls, retryCalls), deps.sessionStatusRetryKeys)
+
+    // when
+    await handler({
+      sessionID,
+      model: "anthropic/claude-opus-4-7",
+      status: {
+        type: "retry",
+        attempt: 1,
+        message: "You've hit your limit [retrying in 8s attempt #1]",
+      },
+    })
+
+    // then
+    expect(abortCalls).toEqual([])
+    expect(retryCalls).toEqual([])
+    expect(deps.sessionRetryInFlight.has(sessionID)).toBe(true)
     SessionCategoryRegistry.clear()
   })
 })

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -3,11 +3,10 @@ import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME, RETRYABLE_ERROR_PATTERNS } from "./constants"
 import { log } from "../../shared/logger"
 import { extractAutoRetrySignal } from "./error-classifier"
-import { createFallbackState } from "./fallback-state"
+import { createFallbackState, prepareFallback } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/retry-status-utils"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
-import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
 
 export function createSessionStatusHandler(
@@ -60,17 +59,8 @@ export function createSessionStatusHandler(
     sessionStatusRetryKeys.set(sessionID, retryKey)
 
     if (sessionRetryInFlight.has(sessionID)) {
-      if (timeoutEnabled) {
-        log(`[${HOOK_NAME}] Overriding in-flight retry due to provider auto-retry signal`, {
-          sessionID,
-          model,
-        })
-        await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
-        sessionRetryInFlight.delete(sessionID)
-      } else {
-        log(`[${HOOK_NAME}] session.status retry skipped - retry already in flight`, { sessionID })
-        return
-      }
+      log(`[${HOOK_NAME}] session.status retry skipped - retry already in flight`, { sessionID })
+      return
     }
 
     const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
@@ -133,14 +123,20 @@ export function createSessionStatusHandler(
       retryAttempt: status.attempt,
     })
 
-    await helpers.abortSessionRequest(sessionID, "session.status.retry-signal")
+    const result = prepareFallback(sessionID, state, fallbackModels, deps.config)
+    if (result.success && result.newModel) {
+      log(`[${HOOK_NAME}] Queued fallback for next provider retry`, {
+        sessionID,
+        model: result.newModel,
+        source: "session.status",
+      })
+      return
+    }
 
-    await dispatchFallbackRetry(deps, helpers, {
+    log(`[${HOOK_NAME}] Fallback preparation failed`, {
       sessionID,
-      state,
-      fallbackModels,
-      resolvedAgent,
       source: "session.status",
+      error: result.error,
     })
   }
 }

--- a/src/plugin/fallback.cliproxyapi-matrix.test.ts
+++ b/src/plugin/fallback.cliproxyapi-matrix.test.ts
@@ -468,7 +468,7 @@ describe("CLIProxyAPI-only fallback matrix", () => {
     expect(output.message["model"]).toEqual(FIRST_FALLBACK_MODEL)
   })
 
-  test("runtime fallback retries CLIProxyAPI session.status auto-retry signals through promptAsync", async () => {
+  test("runtime fallback queues CLIProxyAPI session.status auto-retry signals for the provider retry", async () => {
     const sessionID = "cliproxyapi-runtime-session-status"
     const harness = createHarness({ mode: "runtime" })
 
@@ -480,10 +480,9 @@ describe("CLIProxyAPI-only fallback matrix", () => {
       agent: "sisyphus",
     })
 
-    expect(harness.abortCalls).toEqual([sessionID])
+    expect(harness.abortCalls).toEqual([])
     expect(harness.promptCalls).toEqual([])
-    expect(harness.promptAsyncCalls).toHaveLength(1)
-    expect(harness.promptAsyncCalls[0]?.model).toEqual(FIRST_FALLBACK_MODEL)
+    expect(harness.promptAsyncCalls).toEqual([])
     expect(output.message["model"]).toEqual(FIRST_FALLBACK_MODEL)
   })
 
@@ -525,7 +524,7 @@ describe("CLIProxyAPI-only fallback matrix", () => {
     expect(output.message["model"]).toEqual(FIRST_FALLBACK_MODEL)
   })
 
-  test("model+runtime prefers the runtime path for CLIProxyAPI session.status retry signals", async () => {
+  test("model+runtime queues CLIProxyAPI session.status retry signals for the provider retry", async () => {
     const sessionID = "cliproxyapi-both-session-status"
     const harness = createHarness({ mode: "both" })
 
@@ -537,10 +536,9 @@ describe("CLIProxyAPI-only fallback matrix", () => {
       agent: "sisyphus",
     })
 
-    expect(harness.abortCalls).toEqual([sessionID])
+    expect(harness.abortCalls).toEqual([])
     expect(harness.promptCalls).toEqual([])
-    expect(harness.promptAsyncCalls).toHaveLength(1)
-    expect(harness.promptAsyncCalls[0]?.model).toEqual(FIRST_FALLBACK_MODEL)
+    expect(harness.promptAsyncCalls).toEqual([])
     expect(output.message["model"]).toEqual(FIRST_FALLBACK_MODEL)
   })
 

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -3307,6 +3307,23 @@ describe("sisyphus-task", () => {
        const tool = createDelegateTask({
          manager: mockManager,
          client: mockClient,
+         nativeSkills: {
+           all: () => [{
+             name: "agent-browser",
+             description: "Browser automation",
+             location: "/fake/native/agent-browser/SKILL.md",
+             content: "Use the agent browser for web automation.",
+           }],
+           get: (name: string) => name === "agent-browser"
+             ? {
+                 name: "agent-browser",
+                 description: "Browser automation",
+                 location: "/fake/native/agent-browser/SKILL.md",
+                 content: "Use the agent browser for web automation.",
+               }
+             : undefined,
+           dirs: () => ["/fake/native"],
+         },
        })
 
       const toolContext = {


### PR DESCRIPTION
Fixes #4528.

## Summary
- normalize runtime fallback model state for both string and object model payloads
- queue main-session/session.status runtime fallback for OpenCode provider retry instead of aborting command-mode sessions
- omit plugin display agents from internal fallback prompts so OpenCode does not reject them as unknown agents
- avoid aborting already idle/completed background child sessions after task completion
- treat pending background tasks as active for Atlas/Ralph continuation gates
- start/close Atlas task timers reliably for background launches and plan edits

## Verification
- `bun test src/hooks/runtime-fallback/fallback-state.test.ts src/hooks/runtime-fallback/first-prompt-watchdog.test.ts src/hooks/runtime-fallback/session-status-handler.test.ts src/hooks/runtime-fallback/auto-retry.test.ts`
- `bun test src/features/background-agent/manager.test.ts`
- `bun test src/hooks/atlas/tool-execute-after-task-timers.test.ts src/hooks/atlas/tool-execute-after-background-launch.test.ts src/hooks/atlas/idle-event.test.ts src/hooks/atlas/boulder-continuation-injector.test.ts`
- `bun test src/plugin/fallback.cliproxyapi-matrix.test.ts`
- `bun run typecheck`
- `bun run build`

Full local `bun test --bail` reached 2,294 passing tests before stopping on an environment-dependent existing skill-resolution test: `sisyphus-task > browserProvider propagation > should resolve agent-browser skill even when browserProvider is not set`, because this machine does not have the external `agent-browser` skill installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes runtime fallback by queuing fallbacks for provider auto-retries and normalizing model state, and prevents background subagent stalls by avoiding unnecessary aborts. Also makes Atlas timers and continuation gates reliable when tasks run in the background.

- **Bug Fixes**
  - Queue fallback for the next provider retry on `session.status` and first-prompt watchdog; do not abort in-flight or main sessions.
  - Normalize model identity for string/object payloads and compare models safely.
  - Omit plugin display agents from internal fallback prompts to avoid unknown-agent rejections.
  - Do not abort idle/completed background child sessions on task completion.
  - Treat pending background tasks as active for Atlas/Ralph continuation gates.
  - Start/end Atlas task timers more reliably on background launches and plan edits; more robust file path detection.
  - Stabilize CI by stubbing native `agent-browser` in `delegate-task` tests.

- **Dependencies**
  - Bump `oh-my-opencode-*` platform packages to `4.5.1` in `bun.lock`.

<sup>Written for commit db7c74eacde27cfb22f14ea52b2273e8be51569c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

