### PR TITLE
fix(runtime-fallback): mark synthetic 'continue' fallback as internal (#4085)

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry.test.ts
@@ -99,4 +99,40 @@ describe("createAutoRetryHelpers", () => {
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
     expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
   })
+
+  test("#given compact-flushed session with no recoverable user parts #when auto-retry fires the synthetic continuation #then the injected prompt is marked synthetic and carries the internal initiator marker (#4085)", async () => {
+    // given — capture the actual parts forwarded to client.session.promptAsync
+    const promptCalls = { count: 0, lastBody: undefined as unknown }
+    const deps = createDeps(promptCalls)
+    // Post-compact case: messages() returns no user role entries, so
+    // getLastUserRetryPayload falls through to the synthetic "continue".
+    deps.ctx.client.session.messages = async () => ({ data: [] })
+    deps.ctx.client.session.promptAsync = async (args: unknown) => {
+      promptCalls.count += 1
+      promptCalls.lastBody = (args as { body?: unknown })?.body
+      return {}
+    }
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-compact-flushed"
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    deps.sessionStates.set(sessionID, state)
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+
+    // then
+    expect(promptCalls.count).toBe(1)
+    const body = promptCalls.lastBody as { parts?: ReadonlyArray<Record<string, unknown>> } | undefined
+    expect(body).toBeDefined()
+    const parts = body?.parts ?? []
+    expect(parts.length).toBe(1)
+    const firstPart = parts[0] ?? {}
+    expect(firstPart["type"]).toBe("text")
+    // Without the marker + synthetic flag, OMO's continuation/keyword-detector
+    // hooks treat this as a real user prompt and the TUI shows a bare "continue"
+    // that the user never typed (see #4085 / Discord report).
+    expect(firstPart["synthetic"]).toBe(true)
+    expect(String(firstPart["text"] ?? "")).toContain("OMO_INTERNAL_INITIATOR")
+  })
 })

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -17,6 +17,7 @@ import {
   releasePromptAsyncReservation,
 } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
+import { createInternalAgentContinuationTextPart } from "../../shared/internal-initiator-marker"
 
 const SESSION_TTL_MS = 30 * 60 * 1000
 
@@ -167,7 +168,12 @@ export function createAutoRetryHelpers(deps: HookDeps) {
                   hint: "This can occur when the working directory contains .git and messages are not yet persisted",
                 },
               )
-              return [{ type: "text" as const, text: "continue" }]
+              // Mark the synthetic fallback with the OMO internal initiator
+              // marker + `synthetic: true` so the TUI and OMO's other hooks
+              // (continuation, keyword-detector, etc.) classify it as a
+              // self-issued turn instead of rendering a bare "continue" the
+              // user never typed (#4085).
+              return [createInternalAgentContinuationTextPart("continue")]
             })()
       log(`[${HOOK_NAME}] Auto-retrying with fallback model (${source})`, {
         sessionID,


### PR DESCRIPTION
## Summary

`runtime-fallback`'s auto-retry path has a fallback for the case when `getLastUserRetryPayload` cannot recover any user text parts (the typical trigger: **OpenCode compacted the session, so prior user turns are gone**). That fallback synthesises a bare `{ type: "text", text: "continue" }` and dispatches it through the prompt-async gate.

The bare part is **not classified as synthetic anywhere**:

- the TUI renders it as if the user typed `continue` — matching the Discord report quoted in #4085 (*"OMO prompt itself a 'continue' 😂"*);
- OMO's other hooks (`continuation`, `keyword-detector`, …) check `isSyntheticOrInternalUserMessage` against `synthetic: true` and the `OMO_INTERNAL_INITIATOR` marker — neither is present — so they treat the turn as a real user prompt and can cascade.

## Root cause

`auto-retry.ts` (pre-fix) returned a raw text part:

```ts
return [{ type: "text" as const, text: "continue" }]
```

while the [`fix(continuation): mark fallback resumes synthetic`](https://github.com/code-yeongyu/oh-my-openagent/commit/36f51ddb) / [`mark resumes synthetic`](https://github.com/code-yeongyu/oh-my-openagent/commit/38b1433f) / [`mark atlas resumes synthetic`](https://github.com/code-yeongyu/oh-my-openagent/commit/1189b96d) series already routed sibling spots (e.g. `src/plugin/event.ts:520, 976`) through `createInternalAgentContinuationTextPart`. The runtime-fallback auto-retry synthetic fallback was missed.

## Fix

Route that lone spot through the same helper so the synthetic continuation carries:

- `OMO_INTERNAL_INITIATOR` marker in `text`
- `synthetic: true`
- `metadata: { compaction_continue: true }`

## Reproduction shape (matches #4085 report)

1. User runs an OMO/OpenCode CLI session with `fallback_models` configured.
2. OpenCode compacts after the context grows enough — prior user turns are replaced by the summary.
3. A subsequent model call fails (quota / 429 / API error) and runtime-fallback's auto-retry kicks in.
4. `getLastUserRetryPayload` returns empty `retryParts`; `delegatedChildSessionBootstrap` also empty.
5. **Pre-fix:** the bare `"continue"` is injected, the TUI renders it as a user prompt, and the user sees a self-issued message they never typed.
6. **Post-fix:** the same prompt still routes through the gate but is now flagged synthetic, so the downstream classifiers and the TUI can handle it as an internal turn.

This matches the Discord-reported environment (team disabled, autopilot not used, default compact active) — none of those are required for the bug, only `fallback_models` + a flaky primary model + a compaction cycle.

## Test plan

- [x] **Red-green cycle verified** for the new regression test in `auto-retry.test.ts` ("#given compact-flushed session with no recoverable user parts #when auto-retry fires the synthetic continuation #then the injected prompt is marked synthetic and carries the internal initiator marker (#4085)").
- [x] `bun test src/hooks/runtime-fallback/ src/shared/internal-initiator-marker.test.ts` → **216 pass / 0 fail**.
- [x] No new typecheck regressions introduced (existing dev errors in `bun-file-shim.ts` / `process-cleanup.test-helpers.ts` are pre-existing and unrelated).

Closes #4085.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the synthetic "continue" sent by `runtime-fallback` auto-retry as internal so it no longer appears as a user message or triggers user-facing hooks. Fixes the TUI showing a self-issued "continue" after compaction (fixes #4085).

- **Bug Fixes**
  - Route the fallback through `createInternalAgentContinuationTextPart`, adding `synthetic: true`, `OMO_INTERNAL_INITIATOR`, and `metadata.compaction_continue: true`.
  - Add a regression test that asserts the marker and `synthetic` flag are present in the prompt body.
  - Prevents cascades in `continuation`/`keyword-detector` and stops the TUI from rendering a user-typed "continue".

<sup>Written for commit 640012abd9d383fc905493f24afafe781b88c4f8. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4534?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

