### PR TITLE
fix(auto-update-checker): skip update install when running from OpenCode-managed sandbox (#4318)

### DIFF
--- a/src/hooks/auto-update-checker/hook/background-update-check.test.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { createBackgroundUpdateCheckRunner } from "./background-update-check"
+
+function createCtx(): PluginInput {
+  return { directory: "/project" } as unknown as PluginInput
+}
+
+function joinPosix(...segments: string[]): string {
+  return segments.join("/").replace(/\/+/g, "/")
+}
+
+describe("createBackgroundUpdateCheckRunner — OpenCode-managed sandbox (#4318)", () => {
+  test("#given import.meta.url resolves outside the flat cache workspace and config-dir #when auto-update fires with autoUpdate=true #then bun install is skipped and only the update-available toast is shown (not 'Updated!')", async () => {
+    // given — paths model the reported scenario:
+    //   cacheDir = <CACHE_ROOT>/packages
+    //   configDir = <config>
+    //   sandboxDir = <CACHE_ROOT>/packages/<sanitized-spec>  (where OpenCode's
+    //                Npm.add() installs the plugin)
+    const cacheDir = "/cache/packages"
+    const configDir = "/config"
+    const sandboxDir = "/cache/packages/oh-my-openagent@^4.2"
+
+    const findPluginEntry = mock(() => ({
+      entry: "oh-my-openagent@^4.2",
+      pinnedVersion: "^4.2",
+      isPinned: false,
+      configPath: "/project/opencode.json",
+    }))
+    const getCachedVersion = mock(() => "4.1.2")
+    const getLatestVersion = mock(async () => "4.3.1")
+    const extractChannel = mock(() => "stable")
+    const syncCachePackageJsonToIntent = mock(() => ({ synced: true, error: null as null | "parse_error" | "write_error" }))
+    const invalidatePackage = mock(() => true)
+    const runBunInstallWithDetails = mock(async () => ({ success: true }))
+    const getOpenCodeCacheDir = mock(() => "/cache")
+    const getOpenCodeConfigPaths = mock(() => ({ configDir }))
+    const existsSync = mock(() => false)
+    const showUpdateAvailableToast = mock(async () => {})
+    const showAutoUpdatedToast = mock(async () => {})
+    const logCalls: unknown[][] = []
+    const log = mock((...args: unknown[]) => { logCalls.push(args) })
+
+    // KEY: import.meta.url resolves to a workspace that is neither the flat
+    // cacheDir nor configDir — i.e. an OpenCode-managed sandbox. The current
+    // code path silently runs `bun install` against the flat cacheDir, so
+    // OpenCode (which loads from sandboxDir) never sees the new version and
+    // we end up shipping a misleading "Updated!" toast.
+    const getModuleHostingWorkspace = mock(() => sandboxDir)
+
+    const runner = createBackgroundUpdateCheckRunner({
+      existsSync,
+      // The deps shape uses node's `join`; positional posix is enough for the
+      // mocks below and lets us avoid pulling in node:path in this test.
+      join: joinPosix as unknown as typeof import("node:path").join,
+      runBunInstallWithDetails: runBunInstallWithDetails as unknown as typeof import("../../../cli/config-manager").runBunInstallWithDetails,
+      log: log as unknown as typeof import("../../../shared/logger").log,
+      getOpenCodeCacheDir,
+      getOpenCodeConfigPaths,
+      invalidatePackage,
+      extractChannel,
+      findPluginEntry,
+      getCachedVersion,
+      getLatestVersion,
+      syncCachePackageJsonToIntent: syncCachePackageJsonToIntent as unknown as typeof import("../checker").syncCachePackageJsonToIntent,
+      showUpdateAvailableToast,
+      showAutoUpdatedToast,
+      getModuleHostingWorkspace,
+    } as Parameters<typeof createBackgroundUpdateCheckRunner>[0])
+
+    // when
+    await runner(createCtx(), /* autoUpdate */ true, (_isUpdate, latest) => `OhMyOpenCode Updated! v${latest}`)
+
+    // then — install must NOT have run (we cannot reliably update a sandbox
+    // OpenCode owns), and the user must see the truthful "update available"
+    // toast rather than the misleading "Updated!" toast.
+    expect(runBunInstallWithDetails).not.toHaveBeenCalled()
+    expect(showAutoUpdatedToast).not.toHaveBeenCalled()
+    expect(showUpdateAvailableToast).toHaveBeenCalledTimes(1)
+  })
+
+  test("#given import.meta.url resolves inside the flat cache workspace #when auto-update fires with autoUpdate=true #then existing install flow runs unchanged", async () => {
+    // given
+    const cacheDir = "/cache/packages"
+    const configDir = "/config"
+
+    const findPluginEntry = mock(() => ({
+      entry: "oh-my-openagent",
+      pinnedVersion: null,
+      isPinned: false,
+      configPath: "/project/opencode.json",
+    }))
+    const getCachedVersion = mock(() => "4.1.2")
+    const getLatestVersion = mock(async () => "4.3.1")
+    const extractChannel = mock(() => "stable")
+    const syncCachePackageJsonToIntent = mock(() => ({ synced: true, error: null as null | "parse_error" | "write_error" }))
+    const invalidatePackage = mock(() => true)
+    const runBunInstallWithDetails = mock(async () => ({ success: true }))
+    const getOpenCodeCacheDir = mock(() => "/cache")
+    const getOpenCodeConfigPaths = mock(() => ({ configDir }))
+    const existsSync = mock(() => false)
+    const showUpdateAvailableToast = mock(async () => {})
+    const showAutoUpdatedToast = mock(async () => {})
+    const log = mock(() => {})
+    // Sandbox detection returns the flat cacheDir itself → not a sandbox.
+    const getModuleHostingWorkspace = mock(() => cacheDir)
+
+    const runner = createBackgroundUpdateCheckRunner({
+      existsSync,
+      join: joinPosix as unknown as typeof import("node:path").join,
+      runBunInstallWithDetails: runBunInstallWithDetails as unknown as typeof import("../../../cli/config-manager").runBunInstallWithDetails,
+      log: log as unknown as typeof import("../../../shared/logger").log,
+      getOpenCodeCacheDir,
+      getOpenCodeConfigPaths,
+      invalidatePackage,
+      extractChannel,
+      findPluginEntry,
+      getCachedVersion,
+      getLatestVersion,
+      syncCachePackageJsonToIntent: syncCachePackageJsonToIntent as unknown as typeof import("../checker").syncCachePackageJsonToIntent,
+      showUpdateAvailableToast,
+      showAutoUpdatedToast,
+      getModuleHostingWorkspace,
+    } as Parameters<typeof createBackgroundUpdateCheckRunner>[0])
+
+    // when
+    await runner(createCtx(), /* autoUpdate */ true, (_isUpdate, latest) => `OhMyOpenCode Updated! v${latest}`)
+
+    // then — non-sandbox path keeps the legacy install flow.
+    expect(runBunInstallWithDetails).toHaveBeenCalled()
+    expect(showAutoUpdatedToast).toHaveBeenCalledTimes(1)
+    expect(showUpdateAvailableToast).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/auto-update-checker/hook/background-update-check.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { existsSync } from "node:fs"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { runBunInstallWithDetails } from "../../../cli/config-manager"
 import { log } from "../../../shared/logger"
 import { getOpenCodeCacheDir, getOpenCodeConfigPaths } from "../../../shared"
@@ -8,7 +9,33 @@ import { invalidatePackage } from "../cache"
 import { PACKAGE_NAME } from "../constants"
 import { extractChannel } from "../version-channel"
 import { findPluginEntry, getCachedVersion, getLatestVersion, syncCachePackageJsonToIntent } from "../checker"
+import { findPackageJsonUp } from "../checker/package-json-locator"
 import { showAutoUpdatedToast, showUpdateAvailableToast } from "./update-toasts"
+
+/**
+ * Walk up from this module's location to the host workspace that owns the
+ * installed `node_modules/<pkg>` entry. Returns `null` when the module is not
+ * running from an `npm install`-style layout (e.g. local source-tree dev).
+ *
+ * When OpenCode loads the plugin via `Npm.add()`, this resolves to the
+ * per-spec sandbox (`<CACHE_ROOT>/packages/<sanitized-spec>/`), which is the
+ * directory OpenCode actually reads on next restart. The flat
+ * `<CACHE_ROOT>/packages/` path that the legacy update flow writes to never
+ * intersects that sandbox — see #4318.
+ */
+function defaultGetModuleHostingWorkspace(): string | null {
+  try {
+    const currentDir = dirname(fileURLToPath(import.meta.url))
+    const pkgJsonPath = findPackageJsonUp(currentDir)
+    if (!pkgJsonPath) return null
+    const pkgDir = dirname(pkgJsonPath)
+    const nodeModulesDir = dirname(pkgDir)
+    if (nodeModulesDir.split(/[\\/]/).pop() !== "node_modules") return null
+    return dirname(nodeModulesDir)
+  } catch {
+    return null
+  }
+}
 
 type BackgroundUpdateCheckDeps = {
   existsSync: typeof existsSync
@@ -25,6 +52,12 @@ type BackgroundUpdateCheckDeps = {
   syncCachePackageJsonToIntent: typeof syncCachePackageJsonToIntent
   showUpdateAvailableToast: typeof showUpdateAvailableToast
   showAutoUpdatedToast: typeof showAutoUpdatedToast
+  /**
+   * Returns the workspace directory hosting the currently loaded plugin
+   * module, or `null` if the plugin is not running from a standard install
+   * layout. Used to detect OpenCode-managed sandboxes (see #4318).
+   */
+  getModuleHostingWorkspace: () => string | null
 }
 
 type BackgroundUpdateCheckRunner = (
@@ -52,10 +85,30 @@ const defaultDeps: BackgroundUpdateCheckDeps = {
   syncCachePackageJsonToIntent,
   showUpdateAvailableToast,
   showAutoUpdatedToast,
+  getModuleHostingWorkspace: defaultGetModuleHostingWorkspace,
 }
 
 function getPinnedVersionToastMessage(latestVersion: string): string {
   return `Update available: ${latestVersion} (version pinned, update manually)`
+}
+
+/**
+ * The plugin runs from an OpenCode-managed sandbox (`Npm.add()`-installed
+ * `<CACHE_ROOT>/packages/<sanitized-spec>/`) whenever the module-hosting
+ * workspace is **outside** both the flat cache workspace and the host
+ * `configDir`. In that mode, OMO cannot reliably rewrite the install — even
+ * if `bun install` succeeds against the flat cache path, OpenCode reads from
+ * the sandbox on next restart and the version never switches (#4318).
+ */
+function isOpenCodeManagedSandbox(
+  moduleWorkspace: string | null,
+  cacheWorkspace: string,
+  configDir: string,
+): boolean {
+  if (!moduleWorkspace) return false
+  if (moduleWorkspace === cacheWorkspace) return false
+  if (moduleWorkspace === configDir) return false
+  return true
 }
 
 /**
@@ -164,6 +217,27 @@ export function createBackgroundUpdateCheckRunner(
     if (pluginInfo.isPinned) {
       await deps.showUpdateAvailableToast(ctx, latestVersion, () => getPinnedVersionToastMessage(latestVersion))
       deps.log(`[auto-update-checker] User-pinned version detected (${pluginInfo.entry}), skipping auto-update. Notification only.`)
+      return
+    }
+
+    // #4318: Detect OpenCode-managed sandbox installs and skip the legacy
+    // install flow. OpenCode's `Npm.add()` reads the plugin from a per-spec
+    // sandbox (`<CACHE_ROOT>/packages/<sanitized-spec>/node_modules/<pkg>/`),
+    // not from the flat `<CACHE_ROOT>/packages/node_modules/<pkg>/` path the
+    // legacy flow writes to. Running `bun install` against the flat path
+    // succeeds but is never read on the next OpenCode start, so the user
+    // sees an "Updated!" toast while the runtime keeps loading the old
+    // version in an infinite restart loop.
+    //
+    // For sandbox installs we instead emit the truthful "update available"
+    // toast and rely on OpenCode's own plugin reinstall path to apply the
+    // new version.
+    const moduleWorkspace = deps.getModuleHostingWorkspace()
+    if (isOpenCodeManagedSandbox(moduleWorkspace, getCacheWorkspaceDir(deps), deps.getOpenCodeConfigPaths({ binary: "opencode" }).configDir)) {
+      await deps.showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+      deps.log(
+        `[auto-update-checker] OpenCode-managed sandbox detected (${moduleWorkspace}); skipping auto-update install. Notification only. See #4318.`,
+      )
       return
     }
 


### PR DESCRIPTION
## Summary

When OpenCode loads the plugin via `Npm.add()`, the install lives in a per-spec sandbox at `<CACHE_ROOT>/packages/<sanitized-spec>/node_modules/oh-my-openagent/`. The legacy auto-update flow writes to a flat workspace at `<CACHE_ROOT>/packages/` and runs `bun install` there. **Those two paths differ by one `<sanitized-spec>` directory level and never intersect** (root cause confirmed in the reporter's detailed analysis and `@YOMXXX`'s earlier reviewer note).

The visible consequence (matches the #4318 report):

- `getCachedVersion()` correctly reports the version OpenCode actually runs (via `import.meta.url` → `<sandbox>` → old version)
- the registry check finds a newer version
- `syncCachePackageJsonToIntent()` + `invalidatePackage()` + `bun install` silently succeed against the flat path
- we ship an `OhMyOpenCode Updated! v4.1.2 → v4.3.1` toast, but OpenCode's next start still reads the sandbox, sees the old version, and the cycle repeats every restart

So the bug is **a lying toast**, not just an inert one.

## Architectural framing

`@YOMXXX`'s [earlier reviewer note](https://github.com/code-yeongyu/oh-my-openagent/issues/4318#issuecomment-4529280074) flagged a workspace-selection ordering bug (invalidate-then-resolve falls back to the flat cache workspace when the sandbox already got cleaned). That's a real surface, but the deeper mismatch is **OMO doesn't own the install workspace under `Npm.add()` — OpenCode does**. Fixing the ordering only would still leave us mutating a path OpenCode never reads.

## What this PR does

Adds a sandbox detector `defaultGetModuleHostingWorkspace()` that walks up from the loaded module to the workspace dir owning its `node_modules/<pkg>` entry. When that workspace is **outside** both the flat cache workspace and the host `configDir`, we treat the install as OpenCode-managed and short-circuit the legacy install flow:

- show the truthful **"update available"** toast instead of the misleading **"Updated!"** toast
- skip `syncCachePackageJsonToIntent`, `invalidatePackage`, `bun install`, and `primeCacheWorkspace`
- let OpenCode's own plugin-reinstall pipeline pick up the new version on its next reinstall

Non-sandbox layouts — local source-tree dev, classical config-dir installs, classical flat-cache-dir installs — keep the legacy install flow unchanged. The detector is dependency-injected so tests can mock the workspace directly without touching `import.meta.url`.

## Test plan

A new regression test in `background-update-check.test.ts` covers both branches:

- **sandbox case** (`import.meta.url` resolves to `<CACHE_ROOT>/packages/<spec>` — outside both cache flat dir and config dir): `runBunInstallWithDetails` is **not** called, `showAutoUpdatedToast` is **not** called, only `showUpdateAvailableToast` fires
- **non-sandbox case** (module hosting workspace **is** the flat cache workspace): legacy `runBunInstallWithDetails` and `showAutoUpdatedToast` keep firing

- [x] Red-green cycle verified: revert fix → test 1 fails on `runBunInstallWithDetails.not.toHaveBeenCalled()` with `Received: 2 calls`; restore fix → both tests pass.
- [x] `bun test src/hooks/auto-update-checker/` → **64 pass / 0 fail**.

## Limitations / follow-up

This does **not** auto-apply the update in sandbox mode; the user still needs OpenCode's own reinstall path (or a manual cache clear + restart) to pick up the new version. That's the honest tradeoff — previously the flow lied about success.

A proper sandbox-aware install (write `<sandbox>/package.json`, run `bun update` there with lockfile re-resolution, preserve the sandbox across `invalidatePackage`) is the natural next iteration once we settle on the contract with OpenCode-side `Npm.add()` semantics. Filing as follow-up would be cleanest; happy to take that on after this PR lands.

Closes #4318.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip auto-update installs when `oh-my-openagent` runs from an OpenCode-managed sandbox to stop the false “Updated!” toast loop (fixes #4318). Non-sandbox installs keep the existing flow; we detect the sandbox from the module path and show an “update available” toast instead.

- **Bug Fixes**
  - Detect the module-hosting workspace via `defaultGetModuleHostingWorkspace()` by walking up from `import.meta.url`.
  - If the workspace is outside the flat cache and `configDir`, treat it as OpenCode-managed and skip `syncCachePackageJsonToIntent`, `invalidatePackage`, and `runBunInstallWithDetails`; emit `showUpdateAvailableToast` instead of `showAutoUpdatedToast`.
  - Keep the legacy flow for config-dir and flat-cache installs; make the detector injectable as `getModuleHostingWorkspace` and add regression tests for both paths.

<sup>Written for commit c6e622920191f976f4e58a98d0f2a8a362e4c17c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4535?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

