### PR TITLE
fix(postinstall): warn when platform binary version differs from main package (fixes #3918)

### DIFF
--- a/bin/version-mismatch.js
+++ b/bin/version-mismatch.js
@@ -25,7 +25,7 @@ function normalizeVersion(version) {
  *
  * Comparison is exact on the full semver string (after stripping a leading "v"),
  * including any pre-release suffix. This means `4.5.1-beta.1` and `4.5.1` are
- * treated as DIFFERENT versions — matching the publish workflow that ships
+ * treated as DIFFERENT versions, matching the publish workflow that ships
  * prerelease builds to the `next` dist-tag alongside stable releases.
  *
  * @param {object} input

--- a/bin/version-mismatch.js
+++ b/bin/version-mismatch.js
@@ -4,11 +4,17 @@
 // alongside `oh-my-opencode@4.0.0`, leaving the startup banner pinned to 3.9.0.
 
 /**
+ * Strips an optional leading "v" so callers can pass either "4.5.1" or "v4.5.1".
+ * Pre-release suffixes (e.g. "-beta.1") are preserved because the release
+ * workflow publishes prereleases as standalone versions on the `next` dist-tag,
+ * and `oh-my-opencode@4.5.1-beta.1` paired with `oh-my-opencode-x64@4.5.1`
+ * IS a real mismatch the wrapper would silently honour.
+ *
  * @param {string} version
- * @returns {string} Version core (strips leading "v" and pre-release suffix).
+ * @returns {string} Full version with leading "v" stripped.
  */
 function normalizeVersion(version) {
-  return version.replace(/^v/, "").split("-")[0];
+  return version.replace(/^v/, "");
 }
 
 /**
@@ -16,6 +22,11 @@ function normalizeVersion(version) {
  *
  * Both versions must be known to report a mismatch; if either is null/undefined,
  * the check is skipped (returns null) rather than producing a false alarm.
+ *
+ * Comparison is exact on the full semver string (after stripping a leading "v"),
+ * including any pre-release suffix. This means `4.5.1-beta.1` and `4.5.1` are
+ * treated as DIFFERENT versions — matching the publish workflow that ships
+ * prerelease builds to the `next` dist-tag alongside stable releases.
  *
  * @param {object} input
  * @param {string | null | undefined} input.mainVersion

--- a/bin/version-mismatch.js
+++ b/bin/version-mismatch.js
@@ -1,0 +1,36 @@
+// bin/version-mismatch.js
+// Detects platform binary version mismatch against the main package.
+// Background: issue #3918 - `oh-my-opencode-windows-x64@3.9.0` could stay installed
+// alongside `oh-my-opencode@4.0.0`, leaving the startup banner pinned to 3.9.0.
+
+/**
+ * @param {string} version
+ * @returns {string} Version core (strips leading "v" and pre-release suffix).
+ */
+function normalizeVersion(version) {
+  return version.replace(/^v/, "").split("-")[0];
+}
+
+/**
+ * Detect a main / platform-binary version mismatch.
+ *
+ * Both versions must be known to report a mismatch; if either is null/undefined,
+ * the check is skipped (returns null) rather than producing a false alarm.
+ *
+ * @param {object} input
+ * @param {string | null | undefined} input.mainVersion
+ * @param {string | null | undefined} input.platformVersion
+ * @param {string} input.platformPackage
+ * @returns {{ mainVersion: string, platformVersion: string, platformPackage: string } | null}
+ */
+export function detectPlatformBinaryMismatch({ mainVersion, platformVersion, platformPackage }) {
+  if (!mainVersion || !platformVersion) {
+    return null;
+  }
+
+  if (normalizeVersion(mainVersion) === normalizeVersion(platformVersion)) {
+    return null;
+  }
+
+  return { mainVersion, platformVersion, platformPackage };
+}

--- a/bin/version-mismatch.test.ts
+++ b/bin/version-mismatch.test.ts
@@ -1,0 +1,76 @@
+// bin/version-mismatch.test.ts
+import { describe, expect, test } from "bun:test";
+import { detectPlatformBinaryMismatch } from "./version-mismatch.js";
+
+describe("detectPlatformBinaryMismatch", () => {
+  test("returns null when main and platform versions match", () => {
+    // #given identical main and platform binary versions
+    const input = { mainVersion: "4.5.1", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then no mismatch is reported
+    expect(result).toBeNull();
+  });
+
+  test("reports mismatch when platform version is older than main", () => {
+    // #given main package newer than installed platform binary (issue #3918 case)
+    const input = { mainVersion: "4.5.1", platformVersion: "3.9.0", platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then mismatch object is returned with both versions
+    expect(result).toEqual({
+      mainVersion: "4.5.1",
+      platformVersion: "3.9.0",
+      platformPackage: "oh-my-opencode-windows-x64",
+    });
+  });
+
+  test("reports mismatch when platform version is newer than main", () => {
+    // #given platform binary newer than main wrapper
+    const input = { mainVersion: "4.0.0", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-linux-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then mismatch is still reported (any difference is a mismatch)
+    expect(result).not.toBeNull();
+    expect(result?.platformVersion).toBe("4.5.1");
+  });
+
+  test("returns null when main version is unknown", () => {
+    // #given main version could not be read
+    const input = { mainVersion: null, platformVersion: "4.5.1", platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then no mismatch is reported - cannot compare without main version
+    expect(result).toBeNull();
+  });
+
+  test("returns null when platform version is unknown", () => {
+    // #given platform package.json could not be read
+    const input = { mainVersion: "4.5.1", platformVersion: null, platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then no mismatch is reported - silently skip rather than alarm
+    expect(result).toBeNull();
+  });
+
+  test("ignores pre-release suffixes when comparing equal versions", () => {
+    // #given identical core versions differing only by build metadata suffix
+    const input = { mainVersion: "4.5.1-beta.1", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-darwin-arm64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then versions are treated as equivalent
+    expect(result).toBeNull();
+  });
+});

--- a/bin/version-mismatch.test.ts
+++ b/bin/version-mismatch.test.ts
@@ -63,14 +63,58 @@ describe("detectPlatformBinaryMismatch", () => {
     expect(result).toBeNull();
   });
 
-  test("ignores pre-release suffixes when comparing equal versions", () => {
-    // #given identical core versions differing only by build metadata suffix
+  test("reports mismatch when main is a prerelease and platform is the matching stable", () => {
+    // #given prerelease main against stable platform binary - the publish workflow
+    // ships prereleases under the `next` dist-tag, so this combo is a real
+    // mismatch the wrapper would silently honour
     const input = { mainVersion: "4.5.1-beta.1", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-darwin-arm64" };
 
     // #when detecting mismatch
     const result = detectPlatformBinaryMismatch(input);
 
-    // #then versions are treated as equivalent
+    // #then mismatch is reported with the full prerelease string preserved
+    expect(result).toEqual({
+      mainVersion: "4.5.1-beta.1",
+      platformVersion: "4.5.1",
+      platformPackage: "oh-my-opencode-darwin-arm64",
+    });
+  });
+
+  test("reports mismatch between two different prerelease iterations", () => {
+    // #given two different prerelease iterations - publish.yml allows multiple
+    // beta builds on the `next` dist-tag, so beta.1 vs beta.2 IS a mismatch
+    const input = { mainVersion: "4.5.1-beta.2", platformVersion: "4.5.1-beta.1", platformPackage: "oh-my-opencode-linux-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then mismatch is reported with both prerelease tags preserved
+    expect(result).toEqual({
+      mainVersion: "4.5.1-beta.2",
+      platformVersion: "4.5.1-beta.1",
+      platformPackage: "oh-my-opencode-linux-x64",
+    });
+  });
+
+  test("returns null when both versions are the exact same prerelease", () => {
+    // #given matched prereleases on both sides
+    const input = { mainVersion: "4.5.1-beta.1", platformVersion: "4.5.1-beta.1", platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then no mismatch is reported
+    expect(result).toBeNull();
+  });
+
+  test("normalizes leading 'v' so 'v4.5.1' matches '4.5.1'", () => {
+    // #given the same version with and without a leading "v"
+    const input = { mainVersion: "v4.5.1", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-windows-x64" };
+
+    // #when detecting mismatch
+    const result = detectPlatformBinaryMismatch(input);
+
+    // #then leading "v" is treated as cosmetic, no mismatch reported
     expect(result).toBeNull();
   });
 });

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -8,6 +8,7 @@ import {
   getBinaryPath,
   resolvePlatformPackageBaseName,
 } from "./bin/platform.js";
+import { detectPlatformBinaryMismatch } from "./bin/version-mismatch.js";
 
 const require = createRequire(import.meta.url);
 
@@ -81,12 +82,31 @@ function getLibcFamily() {
   }
 }
 
-function getPackageBaseName() {
+function readMainPackageJson() {
   try {
-    const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
-    return resolvePlatformPackageBaseName(packageJson.name || "oh-my-opencode");
+    return JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
   } catch {
-    return "oh-my-opencode";
+    return null;
+  }
+}
+
+function getPackageBaseName() {
+  const packageJson = readMainPackageJson();
+  return resolvePlatformPackageBaseName(packageJson?.name || "oh-my-opencode");
+}
+
+function getMainPackageVersion() {
+  const packageJson = readMainPackageJson();
+  return packageJson?.version ?? null;
+}
+
+function readPlatformPackageVersion(pkg) {
+  try {
+    const platformPackageJsonPath = require.resolve(`${pkg}/package.json`);
+    const packageJson = JSON.parse(readFileSync(platformPackageJsonPath, "utf8"));
+    return packageJson.version ?? null;
+  } catch {
+    return null;
   }
 }
 
@@ -124,6 +144,19 @@ function main() {
       throw new Error(
         `No platform binary package installed. Tried: ${packageCandidates.join(", ")}`
       );
+    }
+
+    const mismatch = detectPlatformBinaryMismatch({
+      mainVersion: getMainPackageVersion(),
+      platformVersion: readPlatformPackageVersion(resolvedPackage),
+      platformPackage: resolvedPackage,
+    });
+    if (mismatch) {
+      console.warn(`⚠ oh-my-opencode platform binary version mismatch detected`);
+      console.warn(`  ${packageBaseName}: ${mismatch.mainVersion}`);
+      console.warn(`  ${mismatch.platformPackage}: ${mismatch.platformVersion}`);
+      console.warn(`  The startup banner may show the stale version until the platform binary is updated.`);
+      console.warn(`  Fix: npm install -g ${packageBaseName}@${mismatch.mainVersion} ${mismatch.platformPackage}@${mismatch.mainVersion}`);
     }
 
     console.log(`✓ oh-my-opencode binary installed for ${platform}-${arch} (${resolvedPackage})`);


### PR DESCRIPTION
## Summary

`oh-my-opencode-windows-x64@3.x` (and the other platform packages) can stay globally installed when the main `oh-my-opencode` package is upgraded. The wrapper picks up the stale binary, so the OpenCode startup banner pins to the old version even after the main package was upgraded — exactly the symptom reported in #3918.

The fix adds an install-time warning when the platform binary's `package.json` version differs from the main package version, with a clear command to fix it. No behavioral change in the wrapper, no change to binary resolution order.

## Root Cause

`postinstall.mjs` already verifies that the platform binary **exists**, but it never compares the platform package's `package.json` version against the main package version. The sisyphus-bot triage on #3918 called this out explicitly:

> `postinstall.mjs` verifies that a candidate platform binary exists/resolves, but it does not fail or warn on main-package/platform-package version mismatch.

## Changes

| File | Change |
|------|--------|
| `bin/version-mismatch.js` | New pure helper `detectPlatformBinaryMismatch({ mainVersion, platformVersion, platformPackage })` — returns the diverging versions when they don't match, null when either side is unknown. |
| `bin/version-mismatch.test.ts` | 9 unit tests covering match / mismatch (older + newer) / unknown-on-either-side / prerelease-vs-stable / two-different-prereleases / same-prerelease / leading-`v` normalization. |
| `postinstall.mjs` | Reads main + platform `package.json` versions and prints a warning + fix command when they diverge. No-op when versions are equal or either is unreadable. |

The helper deliberately treats an unknown version on either side as "no mismatch" — the existing postinstall path already prints `⚠ oh-my-opencode: ...` if the binary itself is missing, so this fix focuses purely on the *version divergence* case from the issue body.

## Codex P2 follow-up (commit `d618ba1f`)

Codex review on the initial commit flagged that the helper stripped prerelease suffixes (`4.5.1-beta.1` → `4.5.1`) before comparing, which would silently pass mismatch detection when the main package is on a prerelease but the platform binary is on the matching stable build. Since `publish.yml` accepts prerelease versions (line 17 `version` input, line 185-186 regex, line 192-193 `next` dist_tag path) and the release workflow ships prereleases as standalone npm packages, that combination is a real install state the wrapper would silently honour.

The follow-up commit drops the suffix-strip from `normalizeVersion()` and compares the full semver string (after the cosmetic leading `v` is stripped). `4.5.1-beta.1` and `4.5.1` are now correctly reported as a mismatch, while `4.5.1-beta.1` ↔ `4.5.1-beta.1` and `v4.5.1` ↔ `4.5.1` continue to match. 3 new regression tests pin the new behavior.

## Reproduction (before fix)

Recreated the #3918 condition by overriding the installed platform package's `package.json` to v3.9.0 while the main package is on v4.5.1:

```
$ node postinstall.mjs
⚠ oh-my-opencode requires OpenCode >= 1.4.0
  Detected: 1.2.22
  Please update OpenCode to avoid compatibility issues.
✓ oh-my-opencode binary installed for win32-x64 (oh-my-opencode-windows-x64)
```

→ Version divergence is **silent**. The user has no signal that the next OpenCode startup will report `3.9.0` in the banner.

## Verification (after fix)

Same simulated mismatch (4.5.1 main vs 3.9.0 platform):

```
$ node postinstall.mjs
⚠ oh-my-opencode requires OpenCode >= 1.4.0
  Detected: 1.2.22
  Please update OpenCode to avoid compatibility issues.
⚠ oh-my-opencode platform binary version mismatch detected
  oh-my-opencode: 4.5.1
  oh-my-opencode-windows-x64: 3.9.0
  The startup banner may show the stale version until the platform binary is updated.
  Fix: npm install -g oh-my-opencode@4.5.1 oh-my-opencode-windows-x64@4.5.1
✓ oh-my-opencode binary installed for win32-x64 (oh-my-opencode-windows-x64)
```

Prerelease-vs-stable now also detected (post-Codex fix):

```
$ bun -e 'import("./bin/version-mismatch.js").then(m => console.log(m.detectPlatformBinaryMismatch({mainVersion: "4.5.1-beta.1", platformVersion: "4.5.1", platformPackage: "oh-my-opencode-linux-x64"})))'
{ mainVersion: '4.5.1-beta.1', platformVersion: '4.5.1', platformPackage: 'oh-my-opencode-linux-x64' }
```

With versions back in sync (both 4.5.1) the warning stays silent — no false alarm.

## Test

- Regression / new tests: `bin/version-mismatch.test.ts` (9 cases — match, mismatch-older, mismatch-newer, unknown-main, unknown-platform, prerelease-vs-stable mismatch, two-different-prereleases mismatch, same-prerelease match, `v`-prefix normalization)
- Related suite: `bun test bin/` → **26 pass, 0 fail** (9 new + 17 existing `platform.test.ts`)
- Typecheck: `bun run typecheck` → clean

## Design notes / scope guardrails

- **Install-time warning only.** No runtime/wrapper change, no change to binary-resolution order, no new behavior, no new dependencies. This deliberately leaves the wrapper hot path untouched.
- **Renamed package family safe.** Reads the actual platform-package name returned by the existing resolver, so the `oh-my-opencode` → `oh-my-openagent` rename and the baseline variants are all covered by the same code path.
- **Prerelease-aware.** `publish.yml` ships prereleases to `next` dist_tag, so prerelease-vs-stable IS a real mismatch (post-Codex fix).
- **Silent when either side is unreadable.** Better to skip than to false-alarm; the existing postinstall already handles the "binary missing" case separately.

Fixes #3918
