### PR TITLE
fix(model-core): exclude k2p* model IDs from generic kimi heuristic (fixes #4418)

### DIFF
--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -60,9 +60,9 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   },
   {
     family: "kimi",
-    // Match "kimi" anywhere, or "k2" NOT followed by "p" + digit (excludes k2p6/k2p5
-    // from kimi-for-coding which DO support thinking per #4418).
-    pattern: /(?:kimi|k2(?!p\d))/,
+    // Match "kimi" anywhere, or "k2" NOT followed by optional separator + "p" + digit.
+    // Excludes k2p6, k2-p6, k2.p6 from kimi-for-coding which support thinking (#4418).
+    pattern: /(?:kimi|k2(?![-.]?p\d))/,
     variants: ["low", "medium", "high"],
     supportsThinking: false,
   },

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -60,7 +60,9 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   },
   {
     family: "kimi",
-    includes: ["kimi", "k2"],
+    // Match "kimi" anywhere, or "k2" NOT followed by "p" + digit (excludes k2p6/k2p5
+    // from kimi-for-coding which DO support thinking per #4418).
+    pattern: /(?:kimi|k2(?!p\d))/,
     variants: ["low", "medium", "high"],
     supportsThinking: false,
   },

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -573,6 +573,26 @@ describe("resolveCompatibleModelSettings", () => {
     expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")
   })
 
+  test("preserves thinking for kimi-for-coding/k2p6 not matched by generic kimi heuristic", () => {
+    // given
+    const capabilities = getModelCapabilities({
+      providerID: "kimi-for-coding",
+      modelID: "k2p6",
+    })
+
+    // when
+    const result = resolveCompatibleModelSettings({
+      providerID: "kimi-for-coding",
+      modelID: "k2p6",
+      desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
+      capabilities,
+    })
+
+    // then — thinking must NOT be dropped for kimi-for-coding provider (fixes #4418)
+    expect(result.thinking).toEqual({ type: "enabled", budgetTokens: 4096 })
+    expect(result.changes).toEqual([])
+  })
+
   test("clamps maxTokens to the model output limit", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -588,7 +588,7 @@ describe("resolveCompatibleModelSettings", () => {
       capabilities,
     })
 
-    // then — thinking must NOT be dropped for kimi-for-coding provider (fixes #4418)
+    // then: thinking must NOT be dropped for kimi-for-coding provider (fixes #4418)
     expect(result.thinking).toEqual({ type: "enabled", budgetTokens: 4096 })
     expect(result.changes).toEqual([])
   })


### PR DESCRIPTION
## Problem

The generic kimi heuristic family at `model-capability-heuristics.ts` has `includes: ["kimi", "k2"]` with `supportsThinking: false`. The `"k2"` substring match catches `k2p6` and `k2p5` model IDs from the `kimi-for-coding` provider, even though those models **do** support thinking.

This causes `getModelCapabilities()` → `supportsThinking: false` → `resolveCompatibleModelSettings()` strips `output.options.thinking` → the model never receives the thinking parameter at all.

## Root cause

PR #3666 added `"k2"` to the generic kimi heuristic to catch volcengine K2 models, but it also catches `k2p*` models from `kimi-for-coding` which support thinking.

## Fix

Replace `includes: ["kimi", "k2"]` with `pattern: /(?:kimi|k2(?![-.]?p\d))/`:
- Matches `"kimi"` anywhere (covers `kimi-k2.6`, etc.)
- Matches `"k2"` NOT followed by optional separator + `p` + digit (covers `k2-v2`, `k2.6`, `k2-6`; excludes `k2p6`, `k2-p6`, `k2.p6`, `k2p5`)

`k2p*` model IDs now fall through to runtime/snapshot-based capability detection instead of being blocked by heuristic.

## Changes

- **`model-capability-heuristics.ts`**: Change kimi family from `includes` to `pattern` with negative lookahead for `k2p*`
- **`model-settings-compatibility.test.ts`**: Add regression test for `kimi-for-coding/k2p6` preserving thinking

## Testing

```
bun test packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-capabilities.test.ts
```
80 tests pass (0 failures), including the new `kimi-for-coding/k2p6` regression test.

## Related

- Closes #4418
- Closes #3945 (same root cause — macOS thinking missing with OMO)
- Related to #3666 (the original volcengine fix that introduced this regression)