### PR TITLE
fix(tool-pair-validator): diagnose subagent missing tool results

### DIFF
--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -276,6 +276,33 @@ describe("createToolPairValidatorHook", () => {
     }
   })
 
+  it("leaves tracked subagent user turns unchanged when tool_result is missing", async () => {
+    //#given
+    _resetForTesting()
+    subagentSessions.add("ses_background_2")
+    const backgroundMessages = [
+      {
+        info: { role: "assistant", sessionID: "ses_background_2" },
+        parts: [{ type: "tool_use", id: "toolu_background_2" }],
+      },
+      {
+        info: { role: "user", sessionID: "ses_background_2" },
+        parts: [{ type: "text", text: "continue background session" }],
+      },
+    ] satisfies TestMessage[]
+    const originalBackgroundMessages = JSON.parse(JSON.stringify(backgroundMessages))
+
+    try {
+      //#when
+      await runTransform(backgroundMessages)
+
+      //#then
+      expect(backgroundMessages).toEqual(originalBackgroundMessages)
+    } finally {
+      _resetForTesting()
+    }
+  })
+
   it("treats existing camelCase toolUseId results as already paired", async () => {
     //#given
     const messages = [

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -185,38 +185,112 @@ function getMessageSessionID(message: TransformMessageInfo): string | undefined 
   return typeof candidate.sessionID === "string" ? candidate.sessionID : undefined
 }
 
-function repairMissingToolResults(messages: MessageWithParts[], assistantIndex: number): void {
+type MissingToolResultAnalysis = {
+  assistantMessageID: string | undefined
+  toolUseIDs: string[]
+  needsRepair: false
+} | {
+  assistantMessageID: string | undefined
+  toolUseIDs: string[]
+  needsRepair: true
+  missingToolUseIDs: string[]
+  syntheticUserMessageInserted: boolean
+  nextRole: string | undefined
+}
+
+function analyzeMissingToolResults(messages: MessageWithParts[], assistantIndex: number): MissingToolResultAnalysis {
   const assistantMessage = messages[assistantIndex]
+  const assistantMessageID = getMessageID(assistantMessage.info)
   const toolUseIDs = extractUniqueToolUseIDs(assistantMessage.parts)
 
   if (toolUseIDs.length === 0) {
-    return
+    return { assistantMessageID, toolUseIDs, needsRepair: false }
   }
 
   const nextMessage = messages[assistantIndex + 1]
+  const nextRole = nextMessage?.info.role
 
-  if (nextMessage?.info.role !== "user") {
-    messages.splice(assistantIndex + 1, 0, createSyntheticUserMessage(assistantMessage, toolUseIDs))
-    log("[tool-pair-validator] Repaired missing tool_result blocks", {
-      assistantMessageID: getMessageID(assistantMessage.info),
+  if (nextRole !== "user") {
+    return {
+      assistantMessageID,
+      toolUseIDs,
+      needsRepair: true,
+      missingToolUseIDs: toolUseIDs,
       syntheticUserMessageInserted: true,
-      repairedToolUseIDs: toolUseIDs,
-    })
-    return
+      nextRole,
+    }
   }
 
   const existingToolResultIDs = extractToolResultIDs(nextMessage.parts)
   const missingToolUseIDs = toolUseIDs.filter((toolUseID) => !existingToolResultIDs.has(toolUseID))
 
   if (missingToolUseIDs.length === 0) {
+    return { assistantMessageID, toolUseIDs, needsRepair: false }
+  }
+
+  return {
+    assistantMessageID,
+    toolUseIDs,
+    needsRepair: true,
+    missingToolUseIDs,
+    syntheticUserMessageInserted: false,
+    nextRole,
+  }
+}
+
+function repairSubAgentMissingToolResults(messages: MessageWithParts[], assistantIndex: number, sessionID: string): void {
+  const analysis = analyzeMissingToolResults(messages, assistantIndex)
+
+  if (!analysis.needsRepair) {
+    log("[tool-pair-validator] Skipping repair for subagent session", {
+      sessionID,
+      assistantMessageID: analysis.assistantMessageID,
+      toolUseCount: analysis.toolUseIDs.length,
+      needsRepair: false,
+    })
     return
   }
 
-  insertMissingToolResults(nextMessage, missingToolUseIDs)
+  log("[tool-pair-validator] Skipping repair for subagent session", {
+    sessionID,
+    assistantMessageID: analysis.assistantMessageID,
+    toolUseIDs: analysis.toolUseIDs,
+    missingToolUseIDs: analysis.missingToolUseIDs,
+    syntheticUserMessageInserted: analysis.syntheticUserMessageInserted,
+    nextRole: analysis.nextRole ?? "missing",
+    needsRepair: true,
+  })
+}
+
+function repairMissingToolResults(messages: MessageWithParts[], assistantIndex: number): void {
+  const analysis = analyzeMissingToolResults(messages, assistantIndex)
+
+  if (!analysis.needsRepair) {
+    return
+  }
+
+  const assistantMessage = messages[assistantIndex]
+
+  if (analysis.syntheticUserMessageInserted) {
+    messages.splice(assistantIndex + 1, 0, createSyntheticUserMessage(assistantMessage, analysis.missingToolUseIDs))
+    log("[tool-pair-validator] Repaired missing tool_result blocks", {
+      assistantMessageID: analysis.assistantMessageID,
+      syntheticUserMessageInserted: true,
+      repairedToolUseIDs: analysis.missingToolUseIDs,
+    })
+    return
+  }
+
+  const nextMessage = messages[assistantIndex + 1]
+  if (!nextMessage || nextMessage.info.role !== "user") {
+    return
+  }
+
+  insertMissingToolResults(nextMessage, analysis.missingToolUseIDs)
   log("[tool-pair-validator] Repaired missing tool_result blocks", {
-    assistantMessageID: getMessageID(assistantMessage.info),
+    assistantMessageID: analysis.assistantMessageID,
     syntheticUserMessageInserted: false,
-    repairedToolUseIDs: missingToolUseIDs,
+    repairedToolUseIDs: analysis.missingToolUseIDs,
   })
 }
 
@@ -232,7 +306,7 @@ export function createToolPairValidatorHook(): MessagesTransformHook {
 
         const sessionID = getMessageSessionID(messageInfo)
         if (sessionID && subagentSessions.has(sessionID)) {
-          log("[tool-pair-validator] Skipping repair for subagent session", { sessionID })
+          repairSubAgentMissingToolResults(output.messages, i, sessionID)
           continue
         }
 


### PR DESCRIPTION
## Summary

- Add a subagent-specific `tool-pair-validator` path that analyzes missing `tool_result` cases without mutating subagent message history.
- Preserve the #4032 behavior that prevents synthetic placeholder `tool_result` insertion from corrupting background sub-agent sessions.

For tracked subagent sessions, this change is diagnostic-only. The validator analyzes whether missing `tool_result` pairs would require repair and logs that state with fields such as `needsRepair` and `missingToolUseIDs`, but it intentionally does not insert synthetic `tool_result` blocks or mutate subagent message history.

## Changes

- Extract shared missing tool-result detection so main-session repair and subagent diagnostics use the same pairing logic.
- Add `repairSubAgentMissingToolResults()` for tracked subagent sessions; it logs whether repair would be needed, including missing tool-use IDs, but does not insert placeholder results.
- Keep existing main-session repair behavior intact for compaction/orphaned `tool_use` recovery.
- Add regression coverage confirming tracked subagent messages remain unchanged when a user turn is missing matching `tool_result`.

## Testing

```bash
bun test src/hooks/tool-pair-validator/hook.test.ts src/plugin/messages-transform.test.ts
```

## Related Issues

Related to #3996  
Follow-up to #4032



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subagent-aware path in the tool-pair validator that detects missing `tool_result` and logs diagnostics without mutating subagent message history. Main-session repair behavior is unchanged.

- **Bug Fixes**
  - Share detection via `analyzeMissingToolResults` so both paths use the same pairing logic.
  - Add `repairSubAgentMissingToolResults` that logs needed repairs (missing tool_use IDs, next role) for tracked subagent sessions; no placeholders are inserted.
  - Preserve main-session repair: insert a synthetic user turn or missing `tool_result` entries when required.
  - Add a regression test to confirm tracked subagent messages remain unchanged.

<sup>Written for commit 612875472cbd65535f0ed9ac31e9bc8d1bb8e9ae. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

