### PR TITLE
test(shared): add test coverage for classify-path-environment

### DIFF
--- a/packages/omo-opencode/src/shared/classify-path-environment.test.ts
+++ b/packages/omo-opencode/src/shared/classify-path-environment.test.ts
@@ -1,56 +1,148 @@
-import { describe, expect, it } from "bun:test"
-
-import {
-  classifyPathEnvironment,
-  describePathClassification,
-} from "./classify-path-environment"
+import { describe, test, expect } from "bun:test"
+import { classifyPathEnvironment, describePathClassification } from "./classify-path-environment"
 
 describe("classifyPathEnvironment", () => {
-  it("classifies macOS iCloud path as icloud", () => {
-    expect(
-      classifyPathEnvironment(
-        "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/project/file.txt",
-      ),
-    ).toBe("icloud")
+  describe("#given an empty path", () => {
+    test("#then it returns unknown", () => {
+      expect(classifyPathEnvironment("")).toBe("unknown")
+    })
   })
 
-  it("classifies OneDrive path on unix style", () => {
-    expect(classifyPathEnvironment("/Users/x/OneDrive/foo")).toBe("onedrive")
+  describe("#given a path containing OneDrive", () => {
+    describe("#when the path includes /OneDrive (unix style)", () => {
+      test("#then it returns onedrive", () => {
+        expect(classifyPathEnvironment("/Users/x/OneDrive/foo")).toBe("onedrive")
+      })
+    })
+
+    describe("#when the path uses Windows backslashes", () => {
+      test("#then it normalizes and returns onedrive", () => {
+        expect(classifyPathEnvironment("C:\\Users\\x\\OneDrive\\foo")).toBe("onedrive")
+      })
+    })
+
+    describe("#when the case varies", () => {
+      test("#then it matches case-insensitively", () => {
+        expect(classifyPathEnvironment("/Users/x/oNeDrIvE/foo")).toBe("onedrive")
+      })
+
+      test("#then it matches all uppercase", () => {
+        expect(classifyPathEnvironment("/Users/x/ONEDRIVE/foo")).toBe("onedrive")
+      })
+
+      test("#then it matches all lowercase", () => {
+        expect(classifyPathEnvironment("/Users/x/onedrive/foo")).toBe("onedrive")
+      })
+    })
+
+    describe("#when OneDrive is a leaf directory", () => {
+      test("#then it still detects onedrive", () => {
+        expect(classifyPathEnvironment("/Users/x/OneDrive")).toBe("onedrive")
+      })
+    })
   })
 
-  it("classifies OneDrive path on windows style", () => {
-    expect(classifyPathEnvironment("C:\\Users\\x\\OneDrive\\foo")).toBe("onedrive")
+  describe("#given a path containing iCloud", () => {
+    describe("#when the path includes /Library/Mobile Documents/", () => {
+      test("#then it returns icloud", () => {
+        expect(
+          classifyPathEnvironment(
+            "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/project/file.txt",
+          ),
+        ).toBe("icloud")
+      })
+    })
+
+    describe("#when the path has nested iCloud content", () => {
+      test("#then it returns icloud", () => {
+        expect(
+          classifyPathEnvironment("/Users/x/Library/Mobile Documents/iCloud~md~obsidian/Documents"),
+        ).toBe("icloud")
+      })
+    })
   })
 
-  it("classifies macOS Desktop path as desktop-sync", () => {
-    expect(classifyPathEnvironment("/Users/x/Desktop/foo")).toBe("desktop-sync")
+  describe("#given a path under /Volumes", () => {
+    describe("#when the path is a network share", () => {
+      test("#then it returns network-drive", () => {
+        expect(classifyPathEnvironment("/Volumes/NetworkShare/foo")).toBe("network-drive")
+      })
+    })
+
+    describe("#when the path is exactly /Volumes", () => {
+      test("#then it returns network-drive", () => {
+        expect(classifyPathEnvironment("/Volumes")).toBe("network-drive")
+      })
+    })
   })
 
-  it("classifies /Volumes path as network-drive", () => {
-    expect(classifyPathEnvironment("/Volumes/NetworkShare/foo")).toBe("network-drive")
+  describe("#given a path under /Users Desktop or Documents", () => {
+    describe("#when the path includes /Desktop/", () => {
+      test("#then it returns desktop-sync", () => {
+        expect(classifyPathEnvironment("/Users/x/Desktop/foo")).toBe("desktop-sync")
+      })
+    })
+
+    describe("#when the path ends with /Desktop", () => {
+      test("#then it returns desktop-sync", () => {
+        expect(classifyPathEnvironment("/Users/x/Desktop")).toBe("desktop-sync")
+      })
+    })
+
+    describe("#when the path includes /Documents/", () => {
+      test("#then it returns desktop-sync", () => {
+        expect(classifyPathEnvironment("/Users/x/Documents/project")).toBe("desktop-sync")
+      })
+    })
+
+    describe("#when the path ends with /Documents", () => {
+      test("#then it returns desktop-sync", () => {
+        expect(classifyPathEnvironment("/Users/x/Documents")).toBe("desktop-sync")
+      })
+    })
   })
 
-  it("classifies random path as unknown", () => {
-    expect(classifyPathEnvironment("/tmp/foo")).toBe("unknown")
-  })
+  describe("#given a regular path", () => {
+    describe("#when the path is a normal project directory", () => {
+      test("#then it returns unknown", () => {
+        expect(classifyPathEnvironment("/tmp/foo")).toBe("unknown")
+      })
+    })
 
-  it("classifies empty string as unknown", () => {
-    expect(classifyPathEnvironment("")).toBe("unknown")
-  })
+    describe("#when the path is a system directory", () => {
+      test("#then it returns unknown", () => {
+        expect(classifyPathEnvironment("/usr/local/bin")).toBe("unknown")
+      })
+    })
 
-  it("matches OneDrive case-insensitively", () => {
-    expect(classifyPathEnvironment("/Users/x/oNeDrIvE/foo")).toBe("onedrive")
+    describe("#when the path is a home subdirectory without sync", () => {
+      test("#then it returns unknown", () => {
+        expect(classifyPathEnvironment("/Users/x/projects/myapp")).toBe("unknown")
+      })
+    })
   })
 })
 
 describe("describePathClassification", () => {
-  it("returns human-readable descriptions", () => {
-    expect(describePathClassification("icloud")).toBe("iCloud Drive")
-    expect(describePathClassification("onedrive")).toBe("OneDrive")
-    expect(describePathClassification("desktop-sync")).toBe("Desktop sync (macOS)")
-    expect(describePathClassification("network-drive")).toBe("Network drive")
-    expect(describePathClassification("unknown")).toBe(
-      "filesystem that does not support fsync",
-    )
+  describe("#given each classification type", () => {
+    test("#then icloud returns iCloud Drive", () => {
+      expect(describePathClassification("icloud")).toBe("iCloud Drive")
+    })
+
+    test("#then onedrive returns OneDrive", () => {
+      expect(describePathClassification("onedrive")).toBe("OneDrive")
+    })
+
+    test("#then desktop-sync returns Desktop sync (macOS)", () => {
+      expect(describePathClassification("desktop-sync")).toBe("Desktop sync (macOS)")
+    })
+
+    test("#then network-drive returns Network drive", () => {
+      expect(describePathClassification("network-drive")).toBe("Network drive")
+    })
+
+    test("#then unknown returns filesystem that does not support fsync", () => {
+      expect(describePathClassification("unknown")).toBe("filesystem that does not support fsync")
+    })
   })
 })


### PR DESCRIPTION
Add comprehensive test coverage for `src/shared/classify-path-environment.ts`.\n\n## Changes\n- Rewrite src/shared/classify-path-environment.test.ts with 23 tests using given/when/then style covering OneDrive detection (unix/windows/case-insensitive/leaf), iCloud detection (Mobile Documents), network-drive (/Volumes), desktop-sync (Desktop/Documents with trailing slash and without), regular paths (unknown), and describePathClassification for all 5 classification types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add expanded tests for `src/shared/classify-path-environment.ts` validating OneDrive, iCloud (including nested app folders), network drives (including `/Volumes` root), desktop sync (`Desktop` and `Documents`), empty and unknown paths, plus `describePathClassification` outputs. Covers Windows path separators, case-insensitive matches, and leaf-directory detection.

<sup>Written for commit faf14efee4ac09fd8580a83eee5f8a20d02c10dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

