### PR TITLE
test(shared): add test coverage for disabled-tools

### DIFF
--- a/src/shared/disabled-tools.test.ts
+++ b/src/shared/disabled-tools.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "bun:test"
+
+import { filterDisabledTools } from "./disabled-tools"
+
+describe("disabled-tools", () => {
+  describe("#given filterDisabledTools", () => {
+    const mockTools = {
+      grep: { name: "grep", description: "Search files" },
+      glob: { name: "glob", description: "Find files" },
+      edit: { name: "edit", description: "Edit files" },
+      lsp_rename: { name: "lsp_rename", description: "Rename symbol" },
+    } as Record<string, any>
+
+    describe("#when disabledTools is undefined", () => {
+      test("#then returns the original tools object", () => {
+        const result = filterDisabledTools(mockTools, undefined)
+        expect(result).toBe(mockTools)
+      })
+    })
+
+    describe("#when disabledTools is an empty array", () => {
+      test("#then returns the original tools object", () => {
+        const result = filterDisabledTools(mockTools, [])
+        expect(result).toBe(mockTools)
+      })
+    })
+
+    describe("#when disabledTools contains one tool name", () => {
+      test("#then removes only that tool", () => {
+        const result = filterDisabledTools(mockTools, ["grep"])
+        expect(result).toEqual({
+          glob: mockTools.glob,
+          edit: mockTools.edit,
+          lsp_rename: mockTools.lsp_rename,
+        })
+        expect(result).not.toHaveProperty("grep")
+      })
+    })
+
+    describe("#when disabledTools contains multiple tool names", () => {
+      test("#then removes all specified tools", () => {
+        const result = filterDisabledTools(mockTools, ["grep", "edit"])
+        expect(result).toEqual({
+          glob: mockTools.glob,
+          lsp_rename: mockTools.lsp_rename,
+        })
+      })
+    })
+
+    describe("#when disabledTools contains names not in tools", () => {
+      test("#then ignores non-existent tool names", () => {
+        const result = filterDisabledTools(mockTools, ["nonexistent", "also_fake"])
+        expect(result).toEqual(mockTools)
+      })
+    })
+
+    describe("#when disabledTools contains all tool names", () => {
+      test("#then returns an empty object", () => {
+        const result = filterDisabledTools(mockTools, ["grep", "glob", "edit", "lsp_rename"])
+        expect(result).toEqual({})
+      })
+    })
+
+    describe("#when tools is an empty record", () => {
+      test("#then returns an empty object", () => {
+        const result = filterDisabledTools({}, ["grep"])
+        expect(result).toEqual({})
+      })
+    })
+
+    describe("#when disabledTools has duplicates", () => {
+      test("#then handles duplicates gracefully", () => {
+        const result = filterDisabledTools(mockTools, ["grep", "grep", "grep"])
+        expect(result).toEqual({
+          glob: mockTools.glob,
+          edit: mockTools.edit,
+          lsp_rename: mockTools.lsp_rename,
+        })
+      })
+    })
+
+    describe("#when filtering does not mutate original", () => {
+      test("#then original tools object is unchanged", () => {
+        const original = { ...mockTools }
+        filterDisabledTools(mockTools, ["grep", "edit"])
+        expect(mockTools).toEqual(original)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add comprehensive test coverage for \src/shared/disabled-tools.ts\.\n\n## Changes\n- Add src/shared/disabled-tools.test.ts with 9 tests covering filterDisabledTools function: undefined/empty disabled list passthrough, single/multiple tool removal, non-existent tool names, all tools disabled, empty tools record, duplicate entries, and immutability of original object.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `filterDisabledTools` in `src/shared/disabled-tools.test.ts`. Covers undefined/empty lists, single/multiple/all disables, missing names, empty tools, duplicates, and immutability.

<sup>Written for commit 364e503d0970274974229493ea674983d2142317. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4549?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

