### PR TITLE
fix: skip claude hook injection for internal prompts

### DIFF
--- a/src/features/background-agent/background-task-notification-template.test.ts
+++ b/src/features/background-agent/background-task-notification-template.test.ts
@@ -4,6 +4,27 @@ import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
 describe("buildBackgroundTaskNotificationText", () => {
   describe("#given one task still running after a completed task notification", () => {
+    test("#when building the partial notification #then it does not use the final completed heading", () => {
+      // given
+      const notification = buildBackgroundTaskNotificationText({
+        task: {
+          id: "task-1",
+          description: "Index repo",
+          status: "completed",
+        },
+        duration: "42s",
+        statusText: "COMPLETED",
+        allComplete: false,
+        remainingCount: 1,
+        completedTasks: [],
+      })
+
+      // then
+      expect(notification).not.toContain("[BACKGROUND TASK COMPLETED]")
+      expect(notification).toContain("[BACKGROUND TASK RESULT READY]")
+      expect(notification).toContain("You WILL be notified when ALL complete.")
+    })
+
     test("#when building the partial notification #then it preserves the existing completed-task format", () => {
       // given
       const notification = buildBackgroundTaskNotificationText({
@@ -21,7 +42,7 @@ describe("buildBackgroundTaskNotificationText", () => {
 
       // when
       const expectedNotification = `<system-reminder>
-[BACKGROUND TASK COMPLETED]
+[BACKGROUND TASK RESULT READY]
 **ID:** \`task-1\`
 **Description:** Index repo
 **Duration:** 42s
@@ -156,6 +177,32 @@ Use \`background_output(task_id="<id>")\` to retrieve each result.
   })
 
   describe("#given a completed task with retry attempt history", () => {
+    test("#when building the final notification #then it includes the final completed heading", () => {
+      // given
+      const notification = buildBackgroundTaskNotificationText({
+        task: {
+          id: "task-3",
+          description: "Fallback task",
+          status: "completed",
+        },
+        duration: "10s",
+        statusText: "COMPLETED",
+        allComplete: true,
+        remainingCount: 0,
+        completedTasks: [
+          {
+            id: "task-3",
+            description: "Fallback task",
+            status: "completed",
+          },
+        ],
+      })
+
+      // then
+      expect(notification).toContain("[BACKGROUND TASK COMPLETED]")
+      expect(notification).toContain("[ALL BACKGROUND TASKS COMPLETE]")
+    })
+
     test("#when building the final notification #then it renders the spec-aligned balanced attempt timeline", () => {
       // given
       const notification = buildBackgroundTaskNotificationText({

--- a/src/features/background-agent/background-task-notification-template.ts
+++ b/src/features/background-agent/background-task-notification-template.ts
@@ -85,7 +85,7 @@ export function buildBackgroundTaskNotificationText(input: {
     const hasFailures = failedTasks.length > 0
     const header = hasFailures
       ? `[ALL BACKGROUND TASKS FINISHED - ${failedTasks.length} FAILED]`
-      : "[ALL BACKGROUND TASKS COMPLETE]"
+      : "[BACKGROUND TASK COMPLETED]\n[ALL BACKGROUND TASKS COMPLETE]"
 
     let body = ""
     if (succeededText) {
@@ -108,9 +108,10 @@ Use \`background_output(task_id="<id>")\` to retrieve each result.${hasFailures 
   }
 
   const isFailure = statusText !== "COMPLETED"
+  const header = isFailure ? `[BACKGROUND TASK ${statusText}]` : "[BACKGROUND TASK RESULT READY]"
 
   return `<system-reminder>
-[BACKGROUND TASK ${statusText}]
+${header}
 **ID:** \`${task.id}\`
 **Description:** ${safeDescription(task)}
 **Duration:** ${duration}${errorInfo}

--- a/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/src/features/background-agent/task-completion-cleanup.test.ts
@@ -390,7 +390,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
-      expect(notificationPayload).toContain("BACKGROUND TASK COMPLETED")
+      expect(notificationPayload).toContain("BACKGROUND TASK RESULT READY")
       expect(notificationPayload).not.toContain("ALL BACKGROUND TASKS COMPLETE")
     })
 

--- a/src/hooks/claude-code-hooks/handlers/chat-message-handler.ts
+++ b/src/hooks/claude-code-hooks/handlers/chat-message-handler.ts
@@ -50,6 +50,7 @@ export function createChatMessageHandler(
 		})
 
 		const messageParts: MessagePart[] = textParts.map((p) => ({
+			...p,
 			type: "text",
 			text: p.text,
 		}))

--- a/src/hooks/claude-code-hooks/user-prompt-submit.test.ts
+++ b/src/hooks/claude-code-hooks/user-prompt-submit.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect } from "bun:test"
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
+import * as dispatchHookModule from "./dispatch-hook"
 import {
   executeUserPromptSubmitHooks,
   type UserPromptSubmitContext,
 } from "./user-prompt-submit"
 
 describe("executeUserPromptSubmitHooks", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
   it("returns early when no config provided", async () => {
     // given
     const ctx: UserPromptSubmitContext = {
@@ -103,5 +109,66 @@ describe("executeUserPromptSubmitHooks", () => {
     // then
     expect(result1.block).toBe(false)
     expect(result2.block).toBe(false)
+  })
+
+  it("#given synthetic hook context only #when prompt submit runs #then hook command is not dispatched", async () => {
+    // given
+    const dispatchSpy = spyOn(dispatchHookModule, "dispatchHook").mockResolvedValue({
+      exitCode: 0,
+      stdout: "hook output",
+      stderr: "",
+    })
+    const ctx: UserPromptSubmitContext = {
+      sessionId: "test-session-synthetic",
+      prompt: "synthetic hook message",
+      parts: [{ type: "text", text: "synthetic hook message", synthetic: true }],
+      cwd: "/tmp",
+    }
+    const config = {
+      UserPromptSubmit: [
+        { matcher: "*", hooks: [{ type: "command" as const, command: "echo hook" }] },
+      ],
+    }
+
+    // when
+    const result = await executeUserPromptSubmitHooks(ctx, config)
+
+    // then
+    expect(result.block).toBe(false)
+    expect(result.messages).toEqual([])
+    expect(dispatchSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it("#given internal prompt marker only #when prompt submit runs #then hook command is not dispatched", async () => {
+    // given
+    const dispatchSpy = spyOn(dispatchHookModule, "dispatchHook").mockResolvedValue({
+      exitCode: 0,
+      stdout: "hook output",
+      stderr: "",
+    })
+    const ctx: UserPromptSubmitContext = {
+      sessionId: "test-session-internal",
+      prompt: `internal hook message\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+      parts: [
+        {
+          type: "text",
+          text: `internal hook message\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+        },
+      ],
+      cwd: "/tmp",
+    }
+    const config = {
+      UserPromptSubmit: [
+        { matcher: "*", hooks: [{ type: "command" as const, command: "echo hook" }] },
+      ],
+    }
+
+    // when
+    const result = await executeUserPromptSubmitHooks(ctx, config)
+
+    // then
+    expect(result.block).toBe(false)
+    expect(result.messages).toEqual([])
+    expect(dispatchSpy).toHaveBeenCalledTimes(0)
   })
 })

--- a/src/hooks/claude-code-hooks/user-prompt-submit.ts
+++ b/src/hooks/claude-code-hooks/user-prompt-submit.ts
@@ -4,6 +4,7 @@ import type {
   ClaudeHooksConfig,
 } from "./types"
 import { findMatchingHooks, log } from "../../shared"
+import { isRealUserTextPart } from "../../shared/internal-initiator-marker"
 import { dispatchHook, getHookIdentifier } from "./dispatch-hook"
 import { isHookCommandDisabled, type PluginExtendedConfig } from "./config-loader"
 
@@ -44,10 +45,14 @@ export async function executeUserPromptSubmitHooks(
     return { block: false, modifiedParts, messages }
   }
 
+  const realUserTextParts = ctx.parts.filter(isRealUserTextPart)
+  if (realUserTextParts.length === 0) {
+    return { block: false, modifiedParts, messages }
+  }
+
   // Check if hook tags are in the current user input only (not in injected context)
   // by checking only the text parts that were provided in this message
-  const userInputText = ctx.parts
-    .filter((p) => p.type === "text" && p.text)
+  const userInputText = realUserTextParts
     .map((p) => p.text ?? "")
     .join("\n")
 


### PR DESCRIPTION
## Summary
- preserve synthetic/internal message metadata when Claude Code UserPromptSubmit receives OpenCode chat.message parts
- skip UserPromptSubmit hook dispatch when the current message has no real user text
- reserve `[BACKGROUND TASK COMPLETED]` for final all-background-tasks-complete notifications; partial successful results now say `[BACKGROUND TASK RESULT READY]`
- add regressions for synthetic hook context, OMO internal marker prompts, and background completion heading timing

## Evidence
- OpenCode log `/Users/yeongyu/.local/share/opencode/log/2026-05-27T045016.log` shows the affected session flow in `/Users/yeongyu/local-workspaces/omodex` touching `src/agents/hephaestus/gpt-5-5.ts` with repeated prompt loops on `gpt-5.5` subagent sessions.
- OMO duplicate-injection route traced to `src/hooks/claude-code-hooks/handlers/chat-message-handler.ts` -> `executeUserPromptSubmitHooks()` and `src/features/context-injector/injector.ts` synthetic parts.
- Background completion wording route traced to `src/features/background-agent/background-task-notification-template.ts` via `BackgroundManager.notifyParentSession()`.

## Validation
- RED: new synthetic/internal UserPromptSubmit tests failed before the fix because `dispatchHook` was called and hook output was returned.
- RED: new background notification template tests failed before the fix because partial completion used `[BACKGROUND TASK COMPLETED]` and final all-complete did not.
- `bun test src/features/background-agent/background-task-notification-template.test.ts src/features/background-agent/task-completion-cleanup.test.ts`
- `bun test src/features/background-agent/background-task-notification-template.test.ts src/features/background-agent/task-completion-cleanup.test.ts src/features/context-injector/injector.test.ts src/hooks/claude-code-hooks/user-prompt-submit.test.ts src/hooks/claude-code-hooks/pre-tool-use.test.ts src/hooks/claude-code-hooks/stop.test.ts`
- `bun run typecheck`
- `bun run build`

## Scope
- OpenCode source was not modified.
- `packages/omo-codex` was not modified.
