### PR TITLE
fix(shared): handle CRLF in Windows where.exe output for ripgrep resolution

### DIFF
--- a/src/shared/ripgrep-cli.test.ts
+++ b/src/shared/ripgrep-cli.test.ts
@@ -54,3 +54,82 @@ describe("resolveGrepCli OpenCode cache fallback (#3805)", () => {
     expect(resolved.path).toBe(cacheRg)
   })
 })
+
+describe("findExecutable CRLF handling (#4512)", () => {
+  it("strips \\r from where.exe output on Windows", async () => {
+    const { mock } = await import("bun:test")
+
+    // given: spawnSync returns stdout with CRLF line endings (Windows where.exe behavior)
+    const mockSpawnSync = mock(() => ({
+      status: 0,
+      stdout: "C:\\Program Files\\ripgrep\\rg.exe\r\nC:\\Other\\rg.exe\r\n",
+      stderr: "",
+      signal: null,
+      pid: 0,
+      output: [],
+    }))
+
+    mock.module("node:child_process", () => ({
+      spawnSync: mockSpawnSync,
+    }))
+
+    mock.module("node:fs", () => ({
+      existsSync: () => false,
+    }))
+
+    mock.module("../tools/grep/downloader", () => ({
+      downloadAndInstallRipgrep: async () => "",
+      getInstalledRipgrepPath: () => null,
+    }))
+
+    delete require.cache[require.resolve("./ripgrep-cli")]
+    const { resolveGrepCli } = await import("./ripgrep-cli")
+
+    // when
+    const resolved = resolveGrepCli()
+
+    // then: the resolved path should NOT contain \r
+    expect(resolved.path).not.toContain("\r")
+    expect(resolved.path).toBe("C:\\Program Files\\ripgrep\\rg.exe")
+    expect(resolved.backend).toBe("rg")
+  })
+
+  it("handles stdout with only LF (non-Windows)", async () => {
+    const { mock } = await import("bun:test")
+
+    // given: spawnSync returns stdout with LF only
+    const mockSpawnSync = mock(() => ({
+      status: 0,
+      stdout: "/usr/bin/rg\n/usr/local/bin/rg\n",
+      stderr: "",
+      signal: null,
+      pid: 0,
+      output: [],
+    }))
+
+    mock.module("node:child_process", () => ({
+      spawnSync: mockSpawnSync,
+    }))
+
+    mock.module("node:fs", () => ({
+      existsSync: () => false,
+    }))
+
+    mock.module("../tools/grep/downloader", () => ({
+      downloadAndInstallRipgrep: async () => "",
+      getInstalledRipgrepPath: () => null,
+    }))
+
+    delete require.cache[require.resolve("./ripgrep-cli")]
+    const { resolveGrepCli } = await import("./ripgrep-cli")
+
+    // when
+    const resolved = resolveGrepCli()
+
+    // then: first line is returned without trailing newline
+    expect(resolved.path).not.toContain("\n")
+    expect(resolved.path).not.toContain("\r")
+    expect(resolved.path).toBe("/usr/bin/rg")
+    expect(resolved.backend).toBe("rg")
+  })
+})

--- a/src/shared/ripgrep-cli.ts
+++ b/src/shared/ripgrep-cli.ts
@@ -32,7 +32,7 @@ function findExecutable(name: string): string | null {
     })
     const stdout = result.stdout
     if (result.status === 0 && stdout.trim()) {
-      return stdout.trim().split("\n")[0]
+      return stdout.split(/\r?\n/).map(l => l.trim()).filter(Boolean)[0] ?? null
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary
Fixes the Windows ripgrep resolver CRLF bug where `where.exe` output ends with `\r`, causing `rg.exe\r` ENOENT errors.

## Changes
- `src/shared/ripgrep-cli.ts`: Replace `stdout.trim().split('\n')[0]` with `stdout.split(/\r?\n/).map(l => l.trim()).filter(Boolean)[0]` to properly handle CRLF line endings from Windows `where.exe`
- `src/shared/ripgrep-cli.test.ts`: Add tests verifying CRLF and LF-only stdout parsing

Closes #4512

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows ripgrep resolution by handling CRLF from where.exe, so we return a clean rg.exe path and avoid ENOENT errors. Fixes #4512.

- Bug Fixes
  - Parse where.exe output with CRLF/LF, trim lines, and use the first non-empty path.
  - Add tests for CRLF and LF stdout cases.

<sup>Written for commit 2034013d8bd9ec421cc95fb76709a2619e3e0025. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4556?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

