### PR TITLE
test(shared): add test coverage for parse-diff-numstat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ pluginModule.server(input, options)
 
 ## 13 OPENCODE HOOK HANDLERS
 
-11 wired in [`src/plugin-interface.ts`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-interface.ts) + 2 wired directly in [`src/testing/create-plugin-module.ts`](file:///Users/yeongyu/local-workspaces/omo/src/testing/create-plugin-module.ts) (`experimental.session.compacting` + `experimental.compaction.autocontinue`).
+11 wired in [`src/plugin-interface.ts`](src/plugin-interface.ts) + 2 wired directly in [`src/testing/create-plugin-module.ts`](src/testing/create-plugin-module.ts) (`experimental.session.compacting` + `experimental.compaction.autocontinue`).
 
 | Handler | OpenCode Hook | Purpose |
 |---------|---------------|---------|
@@ -106,7 +106,7 @@ pluginModule.server(input, options)
 
 OFF by default. Parallel multi-agent coordination, modeled after Claude Code Agent Teams. Enable via `team_mode.enabled` in `.opencode/oh-my-opencode.jsonc` or user config; restart OpenCode after change.
 
-Full schema in [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-workspaces/omo/src/config/schema/team-mode.ts) (11 fields):
+Full schema in [`src/config/schema/team-mode.ts`](src/config/schema/team-mode.ts) (11 fields):
 
 ```jsonc
 {
@@ -128,14 +128,14 @@ Full schema in [`src/config/schema/team-mode.ts`](file:///Users/yeongyu/local-wo
 
 Teams live as directories under `~/.omo/teams/{name}/config.json` (user) or `<project>/.omo/teams/{name}/config.json` (project; project beats user on collisions). Members declared as `kind: "subagent_type"` (direct agent) or `kind: "category"` (routed through `sisyphus-junior`).
 
-**Member eligibility** (from [`AGENT_ELIGIBILITY_REGISTRY`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/types.ts)):
+**Member eligibility** (from [`AGENT_ELIGIBILITY_REGISTRY`](src/features/team-mode/types.ts)):
 - `eligible`: sisyphus, atlas, sisyphus-junior
 - `conditional`: hephaestus (lacks `teammate: "allow"` permission by default — apply D-36 in `tool-config-handler.ts` or use `subagent_type: "sisyphus"` instead)
 - `hard-reject`: oracle, librarian, explore, multimodal-looker, metis, momus, prometheus (rejected at parse — use `task`/delegate-task)
 
 **Storage layout** (`~/.omo/teams/{name}/`): `config.json` (spec), `state.json` (runtime), `mailbox/` (messages), `tasklist.jsonl` (tasks), `worktrees/` (per-member git worktrees).
 
-**Implementation:** [`src/features/team-mode/`](file:///Users/yeongyu/local-workspaces/omo/src/features/team-mode/AGENTS.md). User docs: [`docs/guide/team-mode.md`](file:///Users/yeongyu/local-workspaces/omo/docs/guide/team-mode.md).
+**Implementation:** [`src/features/team-mode/`](src/features/team-mode/AGENTS.md). User docs: [`docs/guide/team-mode.md`](docs/guide/team-mode.md).
 
 ## MULTI-LEVEL CONFIG
 
@@ -186,7 +186,7 @@ Schema autocomplete: `"$schema": "https://raw.githubusercontent.com/code-yeongyu
 
 ## ARCHITECTURE INVARIANTS
 
-- **Canonical agent order:** Sisyphus → Hephaestus → Prometheus → Atlas. Enforced by `installAgentSortShim()` (patches `Array.prototype.toSorted`/`.sort` narrowly when the array contains ≥2 canonical core agents). See [`src/plugin-handlers/AGENTS.md`](file:///Users/yeongyu/local-workspaces/omo/src/plugin-handlers/AGENTS.md) for the full history of why this exists.
+- **Canonical agent order:** Sisyphus → Hephaestus → Prometheus → Atlas. Enforced by `installAgentSortShim()` (patches `Array.prototype.toSorted`/`.sort` narrowly when the array contains ≥2 canonical core agents). See [`src/plugin-handlers/AGENTS.md`](src/plugin-handlers/AGENTS.md) for the full history of why this exists.
 - **Hashline edit + read pairing:** Every `Read` tool output is tagged with `LINE#ID` content hashes; `hashline_edit` validates the hash before applying. Stale hash → reject.
 - **5-tier hook composition:** Session (24) + ToolGuard (16) + Transform (5) + Continuation (7) + Skill (2) = 54 base. With `team_mode.enabled`: +1 ToolGuard (`team-tool-gating`), +2 Transform (`team-mode-status-injector`, `team-mailbox-injector`), +4 direct event handlers in `src/plugin/event.ts` (`team-session-events/*`) = 61 total. Composed by `createCoreHooks()` + `createContinuationHooks()` + `createSkillHooks()`.
 - **Per-session MCP isolation:** Tier-3 MCP clients keyed by `${sessionID}:${skillName}:${serverName}` so the same skill in two sessions does not share state.
@@ -287,8 +287,8 @@ bunx oh-my-opencode mcp-oauth login <server-url>  # Tier-3 MCP OAuth (PKCE + DCR
 - **Hashline edit:** every `Read` output tagged with `LINE#ID` content hashes (chars from `ZPMQVRWSNKTXJBYH`); edits reject on hash mismatch.
 - **zauc-mocks pattern:** 9 directories named `zauc-mocks-*` (5 in `src/hooks/`, 2 in `src/tools/`, 1 each in `src/mcp/` and `src/shared/`) hold `mock.module()` setup that must load alphabetically before the tests that consume those mocked modules. The `zauc-` prefix is purely a sort-order hack for `bun:test` discovery; these are NOT hooks/tools.
 - **Test discipline meta-audits:** two files (`src/shared/mock-module-lifecycle-audit.test.ts` and `src/shared/prompt-async-route-audit.test.ts`) parse the entire codebase via the TS compiler API and FAIL the suite when an architectural invariant is violated (`mock.module()` without restore, raw `session.promptAsync` outside the gate).
-- **Docs:** see [`docs/guide/`](file:///Users/yeongyu/local-workspaces/omo/docs/guide/) for user-facing guides (overview, installation, orchestration, agent-model-matching, team-mode), [`docs/reference/`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/) for CLI/configuration/features reference. v4.2.0+ adds [`CHANGELOG.md`](file:///Users/yeongyu/local-workspaces/omo/CHANGELOG.md), [`docs/reference/known-issues.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/known-issues.md), [`docs/reference/prompt-async-gate-rfc.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/prompt-async-gate-rfc.md), and [`docs/reference/release-process.md`](file:///Users/yeongyu/local-workspaces/omo/docs/reference/release-process.md).
-- **Rules files** (auto-injected by `rules-injector` hook): [`.omo/rules/modular-code-enforcement.md`](file:///Users/yeongyu/local-workspaces/omo/.omo/rules/modular-code-enforcement.md) + [`.omo/rules/test-discipline.md`](file:///Users/yeongyu/local-workspaces/omo/.omo/rules/test-discipline.md) (forbids `setTimeout(resolve, N)` / `await sleep(N)` in tests unless time IS the SUT). Scans `.omo/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, plus `.github/copilot-instructions.md` and `.mdc` files.
+- **Docs:** see [`docs/guide/`](docs/guide/) for user-facing guides (overview, installation, orchestration, agent-model-matching, team-mode), [`docs/reference/`](docs/reference/) for CLI/configuration/features reference. v4.2.0+ adds [`CHANGELOG.md`](CHANGELOG.md), [`docs/reference/known-issues.md`](docs/reference/known-issues.md), [`docs/reference/prompt-async-gate-rfc.md`](docs/reference/prompt-async-gate-rfc.md), and [`docs/reference/release-process.md`](docs/reference/release-process.md).
+- **Rules files** (auto-injected by `rules-injector` hook): [`.omo/rules/modular-code-enforcement.md`](.omo/rules/modular-code-enforcement.md) + [`.omo/rules/test-discipline.md`](.omo/rules/test-discipline.md) (forbids `setTimeout(resolve, N)` / `await sleep(N)` in tests unless time IS the SUT). Scans `.omo/rules/`, `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, plus `.github/copilot-instructions.md` and `.mdc` files.
 - **Process cleanup:** Background-agent error handlers are now log-only — no force-exit on transient errors. Opt out entirely via `OMO_DISABLE_PROCESS_CLEANUP=1` env var.
 - **First-prompt watchdog:** `src/hooks/runtime-fallback/first-prompt-watchdog.ts` (206 LOC) detects subagent sessions producing no progress within 90s and triggers fallback / abort.
 - **ParentWakeNotifier:** Background-agent parent-wake state extracted to `src/features/background-agent/parent-wake-notifier.ts` (587 LOC) with dependency-injected client and enqueue callback.

--- a/src/shared/git-worktree/parse-diff-numstat.test.ts
+++ b/src/shared/git-worktree/parse-diff-numstat.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test"
+
+import { parseGitDiffNumstat } from "./parse-diff-numstat"
+import type { GitFileStatus } from "./types"
+
+describe("parse-diff-numstat", () => {
+  describe("#given parseGitDiffNumstat", () => {
+    describe("#when output is empty", () => {
+      test("#then returns an empty array", () => {
+        const statusMap = new Map<string, GitFileStatus>()
+        expect(parseGitDiffNumstat("", statusMap)).toEqual([])
+      })
+    })
+
+    describe("#when output has a single file with numeric stats", () => {
+      test("#then parses added and removed counts", () => {
+        const statusMap = new Map<string, GitFileStatus>([["src/index.ts", "modified"]])
+        const output = "10\t5\tsrc/index.ts"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([
+          { path: "src/index.ts", added: 10, removed: 5, status: "modified" },
+        ])
+      })
+    })
+
+    describe("#when output has binary file markers", () => {
+      test("#then treats dash as 0", () => {
+        const statusMap = new Map<string, GitFileStatus>([["image.png", "added"]])
+        const output = "-\t-\timage.png"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([
+          { path: "image.png", added: 0, removed: 0, status: "added" },
+        ])
+      })
+    })
+
+    describe("#when output has multiple files", () => {
+      test("#then parses all entries", () => {
+        const statusMap = new Map<string, GitFileStatus>([
+          ["src/a.ts", "modified"],
+          ["src/b.ts", "added"],
+          ["src/c.ts", "deleted"],
+        ])
+        const output = "3\t1\tsrc/a.ts\n20\t0\tsrc/b.ts\n0\t15\tsrc/c.ts"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([
+          { path: "src/a.ts", added: 3, removed: 1, status: "modified" },
+          { path: "src/b.ts", added: 20, removed: 0, status: "added" },
+          { path: "src/c.ts", added: 0, removed: 15, status: "deleted" },
+        ])
+      })
+    })
+
+    describe("#when file is not in statusMap", () => {
+      test("#then defaults to modified status", () => {
+        const statusMap = new Map<string, GitFileStatus>()
+        const output = "5\t2\tsrc/unknown.ts"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([
+          { path: "src/unknown.ts", added: 5, removed: 2, status: "modified" },
+        ])
+      })
+    })
+
+    describe("#when line has fewer than 3 tab-separated parts", () => {
+      test("#then skips malformed lines", () => {
+        const statusMap = new Map<string, GitFileStatus>()
+        const output = "invalid line\n5\t2\tsrc/valid.ts\n\n"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([
+          { path: "src/valid.ts", added: 5, removed: 2, status: "modified" },
+        ])
+      })
+    })
+
+    describe("#when path contains tabs", () => {
+      test("#then only first two parts are stats, rest is path", () => {
+        const statusMap = new Map<string, GitFileStatus>()
+        const output = "1\t2\tpath\twith\ttabs"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result[0]!.path).toBe("path")
+        expect(result[0]!.added).toBe(1)
+        expect(result[0]!.removed).toBe(2)
+      })
+    })
+
+    describe("#when output has only empty lines", () => {
+      test("#then returns empty array", () => {
+        const statusMap = new Map<string, GitFileStatus>()
+        const output = "\n\n\n"
+        const result = parseGitDiffNumstat(output, statusMap)
+        expect(result).toEqual([])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add comprehensive test coverage for \src/shared/git-worktree/parse-diff-numstat.ts\.\n\n## Changes\n- Add src/shared/git-worktree/parse-diff-numstat.test.ts with 8 tests covering: empty output, single file with numeric stats, binary file markers (dash as 0), multiple files, missing statusMap entries defaulting to modified, malformed lines, paths with tabs, and empty-line-only output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add comprehensive tests for `parseGitDiffNumstat` to lock down parsing of empty output, numeric stats, binary markers, multiple files, missing status, malformed lines, tabbed paths, and empty-lines-only. Also fixes `AGENTS.md` by replacing file:// links with relative paths.

<sup>Written for commit 85a26848a11ec34ade0c5b5a6f10e2c1ab98ec07. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4557?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

