### PR TITLE
test(shared): add test coverage for contains-path

### DIFF
--- a/src/shared/contains-path.test.ts
+++ b/src/shared/contains-path.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "bun:test"
+import { join, resolve } from "path"
+
+import { containsPath, isWithinProject } from "./contains-path"
+
+describe("contains-path", () => {
+  describe("#given containsPath", () => {
+    describe("#when candidate is directly inside root", () => {
+      test("#then returns true", () => {
+        const root = resolve("/tmp/project")
+        const candidate = join(root, "src/index.ts")
+        expect(containsPath(root, candidate)).toBe(true)
+      })
+    })
+
+    describe("#when candidate is the root itself", () => {
+      test("#then returns true", () => {
+        const root = resolve("/tmp/project")
+        expect(containsPath(root, root)).toBe(true)
+      })
+    })
+
+    describe("#when candidate is outside root", () => {
+      test("#then returns false", () => {
+        const root = resolve("/tmp/project")
+        const candidate = resolve("/tmp/other-project/file.ts")
+        expect(containsPath(root, candidate)).toBe(false)
+      })
+    })
+
+    describe("#when candidate uses .. to escape root", () => {
+      test("#then returns false", () => {
+        const root = resolve("/tmp/project")
+        const candidate = join(root, "../other/file.ts")
+        expect(containsPath(root, candidate)).toBe(false)
+      })
+    })
+
+    describe("#when candidate is deeply nested inside root", () => {
+      test("#then returns true", () => {
+        const root = resolve("/tmp/project")
+        const candidate = join(root, "src/shared/utils/deep/file.ts")
+        expect(containsPath(root, candidate)).toBe(true)
+      })
+    })
+  })
+
+  describe("#given isWithinProject", () => {
+    describe("#when candidate is inside project root", () => {
+      test("#then returns true", () => {
+        const projectRoot = resolve("/tmp/my-project")
+        const candidate = join(projectRoot, "src/app.ts")
+        expect(isWithinProject(candidate, projectRoot)).toBe(true)
+      })
+    })
+
+    describe("#when candidate is outside project root", () => {
+      test("#then returns false", () => {
+        const projectRoot = resolve("/tmp/my-project")
+        const candidate = resolve("/tmp/elsewhere/file.ts")
+        expect(isWithinProject(candidate, projectRoot)).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add comprehensive test coverage for \src/shared/contains-path.ts\.\n\n## Changes\n- Add src/shared/contains-path.test.ts with 7 tests covering containsPath and isWithinProject: candidate inside root, candidate is root itself, candidate outside root, candidate escaping with .., deeply nested paths, and isWithinProject wrapper for both inside/outside cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for containsPath and isWithinProject to cover in-root, root-equal, out-of-root, path-escape via .., and deep nesting cases. Improves confidence in path containment logic and guards against directory traversal regressions.

<sup>Written for commit 97f1f171b8fb6afe246a6241d1c30f96cf55a31d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4559?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

