### PR TITLE
test(shared): add tests for isTaskSystemEnabled utility

### DIFF
--- a/src/shared/task-system-enabled.test.ts
+++ b/src/shared/task-system-enabled.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test"
+import { isTaskSystemEnabled, type TaskSystemConfig } from "./task-system-enabled"
+
+describe("isTaskSystemEnabled", () => {
+  describe("#given config with experimental.task_system enabled", () => {
+    test("#when task_system is true #then returns true", () => {
+      const config: TaskSystemConfig = {
+        experimental: {
+          task_system: true,
+        },
+      }
+      expect(isTaskSystemEnabled(config)).toBe(true)
+    })
+  })
+
+  describe("#given config with experimental.task_system disabled", () => {
+    test("#when task_system is false #then returns false", () => {
+      const config: TaskSystemConfig = {
+        experimental: {
+          task_system: false,
+        },
+      }
+      expect(isTaskSystemEnabled(config)).toBe(false)
+    })
+  })
+
+  describe("#given config with missing experimental property", () => {
+    test("#when experimental is undefined #then returns false", () => {
+      const config: TaskSystemConfig = {}
+      expect(isTaskSystemEnabled(config)).toBe(false)
+    })
+  })
+
+  describe("#given config with experimental but missing task_system", () => {
+    test("#when task_system is undefined #then returns false", () => {
+      const config: TaskSystemConfig = {
+        experimental: {},
+      }
+      expect(isTaskSystemEnabled(config)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds 4 tests for src/shared/task-system-enabled.ts covering:
- task_system: true returns true
- task_system: false returns false
- Missing experimental field returns false
- Missing task_system field returns false

## Testing
```nbun test src/shared/task-system-enabled.test.ts
4 pass, 0 fail
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `isTaskSystemEnabled` verifying enabled, disabled, and missing config cases. Improves coverage and guards against regressions in task system flag parsing.

<sup>Written for commit 0c7dfff04e7997b330ce71a0dbba526551a95fc0. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4562?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

