### PR TITLE
fix(skill): include OpenCode host skills.paths in skill tool discovery

### DIFF
--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -1,6 +1,7 @@
 import type { OhMyOpenCodeConfig } from "./config"
 import type { ModelCacheState } from "./plugin-state"
 import type { PluginContext, TmuxConfig } from "./plugin/types"
+import type { SkillsConfig } from "./config/schema/skills"
 
 import type { SubagentSessionCreatedEvent } from "./features/background-agent"
 import { BackgroundManager } from "./features/background-agent"
@@ -52,9 +53,10 @@ export function createManagers(args: {
   tmuxConfig: TmuxConfig
   modelCacheState: ModelCacheState
   backgroundNotificationHookEnabled: boolean
+  hostSkillConfigRef?: { config: SkillsConfig | undefined }
   deps?: Partial<CreateManagersDeps>
 }): Managers {
-  const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled } = args
+  const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled, hostSkillConfigRef } = args
   const deps = { ...defaultCreateManagersDeps, ...args.deps }
 
   // Only mark the server as in-process when the SDK actually exposes a
@@ -151,6 +153,7 @@ export function createManagers(args: {
     ctx: { directory: ctx.directory, client: ctx.client },
     pluginConfig,
     modelCacheState,
+    hostSkillConfigRef,
   })
   return {
     tmuxSessionManager,

--- a/src/create-tools.ts
+++ b/src/create-tools.ts
@@ -4,6 +4,7 @@ import type { BrowserAutomationProvider } from "./config/schema/browser-automati
 import type { LoadedSkill } from "./features/opencode-skill-loader/types"
 import type { PluginContext, ToolsRecord } from "./plugin/types"
 import type { Managers } from "./create-managers"
+import type { SkillsConfig } from "./config/schema/skills"
 
 import { createAvailableCategories } from "./plugin/available-categories"
 import { createSkillContext } from "./plugin/skill-context"
@@ -23,8 +24,9 @@ export async function createTools(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
   managers: Pick<Managers, "backgroundManager" | "tmuxSessionManager" | "skillMcpManager" | "modelFallbackControllerAccessor">
+  hostSkillConfigRef?: { config: SkillsConfig | undefined }
 }): Promise<CreateToolsResult> {
-  const { ctx, pluginConfig, managers } = args
+  const { ctx, pluginConfig, managers, hostSkillConfigRef } = args
 
   const skillContext = await createSkillContext({
     directory: ctx.directory,
@@ -39,6 +41,7 @@ export async function createTools(args: {
     managers,
     skillContext,
     availableCategories,
+    hostSkillConfigRef,
   })
 
   return {

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -10,6 +10,8 @@ import { applyProviderConfig } from "./provider-config-handler";
 import { loadPluginComponents } from "./plugin-components-loader";
 import { applyToolConfig } from "./tool-config-handler";
 import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
+import { adaptHostSkillConfig } from "../shared/host-skill-config"
+import type { SkillsConfig } from "../config/schema/skills"
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
@@ -29,6 +31,7 @@ export interface ConfigHandlerDeps {
   ctx: { directory: string; client?: any };
   pluginConfig: OhMyOpenCodeConfig;
   modelCacheState: ModelCacheState;
+  hostSkillConfigRef?: { config: SkillsConfig | undefined };
 }
 
 export function createConfigHandler(deps: ConfigHandlerDeps) {
@@ -61,6 +64,16 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     await applyCommandConfig({ config, pluginConfig, ctx, pluginComponents });
 
     config.formatter = formatterConfig;
+
+    if (deps.hostSkillConfigRef) {
+      log("[config-handler] inspecting config.skills from OpenCode", {
+        keys: typeof config.skills === "object" && config.skills !== null ? Object.keys(config.skills as object) : [],
+        type: typeof config.skills,
+        isArray: Array.isArray(config.skills),
+        preview: typeof config.skills === "object" ? JSON.stringify(config.skills).slice(0, 500) : String(config.skills),
+      })
+      deps.hostSkillConfigRef.config = adaptHostSkillConfig(config.skills)
+    }
 
     log("[config-handler] config handler applied", {
       agentCount: Object.keys(agentResult).length,

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -49,6 +49,7 @@ import { isTaskSystemEnabled, log } from "../shared"
 import type { Managers } from "../create-managers"
 import type { SkillContext } from "./skill-context"
 import { normalizeToolArgSchemas } from "./normalize-tool-arg-schemas"
+import type { SkillsConfig } from "../config/schema/skills"
 
 type ToolRegistryFactories = {
   createBackgroundTools: typeof createBackgroundTools
@@ -182,6 +183,7 @@ export function createToolRegistry(args: {
   availableCategories: AvailableCategory[]
   interactiveBashEnabled?: boolean
   toolFactories?: Partial<ToolRegistryFactories>
+  hostSkillConfigRef?: { config: SkillsConfig | undefined }
 }): ToolRegistryResult {
   const {
     ctx,
@@ -191,6 +193,7 @@ export function createToolRegistry(args: {
     availableCategories,
     interactiveBashEnabled = isInteractiveBashEnabled(),
     toolFactories,
+    hostSkillConfigRef,
   } = args
   const factories: ToolRegistryFactories = {
     ...defaultToolRegistryFactories,
@@ -283,6 +286,7 @@ export function createToolRegistry(args: {
     browserProvider: skillContext.browserProvider,
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
     nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    hostSkillConfigRef,
     pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
   })

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -133,18 +133,22 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
 
     const modelCacheState = deps.createModelCacheState()
 
+    const hostSkillConfigRef: { config: any } = { config: undefined }
+
     const managers = deps.createManagers({
       ctx: input,
       pluginConfig,
       tmuxConfig,
       modelCacheState,
       backgroundNotificationHookEnabled: isHookEnabled("background-notification"),
+      hostSkillConfigRef,
     })
 
     const toolsResult = await deps.createTools({
       ctx: input,
       pluginConfig,
       managers,
+      hostSkillConfigRef,
     })
 
     const hooks = deps.createHooks({

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -24,6 +24,7 @@ import {
   mergeNativeSkillInfos,
   mergeNativeSkills,
 } from "./native-skills"
+import { discoverConfigSourceSkills } from "../../features/opencode-skill-loader"
 
 export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
   let cachedDescription: string | null = null
@@ -45,6 +46,23 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
       try {
         const nativeAll = await options.nativeSkills.all()
         mergeNativeSkills(allSkills, nativeAll)
+      } catch {
+      }
+    }
+
+    if (options.hostSkillConfigRef?.config) {
+      try {
+        const hostSkills = await discoverConfigSourceSkills({
+          config: options.hostSkillConfigRef.config,
+          configDir: options.directory,
+        })
+        const knownNames = new Set(allSkills.map((s) => s.name))
+        for (const skill of hostSkills) {
+          if (!knownNames.has(skill.name)) {
+            allSkills.push(skill)
+            knownNames.add(skill.name)
+          }
+        }
       } catch {
       }
     }

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -2,6 +2,7 @@ import type { SkillScope, LoadedSkill } from "../../features/opencode-skill-load
 import type { SkillMcpManager } from "../../features/skill-mcp-manager"
 import type { BrowserAutomationProvider, GitMasterConfig } from "../../config/schema"
 import type { CommandInfo } from "../slashcommand/types"
+import type { SkillsConfig } from "../../config/schema/skills"
 
 export interface SkillArgs {
   name: string
@@ -49,4 +50,7 @@ export interface SkillLoadOptions {
     get(name: string): { name: string; description: string; location: string; content: string } | undefined | Promise<{ name: string; description: string; location: string; content: string } | undefined>
     dirs(): string[] | Promise<string[]>
   }
+  /** Shared reference populated by the config hook with host skills config from OpenCode's params.config.skills.
+   *  When set, getSkills() discovers skills from these paths in addition to the hardcoded discovery sources. */
+  hostSkillConfigRef?: { config: SkillsConfig | undefined }
 }


### PR DESCRIPTION
## Summary

The skill tool registered by oh-my-openagent replaces OpenCode's native skill tool. While oh-my-openagent discovers skills from its own hardcoded paths (`.opencode/skills/`, `.agents/skills/`, `.claude/skills/`) and `skills.sources` config, it does not discover skills declared in OpenCode's `skills.paths` config (e.g. `["./skills"]`).

The `nativeSkills` mechanism (PluginInput.skills) designed for this is non-functional in OpenCode v1.15.10 — the field does not exist in PluginInput. agent-config-handler.ts and command-config-handler.ts both use adaptHostSkillConfig() on params.config.skills, but the skill tool's path was missing this.

## Changes

Introduce a shared ref populated by the config hook and read by the skill tool at execute time:

- SkillLoadOptions.hostSkillConfigRef: mutable ref for host skill config
- config-handler.ts populates ref via adaptHostSkillConfig(config.skills)
- getSkills() discovers host skills via discoverConfigSourceSkills when ref is populated; invalidates description cache on new discoveries
- No file reading — data flows from OpenCode's config hook

## Testing

Verified with opencode run: project skills (twitter-daily, reading-list-update) under ./skills/ are discovered and loadable.

params.config.skills = `{ "paths": ["./skills"] }`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skill discovery so the `oh-my-openagent` skill tool also loads skills defined in OpenCode `skills.paths` (e.g., ./skills). This makes project skills visible without relying on the broken `nativeSkills` path.

- **Bug Fixes**
  - Added a shared `hostSkillConfigRef` populated by the config hook via `adaptHostSkillConfig(config.skills)`.
  - Threaded the ref through managers/tools/registry into the skill tool.
  - Skill tool now uses `discoverConfigSourceSkills` to include host-defined skills alongside hardcoded paths and `skills.sources`.
  - No direct file reads; data comes from the OpenCode config hook.

<sup>Written for commit 16ced7233e399dae50999ba7a52943e756464dff. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4566?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

