### PR TITLE
fix(keyword-detector): avoid duplicate mode prompt injection

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -28,6 +28,8 @@ const injectedModeMarkers: Partial<Record<DetectedKeyword["type"], string>> = {
   search: "[search-mode]",
   analyze: "[analyze-mode]",
   team: "[team-mode]",
+  hyperplan: "<hyperplan-mode>",
+  "hyperplan-ultrawork": "<hyperplan-ultrawork-mode>",
 }
 
 function hasInjectedModePrompt(text: string, type: DetectedKeyword["type"]): boolean {

--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -24,8 +24,10 @@ import { detectKeywordsWithType, extractPromptText, looksLikeSlashCommand } from
 const defaultModeUltraworkInjectedSessions = new Set<string>()
 const keywordInjectionSeparator = "\n\n---\n\n"
 const injectedModeMarkers: Partial<Record<DetectedKeyword["type"], string>> = {
+  ultrawork: "<ultrawork-mode>",
   search: "[search-mode]",
   analyze: "[analyze-mode]",
+  team: "[team-mode]",
 }
 
 function hasInjectedModePrompt(text: string, type: DetectedKeyword["type"]): boolean {

--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -22,6 +22,40 @@ import type { DetectedKeyword } from "./detector"
 import { detectKeywordsWithType, extractPromptText, looksLikeSlashCommand } from "./detector"
 
 const defaultModeUltraworkInjectedSessions = new Set<string>()
+const keywordInjectionSeparator = "\n\n---\n\n"
+const injectedModeMarkers: Partial<Record<DetectedKeyword["type"], string>> = {
+  search: "[search-mode]",
+  analyze: "[analyze-mode]",
+}
+
+function hasInjectedModePrompt(text: string, type: DetectedKeyword["type"]): boolean {
+  const marker = injectedModeMarkers[type]
+  return marker ? text.includes(marker) : false
+}
+
+function stripLeadingInjectedModePrompts(text: string): string {
+  let remaining = text
+
+  while (true) {
+    const separatorIndex = remaining.indexOf(keywordInjectionSeparator)
+    if (separatorIndex === -1) return remaining
+
+    const prefix = remaining.slice(0, separatorIndex)
+    const hasKnownModePrompt = Object.values(injectedModeMarkers).some(
+      (marker) => marker !== undefined && prefix.includes(marker),
+    )
+    if (!hasKnownModePrompt) return remaining
+
+    remaining = remaining.slice(separatorIndex + keywordInjectionSeparator.length)
+  }
+}
+
+function filterAlreadyInjectedModePrompts(
+  detectedKeywords: DetectedKeyword[],
+  promptText: string,
+): DetectedKeyword[] {
+  return detectedKeywords.filter((keyword) => !hasInjectedModePrompt(promptText, keyword.type))
+}
 
 function suppressComboStandalones(detected: DetectedKeyword[]): DetectedKeyword[] {
   const hasCombo = detected.some((k) => k.type === "hyperplan-ultrawork")
@@ -85,8 +119,9 @@ export function createKeywordDetectorHook(
       }
 
       const cleanText = removeSystemReminders(promptText)
+      const userIntentText = stripLeadingInjectedModePrompts(cleanText)
       const modelID = input.model?.modelID
-      let detectedKeywords = detectKeywordsWithType(cleanText, currentAgent, modelID, disabledKeywords, enabledExpansions)
+      let detectedKeywords = detectKeywordsWithType(userIntentText, currentAgent, modelID, disabledKeywords, enabledExpansions)
       detectedKeywords = suppressComboStandalones(detectedKeywords)
 
       if (isPlannerAgent(currentAgent)) {
@@ -146,6 +181,12 @@ export function createKeywordDetectorHook(
           })
           return
         }
+      }
+
+      detectedKeywords = filterAlreadyInjectedModePrompts(detectedKeywords, cleanText)
+      if (detectedKeywords.length === 0) {
+        log(`[keyword-detector] Skipping already injected keyword prompts`, { sessionID: input.sessionID })
+        return
       }
 
       const hasUltrawork = detectedKeywords.some((k) => k.type === "ultrawork")
@@ -225,7 +266,7 @@ export function createKeywordDetectorHook(
       const allMessages = detectedKeywords.map((k) => k.message).join("\n\n")
       const originalText = output.parts[textPartIndex].text ?? ""
 
-      output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
+      output.parts[textPartIndex].text = `${allMessages}${keywordInjectionSeparator}${originalText}`
 
       log(`[keyword-detector] Detected ${detectedKeywords.length} keywords`, {
         sessionID: input.sessionID,

--- a/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
+++ b/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
@@ -6,6 +6,10 @@ import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
+function countOccurrences(text: string, marker: string): number {
+  return text.split(marker).length - 1
+}
+
 describe("keyword-detector hyperplan-ultrawork combo", () => {
   let logSpy: ReturnType<typeof spyOn>
   let getMainSessionSpy: ReturnType<typeof spyOn>
@@ -53,6 +57,28 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
     expect(textPart!.text).toContain("<ultrawork-mode>")
     expect(textPart!.text).toContain("refactor the auth module")
+  })
+
+  test("should not duplicate combo mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received combo mode instructions
+    const sessionID = "combo-idempotency-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "hpp ulw review the auth plan" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - combo and embedded ultrawork blocks are not prepended again
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("hpp ulw review the auth plan")
+    expect(countOccurrences(textPart!.text ?? "", "<hyperplan-ultrawork-mode>")).toBe(1)
+    expect(countOccurrences(textPart!.text ?? "", "<ultrawork-mode>")).toBe(1)
   })
 
   test("should inject combo message when user types 'ulw hpp' (reverse order)", async () => {

--- a/src/hooks/keyword-detector/hyperplan.test.ts
+++ b/src/hooks/keyword-detector/hyperplan.test.ts
@@ -5,6 +5,10 @@ import { setMainSession, _resetForTesting } from "../../features/claude-code-ses
 import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
 
+function countOccurrences(text: string, marker: string): number {
+  return text.split(marker).length - 1
+}
+
 describe("keyword-detector hyperplan keyword", () => {
   let logSpy: ReturnType<typeof spyOn>
   let getMainSessionSpy: ReturnType<typeof spyOn>
@@ -61,6 +65,27 @@ describe("keyword-detector hyperplan keyword", () => {
     expect(textPart!.text).toContain("enabled")
     expect(textPart!.text).toContain("refactor the auth module")
     expect(textPart!.text).toContain("---")
+  })
+
+  test("should not duplicate hyperplan-mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received hyperplan mode instructions
+    const sessionID = "hyperplan-idempotency-session"
+    getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+    const hook = createKeywordDetectorHook(createMockPluginInput())
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "hyperplan review the auth plan" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - the hyperplan mode block is not prepended again
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("hyperplan review the auth plan")
+    expect(countOccurrences(textPart!.text ?? "", "<hyperplan-mode>")).toBe(1)
   })
 
   test("should inject hyperplan message when user types 'hpp' shorthand", async () => {

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -164,6 +164,48 @@ describe("keyword-detector message transform", () => {
     expect(countOccurrences(textPart!.text ?? "", "[analyze-mode]")).toBe(1)
   })
 
+  test("should not duplicate team-mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received team mode instructions
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "team-idempotency-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "team mode coordinate this fix" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - the team mode block is not prepended again
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("team mode coordinate this fix")
+    expect(countOccurrences(textPart!.text ?? "", "[team-mode]")).toBe(1)
+  })
+
+  test("should not duplicate ultrawork-mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received ultrawork mode instructions
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "ultrawork-idempotency-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ultrawork fix duplicate keyword prompts" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - the ultrawork mode block is not prepended again
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("ultrawork fix duplicate keyword prompts")
+    expect(countOccurrences(textPart!.text ?? "", "<ultrawork-mode>")).toBe(1)
+  })
+
   test("should not trigger search-mode from an existing analyze-mode block on resend", async () => {
     // given - analyze mode prompt text contains search-related tooling words
     const collector = new ContextCollector()

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -12,6 +12,10 @@ import { createKeywordDetectorHook } from "./index"
 
 type ToastOptions = { body: { title: string } }
 
+function countOccurrences(text: string, marker: string): number {
+  return text.split(marker).length - 1
+}
+
 function createPluginInputWithToast(showToast: (options: ToastOptions) => Promise<void>): PluginInput {
   const client = {} as PluginInput["client"]
   Object.assign(client, { tui: { showToast } })
@@ -25,6 +29,7 @@ function createPluginInputWithToast(showToast: (options: ToastOptions) => Promis
     },
     directory: "/tmp/keyword-detector-test",
     worktree: "/tmp/keyword-detector-test",
+    experimental_workspace: { register: () => {} },
     serverUrl: new URL("http://localhost"),
     $: {} as PluginInput["$"],
   }
@@ -115,6 +120,92 @@ describe("keyword-detector message transform", () => {
     expect(textPart!.text).toContain("Evaluate available skills before dispatch")
     expect(textPart!.text).toContain("pass [] ONLY when no skill matches")
     expect(textPart!.text).not.toContain("ALWAYS include load_skills=[]")
+  })
+
+  test("should not duplicate search-mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received search mode instructions
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "search-idempotency-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "search for the duplicate keyword prompt bug" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - the user intent remains, but only one search block is present
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("search for the duplicate keyword prompt bug")
+    expect(countOccurrences(textPart!.text ?? "", "[search-mode]")).toBe(1)
+  })
+
+  test("should not duplicate analyze-mode when an injected prompt is processed again", async () => {
+    // given - a prompt already received analyze mode instructions
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "analyze-idempotency-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "investigate why keyword prompts duplicate" }],
+    }
+
+    // when - keyword detection runs twice, like edit/resend can do
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - the injected analyze prompt is not prepended again
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("investigate why keyword prompts duplicate")
+    expect(countOccurrences(textPart!.text ?? "", "[analyze-mode]")).toBe(1)
+  })
+
+  test("should not trigger search-mode from an existing analyze-mode block on resend", async () => {
+    // given - analyze mode prompt text contains search-related tooling words
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "analyze-does-not-trigger-search-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "investigate the duplicate keyword prompt" }],
+    }
+
+    // when - keyword detection sees the already-injected analyze prompt again
+    await hook["chat.message"]({ sessionID }, output)
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - analyze remains single and search is not inferred from the mode block
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(countOccurrences(textPart!.text ?? "", "[analyze-mode]")).toBe(1)
+    expect(textPart!.text).not.toContain("[search-mode]")
+  })
+
+  test("should add newly requested analyze-mode while preserving existing search-mode once", async () => {
+    // given - a previously injected search prompt is edited to add analyze intent
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "search-then-analyze-edit-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "search for keyword detector code" }],
+    }
+
+    // when - the edited prompt keeps the search block but adds investigate text
+    await hook["chat.message"]({ sessionID }, output)
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    textPart!.text = `${textPart!.text}\nThen investigate why it duplicates.`
+    await hook["chat.message"]({ sessionID }, output)
+
+    // then - only the newly requested analyze mode is added
+    expect(countOccurrences(textPart!.text ?? "", "[search-mode]")).toBe(1)
+    expect(countOccurrences(textPart!.text ?? "", "[analyze-mode]")).toBe(1)
+    expect(textPart!.text).toContain("Then investigate why it duplicates.")
   })
 
   test("should NOT transform when no keywords detected", async () => {


### PR DESCRIPTION
## Summary
Fixes duplicate keyword mode prompt injection when an edited/resubmitted prompt already contains injected `[search-mode]` or `[analyze-mode]` blocks.

## Changes
- Strips leading already-injected search/analyze mode prompt blocks before keyword detection.
- Skips reinjecting a mode marker that is already present in the current prompt text.
- Adds regression coverage for search/analyze edit-resend idempotency and adjacent mode behavior.
- Updates the keyword-detector test PluginInput mock for the latest OpenCode plugin contract.

## Testing
- `lsp_diagnostics` on changed files: pass
- `bun test src/hooks/keyword-detector/index.test.ts`: pass, 51 tests
- `bun run typecheck`: pass
- `bun run build`: pass
- `git diff --check`: pass

## Notes
Full `bun test` currently has unrelated environment/existing failures: package dry-run tests timeout at 5s during nested build, and one delegate-task test expects an external `agent-browser` skill fixture that is not available locally.

## Merge Policy
Target is `dev`. This repository requires merge commits for PRs into `dev`; do not squash or rebase merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate mode prompt injection on edit/resend. Now handles search, analyze, team, ultrawork, hyperplan, and the hyperplan+ultrawork combo by stripping injected blocks and skipping reinjection.

- **Bug Fixes**
  - Strip leading injected mode blocks using the shared `---` separator before keyword detection.
  - Filter out keywords already present in the prompt and early-return when nothing new is needed.
  - Handle all modes: [search-mode], [analyze-mode], [team-mode], <ultrawork-mode>, <hyperplan-mode>, <hyperplan-ultrawork-mode>.
  - Expand tests for resend idempotency across all modes (incl. hyperplan and combo); cover analyze not triggering search from its own block and search→analyze edits; update test `PluginInput` mock to the latest plugin contract.

<sup>Written for commit c052be74dd4514b3d0d857bd8a910f3e72101003. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4569?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

