### PR TITLE
fix(agents): deduplicate discovered skills before agent prompt render (fixes #4573)

### DIFF
--- a/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
+++ b/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
@@ -168,4 +168,39 @@ describe("applyAgentConfig .agents skills", () => {
     // then - called twice: once for pluginConfig.skills, once for host config.skills
     expect(discoverConfigSourceSkillsSpy).toHaveBeenCalledTimes(2)
   })
+
+  test("deduplicates skills discovered from multiple paths before passing to builtin agents (#4573)", async () => {
+    // given - same skill name reaches the agent prompt from two discovery paths,
+    // mirroring `npx skills add ...` which installs into ~/.agents/skills/ and
+    // creates symlinks at ~/.claude/skills/
+    discoverUserClaudeSkillsSpy.mockResolvedValue([
+      {
+        name: "lark-mail",
+        definition: { name: "lark-mail", template: "claude-user" },
+        scope: "user",
+      },
+    ])
+    discoverGlobalAgentsSkillsSpy.mockResolvedValue([
+      {
+        name: "lark-mail",
+        definition: { name: "lark-mail", template: "agents-user" },
+        scope: "user",
+      },
+    ])
+
+    // when
+    await applyAgentConfig({
+      config: { model: "anthropic/claude-opus-4-7", agent: {} },
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp/project" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then - createBuiltinAgents must receive each skill name only once so the
+    // **YOUR SKILLS (PRIORITY)** prompt line does not render duplicates
+    const discoveredSkills = createBuiltinAgentsSpy.mock.calls[0]?.[6] as Array<{ name: string }>
+    const names = discoveredSkills.map((skill) => skill.name)
+    const larkMailCount = names.filter((name) => name === "lark-mail").length
+    expect(larkMailCount).toBe(1)
+  })
 })

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -11,6 +11,7 @@ import { AGENT_NAME_MAP } from "../shared/migration";
 import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
+  deduplicateSkillsByName,
   discoverConfigSourceSkills,
   discoverGlobalAgentsSkills,
   discoverOpencodeGlobalSkills,
@@ -94,7 +95,15 @@ export async function applyAgentConfig(params: {
     includeClaudeSkillsForAwareness ? discoverGlobalAgentsSkills() : Promise.resolve([]),
   ]);
 
-  const allDiscoveredSkills = [
+  // Same skill name reaches the agent prompt through multiple discovery paths
+  // (e.g. ~/.agents/skills/foo with a symlink at ~/.claude/skills/foo from
+  // `npx skills add ...`). Without dedup the SisyphusKAtlasKHephaestus
+  // `**YOUR SKILLS (PRIORITY)**` line renders the same skill twice, which
+  // both confuses the agent and wastes 5-10k tokens per session for users
+  // with cross-installed skill ecosystems (issue #4573). `discoverAllSkills`
+  // already collapses duplicates via the same helper, so doing it here keeps
+  // both rendering paths agreeing on the skill set.
+  const allDiscoveredSkills = deduplicateSkillsByName([
     ...discoveredConfigSourceSkills,
     ...discoveredHostConfigSkills,
     ...discoveredOpencodeProjectSkills,
@@ -103,7 +112,7 @@ export async function applyAgentConfig(params: {
     ...discoveredOpencodeGlobalSkills,
     ...discoveredUserSkills,
     ...discoveredGlobalAgentsSkills,
-  ];
+  ]);
 
   const browserProvider =
     params.pluginConfig.browser_automation_engine?.provider ?? "playwright";


### PR DESCRIPTION
## Summary

Skill discovery walks seven scope-specific helpers, and when the same skill is reachable from more than one path (e.g. `npx skills add ...` installs into `~/.agents/skills/` and creates symlinks at `~/.claude/skills/`), the raw spread that built `allDiscoveredSkills` let every collision through to the agent prompt. The Sisyphus/Atlas/Hephaestus `**YOUR SKILLS (PRIORITY)**` line then rendered the same skill twice (once `(user)`, once `(project)`), wasting roughly 5-10k tokens per session for users with cross-installed skill ecosystems.

## Root Cause

`src/plugin-handlers/agent-config-handler.ts:97-106` concatenated the seven `discovered*Skills` arrays without deduplication. The cousin path that produces the `<available_items>` block (`discoverAllSkills` in `features/opencode-skill-loader/loader.ts`) already passes the same arrays through `deduplicateSkillsByName`, so the agent prompt was the only outlier.

## Changes

| File | Change |
|------|--------|
| `src/plugin-handlers/agent-config-handler.ts` | Import `deduplicateSkillsByName` from the skill-loader barrel and wrap the seven-way concat with it. |
| `src/plugin-handlers/agent-config-handler-agents-skills.test.ts` | New regression test: identical `lark-mail` returned from `discoverUserClaudeSkills` and `discoverGlobalAgentsSkills` is collapsed to a single entry passed into `createBuiltinAgents`. |

## Verification

TDD red-green for the new regression case in `agent-config-handler-agents-skills.test.ts`:

**RED (before fix, with `git stash` of the handler change):**
```
204 |     expect(larkMailCount).toBe(1)
                                ^
error: expect(received).toBe(expected)

Expected: 1
Received: 2

(fail) applyAgentConfig .agents skills > deduplicates skills discovered from multiple paths
        before passing to builtin agents (#4573) [15.00ms]

 4 pass
 1 fail
```

**GREEN (with the fix):**
```
 5 pass
 0 fail
 7 expect() calls
Ran 5 tests across 1 file. [422.00ms]
```

## Test

- New regression test: `src/plugin-handlers/agent-config-handler-agents-skills.test.ts` ("deduplicates skills discovered from multiple paths before passing to builtin agents (#4573)")
- Related suite: `bun test src/plugin-handlers/ src/features/opencode-skill-loader/ src/agents/builtin-agents/` -> **349 pass / 0 fail**
- Typecheck: `bun run typecheck` -> clean

Fixes #4573

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates skills discovered from all sources before building agent prompts so the same skill doesn’t render twice. Aligns the agent prompt path with `deduplicateSkillsByName` used by `<available_items>`, reducing wasted tokens. Fixes #4573.

- **Bug Fixes**
  - Apply `deduplicateSkillsByName` to the combined discovery arrays in `src/plugin-handlers/agent-config-handler.ts`.
  - Add a regression test to ensure `createBuiltinAgents` receives a single `lark-mail` when found via both `discoverUserClaudeSkills` and `discoverGlobalAgentsSkills`.

<sup>Written for commit d6351473b599ebc4d6ca3dd6c91194cc51bd30ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4574?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

