### PR TITLE
fix(agents): deduplicate availableSkills to prevent double rendering in prompts

### DIFF
--- a/src/agents/builtin-agents/available-skills.test.ts
+++ b/src/agents/builtin-agents/available-skills.test.ts
@@ -105,4 +105,19 @@ describe("buildAvailableSkills - agentName filtering", () => {
     expect(names).toContain("sisyphus-only")
     expect(names).not.toContain("oracle-only")
   })
+
+  it("deduplicates skills with discovered taking priority over builtin", () => {
+    // given: a discovered skill with same name as builtin
+    const discoveredSkills = [makeSkill("playwright")]
+    const disabledSkills = new Set<string>()
+
+    // when
+    const result = buildAvailableSkills(discoveredSkills, undefined, disabledSkills)
+
+    // then: only one "playwright" in result, from discovered (not duplicated)
+    const playwriteSkills = result.filter((s) => s.name === "playwright")
+    expect(playwriteSkills).toHaveLength(1)
+    // discovered skill should have location "user"
+    expect(playwriteSkills[0].location).toBe("user")
+  })
 })

--- a/src/agents/builtin-agents/available-skills.ts
+++ b/src/agents/builtin-agents/available-skills.ts
@@ -27,7 +27,7 @@ export function buildAvailableSkills(
 
   const discoveredAvailable: AvailableSkill[] = discoveredSkills
     .filter(s => {
-      if (builtinSkillNames.has(s.name) || disabledSkills?.has(s.name)) return false
+      if (disabledSkills?.has(s.name)) return false
       // If the skill declares an agent restriction and we know the current agent,
       // exclude skills that don't belong to this agent.
       if (agentName && s.definition.agent && s.definition.agent !== agentName) return false
@@ -39,5 +39,8 @@ export function buildAvailableSkills(
       location: mapScopeToLocation(skill.scope),
     }))
 
-  return [...builtinAvailable, ...discoveredAvailable]
+  const skillMap = new Map<string, AvailableSkill>()
+  builtinAvailable.forEach(skill => skillMap.set(skill.name, skill))
+  discoveredAvailable.forEach(skill => skillMap.set(skill.name, skill))
+  return Array.from(skillMap.values())
 }


### PR DESCRIPTION
## Summary

Fixes #4573

When the same skill exists in both builtin and discovered skill lists, it was rendered twice in agent prompts (Sisyphus/Atlas/Hephaestus).

## Root Cause

\uildAvailableSkills()\ in \src/agents/builtin-agents/available-skills.ts\ concatenated builtin and discovered skills without deduplication:

\\\	ypescript
return [...builtinAvailable, ...discoveredAvailable] // no dedup
\\\

## Fix

Use a Map keyed by skill name. Discovered skills take priority over builtin (matching the documented behavior that user-installed skills override built-in defaults).

## Testing

- Added test verifying duplicate skill names are deduplicated
- Discovered skills take priority over builtin when names conflict

Closes #4573

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicate available skills to stop duplicate entries in agent prompts (Sisyphus, Atlas, Hephaestus). Discovered skills now override built-ins when names match. Fixes #4573.

- **Bug Fixes**
  - Build `availableSkills` with a name-keyed Map; discovered entries replace built-ins.
  - Added a unit test asserting deduplication and that the surviving skill comes from "user".

<sup>Written for commit e67df0a29aebf8b23255971b143604e0582c1085. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4575?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

