### PR TITLE
fix(cli/run): inject server auth into client on fresh server start

### DIFF
--- a/src/cli/run/server-connection.test.ts
+++ b/src/cli/run/server-connection.test.ts
@@ -270,4 +270,19 @@ describe("createServerConnection", () => {
     // then
     expect(mockServerClose).not.toHaveBeenCalled()
   })
+
+  it("fresh server start injects auth into client", async () => {
+    // given
+    const signal = new AbortController().signal
+    mockIsPortAvailable.mockResolvedValueOnce(true)
+
+    // when
+    const result = await createServerConnection({ port: 8080, signal })
+
+    // then
+    expect(mockInjectServerAuthIntoClient).toHaveBeenCalledTimes(1)
+    expect(mockInjectServerAuthIntoClient).toHaveBeenCalledWith(result.client)
+    result.cleanup()
+    expect(mockServerClose).toHaveBeenCalled()
+  })
 })

--- a/src/cli/run/server-connection.ts
+++ b/src/cli/run/server-connection.ts
@@ -75,6 +75,7 @@ async function startServer<TClient>(
     deps.createOpencode({ signal, port, hostname: "127.0.0.1" }),
   )
 
+  deps.injectServerAuthIntoClient(client)
   console.log(pc.dim("Server listening at"), pc.cyan(server.url))
   return { client, cleanup: () => server.close() }
 }


### PR DESCRIPTION
## Summary

Fixes #4572

When \oh-my-opencode run\ starts a fresh OpenCode server (no \--attach\), the SDK client was created without auth headers injected, causing 401 Unauthorized on the first API call.

## Root Cause

In \src/cli/run/server-connection.ts\, the \startServer()\ function creates a client via \deps.createOpencode()\ but never calls \deps.injectServerAuthIntoClient(client)\. All attach paths correctly inject auth, but the fresh-start path was missing it.

## Fix

Added \deps.injectServerAuthIntoClient(client)\ in \startServer()\ after the server is created.

## Testing

- Added test verifying auth is injected when starting a fresh server
- All existing tests pass

Closes #4572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects server auth into the SDK client when `oh-my-opencode run` starts a fresh server, preventing 401s on the first API call. Adds a unit test to verify auth is injected on fresh start.

<sup>Written for commit d74a0b35e5fe1b8ae1cbea82e1b3624618833a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4577?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

