### PR TITLE
fix(background-agent): validate output before completing task on terminal session status

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.polling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.test.ts
@@ -449,6 +449,66 @@ describe("BackgroundManager pollRunningTasks", () => {
       expect(task.completedAt).toBeDefined()
     })
 
+    test('#when session status is "interrupted" but no output exists #then marks task as error', async () => {
+      //#given
+      const manager = createManagerWithClient({
+        status: async () => ({ data: { "ses-interrupted-no-output": { type: "interrupted" } } }),
+        messages: async () => ({ data: [] }),
+      })
+      const task = createRunningTask("ses-interrupted-no-output")
+      injectTask(manager, task)
+
+      //#when
+      const poll = manager["pollRunningTasks"]
+      await poll.call(manager)
+      await manager.shutdown()
+
+      //#then
+      expect(task.status).toBe("error")
+      expect(task.error).toBeDefined()
+      expect(task.error).toContain("terminated without producing any output")
+    })
+
+    test('#when session status is "interrupted" but no output exists #then marks task as error', async () => {
+      //#given
+      const manager = createManagerWithClient({
+        status: async () => ({ data: { "ses-interrupted-no-output": { type: "interrupted" } } }),
+        messages: async () => ({ data: [] }),
+      })
+      const task = createRunningTask("ses-interrupted-no-output")
+      injectTask(manager, task)
+
+      //#when
+      const poll = manager["pollRunningTasks"]
+      await poll.call(manager)
+      await manager.shutdown()
+
+      //#then
+      expect(task.status).toBe("error")
+      expect(task.error).toBeDefined()
+      expect(task.error ?? "").toContain("terminated without producing any output")
+    })
+
+    test('#when session status is "interrupted" but no output exists #then marks task as error', async () => {
+      //#given
+      const manager = createManagerWithClient({
+        status: async () => ({ data: { "ses-interrupted-no-output": { type: "interrupted" } } }),
+        messages: async () => ({ data: [] }),
+      })
+      const task = createRunningTask("ses-interrupted-no-output")
+      injectTask(manager, task)
+
+      //#when
+      const poll = manager["pollRunningTasks"]
+      await poll.call(manager)
+      await manager.shutdown()
+
+      //#then
+      expect(task.status).toBe("error")
+      expect(task.error).toBeDefined()
+      expect(typeof task.error === "string" && task.error.includes("terminated without producing any output")).toBe(true)
+    })
+
     test('#when session status is an unknown type #then completes the task', async () => {
       //#given
       const manager = createManagerWithClient({

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -2895,6 +2895,12 @@ The task was re-queued on a fallback model after a retryable failure.
           }
 
           if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
+            const hasValidOutput = await this.validateSessionHasOutput(sessionID)
+            if (!hasValidOutput) {
+              log("[background-agent] Terminal session status but no valid output yet, marking as error:", task.id)
+              await this.failCrashedTask(task, "Subagent session terminated without producing any output.")
+              continue
+            }
             await this.tryCompleteTask(task, `polling (terminal session status: ${sessionStatus.type})`)
             continue
           }


### PR DESCRIPTION
## Summary

Fixes #4570

Background tasks could be marked as completed even when the subagent never started the LLM. This happened when a session received a terminal status (e.g. 'interrupted') before producing any output.

## Root Cause

In \pollRunningTasks()\, the terminal session status path called \	ryCompleteTask()\ directly without first checking \alidateSessionHasOutput()\. The idle/gone path already had this guard, but the terminal status path was missing it.

## Fix

Added \alidateSessionHasOutput()\ check before \	ryCompleteTask()\ on the terminal session status path. If no output exists, the task is marked as error instead of completed.

## Testing

- Added test: task with terminal session status but no output is marked as error
- All existing tests pass

Closes #4570

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents background tasks from being marked completed when a subagent session reaches a terminal status (e.g., "interrupted") without producing any output. Such tasks are now marked as error instead. Addresses #4570.

- **Bug Fixes**
  - In `pollRunningTasks`, validate output with `validateSessionHasOutput` before calling `tryCompleteTask` for terminal statuses.
  - If no output exists, call `failCrashedTask` with "Subagent session terminated without producing any output."; added tests to assert error presence and message content.

<sup>Written for commit 40831a7d259b82834ebad95699cec21be5f41310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

