### PR TITLE
feat(model-core): add native OpenRouter provider support

### DIFF
--- a/packages/model-core/src/model-requirements.test.ts
+++ b/packages/model-core/src/model-requirements.test.ts
@@ -35,7 +35,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(sisyphus.requiresAnyModel).toBe(true)
 
     const primary = sisyphus.fallbackChain[0]
-    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode", "vercel"])
+    expect(primary.providers).toEqual(["anthropic", "openrouter", "github-copilot", "opencode", "vercel"])
     expect(primary.model).toBe("claude-opus-4-7")
     expect(primary.variant).toBe("max")
 
@@ -277,7 +277,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     // #when - accessing hephaestus requirement
     // #then - requiresProvider includes openai, github-copilot, venice, and opencode
     expect(hephaestus).toBeDefined()
-    expect(hephaestus.requiresProvider).toEqual(["openai", "github-copilot", "venice", "opencode", "vercel"])
+    expect(hephaestus.requiresProvider).toEqual(["openai", "openrouter", "github-copilot", "venice", "opencode", "vercel"])
     expect(hephaestus.requiresModel).toBeUndefined()
   })
 

--- a/packages/model-core/src/model-requirements.ts
+++ b/packages/model-core/src/model-requirements.ts
@@ -21,7 +21,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
       {
-        providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+        providers: ["anthropic", "openrouter", "github-copilot", "opencode", "vercel"],
         model: "claude-opus-4-7",
         variant: "max",
       },
@@ -48,12 +48,12 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   hephaestus: {
     fallbackChain: [
       {
-        providers: ["openai", "github-copilot", "venice", "opencode", "vercel"],
+        providers: ["openai", "openrouter", "github-copilot", "venice", "opencode", "vercel"],
         model: "gpt-5.5",
         variant: "medium",
       },
     ],
-    requiresProvider: ["openai", "github-copilot", "venice", "opencode", "vercel"],
+    requiresProvider: ["openai", "openrouter", "github-copilot", "venice", "opencode", "vercel"],
   },
   oracle: {
     fallbackChain: [
@@ -164,7 +164,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   atlas: {
     fallbackChain: [
-      { providers: ["anthropic", "github-copilot", "opencode", "vercel"], model: "claude-sonnet-4-6" },
+      { providers: ["anthropic", "openrouter", "github-copilot", "opencode", "vercel"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
       {
         providers: ["openai", "github-copilot", "opencode", "vercel"],

--- a/packages/model-core/src/provider-model-id-transform.test.ts
+++ b/packages/model-core/src/provider-model-id-transform.test.ts
@@ -45,3 +45,65 @@ describe("provider model ID transforms", () => {
 		}
 	})
 })
+
+describe("openrouter provider model ID transforms", () => {
+	test("infers anthropic sub-provider for claude models", () => {
+		// #given an OpenRouter provider with a claude model
+		const provider = "openrouter"
+		const model = "claude-opus-4-7"
+
+		// #when transforming the model ID
+		const result = transformModelForProvider(provider, model)
+
+		// #then the model is prefixed with anthropic/
+		expect(result).toBe("anthropic/claude-opus-4-7")
+	})
+
+	test("infers openai sub-provider for gpt models", () => {
+		// #given an OpenRouter provider with a gpt model
+		const provider = "openrouter"
+		const model = "gpt-5.5"
+
+		// #when transforming the model ID
+		const result = transformModelForProvider(provider, model)
+
+		// #then the model is prefixed with openai/
+		expect(result).toBe("openai/gpt-5.5")
+	})
+
+	test("passes through model IDs that already contain a slash", () => {
+		// #given an OpenRouter provider with a fully-qualified model ID
+		const provider = "openrouter"
+		const model = "anthropic/claude-opus-4-7"
+
+		// #when transforming the model ID
+		const result = transformModelForProvider(provider, model)
+
+		// #then the model is returned unchanged
+		expect(result).toBe("anthropic/claude-opus-4-7")
+	})
+
+	test("infers google sub-provider for gemini models", () => {
+		// #given an OpenRouter provider with a gemini model
+		const provider = "openrouter"
+		const model = "gemini-3.1-pro"
+
+		// #when transforming the model ID
+		const result = transformModelForProvider(provider, model)
+
+		// #then the model is prefixed with google/
+		expect(result).toBe("google/gemini-3.1-pro")
+	})
+
+	test("returns model unchanged when sub-provider cannot be inferred", () => {
+		// #given an OpenRouter provider with an unknown model prefix
+		const provider = "openrouter"
+		const model = "unknown-model-xyz"
+
+		// #when transforming the model ID
+		const result = transformModelForProvider(provider, model)
+
+		// #then the model is returned as-is
+		expect(result).toBe("unknown-model-xyz")
+	})
+})

--- a/packages/model-core/src/provider-model-id-transform.ts
+++ b/packages/model-core/src/provider-model-id-transform.ts
@@ -29,6 +29,16 @@ function transformModelForProviderUsingAnthropicBehavior(
 	model: string,
 	directAnthropicTransform: (model: string) => string,
 ): string {
+	if (provider === "openrouter") {
+		if (model.includes("/")) {
+			return model
+		}
+		const subProvider = inferSubProvider(model)
+		if (subProvider) {
+			return `${subProvider}/${model}`
+		}
+		return model
+	}
 	if (provider === "vercel") {
 		const slashIndex = model.indexOf("/")
 		if (slashIndex !== -1) {


### PR DESCRIPTION
Add native OpenRouter provider support to oh-my-openagent.

## Changes
- Add OpenRouter model ID transform in \provider-model-id-transform.ts\
  - Infers sub-provider from model prefix (claude → anthropic, gpt → openai, gemini → google)
  - Passes through model IDs that already contain a slash
  - Returns model unchanged if sub-provider cannot be inferred

- Add OpenRouter to fallback chains in \model-requirements.ts\
  - Added to sisyphus, hephaestus, and atlas agents
  - Positioned after primary providers but before less common ones

- Add comprehensive tests for OpenRouter transforms
  - Tests for claude, gpt, gemini model inference
  - Tests for pass-through behavior with fully-qualified IDs
  - Tests for unknown model prefixes

## Testing
- All 33 tests pass in model-core
- Typecheck passes with no errors
- No breaking changes to existing providers

Closes #1637

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native `openrouter` provider support to model-core. Enables OpenRouter models by auto-inferring sub-providers and adds `openrouter` to key agent fallback chains (addresses #1637).

- **New Features**
  - Model ID transform for `openrouter`: infers sub-provider (`claude`→`anthropic`, `gpt`→`openai`, `gemini`→`google`); passes through namespaced IDs; leaves unknown prefixes unchanged.
  - Added `openrouter` to fallback chains/requirements for `sisyphus`, `hephaestus`, and `atlas`, positioned after primary providers.
  - Tests cover inference, pass-through, and unknown prefixes; all model-core tests pass; no breaking changes.

<sup>Written for commit 8628cc317346e827e7372be614d9674cd4e43e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4587?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

