### PR TITLE
fix(handoff): bind USER REQUESTS to session_read output instead of in-context memory (fixes #4592)

### DIFF
--- a/src/features/builtin-commands/commands.test.ts
+++ b/src/features/builtin-commands/commands.test.ts
@@ -438,4 +438,30 @@ describe("HANDOFF_TEMPLATE", () => {
     const emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2702}-\u{27B0}\u{24C2}-\u{1F251}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u
     expect(emojiRegex.test(HANDOFF_TEMPLATE)).toBe(false)
   })
+
+  test("should mandate session_read as the source of USER REQUESTS verbatim (#4592)", () => {
+    //#given - the template string
+
+    //#when - check the prompt anchors USER REQUESTS extraction to session_read output, not memory
+    const forbidsMemory = /do not (reconstruct|rely on|recall|use) (your )?(in-context )?memory/i.test(HANDOFF_TEMPLATE)
+
+    //#then - the prompt explicitly forbids reconstructing USER REQUESTS from memory
+    expect(forbidsMemory).toBe(true)
+
+    //#and - the prompt explicitly anchors USER REQUESTS extraction to the first user message in session_read output
+    expect(HANDOFF_TEMPLATE).toContain("first user message")
+  })
+
+  test("should sequence session_read BEFORE the USER REQUESTS extraction step (#4592)", () => {
+    //#given - the template string
+
+    //#when - record the textual order of session_read instruction and USER REQUESTS extraction
+    const sessionReadFirstMention = HANDOFF_TEMPLATE.indexOf("session_read")
+    const userRequestsFirstMention = HANDOFF_TEMPLATE.indexOf("USER REQUESTS")
+
+    //#then - both anchors exist AND session_read is mentioned first
+    expect(sessionReadFirstMention >= 0).toBe(true)
+    expect(userRequestsFirstMention >= 0).toBe(true)
+    expect(sessionReadFirstMention < userRequestsFirstMention).toBe(true)
+  })
 })

--- a/src/features/builtin-commands/templates/handoff.ts
+++ b/src/features/builtin-commands/templates/handoff.ts
@@ -21,11 +21,29 @@ If the session is nearly empty or has no meaningful context, inform the user the
 
 ---
 
+# PHASE 0.5: SESSION READ FIRST (MANDATORY FIRST DATA STEP)
+
+Call session_read({ session_id: "$SESSION_ID" }) BEFORE any other context gathering step. The output of session_read is the only authoritative source for what the user originally asked. Do not reconstruct memory of the first request; long sessions and post-compact sessions truncate or summarize early messages, so in-context memory is unreliable.
+
+From the session_read output:
+
+1. Find the first user message in the returned session history (the earliest entry with role "user").
+2. Copy the text of that first user message verbatim into a working note. You will later place it into the USER REQUESTS (AS-IS) section unchanged.
+3. If the user has sent multiple distinct top-level requests in the session, also collect each subsequent verbatim user message that is a new top-level ask (not a follow-up clarification).
+
+Rules:
+- Do not reconstruct user requests from memory. Always quote from session_read output.
+- Do not paraphrase, summarize, or "tidy up" the user's wording.
+- Do not skip session_read even if you feel you remember the first user message.
+- If session_read fails or returns no user messages, state that explicitly in the USER REQUESTS (AS-IS) section rather than guessing.
+
+---
+
 # PHASE 1: GATHER PROGRAMMATIC CONTEXT
 
 Execute these tools to gather concrete data:
 
-1. session_read({ session_id: "$SESSION_ID" }) - full session history
+1. session_read({ session_id: "$SESSION_ID" }) - full session history (already executed in PHASE 0.5; reuse its output here)
 2. todoread() - current task progress
 3. Bash({ command: "git diff --stat HEAD~10..HEAD" }) - recent file changes
 4. Bash({ command: "git status --porcelain" }) - uncommitted changes
@@ -33,19 +51,20 @@ Execute these tools to gather concrete data:
 Suggested execution order:
 
 \`\`\`
-session_read({ session_id: "$SESSION_ID" })
+session_read({ session_id: "$SESSION_ID" })  # already called in PHASE 0.5
 todoread()
 Bash({ command: "git diff --stat HEAD~10..HEAD" })
 Bash({ command: "git status --porcelain" })
 \`\`\`
 
 Analyze the gathered outputs to understand:
-- What the user asked for (exact wording)
 - What work was completed
 - What tasks remain incomplete (include todo state)
 - What decisions were made
 - What files were modified or discussed (include git diff/stat + status)
 - What patterns, constraints, or preferences were established
+
+USER REQUESTS were already captured verbatim from session_read in PHASE 0.5; do not re-derive them here.
 
 ---
 
@@ -57,7 +76,7 @@ Focus on:
 - Capabilities and behavior, not file-by-file implementation details
 - What matters for continuing the work
 - Avoiding excessive implementation details (variable names, storage keys, constants) unless critical
-- USER REQUESTS (AS-IS) must be verbatim (do not paraphrase)
+- USER REQUESTS (AS-IS) must come from the PHASE 0.5 session_read extraction, copied verbatim (do not paraphrase, do not reconstruct from memory)
 - EXPLICIT CONSTRAINTS must be verbatim only (do not invent)
 
 Questions to consider when extracting:


### PR DESCRIPTION
## Summary

The `/handoff` builtin command rendered an inaccurate first user request in long sessions and post-`/compact` sessions because the prompt allowed the agent to reconstruct USER REQUESTS (AS-IS) from in-context memory rather than the actual session history. This PR inserts an explicit PHASE 0.5 that calls `session_read` first and quotes the earliest `role: "user"` message verbatim into the USER REQUESTS field, with a new regression test pinning the contract.

## Root Cause

`src/features/builtin-commands/templates/handoff.ts` already mentioned `session_read` in PHASE 1 and said USER REQUESTS "must be verbatim (do not paraphrase)" in PHASE 2, but it never required the agent to derive USER REQUESTS specifically from `session_read` output. Two mechanisms let the agent satisfy "verbatim" while still being wrong:

1. Long sessions: early messages scroll out of the context window, so "verbatim" gets sourced from a remembered paraphrase.
2. `/compact`: early content gets summarized away entirely, so the agent quotes the post-compaction summary as if it were the original wording.

Issue #4592 reports both as the user-visible symptom.

## Changes

| File | Change |
|------|--------|
| `src/features/builtin-commands/templates/handoff.ts` | Insert new PHASE 0.5 ("SESSION READ FIRST") that calls `session_read` and extracts the first `role: "user"` message verbatim before any other context gathering. PHASE 1 now reuses that output instead of re-deriving USER REQUESTS. PHASE 2 bullet for USER REQUESTS now points back to the PHASE 0.5 extraction and explicitly forbids memory reconstruction. |
| `src/features/builtin-commands/commands.test.ts` | Two new regression tests under `describe("HANDOFF_TEMPLATE")`: one asserts the prompt contains the "do not reconstruct from memory" guardrail and references the "first user message"; the other asserts `session_read` is mentioned in the template before any USER REQUESTS extraction step. |

Diff: +49 / -4 across 2 files. No behavior change for other handoff sections; the format block (PHASE 3) is unchanged.

## Reproduction (before fix)

The new regression tests fail on the previous template:

~~~
(fail) HANDOFF_TEMPLATE > should mandate session_read as the source of USER REQUESTS verbatim (#4592)
Expected: true
Received: false
  at .../commands.test.ts:449:27
 44 pass
 1 fail
 94 expect() calls
~~~

The previous template contained no language forbidding memory-driven extraction and no instruction to use the first `role: "user"` entry from `session_read`. The agent could (and per the issue, did) fill USER REQUESTS (AS-IS) from in-context memory.

## Verification (after fix)

Same suite, same machine:

~~~
bun test src/features/builtin-commands/commands.test.ts
 45 pass
 0 fail
 95 expect() calls
Ran 45 tests across 1 file. [202.00ms]
~~~

Both new contract tests pass:
- `should mandate session_read as the source of USER REQUESTS verbatim (#4592)` -> green
- `should sequence session_read BEFORE the USER REQUESTS extraction step (#4592)` -> green

## Test

- Regression tests: `src/features/builtin-commands/commands.test.ts` (2 new cases marked `(#4592)`)
- Related suite: `bun test src/features/builtin-commands/` -> **48 pass / 0 fail** (45 in `commands.test.ts` + 3 in adjacent template tests)
- Typecheck: `bun run typecheck` -> clean

## Design notes

- PHASE 0.5 is intentionally a small, distinct phase before PHASE 1 rather than a bullet under PHASE 1, so the "do `session_read` first" instruction sits at the top of the agent's attention before it starts the full context-gathering sequence.
- The fix keeps the existing PHASE 1 instruction to call `session_read` so the legacy execution order is still valid; PHASE 0.5 just promotes the first call and binds its output to USER REQUESTS.
- No new dependencies, no new template files, no schema or config changes.

Fixes #4592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4592 by making `/handoff` always quote the first user request from `session_read` instead of in-context memory, preventing wrong or paraphrased text in long or post-`/compact` sessions.

- **Bug Fixes**
  - Added PHASE 0.5 to run `session_read` first and copy the earliest `role: "user"` message verbatim; forbid reconstruction from memory and paraphrasing.
  - Updated PHASE 1 and PHASE 2 to reuse PHASE 0.5 output and explicitly disallow re-deriving USER REQUESTS.
  - Added two regression tests to pin the sequencing (`session_read` before USER REQUESTS) and the “do not reconstruct from memory” guardrail.

<sup>Written for commit 6ede73356e448ab7e005e1302200ef74be6e8d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4602?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

