### PR TITLE
fix(grep): strip trailing CR from where.exe output on Windows

### DIFF
--- a/src/tools/grep/constants.test.ts
+++ b/src/tools/grep/constants.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import { parseFirstExecutablePath } from "./constants"
+
+describe("parseFirstExecutablePath (#4512)", () => {
+  it("strips the trailing CR from CRLF-delimited where.exe output", () => {
+    // #given Windows where.exe returns CRLF-delimited paths
+    const stdout = "C:\\Program Files\\rg\\rg.exe\r\nC:\\other\\rg.exe\r\n"
+
+    // #when parsing the first executable path
+    const resolved = parseFirstExecutablePath(stdout)
+
+    // #then the resolved path has no trailing carriage return
+    expect(resolved).toBe("C:\\Program Files\\rg\\rg.exe")
+    expect(resolved?.includes("\r")).toBe(false)
+  })
+
+  it("returns the first line for LF-delimited which output", () => {
+    // #given a Unix which returns LF-delimited paths
+    const stdout = "/usr/bin/rg\n/usr/local/bin/rg\n"
+
+    // #when parsing the first executable path
+    const resolved = parseFirstExecutablePath(stdout)
+
+    // #then the first path is returned untouched
+    expect(resolved).toBe("/usr/bin/rg")
+  })
+
+  it("trims surrounding whitespace from a single-line result", () => {
+    // #given output padded with spaces and a trailing CRLF
+    const stdout = "  C:\\tools\\rg.exe  \r\n"
+
+    // #when parsing the first executable path
+    const resolved = parseFirstExecutablePath(stdout)
+
+    // #then the path is trimmed on both ends
+    expect(resolved).toBe("C:\\tools\\rg.exe")
+  })
+
+  it("returns null for empty or whitespace-only output", () => {
+    // #given no executable was found
+    // #when parsing empty and whitespace-only output
+    // #then null is returned in both cases
+    expect(parseFirstExecutablePath("")).toBeNull()
+    expect(parseFirstExecutablePath("\r\n")).toBeNull()
+    expect(parseFirstExecutablePath("   \r\n")).toBeNull()
+  })
+})

--- a/src/tools/grep/constants.ts
+++ b/src/tools/grep/constants.ts
@@ -14,14 +14,22 @@ interface ResolvedCli {
 let cachedCli: ResolvedCli | null = null
 let autoInstallAttempted = false
 
+export function parseFirstExecutablePath(stdout: string): string | null {
+  // #4512: where.exe emits CRLF-delimited output on Windows. Splitting on "\n"
+  // alone leaves a trailing \r on the first path (e.g. "C:\\...\\rg.exe\r"), which
+  // then fails spawn with ENOENT. Split on /\r?\n/ and trim the resolved path.
+  const firstLine = stdout.split(/\r?\n/)[0]?.trim()
+  return firstLine ? firstLine : null
+}
+
 function findExecutable(name: string): string | null {
   const isWindows = process.platform === "win32"
   const cmd = isWindows ? "where" : "which"
 
   try {
     const result = spawnSync(cmd, [name], { encoding: "utf-8", timeout: 5000 })
-    if (result.status === 0 && result.stdout.trim()) {
-      return result.stdout.trim().split("\n")[0]
+    if (result.status === 0) {
+      return parseFirstExecutablePath(result.stdout)
     }
   } catch {
     // Command execution failed


### PR DESCRIPTION
## Summary

On Windows, `where.exe` emits **CRLF-delimited** output. The ripgrep/grep executable resolver in `src/tools/grep/constants.ts` split the resolved path on `"\n"` alone, leaving a trailing carriage return on the first path (e.g. `C:\...\rg.exe` followed by CR). That path then fails `spawnSync` with `ENOENT`, breaking `grep`/`glob` on Windows.

Fixes #4512.

## Changes

- Extract `parseFirstExecutablePath(stdout)` that splits on `/\r?\n/` and trims the first path, so the trailing CR (and any stray whitespace) is removed before the path is used with `spawn`.
- `findExecutable()` now delegates to this helper.

## Tests

- New `src/tools/grep/constants.test.ts` with given/when/then cases:
  - strips trailing CR from CRLF-delimited `where.exe` output
  - returns first line for LF-delimited `which` output
  - trims surrounding whitespace
  - returns `null` for empty / whitespace-only output

```
bun test src/tools/grep/constants.test.ts
# 4 pass, 0 fail
```

Typecheck adds no new errors (the 14 pre-existing `ToolContext` errors in unrelated `*.test.ts` files are untouched).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows grep path resolution by stripping trailing CR from `where.exe` output to prevent ENOENT when spawning ripgrep; restores grep/glob on Windows. Fixes #4512.

- **Bug Fixes**
  - Added `parseFirstExecutablePath(stdout)` that splits on `/\r?\n/` and trims the first path.
  - `findExecutable()` now uses the helper.
  - Added tests for CRLF and LF outputs, trimming, and empty output.

<sup>Written for commit d8fe07894881c30d679f1b1a7d12a8e96aef9a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4603?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

