### PR TITLE
fix(agents): deduplicate discovered skills in agent prompts

### DIFF
--- a/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
+++ b/src/plugin-handlers/agent-config-handler-agents-skills.test.ts
@@ -168,4 +168,41 @@ describe("applyAgentConfig .agents skills", () => {
     // then - called twice: once for pluginConfig.skills, once for host config.skills
     expect(discoverConfigSourceSkillsSpy).toHaveBeenCalledTimes(2)
   })
+
+  test("deduplicates skills with the same name across discovery sources (#4573)", async () => {
+    // given - the same skill name is discovered at both project (.agents) and user scope,
+    // as happens when `npx skills add` installs to ~/.agents and symlinks ~/.claude
+    discoverProjectAgentsSkillsSpy.mockResolvedValue([
+      {
+        name: "lark-mail",
+        definition: { name: "lark-mail", template: "project-template" },
+        scope: "project",
+      },
+    ])
+    discoverGlobalAgentsSkillsSpy.mockResolvedValue([
+      {
+        name: "lark-mail",
+        definition: { name: "lark-mail", template: "user-template" },
+        scope: "user",
+      },
+    ])
+
+    // when
+    await applyAgentConfig({
+      config: { model: "anthropic/claude-opus-4-7", agent: {} },
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp/project" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then - the duplicate collapses to a single entry, keeping the higher-priority
+    // (project) occurrence
+    const discoveredSkills = createBuiltinAgentsSpy.mock.calls[0]?.[6] as Array<{
+      name: string
+      scope: string
+    }>
+    const larkMailSkills = discoveredSkills.filter(skill => skill.name === "lark-mail")
+    expect(larkMailSkills).toHaveLength(1)
+    expect(larkMailSkills[0]?.scope).toBe("project")
+  })
 })

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -18,6 +18,7 @@ import {
   discoverProjectAgentsSkills,
   discoverProjectClaudeSkills,
   discoverUserClaudeSkills,
+  deduplicateSkillsByName,
 } from "../features/opencode-skill-loader";
 import { 
   loadProjectAgents, 
@@ -94,7 +95,7 @@ export async function applyAgentConfig(params: {
     includeClaudeSkillsForAwareness ? discoverGlobalAgentsSkills() : Promise.resolve([]),
   ]);
 
-  const allDiscoveredSkills = [
+  const allDiscoveredSkills = deduplicateSkillsByName([
     ...discoveredConfigSourceSkills,
     ...discoveredHostConfigSkills,
     ...discoveredOpencodeProjectSkills,
@@ -103,7 +104,7 @@ export async function applyAgentConfig(params: {
     ...discoveredOpencodeGlobalSkills,
     ...discoveredUserSkills,
     ...discoveredGlobalAgentsSkills,
-  ];
+  ]);
 
   const browserProvider =
     params.pluginConfig.browser_automation_engine?.provider ?? "playwright";


### PR DESCRIPTION
## Summary

`availableSkills` injected into the Sisyphus / Atlas / Hephaestus system prompts was built by spreading all eight skill-discovery sources without deduplication. When the same skill name is discovered through multiple paths, the `**⚡ YOUR SKILLS (PRIORITY)**` list renders the same skill twice, once tagged `(project)` and once `(user)`.

This is common because `npx skills add <...>` installs a skill into `~/.agents/skills/` and creates a symlink at `~/.claude/skills/`, so the same skill is discovered under both the project-agents and user scopes. In the reporter's case 51 raw discovery hits collapsed to 30 unique skills, meaning 21 skills were duplicated, wasting roughly 5-10k tokens of context on every session start.

Fixes #4573.

## Not a duplicate of #3250

#3250 is about the `skill` tool description containing both OMO's `<available_items>` block and OpenCode native's `## Available Skills` block. This issue is internal to OMO: the duplication is inside the Sisyphus/Atlas/Hephaestus prompt path. The `<available_items>` block (which uses `mergedSkills`) was already deduplicated; only `allDiscoveredSkills` in `agent-config-handler.ts` was not.

## Changes

- Wrap `allDiscoveredSkills` in `deduplicateSkillsByName()` in `src/plugin-handlers/agent-config-handler.ts`.
- The spread order already reflects scope precedence (project sources before user sources), and `deduplicateSkillsByName` keeps the first occurrence by name, so the higher-priority (project) entry is preserved.

## Tests

- New given/when/then case in `agent-config-handler-agents-skills.test.ts`: a `lark-mail` skill discovered at both project (`.agents`) and user scope collapses to a single entry, keeping the `project` scope occurrence.

```
bun test src/plugin-handlers/agent-config-handler-agents-skills.test.ts
# 5 pass, 0 fail
```

Typecheck adds no new errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates discovered skills before injecting them into Sisyphus/Atlas/Hephaestus prompts to remove duplicate entries and shrink prompt size. Fixes #4573 by keeping the higher-priority project skill when names collide.

- **Bug Fixes**
  - Wrapped `allDiscoveredSkills` with `deduplicateSkillsByName()` so first-wins based on existing source order (project before user).
  - Added a test to confirm a skill found in both scopes appears once and retains the project scope.

<sup>Written for commit 2eff133f99c2a160c05cde76c1c0e6ae2aaf1ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4604?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

