### PR TITLE
fix(runtime-fallback): normalize object-shaped session model to canonical string

### DIFF
--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -263,14 +263,14 @@ describe("createEventHandler", () => {
     await handler({
       event: {
         type: "session.created",
-        properties: { info: { id: sessionID, model: { id: "gpt-5.3-codex-spark", providerID: "openai", variant: "medium" } } },
+        properties: { info: { id: sessionID, model: { id: "gpt-5.5-codex", providerID: "openai", variant: "medium" } } },
       },
     })
 
     // then - the stored model is the canonical string form, not the object
     const created = deps.sessionStates.get(sessionID)
-    expect(created?.originalModel).toBe("openai/gpt-5.3-codex-spark")
-    expect(created?.currentModel).toBe("openai/gpt-5.3-codex-spark")
+    expect(created?.originalModel).toBe("openai/gpt-5.5-codex")
+    expect(created?.currentModel).toBe("openai/gpt-5.5-codex")
     expect(typeof created?.currentModel).toBe("string")
   })
 })

--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -248,4 +248,29 @@ describe("createEventHandler", () => {
     // then - counter is at 2, not reset to 0
     expect(deps.sessionStates.get(sessionID)?.attemptCount).toBe(2)
   })
+
+  it("#given session.created with an object-shaped model (opencode 1.15.x) #when the event fires #then state stores a canonical string model (issue #4315)", async () => {
+    // given - since opencode 1.15.x, session.created info.model is an object
+    // { id, providerID, variant } rather than a string. Storing it verbatim
+    // made isEquivalentModel call .toLowerCase() on a non-string and crash.
+    const sessionID = "session-object-model"
+    const deps = createDeps()
+    const abortCalls: string[] = []
+    const clearCalls: string[] = []
+    const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
+
+    // when
+    await handler({
+      event: {
+        type: "session.created",
+        properties: { info: { id: sessionID, model: { id: "gpt-5.3-codex-spark", providerID: "openai", variant: "medium" } } },
+      },
+    })
+
+    // then - the stored model is the canonical string form, not the object
+    const created = deps.sessionStates.get(sessionID)
+    expect(created?.originalModel).toBe("openai/gpt-5.3-codex-spark")
+    expect(created?.currentModel).toBe("openai/gpt-5.3-codex-spark")
+    expect(typeof created?.currentModel).toBe("string")
+  })
 })

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -11,11 +11,13 @@ import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { createSessionStatusHandler } from "./session-status-handler"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
+import { isRecord } from "../../shared/record-type-guard"
+import { normalizeModelToCanonicalString } from "./normalize-model"
 
 function resolveEventModel(props: Record<string, unknown> | undefined): string | undefined {
-  const model = props?.model
-  if (typeof model === "string") {
-    return model
+  const normalizedModel = normalizeModelToCanonicalString(props?.model)
+  if (normalizedModel) {
+    return normalizedModel
   }
 
   const providerID = props?.providerID
@@ -45,9 +47,9 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
-    const sessionInfo = props?.info as { id?: string; model?: string } | undefined
+    const sessionInfo = isRecord(props?.info) ? props.info : undefined
     const sessionID = resolveSessionEventID(props)
-    const model = sessionInfo?.model
+    const model = normalizeModelToCanonicalString(sessionInfo?.model)
 
     if (sessionID && model) {
       log(`[${HOOK_NAME}] Session created with model`, { sessionID, model })
@@ -209,7 +211,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       const initialModel = resolveFallbackBootstrapModel({
         sessionID,
         source: "session.error",
-        eventModel: props?.model as string | undefined,
+        eventModel: resolveEventModel(props),
         resolvedAgent,
         pluginConfig,
       })

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -54,7 +54,9 @@ function isEquivalentModel(candidate: string, current: string): boolean {
   const parsedCurrent = parseCanonicalModel(current)
 
   if (!parsedCandidate || !parsedCurrent) {
-    return candidate.toLowerCase() === current.toLowerCase()
+    const candidateString = typeof candidate === "string" ? candidate : String(candidate)
+    const currentString = typeof current === "string" ? current : String(current)
+    return candidateString.toLowerCase() === currentString.toLowerCase()
   }
 
   return (

--- a/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -5,6 +5,7 @@ import { log } from "../../shared/logger"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import { isRecord } from "../../shared/record-type-guard"
+import { normalizeModelToCanonicalString } from "./normalize-model"
 import { createFallbackState } from "./fallback-state"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
@@ -89,8 +90,8 @@ export function observeEventForWatchdog(
     if (!sessionID || !role) return
 
     if (role === "user") {
-      const model = info?.model as string | undefined
-      const agent = info?.agent as string | undefined
+      const model = normalizeModelToCanonicalString(info?.model)
+      const agent = typeof info?.agent === "string" ? info.agent : undefined
       watchdog.onUserMessage(sessionID, model, agent)
       return
     }

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -10,6 +10,7 @@ import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID } from "../../shared/event-session-id"
+import { normalizeModelToCanonicalString } from "./normalize-model"
 
 export { hasVisibleAssistantResponse } from "./visible-assistant-response"
 
@@ -39,7 +40,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       (retrySignal && timeoutEnabled ? { name: "ProviderRateLimitError", message: retrySignal } : undefined) ??
       (errorContentResult.hasError ? { name: "MessageContentError", message: errorContentResult.errorMessage || "Message contains error content" } : undefined)
     const role = info?.role as string | undefined
-    const model = info?.model as string | undefined
+    const model = normalizeModelToCanonicalString(info?.model)
 
     if (sessionID && role === "assistant" && !error) {
       if (!sessionAwaitingFallbackResult.has(sessionID)) {

--- a/src/hooks/runtime-fallback/normalize-model.test.ts
+++ b/src/hooks/runtime-fallback/normalize-model.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeModelToCanonicalString } from "./normalize-model"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+
+describe("normalizeModelToCanonicalString", () => {
+  describe("#given a plain string model", () => {
+    test("#when called #then it returns the trimmed string", () => {
+      // given
+      const model = "  anthropic/claude-opus-4-7  "
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBe("anthropic/claude-opus-4-7")
+    })
+
+    test("#when the string is empty #then it returns undefined", () => {
+      // given
+      const model = "   "
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("#given an object-shaped model from session.created", () => {
+    test("#when it has id + providerID #then it returns the canonical provider/id string", () => {
+      // given
+      const model = unsafeTestValue<unknown>({ id: "gpt-5.3-codex-spark", providerID: "openai", variant: "medium" })
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBe("openai/gpt-5.3-codex-spark")
+    })
+
+    test("#when it exposes modelID instead of id #then it still resolves", () => {
+      // given
+      const model = unsafeTestValue<unknown>({ modelID: "claude-opus-4-7", providerID: "anthropic" })
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBe("anthropic/claude-opus-4-7")
+    })
+
+    test("#when providerID is missing #then it returns undefined", () => {
+      // given
+      const model = unsafeTestValue<unknown>({ id: "gpt-5.3-codex-spark", variant: "medium" })
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("#given a non-model value", () => {
+    test("#when called with undefined #then it returns undefined", () => {
+      // given
+      const model = undefined
+
+      // when
+      const result = normalizeModelToCanonicalString(model)
+
+      // then
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/src/hooks/runtime-fallback/normalize-model.test.ts
+++ b/src/hooks/runtime-fallback/normalize-model.test.ts
@@ -30,13 +30,13 @@ describe("normalizeModelToCanonicalString", () => {
   describe("#given an object-shaped model from session.created", () => {
     test("#when it has id + providerID #then it returns the canonical provider/id string", () => {
       // given
-      const model = unsafeTestValue<unknown>({ id: "gpt-5.3-codex-spark", providerID: "openai", variant: "medium" })
+      const model = unsafeTestValue<unknown>({ id: "gpt-5.5-codex", providerID: "openai", variant: "medium" })
 
       // when
       const result = normalizeModelToCanonicalString(model)
 
       // then
-      expect(result).toBe("openai/gpt-5.3-codex-spark")
+      expect(result).toBe("openai/gpt-5.5-codex")
     })
 
     test("#when it exposes modelID instead of id #then it still resolves", () => {
@@ -52,7 +52,7 @@ describe("normalizeModelToCanonicalString", () => {
 
     test("#when providerID is missing #then it returns undefined", () => {
       // given
-      const model = unsafeTestValue<unknown>({ id: "gpt-5.3-codex-spark", variant: "medium" })
+      const model = unsafeTestValue<unknown>({ id: "gpt-5.5-codex", variant: "medium" })
 
       // when
       const result = normalizeModelToCanonicalString(model)

--- a/src/hooks/runtime-fallback/normalize-model.ts
+++ b/src/hooks/runtime-fallback/normalize-model.ts
@@ -1,0 +1,34 @@
+import { isRecord } from "../../shared/record-type-guard"
+
+/**
+ * Normalize a session model value into a canonical "<providerID>/<id>" string.
+ *
+ * Since opencode 1.15.x the `session.created` event payload exposes
+ * `info.model` as an object (`{ id, providerID, variant }`) rather than a
+ * plain string. Downstream fallback state treats the model as a string and
+ * calls `.toLowerCase()` on it, so an object value crashes the hook. This
+ * helper collapses both the legacy string form and the object form to a
+ * single canonical string at the hook boundary. Returns undefined when no
+ * usable provider/model pair can be derived.
+ */
+export function normalizeModelToCanonicalString(model: unknown): string | undefined {
+  if (typeof model === "string") {
+    const trimmed = model.trim()
+    return trimmed ? trimmed : undefined
+  }
+
+  if (isRecord(model)) {
+    const providerID = typeof model.providerID === "string" ? model.providerID.trim() : undefined
+    const rawModelID = typeof model.id === "string"
+      ? model.id
+      : typeof model.modelID === "string"
+        ? model.modelID
+        : undefined
+    const modelID = rawModelID?.trim()
+    if (providerID && modelID) {
+      return `${providerID}/${modelID}`
+    }
+  }
+
+  return undefined
+}

--- a/src/hooks/runtime-fallback/session-status-handler.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.ts
@@ -9,6 +9,7 @@ import { normalizeRetryStatusMessage, extractRetryAttempt } from "../../shared/r
 import { resolveFallbackBootstrapModel } from "./fallback-bootstrap-model"
 import { dispatchFallbackRetry } from "./fallback-retry-dispatcher"
 import { resolveSessionEventID } from "../../shared/event-session-id"
+import { normalizeModelToCanonicalString } from "./normalize-model"
 
 export function createSessionStatusHandler(
   deps: HookDeps,
@@ -26,7 +27,7 @@ export function createSessionStatusHandler(
     const sessionID = resolveSessionEventID(props)
     const status = props?.status as { type?: string; message?: string; attempt?: number } | undefined
     const agent = props?.agent as string | undefined
-    const model = props?.model as string | undefined
+    const model = normalizeModelToCanonicalString(props?.model)
     const timeoutEnabled = deps.config.timeout_seconds > 0
 
     if (!sessionID || status?.type !== "retry") return

--- a/src/hooks/runtime-fallback/stale-gpt-fixtures.test.ts
+++ b/src/hooks/runtime-fallback/stale-gpt-fixtures.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const staleGptFixturePattern = /gpt-5\.(?:2|3)|gpt-5-[23]|gpt-5[23]/i
+const runtimeFallbackDir = dirname(fileURLToPath(import.meta.url))
+
+const runtimeFallbackFixtureFiles = ["normalize-model.test.ts", "event-handler.test.ts"] as const
+
+describe("runtime-fallback GPT fixture policy", () => {
+  test("#given PR-touched runtime-fallback tests #when scanned #then stale GPT 5.2 and 5.3 fixtures are absent", async () => {
+    // given
+    const staleFixtures: string[] = []
+
+    // when
+    for (const fixtureFile of runtimeFallbackFixtureFiles) {
+      const contents = readFileSync(join(runtimeFallbackDir, fixtureFile), "utf-8")
+      if (staleGptFixturePattern.test(contents)) {
+        staleFixtures.push(fixtureFile)
+      }
+    }
+
+    // then
+    expect(staleFixtures).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4315 — runtime-fallback crashes with `TypeError: current.toLowerCase is not a function` when the active model is object-shaped.

Since opencode 1.15.x the `session.created` event payload exposes `info.model` as an object (`{ id, providerID, variant }`) rather than a plain string. The runtime-fallback hook stored that object verbatim in `FallbackState.currentModel`, and `isEquivalentModel` called `.toLowerCase()` on it, throwing. The unhandled rejection interrupted the in-flight session and, under parallel subagent workloads, propagated across sibling sessions so the completion `system-reminder` was never emitted.

Same root cause as #4145 / #4153, surviving one frame deeper after the merged parser guards.

## Changes

- **New** `src/hooks/runtime-fallback/normalize-model.ts` — `normalizeModelToCanonicalString(model: unknown)` collapses both the legacy string form and the object form to a single canonical `"<providerID>/<id>"` string, returning `undefined` when no usable pair can be derived.
- Apply the normalizer at every hook boundary where a session model value enters:
  - `event-handler.ts` (`resolveEventModel`, `handleSessionCreated`, `session.error` bootstrap)
  - `first-prompt-watchdog.ts` (user-message branch)
  - `message-update-handler.ts`
  - `session-status-handler.ts`
- `fallback-state.ts` `isEquivalentModel` now coerces defensively so it can never throw on an unexpected non-string value.

## Testing

- New `normalize-model.test.ts` (6 given/when/then cases: string passthrough/trim/empty, object → canonical, object missing fields → undefined, modelID alias).
- Extended `event-handler.test.ts` proving a `session.created` with object model `{ id: "gpt-5.3-codex-spark", providerID: "openai", variant: "medium" }` stores the canonical string `"openai/gpt-5.3-codex-spark"`.
- All touched test files pass when run by path (52 pass / 0 fail across the changed files). Typecheck clean for the changed files.

> Note: running the whole `src/hooks/runtime-fallback/` directory at once shows 61 failures that are **pre-existing** cross-file mock-state pollution on `dev` (confirmed by stashing this branch's changes and re-running on a clean tree — same 61 failures). They are unrelated to this change and out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize object-shaped session models to a canonical "providerID/id" string to prevent runtime-fallback crashes and restore stable retries and reminders. Fixes #4315.

- **Bug Fixes**
  - Added normalizeModelToCanonicalString to canonicalize string or object models.
  - Applied normalization in event-handler, first-prompt-watchdog, message-update-handler, and session-status-handler.
  - Hardened isEquivalentModel; refreshed tests to current codex and added a guard against stale GPT-5.2/5.3 fixtures.

<sup>Written for commit 87ddea8b878f3fca305a521e4b2e3f6b7cb09227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

