### PR TITLE
feat(background-agent): hold main explore/librarian when plan delegated

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/constants.ts
+++ b/packages/omo-opencode/src/features/background-agent/constants.ts
@@ -15,6 +15,7 @@ export const MIN_IDLE_TIME_MS = 5000
 export const POLLING_INTERVAL_MS = 3000
 export const TASK_CLEANUP_DELAY_MS = 10 * 60 * 1000
 export const TMUX_CALLBACK_DELAY_MS = 200
+export const TASK_DROPPED_REASON_DELEGATED_TO_PLAN = "delegated_to_plan"
 
 export type ProcessCleanupEvent = NodeJS.Signals | "beforeExit" | "exit"
 

--- a/packages/omo-opencode/src/features/background-agent/manager-subagent-hold.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-subagent-hold.test.ts
@@ -1,0 +1,236 @@
+/// <reference types="bun-types" />
+
+import { tmpdir } from "node:os"
+import { afterEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { createBackgroundOutput } from "../../tools/background-task/create-background-output"
+import type { BackgroundOutputClient } from "../../tools/background-task/clients"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
+import {
+  _resetForTesting as resetClaudeCodeSessionState,
+  setMainSession,
+} from "../claude-code-session-state"
+import { _resetTaskToastManagerForTesting } from "../task-toast-manager/manager"
+import { BackgroundManager } from "./manager"
+import { _resetForTesting as resetProcessCleanupState } from "./process-cleanup"
+import { clearBackgroundTaskRegistryForTesting } from "./task-registry"
+import { clearAllTurnHoldStateForTesting, markSubagentTypeInTurn } from "./subagent-turn-hold-state"
+import type { LaunchInput } from "./types"
+
+function createPluginInput(client: unknown, directory = tmpdir()): PluginInput {
+  return { client, directory } as PluginInput
+}
+
+function createManager(directory = tmpdir(), config?: { taskCleanupDelayMs?: number }): BackgroundManager {
+  const client = {
+    session: {
+      create: async () => ({ data: { id: "ses_child" }, error: null }),
+      get: async () => ({ data: { directory }, error: null }),
+      abort: async () => ({ data: {}, error: null }),
+    },
+  }
+  return new BackgroundManager({ pluginContext: createPluginInput(client, directory), config })
+}
+
+function getPendingParentWakes(manager: BackgroundManager): Map<string, unknown> {
+  const parentWakeNotifier = Reflect.get(manager, "parentWakeNotifier") as {
+    getPendingParentWakes: () => Map<string, unknown>
+  }
+  return parentWakeNotifier.getPendingParentWakes()
+}
+
+function createBackgroundOutputClient(): BackgroundOutputClient {
+  return {
+    session: {
+      messages: async () => ({ data: [] }),
+    },
+  }
+}
+
+function createOutputContext(): ToolContext & { callID: string } {
+  return {
+    sessionID: "ses_main",
+    messageID: "msg_parent",
+    agent: "sisyphus",
+    directory: tmpdir(),
+    worktree: tmpdir(),
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+    callID: "call_1",
+  }
+}
+
+function createInput(parentSessionId: string, agent: string, model?: LaunchInput["model"]): LaunchInput {
+  return {
+    parentSessionId,
+    parentMessageId: "msg_parent",
+    description: `${agent} task`,
+    prompt: "gather context",
+    agent,
+    model,
+  }
+}
+
+afterEach(() => {
+  clearBackgroundTaskRegistryForTesting()
+  releaseAllPromptAsyncReservationsForTesting()
+  resetClaudeCodeSessionState()
+  resetProcessCleanupState()
+  clearAllTurnHoldStateForTesting()
+  _resetTaskToastManagerForTesting()
+})
+
+describe("BackgroundManager main-session context hold", () => {
+  test("holds main-session explore and librarian launches without starting them", async () => {
+    setMainSession("ses_main")
+    const manager = createManager()
+
+    const explore = await manager.launch(createInput("ses_main", "explore", { providerID: "provider", modelID: "model" }))
+    const librarian = await manager.launch(createInput("ses_main", "librarian", { providerID: "provider", modelID: "model" }))
+
+    expect(explore.status).toBe("pending")
+    expect(explore.sessionId).toBeUndefined()
+    expect(librarian.status).toBe("pending")
+    expect(librarian.sessionId).toBeUndefined()
+    await manager.shutdown()
+  })
+
+  test("does not hold plan, non-main, or plan-session launches", async () => {
+    setMainSession("ses_main")
+    const manager = createManager()
+
+    const plan = await manager.launch(createInput("ses_main", "plan"))
+    const nonMainExplore = await manager.launch(createInput("ses_child", "explore"))
+    const planSessionExplore = await manager.launch(createInput("ses_plan", "explore"))
+
+    expect(plan.status).toBe("pending")
+    expect(nonMainExplore.status).toBe("pending")
+    expect(planSessionExplore.status).toBe("pending")
+    await manager.shutdown()
+  })
+
+  test("drops held tasks when plan is recorded in the same turn", async () => {
+    setMainSession("ses_main")
+    const manager = createManager()
+    const task = await manager.launch(createInput("ses_main", "explore"))
+
+    markSubagentTypeInTurn("ses_main", "plan")
+    await manager.dropHeldTasks("ses_main")
+
+    expect(manager.getTask(task.id)?.status).toBe("cancelled")
+    expect(manager.getTask(task.id)?.droppedReason).toBe("delegated_to_plan")
+    await manager.shutdown()
+  })
+
+  test("retains a dropped pre-start task after scheduled removal", async () => {
+    setMainSession("ses_main")
+    const manager = createManager(tmpdir(), { taskCleanupDelayMs: 0 })
+    const task = await manager.launch(createInput("ses_main", "explore"))
+
+    await manager.dropHeldTasks("ses_main")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const outputTool = createBackgroundOutput(manager, createBackgroundOutputClient())
+    const output = await outputTool.execute({ task_id: task.id }, createOutputContext())
+
+    expect(manager.getTask(task.id)?.droppedReason).toBe("delegated_to_plan")
+    expect(output).toContain("This explore/librarian task was skipped")
+    await manager.shutdown()
+  })
+
+  test("releases held tasks to the existing queue when no plan was recorded", async () => {
+    setMainSession("ses_main")
+    const manager = createManager()
+    const task = await manager.launch(createInput("ses_main", "explore"))
+
+    await manager.releaseHeldTasks("ses_main")
+
+    expect(manager.getTask(task.id)?.status).toBe("pending")
+    await manager.shutdown()
+  })
+
+  test("cleans held tasks when the parent session is deleted", async () => {
+    setMainSession("ses_main")
+    const manager = createManager()
+    const task = await manager.launch(createInput("ses_main", "librarian"))
+
+    manager.handleEvent({ type: "session.deleted", properties: { sessionID: "ses_main" } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(manager.getTask(task.id)).toBeUndefined()
+    await manager.shutdown()
+  })
+
+  test("deletes held tasks synchronously before a concurrent release can start them", async () => {
+    setMainSession("ses_main")
+    let childSessionCreates = 0
+    const directory = tmpdir()
+    const client = {
+      session: {
+        create: async () => {
+          childSessionCreates += 1
+          return { data: { id: "ses_child" }, error: null }
+        },
+        get: async () => ({ data: { directory }, error: null }),
+        abort: async () => ({ data: {}, error: null }),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client, directory) })
+    const task = await manager.launch(createInput("ses_main", "explore"))
+
+    manager.handleEvent({ type: "session.deleted", properties: { sessionID: "ses_main" } })
+    await manager.releaseHeldTasks("ses_main")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const discardHeldTasks = Reflect.get(manager, "discardHeldTasksForSession")
+    expect(typeof discardHeldTasks).toBe("function")
+    if (typeof discardHeldTasks !== "function") throw new Error("discardHeldTasksForSession is not callable")
+    expect(discardHeldTasks.call(manager, "ses_main")).toBeUndefined()
+    expect(manager.getTask(task.id)).toBeUndefined()
+    expect(childSessionCreates).toBe(0)
+    await manager.shutdown()
+  })
+
+  test("suppresses parent wakes for session deletion but keeps ordinary cancellation notifications", async () => {
+    const directory = tmpdir()
+    const client = {
+      session: {
+        messages: async () => ({ data: [] }),
+        status: async () => ({ data: { type: "idle" } }),
+        abort: async () => ({ data: {}, error: null }),
+      },
+    }
+    const deletedManager = new BackgroundManager({ pluginContext: createPluginInput(client, directory) })
+    const deletedTask = await deletedManager.trackTask({
+      taskId: "bg_deleted",
+      sessionId: "ses_deleted_child",
+      parentSessionId: "ses_deleted_parent",
+      description: "deleted child",
+      agent: "explore",
+    })
+
+    deletedManager.handleEvent({ type: "session.deleted", properties: { sessionID: "ses_deleted_parent" } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(deletedManager.getTask(deletedTask.id)?.status).toBe("cancelled")
+    expect(deletedManager.hasPendingParentWake("ses_deleted_parent")).toBe(false)
+    expect(getPendingParentWakes(deletedManager).has("ses_deleted_parent")).toBe(false)
+
+    const ordinaryManager = new BackgroundManager({ pluginContext: createPluginInput(client, directory) })
+    const ordinaryTask = await ordinaryManager.trackTask({
+      taskId: "bg_ordinary",
+      sessionId: "ses_ordinary_child",
+      parentSessionId: "ses_ordinary_parent",
+      description: "ordinary child",
+      agent: "explore",
+    })
+
+    await ordinaryManager.cancelTask(ordinaryTask.id, { abortSession: false })
+
+    expect(ordinaryManager.hasPendingParentWake("ses_ordinary_parent")).toBe(true)
+    expect(getPendingParentWakes(ordinaryManager).has("ses_ordinary_parent")).toBe(true)
+    await deletedManager.shutdown()
+    await ordinaryManager.shutdown()
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -32,7 +32,7 @@ import {
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
-import { clearSessionAgent, setSessionAgent, subagentSessions, updateSessionAgent } from "../claude-code-session-state"
+import { clearSessionAgent, getMainSessionID, setSessionAgent, subagentSessions, updateSessionAgent } from "../claude-code-session-state"
 import { MESSAGE_STORAGE } from "../hook-message-injector"
 import { getTaskToastManager } from "../task-toast-manager"
 import { abortWithTimeout } from "./abort-with-timeout"
@@ -56,6 +56,7 @@ import {
 import { ConcurrencyManager } from "./concurrency"
 import {
   POLLING_INTERVAL_MS,
+  TASK_DROPPED_REASON_DELEGATED_TO_PLAN,
   type QueueItem,
   TASK_CLEANUP_DELAY_MS,
   TASK_TTL_MS,
@@ -283,6 +284,8 @@ export class BackgroundManager {
   private cachedCircuitBreakerSettings?: CircuitBreakerSettings
   private readonly scheduledFlushSettledCounts = new Map<string, number>()
   private readonly scheduledFlushSettledWaiters = new Map<string, Array<() => void>>()
+  private heldItems: Map<string, { task: BackgroundTask; input: LaunchInput; attemptID: string; rawConcurrencyKey: string }> = new Map()
+  private heldTaskTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map()
 
   constructor(config: BackgroundManagerConfig) {
     const { pluginContext, ...options } = config
@@ -439,7 +442,7 @@ export class BackgroundManager {
   }
 
   private archiveCompletedTask(task: BackgroundTask): void {
-    if (!task.sessionId) {
+    if (!task.sessionId && !task.droppedReason) {
       return
     }
     if (task.status === "running" || task.status === "pending") {
@@ -455,6 +458,7 @@ export class BackgroundManager {
       agent: task.agent,
       sessionId: task.sessionId,
       status: task.status,
+      droppedReason: task.droppedReason,
       queuedAt: task.queuedAt,
       startedAt: task.startedAt,
       completedAt: task.completedAt,
@@ -622,9 +626,30 @@ export class BackgroundManager {
         this.pendingByParent.set(input.parentSessionId, pending)
       }
 
-      // Add to queue
+      // Hold main-session context tasks until the assistant turn completes.
       const rawConcurrencyKey = this.getRawConcurrencyKeyFromInput(input)
       const key = this.concurrencyManager.getConcurrencyKey(rawConcurrencyKey)
+      if (this.isMainSessionExploreOrLibrarianAgent(input.parentSessionId, input.agent)) {
+        this.heldItems.set(task.id, { task, input, attemptID: firstAttempt.attemptId, rawConcurrencyKey })
+        const timeoutID = setTimeout(() => {
+          void this.releaseHeldTasks(input.parentSessionId).catch((error) => {
+            log("[background-agent] Error auto-releasing held task:", { taskId: task.id, error })
+          })
+        }, 180_000)
+        this.heldTaskTimeouts.set(task.id, timeoutID)
+        getTaskToastManager()?.addTask({
+          id: task.id,
+          description: input.description,
+          agent: input.agent,
+          isBackground: true,
+          status: "queued",
+          skills: input.skills,
+        })
+        spawnReservation.commit()
+        this.markPreStartDescendantReservation(task)
+        this.updateBackgroundTaskMarker(input.parentSessionId)
+        return { ...task, held: true }
+      }
       const queue = this.queuesByKey.get(key) ?? []
       queue.push({ task, input, attemptID: firstAttempt.attemptId, rawConcurrencyKey })
       this.queuesByKey.set(key, queue)
@@ -1187,6 +1212,79 @@ The fallback retry session is now created and can be inspected directly.
     return task.model
       ? `${task.model.providerID}/${task.model.modelID}`
       : task.agent
+  }
+
+  private isMainSessionExploreOrLibrarianAgent(parentSessionId: string, agent: string): boolean {
+    const mainSessionID = getMainSessionID()
+    if (!mainSessionID || mainSessionID !== parentSessionId) {
+      return false
+    }
+    const normalizedAgent = agent.toLowerCase()
+    return normalizedAgent === "explore" || normalizedAgent === "librarian"
+  }
+
+  async dropHeldTasks(sessionID: string): Promise<void> {
+    for (const [taskID, item] of Array.from(this.heldItems.entries())) {
+      if (item.task.parentSessionId !== sessionID) continue
+      const timeoutID = this.heldTaskTimeouts.get(taskID)
+      if (timeoutID) clearTimeout(timeoutID)
+      this.heldTaskTimeouts.delete(taskID)
+      item.task.status = "cancelled"
+      item.task.droppedReason = TASK_DROPPED_REASON_DELEGATED_TO_PLAN
+      item.task.completedAt = new Date()
+      this.heldItems.delete(taskID)
+      this.rollbackPreStartDescendantReservation(item.task)
+      this.cleanupPendingByParent(item.task)
+      removeTaskToastTracking(taskID)
+      this.taskHistory.record(item.task.parentSessionId, {
+        id: item.task.id,
+        agent: item.task.agent,
+        description: item.task.description,
+        status: "cancelled",
+        category: item.task.category,
+        completedAt: item.task.completedAt,
+      })
+      this.updateBackgroundTaskMarker(item.task.parentSessionId)
+      this.scheduleTaskRemoval(taskID)
+    }
+  }
+
+  private discardHeldTasksForSession(parentSessionID: string): void {
+    for (const [taskID, item] of Array.from(this.heldItems.entries())) {
+      if (item.task.parentSessionId !== parentSessionID) continue
+      const timeoutID = this.heldTaskTimeouts.get(taskID)
+      if (timeoutID) clearTimeout(timeoutID)
+      this.heldTaskTimeouts.delete(taskID)
+      this.heldItems.delete(taskID)
+      this.rollbackPreStartDescendantReservation(item.task)
+      this.cleanupPendingByParent(item.task)
+      removeTaskToastTracking(taskID)
+      this.clearNotificationsForTask(taskID)
+      this.removeTask(item.task)
+    }
+    this.updateBackgroundTaskMarker(parentSessionID)
+  }
+
+  async releaseHeldTasks(sessionID: string): Promise<void> {
+    for (const [taskID, item] of Array.from(this.heldItems.entries())) {
+      if (item.task.parentSessionId !== sessionID) continue
+      const timeoutID = this.heldTaskTimeouts.get(taskID)
+      if (timeoutID) clearTimeout(timeoutID)
+      this.heldTaskTimeouts.delete(taskID)
+      this.heldItems.delete(taskID)
+      const key = this.concurrencyManager.getConcurrencyKey(item.rawConcurrencyKey)
+      const queue = this.queuesByKey.get(key) ?? []
+      queue.push({
+        task: item.task,
+        input: item.input,
+        attemptID: item.attemptID,
+        rawConcurrencyKey: item.rawConcurrencyKey,
+      })
+      this.queuesByKey.set(key, queue)
+      void this.processKey(key).catch((error) => {
+        log("[background-agent] Error processing released held task:", { taskId: taskID, error })
+      })
+    }
   }
 
   /**
@@ -1853,6 +1951,7 @@ The fallback retry session is now created and can be inspected directly.
     if (event.type === "session.deleted") {
       const sessionID = resolveSessionEventID(props)
       if (!sessionID) return
+      this.discardHeldTasksForSession(sessionID)
       this.clearSessionOutputObserved(sessionID)
       this.clearSessionTodoObservation(sessionID)
 
@@ -1889,6 +1988,7 @@ The fallback retry session is now created and can be inspected directly.
           void this.cancelTask(task.id, {
             source: "session.deleted",
             reason: "Session deleted",
+            skipNotification: true,
           }).then(() => {
             if (deletedSessionIDs.has(task.parentSessionId)) {
               this.pendingNotifications.delete(task.parentSessionId)
@@ -3176,6 +3276,11 @@ The task was re-queued on a fallback model after a retryable failure.
       clearTimeout(timer)
     }
     this.idleDeferralTimers.clear()
+    for (const timer of this.heldTaskTimeouts.values()) {
+      clearTimeout(timer)
+    }
+    this.heldTaskTimeouts.clear()
+    this.heldItems.clear()
 
     this.parentWakeNotifier.shutdown()
 

--- a/packages/omo-opencode/src/features/background-agent/subagent-turn-hold-state.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/subagent-turn-hold-state.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+
+import {
+  clearAllTurnHoldStateForTesting,
+  clearTurnState,
+  hasPlanInCurrentTurn,
+  markSubagentTypeInTurn,
+} from "./subagent-turn-hold-state"
+
+describe("subagent-turn-hold-state", () => {
+  afterEach(() => {
+    clearAllTurnHoldStateForTesting()
+  })
+
+  it("records subagent types case-insensitively", () => {
+    markSubagentTypeInTurn("session-1", "PLAN")
+    markSubagentTypeInTurn("session-1", "Explore")
+
+    expect(hasPlanInCurrentTurn("session-1")).toBe(true)
+  })
+
+  it("returns false when plan was not recorded", () => {
+    markSubagentTypeInTurn("session-1", "explore")
+
+    expect(hasPlanInCurrentTurn("session-1")).toBe(false)
+  })
+
+  it("clears one session without affecting another", () => {
+    markSubagentTypeInTurn("session-1", "plan")
+    markSubagentTypeInTurn("session-2", "plan")
+
+    clearTurnState("session-1")
+
+    expect(hasPlanInCurrentTurn("session-1")).toBe(false)
+    expect(hasPlanInCurrentTurn("session-2")).toBe(true)
+  })
+
+  it("returns false for an unknown session", () => {
+    expect(hasPlanInCurrentTurn("unknown")).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/subagent-turn-hold-state.ts
+++ b/packages/omo-opencode/src/features/background-agent/subagent-turn-hold-state.ts
@@ -1,0 +1,33 @@
+const HOLD_STATE_KEY = "__omoSubagentTurnHoldState"
+
+interface TurnHoldState {
+  seenSubagentTypes: Set<string>
+}
+
+type GlobalWithHoldState = typeof globalThis & {
+  [HOLD_STATE_KEY]?: Map<string, TurnHoldState>
+}
+
+function getHoldStateMap(): Map<string, TurnHoldState> {
+  const global = globalThis as GlobalWithHoldState
+  global[HOLD_STATE_KEY] ??= new Map()
+  return global[HOLD_STATE_KEY]!
+}
+
+export function markSubagentTypeInTurn(sessionID: string, subagentType: string): void {
+  const state = getHoldStateMap().get(sessionID) ?? { seenSubagentTypes: new Set<string>() }
+  state.seenSubagentTypes.add(subagentType.trim().toLowerCase())
+  getHoldStateMap().set(sessionID, state)
+}
+
+export function hasPlanInCurrentTurn(sessionID: string): boolean {
+  return getHoldStateMap().get(sessionID)?.seenSubagentTypes.has("plan") ?? false
+}
+
+export function clearTurnState(sessionID: string): void {
+  getHoldStateMap().delete(sessionID)
+}
+
+export function clearAllTurnHoldStateForTesting(): void {
+  getHoldStateMap().clear()
+}

--- a/packages/omo-opencode/src/features/background-agent/task-registry.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-registry.ts
@@ -61,6 +61,7 @@ function cloneRegisteredTask(task: BackgroundTask): BackgroundTask {
     spawnDepth: task.spawnDepth,
     sessionId: task.sessionId,
     status: task.status,
+    droppedReason: task.droppedReason,
     queuedAt: task.queuedAt,
     startedAt: task.startedAt,
     completedAt: task.completedAt,
@@ -106,7 +107,7 @@ export function archiveBackgroundTask(task: BackgroundTask): void {
   const registry = getRegistry()
   registry.activeTasks.delete(task.id)
   registry.completedTasks.delete(task.id)
-  if (!task.sessionId || !TERMINAL_TASK_STATUSES.has(task.status)) {
+  if ((!task.sessionId && !task.droppedReason) || !TERMINAL_TASK_STATUSES.has(task.status)) {
     return
   }
   registry.completedTasks.set(task.id, cloneRegisteredTask(task))

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -53,6 +53,8 @@ export interface BackgroundTask {
   agent: string
   spawnDepth?: number
   status: BackgroundTaskStatus
+  held?: boolean
+  droppedReason?: string
   queuedAt?: Date
   startedAt?: Date
   completedAt?: Date

--- a/packages/omo-opencode/src/plugin/event.test.ts
+++ b/packages/omo-opencode/src/plugin/event.test.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../../bun-test.d.ts" />
+import { tmpdir } from "node:os"
 import { describe, it, expect, afterEach, mock, spyOn } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
 
@@ -6,6 +7,12 @@ import { createEventHandler, extractErrorMessage } from "./event"
 import { createChatMessageHandler } from "./chat-message"
 import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
 import { _resetForTesting, setMainSession, subagentSessions } from "../features/claude-code-session-state"
+import { BackgroundManager } from "../features/background-agent/manager"
+import { clearBackgroundTaskRegistryForTesting } from "../features/background-agent/task-registry"
+import { clearAllTurnHoldStateForTesting, hasPlanInCurrentTurn, markSubagentTypeInTurn } from "../features/background-agent/subagent-turn-hold-state"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { _resetForTesting as resetProcessCleanupState } from "../features/background-agent/process-cleanup"
+import { _resetTaskToastManagerForTesting } from "../features/task-toast-manager/manager"
 import { clearPendingModelFallback, createModelFallbackHook } from "../hooks/model-fallback/hook"
 import { getSessionPromptParams, setSessionPromptParams } from "../shared/session-prompt-params-state"
 
@@ -81,6 +88,70 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number = 500): Pro
 	}
 }
 
+function createHeldTaskEventFixture(): {
+  manager: BackgroundManager
+  eventHandler: ReturnType<typeof createEventHandler>
+  childSessionCreates: { count: number }
+} {
+  const childSessionCreates = { count: 0 }
+  const client = {
+    session: {
+      get: async () => ({ data: { directory: tmpdir() }, error: null }),
+      create: async () => {
+        childSessionCreates.count += 1
+        return { data: { id: `ses_child_${childSessionCreates.count}` }, error: null }
+      },
+      abort: async () => ({ data: {}, error: null }),
+      promptAsync: async () => ({}),
+    },
+  }
+  const manager = new BackgroundManager({
+    pluginContext: asPluginInput({ client, directory: tmpdir() }),
+  })
+  const eventHandler = createEventHandler({
+    ctx: asEventHandlerContext({ client, directory: tmpdir() }),
+    pluginConfig: asPluginConfig({}),
+    firstMessageVariantGate: {
+      markSessionCreated: () => {},
+      clear: () => {},
+    },
+    managers: createEventHandlerManagers({
+      backgroundManager: manager,
+      skillMcpManager: { disconnectSession: async () => {} },
+    }),
+    hooks: createEventHandlerHooks({}),
+  })
+  return { manager, eventHandler, childSessionCreates }
+}
+
+function createHeldTaskInput(parentSessionId: string): {
+  description: string
+  prompt: string
+  agent: string
+  parentSessionId: string
+  parentMessageId: string
+} {
+  return {
+    description: "explore task",
+    prompt: "gather context",
+    agent: "explore",
+    parentSessionId,
+    parentMessageId: "msg_parent",
+  }
+}
+
+async function finishAssistantTurn(eventHandler: ReturnType<typeof createEventHandler>, sessionID: string): Promise<void> {
+  await eventHandler(asEventHandlerInput({
+    event: {
+      type: "message.updated",
+      properties: {
+        sessionID,
+        info: { sessionID, role: "assistant", finish: true },
+      },
+    },
+  }))
+}
+
 function createIdleTrackingEventHandler(dispatchCalls: EventInput[]): ReturnType<typeof createEventHandler> {
 	return createEventHandler({
 		ctx: asEventHandlerContext({}),
@@ -146,6 +217,78 @@ async function flushMicrotasks(turns: number = 5): Promise<void> {
 afterEach(() => {
 	mock.restore()
 	_resetForTesting()
+	clearBackgroundTaskRegistryForTesting()
+	releaseAllPromptAsyncReservationsForTesting()
+	resetProcessCleanupState()
+	clearAllTurnHoldStateForTesting()
+	_resetTaskToastManagerForTesting()
+})
+
+describe("main-session held context tasks", () => {
+	it("releases held tasks when the main assistant turn finishes without a plan", async () => {
+		setMainSession("ses_main")
+		const { manager, eventHandler, childSessionCreates } = createHeldTaskEventFixture()
+		const task = await manager.launch(createHeldTaskInput("ses_main"))
+
+		await finishAssistantTurn(eventHandler, "ses_main")
+		await flushMicrotasks(10)
+
+		expect(childSessionCreates.count).toBe(1)
+		expect(manager.getTask(task.id)?.sessionId).toBe("ses_child_1")
+		await manager.shutdown()
+	})
+
+	it("drops held tasks when the main assistant turn includes a plan", async () => {
+		setMainSession("ses_main")
+		const { manager, eventHandler, childSessionCreates } = createHeldTaskEventFixture()
+		const task = await manager.launch(createHeldTaskInput("ses_main"))
+		markSubagentTypeInTurn("ses_main", "plan")
+
+		await finishAssistantTurn(eventHandler, "ses_main")
+
+		expect(childSessionCreates.count).toBe(0)
+		expect(manager.getTask(task.id)?.droppedReason).toBe("delegated_to_plan")
+		await manager.shutdown()
+	})
+
+	it("does not repeat release work on a duplicate finished assistant event", async () => {
+		setMainSession("ses_main")
+		const { manager, eventHandler, childSessionCreates } = createHeldTaskEventFixture()
+		await manager.launch(createHeldTaskInput("ses_main"))
+
+		await finishAssistantTurn(eventHandler, "ses_main")
+		await finishAssistantTurn(eventHandler, "ses_main")
+		await flushMicrotasks(10)
+
+		expect(childSessionCreates.count).toBe(1)
+		await manager.shutdown()
+	})
+
+	it("clears turn state after the main assistant turn finishes", async () => {
+		setMainSession("ses_main")
+		const { manager, eventHandler } = createHeldTaskEventFixture()
+		const task = await manager.launch(createHeldTaskInput("ses_main"))
+		markSubagentTypeInTurn("ses_main", "plan")
+
+		await finishAssistantTurn(eventHandler, "ses_main")
+		await manager.releaseHeldTasks("ses_main")
+
+		expect(hasPlanInCurrentTurn("ses_main")).toBe(false)
+		expect(manager.getTask(task.id)?.droppedReason).toBe("delegated_to_plan")
+		await manager.shutdown()
+	})
+
+	it("does not affect main held tasks when a child assistant turn finishes", async () => {
+		setMainSession("ses_main")
+		const { manager, eventHandler, childSessionCreates } = createHeldTaskEventFixture()
+		const task = await manager.launch(createHeldTaskInput("ses_main"))
+
+		await finishAssistantTurn(eventHandler, "ses_child")
+
+		expect(childSessionCreates.count).toBe(0)
+		expect(manager.getTask(task.id)?.status).toBe("pending")
+		await manager.shutdown()
+	})
 })
 
 describe("event error extraction", () => {

--- a/packages/omo-opencode/src/plugin/event.ts
+++ b/packages/omo-opencode/src/plugin/event.ts
@@ -5,6 +5,7 @@ import type { Managers } from "../create-managers";
 import type { PluginContext } from "./types";
 
 import { getMainSessionID, subagentSessions, syncSubagentSessions } from "../features/claude-code-session-state";
+import { clearTurnState, hasPlanInCurrentTurn } from "../features/background-agent/subagent-turn-hold-state";
 import { invalidateContextWindowUsageCache } from "../shared/dynamic-truncator";
 import { resolveSessionEventID } from "../shared/event-session-id";
 import { log } from "../shared/logger";
@@ -152,6 +153,8 @@ export function createEventHandler(args: {
     }
 
     if (event.type === "session.deleted") {
+      const deletedSessionID = resolveSessionEventID(props);
+      if (deletedSessionID) clearTurnState(deletedSessionID);
       await handleSessionDeletedEvent({
         props,
         tmuxIntegrationEnabled,
@@ -186,6 +189,23 @@ export function createEventHandler(args: {
       });
       if (state.sessionID && ((typeof state.info?.finish === "string" && state.info.finish.length > 0) || state.info?.finish === true)) {
         invalidateContextWindowUsageCache(pluginContext as PluginInput, state.sessionID);
+        const mainSessionID = getMainSessionID();
+        if (state.role === "assistant" && state.sessionID === mainSessionID && managers.backgroundManager) {
+          try {
+            if (hasPlanInCurrentTurn(state.sessionID)) {
+              await managers.backgroundManager.dropHeldTasks(state.sessionID);
+            } else {
+              await managers.backgroundManager.releaseHeldTasks(state.sessionID);
+            }
+          } catch (error) {
+            log("[event] Error processing held tasks on main session finish:", {
+              sessionID: state.sessionID,
+              error,
+            });
+          } finally {
+            clearTurnState(state.sessionID);
+          }
+        }
       }
       if (state.sessionID && state.role === "assistant") {
         try {

--- a/packages/omo-opencode/src/plugin/tool-execute-before.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.test.ts
@@ -2,8 +2,18 @@ const { afterEach, describe, expect, test } = require("bun:test")
 const { createToolExecuteBeforeHandler } = require("./tool-execute-before")
 const { createToolRegistry } = require("./tool-registry")
 const { resetStorageClient } = require("../tools/session-manager/storage")
+const { _resetForTesting: resetClaudeCodeSessionState, setMainSession } = require("../features/claude-code-session-state")
+const {
+  clearAllTurnHoldStateForTesting,
+  hasPlanInCurrentTurn,
+} = require("../features/background-agent/subagent-turn-hold-state")
 
 describe("createToolExecuteBeforeHandler", () => {
+  afterEach(() => {
+    resetClaudeCodeSessionState()
+    clearAllTurnHoldStateForTesting()
+  })
+
   test("does not execute subagent question blocker hook for question tool", async () => {
     //#given
     const ctx = {
@@ -271,12 +281,136 @@ describe("createToolExecuteBeforeHandler", () => {
       //#then
       expect(output.args.subagent_type).toBe("oracle")
     })
+
+    test("records a plan launch only for the main session", async () => {
+      //#given
+      setMainSession("ses_main")
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const mainOutput = { args: { subagent_type: "plan", description: "Plan task" } as Record<string, unknown> }
+      const childOutput = { args: { subagent_type: "plan", description: "Child plan task" } as Record<string, unknown> }
+
+      //#when
+      await handler({ tool: "task", sessionID: "ses_main", callID: "call_main" }, mainOutput)
+      await handler({ tool: "task", sessionID: "ses_child", callID: "call_child" }, childOutput)
+
+      //#then
+      expect(hasPlanInCurrentTurn("ses_main")).toBe(true)
+      expect(hasPlanInCurrentTurn("ses_child")).toBe(false)
+    })
+
+    test("awaits dropping held tasks for a normalized main-session plan before returning", async () => {
+      //#given
+      setMainSession("ses_main")
+      let resolveDrop: (() => void) | undefined
+      let dropCalls = 0
+      let dropSettled = false
+      const backgroundManager = {
+        dropHeldTasks: async (sessionID: string) => {
+          expect(sessionID).toBe("ses_main")
+          dropCalls += 1
+          await new Promise<void>((resolve) => {
+            resolveDrop = resolve
+          })
+          dropSettled = true
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({
+        ctx: createCtxWithSessionMessages(),
+        hooks: emptyHooks,
+        backgroundManager,
+      })
+      const run = handler(
+        { tool: "task", sessionID: "ses_main", callID: "call_main" },
+        { args: { subagent_type: "plan", description: "Plan task" } as Record<string, unknown> },
+      )
+
+      //#when
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      //#then
+      expect(dropCalls).toBe(1)
+      expect(dropSettled).toBe(false)
+      resolveDrop?.()
+      await run
+      expect(dropSettled).toBe(true)
+    })
+
+    test("does not drop main held tasks for a non-main plan", async () => {
+      //#given
+      setMainSession("ses_main")
+      let dropCalls = 0
+      const handler = createToolExecuteBeforeHandler({
+        ctx: createCtxWithSessionMessages(),
+        hooks: emptyHooks,
+        backgroundManager: { dropHeldTasks: async () => { dropCalls += 1 } },
+      })
+
+      //#when
+      await handler(
+        { tool: "task", sessionID: "ses_child", callID: "call_child" },
+        { args: { subagent_type: "plan", description: "Child plan task" } as Record<string, unknown> },
+      )
+
+      //#then
+      expect(dropCalls).toBe(0)
+      expect(hasPlanInCurrentTurn("ses_main")).toBe(false)
+      expect(hasPlanInCurrentTurn("ses_child")).toBe(false)
+    })
+
+    test("records main explore and librarian launches without dropping held tasks", async () => {
+      //#given
+      setMainSession("ses_main")
+      let dropCalls = 0
+      const handler = createToolExecuteBeforeHandler({
+        ctx: createCtxWithSessionMessages(),
+        hooks: emptyHooks,
+        backgroundManager: { dropHeldTasks: async () => { dropCalls += 1 } },
+      })
+
+      //#when
+      await handler(
+        { tool: "task", sessionID: "ses_main", callID: "call_explore" },
+        { args: { subagent_type: "explore", description: "Explore task" } as Record<string, unknown> },
+      )
+      await handler(
+        { tool: "task", sessionID: "ses_main", callID: "call_librarian" },
+        { args: { subagent_type: "librarian", description: "Librarian task" } as Record<string, unknown> },
+      )
+
+      //#then
+      expect(dropCalls).toBe(0)
+      expect(hasPlanInCurrentTurn("ses_main")).toBe(false)
+    })
+
+    test("propagates a held-task drop failure after recording a main-session plan", async () => {
+      //#given
+      setMainSession("ses_main")
+      const dropError = new Error("drop failed")
+      const handler = createToolExecuteBeforeHandler({
+        ctx: createCtxWithSessionMessages(),
+        hooks: emptyHooks,
+        backgroundManager: { dropHeldTasks: async () => { throw dropError } },
+      })
+
+      //#when
+      const run = handler(
+        { tool: "task", sessionID: "ses_main", callID: "call_main" },
+        { args: { subagent_type: "plan", description: "Plan task" } as Record<string, unknown> },
+      )
+
+      //#then
+      await expect(run).rejects.toBe(dropError)
+      expect(hasPlanInCurrentTurn("ses_main")).toBe(true)
+    })
   })
 })
 
 describe("createToolRegistry", () => {
   afterEach(() => {
     resetStorageClient()
+    resetClaudeCodeSessionState()
+    clearAllTurnHoldStateForTesting()
   })
 
   function createRegistryInput(overrides = {}) {

--- a/packages/omo-opencode/src/plugin/tool-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.ts
@@ -1,6 +1,7 @@
 import type { PluginContext } from "./types"
 
 import { getMainSessionID } from "../features/claude-code-session-state"
+import { markSubagentTypeInTurn } from "../features/background-agent/subagent-turn-hold-state"
 import { log, replaceToolArgs } from "../shared"
 import { resolveSessionAgent } from "./session-agent-resolver"
 import { stopContinuation } from "./stop-continuation"
@@ -27,7 +28,7 @@ function isPureSleepCommand(command: string): boolean {
 export function createToolExecuteBeforeHandler(args: {
   ctx: PluginContext
   hooks: CreatedHooks
-  backgroundManager?: Pick<BackgroundManager, "hasActiveChildTasks" | "hasPendingParentWake">
+  backgroundManager?: Pick<BackgroundManager, "hasActiveChildTasks" | "hasPendingParentWake" | "dropHeldTasks">
 }): (
   input: { tool: string; sessionID: string; callID: string },
   output: { args: Record<string, unknown> },
@@ -116,6 +117,14 @@ export function createToolExecuteBeforeHandler(args: {
       } else if (!subagentType && taskId) {
         const resolvedAgent = await resolveSessionAgent(ctx.client, taskId)
         replaceToolArgs(output, { subagent_type: resolvedAgent ?? "continue" })
+      }
+      const normalizedSubagentType = typeof output.args.subagent_type === "string" ? output.args.subagent_type : undefined
+      const mainSessionID = getMainSessionID()
+      if (input.sessionID === mainSessionID && normalizedSubagentType) {
+        markSubagentTypeInTurn(input.sessionID, normalizedSubagentType)
+        if (normalizedSubagentType.trim().toLowerCase() === "plan") {
+          await backgroundManager?.dropHeldTasks(mainSessionID)
+        }
       }
     }
 

--- a/packages/omo-opencode/src/tools/background-task/create-background-output.dropped-task.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.dropped-task.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="bun-types" />
+
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { describe, expect, test } from "bun:test"
+import type { BackgroundTask } from "../../features/background-agent"
+import { TASK_DROPPED_REASON_DELEGATED_TO_PLAN } from "../../features/background-agent/constants"
+import type { BackgroundOutputClient, BackgroundOutputManager } from "./clients"
+import { createBackgroundOutput } from "./create-background-output"
+
+type TestToolContext = ToolContext & { callID: string }
+
+function createContext(): TestToolContext {
+  return {
+    sessionID: "ses_parent",
+    messageID: "msg_parent",
+    agent: "sisyphus",
+    directory: "/tmp",
+    worktree: "/tmp",
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+    callID: "call_1",
+  }
+}
+
+function createClient(messagesCalled?: { value: boolean }): BackgroundOutputClient {
+  return {
+    session: {
+      messages: async () => {
+        if (messagesCalled) messagesCalled.value = true
+        return { data: [] }
+      },
+    },
+  }
+}
+
+function createDroppedTask(): BackgroundTask {
+  return {
+    id: "bg_dropped",
+    sessionId: "ses_child",
+    parentSessionId: "ses_parent",
+    parentMessageId: "msg_parent",
+    description: "explore code patterns",
+    prompt: "find patterns",
+    agent: "explore",
+    status: "cancelled",
+    droppedReason: TASK_DROPPED_REASON_DELEGATED_TO_PLAN,
+    completedAt: new Date(),
+  }
+}
+
+describe("background_output dropped tasks", () => {
+  test("returns the dropped-task explanation before full-session formatting", async () => {
+    const task = createDroppedTask()
+    const manager: BackgroundOutputManager = { getTask: (id) => id === task.id ? task : undefined }
+    const messagesCalled = { value: false }
+    const tool = createBackgroundOutput(manager, createClient(messagesCalled))
+
+    const output = await tool.execute({ task_id: task.id, full_session: true }, createContext())
+
+    expect(output).toContain("This explore/librarian task was skipped")
+    expect(output).toContain("plan agent was delegated")
+    expect(output).toContain(task.id)
+    expect(output).not.toContain("Context Gathering Task IDs")
+    expect(messagesCalled.value).toBe(false)
+  })
+
+  test("keeps the normal cancelled status for unrelated cancellations", async () => {
+    const task = { ...createDroppedTask(), id: "bg_cancelled", droppedReason: undefined, description: "normal task" }
+    const manager: BackgroundOutputManager = { getTask: (id) => id === task.id ? task : undefined }
+    const tool = createBackgroundOutput(manager, createClient())
+
+    const output = await tool.execute({ task_id: task.id }, createContext())
+
+    expect(output).toContain("# Task Status")
+    expect(output).not.toContain("This explore/librarian task was skipped")
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/create-background-output.ts
+++ b/packages/omo-opencode/src/tools/background-task/create-background-output.ts
@@ -8,7 +8,7 @@ import { BACKGROUND_OUTPUT_DESCRIPTION } from "./constants"
 import { delay } from "./delay"
 import { formatFullSession } from "./full-session-format"
 import { formatTaskResult } from "./task-result-format"
-import { formatTaskStatus } from "./task-status-format"
+import { formatTaskDroppedMessage, formatTaskStatus } from "./task-status-format"
 
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { recordBackgroundOutputConsumption } from "../../shared/background-output-consumption"
@@ -170,6 +170,9 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
         }
 
         const isActive = isTaskActiveStatus(resolvedTask.status)
+        if (resolvedTask.droppedReason === "delegated_to_plan") {
+          return formatTaskDroppedMessage(resolvedTask)
+        }
         const fullSession = args.full_session ?? false
         const includeThinking = isActive || (args.include_thinking ?? false)
         const includeToolResults = isActive || (args.include_tool_results ?? false)

--- a/packages/omo-opencode/src/tools/background-task/task-status-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/task-status-format.ts
@@ -32,24 +32,24 @@ ${truncated}
 \`\`\``
   }
 
-   let statusNote = ""
-   if (task.status === "pending") {
-     statusNote = `
+  let statusNote = ""
+  if (task.status === "pending") {
+    statusNote = `
 
 > **Queued**: Task is waiting for a concurrency slot to become available.`
-   } else if (task.status === "running") {
-     statusNote = `
+  } else if (task.status === "running") {
+    statusNote = `
 
 > **Note**: No need to wait explicitly - the system will notify you when this task completes.`
-   } else if (task.status === "error") {
-     statusNote = `
+  } else if (task.status === "error") {
+    statusNote = `
 
 > **Failed**: The task encountered an error. Check the last message for details.`
-   } else if (task.status === "interrupt") {
-     statusNote = `
+  } else if (task.status === "interrupt") {
+    statusNote = `
 
 > **Interrupted**: The task was interrupted by a prompt error. The session may contain partial results.`
-   }
+  }
 
   const durationLabel = task.status === "pending" ? "Queued for" : "Duration"
 
@@ -69,4 +69,13 @@ ${statusNote}
 \`\`\`
 ${promptPreview}
 \`\`\`${lastMessageSection}`
+}
+
+export function formatTaskDroppedMessage(task: BackgroundTask): string {
+  return `This explore/librarian task was skipped because a plan agent was delegated in the same turn.
+
+The plan agent gathered context itself. Query the recorded task IDs via background_output.
+
+Task ID: \`${task.id}\`
+Description: ${task.description}`
 }

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -9,6 +9,50 @@ const { executeBackgroundTask } = require("./background-task")
 const { __setTimingConfig, __resetTimingConfig } = require("./timing")
 const { SessionCategoryRegistry } = require("../../shared/session-category-registry")
 
+async function runCallOrderScenario(agentOrder: string[]): Promise<unknown> {
+  const tasks = new Map<string, { sessionId?: string; status: string; held?: boolean }>()
+  const manager = {
+    launch: async (input: { agent: string }) => {
+      const id = `bg_${input.agent}`
+      const held = input.agent === "explore" || input.agent === "librarian"
+      const task = {
+        id,
+        sessionId: held ? undefined : `ses_${input.agent}`,
+        description: input.agent,
+        agent: input.agent,
+        status: held ? "pending" : "running",
+        ...(held ? { held: true } : {}),
+      }
+      tasks.set(id, task)
+      return task
+    },
+    getTask: (taskID: string) => tasks.get(taskID),
+  }
+  return Promise.race([
+    Promise.all(agentOrder.map((agent, index) => executeBackgroundTask(
+      {
+        description: `${agent} call ${index}`,
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: `call_${agent}_${index}`,
+        metadata: async () => {},
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: `msg_${agent}_${index}` },
+      agent,
+      undefined,
+      undefined,
+      undefined,
+    ))),
+    new Promise<"timed_out">(resolve => setTimeout(() => resolve("timed_out"), 25)),
+  ])
+}
+
 describeFn("executeBackgroundTask output/session metadata compatibility", () => {
   beforeEachFn(() => {
     //#given - reduce waiting to keep tests fast
@@ -650,5 +694,129 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     expectFn(result).not.toContain("to check.")
     expectFn(result).toContain("Do NOT call background_output now")
     expectFn(result).toContain("<system-reminder>")
+  })
+
+  testFn("returns an explicitly held pending launch without waiting for a session id", async () => {
+    //#given - the manager holds this task until the parent assistant turn finishes
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
+    const manager = {
+      launch: async () => ({
+        id: "bg_held",
+        sessionId: undefined,
+        description: "Held research",
+        agent: "explore",
+        status: "pending",
+        held: true,
+      }),
+      getTask: () => ({ sessionId: undefined, status: "pending", held: true }),
+    }
+
+    //#when
+    const result = await Promise.race([
+      executeBackgroundTask(
+        {
+          description: "Held research",
+          prompt: "check",
+          run_in_background: true,
+          load_skills: [],
+        },
+        {
+          sessionID: "ses_parent",
+          callID: "call_held",
+          metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
+          abort: new AbortController().signal,
+        },
+        { manager },
+        { sessionID: "ses_parent", messageID: "msg_held" },
+        "explore",
+        undefined,
+        undefined,
+        undefined,
+      ),
+      new Promise<"timed_out">(resolve => setTimeout(() => resolve("timed_out"), 10)),
+    ])
+
+    //#then - held task returns its stable background id and keeps session metadata absent
+    expectFn(result).not.toBe("timed_out")
+    expectFn(result).toContain("Background Task ID: bg_held")
+    expectFn(result).toContain("Status: pending")
+    expectFn(metadataCalls).toHaveLength(1)
+    expectFn("sessionId" in metadataCalls[0].metadata).toBe(false)
+    expectFn("held" in metadataCalls[0].metadata).toBe(false)
+    expectFn(result).not.toContain("held: true")
+  })
+
+  testFn("continues waiting for an ordinary pending launch to receive a session id", async () => {
+    //#given - ordinary pending work still starts through the session wait path
+    let sessionId: string | undefined
+    let settled = false
+    const manager = {
+      launch: async () => ({
+        id: "bg_ordinary_pending",
+        sessionId: undefined,
+        description: "Ordinary pending",
+        agent: "atlas",
+        status: "pending",
+      }),
+      getTask: () => ({ sessionId, status: sessionId ? "running" : "pending" }),
+    }
+
+    //#when
+    const run = executeBackgroundTask(
+      {
+        description: "Ordinary pending",
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_ordinary_pending",
+        metadata: async () => {},
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_ordinary_pending" },
+      "atlas",
+      undefined,
+      undefined,
+      undefined,
+    ).then(() => {
+      settled = true
+    })
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    //#then - ordinary pending launch does not settle before session startup completes
+    expectFn(settled).toBe(false)
+    sessionId = "ses_ordinary_pending"
+    await run
+    expectFn(settled).toBe(true)
+  })
+
+  testFn("settles research-before-plan call order without waiting for held sessions", async () => {
+    //#given - research calls are held before a plan call in one parent turn
+    const result = await runCallOrderScenario(["explore", "librarian", "plan"])
+
+    //#then - every sibling executor promise can settle before the parent finish event
+    expectFn(result).not.toBe("timed_out")
+    expectFn(result).toHaveLength(3)
+  })
+
+  testFn("settles plan-before-research call order without waiting for held sessions", async () => {
+    //#given - the plan call appears before held research calls
+    const result = await runCallOrderScenario(["plan", "explore", "librarian"])
+
+    //#then - call ordering does not restore the session-start wait deadlock
+    expectFn(result).not.toBe("timed_out")
+    expectFn(result).toHaveLength(3)
+  })
+
+  testFn("settles a no-plan research call without waiting for a held session", async () => {
+    //#given - no plan call exists to release the held research task
+    const result = await runCallOrderScenario(["explore", "librarian"])
+
+    //#then - both tools return their stable pending task outputs
+    expectFn(result).not.toBe("timed_out")
+    expectFn(result).toHaveLength(2)
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -141,23 +141,25 @@ export async function executeBackgroundTask(
     // BackgroundManager.launch() returns immediately (pending) before the session exists,
     // so we must wait briefly for the session to be created to set metadata correctly.
     const timing = getTimingConfig()
-    let sessionId = await waitForBackgroundSessionStart({
-      taskId: task.id,
-      initialSessionId: task.sessionId,
-      manager,
-      timing,
-      abortSignal: ctx.abort,
-      onAbort: () => {
-        continueSessionSetup({
-          taskID: task.id,
-          manager,
-          timing,
-          fallbackChain,
-          category: args.category,
-          modelFallbackControllerAccessor: executorCtx.modelFallbackControllerAccessor,
-        })
-      },
-    })
+    let sessionId = task.held
+      ? task.sessionId
+      : await waitForBackgroundSessionStart({
+        taskId: task.id,
+        initialSessionId: task.sessionId,
+        manager,
+        timing,
+        abortSignal: ctx.abort,
+        onAbort: () => {
+          continueSessionSetup({
+            taskID: task.id,
+            manager,
+            timing,
+            fallbackChain,
+            category: args.category,
+            modelFallbackControllerAccessor: executorCtx.modelFallbackControllerAccessor,
+          })
+        },
+      })
 
     const updatedTask = typeof manager.getTask === "function"
       ? manager.getTask(task.id)

--- a/packages/omo-opencode/src/tools/delegate-task/constants.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/constants.ts
@@ -26,12 +26,18 @@ MANDATORY CONTEXT GATHERING PROTOCOL:
    - call_omo_agent(description="Explore codebase patterns", subagent_type="explore", run_in_background=true, prompt="<search for relevant patterns, files, and implementations in the codebase related to user's request>")
    - call_omo_agent(description="Research documentation", subagent_type="librarian", run_in_background=true, prompt="<search for external documentation, examples, and best practices related to user's request>")
 
-2. After gathering context, ALWAYS present:
+2. Capture Task IDs from background agent responses when they are available:
+   - If a response includes "Task ID: <task_id>", record the actual ID.
+   - Include Context Gathering Task IDs only when background agents were launched and actual Task IDs are available.
+   - Do NOT invent, guess, or fabricate Task IDs.
+   - Query those IDs with background_output when needed.
+
+3. After gathering context, ALWAYS present:
    - **User Request Summary**: Concise restatement of what the user is asking for
    - **Uncertainties**: List of unclear points, ambiguities, or assumptions you're making
    - **Clarifying Questions**: Specific questions to resolve the uncertainties
 
-3. ITERATE until ALL requirements are crystal clear:
+4. ITERATE until ALL requirements are crystal clear:
    - Do NOT proceed to planning until you have 100% clarity
    - Ask the user to confirm your understanding
    - Resolve every ambiguity before generating the work plan
@@ -157,6 +163,15 @@ YOUR PLAN OUTPUT MUST FOLLOW THIS EXACT STRUCTURE:
 
 \`\`\`markdown
 # [Plan Title]
+
+## Context Gathering Task IDs
+
+Include this section only when background agents were launched during context gathering and their responses provided actual Task IDs.
+
+- **Explore Agent Task ID**: [actual Task ID, if available]
+- **Librarian Agent Task ID**: [actual Task ID, if available]
+
+Do NOT invent Task IDs. If no actual Task IDs are available, omit this section.
 
 ## Context
 [User request summary, interview findings, research results]

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -3633,8 +3633,13 @@ describe("sisyphus-task", () => {
       // then
       expect(result).toContain("<system>")
       expect(result).toContain("MANDATORY CONTEXT GATHERING PROTOCOL")
+      expect(result).toContain("Context Gathering Task IDs")
+      expect(result).toContain("only when background agents were launched and actual Task IDs are available")
+      expect(result).toContain("Do NOT invent Task IDs")
       expect(result).toContain("### AVAILABLE CATEGORIES")
       expect(result).toContain("`deep`")
+      expect(result).not.toContain("- **Explore Agent Task ID**: bg_...")
+      expect(result).not.toContain("- **Librarian Agent Task ID**: bg_...")
       expect(result).not.toContain("prompt-engineer")
       expect(result).toBe(buildPlanAgentSystemPrepend(availableCategories, availableSkills))
     })


### PR DESCRIPTION
## Summary

- Prevent redundant main-session `explore`/`librarian` background agents when a `plan` agent is delegated in the same turn — the plan agent already gathers context itself, so the parent-level research duplicates that work.
- Implemented as a deterministic runtime guard (hold-then-decide on turn completion), independent of the plan agent's foreground/background mode and of tool-call emit order.

## Changes

- Add `subagent-turn-hold-state` module that records, per turn, which `subagent_type`s the main session delegated.
- `BackgroundManager`: hold main-session `explore`/`librarian` tasks in a zero-token `pending` state (`heldItems`) instead of launching them; add `dropHeldTasks`/`releaseHeldTasks`, a 180s safety auto-release, and cleanup on `session.deleted` and shutdown.
- `tool.execute.before`: record the delegated `subagent_type` for the main session only (plan-internal delegations run in a different session and are untouched).
- `message.updated` finish handler: if a `plan` was delegated this turn, drop the held tasks; otherwise release them for normal execution. Turn state is always cleared.
- Dropped tasks are marked `cancelled` with a `droppedReason`; `background_output` returns a clear "delegated to plan" message instead of a generic cancellation.
- The plan agent prompt now reports its context-gathering task IDs, so the orchestrator can retrieve raw results via `background_output` and avoid information loss from dropping the redundant main-session research.

## Testing

```bash
bun run typecheck
bun test
```

- New unit + integration tests cover: hold of main-session explore/librarian, drop when plan is present, release when plan is absent, plan-session (grandchild) tasks left untouched, `session.deleted` cleanup, the `message.updated` finish decision path, the `tool.execute.before` aggregation path, and the dropped-task output message.

## Related Issues

Closes #4589

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Holds main-session `explore`/`librarian` background tasks until the assistant turn finishes to prevent duplicate research when a `plan` agent runs. Previously these tasks queued immediately; now we hold them, then drop them if a plan was delegated or release them if not.

- Deterministic hold for the main session only: 180s safety auto-release; discard on `session.deleted` and on shutdown. Non‑main and plan‑internal tasks are unchanged.
- Turn tracking: in-memory per-session state records delegated `subagent_type`s; `tool.execute.before` marks the main session and eagerly calls `dropHeldTasks` when a `plan` is launched.
- Event integration: on main-session assistant finish (`message.updated`), drop or release held tasks and always clear turn state; also clear state on `session.deleted`. Suppresses parent wakes for deletions while keeping ordinary cancellation notifications.
- Task UX: held launches return immediately with a stable task ID (no session wait); dropped tasks are `cancelled` with `droppedReason=delegated_to_plan`. `background_output` short-circuits to a clear “delegated to plan” message (works with `full_session=true`). Registry archives dropped tasks even without a session ID.
- Plan prompt: adds “Context Gathering Task IDs.” Capture real Task IDs only when present in background agent responses; never invent IDs. Orchestrator can query `background_output(task_id=...)`.

<sup>Written for commit 1eba8b09764e776d75fc634588bd16dbd9106c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

