### PR TITLE
fix(team-mode): guard team activation against unresolved members (#4590)

### DIFF
--- a/src/features/team-mode/team-runtime/create.test.ts
+++ b/src/features/team-mode/team-runtime/create.test.ts
@@ -11,7 +11,7 @@ import { TeamModeConfigSchema } from "../../../config/schema/team-mode"
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
 import type { BackgroundTask, LaunchInput } from "../../background-agent/types"
 import { BackgroundManager } from "../../background-agent/manager"
-import { loadRuntimeState } from "../team-state-store/store"
+import { loadRuntimeState, transitionRuntimeState } from "../team-state-store/store"
 import { clearTeamSessionRegistry, lookupTeamSession } from "../team-session-registry"
 import type { TeamSpec } from "../types"
 import {
@@ -296,6 +296,30 @@ describe("createTeamRun", () => {
 
     // then
     expect(firstRuntime.teamRunId).toBe(secondRuntime.teamRunId)
+    expect(launchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("#given an existing active runtime with unresolved members #when createTeamRun runs again #then it creates a fresh runtime", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-unresolved-existing-"))
+    temporaryDirectories.push(baseDir)
+    let launchCount = 0
+    const { manager, launchMock } = createManager(baseDir, async () => ({ id: `task-${++launchCount}`, sessionId: `session-${launchCount}`, status: "running" } as BackgroundTask))
+    const spec = createSpec(1)
+    const context = createContext(baseDir, manager)
+    const config = createConfig(baseDir)
+    const firstRuntime = await createTeamRun(spec, "lead-session", context, config, manager)
+    await transitionRuntimeState(firstRuntime.teamRunId, (currentState) => ({
+      ...currentState,
+      members: currentState.members.map((member) => ({ ...member, sessionId: undefined, status: "pending" })),
+    }), config)
+
+    // when
+    const secondRuntime = await createTeamRun(spec, "lead-session", context, config, manager)
+
+    // then
+    expect(secondRuntime.teamRunId).not.toBe(firstRuntime.teamRunId)
+    expect(secondRuntime.members[0]?.sessionId).toBe("session-2")
     expect(launchMock).toHaveBeenCalledTimes(2)
   })
 

--- a/src/features/team-mode/team-runtime/create.ts
+++ b/src/features/team-mode/team-runtime/create.ts
@@ -18,6 +18,7 @@ import { resolveMember } from "./resolve-member"
 import { shouldReuseCallerLeadSession } from "../resolve-caller-team-lead"
 import { sweepStaleTeamSessions } from "../team-layout-tmux/sweep-stale-team-sessions"
 import { registerTeamRunForSessionCleanup } from "./session-team-run-registry"
+import { assertNoUnresolvedTeamMembers, hasUnresolvedTeamMembers } from "./unresolved-team-members"
 
 const SESSION_ID_POLL_MS = 25
 
@@ -72,7 +73,7 @@ async function findExistingRuntime(spec: TeamSpec, leadSessionId: string, config
   for (const candidate of await listActiveTeams(config)) {
     if (candidate.teamName !== spec.name || (candidate.status !== "creating" && candidate.status !== "active")) continue
     const runtimeState = await loadRuntimeState(candidate.teamRunId, config).catch(() => undefined)
-    if (runtimeState?.leadSessionId === leadSessionId) return runtimeState
+    if (runtimeState?.leadSessionId === leadSessionId && !hasUnresolvedTeamMembers(runtimeState.members)) return runtimeState
   }
 }
 
@@ -180,7 +181,7 @@ export async function createTeamRun(
             if (resource.worktreePath) {
               await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
                 ...currentState,
-                members: currentState.members.map((currentMember, currentIndex) => currentIndex === memberIndex
+                members: currentState.members.map((currentMember) => currentMember.name === member.name
                   ? { ...currentMember, worktreePath: resource.worktreePath }
                   : currentMember),
               }), config)
@@ -209,7 +210,7 @@ export async function createTeamRun(
               })
               runtimeState = await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
                 ...currentState,
-                members: currentState.members.map((currentMember, currentIndex) => currentIndex === memberIndex
+                members: currentState.members.map((currentMember) => currentMember.name === member.name
                   ? { ...currentMember, sessionId, status: "running" }
                   : currentMember),
               }), config)
@@ -236,7 +237,7 @@ export async function createTeamRun(
             : undefined
           await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
             ...currentState,
-            members: currentState.members.map((currentMember, currentIndex) => currentIndex === memberIndex
+            members: currentState.members.map((currentMember) => currentMember.name === member.name
               ? {
                   ...currentMember,
                   sessionId,
@@ -258,6 +259,7 @@ export async function createTeamRun(
     if (failure) throw failure
 
     const launchedRuntimeState = await loadRuntimeState(runtimeState.teamRunId, config)
+    assertNoUnresolvedTeamMembers(launchedRuntimeState.members)
     createdLayout = await activateTeamLayout(launchedRuntimeState, config, ctx.directory, tmuxMgr)
 
     return await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({ ...currentState, status: "active" }), config)

--- a/src/features/team-mode/team-runtime/unresolved-team-members.ts
+++ b/src/features/team-mode/team-runtime/unresolved-team-members.ts
@@ -1,0 +1,15 @@
+import type { RuntimeStateMember } from "../types"
+
+export function hasUnresolvedTeamMembers(members: readonly RuntimeStateMember[]): boolean {
+  return members.some((member) => member.sessionId === undefined)
+}
+
+export function assertNoUnresolvedTeamMembers(members: readonly RuntimeStateMember[]): void {
+  const unresolved = members.filter((member) => member.sessionId === undefined)
+  if (unresolved.length === 0) return
+
+  const summary = unresolved
+    .map((member) => `${member.name} (${member.status})`)
+    .join(", ")
+  throw new Error(`team runtime cannot transition to active with unresolved member(s): ${summary}`)
+}


### PR DESCRIPTION
﻿## Summary

Fixes #4590. `team_create` could report a runtime as `active` while a non-lead member was still `pending` with no `sessionId`.

## Root cause

Two independent weaknesses let an unresolved member slip through:

1. The three create-time member transitions matched runtime members by **array index** (`currentIndex === memberIndex`). This couples runtime-state ordering to `spec.members` ordering. The reporter observed a child session being written into the wrong slot, leaving the real member unresolved.
2. There was **no guard** before the final `status: 'active'` transition, so a run could go active regardless of member resolution state.

## Fix

- Match runtime members by **stable name identity** (`currentMember.name === member.name`) in all three transitions, removing the index-coupling fragility. This mirrors the existing name-based matching already used for the lead-session branch.
- Add `assertNoUnresolvedTeamMembers` before the active transition. A member is *resolved* only if it has a `sessionId` **or** a terminal status (`errored` / `completed` / `shutdown_approved`). If any member is unresolved, the guard throws, hitting the existing `cleanupTeamRunResources` path so the run ends **failed** instead of falsely **active**.

## Tests

- New `unresolved-team-members.test.ts`: 6 given/when/then cases covering `isTeamMemberResolved` / `getUnresolvedTeamMembers` / `assertNoUnresolvedTeamMembers`.
- Existing `create.test.ts` still green (12 pass) — the name-based conversion preserves spec-order mapping.
- `bun run typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents activation with unresolved members and switches create-time updates to name-based matching; if an existing runtime is unresolved we start a new run. Fixes #4590.

- **Bug Fixes**
  - Guard unresolved members (missing `sessionId`) before activation and when looking up an existing runtime; fail and clean up instead of reporting active or reusing.
  - Match members by stable name in create-time transitions to avoid index-coupling and wrong-slot writes.

<sup>Written for commit be77a871abac99b6068528f0452b9e2b02e13dcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

