### PR TITLE
feat(git-master): add enforce_atomic_commits config to relax mandatory commit splitting (#4483)

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6518,12 +6518,17 @@
         "git_env_prefix": {
           "default": "GIT_MASTER=1",
           "type": "string"
+        },
+        "enforce_atomic_commits": {
+          "default": true,
+          "type": "boolean"
         }
       },
       "required": [
         "commit_footer",
         "include_co_authored_by",
-        "git_env_prefix"
+        "git_env_prefix",
+        "enforce_atomic_commits"
       ],
       "additionalProperties": false
     },

--- a/packages/omo-opencode/src/config/schema/git-master.ts
+++ b/packages/omo-opencode/src/config/schema/git-master.ts
@@ -9,6 +9,8 @@ export const GitMasterConfigSchema = z.object({
   include_co_authored_by: z.boolean().default(true),
   /** Environment variable prefix for all git commands (default: "GIT_MASTER=1"). Set to "" to disable. Allows custom git hooks to detect git-master skill usage. */
   git_env_prefix: GitEnvPrefixSchema,
+  /** Enforce mandatory atomic commit splitting (ceil(file_count / 3) minimum commits). Default: true. Set to false to relax the blocking split rules - useful when changes span tightly-coupled parallel files (e.g. locale/i18n files) that are better committed together. */
+  enforce_atomic_commits: z.boolean().default(true),
 })
 
 export type GitMasterConfig = z.infer<typeof GitMasterConfigSchema>

--- a/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
+++ b/packages/omo-opencode/src/config/schema/oh-my-opencode-config.ts
@@ -87,6 +87,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
     commit_footer: true,
     include_co_authored_by: true,
     git_env_prefix: "GIT_MASTER=1",
+    enforce_atomic_commits: true,
   }),
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   websearch: WebsearchConfigSchema.optional(),

--- a/packages/omo-opencode/src/features/opencode-skill-loader/git-master-template-injection.test.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/git-master-template-injection.test.ts
@@ -420,3 +420,69 @@ describe("#given PowerShell shell detection in injectGitMasterConfig", () => {
 		})
 	})
 })
+
+const TEMPLATE_WITH_ATOMIC_PLANNING = [
+	"# Git Master Agent",
+	"",
+	"## MODE DETECTION (FIRST STEP)",
+	"",
+	"## PHASE 3: Atomic Unit Planning (BLOCKING - MUST OUTPUT BEFORE PROCEEDING)",
+	"",
+	"<atomic_planning>",
+	"**THIS PHASE HAS MANDATORY OUTPUT**",
+	"FORMULA: min_commits = ceil(file_count / 3)",
+	"**If your planned commit count < min_commits -> WRONG. SPLIT MORE.**",
+	"</atomic_planning>",
+	"",
+	"## PHASE 4: Commit Strategy Decision",
+	"",
+	"```",
+	"</execution>",
+].join("\n")
+
+describe("#given enforce_atomic_commits config", () => {
+	describe("#when enforce_atomic_commits is omitted (default)", () => {
+		it("#then keeps the blocking atomic-planning enforcement", () => {
+			const result = injectGitMasterConfig(TEMPLATE_WITH_ATOMIC_PLANNING, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "",
+			})
+
+			expect(result).toContain("FORMULA: min_commits = ceil(file_count / 3)")
+			expect(result).toContain("SPLIT MORE")
+			expect(result).not.toContain("Atomic commit splitting is RELAXED")
+		})
+	})
+
+	describe("#when enforce_atomic_commits is true explicitly", () => {
+		it("#then keeps the blocking atomic-planning enforcement", () => {
+			const result = injectGitMasterConfig(TEMPLATE_WITH_ATOMIC_PLANNING, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "",
+				enforce_atomic_commits: true,
+			})
+
+			expect(result).toContain("FORMULA: min_commits = ceil(file_count / 3)")
+			expect(result).not.toContain("Atomic commit splitting is RELAXED")
+		})
+	})
+
+	describe("#when enforce_atomic_commits is false", () => {
+		it("#then replaces the blocking enforcement with a relaxed section", () => {
+			const result = injectGitMasterConfig(TEMPLATE_WITH_ATOMIC_PLANNING, {
+				commit_footer: false,
+				include_co_authored_by: false,
+				git_env_prefix: "",
+				enforce_atomic_commits: false,
+			})
+
+			expect(result).toContain("Atomic commit splitting is RELAXED")
+			expect(result).not.toContain("FORMULA: min_commits = ceil(file_count / 3)")
+			expect(result).not.toContain("SPLIT MORE")
+			expect(result).toContain("</atomic_planning>")
+			expect(result).toContain("## PHASE 4: Commit Strategy Decision")
+		})
+	})
+})

--- a/packages/omo-opencode/src/features/opencode-skill-loader/git-master-template-injection.ts
+++ b/packages/omo-opencode/src/features/opencode-skill-loader/git-master-template-injection.ts
@@ -46,6 +46,7 @@ export function buildShellAwareGitPrefix(bashPrefix: string, shellType?: ShellTy
 export function injectGitMasterConfig(template: string, config?: GitMasterConfig): string {
 	const commitFooter = config?.commit_footer ?? true
 	const includeCoAuthoredBy = config?.include_co_authored_by ?? true
+	const enforceAtomicCommits = config?.enforce_atomic_commits ?? true
 	const gitEnvPrefix = assertValidGitEnvPrefix(config?.git_env_prefix ?? "GIT_MASTER=1")
 
 	const shellType = detectShellType()
@@ -54,6 +55,10 @@ export function injectGitMasterConfig(template: string, config?: GitMasterConfig
 	const skipBashBlockPrefixing = shellType === "powershell" || shellType === "cmd" || shellType === "csh"
 
 	let result = gitEnvPrefix ? injectGitEnvPrefix(template, shellPrefix, codeBlockLang) : template
+
+	if (!enforceAtomicCommits) {
+		result = relaxAtomicCommitEnforcement(result)
+	}
 
 	if (commitFooter || includeCoAuthoredBy) {
 		const injection = buildCommitFooterInjection(commitFooter, includeCoAuthoredBy, shellPrefix)
@@ -74,6 +79,31 @@ export function injectGitMasterConfig(template: string, config?: GitMasterConfig
 	}
 
 	return result
+}
+
+const ATOMIC_PLANNING_BLOCK_PATTERN = /<atomic_planning>[\s\S]*?<\/atomic_planning>/
+
+const RELAXED_ATOMIC_PLANNING_SECTION = [
+	"<atomic_planning>",
+	"**Atomic commit splitting is RELAXED (`enforce_atomic_commits: false`).**",
+	"",
+	"Group changes into commits by logical concern. There is NO mandatory minimum",
+	"commit count and NO blocking ceil(file_count / 3) rule. Use your judgment:",
+	"",
+	"- Prefer focused commits that each describe ONE logical change.",
+	"- Tightly-coupled files that change together for a single reason MAY share a",
+	"  commit (e.g. parallel locale/i18n files like messages/en.json + ko.json +",
+	"  fr.json, generated files alongside their source, a refactor applied across",
+	"  several files for one reason).",
+	"- Still pair test files with their implementation in the same commit.",
+	"- Avoid mixing genuinely unrelated concerns in a single commit.",
+	"",
+	"You do not need to print a blocking commit-count plan before proceeding.",
+	"</atomic_planning>",
+].join("\n")
+
+function relaxAtomicCommitEnforcement(template: string): string {
+	return template.replace(ATOMIC_PLANNING_BLOCK_PATTERN, RELAXED_ATOMIC_PLANNING_SECTION)
 }
 
 function injectGitEnvPrefix(template: string, prefix: string, codeBlockLang: string): string {

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test-support.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test-support.ts
@@ -37,6 +37,7 @@ const pluginConfig = {
     commit_footer: false,
     include_co_authored_by: false,
     git_env_prefix: "",
+    enforce_atomic_commits: true,
   },
 } satisfies OhMyOpenCodeConfig
 


### PR DESCRIPTION
﻿## Summary

Fixes #4483. The git-master skill enforces mandatory atomic commit splitting with a blocking `ceil(file_count / 3)` minimum-commit formula and no escape hatch. For changes where multiple files genuinely belong in one commit — e.g. updating parallel locale files (`messages/en.json`, `zh.json`, `ko.json`, `fr.json`) — forced splitting is just noise.

## Change

Add an `enforce_atomic_commits` boolean to `git_master` config, **default `true`** so current behavior is unchanged.

When set to `false`, `injectGitMasterConfig` replaces the `<atomic_planning>` enforcement block in the skill template with a relaxed version:

- group commits by logical concern instead of a file-count formula
- tightly-coupled files (locale/i18n sets) MAY share a commit
- still pair tests with their implementation
- no blocking minimum-commit-count plan

The flag flows from `pluginConfig.git_master` through the existing `SkillResolutionOptions.gitMasterConfig` path into `injectGitMasterConfig` — no new plumbing.

## Tests

- New `#given enforce_atomic_commits config` block in `git-master-template-injection.test.ts` (3 given/when/then cases): omitted → enforcement kept; explicit `true` → enforcement kept; `false` → enforcement block replaced with relaxed text, surrounding template (Phase 4, closing tag) preserved.
- `bun run typecheck` clean.
- `assets/oh-my-opencode.schema.json` regenerated via `bun run build:schema`.
