### PR TITLE
fix(boulder-state): create .omo/.gitignore to self-ignore temp files

### DIFF
--- a/packages/boulder-state/src/storage/write-state.ts
+++ b/packages/boulder-state/src/storage/write-state.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs"
-import { dirname } from "node:path"
+import { dirname, join } from "node:path"
 
 import type { BoulderState, BoulderWorkState } from "../types"
 import { getBoulderFilePath } from "./path"
@@ -13,6 +13,8 @@ export function writeBoulderState(directory: string, state: BoulderState): boole
     const dir = dirname(filePath)
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true })
+      // Self-ignoring .gitignore — excludes rules/ which is tracked in git
+      writeFileSync(join(dir, ".gitignore"), ["*", "!/rules/", "!/rules/**", ""].join("\n"), "utf-8")
     }
 
     const stateToWrite: BoulderState = { ...state }

--- a/packages/boulder-state/src/storage/write-state.ts
+++ b/packages/boulder-state/src/storage/write-state.ts
@@ -13,7 +13,7 @@ export function writeBoulderState(directory: string, state: BoulderState): boole
     const dir = dirname(filePath)
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true })
-      // Self-ignoring .gitignore — excludes rules/ which is tracked in git
+      // Self-ignoring .gitignore - excludes rules/ which is tracked in git
       writeFileSync(join(dir, ".gitignore"), ["*", "!/rules/", "!/rules/**", ""].join("\n"), "utf-8")
     }
 

--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -247,6 +247,30 @@ describe("boulder-state", () => {
       expect(success).toBe(true)
       expect(readBack).not.toBeNull()
       expect(readBack?.active_plan).toBe("/test/plan.md")
+    })
+
+    test('should create .omo/.gitignore when .omo directory is first created', () => {
+      // given - a fresh temp directory without .omo
+      const freshDir = join(tmpdir(), 'boulder-state-fresh-' + Date.now())
+      try {
+        // when - write boulder state to a fresh directory
+        const state: BoulderState = {
+          active_plan: '/test/gitignore-plan.md',
+          started_at: '2026-05-01T00:00:00Z',
+          session_ids: ['ses-gitignore'],
+          plan_name: 'gitignore-test',
+        }
+        const success = writeBoulderState(freshDir, state)
+
+        // then
+        expect(success).toBe(true)
+        const gitignorePath = join(freshDir, '.omo', '.gitignore')
+        expect(existsSync(gitignorePath)).toBe(true)
+        const content = readFileSync(gitignorePath, 'utf-8')
+        expect(content).toBe('*\n!/rules/\n!/rules/**\n')
+      } finally {
+        rmSync(freshDir, { recursive: true, force: true })
+      }
     })
   })
 


### PR DESCRIPTION
Fixes #4536

## Changes
- When `.omo/` directory is first created by `writeBoulderState()`, also write `.omo/.gitignore`
- Patterns: ignore everything (`*`) except `rules/` which is intentionally tracked in git
- Only creates the `.gitignore` on first creation (directory didn't exist), never overwrites

## Testing
- `bun run typecheck` ✅
- `bun test` — 57 pass, 0 fail ✅
- `bun run build` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create `.omo/.gitignore` when the boulder state directory is first created to keep temp files out of git; only `rules/` remains tracked. Adds a test to verify the file content and that it's only written on first creation, fixing #4536.

<sup>Written for commit 2551d686b538f04126aac2cd95ea442919a2e606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

