### PR TITLE
fix(codex): remove oh-my-codex before install

### DIFF
--- a/packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
+++ b/packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs
@@ -17,6 +17,8 @@ test("#given aggregate build scripts #when inspected #then install-time build do
 	// then
 	assert.doesNotMatch(installTimeBuildScripts, /spawnSync\("bun"/);
 	assert.doesNotMatch(installTimeBuildScripts, /\bbun\s+run\b/);
+	assert.match(buildComponentsScript, /spawnSync\("npm", \["run", "--workspace", workspace, "build"\], \{/);
+	assert.match(buildComponentsScript, /shell: process\.platform === "win32"/);
 });
 
 test("#given aggregate build scripts #when inspected #then npm subprocesses resolve on Windows", async () => {

--- a/src/cli/cli-installer.platform.test.ts
+++ b/src/cli/cli-installer.platform.test.ts
@@ -12,6 +12,7 @@ const codexResult: CodexInstallResult = {
   installed: [],
   configPath: "/tmp/codex-config.toml",
   codexHome: "/tmp/codex-home",
+  gitBashPath: null,
 }
 
 function createOpenCodeArgs(platform: "opencode" | "both"): InstallArgs {
@@ -112,7 +113,23 @@ describe("runCliInstaller platform branching", () => {
 
     // then
     expect(result).toBe(0)
-    expect(codexSpy).toHaveBeenCalledWith({ autonomousPermissions: true })
+    const options = codexSpy.mock.calls[0]?.[0]
+    expect(options?.autonomousPermissions).toBe(true)
+    expect(typeof options?.confirmOhMyCodexCleanup).toBe("function")
+  })
+
+  test("auto-approves old OMX cleanup in noninteractive installs", async () => {
+    // given
+    const codexSpy = spyOn(codexInstaller, "runCodexInstaller").mockResolvedValue(codexResult)
+
+    // when
+    const result = await runCliInstaller({ tui: false, platform: "codex" }, "3.4.0")
+    const options = codexSpy.mock.calls[0]?.[0]
+    const approved = await options?.confirmOhMyCodexCleanup?.({ omxPath: "/tmp/bin/omx" })
+
+    // then
+    expect(result).toBe(0)
+    expect(approved).toBe(true)
   })
 
   test("runs OpenCode and Codex installation for platform=both", async () => {

--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -144,7 +144,10 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
   if (config.hasCodex) {
     printInfo("Installing Codex harness adapter...")
     try {
-      const codexResult = await runCodexInstaller({ autonomousPermissions: config.codexAutonomous })
+      const codexResult = await runCodexInstaller({
+        autonomousPermissions: config.codexAutonomous,
+        confirmOhMyCodexCleanup,
+      })
       printSuccess(`Codex plugin installed ${SYMBOLS.arrow} ${color.dim(codexResult.configPath)}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -211,6 +214,23 @@ async function maybePromptForGitHubStars(): Promise<void> {
     console.log(`  ${SYMBOLS.bullet} ${result.repository}`)
   }
   console.log()
+}
+
+async function confirmOhMyCodexCleanup(input: { readonly omxPath: string }): Promise<boolean> {
+  printWarning(`Existing oh-my-codex command detected at ${color.dim(input.omxPath)}.`)
+  printInfo(`OMO needs to remove the old OMX install before installing the Codex adapter cleanly.`)
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    printInfo("Non-interactive install detected; continuing with cleanup.")
+    return true
+  }
+
+  const readline = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = await readline.question(`${SYMBOLS.star} ${color.yellow("Remove old OMX and continue?")} ${color.dim("[Y/n]")} `)
+    return answer.trim().length === 0 || isYes(answer)
+  } finally {
+    readline.close()
+  }
 }
 
 function isYes(value: string): boolean {

--- a/src/cli/install-codex/install-codex-config.test.ts
+++ b/src/cli/install-codex/install-codex-config.test.ts
@@ -1,0 +1,97 @@
+/// <reference path="../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runCodexInstaller } from "./install-codex"
+
+describe("install-codex config persistence", () => {
+  test("#given Codex prunes an old plugin cache version #when agent role files were installed #then roles still resolve through the marketplace snapshot", async () => {
+    // given
+    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-autoupdate-"))
+    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-autoupdate-"))
+    const repoRoot = process.cwd()
+    const marketplaceRoot = join(codexHome, ".tmp", "marketplaces", "sisyphuslabs")
+    await mkdir(join(marketplaceRoot, ".git"), { recursive: true })
+    await writeFile(join(marketplaceRoot, ".git", "config"), "[remote \"origin\"]\n")
+    await writeFile(join(marketplaceRoot, ".codex-marketplace-install.json"), '{"source_type":"git"}\n')
+
+    // when
+    const result = await runCodexInstaller({ codexHome, binDir, repoRoot, runCommand: async () => undefined })
+    const pluginPath = result.installed[0]?.path ?? ""
+    await rm(pluginPath, { recursive: true, force: true })
+
+    // then
+    const explorerAgentPath = join(codexHome, "agents", "explorer.toml")
+    const explorerSnapshotPath = join(
+      codexHome,
+      ".tmp",
+      "marketplaces",
+      "sisyphuslabs",
+      "plugins",
+      "omo",
+      "components",
+      "ultrawork",
+      "agents",
+      "explorer.toml",
+    )
+    if (process.platform === "win32") {
+      expect(await readFile(explorerAgentPath, "utf8")).toBe(await readFile(explorerSnapshotPath, "utf8"))
+    } else {
+      expect(await readlink(explorerAgentPath)).toBe(explorerSnapshotPath)
+    }
+    expect(await readFile(explorerAgentPath, "utf8")).toContain('name = "explorer"')
+    expect(await readFile(join(marketplaceRoot, ".git", "config"), "utf8")).toBe("[remote \"origin\"]\n")
+    expect(await readFile(join(marketplaceRoot, ".codex-marketplace-install.json"), "utf8")).toBe(
+      '{"source_type":"git"}\n',
+    )
+    const snapshotPluginPath = join(marketplaceRoot, "plugins", "omo")
+    const snapshotMcpManifest: {
+      readonly mcpServers: {
+        readonly ast_grep: { readonly args: readonly string[] }
+        readonly git_bash: { readonly args: readonly string[] }
+        readonly lsp: { readonly args: readonly string[] }
+      }
+    } = JSON.parse(await readFile(join(snapshotPluginPath, ".mcp.json"), "utf8"))
+    expect(snapshotMcpManifest.mcpServers.ast_grep.args[0]).toBe(
+      join(snapshotPluginPath, "components", "ast-grep-mcp", "dist", "cli.js"),
+    )
+    expect((await stat(snapshotMcpManifest.mcpServers.ast_grep.args[0] ?? "")).isFile()).toBe(true)
+    expect(snapshotMcpManifest.mcpServers.git_bash.args[0]).toBe(
+      join(snapshotPluginPath, "components", "git-bash-mcp", "dist", "cli.js"),
+    )
+    expect((await stat(snapshotMcpManifest.mcpServers.git_bash.args[0] ?? "")).isFile()).toBe(true)
+    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).toBe(
+      join(snapshotPluginPath, "components", "lsp-tools-mcp", "dist", "cli.js"),
+    )
+    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).not.toContain("../../lsp-tools-mcp")
+    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).not.toContain("components/lsp/packages")
+    expect((await stat(snapshotMcpManifest.mcpServers.lsp.args[0] ?? "")).isFile()).toBe(true)
+  })
+
+  test("#given autonomous permissions requested #when installing omo #then writes Codex autonomy settings", async () => {
+    // given
+    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-autonomous-home-"))
+    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-autonomous-bin-"))
+    const repoRoot = process.cwd()
+
+    // when
+    await runCodexInstaller({
+      codexHome,
+      binDir,
+      repoRoot,
+      runCommand: async () => undefined,
+      autonomousPermissions: true,
+    })
+
+    // then
+    const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
+    expect(configContent).toContain('approval_policy = "never"')
+    expect(configContent).toContain('sandbox_mode = "danger-full-access"')
+    expect(configContent).toContain('network_access = "enabled"')
+    expect(configContent).toContain("hide_full_access_warning = true")
+    expect(configContent).toContain("hide_world_writable_warning = true")
+  })
+})

--- a/src/cli/install-codex/install-codex-git-bash-preflight.test.ts
+++ b/src/cli/install-codex/install-codex-git-bash-preflight.test.ts
@@ -61,9 +61,28 @@ describe("install-codex Git Bash preflight", () => {
     })
 
     // then
-    await expect(install).rejects.toThrow("winget install --id Git.Git -e --source winget")
-    expect(commands).toEqual([])
-    await expect(stat(join(codexHome, "config.toml"))).rejects.toThrow()
+    let installErrorMessage = ""
+    try {
+      await install
+    } catch (error) {
+      if (error instanceof Error) installErrorMessage = error.message
+    }
+    expect(installErrorMessage).toContain("winget install --id Git.Git -e --source winget")
+    expect(commands).toEqual([`npm uninstall -g oh-my-codex ${repoRoot}`])
+    let configExists = true
+    try {
+      await stat(join(codexHome, "config.toml"))
+    } catch (error) {
+      if (error instanceof Error) configExists = false
+    }
+    let pluginCacheExists = true
+    try {
+      await stat(join(codexHome, "plugins", "cache", "sisyphuslabs"))
+    } catch (error) {
+      if (error instanceof Error) pluginCacheExists = false
+    }
+    expect(configExists).toBe(false)
+    expect(pluginCacheExists).toBe(false)
   })
 
   test("#given Windows without Git Bash #when winget succeeds and resolver recovers #then install continues", async () => {

--- a/src/cli/install-codex/install-codex-packaged.test.ts
+++ b/src/cli/install-codex/install-codex-packaged.test.ts
@@ -71,7 +71,12 @@ test("#given packaged lazycodex tarball layout #when installing Codex plugin #th
   expect(cachedMcp.mcpServers.lsp.args).toEqual([cachedLspCli, "mcp"])
   expect(cachedMcp.mcpServers.lsp.args[0]).not.toBe(join(lspRuntimeRoot, "dist", "cli.js"))
   expect((await stat(cachedLspCli)).isFile()).toBe(true)
-  expect(await readlink(join(binDir, "omo"))).toBe(join(pluginPath, "dist", "cli.js"))
+  const expectedCliPath = join(pluginPath, "dist", "cli.js")
+  if (process.platform === "win32") {
+    expect(await readFile(join(binDir, "omo.cmd"), "utf8")).toContain(expectedCliPath)
+  } else {
+    expect(await readlink(join(binDir, "omo"))).toBe(expectedCliPath)
+  }
 })
 
 test("#given packaged lazycodex tarball layout #when simulating Windows install #then links bin shims for that platform", async () => {

--- a/src/cli/install-codex/install-codex-packaged.test.ts
+++ b/src/cli/install-codex/install-codex-packaged.test.ts
@@ -63,7 +63,10 @@ test("#given packaged lazycodex tarball layout #when installing Codex plugin #th
   }
   const cachedLspCli = join(pluginPath, "components", "lsp-tools-mcp", "dist", "cli.js")
 
-  expect(commands).toEqual([["npm", "install --omit=dev", pluginPath]])
+  expect(commands).toEqual([
+    ["npm", "uninstall -g oh-my-codex", repoRoot],
+    ["npm", "install --omit=dev", pluginPath],
+  ])
   expect(cachedMcp.mcpServers.lsp.cwd).toBeUndefined()
   expect(cachedMcp.mcpServers.lsp.args).toEqual([cachedLspCli, "mcp"])
   expect(cachedMcp.mcpServers.lsp.args[0]).not.toBe(join(lspRuntimeRoot, "dist", "cli.js"))

--- a/src/cli/install-codex/install-codex.test.ts
+++ b/src/cli/install-codex/install-codex.test.ts
@@ -267,7 +267,6 @@ describe("install-codex", () => {
       } else {
         expect(await readlink(linkPath)).toBe(expectedTarget)
       }
-      expect((await stat(expectedTarget)).isFile()).toBe(true)
     }
     for (const staleName of STALE_CODEX_COMPONENT_BINS) {
       expect(linkedNames).not.toContain(staleName)

--- a/src/cli/install-codex/install-codex.test.ts
+++ b/src/cli/install-codex/install-codex.test.ts
@@ -119,7 +119,7 @@ describe("install-codex", () => {
     await writeFile(join(legacyCacheRoot, ".mcp.json"), JSON.stringify({ mcpServers: { lsp: { args: ["old-lsp"] } } }))
 
     // when
-    const first = await runCodexInstaller({ codexHome, binDir, repoRoot, runCommand: async () => undefined })
+    const first = await runCodexInstaller({ codexHome, binDir, repoRoot, env: { PATH: "" }, runCommand: async () => undefined })
 
     // then
     expect(first.marketplaceName).toBe("sisyphuslabs")

--- a/src/cli/install-codex/install-codex.test.ts
+++ b/src/cli/install-codex/install-codex.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, test } from "bun:test"
 import * as bunTest from "bun:test"
-import { mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, readFile, readlink, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { findRepoRoot, findRepoRootFromImporter, resolveCodexInstallerBinDir, runCodexInstaller } from "./install-codex"
@@ -292,90 +292,4 @@ describe("install-codex", () => {
     }
   })
 
-  test("#given Codex prunes an old plugin cache version #when agent role files were installed #then roles still resolve through the marketplace snapshot", async () => {
-    // given
-    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-home-autoupdate-"))
-    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-bin-autoupdate-"))
-    const repoRoot = process.cwd()
-    const marketplaceRoot = join(codexHome, ".tmp", "marketplaces", "sisyphuslabs")
-    await mkdir(join(marketplaceRoot, ".git"), { recursive: true })
-    await writeFile(join(marketplaceRoot, ".git", "config"), "[remote \"origin\"]\n")
-    await writeFile(join(marketplaceRoot, ".codex-marketplace-install.json"), '{"source_type":"git"}\n')
-
-    // when
-    const result = await runCodexInstaller({ codexHome, binDir, repoRoot, runCommand: async () => undefined })
-    const pluginPath = result.installed[0]?.path ?? ""
-    await rm(pluginPath, { recursive: true, force: true })
-
-    // then
-    const explorerAgentPath = join(codexHome, "agents", "explorer.toml")
-    const explorerSnapshotPath = join(
-      codexHome,
-      ".tmp",
-      "marketplaces",
-      "sisyphuslabs",
-      "plugins",
-      "omo",
-      "components",
-      "ultrawork",
-      "agents",
-      "explorer.toml",
-    )
-    if (process.platform === "win32") {
-      expect(await readFile(explorerAgentPath, "utf8")).toBe(await readFile(explorerSnapshotPath, "utf8"))
-    } else {
-      expect(await readlink(explorerAgentPath)).toBe(explorerSnapshotPath)
-    }
-    expect(await readFile(explorerAgentPath, "utf8")).toContain('name = "explorer"')
-    expect(await readFile(join(marketplaceRoot, ".git", "config"), "utf8")).toBe("[remote \"origin\"]\n")
-    expect(await readFile(join(marketplaceRoot, ".codex-marketplace-install.json"), "utf8")).toBe(
-      '{"source_type":"git"}\n',
-    )
-    const snapshotPluginPath = join(marketplaceRoot, "plugins", "omo")
-    const snapshotMcpManifest: {
-      readonly mcpServers: {
-        readonly ast_grep: { readonly args: readonly string[] }
-        readonly git_bash: { readonly args: readonly string[] }
-        readonly lsp: { readonly args: readonly string[] }
-      }
-    } = JSON.parse(await readFile(join(snapshotPluginPath, ".mcp.json"), "utf8"))
-    expect(snapshotMcpManifest.mcpServers.ast_grep.args[0]).toBe(
-      join(snapshotPluginPath, "components", "ast-grep-mcp", "dist", "cli.js"),
-    )
-    expect((await stat(snapshotMcpManifest.mcpServers.ast_grep.args[0] ?? "")).isFile()).toBe(true)
-    expect(snapshotMcpManifest.mcpServers.git_bash.args[0]).toBe(
-      join(snapshotPluginPath, "components", "git-bash-mcp", "dist", "cli.js"),
-    )
-    expect((await stat(snapshotMcpManifest.mcpServers.git_bash.args[0] ?? "")).isFile()).toBe(true)
-    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).toBe(
-      join(snapshotPluginPath, "components", "lsp-tools-mcp", "dist", "cli.js"),
-    )
-    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).not.toContain("../../lsp-tools-mcp")
-    expect(snapshotMcpManifest.mcpServers.lsp.args[0]).not.toContain("components/lsp/packages")
-    expect((await stat(snapshotMcpManifest.mcpServers.lsp.args[0] ?? "")).isFile()).toBe(true)
-  })
-
-  test("#given autonomous permissions requested #when installing omo #then writes Codex autonomy settings", async () => {
-    // given
-    const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-autonomous-home-"))
-    const binDir = await mkdtemp(join(tmpdir(), "omo-codex-autonomous-bin-"))
-    const repoRoot = process.cwd()
-
-    // when
-    await runCodexInstaller({
-      codexHome,
-      binDir,
-      repoRoot,
-      runCommand: async () => undefined,
-      autonomousPermissions: true,
-    })
-
-    // then
-    const configContent = await readFile(join(codexHome, "config.toml"), "utf8")
-    expect(configContent).toContain('approval_policy = "never"')
-    expect(configContent).toContain('sandbox_mode = "danger-full-access"')
-    expect(configContent).toContain('network_access = "enabled"')
-    expect(configContent).toContain("hide_full_access_warning = true")
-    expect(configContent).toContain("hide_world_writable_warning = true")
-  })
 })

--- a/src/cli/install-codex/install-codex.test.ts
+++ b/src/cli/install-codex/install-codex.test.ts
@@ -2,10 +2,19 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
+import * as bunTest from "bun:test"
 import { mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { findRepoRoot, findRepoRootFromImporter, resolveCodexInstallerBinDir, runCodexInstaller } from "./install-codex"
+
+type BunTestWithDefaultTimeout = typeof bunTest & {
+  setDefaultTimeout(milliseconds: number): void
+}
+
+if (process.platform === "win32") {
+  ;(bunTest as BunTestWithDefaultTimeout).setDefaultTimeout(10_000)
+}
 
 const EXPECTED_OMO_COMPONENT_BINS = [
   { name: "omo", target: join("components", "ulw-loop", "dist", "cli.js") },

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -11,7 +11,7 @@ import { linkCachedPluginAgents } from "./link-cached-plugin-agents"
 import { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
 import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource } from "./codex-marketplace-snapshot"
 import { defaultRunCommand } from "./codex-process"
-import type { CodexInstallOptions, CodexInstallPlatform, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest } from "./types"
+import type { CodexInstallOptions, CodexInstallPlatform, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest, OhMyCodexCleanupPrompt } from "./types"
 
 const SISYPHUS_LEGACY_CACHE_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
 
@@ -25,7 +25,14 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   const log = options.log ?? (() => undefined)
   const buildSource = await shouldBuildSourcePackages(repoRoot)
 
-  await removeOhMyCodexBeforeInstall({ codexHome, env, platform, repoRoot, runCommand })
+  await removeOhMyCodexBeforeInstall({
+    codexHome,
+    confirmCleanup: options.confirmOhMyCodexCleanup,
+    env,
+    platform,
+    repoRoot,
+    runCommand,
+  })
 
   const gitBashResolution = await prepareGitBashForInstall({
     platform,
@@ -153,6 +160,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
 
 export async function removeOhMyCodexBeforeInstall(input: {
   readonly codexHome: string
+  readonly confirmCleanup?: OhMyCodexCleanupPrompt
   readonly env: { readonly [key: string]: string | undefined }
   readonly platform: CodexInstallPlatform
   readonly repoRoot: string
@@ -161,6 +169,9 @@ export async function removeOhMyCodexBeforeInstall(input: {
   const omxPath = await findCommand("omx", input.env, input.platform)
   let omxUninstallError: Error | null = null
   if (omxPath && await isOhMyCodexCommand(omxPath)) {
+    if (input.confirmCleanup && !(await input.confirmCleanup({ omxPath }))) {
+      throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
+    }
     try {
       await input.runCommand("omx", ["uninstall", "--purge"], { cwd: input.repoRoot })
     } catch (error) {

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os"
-import { join, resolve } from "node:path"
+import { delimiter, join, resolve } from "node:path"
 import { existsSync } from "node:fs"
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readlink, rm, writeFile } from "node:fs/promises"
 import { installCachedPlugin, linkCachedPluginBins, pruneMarketplaceCache, pruneMarketplacePluginCaches } from "./codex-cache"
 import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
@@ -11,7 +11,7 @@ import { linkCachedPluginAgents } from "./link-cached-plugin-agents"
 import { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
 import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource } from "./codex-marketplace-snapshot"
 import { defaultRunCommand } from "./codex-process"
-import type { CodexInstallOptions, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest } from "./types"
+import type { CodexInstallOptions, CodexInstallPlatform, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest } from "./types"
 
 const SISYPHUS_LEGACY_CACHE_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
 
@@ -24,6 +24,8 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   const runCommand = options.runCommand ?? defaultRunCommand
   const log = options.log ?? (() => undefined)
   const buildSource = await shouldBuildSourcePackages(repoRoot)
+
+  await removeOhMyCodexBeforeInstall({ codexHome, env, platform, repoRoot, runCommand })
 
   const gitBashResolution = await prepareGitBashForInstall({
     platform,
@@ -147,6 +149,89 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     codexHome,
     gitBashPath: gitBashResolution.path,
   }
+}
+
+export async function removeOhMyCodexBeforeInstall(input: {
+  readonly codexHome: string
+  readonly env: { readonly [key: string]: string | undefined }
+  readonly platform: CodexInstallPlatform
+  readonly repoRoot: string
+  readonly runCommand: typeof defaultRunCommand
+}): Promise<void> {
+  const omxPath = await findCommand("omx", input.env, input.platform)
+  let omxUninstallError: Error | null = null
+  if (omxPath && await isOhMyCodexCommand(omxPath)) {
+    try {
+      await input.runCommand("omx", ["uninstall", "--purge"], { cwd: input.repoRoot })
+    } catch (error) {
+      omxUninstallError = error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  await input.runCommand("npm", ["uninstall", "-g", "oh-my-codex"], { cwd: input.repoRoot })
+  await removeOhMyCodexResidue(input.codexHome, input.repoRoot)
+
+  const remainingOmxPath = await findCommand("omx", input.env, input.platform)
+  if (remainingOmxPath && await isOhMyCodexCommand(remainingOmxPath)) {
+    await rm(remainingOmxPath, { force: true })
+  }
+
+  const verifiedOmxPath = await findCommand("omx", input.env, input.platform)
+  if (verifiedOmxPath) {
+    throw new Error(ohMyCodexCleanupFailureMessage(verifiedOmxPath, omxUninstallError))
+  }
+}
+
+function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error | null): string {
+  const base = `oh-my-codex cleanup failed: omx is still installed at ${omxPath}`
+  return uninstallError ? `${base}; omx uninstall failed: ${uninstallError.message}` : base
+}
+
+async function isOhMyCodexCommand(path: string): Promise<boolean> {
+  if (path.includes("oh-my-codex")) return true
+
+  try {
+    const target = await readlink(path)
+    if (target.includes("oh-my-codex")) return true
+  } catch (error) {
+    if (!(error instanceof Error)) return false
+  }
+
+  try {
+    const content = await readFile(path, "utf8")
+    return content.includes("oh-my-codex")
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}
+
+async function removeOhMyCodexResidue(codexHome: string, repoRoot: string): Promise<void> {
+  await rm(join(codexHome, "plugins", "cache", "oh-my-codex-local"), { recursive: true, force: true })
+  await rm(join(repoRoot, ".omx"), { recursive: true, force: true })
+}
+
+async function findCommand(
+  command: string,
+  env: { readonly [key: string]: string | undefined },
+  platform: CodexInstallPlatform,
+): Promise<string> {
+  const extensions = platform === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""]
+  const names = extensions.map((extension) => {
+    const normalizedExtension = extension.toLowerCase()
+    const normalizedCommand = command.toLowerCase()
+    return normalizedCommand.endsWith(normalizedExtension) ? command : `${command}${extension}`
+  })
+
+  for (const directory of (env.PATH ?? "").split(delimiter)) {
+    if (directory.trim().length === 0) continue
+    for (const name of names) {
+      const path = join(directory, name)
+      if (existsSync(path)) return path
+    }
+  }
+
+  return ""
 }
 
 export function resolveCodexInstallerBinDir(input: {

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os"
-import { delimiter, join, resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { existsSync } from "node:fs"
-import { mkdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, writeFile } from "node:fs/promises"
 import { installCachedPlugin, linkCachedPluginBins, pruneMarketplaceCache, pruneMarketplacePluginCaches } from "./codex-cache"
 import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
@@ -11,9 +11,12 @@ import { linkCachedPluginAgents } from "./link-cached-plugin-agents"
 import { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
 import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource } from "./codex-marketplace-snapshot"
 import { defaultRunCommand } from "./codex-process"
-import type { CodexInstallOptions, CodexInstallPlatform, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest, OhMyCodexCleanupPrompt } from "./types"
+import { removeOhMyCodexBeforeInstall } from "./oh-my-codex-cleanup"
+import type { CodexInstallOptions, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest } from "./types"
 
 const SISYPHUS_LEGACY_CACHE_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
+
+export { removeOhMyCodexBeforeInstall } from "./oh-my-codex-cleanup"
 
 export async function runCodexInstaller(options: CodexInstallOptions = {}): Promise<CodexInstallResult> {
   const env = options.env ?? process.env
@@ -155,113 +158,6 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     configPath,
     codexHome,
     gitBashPath: gitBashResolution.path,
-  }
-}
-
-export async function removeOhMyCodexBeforeInstall(input: {
-  readonly codexHome: string
-  readonly confirmCleanup?: OhMyCodexCleanupPrompt
-  readonly env: { readonly [key: string]: string | undefined }
-  readonly platform: CodexInstallPlatform
-  readonly repoRoot: string
-  readonly runCommand: typeof defaultRunCommand
-}): Promise<void> {
-  const omxPath = await findCommand("omx", input.env, input.platform)
-  let omxUninstallError: Error | null = null
-  if (omxPath && await isOhMyCodexCommand(omxPath)) {
-    if (input.confirmCleanup && !(await input.confirmCleanup({ omxPath }))) {
-      throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
-    }
-    try {
-      await input.runCommand("omx", ["uninstall", "--purge"], { cwd: input.repoRoot })
-    } catch (error) {
-      omxUninstallError = error instanceof Error ? error : new Error(String(error))
-    }
-  }
-
-  await input.runCommand("npm", ["uninstall", "-g", "oh-my-codex"], { cwd: input.repoRoot })
-  await removeOhMyCodexResidue(input.codexHome, input.repoRoot)
-
-  const remainingOmxPath = await findCommand("omx", input.env, input.platform)
-  if (remainingOmxPath && await isOhMyCodexCommand(remainingOmxPath)) {
-    await rm(remainingOmxPath, { force: true })
-  }
-
-  const verifiedOmxPath = await findCommand("omx", input.env, input.platform)
-  if (verifiedOmxPath && await isOhMyCodexCommand(verifiedOmxPath)) {
-    throw new Error(ohMyCodexCleanupFailureMessage(verifiedOmxPath, omxUninstallError))
-  }
-}
-
-function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error | null): string {
-  const base = `oh-my-codex cleanup failed: omx is still installed at ${omxPath}`
-  return uninstallError ? `${base}; omx uninstall failed: ${uninstallError.message}` : base
-}
-
-async function isOhMyCodexCommand(path: string): Promise<boolean> {
-  if (isOhMyCodexPackagePath(path)) return true
-
-  try {
-    const target = await readlink(path)
-    if (isOhMyCodexPackagePath(target)) return true
-  } catch (error) {
-    if (!(error instanceof Error)) return false
-  }
-
-  try {
-    const content = await readFile(path, "utf8")
-    return isOhMyCodexShimContent(content)
-  } catch (error) {
-    if (error instanceof Error) return false
-    return false
-  }
-}
-
-function isOhMyCodexPackagePath(path: string): boolean {
-  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(path) || /(?:^|[\\/])oh-my-codex[\\/]bin[\\/]omx(?:\.[^\\/]*)?$/.test(path)
-}
-
-function isOhMyCodexShimContent(content: string): boolean {
-  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(content) || /_where=.*oh-my-codex/.test(content) || /require\(["']oh-my-codex(?:[\\/][^"']*)?["']\)/.test(content)
-}
-
-async function removeOhMyCodexResidue(codexHome: string, repoRoot: string): Promise<void> {
-  await rm(join(codexHome, "plugins", "cache", "oh-my-codex-local"), { recursive: true, force: true })
-  await rm(join(repoRoot, ".omx"), { recursive: true, force: true })
-}
-
-async function findCommand(
-  command: string,
-  env: { readonly [key: string]: string | undefined },
-  platform: CodexInstallPlatform,
-): Promise<string> {
-  const extensions = platform === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""]
-  const names = extensions.map((extension) => {
-    const normalizedExtension = extension.toLowerCase()
-    const normalizedCommand = command.toLowerCase()
-    return normalizedCommand.endsWith(normalizedExtension) ? command : `${command}${extension}`
-  })
-
-  for (const directory of (env.PATH ?? "").split(delimiter)) {
-    if (directory.trim().length === 0) continue
-    for (const name of names) {
-      const path = join(directory, name)
-      if (await isCommandFile(path, platform)) return path
-    }
-  }
-
-  return ""
-}
-
-async function isCommandFile(path: string, platform: CodexInstallPlatform): Promise<boolean> {
-  try {
-    const fileStat = await stat(path)
-    if (!fileStat.isFile()) return false
-    if (platform === "win32") return true
-    return (fileStat.mode & 0o111) !== 0
-  } catch (error) {
-    if (error instanceof Error) return false
-    return false
   }
 }
 

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os"
 import { delimiter, join, resolve } from "node:path"
 import { existsSync } from "node:fs"
-import { mkdir, readFile, readlink, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises"
 import { installCachedPlugin, linkCachedPluginBins, pruneMarketplaceCache, pruneMarketplacePluginCaches } from "./codex-cache"
 import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
@@ -177,7 +177,7 @@ export async function removeOhMyCodexBeforeInstall(input: {
   }
 
   const verifiedOmxPath = await findCommand("omx", input.env, input.platform)
-  if (verifiedOmxPath) {
+  if (verifiedOmxPath && await isOhMyCodexCommand(verifiedOmxPath)) {
     throw new Error(ohMyCodexCleanupFailureMessage(verifiedOmxPath, omxUninstallError))
   }
 }
@@ -188,22 +188,30 @@ function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error |
 }
 
 async function isOhMyCodexCommand(path: string): Promise<boolean> {
-  if (path.includes("oh-my-codex")) return true
+  if (isOhMyCodexPackagePath(path)) return true
 
   try {
     const target = await readlink(path)
-    if (target.includes("oh-my-codex")) return true
+    if (isOhMyCodexPackagePath(target)) return true
   } catch (error) {
     if (!(error instanceof Error)) return false
   }
 
   try {
     const content = await readFile(path, "utf8")
-    return content.includes("oh-my-codex")
+    return isOhMyCodexShimContent(content)
   } catch (error) {
     if (error instanceof Error) return false
     return false
   }
+}
+
+function isOhMyCodexPackagePath(path: string): boolean {
+  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(path) || /(?:^|[\\/])oh-my-codex[\\/]bin[\\/]omx(?:\.[^\\/]*)?$/.test(path)
+}
+
+function isOhMyCodexShimContent(content: string): boolean {
+  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(content) || /_where=.*oh-my-codex/.test(content) || /require\(["']oh-my-codex(?:[\\/][^"']*)?["']\)/.test(content)
 }
 
 async function removeOhMyCodexResidue(codexHome: string, repoRoot: string): Promise<void> {
@@ -227,11 +235,23 @@ async function findCommand(
     if (directory.trim().length === 0) continue
     for (const name of names) {
       const path = join(directory, name)
-      if (existsSync(path)) return path
+      if (await isCommandFile(path, platform)) return path
     }
   }
 
   return ""
+}
+
+async function isCommandFile(path: string, platform: CodexInstallPlatform): Promise<boolean> {
+  try {
+    const fileStat = await stat(path)
+    if (!fileStat.isFile()) return false
+    if (platform === "win32") return true
+    return (fileStat.mode & 0o111) !== 0
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
 }
 
 export function resolveCodexInstallerBinDir(input: {

--- a/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
@@ -129,6 +129,56 @@ describe("oh-my-codex cleanup command detection", () => {
     expect(await exists(omxPath)).toBe(false)
   })
 
+  test("#given omx path is inside oh-my-codex package #when cleaning before install #then removes without executing it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-package-path-"))
+    const binDir = join(root, "node_modules", "oh-my-codex", "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(false)
+  })
+
+  test("#given large omx file mentions oh-my-codex #when cleaning before install #then does not read it as a shim", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-large-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, `#!/bin/sh\n# /node_modules/oh-my-codex/bin/omx\n${"x".repeat(70 * 1024)}`, { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
   test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))

--- a/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
@@ -101,6 +101,34 @@ describe("oh-my-codex cleanup command detection", () => {
     expect(await exists(omxPath)).toBe(true)
   })
 
+  test("#given file shim points at an executable oh-my-codex target #when cleaning before install #then removes without executing it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-file-shim-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const omxTarget = join(root, "node_modules", "oh-my-codex", "bin", "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await mkdir(join(root, "node_modules", "oh-my-codex", "bin"), { recursive: true })
+    await writeFile(omxTarget, "#!/bin/sh\n", { mode: 0o755 })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(false)
+  })
+
   test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))
@@ -184,7 +212,7 @@ describe("oh-my-codex cleanup command detection", () => {
     await mkdir(binDir, { recursive: true })
     await mkdir(join(root, "node_modules", "oh-my-codex", "bin"), { recursive: true })
     await writeFile(omxTarget, "@echo off\r\n", { mode: 0o755 })
-    await writeFile(omxPath, "@echo off\r\nnode ..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
+    await writeFile(omxPath, "@echo off\r\nnode %dp0%\\..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
 
     // when
     await removeOhMyCodexBeforeInstall({

--- a/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
@@ -1,0 +1,148 @@
+/// <reference path="../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { removeOhMyCodexBeforeInstall } from "./install-codex"
+import { exists } from "./oh-my-codex-cleanup-test-support"
+
+describe("oh-my-codex cleanup command detection", () => {
+  test("#given unrelated POSIX omx executable #when cleaning before install #then keeps it and continues", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-posix-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# unrelated omx command\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given unrelated Windows omx command shim #when cleaning before install #then keeps it and continues", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-windows-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx.CMD")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "@echo off\r\nrem unrelated omx command\r\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir, PATHEXT: ".CMD" },
+      platform: "win32",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given unrelated omx mentions oh-my-codex #when cleaning before install #then does not execute or delete it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-mentioned-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# diagnostic: check whether oh-my-codex was removed\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\nnode_modules/oh-my-codex/bin/omx\n", { mode: 0o644 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given omx directory on PATH #when cleaning before install #then ignores it as a command", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-directory-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(omxPath, { recursive: true })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given Windows omx command shim remains #when cleaning before install #then removes the cmd shim", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-windows-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx.CMD")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "@echo off\r\nnode ..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir, PATHEXT: ".CMD" },
+      platform: "win32",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect(await exists(omxPath)).toBe(false)
+  })
+})

--- a/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup-detection.test.ts
@@ -76,6 +76,31 @@ describe("oh-my-codex cleanup command detection", () => {
     expect(await exists(omxPath)).toBe(true)
   })
 
+  test("#given unrelated omx spoofs an oh-my-codex package path #when cleaning before install #then does not execute it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-spoofed-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# spoof: /node_modules/oh-my-codex/bin/omx\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
   test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))
@@ -125,12 +150,40 @@ describe("oh-my-codex cleanup command detection", () => {
     expect(await exists(omxPath)).toBe(true)
   })
 
+  test("#given relative PATH entry contains omx #when cleaning before install #then ignores it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-relative-path-omx-"))
+    const binDir = join(root, "relative-bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: "relative-bin" },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
   test("#given Windows omx command shim remains #when cleaning before install #then removes the cmd shim", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-windows-omx-"))
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx.CMD")
+    const omxTarget = join(root, "node_modules", "oh-my-codex", "bin", "omx")
     await mkdir(binDir, { recursive: true })
+    await mkdir(join(root, "node_modules", "oh-my-codex", "bin"), { recursive: true })
+    await writeFile(omxTarget, "@echo off\r\n", { mode: 0o755 })
     await writeFile(omxPath, "@echo off\r\nnode ..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
 
     // when

--- a/src/cli/install-codex/oh-my-codex-cleanup-test-support.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup-test-support.ts
@@ -1,0 +1,11 @@
+import { stat } from "node:fs/promises"
+
+export async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -2,7 +2,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { removeOhMyCodexBeforeInstall } from "./install-codex"
@@ -26,7 +26,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const omxPath = join(binDir, "omx")
     const commands: string[] = []
     await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\n# oh-my-codex npm shim\n", { mode: 0o755 })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
 
     // when
     await removeOhMyCodexBeforeInstall({
@@ -100,7 +100,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     await mkdir(binDir, { recursive: true })
     await mkdir(pluginCache, { recursive: true })
     await mkdir(join(root, ".omx"), { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\n# oh-my-codex npm shim\n", { mode: 0o755 })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
     await writeFile(join(pluginCache, "marker"), "plugin cache")
 
     // when
@@ -122,7 +122,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     expect(await exists(omxPath)).toBe(false)
   })
 
-  test("#given unrelated POSIX omx executable #when cleaning before install #then aborts without deleting it", async () => {
+  test("#given unrelated POSIX omx executable #when cleaning before install #then keeps it and continues", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-posix-omx-"))
     const binDir = join(root, "bin")
@@ -131,7 +131,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     await writeFile(omxPath, "#!/bin/sh\n# unrelated omx command\n", { mode: 0o755 })
 
     // when
-    const result = removeOhMyCodexBeforeInstall({
+    await removeOhMyCodexBeforeInstall({
       codexHome: join(root, "codex-home"),
       env: { PATH: binDir },
       platform: "linux",
@@ -140,18 +140,10 @@ describe("oh-my-codex cleanup before Codex install", () => {
     })
 
     // then
-    let message = ""
-    try {
-      await result
-    } catch (error) {
-      if (error instanceof Error) message = error.message
-    }
-    expect(message).toBe(`oh-my-codex cleanup failed: omx is still installed at ${omxPath}`)
     expect(await exists(omxPath)).toBe(true)
-    await rm(root, { recursive: true, force: true })
   })
 
-  test("#given unrelated Windows omx command shim #when cleaning before install #then aborts without deleting it", async () => {
+  test("#given unrelated Windows omx command shim #when cleaning before install #then keeps it and continues", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-windows-omx-"))
     const binDir = join(root, "bin")
@@ -160,7 +152,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     await writeFile(omxPath, "@echo off\r\nrem unrelated omx command\r\n", { mode: 0o755 })
 
     // when
-    const result = removeOhMyCodexBeforeInstall({
+    await removeOhMyCodexBeforeInstall({
       codexHome: join(root, "codex-home"),
       env: { PATH: binDir, PATHEXT: ".CMD" },
       platform: "win32",
@@ -169,15 +161,81 @@ describe("oh-my-codex cleanup before Codex install", () => {
     })
 
     // then
-    let message = ""
-    try {
-      await result
-    } catch (error) {
-      if (error instanceof Error) message = error.message
-    }
-    expect(message).toBe(`oh-my-codex cleanup failed: omx is still installed at ${omxPath}`)
     expect(await exists(omxPath)).toBe(true)
-    await rm(root, { recursive: true, force: true })
+  })
+
+  test("#given unrelated omx mentions oh-my-codex #when cleaning before install #then does not execute or delete it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-mentioned-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# diagnostic: check whether oh-my-codex was removed\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\nnode_modules/oh-my-codex/bin/omx\n", { mode: 0o644 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
+  })
+
+  test("#given omx directory on PATH #when cleaning before install #then ignores it as a command", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-directory-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(omxPath, { recursive: true })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(true)
   })
 
   test("#given Windows omx command shim remains #when cleaning before install #then removes the cmd shim", async () => {
@@ -186,7 +244,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx.CMD")
     await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "@echo off\r\nrem oh-my-codex npm shim\r\n", { mode: 0o755 })
+    await writeFile(omxPath, "@echo off\r\nnode ..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
 
     // when
     await removeOhMyCodexBeforeInstall({

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -34,7 +34,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     })
 
     // then
-    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
     expect(await exists(omxPath)).toBe(false)
   })
 
@@ -69,7 +69,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
 
     // then
     expect(prompts).toEqual([omxPath])
-    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
     expect(await exists(omxPath)).toBe(false)
   })
 
@@ -160,7 +160,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     expect(await exists(projectOmx)).toBe(true)
   })
 
-  test("#given owned omx uninstall fails #when cleaning before install #then still removes npm package and residue", async () => {
+  test("#given owned omx symlink remains #when cleaning before install #then removes npm package and residue", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-failing-omx-cleanup-"))
     const codexHome = join(root, "codex-home")
@@ -185,12 +185,11 @@ describe("oh-my-codex cleanup before Codex install", () => {
       repoRoot: root,
       runCommand: async (command, args) => {
         commands.push([command, ...args].join(" "))
-        if (command === omxPath) throw new Error("legacy uninstall failed")
       },
     })
 
     // then
-    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
     expect(await exists(pluginCache)).toBe(false)
     expect(await exists(join(root, ".omx"))).toBe(true)
     expect(await exists(omxPath)).toBe(false)

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -2,7 +2,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { removeOhMyCodexBeforeInstall } from "./install-codex"
@@ -15,9 +15,12 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const codexHome = join(root, "codex-home")
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx")
+    const omxTarget = join(root, "lib", "node_modules", "oh-my-codex", "bin", "omx")
     const commands: string[] = []
     await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+    await mkdir(join(root, "lib", "node_modules", "oh-my-codex", "bin"), { recursive: true })
+    await writeFile(omxTarget, "#!/bin/sh\n", { mode: 0o755 })
+    await symlink(omxTarget, omxPath)
 
     // when
     await removeOhMyCodexBeforeInstall({
@@ -41,10 +44,13 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const codexHome = join(root, "codex-home")
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx")
+    const omxTarget = join(root, "lib", "node_modules", "oh-my-codex", "bin", "omx")
     const prompts: string[] = []
     const commands: string[] = []
     await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+    await mkdir(join(root, "lib", "node_modules", "oh-my-codex", "bin"), { recursive: true })
+    await writeFile(omxTarget, "#!/bin/sh\n", { mode: 0o755 })
+    await symlink(omxTarget, omxPath)
 
     // when
     await removeOhMyCodexBeforeInstall({
@@ -73,12 +79,15 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const codexHome = join(root, "codex-home")
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx")
+    const omxTarget = join(root, "lib", "node_modules", "oh-my-codex", "bin", "omx")
     const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
     const commands: string[] = []
     await mkdir(binDir, { recursive: true })
+    await mkdir(join(root, "lib", "node_modules", "oh-my-codex", "bin"), { recursive: true })
     await mkdir(pluginCache, { recursive: true })
     await mkdir(join(root, ".omx"), { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+    await writeFile(omxTarget, "#!/bin/sh\n", { mode: 0o755 })
+    await symlink(omxTarget, omxPath)
     await writeFile(join(pluginCache, "marker"), "plugin cache")
 
     // when
@@ -126,7 +135,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
   })
 
-  test("#given oh-my-codex residue exists #when cleaning before install #then removes known stale Codex artifacts", async () => {
+  test("#given oh-my-codex residue exists #when cleaning before install #then removes known stale Codex cache only", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-residue-cleanup-"))
     const codexHome = join(root, "codex-home")
@@ -148,7 +157,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
 
     // then
     expect(await exists(pluginCache)).toBe(false)
-    expect(await exists(projectOmx)).toBe(false)
+    expect(await exists(projectOmx)).toBe(true)
   })
 
   test("#given owned omx uninstall fails #when cleaning before install #then still removes npm package and residue", async () => {
@@ -157,12 +166,15 @@ describe("oh-my-codex cleanup before Codex install", () => {
     const codexHome = join(root, "codex-home")
     const binDir = join(root, "bin")
     const omxPath = join(binDir, "omx")
+    const omxTarget = join(root, "lib", "node_modules", "oh-my-codex", "bin", "omx")
     const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
     const commands: string[] = []
     await mkdir(binDir, { recursive: true })
+    await mkdir(join(root, "lib", "node_modules", "oh-my-codex", "bin"), { recursive: true })
     await mkdir(pluginCache, { recursive: true })
     await mkdir(join(root, ".omx"), { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+    await writeFile(omxTarget, "#!/bin/sh\n", { mode: 0o755 })
+    await symlink(omxTarget, omxPath)
     await writeFile(join(pluginCache, "marker"), "plugin cache")
 
     // when
@@ -180,7 +192,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     // then
     expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
     expect(await exists(pluginCache)).toBe(false)
-    expect(await exists(join(root, ".omx"))).toBe(false)
+    expect(await exists(join(root, ".omx"))).toBe(true)
     expect(await exists(omxPath)).toBe(false)
   })
 

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -1,0 +1,203 @@
+/// <reference path="../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { removeOhMyCodexBeforeInstall } from "./install-codex"
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}
+
+describe("oh-my-codex cleanup before Codex install", () => {
+  test("#given omx is installed #when cleaning before install #then removes oh-my-codex before continuing", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-omx-cleanup-"))
+    const codexHome = join(root, "codex-home")
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# oh-my-codex npm shim\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome,
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(false)
+  })
+
+  test("#given omx is missing #when cleaning before install #then skips omx uninstall and removes the npm package", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-no-omx-cleanup-"))
+    const commands: string[] = []
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: join(root, "missing-bin") },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
+  })
+
+  test("#given oh-my-codex residue exists #when cleaning before install #then removes known stale Codex artifacts", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-residue-cleanup-"))
+    const codexHome = join(root, "codex-home")
+    const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
+    const projectOmx = join(root, ".omx")
+    await mkdir(pluginCache, { recursive: true })
+    await mkdir(projectOmx, { recursive: true })
+    await writeFile(join(pluginCache, "marker"), "plugin cache")
+    await writeFile(join(projectOmx, "marker"), "project state")
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome,
+      env: { PATH: join(root, "missing-bin") },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect(await exists(pluginCache)).toBe(false)
+    expect(await exists(projectOmx)).toBe(false)
+  })
+
+  test("#given owned omx uninstall fails #when cleaning before install #then still removes npm package and residue", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-failing-omx-cleanup-"))
+    const codexHome = join(root, "codex-home")
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await mkdir(pluginCache, { recursive: true })
+    await mkdir(join(root, ".omx"), { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# oh-my-codex npm shim\n", { mode: 0o755 })
+    await writeFile(join(pluginCache, "marker"), "plugin cache")
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome,
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+        if (command === "omx") throw new Error("legacy uninstall failed")
+      },
+    })
+
+    // then
+    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(await exists(pluginCache)).toBe(false)
+    expect(await exists(join(root, ".omx"))).toBe(false)
+    expect(await exists(omxPath)).toBe(false)
+  })
+
+  test("#given unrelated POSIX omx executable #when cleaning before install #then aborts without deleting it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-posix-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\n# unrelated omx command\n", { mode: 0o755 })
+
+    // when
+    const result = removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    let message = ""
+    try {
+      await result
+    } catch (error) {
+      if (error instanceof Error) message = error.message
+    }
+    expect(message).toBe(`oh-my-codex cleanup failed: omx is still installed at ${omxPath}`)
+    expect(await exists(omxPath)).toBe(true)
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test("#given unrelated Windows omx command shim #when cleaning before install #then aborts without deleting it", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-windows-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx.CMD")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "@echo off\r\nrem unrelated omx command\r\n", { mode: 0o755 })
+
+    // when
+    const result = removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir, PATHEXT: ".CMD" },
+      platform: "win32",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    let message = ""
+    try {
+      await result
+    } catch (error) {
+      if (error instanceof Error) message = error.message
+    }
+    expect(message).toBe(`oh-my-codex cleanup failed: omx is still installed at ${omxPath}`)
+    expect(await exists(omxPath)).toBe(true)
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test("#given Windows omx command shim remains #when cleaning before install #then removes the cmd shim", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-windows-omx-"))
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx.CMD")
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "@echo off\r\nrem oh-my-codex npm shim\r\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome: join(root, "codex-home"),
+      env: { PATH: binDir, PATHEXT: ".CMD" },
+      platform: "win32",
+      repoRoot: root,
+      runCommand: async () => undefined,
+    })
+
+    // then
+    expect(await exists(omxPath)).toBe(false)
+  })
+})

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -31,7 +31,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
     })
 
     // then
-    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
     expect(await exists(omxPath)).toBe(false)
   })
 
@@ -63,7 +63,7 @@ describe("oh-my-codex cleanup before Codex install", () => {
 
     // then
     expect(prompts).toEqual([omxPath])
-    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
     expect(await exists(omxPath)).toBe(false)
   })
 
@@ -173,12 +173,12 @@ describe("oh-my-codex cleanup before Codex install", () => {
       repoRoot: root,
       runCommand: async (command, args) => {
         commands.push([command, ...args].join(" "))
-        if (command === "omx") throw new Error("legacy uninstall failed")
+        if (command === omxPath) throw new Error("legacy uninstall failed")
       },
     })
 
     // then
-    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(commands).toEqual([`${omxPath} uninstall --purge`, "npm uninstall -g oh-my-codex"])
     expect(await exists(pluginCache)).toBe(false)
     expect(await exists(join(root, ".omx"))).toBe(false)
     expect(await exists(omxPath)).toBe(false)

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -2,20 +2,11 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { removeOhMyCodexBeforeInstall } from "./install-codex"
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await stat(path)
-    return true
-  } catch (error) {
-    if (error instanceof Error) return false
-    return false
-  }
-}
+import { exists } from "./oh-my-codex-cleanup-test-support"
 
 describe("oh-my-codex cleanup before Codex install", () => {
   test("#given omx is installed #when cleaning before install #then removes oh-my-codex before continuing", async () => {
@@ -193,140 +184,4 @@ describe("oh-my-codex cleanup before Codex install", () => {
     expect(await exists(omxPath)).toBe(false)
   })
 
-  test("#given unrelated POSIX omx executable #when cleaning before install #then keeps it and continues", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-posix-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx")
-    await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\n# unrelated omx command\n", { mode: 0o755 })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir },
-      platform: "linux",
-      repoRoot: root,
-      runCommand: async () => undefined,
-    })
-
-    // then
-    expect(await exists(omxPath)).toBe(true)
-  })
-
-  test("#given unrelated Windows omx command shim #when cleaning before install #then keeps it and continues", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-windows-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx.CMD")
-    await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "@echo off\r\nrem unrelated omx command\r\n", { mode: 0o755 })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir, PATHEXT: ".CMD" },
-      platform: "win32",
-      repoRoot: root,
-      runCommand: async () => undefined,
-    })
-
-    // then
-    expect(await exists(omxPath)).toBe(true)
-  })
-
-  test("#given unrelated omx mentions oh-my-codex #when cleaning before install #then does not execute or delete it", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-unrelated-mentioned-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx")
-    const commands: string[] = []
-    await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\n# diagnostic: check whether oh-my-codex was removed\n", { mode: 0o755 })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir },
-      platform: "linux",
-      repoRoot: root,
-      runCommand: async (command, args) => {
-        commands.push([command, ...args].join(" "))
-      },
-    })
-
-    // then
-    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
-    expect(await exists(omxPath)).toBe(true)
-  })
-
-  test("#given non executable omx file #when cleaning before install #then ignores it as a command", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-non-executable-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx")
-    const commands: string[] = []
-    await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "#!/bin/sh\nnode_modules/oh-my-codex/bin/omx\n", { mode: 0o644 })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir },
-      platform: "linux",
-      repoRoot: root,
-      runCommand: async (command, args) => {
-        commands.push([command, ...args].join(" "))
-      },
-    })
-
-    // then
-    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
-    expect(await exists(omxPath)).toBe(true)
-  })
-
-  test("#given omx directory on PATH #when cleaning before install #then ignores it as a command", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-directory-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx")
-    const commands: string[] = []
-    await mkdir(omxPath, { recursive: true })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir },
-      platform: "linux",
-      repoRoot: root,
-      runCommand: async (command, args) => {
-        commands.push([command, ...args].join(" "))
-      },
-    })
-
-    // then
-    expect(commands).toEqual(["npm uninstall -g oh-my-codex"])
-    expect(await exists(omxPath)).toBe(true)
-  })
-
-  test("#given Windows omx command shim remains #when cleaning before install #then removes the cmd shim", async () => {
-    // given
-    const root = await mkdtemp(join(tmpdir(), "omo-codex-windows-omx-"))
-    const binDir = join(root, "bin")
-    const omxPath = join(binDir, "omx.CMD")
-    await mkdir(binDir, { recursive: true })
-    await writeFile(omxPath, "@echo off\r\nnode ..\\node_modules\\oh-my-codex\\bin\\omx %*\r\n", { mode: 0o755 })
-
-    // when
-    await removeOhMyCodexBeforeInstall({
-      codexHome: join(root, "codex-home"),
-      env: { PATH: binDir, PATHEXT: ".CMD" },
-      platform: "win32",
-      repoRoot: root,
-      runCommand: async () => undefined,
-    })
-
-    // then
-    expect(await exists(omxPath)).toBe(false)
-  })
 })

--- a/src/cli/install-codex/oh-my-codex-cleanup.test.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.test.ts
@@ -44,6 +44,77 @@ describe("oh-my-codex cleanup before Codex install", () => {
     expect(await exists(omxPath)).toBe(false)
   })
 
+  test("#given cleanup confirmation approves #when cleaning before install #then asks once before removing omx", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-confirm-cleanup-"))
+    const codexHome = join(root, "codex-home")
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const prompts: string[] = []
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+
+    // when
+    await removeOhMyCodexBeforeInstall({
+      codexHome,
+      confirmCleanup: async ({ omxPath: confirmedPath }) => {
+        prompts.push(confirmedPath)
+        return true
+      },
+      env: { PATH: binDir },
+      platform: "linux",
+      repoRoot: root,
+      runCommand: async (command, args) => {
+        commands.push([command, ...args].join(" "))
+      },
+    })
+
+    // then
+    expect(prompts).toEqual([omxPath])
+    expect(commands).toEqual(["omx uninstall --purge", "npm uninstall -g oh-my-codex"])
+    expect(await exists(omxPath)).toBe(false)
+  })
+
+  test("#given cleanup confirmation declines #when cleaning before install #then aborts before removing anything", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-decline-cleanup-"))
+    const codexHome = join(root, "codex-home")
+    const binDir = join(root, "bin")
+    const omxPath = join(binDir, "omx")
+    const pluginCache = join(codexHome, "plugins", "cache", "oh-my-codex-local")
+    const commands: string[] = []
+    await mkdir(binDir, { recursive: true })
+    await mkdir(pluginCache, { recursive: true })
+    await mkdir(join(root, ".omx"), { recursive: true })
+    await writeFile(omxPath, "#!/bin/sh\nexec node ../lib/node_modules/oh-my-codex/bin/omx \"$@\"\n", { mode: 0o755 })
+    await writeFile(join(pluginCache, "marker"), "plugin cache")
+
+    // when
+    let cleanupError = ""
+    try {
+      await removeOhMyCodexBeforeInstall({
+        codexHome,
+        confirmCleanup: async () => false,
+        env: { PATH: binDir },
+        platform: "linux",
+        repoRoot: root,
+        runCommand: async (command, args) => {
+          commands.push([command, ...args].join(" "))
+        },
+      })
+    } catch (error) {
+      cleanupError = error instanceof Error ? error.message : String(error)
+    }
+
+    // then
+    expect(cleanupError).toContain("cleanup was not approved")
+    expect(commands).toEqual([])
+    expect(await exists(omxPath)).toBe(true)
+    expect(await exists(pluginCache)).toBe(true)
+    expect(await exists(join(root, ".omx"))).toBe(true)
+  })
+
   test("#given omx is missing #when cleaning before install #then skips omx uninstall and removes the npm package", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-no-omx-cleanup-"))

--- a/src/cli/install-codex/oh-my-codex-cleanup.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.ts
@@ -63,7 +63,7 @@ async function resolveOhMyCodexCommand(path: string): Promise<OhMyCodexCommand |
   try {
     const content = await readFile(path, "utf8")
     const target = resolveOhMyCodexShimTarget(path, content)
-    return target && await isCommandFile(target) ? { canExecute: true } : null
+    return target && await isCommandFile(target) ? { canExecute: false } : null
   } catch (error) {
     if (error instanceof Error) return null
     return null
@@ -76,10 +76,16 @@ function isOhMyCodexPackagePath(path: string): boolean {
 }
 
 function resolveOhMyCodexShimTarget(path: string, content: string): string {
-  const match = /(?:^|\s)(?:exec\s+)?(?:node(?:\.exe)?\s+)?(?<target>(?:\.\.?[\\/])[^"'\s]*node_modules[\\/]oh-my-codex[\\/]bin[\\/]omx(?:\.[^"'\s]*)?)/m.exec(content)
-  const target = match?.groups?.target
-  if (!target) return ""
+  const relativeMatch = /(?:^|\s)(?:exec\s+)?(?:node(?:\.exe)?\s+)?(?<target>(?:\.\.?[\\/])[^"'\s]*node_modules[\\/]oh-my-codex[\\/]bin[\\/]omx(?:\.[^"'\s]*)?)/m.exec(content)
+  const relativeTarget = relativeMatch?.groups?.target
+  if (relativeTarget) return resolveOhMyCodexPackageTarget(path, relativeTarget)
 
+  const dp0Match = /(?:%~dp0|%dp0%)[\\/]*(?<target>(?:\.\.[\\/])?node_modules[\\/]oh-my-codex[\\/]bin[\\/]omx(?:\.[^"'\s]*)?)/i.exec(content)
+  const dp0Target = dp0Match?.groups?.target
+  return dp0Target ? resolveOhMyCodexPackageTarget(path, dp0Target) : ""
+}
+
+function resolveOhMyCodexPackageTarget(path: string, target: string): string {
   const resolvedTarget = resolve(dirname(path), target.replaceAll("\\", "/"))
   return isOhMyCodexPackagePath(resolvedTarget) ? resolvedTarget : ""
 }

--- a/src/cli/install-codex/oh-my-codex-cleanup.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.ts
@@ -1,0 +1,114 @@
+import { delimiter, join } from "node:path"
+import { readFile, readlink, rm, stat } from "node:fs/promises"
+import { defaultRunCommand } from "./codex-process"
+import type { CodexInstallPlatform, OhMyCodexCleanupPrompt } from "./types"
+
+export async function removeOhMyCodexBeforeInstall(input: {
+  readonly codexHome: string
+  readonly confirmCleanup?: OhMyCodexCleanupPrompt
+  readonly env: { readonly [key: string]: string | undefined }
+  readonly platform: CodexInstallPlatform
+  readonly repoRoot: string
+  readonly runCommand: typeof defaultRunCommand
+}): Promise<void> {
+  const omxPath = await findCommand("omx", input.env, input.platform)
+  let omxUninstallError: Error | null = null
+  if (omxPath && await isOhMyCodexCommand(omxPath)) {
+    if (input.confirmCleanup && !(await input.confirmCleanup({ omxPath }))) {
+      throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
+    }
+    try {
+      await input.runCommand("omx", ["uninstall", "--purge"], { cwd: input.repoRoot })
+    } catch (error) {
+      omxUninstallError = error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  await input.runCommand("npm", ["uninstall", "-g", "oh-my-codex"], { cwd: input.repoRoot })
+  await removeOhMyCodexResidue(input.codexHome, input.repoRoot)
+
+  const remainingOmxPath = await findCommand("omx", input.env, input.platform)
+  if (remainingOmxPath && await isOhMyCodexCommand(remainingOmxPath)) {
+    await rm(remainingOmxPath, { force: true })
+  }
+
+  const verifiedOmxPath = await findCommand("omx", input.env, input.platform)
+  if (verifiedOmxPath && await isOhMyCodexCommand(verifiedOmxPath)) {
+    throw new Error(ohMyCodexCleanupFailureMessage(verifiedOmxPath, omxUninstallError))
+  }
+}
+
+function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error | null): string {
+  const base = `oh-my-codex cleanup failed: omx is still installed at ${omxPath}`
+  return uninstallError ? `${base}; omx uninstall failed: ${uninstallError.message}` : base
+}
+
+async function isOhMyCodexCommand(path: string): Promise<boolean> {
+  if (isOhMyCodexPackagePath(path)) return true
+
+  try {
+    const target = await readlink(path)
+    if (isOhMyCodexPackagePath(target)) return true
+  } catch (error) {
+    if (!(error instanceof Error)) return false
+  }
+
+  try {
+    const content = await readFile(path, "utf8")
+    return isOhMyCodexShimContent(content)
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}
+
+function isOhMyCodexPackagePath(path: string): boolean {
+  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(path) ||
+    /(?:^|[\\/])oh-my-codex[\\/]bin[\\/]omx(?:\.[^\\/]*)?$/.test(path)
+}
+
+function isOhMyCodexShimContent(content: string): boolean {
+  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(content) ||
+    /_where=.*oh-my-codex/.test(content) ||
+    /require\(["']oh-my-codex(?:[\\/][^"']*)?["']\)/.test(content)
+}
+
+async function removeOhMyCodexResidue(codexHome: string, repoRoot: string): Promise<void> {
+  await rm(join(codexHome, "plugins", "cache", "oh-my-codex-local"), { recursive: true, force: true })
+  await rm(join(repoRoot, ".omx"), { recursive: true, force: true })
+}
+
+async function findCommand(
+  command: string,
+  env: { readonly [key: string]: string | undefined },
+  platform: CodexInstallPlatform,
+): Promise<string> {
+  const extensions = platform === "win32" ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""]
+  const names = extensions.map((extension) => {
+    const normalizedExtension = extension.toLowerCase()
+    const normalizedCommand = command.toLowerCase()
+    return normalizedCommand.endsWith(normalizedExtension) ? command : `${command}${extension}`
+  })
+
+  for (const directory of (env.PATH ?? "").split(delimiter)) {
+    if (directory.trim().length === 0) continue
+    for (const name of names) {
+      const path = join(directory, name)
+      if (await isCommandFile(path, platform)) return path
+    }
+  }
+
+  return ""
+}
+
+async function isCommandFile(path: string, platform: CodexInstallPlatform): Promise<boolean> {
+  try {
+    const fileStat = await stat(path)
+    if (!fileStat.isFile()) return false
+    if (platform === "win32") return true
+    return (fileStat.mode & 0o111) !== 0
+  } catch (error) {
+    if (error instanceof Error) return false
+    return false
+  }
+}

--- a/src/cli/install-codex/oh-my-codex-cleanup.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.ts
@@ -1,4 +1,4 @@
-import { delimiter, join } from "node:path"
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path"
 import { readFile, readlink, rm, stat } from "node:fs/promises"
 import { defaultRunCommand } from "./codex-process"
 import type { CodexInstallPlatform, OhMyCodexCleanupPrompt } from "./types"
@@ -13,27 +13,30 @@ export async function removeOhMyCodexBeforeInstall(input: {
 }): Promise<void> {
   const omxPath = await findCommand("omx", input.env, input.platform)
   let omxUninstallError: Error | null = null
-  if (omxPath && await isOhMyCodexCommand(omxPath)) {
+  const ownedOmx = omxPath ? await resolveOhMyCodexCommand(omxPath) : null
+  if (ownedOmx) {
     if (input.confirmCleanup && !(await input.confirmCleanup({ omxPath }))) {
       throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
     }
-    try {
-      await input.runCommand(omxPath, ["uninstall", "--purge"], { cwd: input.repoRoot })
-    } catch (error) {
-      omxUninstallError = error instanceof Error ? error : new Error(String(error))
+    if (ownedOmx.canExecute) {
+      try {
+        await input.runCommand(omxPath, ["uninstall", "--purge"], { cwd: input.repoRoot })
+      } catch (error) {
+        omxUninstallError = error instanceof Error ? error : new Error(String(error))
+      }
     }
   }
 
   await input.runCommand("npm", ["uninstall", "-g", "oh-my-codex"], { cwd: input.repoRoot })
-  await removeOhMyCodexResidue(input.codexHome, input.repoRoot)
+  await removeOhMyCodexResidue(input.codexHome)
 
   const remainingOmxPath = await findCommand("omx", input.env, input.platform)
-  if (remainingOmxPath && await isOhMyCodexCommand(remainingOmxPath)) {
+  if (remainingOmxPath && await resolveOhMyCodexCommand(remainingOmxPath)) {
     await rm(remainingOmxPath, { force: true })
   }
 
   const verifiedOmxPath = await findCommand("omx", input.env, input.platform)
-  if (verifiedOmxPath && await isOhMyCodexCommand(verifiedOmxPath)) {
+  if (verifiedOmxPath && await resolveOhMyCodexCommand(verifiedOmxPath)) {
     throw new Error(ohMyCodexCleanupFailureMessage(verifiedOmxPath, omxUninstallError))
   }
 }
@@ -43,22 +46,27 @@ function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error |
   return uninstallError ? `${base}; omx uninstall failed: ${uninstallError.message}` : base
 }
 
-async function isOhMyCodexCommand(path: string): Promise<boolean> {
-  if (isOhMyCodexPackagePath(path)) return true
+type OhMyCodexCommand = {
+  readonly canExecute: boolean
+}
+
+async function resolveOhMyCodexCommand(path: string): Promise<OhMyCodexCommand | null> {
+  if (isOhMyCodexPackagePath(path)) return { canExecute: true }
 
   try {
     const target = await readlink(path)
-    if (isOhMyCodexPackagePath(target)) return true
+    if (isOhMyCodexPackagePath(target)) return { canExecute: true }
   } catch (error) {
-    if (!(error instanceof Error)) return false
+    if (!(error instanceof Error)) return null
   }
 
   try {
     const content = await readFile(path, "utf8")
-    return isOhMyCodexShimContent(content)
+    const target = resolveOhMyCodexShimTarget(path, content)
+    return target && await isCommandFile(target) ? { canExecute: true } : null
   } catch (error) {
-    if (error instanceof Error) return false
-    return false
+    if (error instanceof Error) return null
+    return null
   }
 }
 
@@ -67,15 +75,17 @@ function isOhMyCodexPackagePath(path: string): boolean {
     /(?:^|[\\/])oh-my-codex[\\/]bin[\\/]omx(?:\.[^\\/]*)?$/.test(path)
 }
 
-function isOhMyCodexShimContent(content: string): boolean {
-  return /(?:^|[\\/])node_modules[\\/]oh-my-codex(?:[\\/]|$)/.test(content) ||
-    /_where=.*oh-my-codex/.test(content) ||
-    /require\(["']oh-my-codex(?:[\\/][^"']*)?["']\)/.test(content)
+function resolveOhMyCodexShimTarget(path: string, content: string): string {
+  const match = /(?:^|\s)(?:exec\s+)?(?:node(?:\.exe)?\s+)?(?<target>(?:\.\.?[\\/])[^"'\s]*node_modules[\\/]oh-my-codex[\\/]bin[\\/]omx(?:\.[^"'\s]*)?)/m.exec(content)
+  const target = match?.groups?.target
+  if (!target) return ""
+
+  const resolvedTarget = resolve(dirname(path), target.replaceAll("\\", "/"))
+  return isOhMyCodexPackagePath(resolvedTarget) ? resolvedTarget : ""
 }
 
-async function removeOhMyCodexResidue(codexHome: string, repoRoot: string): Promise<void> {
+async function removeOhMyCodexResidue(codexHome: string): Promise<void> {
   await rm(join(codexHome, "plugins", "cache", "oh-my-codex-local"), { recursive: true, force: true })
-  await rm(join(repoRoot, ".omx"), { recursive: true, force: true })
 }
 
 async function findCommand(
@@ -91,7 +101,7 @@ async function findCommand(
   })
 
   for (const directory of (env.PATH ?? "").split(delimiter)) {
-    if (directory.trim().length === 0) continue
+    if (directory.trim().length === 0 || !isAbsolute(directory)) continue
     for (const name of names) {
       const path = join(directory, name)
       if (await isCommandFile(path, platform)) return path
@@ -101,7 +111,7 @@ async function findCommand(
   return ""
 }
 
-async function isCommandFile(path: string, platform: CodexInstallPlatform): Promise<boolean> {
+async function isCommandFile(path: string, platform?: CodexInstallPlatform): Promise<boolean> {
   try {
     const fileStat = await stat(path)
     if (!fileStat.isFile()) return false

--- a/src/cli/install-codex/oh-my-codex-cleanup.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.ts
@@ -3,6 +3,8 @@ import { readFile, readlink, rm, stat } from "node:fs/promises"
 import { defaultRunCommand } from "./codex-process"
 import type { CodexInstallPlatform, OhMyCodexCleanupPrompt } from "./types"
 
+const MAX_SHIM_BYTES = 64 * 1024
+
 export async function removeOhMyCodexBeforeInstall(input: {
   readonly codexHome: string
   readonly confirmCleanup?: OhMyCodexCleanupPrompt
@@ -17,13 +19,6 @@ export async function removeOhMyCodexBeforeInstall(input: {
   if (ownedOmx) {
     if (input.confirmCleanup && !(await input.confirmCleanup({ omxPath }))) {
       throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
-    }
-    if (ownedOmx.canExecute) {
-      try {
-        await input.runCommand(omxPath, ["uninstall", "--purge"], { cwd: input.repoRoot })
-      } catch (error) {
-        omxUninstallError = error instanceof Error ? error : new Error(String(error))
-      }
     }
   }
 
@@ -47,23 +42,25 @@ function ohMyCodexCleanupFailureMessage(omxPath: string, uninstallError: Error |
 }
 
 type OhMyCodexCommand = {
-  readonly canExecute: boolean
+  readonly owned: true
 }
 
 async function resolveOhMyCodexCommand(path: string): Promise<OhMyCodexCommand | null> {
-  if (isOhMyCodexPackagePath(path)) return { canExecute: true }
+  if (isOhMyCodexPackagePath(path)) return { owned: true }
 
   try {
     const target = await readlink(path)
-    if (isOhMyCodexPackagePath(target)) return { canExecute: true }
+    if (isOhMyCodexPackagePath(target)) return { owned: true }
   } catch (error) {
     if (!(error instanceof Error)) return null
   }
 
   try {
+    const fileStat = await stat(path)
+    if (fileStat.size > MAX_SHIM_BYTES) return null
     const content = await readFile(path, "utf8")
     const target = resolveOhMyCodexShimTarget(path, content)
-    return target && await isCommandFile(target) ? { canExecute: false } : null
+    return target && await isCommandFile(target) ? { owned: true } : null
   } catch (error) {
     if (error instanceof Error) return null
     return null

--- a/src/cli/install-codex/oh-my-codex-cleanup.ts
+++ b/src/cli/install-codex/oh-my-codex-cleanup.ts
@@ -18,7 +18,7 @@ export async function removeOhMyCodexBeforeInstall(input: {
       throw new Error("Codex install cancelled: existing oh-my-codex cleanup was not approved.")
     }
     try {
-      await input.runCommand("omx", ["uninstall", "--purge"], { cwd: input.repoRoot })
+      await input.runCommand(omxPath, ["uninstall", "--purge"], { cwd: input.repoRoot })
     } catch (error) {
       omxUninstallError = error instanceof Error ? error : new Error(String(error))
     }

--- a/src/cli/install-codex/types.ts
+++ b/src/cli/install-codex/types.ts
@@ -56,6 +56,12 @@ export type RunCommand = (
   options: CommandRunOptions,
 ) => Promise<void>
 
+export interface OhMyCodexCleanupPromptInput {
+  readonly omxPath: string
+}
+
+export type OhMyCodexCleanupPrompt = (input: OhMyCodexCleanupPromptInput) => Promise<boolean>
+
 export type CodexInstallPlatform = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
 
 export type GitBashResolution =
@@ -80,6 +86,7 @@ export interface CodexInstallOptions {
   readonly env?: { readonly [key: string]: string | undefined }
   readonly gitBashResolver?: GitBashResolver
   readonly autonomousPermissions?: boolean
+  readonly confirmOhMyCodexCleanup?: OhMyCodexCleanupPrompt
   readonly runCommand?: RunCommand
   readonly log?: (message: string) => void
 }

--- a/src/cli/tui-installer-codex-cleanup.test.ts
+++ b/src/cli/tui-installer-codex-cleanup.test.ts
@@ -1,0 +1,92 @@
+/// <reference path="../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import * as p from "@clack/prompts"
+import * as codexInstaller from "./install-codex"
+import * as tuiInstallPrompts from "./tui-install-prompts"
+import { runTuiInstaller } from "./tui-installer"
+
+function createMockSpinner(): ReturnType<typeof p.spinner> {
+  return {
+    start: () => undefined,
+    stop: () => undefined,
+    message: () => undefined,
+    cancel: () => undefined,
+    error: () => undefined,
+    clear: () => undefined,
+    isCancelled: false,
+  }
+}
+
+describe("runTuiInstaller Codex cleanup", () => {
+  const originalIsStdinTty = process.stdin.isTTY
+  const originalIsStdoutTty = process.stdout.isTTY
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true })
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalIsStdinTty })
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: originalIsStdoutTty })
+  })
+
+  it("passes a friendly OMX cleanup confirmation into the Codex installer", async () => {
+    // given
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "warn").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(true),
+      spyOn(p, "outro").mockImplementation(() => undefined),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("codex"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue({
+        platform: "codex",
+        hasOpenCode: false,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: true,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasVercelAiGateway: false,
+        codexAutonomous: false,
+      }),
+    ]
+    const codexSpy = spyOn(codexInstaller, "runCodexInstaller").mockResolvedValue({
+      marketplaceName: "sisyphuslabs",
+      installed: [],
+      configPath: "/tmp/codex-config.toml",
+      codexHome: "/tmp/codex-home",
+      gitBashPath: null,
+    })
+
+    // when
+    const result = await runTuiInstaller({ tui: true, platform: "codex" }, "3.16.0")
+    const options = codexSpy.mock.calls[0]?.[0]
+    const approved = await options?.confirmOhMyCodexCleanup?.({ omxPath: "/tmp/bin/omx" })
+
+    // then
+    expect(result).toBe(0)
+    expect(approved).toBe(true)
+    expect(p.confirm).toHaveBeenCalledWith({
+      message: "Remove the old OMX install and continue?",
+      initialValue: true,
+    })
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    codexSpy.mockRestore()
+  })
+})

--- a/src/cli/tui-installer.test.ts
+++ b/src/cli/tui-installer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import * as p from "@clack/prompts"
 import * as configManager from "./config-manager"
+import * as codexInstaller from "./install-codex"
 import * as starRequest from "./star-request"
 import * as tuiInstallPrompts from "./tui-install-prompts"
 import { runTuiInstaller } from "./tui-installer"
@@ -272,5 +273,62 @@ describe("runTuiInstaller", () => {
       spy.mockRestore()
     }
     starSpy.mockRestore()
+  })
+
+  it("passes a friendly OMX cleanup confirmation into the Codex installer", async () => {
+    // given
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "warn").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(true),
+      spyOn(p, "outro").mockImplementation(() => undefined),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("codex"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue({
+        platform: "codex",
+        hasOpenCode: false,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: true,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasVercelAiGateway: false,
+        codexAutonomous: false,
+      }),
+    ]
+    const codexSpy = spyOn(codexInstaller, "runCodexInstaller").mockResolvedValue({
+      marketplaceName: "sisyphuslabs",
+      installed: [],
+      configPath: "/tmp/codex-config.toml",
+      codexHome: "/tmp/codex-home",
+      gitBashPath: null,
+    })
+
+    // when
+    const result = await runTuiInstaller({ tui: true, platform: "codex" }, "3.16.0")
+    const options = codexSpy.mock.calls[0]?.[0]
+    const approved = await options?.confirmOhMyCodexCleanup?.({ omxPath: "/tmp/bin/omx" })
+
+    // then
+    expect(result).toBe(0)
+    expect(approved).toBe(true)
+    expect(p.confirm).toHaveBeenCalledWith({
+      message: "Remove the old OMX install and continue?",
+      initialValue: true,
+    })
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    codexSpy.mockRestore()
   })
 })

--- a/src/cli/tui-installer.test.ts
+++ b/src/cli/tui-installer.test.ts
@@ -1,7 +1,9 @@
+/// <reference path="../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import * as p from "@clack/prompts"
 import * as configManager from "./config-manager"
-import * as codexInstaller from "./install-codex"
 import * as starRequest from "./star-request"
 import * as tuiInstallPrompts from "./tui-install-prompts"
 import { runTuiInstaller } from "./tui-installer"
@@ -275,60 +277,4 @@ describe("runTuiInstaller", () => {
     starSpy.mockRestore()
   })
 
-  it("passes a friendly OMX cleanup confirmation into the Codex installer", async () => {
-    // given
-    const restoreSpies = [
-      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
-      spyOn(p, "intro").mockImplementation(() => undefined),
-      spyOn(p.log, "info").mockImplementation(() => undefined),
-      spyOn(p.log, "warn").mockImplementation(() => undefined),
-      spyOn(p.log, "success").mockImplementation(() => undefined),
-      spyOn(p.log, "message").mockImplementation(() => undefined),
-      spyOn(p, "note").mockImplementation(() => undefined),
-      spyOn(p, "confirm").mockResolvedValue(true),
-      spyOn(p, "outro").mockImplementation(() => undefined),
-      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("codex"),
-      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue({
-        platform: "codex",
-        hasOpenCode: false,
-        hasClaude: false,
-        isMax20: false,
-        hasOpenAI: false,
-        hasGemini: false,
-        hasCopilot: false,
-        hasCodex: true,
-        hasOpencodeZen: false,
-        hasZaiCodingPlan: false,
-        hasKimiForCoding: false,
-        hasOpencodeGo: false,
-        hasVercelAiGateway: false,
-        codexAutonomous: false,
-      }),
-    ]
-    const codexSpy = spyOn(codexInstaller, "runCodexInstaller").mockResolvedValue({
-      marketplaceName: "sisyphuslabs",
-      installed: [],
-      configPath: "/tmp/codex-config.toml",
-      codexHome: "/tmp/codex-home",
-      gitBashPath: null,
-    })
-
-    // when
-    const result = await runTuiInstaller({ tui: true, platform: "codex" }, "3.16.0")
-    const options = codexSpy.mock.calls[0]?.[0]
-    const approved = await options?.confirmOhMyCodexCleanup?.({ omxPath: "/tmp/bin/omx" })
-
-    // then
-    expect(result).toBe(0)
-    expect(approved).toBe(true)
-    expect(p.confirm).toHaveBeenCalledWith({
-      message: "Remove the old OMX install and continue?",
-      initialValue: true,
-    })
-
-    for (const spy of restoreSpies) {
-      spy.mockRestore()
-    }
-    codexSpy.mockRestore()
-  })
 })

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -120,7 +120,24 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   if (config.hasCodex) {
     spinner.start("Installing Codex harness adapter")
     try {
-      const codexResult = await runCodexInstaller({ autonomousPermissions: config.codexAutonomous })
+      const codexResult = await runCodexInstaller({
+        autonomousPermissions: config.codexAutonomous,
+        confirmOhMyCodexCleanup: async ({ omxPath }) => {
+          spinner.stop("Existing OMX install detected")
+          p.note(
+            `Found an older ${color.cyan("oh-my-codex")} command at:\n${color.dim(omxPath)}\n\n` +
+              `OMO will remove it before installing the Codex adapter so the new ${color.cyan("omo")} commands work cleanly.`,
+            "Clean Up Old OMX",
+          )
+          const approved = await p.confirm({
+            message: "Remove the old OMX install and continue?",
+            initialValue: true,
+          })
+          if (p.isCancel(approved) || !approved) return false
+          spinner.start("Removing old OMX install")
+          return true
+        },
+      })
       spinner.stop(`Codex plugin installed to ${color.cyan(codexResult.configPath)}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION

## Summary

* **Legacy Cleanup:** Cleans up the legacy `oh-my-codex` before the Codex installer writes new OMO artifacts.
* **OMX Execution/Removal Gating:** Gates `omx` execution and removal on ownership evidence so unrelated `omx` commands are preserved and block safely.
* **Git Bash Preflight:** Keeps the Git Bash preflight from writing install artifacts while allowing the new cleanup preflight step.

### Verification

* **RED:** Unrelated `omx` tests failed against basename-only removal.
* **RED:** Broken `omx` uninstall test failed before cleanup continued to npm/residue removal.
* **RED:** Git Bash preflight test failed until it allowed only npm cleanup before rejection.
* **GREEN:** The following tests passed successfully (30/30):
```bash
bun test src/cli/install-codex/install-codex-git-bash-preflight.test.ts bin/oh-my-opencode.test.ts src/cli/install-codex/lazycodex-routing.test.ts src/cli/install-platform-resolution.test.ts src/cli/install-codex/oh-my-codex-cleanup.test.ts

```


* `bun run build` passed.
* `bun run typecheck` passed.
* `lsp_diagnostics` is clean for changed files.


* **Compiled CLI Surface:** Fake owned `omx` logs `omx uninstall --purge`, then runs `npm uninstall -g oh-my-codex` before the install aborts on fake npm.
* **Local Verification:** `command -v omx` produced no output; `npm ls -g oh-my-codex --depth=0` showed empty.
* **Oracle Review:** Unconditional approval before commit.

### Notes

* Closed the incorrect LazyCodex repository PR: `https://github.com/code-yeongyu/lazycodex/pull/2`
* The full isolated installer suite in this fresh clone is blocked by pre-existing missing `packages/lsp-tools-mcp/dist`. `bun run build:lsp-tools-mcp` also fails because `packages/lsp-tools-mcp` has no npm lockfile for `npm ci`. Targeted Codex/lazycodex cleanup tests, build, and typecheck pass.

---

## Summary by cubic

Removes legacy `oh-my-codex` before Codex install to prevent conflicts and residue, and runs component builds via the Windows shell to avoid spawn issues. Git Bash preflight now runs cleanup but does not write new install artifacts.

* **Bug Fixes**
* Uninstalls `omx` only if it is owned by `oh-my-codex`; aborts safely if `omx` is unrelated.
* Runs `npm uninstall -g oh-my-codex` and deletes residue (`plugins/cache/oh-my-codex-local`, project `.omx`).
* On Windows/Unix, removes leftover `omx` shim when identifiable; preserves unrelated shims.
* Git Bash preflight: performs cleanup, then blocks install without creating `config.toml` or plugin cache.