### PR TITLE
fix(tmux): escape quotes in placeholder command

### DIFF
--- a/src/shared/tmux/tmux-utils/pane-command.test.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.test.ts
@@ -53,6 +53,7 @@ describe("buildTmuxPlaceholderCommand", () => {
   it("keeps single quotes and percent signs inside safe printf arguments", () => {
     const cmd = buildTmuxPlaceholderCommand("Fix Bob's 100% broken pane")
     expect(cmd).toContain(`printf '%s\\n%s\\n'`)
-    expect(cmd).toContain(`"OMO subagent pane ready: Fix Bob's 100% broken pane"`)
+    // Escaped quotes \" required for nested shell -c "..." argument
+    expect(cmd).toContain(`\\"OMO subagent pane ready: Fix Bob's 100% broken pane\\"`)
   })
 })

--- a/src/shared/tmux/tmux-utils/pane-command.ts
+++ b/src/shared/tmux/tmux-utils/pane-command.ts
@@ -11,5 +11,5 @@ export function buildTmuxAttachCommand(serverUrl: string, sessionId: string, dir
 
 export function buildTmuxPlaceholderCommand(description: string): string {
   const escapedDescription = shellEscapeForDoubleQuotedCommand(description)
-  return `${TMUX_COMMAND_SHELL} -c "printf '%s\\n%s\\n' \"OMO subagent pane ready: ${escapedDescription}\" \"Focus this pane to attach.\"; while :; do sleep 86400; done"`
+  return `${TMUX_COMMAND_SHELL} -c "printf '%s\\n%s\\n' \\"OMO subagent pane ready: ${escapedDescription}\\" \\"Focus this pane to attach.\\"; while :; do sleep 86400; done"`
 }


### PR DESCRIPTION
## Root cause

Shell quoting broken in `buildTmuxPlaceholderCommand`. In JS template literals, `\"` produces literal `"` not escaped quote. Shell saw unbalanced quotes → command failed → pane exited within ~27ms.

## Fix

Changed `\"` to `\\"` in `src/shared/tmux/tmux-utils/pane-command.ts:14` so output contains proper escaped quotes for nested shell `-c "..."` argument.

## Files changed

- `src/shared/tmux/tmux-utils/pane-command.ts`
- `src/shared/tmux/tmux-utils/pane-command.test.ts`

## Verification

- `bun test src/shared/tmux/tmux-utils/pane-command.test.ts` → PASS
- `bun run build` → PASS
- Live test: spawned pane stays visible, placeholder message displays correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken shell quoting in the tmux placeholder command so the pane stays open and the message displays correctly.

- **Bug Fixes**
  - Escaped quotes with `\\"` in `buildTmuxPlaceholderCommand` for the nested `-c "..."` command to avoid unbalanced quotes and early pane exit.
  - Updated the test to assert the escaped quotes.

<sup>Written for commit b74758a1759187b4d22cfb2b83b3b3d1db9fa550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

