### PR TITLE
fix: invalidate opencode plugin cache on postinstall

### DIFF
--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,8 +1,10 @@
 // postinstall.mjs
 // Runs after npm install to verify platform binary is available
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   getPlatformPackageCandidates,
   getBinaryPath,
@@ -13,6 +15,7 @@ import { detectPlatformBinaryMismatch } from "./bin/version-mismatch.js";
 const require = createRequire(import.meta.url);
 
 const MIN_OPENCODE_VERSION = "1.4.0";
+const OPENCODE_PLUGIN_PACKAGES = ["oh-my-opencode", "oh-my-openagent"];
 
 /**
  * Parse version string into numeric parts
@@ -100,6 +103,24 @@ function getMainPackageVersion() {
   return packageJson?.version ?? null;
 }
 
+function invalidateOpenCodePluginCache() {
+  const cacheDir = join(process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache"), "opencode");
+  const parentDirs = [cacheDir, join(cacheDir, "packages")];
+  const prefixes = OPENCODE_PLUGIN_PACKAGES.map((packageName) => `${packageName}@`);
+
+  for (const parentDir of parentDirs) {
+    try {
+      for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
+        if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
+          rmSync(join(parentDir, entry.name), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // Cache invalidation is best-effort; postinstall should not fail package installs.
+    }
+  }
+}
+
 function readPlatformPackageVersion(pkg) {
   try {
     const platformPackageJsonPath = require.resolve(`${pkg}/package.json`);
@@ -114,6 +135,8 @@ function main() {
   const { platform, arch } = process;
   const libcFamily = getLibcFamily();
   const packageBaseName = getPackageBaseName();
+
+  invalidateOpenCodePluginCache();
 
   // Check opencode version requirement
   const versionCheck = checkOpenCodeVersion();


### PR DESCRIPTION
## Summary
- Refreshed/rebased implementation of #2402 for the current `dev` branch.
- Keep this PR intentionally small per review feedback: `postinstall.mjs` now only removes OpenCode plugin specifier cache directories for `oh-my-opencode@...` / `oh-my-openagent@...`.
- Cover both cache layouts seen in practice: `~/.cache/opencode/<plugin>@...` and `~/.cache/opencode/packages/<plugin>@...`.

## Context
This PR is a current-code rework of #2402 (`fix: invalidate opencode plugin cache on global install`). The old PR is stale/dirty, but the underlying issue remains the same: global npm/bun installs can update the global package while OpenCode keeps loading a stale cached plugin copy.

Per the review request, the larger `postinstall.test.mjs` coverage and the unrelated Windows Codex installer timeout change have been removed from this PR and will be handled separately.

## Testing
- `node --check postinstall.mjs`
- Manual smoke test with a temporary `XDG_CACHE_HOME` confirming only matching oh-my plugin specifier cache directories are removed
- `git diff --check`