### PR TITLE
fix(anthropic-context-window-limit-recovery): honor experimental.aggressive_truncation flag in executor (fixes #3899)

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -348,7 +348,7 @@ describe("executeCompact lock management", () => {
   })
 
   test("falls through to summarize when truncation is insufficient", async () => {
-    // given: Over token limit with truncation returning insufficient
+    // given: Over token limit with truncation returning insufficient, aggressive truncation opted in
     autoCompactState.errorDataBySession.set(sessionID, {
       errorType: "token_limit",
       currentTokens: 250000,
@@ -363,8 +363,20 @@ describe("executeCompact lock management", () => {
       nextTruncateAttempt: params.truncateAttempt + 1,
     }))
 
-    // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    const experimental = {
+      aggressive_truncation: true,
+    }
+
+    // when: Execute compaction with aggressive truncation enabled
+    await executeCompact(
+      sessionID,
+      msg,
+      autoCompactState,
+      mockClient,
+      directory,
+      pluginConfig,
+      experimental,
+    )
 
     // then: Truncation was attempted
     expect(truncateSpy).toHaveBeenCalled()
@@ -383,8 +395,76 @@ describe("executeCompact lock management", () => {
     truncateSpy.mockRestore()
   })
 
+  test("does NOT run aggressive truncation when experimental.aggressive_truncation is not enabled (#3899)", async () => {
+    //#given - Over token limit but experimental.aggressive_truncation is undefined (default)
+    autoCompactState.errorDataBySession.set(sessionID, {
+      errorType: "token_limit",
+      currentTokens: 250000,
+      maxTokens: 200000,
+    })
+
+    const truncateSpy = spyOn(
+      recoveryStrategy,
+      "runAggressiveTruncationStrategy",
+    ).mockImplementation(async (params) => ({
+      handled: false,
+      nextTruncateAttempt: params.truncateAttempt + 1,
+    }))
+
+    //#when - Execute compaction without experimental config (default behavior)
+    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+
+    //#then - Aggressive truncation must be skipped per docs (defaults false)
+    expect(truncateSpy).not.toHaveBeenCalled()
+
+    //#and - Summarize should still run as the primary recovery path
+    expect(mockClient.session.summarize).toHaveBeenCalled()
+
+    truncateSpy.mockRestore()
+  })
+
+  test("does NOT run aggressive truncation when experimental.aggressive_truncation is explicitly false (#3899)", async () => {
+    //#given - Over token limit with experimental flag explicitly false
+    autoCompactState.errorDataBySession.set(sessionID, {
+      errorType: "token_limit",
+      currentTokens: 250000,
+      maxTokens: 200000,
+    })
+
+    const truncateSpy = spyOn(
+      recoveryStrategy,
+      "runAggressiveTruncationStrategy",
+    ).mockImplementation(async (params) => ({
+      handled: false,
+      nextTruncateAttempt: params.truncateAttempt + 1,
+    }))
+
+    const experimental = {
+      aggressive_truncation: false,
+    }
+
+    //#when - Execute compaction with explicit false
+    await executeCompact(
+      sessionID,
+      msg,
+      autoCompactState,
+      mockClient,
+      directory,
+      pluginConfig,
+      experimental,
+    )
+
+    //#then - Aggressive truncation must be skipped
+    expect(truncateSpy).not.toHaveBeenCalled()
+
+    //#and - Summarize should run
+    expect(mockClient.session.summarize).toHaveBeenCalled()
+
+    truncateSpy.mockRestore()
+  })
+
   test("does NOT call summarize when truncation is sufficient", async () => {
-    // given: Over token limit with truncation returning sufficient
+    // given: Over token limit with truncation returning sufficient, aggressive truncation opted in
     autoCompactState.errorDataBySession.set(sessionID, {
       errorType: "token_limit",
       currentTokens: 250000,
@@ -411,8 +491,20 @@ describe("executeCompact lock management", () => {
       }
     })
 
-    // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    const experimental = {
+      aggressive_truncation: true,
+    }
+
+    // when: Execute compaction with aggressive truncation enabled
+    await executeCompact(
+      sessionID,
+      msg,
+      autoCompactState,
+      mockClient,
+      directory,
+      pluginConfig,
+      experimental,
+    )
 
     // Wait for setTimeout callback
     await fakeTimeouts.advanceBy(600)

--- a/src/hooks/anthropic-context-window-limit-recovery/executor.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.ts
@@ -21,10 +21,8 @@ export async function executeCompact(
   client: Client,
   directory: string,
   pluginConfig: OhMyOpenCodeConfig,
-  _experimental?: ExperimentalConfig
+  experimental?: ExperimentalConfig
 ): Promise<void> {
-  void _experimental
-
   if (autoCompactState.compactionInProgress.has(sessionID)) {
     await client.tui
       .showToast({
@@ -57,8 +55,11 @@ export async function executeCompact(
       errorData?.maxTokens &&
       errorData.currentTokens > errorData.maxTokens;
 
-    // Aggressive Truncation - always try when over limit
+    // Aggressive Truncation - opt-in via experimental.aggressive_truncation.
+    // Docs declare this default-off (docs/reference/configuration.md), and the
+    // confirmed bug in #3899 was that this branch ran regardless of the flag.
     if (
+      experimental?.aggressive_truncation === true &&
       isOverLimit &&
       truncateState.truncateAttempt < TRUNCATE_CONFIG.maxTruncateAttempts
     ) {


### PR DESCRIPTION
## Summary

The context-window-limit-recovery executor ignored the `experimental.aggressive_truncation` flag (default false per docs) and ran the aggressive-truncation strategy unconditionally on every token-limit error. This PR honors the documented default-off contract: aggressive truncation now only runs when the user opts in.

## Root Cause

[`src/hooks/anthropic-context-window-limit-recovery/executor.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/hooks/anthropic-context-window-limit-recovery/executor.ts) had two interlocking bugs:

1. Line 24 (pre-fix): `void _experimental` explicitly discarded the parameter, so the executor never saw the user's opt-in flag.
2. Lines 60-77 (pre-fix): the aggressive-truncation block ran whenever `isOverLimit && truncateAttempt < max`, with the inline comment literally reading `// Aggressive Truncation - always try when over limit`.

Maintainer triage on the issue (https://github.com/code-yeongyu/oh-my-openagent/issues/3899#issuecomment-4466435420) called this out directly: "the executor currently ignores the experimental config argument and always attempts the aggressive truncation recovery strategy when the token limit is exceeded."

Wiring was already correct on the caller side. [`recovery-hook.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts#L103-L114) passes `experimental` into both `executeCompact` call sites (the `session.error` setTimeout path and the `session.idle` path). The executor was the only place the value got dropped.

## Changes

| File | Change |
|------|--------|
| `src/hooks/anthropic-context-window-limit-recovery/executor.ts` | Rename `_experimental` -> `experimental`, drop the `void _experimental` discard, gate the aggressive-truncation block on `experimental?.aggressive_truncation === true`. |
| `src/hooks/anthropic-context-window-limit-recovery/executor.test.ts` | Two new regression tests under `executeCompact lock management` that pin the contract (skip aggressive when flag is undefined or false). Two existing tests that exercised the aggressive path now pass `{ aggressive_truncation: true }` explicitly so they continue to cover the opt-in branch. |

Diff: +103 / -10 across 2 files. Production code change is 9 lines.

## Reproduction (before fix)

Two new regression tests in `executor.test.ts` fail on `dev`:

~~~
(fail) executeCompact lock management > does NOT run aggressive truncation when experimental.aggressive_truncation is not enabled (#3899)
Expected number of calls: 0
Received number of calls: 1
  at executor.test.ts:418:29

(fail) executeCompact lock management > does NOT run aggressive truncation when experimental.aggressive_truncation is explicitly false (#3899)
Expected number of calls: 0
Received number of calls: 1
  at executor.test.ts:458:29

 11 pass
 2 fail
 27 expect() calls
~~~

The `runAggressiveTruncationStrategy` spy is invoked even though no `experimental` config is passed and the docs declare the flag default-off.

## Verification (after fix)

Same regression tests now pass:

~~~
bun test src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
 14 pass
 0 fail
 29 expect() calls
Ran 14 tests across 1 file. [3.32s]
~~~

Both new contract tests pass:
- `does NOT run aggressive truncation when experimental.aggressive_truncation is not enabled (#3899)` -> green
- `does NOT run aggressive truncation when experimental.aggressive_truncation is explicitly false (#3899)` -> green

The two pre-existing aggressive-path tests (`falls through to summarize when truncation is insufficient`, `does NOT call summarize when truncation is sufficient`) still pass with the explicit `{ aggressive_truncation: true }` payload, so the opt-in branch retains full coverage.

## Test

- Regression tests: `src/hooks/anthropic-context-window-limit-recovery/executor.test.ts` (2 new cases marked `(#3899)`)
- Related suite: `bun test src/hooks/anthropic-context-window-limit-recovery/{executor,recovery-hook,recovery-hook-regression}.test.ts` -> **20 pass / 0 fail**
- Typecheck: `bun run typecheck` -> clean

`bun test src/hooks/anthropic-context-window-limit-recovery/` shows 2 pre-existing failures in `storage.test.ts` (`truncates all if target not reached` x2) that manifest only when the full module is run together; the file passes in isolation both before and after my changes. Filed as Known Flaky Tests per the maintainer's contributor guidelines; not caused by this PR.

## Design notes / scope guardrails

- **Behavior preservation.** Users who already opt in via `{ experimental: { aggressive_truncation: true } }` see no change. Users who never set the flag now match the documented default and fall straight through to `runSummarizeRetryStrategy`. The summarize path is the documented primary recovery, and the hook's own AGENTS.md lists aggressive truncation as recovery strategy 4 of 5, not strategy 1.
- **No new defaults.** `ExperimentalConfigSchema` already declares `aggressive_truncation: z.boolean().optional()` with no default; the docs at `docs/reference/configuration.md` describe it as `false`. The fix relies on the existing schema and existing wiring, not a new default value.
- **No new dependencies, no new files, no schema changes.**

Fixes #3899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the context-window limit recovery executor to honor `experimental.aggressive_truncation`. Aggressive truncation now runs only when opted in; otherwise it falls back to the summarize strategy. Fixes #3899.

- **Bug Fixes**
  - Stop discarding the `experimental` param in the executor.
  - Gate aggressive truncation on `experimental.aggressive_truncation === true` instead of always running.
  - Add regression tests to ensure aggressive truncation is skipped when the flag is undefined or false; update existing tests to explicitly opt in.

<sup>Written for commit d8a14816cf2881068eca8e18c5ec4732fbfd9b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

