### PR TITLE
fix(hashline-core): stripRangeBoundaryEcho false positive on indent change

### DIFF
--- a/packages/hashline-core/src/edit-operations.test.ts
+++ b/packages/hashline-core/src/edit-operations.test.ts
@@ -214,6 +214,39 @@ describe("hashline edit operations", () => {
     expect(result).toEqual(["before", "new 1", "new 2", "after"])
   })
 
+it("preserves last replacement line when indentation differs from surrounding context", () => {
+  //#given - re-indentation where closing brace indent deepens
+  const lines = [
+    "    before_context",
+    "old_line_1",
+    "old_line_2",
+    "old_line_3",
+    "    after_context",
+  ]
+
+  //#when - replace 3 lines with 4; last line has deeper indent than line after range
+  const result = applyReplaceLines(
+    lines,
+    anchorFor(lines, 2),
+    anchorFor(lines, 4),
+    [
+      "    before_context",  // exact copy of line[0] → genuine echo, should strip
+      "new_line_1",
+      "new_line_2",
+      "      after_context", // deeper indent than line[4] → NOT an echo, should keep
+    ]
+  )
+
+  //#then
+  expect(result).toEqual([
+    "    before_context",
+    "new_line_1",
+    "new_line_2",
+    "      after_context",
+    "    after_context",
+  ])
+})
+
 
   it("restores indentation for first replace_lines entry", () => {
     //#given

--- a/packages/hashline-core/src/edit-text-normalization.ts
+++ b/packages/hashline-core/src/edit-text-normalization.ts
@@ -98,12 +98,12 @@ export function stripRangeBoundaryEcho(
 
   let out = newLines
   const beforeIdx = startLine - 2
-  if (beforeIdx >= 0 && equalsIgnoringWhitespace(out[0], lines[beforeIdx])) {
+  if (beforeIdx >= 0 && out[0] === lines[beforeIdx]) {
     out = out.slice(1)
   }
 
   const afterIdx = endLine
-  if (afterIdx < lines.length && out.length > 0 && equalsIgnoringWhitespace(out[out.length - 1], lines[afterIdx])) {
+  if (afterIdx < lines.length && out.length > 0 && out[out.length - 1] === lines[afterIdx]) {
     out = out.slice(0, -1)
   }
 


### PR DESCRIPTION
## Description

`stripRangeBoundaryEcho` in `edit-text-normalization.ts` uses `equalsIgnoringWhitespace` to detect boundary echoes — when the LLM accidentally includes surrounding unmodified lines in the replacement text.

The problem is that **`equalsIgnoringWhitespace` strips all whitespace before comparing**, which means a legitimate re-indentation change like `"                  ),"` (18 spaces) is treated as identical to the surrounding line `"             ),"` (13 spaces) and gets stripped from the result.

### Root Cause

```typescript
// Before (bug): whitespace-agnostic comparison treats differently-indented
// lines as echoes and drops them
if (equalsIgnoringWhitespace(out[out.length - 1], lines[afterIdx])) {
    out = out.slice(0, -1)
}
```

### Fix

Use exact string comparison (`===`) instead. Only verbatim copies of surrounding lines are genuine echoes; intentional indentation changes should be preserved.

```typescript
// After (fix): exact comparison preserves intentional indentation changes
if (out[out.length - 1] === lines[afterIdx]) {
    out = out.slice(0, -1)
}
```

### Test

Added a test that reproduces the exact scenario: a range replace where the last replacement line has the same structural content but **deeper indentation** than the line immediately after the replaced range. The old code strips it; the fix keeps it.

```
 77 pass, 0 fail (all existing tests + new test)
```

### Impact

- **Before:** Re-indentation edits that increase the indent level of a closing brace/line would silently drop that last line
- **After:** Only verbatim copies of surrounding lines are stripped; indentation changes are preserved
- **Scope:** Only affects `stripRangeBoundaryEcho` (range replace with pos+end). Safe from regressions on append/prepend/single-line replace paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `hashline-core` where the last replacement line was dropped on indent-only changes during range replaces. We now compare boundary lines exactly, preserving intentional re-indentation.

- **Bug Fixes**
  - Switched `stripRangeBoundaryEcho` to use strict equality (`===`) instead of `equalsIgnoringWhitespace`.
  - Added a test to ensure a deeper-indented trailing line is kept.

<sup>Written for commit 69f7009c65a353b082ba053c8cf090417f90b2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

