### PR TITLE
fix: stop duplicate parent wakes and Opus prefill failures

### DIFF
--- a/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -140,6 +140,75 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
     }
   })
 
+  test("#given stale deferral but fresh unfinished assistant text #when flushing parent wake #then parent wake stays queued without dispatch", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    let promptAsyncCallCount = 0
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "unknown",
+                time: { created: 99_000 },
+              },
+              parts: [{ type: "text", text: "still streaming" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-fresh-text-flush": { type: "idle" } } }),
+        promptAsync: async () => {
+          promptAsyncCallCount += 1
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-fresh-text-flush",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text-flush")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-fresh-text-flush")
+
+      // then
+      expect(promptAsyncCallCount).toBe(0)
+      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given parent session messages cannot be inspected #when checking parent wake history #then parent wake stays deferred", async () => {
     // given
     const client = unsafeTestValue<ParentWakeClient>({

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -451,9 +451,10 @@ export class ParentWakeNotifier {
       if (role === "assistant") {
         const waiting = this.getParentWakeMessageFinish(message) === "tool-calls"
           || message.parts?.some((part) => this.parentWakePartIsWaitingOnTool(part)) === true
+        const activityAt = getParentWakeMessageActivityAt(message)
         return waiting
-          ? { waiting: true, activityAt: getParentWakeMessageActivityAt(message) }
-          : { waiting: false }
+          ? { waiting: true, activityAt }
+          : { waiting: false, activityAt }
       }
       if (role === "user") {
         if (isSyntheticOrInternalUserMessage(message)) {
@@ -572,6 +573,9 @@ export class ParentWakeNotifier {
       ? 0
       : now - toolWaitState.activityAt
     const deferAge = now - wake.toolCallDeferralStartedAt
+    const latestAssistantActivityAgeMs = toolWaitState.activityAt === undefined
+      ? deferAge
+      : now - toolWaitState.activityAt
     if (
       wake.shouldReply
       && toolWaitState.waiting
@@ -583,10 +587,15 @@ export class ParentWakeNotifier {
       })
       return { defer: false, skipPromptGateToolStateCheck: true }
     }
-    if (!toolWaitState.waiting && deferAge >= this.options.toolCallDeferMaxMs) {
+    if (
+      !toolWaitState.waiting
+      && deferAge >= this.options.toolCallDeferMaxMs
+      && latestAssistantActivityAgeMs >= this.options.toolCallDeferMaxMs
+    ) {
       log("[background-agent] Sending parent wake after stale assistant-text deferral window:", {
         sessionID,
         deferAgeMs: deferAge,
+        latestAssistantActivityAgeMs,
       })
       return { defer: false, skipPromptGateToolStateCheck: true }
     }

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -245,6 +245,51 @@ describe("createMessagesTransformHandler", () => {
     })
   })
 
+  it("#given an Anthropic Opus 4.8 history ends with an ordinary assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_opus48",
+          role: "user",
+          sessionID: "ses_opus48_prefill",
+          agent: "sisyphus",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+          system: "system-prompt",
+          tools: { bash: true },
+        },
+        parts: [{ type: "text", text: "finish the debugging report" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_opus48",
+          role: "assistant",
+          sessionID: "ses_opus48_prefill",
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info).toMatchObject({
+      role: "user",
+      sessionID: "ses_opus48_prefill",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      system: "system-prompt",
+      tools: { bash: true },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
   it("#given rejecting model metadata is only on the assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
     //#given
     const messages: TestMessage[] = [

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -10,8 +10,7 @@ const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS = new Set([
   "google-vertex-anthropic",
 ])
 const ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES = [
-  "claude-opus-4-7",
-  "claude-opus-4-6",
+  "claude-opus-4",
   "claude-sonnet-4-6",
   "claude-mythos",
 ]


### PR DESCRIPTION
## Summary
Fixes the two mechanisms observed in `ses_17e349979ffeExO4ePTwVPAgTz`: Anthropic Opus 4.8 assistant-prefill rejection and parent-wake dispatch during fresh assistant text.

## Changes
- Treat Anthropic-family `claude-opus-4*` models as assistant-prefill unsupported so an assistant-tail history gets a synthetic user recovery turn before provider dispatch.
- Keep parent wake notifications queued when only the deferral timer is stale but the latest assistant text activity is still fresh.
- Add red-to-green regressions for Opus 4.8 prefill repair and the fresh assistant text parent-wake race.

## Evidence
- OpenCode DB/log inspection confirmed the target session used `anthropic/claude-opus-4-8` and started a second parent prompt loop at `06:11:49` while previous assistant loops were still advancing.
- Anthropic docs state assistant prefill is not supported on Opus 4.8: https://docs.anthropic.com/en/docs/upgrading-to-the-messages-api
- ULW evidence files captured under `.omo/ulw-loop/evidence/` in the worktree for C001, C002, and C003.

## Testing
- `bun test src/plugin/messages-transform.test.ts`
- `bun test src/features/background-agent/parent-wake-history-deferral.test.ts`
- `bun test src/shared/prompt-async-route-audit.test.ts`
- `bun test src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts`
- `bun test src/hooks/session-recovery/detect-error-type.test.ts src/hooks/session-recovery/hook.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate parent prompt loops and fixes Opus 4 assistant-prefill rejections. We now disable assistant prefill for the Claude Opus 4 family and keep parent wake notifications queued while assistant text is still active.

- **Bug Fixes**
  - Treat `anthropic/claude-opus-4*` as assistant-prefill unsupported; when the history ends with an assistant tail, append a synthetic user recovery turn before provider dispatch. Includes a test for `anthropic/claude-opus-4-8`.
  - Defer parent wake dispatch if the latest assistant text/activity is fresh, even when the deferral timer is stale; only flush when both windows are stale. Adds a regression test for the stale-deferral + fresh-text case.

<sup>Written for commit bb51dcbda2a0c6efa03200e7dcf97757b2cbb627. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

