### PR TITLE
fix: harden Anthropic prefill aliases and run startup

### DIFF
--- a/src/cli/run/event-handlers.test.ts
+++ b/src/cli/run/event-handlers.test.ts
@@ -49,6 +49,7 @@ describe("handleSessionStatus", () => {
 
     //#then - state.mainSessionIdle === false
     expect(state.mainSessionIdle).toBe(false)
+    expect(state.mainSessionStarted).toBe(true)
   })
 
   it("does nothing for different session ID", () => {
@@ -119,6 +120,7 @@ describe("handleMessagePartUpdated", () => {
 
     //#then
     expect(state.hasReceivedMeaningfulWork).toBe(true)
+    expect(state.mainSessionStarted).toBe(true)
     expect(state.lastPartText).toBe("Hello world")
     expect(stdoutSpy).toHaveBeenCalled()
     stdoutSpy.mockRestore()
@@ -176,6 +178,7 @@ describe("handleMessagePartUpdated", () => {
     //#then
     expect(state.currentTool).toBe("read")
     expect(state.hasReceivedMeaningfulWork).toBe(true)
+    expect(state.mainSessionStarted).toBe(true)
     stdoutSpy.mockRestore()
   })
 

--- a/src/cli/run/event-handlers.ts
+++ b/src/cli/run/event-handlers.ts
@@ -81,10 +81,12 @@ export function handleSessionStatus(ctx: RunContext, payload: EventPayload, stat
 
   if (props?.status?.type === "busy") {
     state.mainSessionIdle = false
+    state.mainSessionStarted = true
   } else if (props?.status?.type === "idle") {
     state.mainSessionIdle = true
   } else if (props?.status?.type === "retry") {
     state.mainSessionIdle = false
+    state.mainSessionStarted = true
   }
 }
 
@@ -128,6 +130,7 @@ export function handleMessagePartUpdated(ctx: RunContext, payload: EventPayload,
       const padded = writePaddedText(newText, state.thinkingAtLineStart)
       process.stdout.write(pc.dim(padded.output))
       state.thinkingAtLineStart = padded.atLineStart
+      state.mainSessionStarted = true
       state.hasReceivedMeaningfulWork = true
     }
     state.lastReasoningText = reasoningText
@@ -142,6 +145,7 @@ export function handleMessagePartUpdated(ctx: RunContext, payload: EventPayload,
       const padded = writePaddedText(newText, state.textAtLineStart)
       process.stdout.write(padded.output)
       state.textAtLineStart = padded.atLineStart
+      state.mainSessionStarted = true
       state.hasReceivedMeaningfulWork = true
     }
     state.lastPartText = part.text
@@ -155,6 +159,7 @@ export function handleMessagePartUpdated(ctx: RunContext, payload: EventPayload,
   }
 
   if (part.type === "tool") {
+    state.mainSessionStarted = true
     handleToolPart(ctx, part, state)
   }
 }
@@ -184,6 +189,7 @@ export function handleMessagePartDelta(ctx: RunContext, payload: EventPayload, s
     process.stdout.write(pc.dim(padded.output))
     state.thinkingAtLineStart = padded.atLineStart
     state.lastReasoningText += delta
+    state.mainSessionStarted = true
     state.hasReceivedMeaningfulWork = true
     return
   }
@@ -194,6 +200,7 @@ export function handleMessagePartDelta(ctx: RunContext, payload: EventPayload, s
   process.stdout.write(padded.output)
   state.textAtLineStart = padded.atLineStart
   state.lastPartText += delta
+  state.mainSessionStarted = true
   state.hasReceivedMeaningfulWork = true
 }
 
@@ -242,12 +249,16 @@ export function handleMessageUpdated(ctx: RunContext, payload: EventPayload, sta
   if (messageID && role) {
     state.messageRoleById[messageID] = role
   }
+  if (messageID) {
+    state.mainSessionStarted = true
+  }
 
   if (props?.info?.role !== "assistant") return
 
   const isNewMessage = !messageID || messageID !== state.currentMessageId
   if (isNewMessage) {
     state.currentMessageId = messageID
+    state.mainSessionStarted = true
     state.hasReceivedMeaningfulWork = true
     state.messageCount++
     state.lastPartText = ""
@@ -286,6 +297,7 @@ export function handleToolExecute(ctx: RunContext, payload: EventPayload, state:
 
   const toolName = props?.name || "unknown"
   state.currentTool = toolName
+  state.mainSessionStarted = true
   const header = formatToolHeader(toolName, props?.input ?? {})
   const suffix = header.description ? ` ${pc.dim(header.description)}` : ""
 

--- a/src/cli/run/event-state.ts
+++ b/src/cli/run/event-state.ts
@@ -1,5 +1,6 @@
 export interface EventState {
   mainSessionIdle: boolean
+  mainSessionStarted: boolean
   mainSessionError: boolean
   lastError: string | null
   lastOutput: string
@@ -48,6 +49,7 @@ export interface EventState {
 export function createEventState(): EventState {
   return {
     mainSessionIdle: false,
+    mainSessionStarted: false,
     mainSessionError: false,
     lastError: null,
     lastOutput: "",

--- a/src/cli/run/events.test.ts
+++ b/src/cli/run/events.test.ts
@@ -334,5 +334,6 @@ describe("event handling", () => {
 
     // then
     expect(state.mainSessionIdle).toBe(false)
+    expect(state.mainSessionStarted).toBe(true)
   })
 })

--- a/src/cli/run/poll-for-completion.test.ts
+++ b/src/cli/run/poll-for-completion.test.ts
@@ -391,4 +391,58 @@ describe("pollForCompletion", () => {
     expect(result).toBe(1)
   })
 
+  it("returns 1 when CLI run requires meaningful work but the prompt never produces output", async () => {
+    //#given
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.mainSessionStarted = true
+    eventState.hasReceivedMeaningfulWork = false
+    const abortController = new AbortController()
+
+    //#when
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 5,
+      requiredConsecutive: 1,
+      minStabilizationMs: 1,
+      secondaryMeaningfulWorkTimeoutMs: 10,
+      requireMeaningfulWork: true,
+    })
+
+    //#then
+    expect(result).toBe(1)
+    const errorCalls = (console.error as ReturnType<typeof mock>).mock.calls
+    expect(errorCalls.some((call: unknown[]) =>
+      String(call[0] ?? "").includes("Session never produced assistant output")
+    )).toBe(true)
+  })
+
+  it("keeps waiting when meaningful work is required and active child work exists", async () => {
+    //#given
+    const ctx = createMockContext({
+      childrenBySession: {
+        "test-session": [{ id: "child-session" }],
+        "child-session": [],
+      },
+    })
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.mainSessionStarted = true
+    eventState.hasReceivedMeaningfulWork = false
+    const abortController = new AbortController()
+
+    //#when
+    abortAfter(abortController, 50)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 5,
+      requiredConsecutive: 1,
+      minStabilizationMs: 1,
+      secondaryMeaningfulWorkTimeoutMs: 10,
+      requireMeaningfulWork: true,
+    })
+
+    //#then
+    expect(result).toBe(130)
+  })
+
 })

--- a/src/cli/run/poll-for-completion.ts
+++ b/src/cli/run/poll-for-completion.ts
@@ -28,6 +28,7 @@ export interface PollOptions {
   minStabilizationMs?: number
   eventWatchdogMs?: number
   secondaryMeaningfulWorkTimeoutMs?: number
+  requireMeaningfulWork?: boolean
 }
 
 export async function pollForCompletion(
@@ -48,6 +49,7 @@ export async function pollForCompletion(
   const secondaryMeaningfulWorkTimeoutMs =
     options.secondaryMeaningfulWorkTimeoutMs ??
     DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS
+  const requireMeaningfulWork = options.requireMeaningfulWork ?? false
   let consecutiveCompleteChecks = 0
   let errorCycleCount = 0
   let firstWorkTimestamp: number | null = null
@@ -125,28 +127,27 @@ export async function pollForCompletion(
         continue
       }
 
-      if (
-        Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs &&
-        !secondaryTimeoutChecked
-      ) {
-        secondaryTimeoutChecked = true
-        const childrenRes = await ctx.client.session.children({
-          path: { id: ctx.sessionID },
-          query: { directory: ctx.directory },
-        })
-        const children = normalizeSDKResponse<unknown[]>(childrenRes, [])
-        const todosRes = await ctx.client.session.todo({
-          path: { id: ctx.sessionID },
-          query: { directory: ctx.directory },
-        })
-        const todos = normalizeSDKResponse<unknown[]>(todosRes, [])
+      if (requireMeaningfulWork) {
+        if (Date.now() - pollStartTimestamp <= secondaryMeaningfulWorkTimeoutMs) {
+          consecutiveCompleteChecks = 0
+          continue
+        }
 
-        const hasActiveChildren =
-          Array.isArray(children) && children.length > 0
-        const hasActiveTodos =
-          Array.isArray(todos) &&
-          todos.some(isIncompleteTodo)
-        const hasActiveWork = hasActiveChildren || hasActiveTodos
+        const hasActiveWork = await hasActiveSessionWork(ctx)
+        if (hasActiveWork) {
+          consecutiveCompleteChecks = 0
+          continue
+        }
+
+        console.error(
+          pc.red("\n\nSession never produced assistant output, tool activity, or reasoning after the prompt started.")
+        )
+        return 1
+      }
+
+      if (Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs && !secondaryTimeoutChecked) {
+        secondaryTimeoutChecked = true
+        const hasActiveWork = await hasActiveSessionWork(ctx)
 
         if (hasActiveWork) {
           eventState.hasReceivedMeaningfulWork = true
@@ -187,6 +188,23 @@ export async function pollForCompletion(
   }
 
   return 130
+}
+
+async function hasActiveSessionWork(ctx: RunContext): Promise<boolean> {
+  const childrenRes = await ctx.client.session.children({
+    path: { id: ctx.sessionID },
+    query: { directory: ctx.directory },
+  })
+  const children = normalizeSDKResponse<unknown[]>(childrenRes, [])
+  const todosRes = await ctx.client.session.todo({
+    path: { id: ctx.sessionID },
+    query: { directory: ctx.directory },
+  })
+  const todos = normalizeSDKResponse<unknown[]>(todosRes, [])
+
+  const hasActiveChildren = Array.isArray(children) && children.length > 0
+  const hasActiveTodos = Array.isArray(todos) && todos.some(isIncompleteTodo)
+  return hasActiveChildren || hasActiveTodos
 }
 
 async function getMainSessionStatus(

--- a/src/cli/run/prompt-start.test.ts
+++ b/src/cli/run/prompt-start.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+
+import { createEventState } from "./events"
+import { waitForPromptStart } from "./prompt-start"
+import type { RunContext, SessionStatus } from "./types"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+
+function createMockContext(input: {
+  statuses?: Record<string, SessionStatus>
+  messages?: unknown[]
+} = {}): RunContext {
+  const statuses = input.statuses ?? {}
+  const messages = input.messages ?? []
+
+  return {
+    client: unsafeTestValue<RunContext["client"]>({
+      session: {
+        status: mock(() => Promise.resolve({ data: statuses })),
+        messages: mock(() => Promise.resolve({ data: messages })),
+      },
+    }),
+    sessionID: "ses_run",
+    directory: "/tmp/project",
+    abortController: new AbortController(),
+  }
+}
+
+let consoleErrorSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe("waitForPromptStart", () => {
+  it("#given the run session reaches busy status #when waiting for prompt start #then it resolves with start evidence", async () => {
+    //#given
+    const ctx = createMockContext({
+      statuses: { ses_run: { type: "busy" } },
+    })
+    const eventState = createEventState()
+
+    //#when
+    await waitForPromptStart(ctx, eventState, ctx.abortController, {
+      timeoutMs: 20,
+      pollIntervalMs: 1,
+    })
+
+    //#then
+    expect(eventState.mainSessionStarted).toBe(true)
+    expect(eventState.mainSessionIdle).toBe(false)
+  })
+
+  it("#given messages are persisted before a busy status is observed #when waiting for prompt start #then it resolves", async () => {
+    //#given
+    const ctx = createMockContext({
+      messages: [{ info: { id: "msg_user", role: "user" } }],
+    })
+    const eventState = createEventState()
+
+    //#when
+    await waitForPromptStart(ctx, eventState, ctx.abortController, {
+      timeoutMs: 20,
+      pollIntervalMs: 1,
+    })
+
+    //#then
+    expect(eventState.mainSessionStarted).toBe(true)
+  })
+
+  it("#given no status or message start evidence arrives #when waiting for prompt start #then it fails instead of allowing silent success", async () => {
+    //#given
+    const ctx = createMockContext()
+    const eventState = createEventState()
+
+    //#when
+    const result = waitForPromptStart(ctx, eventState, ctx.abortController, {
+      timeoutMs: 5,
+      pollIntervalMs: 1,
+    })
+
+    //#then
+    await expect(result).rejects.toThrow("Prompt did not start within 5ms")
+    expect(eventState.mainSessionStarted).toBe(false)
+  })
+
+  it("#given the session errors before starting #when waiting for prompt start #then it reports the session error", async () => {
+    //#given
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionError = true
+    eventState.lastError = "startup failed"
+
+    //#when
+    const result = waitForPromptStart(ctx, eventState, ctx.abortController, {
+      timeoutMs: 20,
+      pollIntervalMs: 1,
+    })
+
+    //#then
+    await expect(result).rejects.toThrow("Session errored before prompt started: startup failed")
+  })
+})

--- a/src/cli/run/prompt-start.ts
+++ b/src/cli/run/prompt-start.ts
@@ -1,0 +1,115 @@
+import type { EventState } from "./events"
+import type { RunContext, SessionStatus } from "./types"
+import { normalizeSDKResponse } from "../../shared"
+
+const DEFAULT_PROMPT_START_TIMEOUT_MS = 30_000
+const DEFAULT_PROMPT_START_POLL_INTERVAL_MS = 100
+
+type SessionStatusMap = Record<string, SessionStatus>
+
+export interface PromptStartOptions {
+  timeoutMs?: number
+  pollIntervalMs?: number
+}
+
+function createAbortError(): Error {
+  const error = new Error("Prompt start wait aborted")
+  error.name = "AbortError"
+  return error
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+function hasPromptStartEvidence(eventState: EventState): boolean {
+  return eventState.mainSessionStarted ||
+    eventState.hasReceivedMeaningfulWork ||
+    eventState.messageCount > 0 ||
+    eventState.currentTool !== null
+}
+
+async function readMainSessionStatus(ctx: RunContext): Promise<SessionStatus["type"] | null> {
+  if (typeof ctx.client.session.status !== "function") {
+    return null
+  }
+
+  try {
+    const statusRes = await ctx.client.session.status({
+      query: { directory: ctx.directory },
+    })
+    const statuses = normalizeSDKResponse<SessionStatusMap>(statusRes, {})
+    return statuses[ctx.sessionID]?.type ?? "idle"
+  } catch (error) {
+    if (ctx.verbose) {
+      console.error(`[run] failed to read session status while waiting for prompt start: ${String(error)}`)
+    }
+    return null
+  }
+}
+
+async function hasPersistedMessages(ctx: RunContext): Promise<boolean> {
+  if (typeof ctx.client.session.messages !== "function") {
+    return false
+  }
+
+  try {
+    const messagesRes = await ctx.client.session.messages({
+      path: { id: ctx.sessionID },
+      query: { directory: ctx.directory },
+    })
+    const messages = normalizeSDKResponse<unknown[]>(messagesRes, [])
+    return messages.length > 0
+  } catch (error) {
+    if (ctx.verbose) {
+      console.error(`[run] failed to read session messages while waiting for prompt start: ${String(error)}`)
+    }
+    return false
+  }
+}
+
+export async function waitForPromptStart(
+  ctx: RunContext,
+  eventState: EventState,
+  abortController: AbortController,
+  options: PromptStartOptions = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROMPT_START_TIMEOUT_MS
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_PROMPT_START_POLL_INTERVAL_MS
+  const startedAt = Date.now()
+
+  while (!abortController.signal.aborted) {
+    if (hasPromptStartEvidence(eventState)) {
+      return
+    }
+
+    if (eventState.mainSessionError) {
+      throw new Error(`Session errored before prompt started: ${eventState.lastError ?? "unknown error"}`)
+    }
+
+    const status = await readMainSessionStatus(ctx)
+    if (status === "busy" || status === "retry") {
+      eventState.mainSessionStarted = true
+      eventState.mainSessionIdle = false
+      return
+    }
+    if (status === "idle") {
+      eventState.mainSessionIdle = true
+    }
+
+    if (await hasPersistedMessages(ctx)) {
+      eventState.mainSessionStarted = true
+      return
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(
+        `Prompt did not start within ${timeoutMs}ms; no busy status, message event, or persisted message was observed.`
+      )
+    }
+
+    await sleep(pollIntervalMs)
+  }
+
+  throw createAbortError()
+}

--- a/src/cli/run/runner.telemetry.test.ts
+++ b/src/cli/run/runner.telemetry.test.ts
@@ -47,6 +47,9 @@ describe("run telemetry isolation", () => {
     mock.module("./poll-for-completion", () => ({
       pollForCompletion: mock(async () => 0),
     }))
+    mock.module("./prompt-start", () => ({
+      waitForPromptStart: mock(async () => {}),
+    }))
     mock.module("./agent-profile-colors", () => ({
       loadAgentProfileColors: mock(async () => ({})),
     }))

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -9,6 +9,7 @@ import { executeOnCompleteHook } from "./on-complete-hook"
 import { resolveRunAgent } from "./agent-resolver"
 import { resolveRunModel } from "./model-resolver"
 import { pollForCompletion } from "./poll-for-completion"
+import { waitForPromptStart } from "./prompt-start"
 import { loadAgentProfileColors } from "./agent-profile-colors"
 import { suppressRunInput } from "./stdin-suppression"
 import { createTimestampedStdoutController } from "./timestamp-output"
@@ -145,7 +146,10 @@ export async function run(options: RunOptions): Promise<number> {
       if (!promptMayHaveBeenAccepted && !isInternalPromptDispatchAccepted(promptResult)) {
         throw new Error(`Session ${sessionID} is not idle; promptAsync skipped by gate: ${promptResult.status}`)
       }
-      const exitCode = await pollForCompletion(ctx, eventState, abortController)
+      await waitForPromptStart(ctx, eventState, abortController)
+      const exitCode = await pollForCompletion(ctx, eventState, abortController, {
+        requireMeaningfulWork: true,
+      })
 
       abortController.abort()
 

--- a/src/plugin/messages-transform-prefill-alias.test.ts
+++ b/src/plugin/messages-transform-prefill-alias.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, Part } from "@opencode-ai/sdk"
+
+import { createMessagesTransformHandler } from "./messages-transform"
+
+type TestMessage = {
+  info: Message
+  parts: Part[]
+}
+
+function userMessage(input: {
+  id: string
+  sessionID: string
+  providerID: string
+  modelID: string
+}): Message {
+  return {
+    id: input.id,
+    sessionID: input.sessionID,
+    role: "user",
+    time: { created: 1 },
+    agent: "sisyphus",
+    model: { providerID: input.providerID, modelID: input.modelID },
+  }
+}
+
+function assistantMessage(input: { id: string; sessionID: string }): Message {
+  return {
+    id: input.id,
+    sessionID: input.sessionID,
+    role: "assistant",
+    time: { created: 2 },
+    parentID: "msg_parent",
+    modelID: "test-model",
+    providerID: "test-provider",
+    mode: "build",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  }
+}
+
+function textPart(input: { id: string; sessionID: string; messageID: string; text: string }): Part {
+  return {
+    id: input.id,
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    type: "text",
+    text: input.text,
+  }
+}
+
+async function runHandler(messages: TestMessage[]): Promise<void> {
+  const handler = createMessagesTransformHandler({ hooks: {} })
+  await handler({}, { messages })
+}
+
+describe("messages transform assistant prefill alias repair", () => {
+  test("#given Anthropic-backed alias providers end with a rejecting assistant tail #when messages transform runs #then it appends a synthetic user recovery turn", async () => {
+    //#given
+    const scenarios: Array<{ name: string; providerID: string; modelID: string }> = [
+      {
+        name: "opencode anthropic npm alias",
+        providerID: "opencode",
+        modelID: "claude-opus-4-8",
+      },
+      {
+        name: "opencode go anthropic npm alias",
+        providerID: "opencode-go",
+        modelID: "claude-opus-4-8",
+      },
+      {
+        name: "opencode zen proxy anthropic npm alias",
+        providerID: "opencode-zen-proxy",
+        modelID: "claude-sonnet-4.6",
+      },
+      {
+        name: "github copilot claude alias",
+        providerID: "github-copilot",
+        modelID: "claude-sonnet-4.6",
+      },
+      {
+        name: "github copilot enterprise claude alias",
+        providerID: "github-copilot-enterprise",
+        modelID: "claude-opus-4.7",
+      },
+      {
+        name: "openrouter anthropic namespace",
+        providerID: "openrouter",
+        modelID: "anthropic/claude-opus-4.8",
+      },
+      {
+        name: "openrouter tilde anthropic namespace",
+        providerID: "openrouter",
+        modelID: "~anthropic/claude-sonnet-4.6",
+      },
+      {
+        name: "openrouter scoped anthropic namespace",
+        providerID: "openrouter",
+        modelID: "@anthropic/claude-opus-4.8",
+      },
+      {
+        name: "openrouter colon anthropic namespace",
+        providerID: "openrouter",
+        modelID: "anthropic:claude-sonnet-4.6",
+      },
+      {
+        name: "vercel claude alias",
+        providerID: "vercel",
+        modelID: "claude-sonnet-4.6",
+      },
+      {
+        name: "generic anthropic dotted namespace",
+        providerID: "litellm",
+        modelID: "anthropic.claude-opus-4-8",
+      },
+      {
+        name: "bedrock anthropic dotted id",
+        providerID: "aws-bedrock-anthropic",
+        modelID: "us.anthropic.claude-opus-4-8",
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const messages: TestMessage[] = [
+        {
+          info: userMessage({
+            id: `msg_user_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            providerID: scenario.providerID,
+            modelID: scenario.modelID,
+          }),
+          parts: [textPart({
+            id: `part_user_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            messageID: `msg_user_${scenario.providerID}`,
+            text: scenario.name,
+          })],
+        },
+        {
+          info: assistantMessage({
+            id: `msg_assistant_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+          }),
+          parts: [textPart({
+            id: `part_assistant_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            messageID: `msg_assistant_${scenario.providerID}`,
+            text: "done",
+          })],
+        },
+      ]
+
+      //#when
+      await runHandler(messages)
+
+      //#then
+      expect(messages, scenario.name).toHaveLength(3)
+      expect(messages.at(-1)?.info, scenario.name).toMatchObject({
+        role: "user",
+        sessionID: `ses_${scenario.providerID}`,
+        agent: "sisyphus",
+        model: { providerID: scenario.providerID, modelID: scenario.modelID },
+      })
+      expect(messages.at(-1)?.parts[0], scenario.name).toMatchObject({
+        type: "text",
+        text: "[internal] Continue from the previous assistant state.",
+        synthetic: true,
+      })
+    }
+  })
+
+  test("#given alias providers with models outside the unsupported Anthropic family #when messages transform runs #then it keeps the assistant tail unchanged", async () => {
+    //#given
+    const scenarios: Array<{ name: string; providerID: string; modelID: string }> = [
+      { name: "opencode non-claude model", providerID: "opencode", modelID: "big-pickle" },
+      { name: "opencode older claude model", providerID: "opencode", modelID: "claude-sonnet-4-5" },
+      { name: "openrouter non-anthropic namespace", providerID: "openrouter", modelID: "openai/gpt-5.4" },
+      { name: "openrouter bare claude-looking id", providerID: "openrouter", modelID: "claude-opus-4-8" },
+    ]
+
+    for (const scenario of scenarios) {
+      const messages: TestMessage[] = [
+        {
+          info: userMessage({
+            id: `msg_user_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            providerID: scenario.providerID,
+            modelID: scenario.modelID,
+          }),
+          parts: [textPart({
+            id: `part_user_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            messageID: `msg_user_${scenario.providerID}`,
+            text: scenario.name,
+          })],
+        },
+        {
+          info: assistantMessage({
+            id: `msg_assistant_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+          }),
+          parts: [textPart({
+            id: `part_assistant_${scenario.providerID}`,
+            sessionID: `ses_${scenario.providerID}`,
+            messageID: `msg_assistant_${scenario.providerID}`,
+            text: "completed assistant answer",
+          })],
+        },
+      ]
+
+      //#when
+      await runHandler(messages)
+
+      //#then
+      expect(messages, scenario.name).toHaveLength(2)
+      expect(messages.at(-1)?.info.role, scenario.name).toBe("assistant")
+    }
+  })
+})

--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -489,7 +489,7 @@ describe("createMessagesTransformHandler", () => {
         name: "non-anthropic provider",
         userInfo: {
           role: "user",
-          model: { providerID: "opencode", modelID: "claude-opus-4-7" },
+          model: { providerID: "openai", modelID: "claude-opus-4-7" },
         },
       },
     ]

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -7,7 +7,14 @@ import type { CreatedHooks } from "../create-hooks"
 const ASSISTANT_PREFILL_RECOVERY_TEXT = "[internal] Continue from the previous assistant state."
 const ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS = new Set([
   "anthropic",
+  "aws-bedrock-anthropic",
+  "github-copilot",
+  "github-copilot-enterprise",
   "google-vertex-anthropic",
+  "opencode",
+  "opencode-go",
+  "opencode-zen-proxy",
+  "vercel",
 ])
 const ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES = [
   "claude-opus-4",
@@ -21,6 +28,13 @@ type MessageWithParts = {
 }
 
 type MessagesTransformOutput = { messages: MessageWithParts[] }
+type MessagesTransformHooks = {
+  contextInjectorMessagesTransform?: CreatedHooks["contextInjectorMessagesTransform"]
+  teamModeStatusInjector?: CreatedHooks["teamModeStatusInjector"]
+  teamMailboxInjector?: CreatedHooks["teamMailboxInjector"]
+  thinkingBlockValidator?: CreatedHooks["thinkingBlockValidator"]
+  toolPairValidator?: CreatedHooks["toolPairValidator"]
+}
 type UserMessageInfo = Extract<Message, { role: "user" }>
 type ModelIdentifier = {
   providerID: string
@@ -90,17 +104,34 @@ function findLastUserModel(messages: MessageWithParts[]): ModelIdentifier | unde
   return undefined
 }
 
+function normalizeAssistantPrefillModelID(modelID: string): string {
+  const normalizedModelID = normalizeModelID(modelID.toLowerCase())
+  return normalizedModelID
+    .split(/[/.~:@]+/)
+    .find((segment) => segment.startsWith("claude-")) ?? normalizedModelID
+}
+
+function hasAnthropicModelNamespace(modelID: string): boolean {
+  const normalizedModelID = normalizeModelID(modelID.toLowerCase())
+  return /(?:^|[/.~:@])anthropic(?:$|[/.~:@])/.test(normalizedModelID)
+}
+
+function providerCanExposeUnsupportedAssistantPrefill(providerID: string, modelID: string): boolean {
+  return ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS.has(providerID) ||
+    hasAnthropicModelNamespace(modelID)
+}
+
 function shouldRepairAssistantPrefillForModel(model: ModelIdentifier | undefined): boolean {
   if (!model) {
     return false
   }
 
   const providerID = model.providerID.toLowerCase()
-  if (!ASSISTANT_PREFILL_UNSUPPORTED_PROVIDERS.has(providerID)) {
+  if (!providerCanExposeUnsupportedAssistantPrefill(providerID, model.modelID)) {
     return false
   }
 
-  const modelID = normalizeModelID(model.modelID.toLowerCase())
+  const modelID = normalizeAssistantPrefillModelID(model.modelID)
   return ASSISTANT_PREFILL_UNSUPPORTED_MODEL_PREFIXES.some((prefix) => modelID.startsWith(prefix))
 }
 
@@ -179,19 +210,20 @@ async function runMessagesTransformHookSafely<I, O>(
   try {
     await Promise.resolve(handler(input, output))
   } catch (error) {
+    const hookError = error instanceof Error ? error : new Error(String(error))
     // Isolate per-handler failures so later handlers (notably toolPairValidator)
     // always run. A throw here used to leave orphaned tool_use blocks in the
     // post-compaction payload, producing API 400s like
     // "tool_use ids were found without tool_result blocks immediately after".
     log("[messages-transform] hook execution failed", {
       hook: hookName,
-      error,
+      error: hookError,
     })
   }
 }
 
 export function createMessagesTransformHandler(args: {
-  hooks: CreatedHooks
+  hooks: MessagesTransformHooks
 }): (input: Record<string, never>, output: MessagesTransformOutput) => Promise<void> {
   return async (input, output): Promise<void> => {
     await runMessagesTransformHookSafely(


### PR DESCRIPTION
## Summary
- Repair assistant-tail prefill histories for OpenCode/Copilot/Bedrock/Vercel and Anthropic-namespaced Claude aliases, including `opencode/claude-opus-4-8`.
- Add a CLI run start gate so `oh-my-openagent run --json` cannot report `success:true` with `messageCount:0` before the prompt actually starts.
- Keep duplicate internal prompt routes behind the shared prompt gate and extend tests around start/meaningful-work races.

## Testing
- `bun test src/plugin/messages-transform.test.ts src/plugin/messages-transform-prefill-alias.test.ts --bail`
- duplicate prompt gate bundle: parent wake/model fallback/prompt route audit/prompt gate semantic dedupe tests
- internal route bundle: compaction/team/runtime fallback/session recovery/todo/boulder/team messaging tests
- opencode QA: DB read/export for `ses_17e349979ffeExO4ePTwVPAgTz`, HTTP health/doc/auth smoke, SSE `server.connected` probe
- `bun run typecheck -- --pretty false`
- `bun test`
- `bun run build`
- `bun run test:codex`

## Related
- Fixes #4642
- Follows up duplicate/prefill reports observed in session `ses_17e349979ffeExO4ePTwVPAgTz`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened assistant prefill repair for Anthropic aliases/namespaces and added a CLI run start gate so runs can’t “succeed” before any output. Fixes #4642.

- **Bug Fixes**
  - Repair assistant prefill tails for Anthropic `claude-*` families by normalizing model IDs and detecting Anthropic namespaces across separators; append a synthetic user continuation for unsupported tails (covers aliases via `opencode`, `openrouter` namespaces, `github-copilot`, `aws-bedrock-anthropic`, `vercel`, and more).
  - Prevent silent success in `run`: added a `waitForPromptStart` gate and updated `pollForCompletion` to require meaningful work; returns 1 with an error if no assistant output/reasoning/tooling occurs after start, but continues waiting when child sessions/todos are active.

- **Refactors**
  - Track `mainSessionStarted` in event state and set it on status, message, delta, text, and tool events.
  - Extract `hasActiveSessionWork` helper used by completion polling.
  - Make messages-transform hooks optional and isolate per-hook failures so later validators still run.

<sup>Written for commit 01750b6c0d23615f87e07d4d0447835a5d3111d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

