### PR TITLE
fix(doctor): skip TUI entry advice when package does not export ./tui (fixes #4643)

### DIFF
--- a/src/cli/doctor/checks/tui-plugin-config.test.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.test.ts
@@ -35,6 +35,18 @@ function writeFilePluginPackage(dir: string, packageName: string): string {
   return `file:${dir}`
 }
 
+function writeInstalledPackage(
+  configDir: string,
+  packageName: string,
+  exportsField: Record<string, unknown> | null,
+): void {
+  const pkgDir = join(configDir, "node_modules", packageName)
+  mkdirSync(pkgDir, { recursive: true })
+  const packageJson: Record<string, unknown> = { name: packageName, version: "4.5.12" }
+  if (exportsField !== null) packageJson["exports"] = exportsField
+  writeFileSync(join(pkgDir, "package.json"), JSON.stringify(packageJson, null, 2) + "\n", "utf-8")
+}
+
 describe("tui-plugin-config check", () => {
   beforeEach(() => {
     originalConfigDir = process.env.OPENCODE_CONFIG_DIR
@@ -155,5 +167,69 @@ describe("tui-plugin-config check", () => {
     //#then legacy aliases are accepted
     expect(result.status).toBe("pass")
     expect(result.issues).toHaveLength(0)
+  })
+
+  it("does not warn about missing TUI entry when installed package has no ./tui export (fixes #4643)", async () => {
+    //#given the server plugin is registered but the locally installed
+    //#       package.json has no `./tui` export (matches the published 4.5.12 tarball).
+    //#       Following the old `add "oh-my-openagent/tui" to tui.json` advice would
+    //#       make OpenCode interpret it as a GitHub `owner/repo` and hang ~140s.
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig(["some-other-tui-plugin"])
+    writeInstalledPackage(testConfigDir, "oh-my-opencode", {
+      ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      "./server": "./dist/index.js",
+      "./schema.json": "./dist/oh-my-opencode.schema.json",
+    })
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then status is pass — the package does not ship a TUI subpath, so no entry
+    //#       should be recommended
+    expect(result.status).toBe("pass")
+    expect(result.issues).toHaveLength(0)
+  })
+
+  it("warns when tui.json already contains the unresolvable TUI entry (fixes #4643)", async () => {
+    //#given the user previously followed the doctor's old recommendation and added
+    //#       `oh-my-openagent/tui` to tui.json, but the installed package still
+    //#       does not expose `./tui`. OpenCode hangs ~140s trying to git-clone the
+    //#       non-existent `oh-my-openagent/tui` repository.
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig([PLUGIN_NAME, `${PLUGIN_NAME}/tui`])
+    writeInstalledPackage(testConfigDir, "oh-my-opencode", {
+      ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      "./server": "./dist/index.js",
+      "./schema.json": "./dist/oh-my-opencode.schema.json",
+    })
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then status is warn — the entry would cause OpenCode to hang on plugin load
+    expect(result.status).toBe("warn")
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].title).toContain("unresolvable")
+    expect(result.issues[0].fix).toContain("Remove")
+  })
+
+  it("still warns about missing TUI entry when installed package exports ./tui", async () => {
+    //#given a future package that does ship the `./tui` subpath export
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig(["some-other-tui-plugin"])
+    writeInstalledPackage(testConfigDir, "oh-my-opencode", {
+      ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      "./server": "./dist/index.js",
+      "./tui": "./dist/tui.js",
+    })
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then existing warn behavior is preserved — the entry would actually work
+    expect(result.status).toBe("warn")
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].title).toContain("TUI plugin entry missing")
   })
 })

--- a/src/cli/doctor/checks/tui-plugin-config.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.ts
@@ -13,6 +13,50 @@ import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import type { CheckResult, DoctorIssue } from "../types"
 
 const TUI_SUBPATH = "tui"
+const TUI_EXPORT_KEY = "./tui"
+
+interface PackageJsonExportsShape {
+  exports?: unknown
+}
+
+// Locates the installed package.json that the doctor check should consult.
+// Scoped to the configured OpenCode config dir so we never accidentally
+// inspect the source repo's own package.json (when running from a dev tree)
+// or the host's cache dir (when running tests). Returns null when no
+// `node_modules/<pkg>/package.json` exists under the configured config dir.
+function findInstalledPackageJsonInConfigDir(): string | null {
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  for (const packageName of ACCEPTED_PACKAGE_NAMES) {
+    const candidate = join(configDir, "node_modules", packageName, "package.json")
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+// Returns true when the locally installed `oh-my-opencode` / `oh-my-openagent`
+// package.json declares a `./tui` entry in its `exports` map. Returns false
+// when the package exists but does not expose the subpath (matches the
+// published 4.5.x tarball). Returns null when we cannot locate the installed
+// package under the OpenCode config dir — in that case we keep the legacy
+// warn behavior so we never regress users on a future version that ships
+// ./tui.
+//
+// Background: when `./tui` is NOT exported, recommending users add
+// `oh-my-openagent/tui` to tui.json triggers OpenCode's GitHub `owner/repo`
+// fallback and hangs the TUI loader for ~140s (see #4643, #4598).
+export function installedPackageExportsTui(): boolean | null {
+  const installedPackagePath = findInstalledPackageJsonInConfigDir()
+  if (!installedPackagePath) return null
+  let parsed: PackageJsonExportsShape | null = null
+  try {
+    parsed = parseJsonc<PackageJsonExportsShape>(readFileSync(installedPackagePath, "utf-8"))
+  } catch {
+    return null
+  }
+  const exportsField = parsed?.exports
+  if (!exportsField || typeof exportsField !== "object" || Array.isArray(exportsField)) return false
+  return Object.prototype.hasOwnProperty.call(exportsField, TUI_EXPORT_KEY)
+}
 
 interface OpenCodeConfigShape {
   plugin?: string[]
@@ -114,9 +158,11 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
   const tui = detectTuiPluginRegistration()
   const issues: DoctorIssue[] = []
   const details: string[] = []
+  const exportsTui = installedPackageExportsTui()
 
   if (server.configPath) details.push(`opencode.json: ${server.configPath}`)
   if (tui.configPath) details.push(`tui.json: ${tui.configPath}`)
+  if (exportsTui === false) details.push("package exports: ./tui not declared")
 
   if (!server.registered && !tui.registered) {
     return {
@@ -129,6 +175,18 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
   }
 
   if (server.registered && !tui.registered) {
+    // If the installed package does not expose `./tui`, recommending users add
+    // the entry would actively break their setup: opencode-tui would fall back
+    // to GitHub `owner/repo` resolution and hang ~140s. See #4643 / #4598.
+    if (exportsTui === false) {
+      return {
+        name,
+        status: "pass",
+        message: "Server plugin registered; TUI subpath not shipped by this package version",
+        details: details.length > 0 ? details : undefined,
+        issues,
+      }
+    }
     issues.push({
       title: "TUI plugin entry missing from tui.json",
       description:
@@ -166,6 +224,35 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
       name,
       status: "warn",
       message: "Server plugin entry missing from opencode.json",
+      details: details.length > 0 ? details : undefined,
+      issues,
+    }
+  }
+
+  // Both registered. If the installed package does not actually export `./tui`,
+  // the entry the user has in tui.json is unresolvable: opencode-tui falls back
+  // to GitHub `owner/repo` and hangs ~140s on plugin load. See #4643 / #4598.
+  if (exportsTui === false) {
+    issues.push({
+      title: "TUI plugin entry in tui.json is unresolvable",
+      description:
+        `The TUI plugin entry ("${PLUGIN_NAME}/${TUI_SUBPATH}") is registered in `
+        + `${tui.configPath ?? "tui.json"}, but the installed package does not declare `
+        + `a "./tui" entry in its package.json "exports". OpenCode falls back to `
+        + "interpreting it as a GitHub `owner/repo` shorthand and hangs ~140s "
+        + "on plugin load before failing with NpmInstallFailedError.",
+      fix:
+        `Remove "${PLUGIN_NAME}/${TUI_SUBPATH}" (and any legacy `
+        + `"${LEGACY_PLUGIN_NAME}/${TUI_SUBPATH}") from the "plugin" array in `
+        + `${tui.configPath ?? "tui.json"}. If tui.json then has no other entries, `
+        + "you can delete the file entirely.",
+      affects: ["plugin loading", "OpenCode startup time"],
+      severity: "warning",
+    })
+    return {
+      name,
+      status: "warn",
+      message: "TUI plugin entry in tui.json is unresolvable",
       details: details.length > 0 ? details : undefined,
       issues,
     }


### PR DESCRIPTION
## Summary

The TUI plugin doctor check has been telling users to add `oh-my-openagent/tui` to `tui.json`, but the published `oh-my-opencode` tarball does not declare a `./tui` entry in its `package.json` `exports`. Following that advice causes opencode-tui to fall back to GitHub `owner/repo` resolution and **hang ~140s** on plugin load before failing with `NpmInstallFailedError`.

This PR gates the warning on the actual `exports` field of the installed `package.json`, and adds a new warning that tells users with the broken entry to remove it.

Fixes #4643. Also resolves the duplicate user report #4598.

## Root Cause

`src/cli/doctor/checks/tui-plugin-config.ts` checked only registration state, not whether the package the user has installed actually exposes the `./tui` subpath. The published 4.5.x `package.json` exports `.`, `./server`, `./schema.json` — no `./tui`.

| Scenario | Old behavior | New behavior |
|----------|--------------|--------------|
| Server registered, no TUI entry, package has no `./tui` | warn: "add `oh-my-openagent/tui` to tui.json" (following this → 140s hang) | **pass**: "Server plugin registered; TUI subpath not shipped by this package version" |
| Server + TUI both registered, package has no `./tui` | pass: "both registered" (but plugin load hangs ~140s) | **warn**: "TUI plugin entry in tui.json is unresolvable" with `Remove "oh-my-openagent/tui" from tui.json` fix |
| Server registered, no TUI entry, package HAS `./tui` | warn (correct) | warn (preserved) |
| Package cannot be located (unknown install) | warn (correct fallback) | warn (preserved — legacy behavior retained) |

## Changes

| File | Change |
|------|--------|
| `src/cli/doctor/checks/tui-plugin-config.ts` | Add `installedPackageExportsTui()` helper scoped to `OPENCODE_CONFIG_DIR/node_modules`; gate the existing "missing TUI entry" warning on it; emit a new warning when an unresolvable TUI entry is already present. |
| `src/cli/doctor/checks/tui-plugin-config.test.ts` | Add 3 new tests covering both bug scenarios + the regression case where a future package version ships `./tui`. |

The helper deliberately only consults `${OPENCODE_CONFIG_DIR}/node_modules/<pkg>/package.json`. It avoids `getLoadedPluginVersion()`'s cache-dir + `require.resolve` fallbacks so tests can isolate via `OPENCODE_CONFIG_DIR`, and the doctor never accidentally reads the source repo's own `package.json` when running from a dev tree. When the helper cannot resolve the install, it returns `null` and the legacy warn behavior is preserved.

## Reproduction (before fix)

Synthetic OpenCode config with a 4.5.12-shaped package and the broken entry the doctor previously recommended:

~~~text
$ OPENCODE_CONFIG_DIR=/tmp/repro-4643 bun -e '... checkTuiPluginConfig() ...'
{
  "status": "pass",
  "message": "Server and TUI plugin entries are both registered",
  "issues": []
}
~~~

Doctor silently blessed the configuration that causes OpenCode to hang on plugin load.

For the fresh-install scenario (only opencode.json registered):

~~~text
{
  "status": "warn",
  "message": "TUI plugin entry missing from tui.json",
  "issues": [{
    "title": "TUI plugin entry missing from tui.json",
    "fix": "Re-run the installer ... or add \"oh-my-openagent/tui\" to the \"plugin\" array in /tmp/repro-4643-fresh/tui.json."
  }]
}
~~~

Following this advice triggers #4643 / #4598.

## Verification (after fix)

Same scenarios, same config:

~~~text
# Existing broken entry
$ OPENCODE_CONFIG_DIR=/tmp/repro-4643 bun -e '... checkTuiPluginConfig() ...'
{
  "status": "warn",
  "message": "TUI plugin entry in tui.json is unresolvable",
  "issues": [{
    "title": "TUI plugin entry in tui.json is unresolvable",
    "fix": "Remove \"oh-my-openagent/tui\" ... from the \"plugin\" array in /tmp/repro-4643/tui.json."
  }]
}

# Fresh install
$ OPENCODE_CONFIG_DIR=/tmp/repro-4643-fresh bun -e '... checkTuiPluginConfig() ...'
{
  "status": "pass",
  "message": "Server plugin registered; TUI subpath not shipped by this package version",
  "issues": []
}
~~~

## Test

- Regression test: `src/cli/doctor/checks/tui-plugin-config.test.ts` — 3 new cases added (`does not warn ... when installed package has no ./tui export`, `warns when tui.json already contains the unresolvable TUI entry`, `still warns ... when installed package exports ./tui`).
- `bun test src/cli/doctor/checks/tui-plugin-config.test.ts` — **10 pass / 0 fail** (7 pre-existing + 3 new).
- `bun test src/cli/doctor/checks/` — 71 / 72 pass; the 1 unrelated failure (`config check > respects OPENCODE_CONFIG_DIR even when the env var changes after module import`) reproduces on clean `upstream/dev` with my changes stashed (pre-existing Windows path-separator issue, not touched by this PR).
- `bun run typecheck` — exit 0 (clean).

Rebased onto current `upstream/dev` at push time.

Fixes #4643

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the doctor TUI check to stop recommending `oh-my-openagent/tui` when the installed `oh-my-opencode` package doesn’t export `./tui`, preventing ~140s hangs during plugin load. Also flags and guides removal of an existing unresolvable TUI entry.

- **Bug Fixes**
  - Gate the “add TUI entry” advice on `package.json` `exports` containing `./tui`; otherwise pass.
  - If `tui.json` already includes `oh-my-openagent/tui` but the package lacks `./tui`, warn and suggest removing it.
  - Read the installed package from `OPENCODE_CONFIG_DIR/node_modules` to avoid false positives.
  - Add 3 tests covering both scenarios and the future case where `./tui` is exported.

<sup>Written for commit 17ef98311af541aa7e8dff1a8a34563729b74598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

