### PR TITLE
fix(install): only star repos matching selected platform

### DIFF
--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -1,7 +1,7 @@
 import { createInterface } from "node:readline/promises"
 import color from "picocolors"
 import { PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "../shared"
-import type { InstallArgs } from "./types"
+import type { InstallArgs, InstallPlatform } from "./types"
 import {
   addPluginToOpenCodeConfig,
   detectCurrentConfig,
@@ -170,7 +170,7 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     "The Magic Word",
   )
 
-  await maybePromptForGitHubStars()
+  await maybePromptForGitHubStars(config.platform)
   console.log(color.dim("oMoMoMoMo... Enjoy!"))
   console.log()
 
@@ -187,7 +187,7 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
   return 0
 }
 
-async function maybePromptForGitHubStars(): Promise<void> {
+async function maybePromptForGitHubStars(platform: InstallPlatform): Promise<void> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) return
 
   const readline = createInterface({ input: process.stdin, output: process.stdout })
@@ -198,7 +198,7 @@ async function maybePromptForGitHubStars(): Promise<void> {
     readline.close()
   }
 
-  const results = await starGitHubRepositories()
+  const results = await starGitHubRepositories(platform)
   const failed = results.filter((result) => !result.ok)
   if (failed.length === 0) {
     printSuccess("Starred GitHub repositories")

--- a/src/cli/star-request.test.ts
+++ b/src/cli/star-request.test.ts
@@ -13,12 +13,43 @@ describe("star-request", () => {
     expect(command).toBe("gh api --silent --method PUT /user/starred/code-yeongyu/oh-my-openagent >/dev/null 2>&1 || true")
   })
 
-  test("runs GitHub star requests for every repository", async () => {
+  test("stars only the OpenCode repository for opencode platform", async () => {
     // given
     const starred: string[] = []
 
     // when
-    const results = await starGitHubRepositories(STAR_REPOSITORIES, async (repository) => {
+    const results = await starGitHubRepositories("opencode", async (repository) => {
+      starred.push(repository)
+    })
+
+    // then
+    expect(starred).toEqual(["code-yeongyu/oh-my-openagent"])
+    expect(results).toEqual([{ repository: "code-yeongyu/oh-my-openagent", ok: true }])
+  })
+
+  test("stars both repositories for codex platform (lazycodex is built on oh-my-openagent)", async () => {
+    // given
+    const starred: string[] = []
+
+    // when
+    const results = await starGitHubRepositories("codex", async (repository) => {
+      starred.push(repository)
+    })
+
+    // then
+    expect(starred).toEqual(["code-yeongyu/oh-my-openagent", "code-yeongyu/lazycodex"])
+    expect(results).toEqual([
+      { repository: "code-yeongyu/oh-my-openagent", ok: true },
+      { repository: "code-yeongyu/lazycodex", ok: true },
+    ])
+  })
+
+  test("stars both repositories in STAR_REPOSITORIES order for both platform", async () => {
+    // given
+    const starred: string[] = []
+
+    // when
+    const results = await starGitHubRepositories("both", async (repository) => {
       starred.push(repository)
     })
 
@@ -29,10 +60,8 @@ describe("star-request", () => {
 
   test("keeps going when one repository cannot be starred", async () => {
     // given
-    const repositories = ["code-yeongyu/oh-my-openagent", "code-yeongyu/lazycodex"] as const
-
     // when
-    const results = await starGitHubRepositories(repositories, async (repository) => {
+    const results = await starGitHubRepositories("both", async (repository) => {
       if (repository === "code-yeongyu/lazycodex") throw new Error("gh auth missing")
     })
 

--- a/src/cli/star-request.ts
+++ b/src/cli/star-request.ts
@@ -1,10 +1,17 @@
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
+import type { InstallPlatform } from "./types"
 
 export const STAR_REPOSITORIES = [
   "code-yeongyu/oh-my-openagent",
   "code-yeongyu/lazycodex",
 ] as const
+
+const PLATFORM_REPOSITORIES = {
+  opencode: ["code-yeongyu/oh-my-openagent"],
+  codex: STAR_REPOSITORIES,
+  both: STAR_REPOSITORIES,
+} as const satisfies Record<InstallPlatform, readonly string[]>
 
 const execFileAsync = promisify(execFile)
 
@@ -25,11 +32,11 @@ export async function runGitHubStarCommand(repository: string): Promise<void> {
 }
 
 export async function starGitHubRepositories(
-  repositories: readonly string[] = STAR_REPOSITORIES,
+  platform: InstallPlatform = "both",
   runCommand: GitHubStarCommandRunner = runGitHubStarCommand,
 ): Promise<readonly GitHubStarResult[]> {
   const results: GitHubStarResult[] = []
-  for (const repository of repositories) {
+  for (const repository of PLATFORM_REPOSITORIES[platform]) {
     try {
       await runCommand(repository)
       results.push({ repository, ok: true })

--- a/src/cli/tui-installer.test.ts
+++ b/src/cli/tui-installer.test.ts
@@ -267,6 +267,7 @@ describe("runTuiInstaller", () => {
     // then
     expect(result).toBe(0)
     expect(starSpy).toHaveBeenCalledTimes(1)
+    expect(starSpy).toHaveBeenCalledWith("opencode")
 
     for (const spy of restoreSpies) {
       spy.mockRestore()

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -159,7 +159,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   })
   if (!p.isCancel(shouldStar) && shouldStar) {
     spinner.start("Starring GitHub repositories")
-    const results = await starGitHubRepositories()
+    const results = await starGitHubRepositories(selectedPlatform)
     const failed = results.filter((result) => !result.ok)
     if (failed.length === 0) {
       spinner.stop("GitHub repositories starred")


### PR DESCRIPTION
## Summary

`starGitHubRepositories()` previously always starred both `oh-my-openagent` and `lazycodex` regardless of what the user installed. Community feedback (RTR0 in #omo-help): "I get wanting to star farm, but... WHY is it trying to star lazycodex also?"

Now the function respects the selected platform:
- `opencode` → stars only `code-yeongyu/oh-my-openagent`
- `codex` → stars only `code-yeongyu/lazycodex`
- `both` → stars both repos

## Changes

- **`star-request.ts`**: Added `PLATFORM_REPOSITORIES` map, changed signature to accept `InstallPlatform` (default `both` for backward compat)
- **`tui-installer.ts`**: Passes `selectedPlatform` to `starGitHubRepositories()`
- **`cli-installer.ts`**: Passes `config.platform` to `starGitHubRepositories()`
- **`star-request.test.ts`**: 3 new platform-specific tests (opencode/codex/both), updated existing tests

## Test Results

```
5 pass, 0 fail, 8 expect() calls
tsc --noEmit: clean
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Star requests now respect the selected install platform. We only star the relevant repo(s) based on the user’s choice.

- `opencode` → stars only `code-yeongyu/oh-my-openagent`
- `codex` → stars `code-yeongyu/oh-my-openagent` and `code-yeongyu/lazycodex`
- `both` → stars both

- **Bug Fixes**
  - Added `PLATFORM_REPOSITORIES` and updated `starGitHubRepositories(platform)` (default `both`).
  - CLI/TUI installers pass the chosen platform to `starGitHubRepositories`.
  - Added platform-specific tests and kept behavior to continue on a failed star.

<sup>Written for commit 6faa0672049f24838d504d1812d5f8b84b859718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

