### PR TITLE
fix(lazycodex): wire startup auto update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "commander": "^14.0.3",
         "detect-libc": "^2.1.2",
         "diff": "^9.0.0",
-        "effect": "4.0.0-beta.65",
         "js-yaml": "^4.1.1",
         "jsonc-parser": "^3.3.1",
         "picocolors": "^1.1.1",
@@ -45,17 +44,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.5.12",
-        "oh-my-opencode-darwin-x64": "4.5.12",
-        "oh-my-opencode-darwin-x64-baseline": "4.5.12",
-        "oh-my-opencode-linux-arm64": "4.5.12",
-        "oh-my-opencode-linux-arm64-musl": "4.5.12",
-        "oh-my-opencode-linux-x64": "4.5.12",
-        "oh-my-opencode-linux-x64-baseline": "4.5.12",
-        "oh-my-opencode-linux-x64-musl": "4.5.12",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.5.12",
-        "oh-my-opencode-windows-x64": "4.5.12",
-        "oh-my-opencode-windows-x64-baseline": "4.5.12",
+        "oh-my-opencode-darwin-arm64": "4.6.0",
+        "oh-my-opencode-darwin-x64": "4.6.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.6.0",
+        "oh-my-opencode-linux-arm64": "4.6.0",
+        "oh-my-opencode-linux-arm64-musl": "4.6.0",
+        "oh-my-opencode-linux-x64": "4.6.0",
+        "oh-my-opencode-linux-x64-baseline": "4.6.0",
+        "oh-my-opencode-linux-x64-musl": "4.6.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.6.0",
+        "oh-my-opencode-windows-x64": "4.6.0",
+        "oh-my-opencode-windows-x64-baseline": "4.6.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -334,7 +333,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-beta.65", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw=="],
+    "effect": ["effect@4.0.0-beta.66", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -444,27 +443,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.5.12", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ivvx5oy+5HFTVWpSKcACUaByWsH6lAf8ICZ55isUmtjARVNZbkEv5c0uXelJfvqBJ114wtjAv333LWc4X30brQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.6.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-S0zte3OFNmfOJpXAKglwEQnuh1UzypMPb6JqfD4mH7YWh+lxldKPkOU6x74Vv2n80Bb3w7MR2QS1C18pYbGEmw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.5.12", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-2LuglSUqPfvGTYU3CgdpeNqBYxVvndpRFiLAFkiSMDWFZ17Yv6tcqEz/PsimwITv5zXug+i9RzgIS1NKVqaESw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Oq4rbqRDFXeug3Ihthuy/b/se9bYwSgbMi1UI8x9SiULmShjcFRjCh9XVK/naqG9+HGPR69eU3+E4lcQHYOe8Q=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.5.12", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Zk+ikM/kL3WqT5bTajyLlzlJr1glvwTlt1ETqDmgG6aZ623scdclq5g6ZdgzHl9Bz03BIFEvV00rfnRiWjQf6Q=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-bYOZQUnjCypZCUcGuUHJzJNEUWnjGdOcEXQtRf5AAfXf3a9eL9dpWK4aAiyT4aFIku+AZQrbcYt5iCrxxU2eoA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.5.12", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-u73EaDVwPgrbP86zXXs8MvHiP8Wlf/W+utq95uRAu5i1GNPT/TVWXQmhz9muwTYagLgHpsiKYkU77mTsbpIMIQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-HLn5h6CyzQZzeRYhBxVNi2UFhaYP19lP6vN+HsXOh5FNRL0zsQLnlh+zziD0Tbstr69OP8fK/f2k8YWXKv6Jfw=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.5.12", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-qSLIqmjhc1LnV/zmX1+UZvZZdPcX2aD6cKaoYeNvt0Z7mf5iRzdymnHsABiShO62dztacXniu6KFLm5HdvYECg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WYQSNkjmubRu87T/2eHlYnJzcCWBcwMGEkvSTUEm+Gxy9sd5Zsm8yrHQRDBOlvefHE+pej5q5YfBb3RaOVU9Mw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.5.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-K5wHbomCwOAvMKx6BCpwIt92AkujhpSeXXp871ZsBxExRu4PC00X8lTCaL7wVjM/2sq8apT9c1z8sSK0mrat3Q=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Tx9v63VW3lEV2EGjkF/w3y8ZAWbip1bQ/nE15Sx3TOuSvOsNcz+X+t004kPrZRQjJQw+7SJIAHNPHhmPVC9pfg=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.5.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-byCOE84Z/nztKl8XWJoP4kgIlEUwz0ZPAit00FBSUTart8u326HZduL1Z8mzG0QTKF5oMBYVvaZRWNoPvOd3Tg=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0DG7TPssoRk219LKSBL305WNSHBEIlSNFvneKFPzwy2vAAHqXiUTQEpxVgkRt2my4GOpw41U8JHvAKHiMJBAaQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.5.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-mVNLDHcNoQ0gFIuD/MseVrWo2ADB9TmGrzN26bQoHhtqDLdak9s0ukvfcXGICPIMOov3R117UpQ14mpggdjGVQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3tOXsxQMdiXz6LGdjzEqCwpDTquTJWERCYSdGSdShMGb1f0eM9uIhR9ifWOgqN7U5lBp4u0bN7ovp7jJu53lZA=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.5.12", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ODhkALqNEd66ndZARYZQRH1psbFWA8oIjskR+NSWWOpJAlcecArnLfJF78M7d0MrUvan8GnxHayHZ/XSrYodUQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-aFy82RuSmP4idvigTnbzzMj7SqG1gFMffBkIr7EHtngvAQXHPrbf4zIFtOaflzyaWz+KLc57uU7+qIbh5owr/w=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.5.12", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-mRsNfyyDqvMpc6jD1d2VfNJW4joaeIfBKOcpJ0FtDQkPf7pWc2HVCSi/w/m7y+1dwzOFHFYAQ1UeLpsONbnNgA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Pl6oajxPbA2vlcVu7q2UdvkSHHcpe1ORpNyBjwm1vKa5eHmixBLDpmNvy6qPSxR8eZBd8Zm22yYOJDti+kSNjw=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.5.12", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-15z4hJpzSoPkdOajd3dftso+tpGaJch8v942kttisdZIlWhSp2P0YA1Grs1n9CjsqcCj6JV50KX2eketdguTwQ=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-7pKH1bCQJlxj2U7G9yiBFOFQf/hCnPsSIAxWKL1brxVVtAS+2QkJnu7/SdKELjBuLBLMQrkb1OvdAP5GEbqXxA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -555,8 +554,6 @@
     "@oh-my-opencode/ast-grep-mcp/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@oh-my-opencode/git-bash-mcp/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@opencode-ai/plugin/effect": ["effect@4.0.0-beta.66", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw=="],
 
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "commander": "^14.0.3",
     "detect-libc": "^2.1.2",
     "diff": "^9.0.0",
-    "effect": "4.0.0-beta.65",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",

--- a/packages/omo-codex/plugin/hooks/hooks.json
+++ b/packages/omo-codex/plugin/hooks/hooks.json
@@ -20,6 +20,17 @@
 						"statusMessage": "LazyCodex(0.1.0): Recording Session Telemetry"
 					}
 				]
+			},
+			{
+				"matcher": "^startup$",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"${PLUGIN_ROOT}/scripts/auto-update.mjs\" hook session-start",
+						"timeout": 5,
+						"statusMessage": "LazyCodex(0.1.0): Checking Auto Update"
+					}
+				]
 			}
 		],
 		"UserPromptSubmit": [

--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_LOCK_STALE_MS = 10 * 60 * 1_000;
+
+export function resolveAutoUpdatePlan({ env = process.env, now = Date.now(), lastCheckedAt } = {}) {
+	if (env.LAZYCODEX_AUTO_UPDATE_DISABLED === "1" || env.OMO_CODEX_AUTO_UPDATE_DISABLED === "1") {
+		return { shouldRun: false, reason: "disabled" };
+	}
+
+	const intervalMs = parsePositiveInteger(env.LAZYCODEX_AUTO_UPDATE_INTERVAL_MS, DEFAULT_INTERVAL_MS);
+	if (typeof lastCheckedAt === "number" && intervalMs > 0 && now - lastCheckedAt < intervalMs) {
+		return { shouldRun: false, reason: "throttled" };
+	}
+
+	return {
+		shouldRun: true,
+		command: resolveCommand(env),
+		args: resolveArgs(env),
+		env: {
+			...env,
+			LAZYCODEX_AUTO_UPDATE_DISABLED: "1",
+			OMO_CODEX_AUTO_UPDATE_DISABLED: "1",
+		},
+	};
+}
+
+export async function runAutoUpdateCheck({ env = process.env, now = Date.now() } = {}) {
+	const statePath = resolveStatePath(env);
+	const state = await readState(statePath);
+	const plan = resolveAutoUpdatePlan({ env, now, lastCheckedAt: state.lastCheckedAt });
+	if (!plan.shouldRun) return { started: false, reason: plan.reason };
+
+	const lock = await acquireLock(resolveLockPath(env, statePath), now, env);
+	if (lock === null) return { started: false, reason: "locked" };
+	try {
+		await writeState(statePath, { lastCheckedAt: now });
+		if (env.LAZYCODEX_AUTO_UPDATE_WAIT === "1") {
+			const result = spawnSync(plan.command, plan.args, {
+				env: plan.env,
+				stdio: "ignore",
+			});
+			return { started: true, status: result.status ?? 0 };
+		}
+
+		const child = spawn(plan.command, plan.args, {
+			env: plan.env,
+			stdio: "ignore",
+			detached: true,
+		});
+		child.unref();
+		return { started: true };
+	} finally {
+		await lock.release();
+	}
+}
+
+function resolveCommand(env) {
+	return env.LAZYCODEX_AUTO_UPDATE_COMMAND?.trim() || "npx";
+}
+
+function resolveArgs(env) {
+	if (env.LAZYCODEX_AUTO_UPDATE_ARGS_JSON) {
+		const parsed = JSON.parse(env.LAZYCODEX_AUTO_UPDATE_ARGS_JSON);
+		if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== "string")) {
+			throw new TypeError("LAZYCODEX_AUTO_UPDATE_ARGS_JSON must be a JSON string array");
+		}
+		return parsed;
+	}
+	return ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--skip-auth"];
+}
+
+function resolveStatePath(env) {
+	if (env.LAZYCODEX_AUTO_UPDATE_STATE_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_STATE_PATH;
+	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
+	return join(dataRoot, "auto-update.json");
+}
+
+function resolveLockPath(env, statePath) {
+	if (env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH;
+	return `${statePath}.lock`;
+}
+
+async function acquireLock(lockPath, now, env) {
+	await mkdir(dirname(lockPath), { recursive: true });
+	const staleMs = parsePositiveInteger(env.LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS, DEFAULT_LOCK_STALE_MS);
+	try {
+		const handle = await open(lockPath, "wx");
+		await handle.writeFile(`${now}\n`);
+		await handle.close();
+		return {
+			release: () => rm(lockPath, { force: true }),
+		};
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+		if (!(await removeStaleLock(lockPath, now, staleMs))) return null;
+		return acquireLock(lockPath, now, { ...env, LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS: "0" });
+	}
+}
+
+async function removeStaleLock(lockPath, now, staleMs) {
+	if (staleMs <= 0) return false;
+	try {
+		const lockStat = await stat(lockPath);
+		if (now - lockStat.mtimeMs < staleMs) return false;
+		await rm(lockPath, { force: true });
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+		throw error;
+	}
+}
+
+async function readState(statePath) {
+	try {
+		const raw = await readFile(statePath, "utf8");
+		const parsed = JSON.parse(raw);
+		return typeof parsed === "object" && parsed !== null ? parsed : {};
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return {};
+		return {};
+	}
+}
+
+async function writeState(statePath, state) {
+	await mkdir(dirname(statePath), { recursive: true });
+	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function parsePositiveInteger(value, fallback) {
+	if (value === undefined || value === "") return fallback;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	runAutoUpdateCheck().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(0);
+	});
+}

--- a/packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
@@ -37,7 +37,9 @@ async function readComponentVersions(root) {
 	const versions = new Map();
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
-		versions.set(entry.name, await readPackageVersion(join(componentsRoot, entry.name, "package.json")));
+		const packageJsonPath = join(componentsRoot, entry.name, "package.json");
+		if (!(await exists(packageJsonPath))) continue;
+		versions.set(entry.name, await readPackageVersion(packageJsonPath));
 	}
 	return versions;
 }

--- a/packages/omo-codex/plugin/test/aggregate.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate.test.mjs
@@ -10,12 +10,23 @@ async function readJson(relativePath) {
 	return JSON.parse(await readFile(join(root, relativePath), "utf8"));
 }
 
+async function exists(relativePath) {
+	try {
+		await stat(join(root, relativePath));
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
 async function readComponentHookManifests() {
 	const components = await readdir(join(root, "components"), { withFileTypes: true });
 	const manifests = [];
 	for (const entry of components) {
 		if (!entry.isDirectory()) continue;
 		const source = join("components", entry.name, "hooks", "hooks.json");
+		if (!(await exists(source))) continue;
 		manifests.push({ source, hooks: await readJson(source) });
 	}
 	return manifests.sort((left, right) => left.source.localeCompare(right.source));
@@ -99,6 +110,7 @@ test("#given isolated components #when hooks are inspected #then commands stay i
 		"components/telemetry/dist/cli.js",
 		"components/ulw-loop/dist/cli.js",
 		"components/ultrawork/dist/cli.js",
+		"scripts/auto-update.mjs",
 	];
 
 	// then
@@ -170,6 +182,24 @@ test("#given aggregate OMO plugin is enabled #when hooks are inspected #then she
 	assert.match(text, /components\/ulw-loop\/dist\/cli\.js/);
 	assert.match(text, /hook pre-tool-use/);
 	assert.deepEqual(preToolUseGroups.map((group) => group.matcher), ["^Bash$", "^create_goal$"]);
+});
+
+test("#given aggregate SessionStart hooks #when inspected #then LazyCodex auto-update is registered", async () => {
+	// given
+	const hooks = await readJson("hooks/hooks.json");
+	const text = JSON.stringify(hooks);
+
+	// when
+	const sessionStartCommands = collectCommandHooks(hooks, "hooks/hooks.json")
+		.filter(({ eventName }) => eventName === "SessionStart")
+		.map(({ handler }) => handler.command);
+	const autoUpdateGroup = hooks.hooks.SessionStart.find((group) => JSON.stringify(group).includes("scripts/auto-update.mjs"));
+
+	// then
+	assert.equal(autoUpdateGroup?.matcher, "^startup$");
+	assert.match(text, /scripts\/auto-update\.mjs/);
+	assert.match(text, /Checking Auto Update/);
+	assert(sessionStartCommands.some((command) => command.includes("scripts/auto-update.mjs")));
 });
 
 test("#given aggregate MCP config #when inspected #then code MCPs reference package runtimes without package names", async () => {
@@ -261,7 +291,13 @@ test("#given component directories #when scanned #then only intentional resource
 	const expectedComponentManifests = new Map([["rules", { hooks: "./hooks/hooks.json" }]]);
 
 	// when
-	const componentNames = components.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+	const componentNames = [];
+	for (const entry of components) {
+		if (!entry.isDirectory()) continue;
+		if (!(await exists(join("components", entry.name, "package.json")))) continue;
+		componentNames.push(entry.name);
+	}
+	componentNames.sort();
 
 	// then
 	assert.deepEqual(componentNames, [

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { resolveAutoUpdatePlan, runAutoUpdateCheck } from "../scripts/auto-update.mjs";
+
+test("#given auto update is disabled #when resolving plan #then no command is scheduled", () => {
+	const plan = resolveAutoUpdatePlan({
+		env: { LAZYCODEX_AUTO_UPDATE_DISABLED: "1" },
+		now: 1_000,
+		lastCheckedAt: 0,
+	});
+
+	assert.equal(plan.shouldRun, false);
+	assert.equal(plan.reason, "disabled");
+});
+
+test("#given stale state #when resolving plan #then installer update command is scheduled", () => {
+	const plan = resolveAutoUpdatePlan({
+		env: {},
+		now: 90_000_000,
+		lastCheckedAt: 0,
+	});
+
+	assert.equal(plan.shouldRun, true);
+	assert.deepEqual(plan.command, "npx");
+	assert.deepEqual(plan.args, ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--skip-auth"]);
+});
+
+test("#given recent state #when resolving plan #then update is throttled", () => {
+	const plan = resolveAutoUpdatePlan({
+		env: {},
+		now: 90_000_000,
+		lastCheckedAt: 89_999_000,
+	});
+
+	assert.equal(plan.shouldRun, false);
+	assert.equal(plan.reason, "throttled");
+});
+
+test("#given test command override #when running check #then records state and launches command", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-"));
+	const logPath = join(root, "spawn.log");
+	const statePath = join(root, "state.json");
+
+	const result = await runAutoUpdateCheck({
+		env: {
+			LAZYCODEX_AUTO_UPDATE_STATE_PATH: statePath,
+			LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
+			LAZYCODEX_AUTO_UPDATE_COMMAND: process.execPath,
+			LAZYCODEX_AUTO_UPDATE_ARGS_JSON: JSON.stringify(["-e", `require("node:fs").writeFileSync(${JSON.stringify(logPath)}, "ok")`]),
+			LAZYCODEX_AUTO_UPDATE_WAIT: "1",
+		},
+		now: 123_456,
+	});
+
+	assert.equal(result.started, true);
+	assert.equal(JSON.parse(await readFile(statePath, "utf8")).lastCheckedAt, 123_456);
+	assert.equal(await readFile(logPath, "utf8"), "ok");
+});
+
+test("#given active lock #when running check #then skips concurrent update", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-lock-"));
+	const statePath = join(root, "state.json");
+	const lockPath = join(root, "state.json.lock");
+	await writeFile(lockPath, "locked\n");
+
+	const result = await runAutoUpdateCheck({
+		env: {
+			LAZYCODEX_AUTO_UPDATE_STATE_PATH: statePath,
+			LAZYCODEX_AUTO_UPDATE_LOCK_PATH: lockPath,
+			LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
+			LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS: "600000",
+		},
+		now: 123_456,
+	});
+
+	assert.equal(result.started, false);
+	assert.equal(result.reason, "locked");
+});

--- a/packages/omo-codex/plugin/test/hook-status-message.test.mjs
+++ b/packages/omo-codex/plugin/test/hook-status-message.test.mjs
@@ -15,6 +15,7 @@ const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const AGGREGATE_EXPECTED_LABELS = new Map([
 	["hooks/hooks.json:SessionStart:0:0", "Loading Project Rules"],
 	["hooks/hooks.json:SessionStart:1:0", "Recording Session Telemetry"],
+	["hooks/hooks.json:SessionStart:2:0", "Checking Auto Update"],
 	["hooks/hooks.json:UserPromptSubmit:0:0", "Loading Project Rules"],
 	["hooks/hooks.json:UserPromptSubmit:1:0", "Checking Ultrawork Trigger"],
 	["hooks/hooks.json:UserPromptSubmit:2:0", "Checking Ulw-Loop Steering"],
@@ -74,6 +75,7 @@ async function readComponentVersions() {
 	const versions = new Map();
 	for (const entry of components) {
 		if (!entry.isDirectory()) continue;
+		if (!(await exists(join("components", entry.name, "package.json")))) continue;
 		const packageJson = await readJson(join("components", entry.name, "package.json"));
 		versions.set(entry.name, packageJson.version);
 	}

--- a/packages/omo-codex/plugin/test/sync-hook-status-messages.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-hook-status-messages.test.mjs
@@ -21,6 +21,7 @@ test("#given a component without hooks #when hook status messages sync #then bui
 	await mkdir(join(root, "hooks"), { recursive: true });
 	await mkdir(join(root, "components", "comment-checker", "hooks"), { recursive: true });
 	await mkdir(join(root, "components", "git-bash"), { recursive: true });
+	await mkdir(join(root, "components", "stale-build-output", "dist"), { recursive: true });
 	await writeJson(join(root, ".codex-plugin", "plugin.json"), { version: "0.1.0" });
 	await writeJson(join(root, "components", "comment-checker", "package.json"), { version: "0.1.1" });
 	await writeJson(join(root, "components", "git-bash", "package.json"), { version: "0.3.0" });

--- a/packages/omo-codex/scripts/install-bin-links.test.mjs
+++ b/packages/omo-codex/scripts/install-bin-links.test.mjs
@@ -76,6 +76,29 @@ test("#given managed legacy Codex component symlink #when linking bins #then rem
 	assert.equal(await readlink(join(binDir, "omo-rules")), join(pluginRoot, "dist", "cli.js"));
 });
 
+test("#given managed legacy Codex LSP symlink #when linking bins #then removes stale lsp symlink", async () => {
+	const root = await makeTempDir();
+	const pluginRoot = join(root, "plugin");
+	const binDir = join(root, "bin");
+	const oldTarget = join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "lsp", "dist", "cli.js");
+
+	await mkdir(join(pluginRoot, "dist"), { recursive: true });
+	await mkdir(join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "lsp", "dist"), { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await writeJson(join(pluginRoot, "package.json"), {
+		name: "@example/omo",
+		bin: { omo: "./dist/cli.js" },
+	});
+	await writeFile(join(pluginRoot, "dist", "cli.js"), "#!/usr/bin/env node\n");
+	await writeFile(oldTarget, "#!/usr/bin/env node\n");
+	await symlink(oldTarget, join(binDir, "codex-lsp"));
+
+	await linkCachedPluginBins({ binDir, pluginRoot, platform: "linux" });
+
+	await assert.rejects(readlink(join(binDir, "codex-lsp")));
+	assert.equal(await readlink(join(binDir, "omo")), join(pluginRoot, "dist", "cli.js"));
+});
+
 test("#given user-owned legacy Codex symlink #when linking bins #then preserves the user symlink", async () => {
 	const root = await makeTempDir();
 	const pluginRoot = join(root, "plugin");

--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -100,6 +100,19 @@ test("#given dry-run cleanup #when running the Node installer entrypoint #then p
 	assert.equal(output, "npx --yes --package oh-my-openagent omo cleanup --platform=codex --project /tmp/lazycodex-qa");
 });
 
+test("#given dry-run ulw-loop #when running the Node installer entrypoint #then prints delegated ulw-loop command", () => {
+	// given
+	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
+
+	// when
+	const output = execFileSync(process.execPath, [scriptPath, "--dry-run", "ulw-loop", "help"], {
+		encoding: "utf8",
+	}).trim();
+
+	// then
+	assert.equal(output, "npx --yes --package oh-my-openagent omo ulw-loop help");
+});
+
 test("#given the invoking argv path disappears #when importing the Node installer module #then the entrypoint guard does not throw", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));

--- a/packages/omo-codex/scripts/install/cli-args.mjs
+++ b/packages/omo-codex/scripts/install/cli-args.mjs
@@ -1,5 +1,5 @@
 const CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs.";
-const PASSTHROUGH_COMMANDS = new Set(["doctor", "cleanup", "get-local-version", "boulder", "refresh-model-capabilities", "run"]);
+const PASSTHROUGH_COMMANDS = new Set(["doctor", "cleanup", "get-local-version", "boulder", "refresh-model-capabilities", "run", "ulw-loop"]);
 
 export function parseLazyCodexInstallCliArgs(argv) {
 	const args = [...argv];

--- a/packages/omo-codex/scripts/install/legacy-bins.mjs
+++ b/packages/omo-codex/scripts/install/legacy-bins.mjs
@@ -5,6 +5,7 @@ import { COMMAND_SHIM_MARKER } from "./command-shim.mjs";
 
 const LEGACY_CODEX_COMPONENT_BINS = [
 	{ name: "codex-comment-checker", component: "comment-checker" },
+	{ name: "codex-lsp", component: "lsp" },
 	{ name: "codex-rules", component: "rules" },
 	{ name: "codex-start-work-continuation", component: "start-work-continuation" },
 	{ name: "codex-telemetry", component: "telemetry" },

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -7,6 +7,7 @@ import { doctor } from "./doctor"
 import { refreshModelCapabilities } from "./refresh-model-capabilities"
 import { createMcpOAuthCommand } from "./mcp-oauth"
 import { boulder } from "./boulder"
+import { codexUlwLoop } from "./codex-ulw-loop"
 import type { InstallArgs } from "./types"
 import type { RunOptions } from "./run"
 import type { GetLocalVersionOptions } from "./get-local-version/types"
@@ -260,6 +261,16 @@ program
       workId: options.workId,
       json: options.json ?? false,
     })
+    process.exit(exitCode)
+  })
+
+program
+  .command("ulw-loop [args...]")
+  .allowUnknownOption()
+  .passThroughOptions()
+  .description("Run the Codex LazyCodex ulw-loop CLI")
+  .action(async (args: string[] = []) => {
+    const exitCode = await codexUlwLoop(args)
     process.exit(exitCode)
   })
 

--- a/src/cli/codex-ulw-loop.test.ts
+++ b/src/cli/codex-ulw-loop.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { resolveCodexUlwLoopCommand } from "./codex-ulw-loop"
+
+describe("Codex ulw-loop routing", () => {
+  test("prefers the Codex-local omo bin so a global omo can reach ulw-loop", () => {
+    // given
+    const root = join(tmpdir(), `omo-ulw-loop-${randomUUID()}`)
+    const binDir = join(root, "bin")
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(join(binDir, "omo"), "#!/usr/bin/env node\n")
+
+    // when
+    const command = resolveCodexUlwLoopCommand({
+      env: { CODEX_LOCAL_BIN_DIR: binDir },
+      homeDir: root,
+    })
+
+    // then
+    expect(command).toEqual({ executable: join(binDir, "omo"), argsPrefix: ["ulw-loop"] })
+  })
+
+  test("falls back to the newest cached ulw-loop component cli", () => {
+    // given
+    const root = join(tmpdir(), `omo-ulw-loop-cache-${randomUUID()}`)
+    const oldCli = join(root, ".codex", "plugins", "cache", "sisyphuslabs", "omo", "0.1.0", "components", "ulw-loop", "dist", "cli.js")
+    const newCli = join(root, ".codex", "plugins", "cache", "sisyphuslabs", "omo", "0.2.0", "components", "ulw-loop", "dist", "cli.js")
+    mkdirSync(dirname(oldCli), { recursive: true })
+    mkdirSync(dirname(newCli), { recursive: true })
+    writeFileSync(oldCli, "#!/usr/bin/env node\n")
+    writeFileSync(newCli, "#!/usr/bin/env node\n")
+
+    // when
+    const command = resolveCodexUlwLoopCommand({
+      env: {},
+      homeDir: root,
+    })
+
+    // then
+    expect(command).toEqual({ executable: process.execPath, argsPrefix: [newCli] })
+  })
+
+  test("skips the local omo bin when it points at the current CLI", () => {
+    // given
+    const root = join(tmpdir(), `omo-ulw-loop-self-${randomUUID()}`)
+    const binDir = join(root, "bin")
+    const selfBin = join(binDir, "omo")
+    const componentCli = join(root, ".codex", "plugins", "cache", "sisyphuslabs", "omo", "0.1.0", "components", "ulw-loop", "dist", "cli.js")
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(dirname(componentCli), { recursive: true })
+    writeFileSync(selfBin, "#!/usr/bin/env node\n")
+    writeFileSync(componentCli, "#!/usr/bin/env node\n")
+
+    // when
+    const command = resolveCodexUlwLoopCommand({
+      env: { CODEX_LOCAL_BIN_DIR: binDir },
+      homeDir: root,
+      currentExecutablePaths: [selfBin],
+    })
+
+    // then
+    expect(command).toEqual({ executable: process.execPath, argsPrefix: [componentCli] })
+  })
+})

--- a/src/cli/codex-ulw-loop.ts
+++ b/src/cli/codex-ulw-loop.ts
@@ -1,0 +1,96 @@
+import { spawn } from "node:child_process"
+import { existsSync, readdirSync, realpathSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export type CodexUlwLoopCommand = {
+  readonly executable: string
+  readonly argsPrefix: readonly string[]
+}
+
+type ResolveCodexUlwLoopCommandInput = {
+  readonly env?: NodeJS.ProcessEnv
+  readonly homeDir?: string
+  readonly currentExecutablePaths?: readonly string[]
+}
+
+export function resolveCodexUlwLoopCommand(input: ResolveCodexUlwLoopCommandInput = {}): CodexUlwLoopCommand | null {
+  const env = input.env ?? process.env
+  const homeDir = input.homeDir ?? homedir()
+  const localBin = resolveLocalOmoBin(env, homeDir, input.currentExecutablePaths ?? [process.argv[1]].filter((value): value is string => typeof value === "string"))
+  if (localBin !== null) return { executable: localBin, argsPrefix: ["ulw-loop"] }
+
+  const componentCli = resolveNewestCachedUlwLoopCli(env.CODEX_HOME ?? join(homeDir, ".codex"))
+  if (componentCli !== null) return { executable: process.execPath, argsPrefix: [componentCli] }
+
+  return null
+}
+
+export async function codexUlwLoop(args: readonly string[]): Promise<number> {
+  const command = resolveCodexUlwLoopCommand()
+  if (command === null) {
+    console.error("Codex ulw-loop is not installed. Run: npx lazycodex-ai@latest install --no-tui")
+    return 1
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(command.executable, [...command.argsPrefix, ...args], { stdio: "inherit" })
+    child.on("error", (error) => {
+      console.error(error.message)
+      resolve(1)
+    })
+    child.on("close", (code) => resolve(code ?? 1))
+  })
+}
+
+function resolveLocalOmoBin(env: NodeJS.ProcessEnv, homeDir: string, currentExecutablePaths: readonly string[]): string | null {
+  const candidates = [
+    env.CODEX_LOCAL_BIN_DIR ? join(env.CODEX_LOCAL_BIN_DIR, "omo") : undefined,
+    join(homeDir, ".local", "bin", "omo"),
+    join(homeDir, ".codex", "bin", "omo"),
+  ].filter((value): value is string => typeof value === "string")
+
+  return candidates.find((candidate) => existsSync(candidate) && !isCurrentExecutable(candidate, currentExecutablePaths)) ?? null
+}
+
+function isCurrentExecutable(candidate: string, currentExecutablePaths: readonly string[]): boolean {
+  const candidateRealPath = realpathOrSelf(candidate)
+  return currentExecutablePaths.some((currentPath) => realpathOrSelf(currentPath) === candidateRealPath)
+}
+
+function realpathOrSelf(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return path
+  }
+}
+
+function resolveNewestCachedUlwLoopCli(codexHome: string): string | null {
+  const versionsRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo")
+  if (!existsSync(versionsRoot)) return null
+
+  const versions = readdirSync(versionsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort(compareVersionNames)
+    .reverse()
+
+  for (const version of versions) {
+    const candidate = join(versionsRoot, version, "components", "ulw-loop", "dist", "cli.js")
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function compareVersionNames(left: string, right: string): number {
+  const leftParts = left.split(".").map((part) => Number.parseInt(part, 10))
+  const rightParts = right.split(".").map((part) => Number.parseInt(part, 10))
+  const length = Math.max(leftParts.length, rightParts.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = Number.isFinite(leftParts[index] ?? Number.NaN) ? leftParts[index] ?? 0 : 0
+    const rightValue = Number.isFinite(rightParts[index] ?? Number.NaN) ? rightParts[index] ?? 0 : 0
+    if (leftValue !== rightValue) return leftValue - rightValue
+  }
+  return left.localeCompare(right)
+}

--- a/src/cli/install-codex/codex-cache-legacy-bins.ts
+++ b/src/cli/install-codex/codex-cache-legacy-bins.ts
@@ -6,6 +6,7 @@ type LinkPlatform = NodeJS.Platform
 
 const LEGACY_CODEX_COMPONENT_BINS = [
   { name: "codex-comment-checker", component: "comment-checker" },
+  { name: "codex-lsp", component: "lsp" },
   { name: "codex-rules", component: "rules" },
   { name: "codex-start-work-continuation", component: "start-work-continuation" },
   { name: "codex-telemetry", component: "telemetry" },

--- a/src/cli/install-codex/codex-cache.test.ts
+++ b/src/cli/install-codex/codex-cache.test.ts
@@ -174,13 +174,17 @@ describe("codex-cache", () => {
     const pluginRoot = join(root, "plugin")
     const binDir = join(root, "bin")
     const oldTarget = join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "rules", "dist", "cli.js")
+    const oldLspTarget = join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "lsp", "dist", "cli.js")
     await mkdir(join(pluginRoot, "dist"), { recursive: true })
     await mkdir(join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "rules", "dist"), { recursive: true })
+    await mkdir(join(root, "codex-home", "plugins", "cache", "legacy-market", "omo", "0.0.1", "components", "lsp", "dist"), { recursive: true })
     await mkdir(binDir, { recursive: true })
     await writeFile(join(pluginRoot, "package.json"), JSON.stringify({ name: "@scope/omo", bin: { "omo-rules": "dist/cli.js" } }))
     await writeFile(join(pluginRoot, "dist", "cli.js"), "#!/usr/bin/env node\n")
     await writeFile(oldTarget, "#!/usr/bin/env node\n")
+    await writeFile(oldLspTarget, "#!/usr/bin/env node\n")
     await symlink(oldTarget, join(binDir, "codex-rules"))
+    await symlink(oldLspTarget, join(binDir, "codex-lsp"))
     await writeFile(join(binDir, "codex-comment-checker"), "user managed file\n")
 
     // when
@@ -188,6 +192,7 @@ describe("codex-cache", () => {
 
     // then
     await expect(readlink(join(binDir, "codex-rules"))).rejects.toThrow()
+    await expect(readlink(join(binDir, "codex-lsp"))).rejects.toThrow()
     expect(await readFile(join(binDir, "codex-comment-checker"), "utf8")).toBe("user managed file\n")
     expect(await readlink(join(binDir, "omo-rules"))).toBe(join(pluginRoot, "dist", "cli.js"))
   })

--- a/src/dependency-security.test.ts
+++ b/src/dependency-security.test.ts
@@ -15,6 +15,12 @@ type BunLock = {
 
 const MINIMUM_SAFE_PICOMATCH_VERSION = "4.0.4"
 const REPOSITORY_ROOT = dirname(fileURLToPath(import.meta.url))
+const FIRST_PARTY_SOURCE_GLOBS = [
+  "src/**/*.ts",
+  "packages/**/*.ts",
+  "script/**/*.ts",
+  "test-support/**/*.ts",
+] as const
 
 function parseVersion(version: string): [number, number, number] {
   const [major = "0", minor = "0", patch = "0"] = version.split(".")
@@ -47,6 +53,23 @@ function extractLockedVersion(packageReference: string): string {
   return packageReference.slice(versionSeparatorIndex + 1)
 }
 
+async function findFirstPartyEffectImports(): Promise<string[]> {
+  const matches: string[] = []
+  const importPattern = /(?:from\s+["']effect(?:\/[^"']*)?["']|import\(\s*["']effect(?:\/[^"']*)?["']|require\(\s*["']effect(?:\/[^"']*)?["'])/
+
+  for (const globPattern of FIRST_PARTY_SOURCE_GLOBS) {
+    const glob = new Bun.Glob(globPattern)
+    for await (const filePath of glob.scan({ cwd: join(REPOSITORY_ROOT, ".."), onlyFiles: true })) {
+      const source = await Bun.file(join(REPOSITORY_ROOT, "..", filePath)).text()
+      if (importPattern.test(source)) {
+        matches.push(filePath)
+      }
+    }
+  }
+
+  return matches
+}
+
 describe("dependency security", () => {
   it("#given picomatch is a runtime dependency #when dependencies are locked #then it uses the patched ReDoS-safe release", () => {
     const packageJson = JSON.parse(readFileSync(join(REPOSITORY_ROOT, "..", "package.json"), "utf-8")) as {
@@ -62,5 +85,26 @@ describe("dependency security", () => {
     const lockedVersion = extractLockedVersion(lockedReference ?? "")
     expect(compareVersions(lockedVersion, MINIMUM_SAFE_PICOMATCH_VERSION)).toBeGreaterThanOrEqual(0)
     expect(bunLock.workspaces?.[""]?.dependencies?.picomatch).toBe(`^${MINIMUM_SAFE_PICOMATCH_VERSION}`)
+  })
+
+  it("#given effect is only needed by OpenCode internals #when root dependencies are locked #then the root package does not depend on effect directly", () => {
+    const packageJson = JSON.parse(readFileSync(join(REPOSITORY_ROOT, "..", "package.json"), "utf-8")) as {
+      dependencies?: Record<string, string>
+    }
+    const bunLock = parse(readFileSync(join(REPOSITORY_ROOT, "..", "bun.lock"), "utf-8")) as BunLock
+    const opencodePluginDependencies = bunLock.packages?.["@opencode-ai/plugin"]?.[2]
+
+    expect(packageJson.dependencies?.effect).toBeUndefined()
+    expect(bunLock.workspaces?.[""]?.dependencies?.effect).toBeUndefined()
+    expect(opencodePluginDependencies).toMatchObject({
+      dependencies: expect.objectContaining({ effect: expect.any(String) }),
+    })
+    expect(bunLock.packages?.effect?.[0]).toBe("effect@4.0.0-beta.66")
+  })
+
+  it("#given first-party TypeScript sources #when dependency imports are scanned #then no source imports effect directly", async () => {
+    const effectImports = await findFirstPartyEffectImports()
+
+    expect(effectImports).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- add startup-only LazyCodex auto-update hook with throttle and lock
- clean stale codex-lsp links in Node and TS Codex installers
- route `omo ulw-loop` safely and allow lazycodex-ai passthrough
- keep component scans resilient to stale non-package build output

## Verification
- node --test packages/omo-codex/plugin/test/auto-update.test.mjs packages/omo-codex/plugin/test/aggregate.test.mjs packages/omo-codex/plugin/test/hook-status-message.test.mjs packages/omo-codex/plugin/test/sync-hook-status-messages.test.mjs packages/omo-codex/scripts/install-bin-links.test.mjs packages/omo-codex/scripts/install-local-entrypoint.test.mjs
- bun test src/cli/codex-ulw-loop.test.ts src/cli/install-codex/codex-cache.test.ts src/cli/cli-program.test.ts src/cli/install-platform-resolution.test.ts && bun run tsc --noEmit --pretty false
- node --test packages/omo-codex/scripts/install-bin-links.test.mjs packages/omo-codex/scripts/install-local-entrypoint.test.mjs packages/omo-codex/scripts/install-cli-args.test.mjs packages/omo-codex/scripts/install-config.test.mjs packages/omo-codex/scripts/install-config-autonomous.test.mjs packages/omo-codex/scripts/install-local.test.mjs packages/omo-codex/scripts/install-project-local-cleanup.test.mjs packages/omo-codex/scripts/install-packaged-local.test.mjs
- tmux local install QA: `node packages/omo-codex/scripts/install-local.mjs --repo-root /Users/yeongyu/local-workspaces/omo --no-tui --skip-auth --codex-autonomous` => EXIT:0
- installed hook matcher/trust, codex-lsp cleanup, `omo ulw-loop help`, auto-update lock smoke verified locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a startup-only LazyCodex auto-update (throttled and lock-protected) and wires safe `ulw-loop` routing to the correct Codex CLI. Also cleans stale Codex LSP links and hardens component scans.

- New Features
  - Startup auto-update hook on `SessionStart startup`, with interval throttling and a file lock to prevent overlap.
  - Defaults to `npx --yes lazycodex-ai@latest install --no-tui --skip-auth`, supports env overrides, and runs detached or sync when requested.
  - New `ulw-loop` command: prefers the Codex-local `omo` bin, falls back to the newest cached component CLI, and is pass-through from the installer.

- Bug Fixes
  - Removes stale `codex-lsp` symlinks during bin linking in both Node and TS installers.
  - Component scans and hook/status sync skip non-package build output and missing manifests to avoid false positives.
  - Dependencies: removed root `effect`; plugin locks to `effect@4.0.0-beta.66`; bumped optional `oh-my-opencode-*` to `4.6.0`; tests ensure no first-party `effect` imports.

<sup>Written for commit fe28e0f763d62ed79e4b43f9b0d27e91bfd07d96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

