### PR TITLE
fix(runtime-skills): do not block Desktop startup without Bun.serve

### DIFF
--- a/src/testing/create-plugin-module.test.ts
+++ b/src/testing/create-plugin-module.test.ts
@@ -156,6 +156,36 @@ describe("createPluginModule()", () => {
       })
     })
 
+    it("#given the runtime skill source server is unavailable #then startup continues without a source URL", async () => {
+      // given
+      const pluginModule = createTestPluginModule()
+      const consoleWarn = mock(() => {})
+      const originalWarn = console.warn
+      console.warn = consoleWarn
+      mockLoadPluginConfig.mockReturnValue({})
+      mockCreateRuntimeSkillSourceServer.mockImplementationOnce(() => {
+        throw new Error("Runtime skill source server requires Bun.serve")
+      })
+
+      try {
+        // when
+        await pluginModule.server({
+          directory: "/tmp/project",
+          client: {},
+        } as Parameters<typeof pluginModule.server>[0])
+
+        // then
+        expect(mockCreateManagers.mock.calls.at(0)?.[0]?.runtimeSkillSourceUrl).toBeUndefined()
+        expect(mockCreateTools).toHaveBeenCalledTimes(1)
+        expect(mockCreatePluginInterface).toHaveBeenCalledTimes(1)
+        expect(consoleWarn).toHaveBeenCalledWith(
+          "[runtime-skills] bundled security skill source unavailable; continuing without config.skills.urls: Runtime skill source server requires Bun.serve",
+        )
+      } finally {
+        console.warn = originalWarn
+      }
+    })
+
     it("#then dispose stops the runtime skill source", async () => {
       // given
       const pluginModule = createTestPluginModule()

--- a/src/testing/create-plugin-module.ts
+++ b/src/testing/create-plugin-module.ts
@@ -117,10 +117,15 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
 
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
     const runtimeSecuritySkills = selectRuntimeSecuritySkills(pluginConfig)
-    const runtimeSkillSource =
-      runtimeSecuritySkills.length > 0
-        ? deps.createRuntimeSkillSourceServer({ skills: runtimeSecuritySkills })
-        : undefined
+    let runtimeSkillSource: ReturnType<PluginModuleDeps["createRuntimeSkillSourceServer"]> | undefined
+    if (runtimeSecuritySkills.length > 0) {
+      try {
+        runtimeSkillSource = deps.createRuntimeSkillSourceServer({ skills: runtimeSecuritySkills })
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        console.warn(`[runtime-skills] bundled security skill source unavailable; continuing without config.skills.urls: ${detail}`)
+      }
+    }
     deps.initI18n(pluginConfig.i18n?.locale ? { locale: pluginConfig.i18n.locale } : undefined)
     deps.setAgentSortOrder(pluginConfig.agent_order)
 


### PR DESCRIPTION
## Summary

Fixes the OpenCode Desktop startup regression where bundled runtime security skill registration could throw `Runtime skill source server requires Bun.serve` before OMO agents/tools/hooks were registered.

## Changes

- Downgrade runtime skill source server startup failure to a warning.
- Continue plugin startup without adding a `config.skills.urls` runtime source when the host runtime cannot provide `Bun.serve`.
- Add a regression test proving plugin startup reaches managers/tools/interface creation when the runtime source server is unavailable.

## Testing

- `bun run typecheck`
- `bun test src/testing/create-plugin-module.test.ts`
- `bun test src/features/opencode-runtime-skills src/testing/create-plugin-module.test.ts src/plugin-handlers/config-handler.test.ts`
- `bun test src/shared/dist-bundle-bun-globals.test.ts`
- `node --input-type=module -e "import('./dist/index.js').then(() => console.log('node-import-ok'))"`
- `bun run build`

Note: local full `bun test` exits 0 but still prints unrelated pre-existing failures in `src/plugin/ultrawork-db-model-override.test.ts` and `src/tools/delegate-task/tools.test.ts` under this workspace; focused tests for this change pass.

## Related Issues

Fixes #4662


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Desktop startup from failing when `Bun.serve` isn’t available by downgrading the runtime skill source server error to a warning and continuing without a source URL. Fixes #4662.

- **Bug Fixes**
  - Warn if the runtime skill source server can’t start.
  - Continue startup without `config.skills.urls` when `Bun.serve` is missing.
  - Add a regression test verifying managers, tools, and the plugin interface initialize and the warning is logged.

<sup>Written for commit d8fd5a02b5c138368287508475a1f2a0acc51aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

