### PR TITLE
Make LazyCodex installs autonomous by default

### DIFF
--- a/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
+++ b/packages/omo-codex/scripts/install-local-entrypoint.test.mjs
@@ -57,19 +57,34 @@ test("#given lazycodex runs through an npm bin symlink #when running the Node in
 	}
 });
 
-test("#given dry-run install flags #when running the Node installer entrypoint #then prints delegated codex install command", () => {
+test("#given dry-run install flags #when running the Node installer entrypoint #then prints delegated autonomous codex install command", () => {
 	// given
 	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
 
 	// when
 	const output = execFileSync(
 		process.execPath,
-		[scriptPath, "--dry-run", "install", "--no-tui", "--codex-autonomous"],
+		[scriptPath, "--dry-run", "install", "--no-tui"],
 		{ encoding: "utf8" },
 	).trim();
 
 	// then
 	assert.equal(output, "npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --codex-autonomous");
+});
+
+test("#given dry-run install opt-out #when running the Node installer entrypoint #then preserves existing Codex permission settings", () => {
+	// given
+	const scriptPath = fileURLToPath(new URL("./install-local.mjs", import.meta.url));
+
+	// when
+	const output = execFileSync(
+		process.execPath,
+		[scriptPath, "--dry-run", "install", "--no-tui", "--no-codex-autonomous"],
+		{ encoding: "utf8" },
+	).trim();
+
+	// then
+	assert.equal(output, "npx --yes --package oh-my-openagent omo install --platform=codex --no-tui --no-codex-autonomous");
 });
 
 test("#given dry-run doctor #when running the Node installer entrypoint #then prints delegated doctor command", () => {

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -147,7 +147,7 @@ export async function installMarketplaceLocally(options = {}) {
 		platform,
 		trustedHookStates,
 		agentConfigs: [...agentConfigs.values()].sort((left, right) => left.name.localeCompare(right.name)),
-		autonomousPermissions: options.autonomousPermissions === true,
+		autonomousPermissions: options.autonomousPermissions !== false,
 	});
 	const projectCleanup = await repairProjectLocalCodexArtifactsBestEffort({ startDirectory: projectDirectory, codexHome, log });
 	for (const configCleanup of projectCleanup.configs) {

--- a/packages/omo-codex/scripts/install/delegated-command.mjs
+++ b/packages/omo-codex/scripts/install/delegated-command.mjs
@@ -13,7 +13,7 @@ export function buildDelegatedOmoInvocation(parsed) {
 		args.push("--platform=codex");
 		if (parsed.noTui) args.push("--no-tui");
 		if (parsed.skipAuth) args.push("--skip-auth");
-		if (parsed.autonomousPermissions === true) args.push("--codex-autonomous");
+		if (parsed.autonomousPermissions !== false) args.push("--codex-autonomous");
 		if (parsed.autonomousPermissions === false) args.push("--no-codex-autonomous");
 		if (parsed.repoRoot) args.push(`--repo-root=${parsed.repoRoot}`);
 	} else if (parsed.command === "cleanup") {

--- a/src/cli/cli-installer.platform.test.ts
+++ b/src/cli/cli-installer.platform.test.ts
@@ -109,7 +109,7 @@ describe("runCliInstaller platform branching", () => {
     expect(result).toBe(0)
     expect(versionSpy).not.toHaveBeenCalled()
     expect(writeSpy).not.toHaveBeenCalled()
-    expect(codexSpy).toHaveBeenCalledTimes(1)
+    expect(codexSpy).toHaveBeenCalledWith({ autonomousPermissions: true })
   })
 
   test("passes Codex autonomous selection into Codex installer", async () => {
@@ -122,6 +122,18 @@ describe("runCliInstaller platform branching", () => {
     // then
     expect(result).toBe(0)
     expect(codexSpy).toHaveBeenCalledWith({ autonomousPermissions: true })
+  })
+
+  test("passes explicit Codex autonomous opt-out into Codex installer", async () => {
+    // given
+    const codexSpy = spyOn(codexInstaller, "runCodexInstaller").mockResolvedValue(codexResult)
+
+    // when
+    const result = await runCliInstaller({ tui: false, platform: "codex", codexAutonomous: false }, "3.4.0")
+
+    // then
+    expect(result).toBe(0)
+    expect(codexSpy).toHaveBeenCalledWith({ autonomousPermissions: false })
   })
 
   test("runs OpenCode and Codex installation for platform=both", async () => {

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -137,7 +137,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     platform,
     trustedHookStates,
     agentConfigs: [...agentConfigs.values()].sort((left, right) => left.name.localeCompare(right.name)),
-    autonomousPermissions: options.autonomousPermissions === true,
+    autonomousPermissions: options.autonomousPermissions !== false,
   })
 
   const projectCleanup = await repairProjectLocalCodexArtifactsBestEffort({

--- a/src/cli/install-validators.test.ts
+++ b/src/cli/install-validators.test.ts
@@ -36,9 +36,9 @@ describe("argsToConfig", () => {
     expect(config.hasCodex).toBe(false)
   })
 
-  test("enables only Codex when platform is codex", () => {
+  test("enables Codex autonomous mode by default when platform is codex", () => {
     // #given
-    const args = createArgs({ platform: "codex", codexAutonomous: true })
+    const args = createArgs({ platform: "codex" })
 
     // #when
     const config = argsToConfig(args)
@@ -48,6 +48,18 @@ describe("argsToConfig", () => {
     expect(config.hasOpenCode).toBe(false)
     expect(config.hasCodex).toBe(true)
     expect(config.codexAutonomous).toBe(true)
+  })
+
+  test("leaves Codex permission settings unchanged when explicitly disabled", () => {
+    // #given
+    const args = createArgs({ platform: "codex", codexAutonomous: false })
+
+    // #when
+    const config = argsToConfig(args)
+
+    // #then
+    expect(config.hasCodex).toBe(true)
+    expect(config.codexAutonomous).toBe(false)
   })
 
   test("ignores Codex autonomous mode when Codex is not installed", () => {

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -215,7 +215,7 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasKimiForCoding: hasOpenCode && args.kimiForCoding === "yes",
     hasOpencodeGo: hasOpenCode && args.opencodeGo === "yes",
     hasVercelAiGateway: hasOpenCode && args.vercelAiGateway === "yes",
-    codexAutonomous: hasCodex && args.codexAutonomous === true,
+    codexAutonomous: hasCodex && args.codexAutonomous !== false,
   }
 }
 

--- a/src/cli/tui-install-prompts.test.ts
+++ b/src/cli/tui-install-prompts.test.ts
@@ -101,7 +101,7 @@ describe("promptInstallConfig platform branching", () => {
 
   test("skips OpenCode questions when the user selects codex", async () => {
     // given
-    const selectSpy = spyOn(p, "select").mockResolvedValue(true)
+    const selectSpy = spyOn(p, "select").mockResolvedValue("no")
 
     // when
     const config = await prompts.promptInstallConfig(createDetectedConfig(), "codex")
@@ -113,11 +113,7 @@ describe("promptInstallConfig platform branching", () => {
       hasCodex: true,
       codexAutonomous: true,
     } satisfies Partial<InstallConfig>)
-    expect(selectSpy).toHaveBeenCalledTimes(1)
-    expect(selectSpy.mock.calls[0]?.[0]).toMatchObject({
-      initialValue: true,
-      options: [{ value: true }, { value: false }],
-    })
+    expect(selectSpy).not.toHaveBeenCalled()
   })
 
   test.each([
@@ -134,7 +130,7 @@ describe("promptInstallConfig platform branching", () => {
 
       // then
       expect(config).toMatchObject({ platform, hasOpenCode: true, hasCodex } satisfies Partial<InstallConfig>)
-      expect(selectSpy).toHaveBeenCalledTimes(hasCodex ? 10 : 9)
+      expect(selectSpy).toHaveBeenCalledTimes(9)
     },
   )
 

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -189,13 +189,5 @@ async function resolveCodexAutonomous(
 ): Promise<boolean | null> {
   if (!hasCodex) return false
   if (override !== undefined) return override
-
-  return selectOrCancel<boolean>({
-    message: "Configure Codex for autonomous full-permissions mode?",
-    options: [
-      { value: true, label: "Yes", hint: "Recommended: approval never, danger-full-access, network enabled" },
-      { value: false, label: "No", hint: "Leave existing Codex permissions unchanged" },
-    ],
-    initialValue: true,
-  })
+  return true
 }


### PR DESCRIPTION
## Summary
Make Codex Light / lazycodex installs configure Codex autonomous full-permissions mode by default across platforms, while preserving the explicit --no-codex-autonomous opt-out.

I checked the current OpenAI Codex source before changing this: root config keys approval_policy, sandbox_mode = danger-full-access, network_access, notice warning keys, and Windows sandbox config remain active in Codex core/TUI.

## Changes
- Default Codex install config to autonomous permissions when Codex is included.
- Skip the interactive autonomous-permissions prompt and use full permissions unless explicitly disabled.
- Make the Node lazycodex installer and dry-run delegation pass --codex-autonomous by default.
- Add regression coverage for default autonomous installs and explicit opt-out.

## Testing
- PATH="/Users/yeongyu/.bun/bin:/Users/yeongyu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/yeongyu/.cargo/bin:/Users/yeongyu/.venv/bin:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg0tUPQqA:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg05sDgWR:/Users/yeongyu/.local/bin:/Users/yeongyu/.orbstack/bin" bun test src/cli/install-validators.test.ts src/cli/cli-installer.platform.test.ts src/cli/tui-install-prompts.test.ts src/cli/install-codex/codex-config-toml.test.ts src/cli/install-codex/install-codex.test.ts
- node --test packages/omo-codex/scripts/install-local-entrypoint.test.mjs packages/omo-codex/scripts/install-config-autonomous.test.mjs packages/omo-codex/scripts/install-cli-args.test.mjs
- PATH="/Users/yeongyu/.bun/bin:/Users/yeongyu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/yeongyu/.cargo/bin:/Users/yeongyu/.venv/bin:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg0tUPQqA:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg05sDgWR:/Users/yeongyu/.local/bin:/Users/yeongyu/.orbstack/bin" bun run test:codex
- PATH="/Users/yeongyu/.bun/bin:/Users/yeongyu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/yeongyu/.cargo/bin:/Users/yeongyu/.venv/bin:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg0tUPQqA:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg05sDgWR:/Users/yeongyu/.local/bin:/Users/yeongyu/.orbstack/bin" bun run typecheck
- PATH="/Users/yeongyu/.bun/bin:/Users/yeongyu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/yeongyu/.cargo/bin:/Users/yeongyu/.venv/bin:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg0tUPQqA:/Users/yeongyu/.codex-remote/tmp/arg0/codex-arg05sDgWR:/Users/yeongyu/.local/bin:/Users/yeongyu/.orbstack/bin" bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
LazyCodex now installs Codex in autonomous full-permissions mode by default and skips the prompt. You can still opt out with --no-codex-autonomous.

- **New Features**
  - Default autonomous mode when installing with platform=codex (CLI and Node installer).
  - Delegated `npx` call (`--package oh-my-openagent`) adds `--codex-autonomous` unless explicitly disabled.
  - Keeps explicit opt-out via `--no-codex-autonomous`; TUI no longer asks.
  - Added tests covering default behavior and the opt-out path.

<sup>Written for commit 98990d93429b45db1e58b506adbc956dbd23334e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

