### PR TITLE
fix(team-mode): expose inline team spec schema

### DIFF
--- a/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
+++ b/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
@@ -134,6 +134,27 @@ describe("createTeamCreateTool inline_spec normalization", () => {
     expect(result.runtimeState.members.map((member: { name: string }) => member.name)).toEqual(["lead", "quick-1", "atlas-1"])
   })
 
+  test("exposes inline_spec object shape in the tool schema", async () => {
+    // given
+    const createTeamCreateTool = await loadCreateTeamCreateTool()
+    const config = createConfig()
+    const teamCreateTool = createTeamCreateToolForTest(createTeamCreateTool, config)
+
+    // when
+    const inlineSpecSchema = teamCreateTool.args.inline_spec.unwrap()
+    const inlineSpecObjectSchema = inlineSpecSchema.options.find((option) => option.type === "object")
+
+    // then
+    expect(inlineSpecSchema.type).toBe("union")
+    expect(inlineSpecSchema.options.map((option) => option.type)).toEqual(["object", "string"])
+    expect(inlineSpecObjectSchema?.shape.name.type).toBe("string")
+    expect(inlineSpecObjectSchema?.shape.members.type).toBe("array")
+    expect(inlineSpecObjectSchema?.shape.members.element.type).toBe("object")
+    expect(inlineSpecObjectSchema?.shape.members.element.shape.category.type).toBe("optional")
+    expect(inlineSpecObjectSchema?.shape.members.element.shape.subagent_type.type).toBe("optional")
+    expect(teamCreateTool.args.inline_spec.description).toContain("members must be a flat array")
+  })
+
   test("accepts stringified inline_spec values from tool calling", async () => {
     // given
     const createTeamCreateTool = await loadCreateTeamCreateTool()

--- a/src/features/team-mode/tools/lifecycle.ts
+++ b/src/features/team-mode/tools/lifecycle.ts
@@ -32,6 +32,31 @@ const TeamCreateArgsSchema = z.object({
   }
 })
 
+const TeamCreateInlineMemberToolSchema = tool.schema.object({
+  name: tool.schema.string().optional().describe("Member name, kebab-case or natural text; normalized before team creation."),
+  kind: tool.schema.enum(["category", "subagent_type"]).optional().describe("Member kind. Use category for category-routed workers, or subagent_type for a specific eligible agent."),
+  category: tool.schema.string().optional().describe("Required for category members unless a fallback category can be inferred. Examples: quick, unspecified-low, unspecified-high, deep, ultrabrain, visual-engineering, writing, artistry, git, data-analysis."),
+  subagent_type: tool.schema.string().optional().describe("Required for subagent_type members. Eligible examples: sisyphus, atlas, sisyphus-junior."),
+  prompt: tool.schema.string().optional().describe("Task prompt for this member. Category members need a concrete work prompt."),
+  systemPrompt: tool.schema.string().optional().describe("Legacy alias for prompt; normalized before team creation."),
+  loadSkills: tool.schema.array(tool.schema.string()).optional().describe("Optional skills to load for this member."),
+  role: tool.schema.string().optional().describe("Optional natural-language role used to build a prompt when prompt is omitted."),
+  description: tool.schema.string().optional().describe("Optional natural-language description used to build a prompt when prompt is omitted."),
+})
+
+const TeamCreateInlineSpecToolSchema = tool.schema.union([
+  tool.schema.object({
+    name: tool.schema.string().describe("Team name, kebab-case or natural text; normalized before team creation."),
+    description: tool.schema.string().optional().describe("Optional team description."),
+    leadAgentId: tool.schema.string().optional().describe("Optional member name to use as team lead."),
+    lead: TeamCreateInlineMemberToolSchema.optional().describe("Optional explicit lead member."),
+    members: tool.schema.array(TeamCreateInlineMemberToolSchema).describe("Team members; members must be a flat array, not an object or nested groups. Provide 1-8 members."),
+    teamAllowedPaths: tool.schema.array(tool.schema.string()).optional().describe("Optional paths the team may access."),
+    sessionPermission: tool.schema.string().optional().describe("Optional session permission policy."),
+  }),
+  tool.schema.string().describe("JSON string containing the same inline team spec object."),
+])
+
 const TeamDeleteArgsSchema = z.object({ teamRunId: z.string().min(1), force: z.boolean().optional() })
 const TeamShutdownRequestArgsSchema = z.object({ teamRunId: z.string().min(1), targetMemberName: z.string().min(1) })
 const TeamApproveShutdownArgsSchema = z.object({ teamRunId: z.string().min(1), memberName: z.string().min(1) })
@@ -189,7 +214,7 @@ export function createTeamCreateTool(
     description: "Create a team run from a named or inline team spec.",
     args: {
       teamName: tool.schema.string().optional().describe("Named team spec to load. Provide exactly one of teamName or inline_spec."),
-      inline_spec: tool.schema.unknown().optional().describe("Inline team spec object or JSON string. Provide exactly one of teamName or inline_spec."),
+      inline_spec: TeamCreateInlineSpecToolSchema.optional().describe("Inline team spec object or JSON string. Provide exactly one of teamName or inline_spec; members must be a flat array, e.g. { name: \"project-analysis-team\", members: [{ name: \"structure-analyst\", category: \"quick\", prompt: \"Analyze project structure.\" }] }."),
       leadSessionId: tool.schema.string().optional().describe("Optional non-empty session ID override. Usually omit this and let team_create use the current session."),
     },
     async execute(rawArgs, toolContext) {


### PR DESCRIPTION
## Summary

Fixes #4656 by replacing the model-facing `team_create.inline_spec` `unknown` schema with a structured object-or-string union.

This keeps the existing runtime behavior intact: object inline specs and JSON-string inline specs are still accepted, but the model now sees the concrete object shape and the flat `members` array requirement.

## QA

- Reproduced before fix: focused regression failed because `teamCreateTool.args.inline_spec.unwrap().type` was `unknown`.
- `PATH="$HOME/.bun/bin:$PATH" bun test src/features/team-mode/tools/lifecycle-inline-spec.test.ts src/features/team-mode/tools/lifecycle.test.ts src/plugin/tool-registry.team-mode.test.ts --bail` — 27 pass / 0 fail
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck` — pass
- `PATH="$HOME/.bun/bin:$PATH" bun run build` — pass

## Behavior / architecture note

This is intentionally narrow. It exposes the schema for the existing accepted input shape and preserves JSON-string compatibility; it does not change team-mode creation semantics.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4656 by exposing a structured schema for `team_create.inline_spec`, replacing the `unknown` type with an object-or-string union. Keeps current behavior while giving the model a clear object shape and a flat `members` array rule.

- Bug Fixes
  - Replaced `unknown` with `union([object, string])`; the object includes `name`, optional `lead`, and `members` as a flat array.
  - Added tests to verify schema visibility and JSON-string compatibility.

<sup>Written for commit 6a05e09e1799dae03fe426ad407229bca3149303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

