### PR TITLE
fix(doctor): gate TUI plugin advice on package exports

### DIFF
--- a/src/cli/doctor/checks/tui-plugin-config.test.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.test.ts
@@ -25,14 +25,24 @@ function writeTuiConfig(plugins: string[]): void {
   )
 }
 
-function writeFilePluginPackage(dir: string, packageName: string): string {
+function createPackageJson(packageName: string, exportsValue: Record<string, unknown> = { ".": "./dist/index.js" }): string {
+  return JSON.stringify({ name: packageName, exports: exportsValue }, null, 2) + "\n"
+}
+
+function writeFilePluginPackage(dir: string, packageName: string, exportsValue?: Record<string, unknown>): string {
   mkdirSync(dir, { recursive: true })
   writeFileSync(
     join(dir, "package.json"),
-    JSON.stringify({ name: packageName }, null, 2) + "\n",
+    createPackageJson(packageName, exportsValue),
     "utf-8",
   )
   return `file:${dir}`
+}
+
+function writeInstalledPackage(packageName: string, exportsValue?: Record<string, unknown>): void {
+  const packageDir = join(testConfigDir, "node_modules", packageName)
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, "package.json"), createPackageJson(packageName, exportsValue), "utf-8")
 }
 
 describe("tui-plugin-config check", () => {
@@ -85,6 +95,55 @@ describe("tui-plugin-config check", () => {
     expect(result.issues[0].fix).toBeDefined()
   })
 
+  it("does not suggest a missing TUI entry when the installed package has no tui export", async () => {
+    //#given opencode.json has the server entry, tui.json is missing the TUI entry,
+    //#       and the installed published package has no ./tui export
+    writeInstalledPackage(PLUGIN_NAME)
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig(["some-other-tui-plugin"])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then doctor avoids recommending an unresolvable TUI plugin entry
+    expect(result.status).toBe("pass")
+    expect(result.issues).toHaveLength(0)
+    expect(result.message).toContain("TUI subpath not shipped")
+  })
+
+  it("warns to remove an explicit TUI entry when the installed package has no tui export", async () => {
+    //#given opencode.json has the server entry, tui.json has the broken TUI entry,
+    //#       and the installed published package has no ./tui export
+    writeInstalledPackage(PLUGIN_NAME)
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig([`${PLUGIN_NAME}/tui`])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then doctor flags the unresolvable entry instead of blessing it
+    expect(result.status).toBe("warn")
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].title).toContain("unresolvable")
+    expect(result.issues[0].fix).toContain("Remove")
+  })
+
+  it("uses the registered server package when canonical and legacy installs disagree", async () => {
+    //#given both package folders exist, but the registered server entry is canonical
+    //#       and only the legacy folder exports ./tui
+    writeInstalledPackage(PLUGIN_NAME)
+    writeInstalledPackage("oh-my-opencode", { ".": "./dist/index.js", "./tui": "./dist/tui.js" })
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig([`${PLUGIN_NAME}/tui`])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then doctor diagnoses the canonical installed package instead of the legacy folder
+    expect(result.status).toBe("warn")
+    expect(result.issues[0].title).toContain("unresolvable")
+  })
+
   it("warns when server is registered but tui.json does not exist", async () => {
     //#given opencode.json has the server entry and tui.json is absent
     writeOpenCodeConfig([PLUGIN_NAME])
@@ -103,7 +162,10 @@ describe("tui-plugin-config check", () => {
     //#       pointing at a local checkout of our package
     writeOpenCodeConfig([PLUGIN_NAME])
     const localPkgDir = join(testConfigDir, "local-checkout")
-    const fileEntry = writeFilePluginPackage(localPkgDir, "oh-my-opencode")
+    const fileEntry = writeFilePluginPackage(localPkgDir, "oh-my-opencode", {
+      ".": "./dist/index.js",
+      "./tui": "./dist/tui.js",
+    })
     writeTuiConfig([fileEntry])
 
     //#when running the check

--- a/src/cli/doctor/checks/tui-plugin-config.test.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.test.ts
@@ -128,6 +128,26 @@ describe("tui-plugin-config check", () => {
     expect(result.issues[0].fix).toContain("Remove")
   })
 
+  it("does not warn for a file TUI entry when the server package has no tui export", async () => {
+    //#given opencode.json has the server entry, the installed package has no ./tui export,
+    //#       and tui.json uses a file: URL pointing at a local package that exports ./tui
+    writeInstalledPackage(PLUGIN_NAME)
+    writeOpenCodeConfig([PLUGIN_NAME])
+    const localPkgDir = join(testConfigDir, "local-checkout")
+    const fileEntry = writeFilePluginPackage(localPkgDir, "oh-my-opencode", {
+      ".": "./dist/index.js",
+      "./tui": "./dist/tui.js",
+    })
+    writeTuiConfig([fileEntry])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then doctor does not treat the file: URL as an unresolvable named package subpath
+    expect(result.status).toBe("pass")
+    expect(result.issues).toHaveLength(0)
+  })
+
   it("uses the registered server package when canonical and legacy installs disagree", async () => {
     //#given both package folders exist, but the registered server entry is canonical
     //#       and only the legacy folder exports ./tui

--- a/src/cli/doctor/checks/tui-plugin-config.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.ts
@@ -13,6 +13,7 @@ import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import type { CheckResult, DoctorIssue } from "../types"
 
 const TUI_SUBPATH = "tui"
+const TUI_EXPORT_SUBPATH = `./${TUI_SUBPATH}`
 
 interface OpenCodeConfigShape {
   plugin?: string[]
@@ -25,12 +26,49 @@ interface TuiConfigShape {
 interface ServerPluginInfo {
   registered: boolean
   configPath: string | null
+  packageExportsTui: boolean | null
 }
 
 interface TuiPluginInfo {
   registered: boolean
   configPath: string | null
   exists: boolean
+}
+
+function fileEntryPackageJsonPath(entry: string): string {
+  let path = entry.slice("file:".length)
+  if (path.startsWith("//")) path = path.slice(2)
+  return join(path, "package.json")
+}
+
+function packageJsonExportsTui(pkgJsonPath: string): boolean | null {
+  if (!existsSync(pkgJsonPath)) return null
+
+  try {
+    const parsed = JSON.parse(readFileSync(pkgJsonPath, "utf-8")) as { exports?: unknown }
+    if (parsed.exports === undefined) return null
+    if (typeof parsed.exports === "string") return false
+    if (parsed.exports == null || typeof parsed.exports !== "object" || Array.isArray(parsed.exports)) return null
+    return Object.hasOwn(parsed.exports, TUI_EXPORT_SUBPATH)
+  } catch (error) {
+    void error
+    return null
+  }
+}
+
+function packageNameFromServerEntry(entry: string): string | null {
+  if (entry === PLUGIN_NAME || entry.startsWith(`${PLUGIN_NAME}@`)) return PLUGIN_NAME
+  if (entry === LEGACY_PLUGIN_NAME || entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)) return LEGACY_PLUGIN_NAME
+  return null
+}
+
+function packageExportsTuiForServerEntry(entry: string): boolean | null {
+  if (entry.startsWith("file:")) return packageJsonExportsTui(fileEntryPackageJsonPath(entry))
+
+  const packageName = packageNameFromServerEntry(entry)
+  if (packageName === null) return null
+
+  return packageJsonExportsTui(join(getOpenCodeConfigDir({ binary: "opencode" }), "node_modules", packageName, "package.json"))
 }
 
 // Returns true if `entry` is a file:-URL pointing at a directory whose
@@ -41,15 +79,14 @@ interface TuiPluginInfo {
 // add-tui-plugin-to-tui-config.ts during installation.
 function isOurFilePluginEntry(entry: string): boolean {
   if (!entry.startsWith("file:")) return false
-  let path = entry.slice("file:".length)
-  if (path.startsWith("//")) path = path.slice(2)
   try {
-    const pkgJsonPath = join(path, "package.json")
+    const pkgJsonPath = fileEntryPackageJsonPath(entry)
     if (!existsSync(pkgJsonPath)) return false
     const parsed = JSON.parse(readFileSync(pkgJsonPath, "utf-8")) as { name?: unknown }
     return typeof parsed.name === "string"
       && (ACCEPTED_PACKAGE_NAMES as readonly string[]).includes(parsed.name)
-  } catch {
+  } catch (error) {
+    void error
     return false
   }
 }
@@ -81,15 +118,21 @@ export function detectServerPluginRegistration(): ServerPluginInfo {
       : null
 
   if (!configPath) {
-    return { registered: false, configPath: null }
+    return { registered: false, configPath: null, packageExportsTui: null }
   }
 
   try {
     const parsed = parseJsonc<OpenCodeConfigShape>(readFileSync(configPath, "utf-8"))
     const plugins = parsed.plugin ?? []
-    return { registered: plugins.some(isServerPluginEntry), configPath }
-  } catch {
-    return { registered: false, configPath }
+    const serverEntry = plugins.find(isServerPluginEntry)
+    return {
+      registered: serverEntry !== undefined,
+      configPath,
+      packageExportsTui: serverEntry === undefined ? null : packageExportsTuiForServerEntry(serverEntry),
+    }
+  } catch (error) {
+    void error
+    return { registered: false, configPath, packageExportsTui: null }
   }
 }
 
@@ -103,7 +146,8 @@ export function detectTuiPluginRegistration(): TuiPluginInfo {
     const parsed = parseJsonc<TuiConfigShape>(readFileSync(tuiJsonPath, "utf-8"))
     const plugins = parsed.plugin ?? []
     return { registered: plugins.some(isTuiPluginEntry), configPath: tuiJsonPath, exists: true }
-  } catch {
+  } catch (error) {
+    void error
     return { registered: false, configPath: tuiJsonPath, exists: true }
   }
 }
@@ -128,7 +172,37 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
     }
   }
 
+  if (server.registered && server.packageExportsTui === false && tui.registered) {
+    issues.push({
+      title: "TUI plugin entry in tui.json is unresolvable",
+      description:
+        `The installed ${PLUGIN_NAME} package registered in opencode.json does not export `
+        + `"${TUI_EXPORT_SUBPATH}", but tui.json contains "${PLUGIN_NAME}/${TUI_SUBPATH}". `
+        + "OpenCode TUI may try to resolve that package subpath as a GitHub repository and fail.",
+      fix: `Remove "${PLUGIN_NAME}/${TUI_SUBPATH}" or "${LEGACY_PLUGIN_NAME}/${TUI_SUBPATH}" from the "plugin" array in ${tui.configPath}.`,
+      affects: ["TUI startup", "plugin loading"],
+      severity: "warning",
+    })
+    return {
+      name,
+      status: "warn",
+      message: "TUI plugin entry in tui.json is unresolvable",
+      details: details.length > 0 ? details : undefined,
+      issues,
+    }
+  }
+
   if (server.registered && !tui.registered) {
+    if (server.packageExportsTui === false) {
+      return {
+        name,
+        status: "pass",
+        message: "Server plugin registered; TUI subpath not shipped by this package version",
+        details: details.length > 0 ? details : undefined,
+        issues,
+      }
+    }
+
     issues.push({
       title: "TUI plugin entry missing from tui.json",
       description:

--- a/src/cli/doctor/checks/tui-plugin-config.ts
+++ b/src/cli/doctor/checks/tui-plugin-config.ts
@@ -33,6 +33,7 @@ interface TuiPluginInfo {
   registered: boolean
   configPath: string | null
   exists: boolean
+  hasNamedTuiEntry: boolean
 }
 
 function fileEntryPackageJsonPath(entry: string): string {
@@ -99,13 +100,18 @@ function isServerPluginEntry(entry: string): boolean {
 }
 
 function isTuiPluginEntry(entry: string): boolean {
+  if (isNamedTuiPluginEntry(entry)) return true
+  // file: entries pointing at our package already expose the ./tui subpath via
+  // package.json `exports`, so the TUI plugin loads without a separate entry.
+  if (entry.startsWith("file:") && isOurFilePluginEntry(entry)) return true
+  return false
+}
+
+function isNamedTuiPluginEntry(entry: string): boolean {
   const canonicalPrefix = `${PLUGIN_NAME}/${TUI_SUBPATH}`
   const legacyPrefix = `${LEGACY_PLUGIN_NAME}/${TUI_SUBPATH}`
   if (entry === canonicalPrefix || entry.startsWith(`${canonicalPrefix}@`)) return true
   if (entry === legacyPrefix || entry.startsWith(`${legacyPrefix}@`)) return true
-  // file: entries pointing at our package already expose the ./tui subpath via
-  // package.json `exports`, so the TUI plugin loads without a separate entry.
-  if (entry.startsWith("file:") && isOurFilePluginEntry(entry)) return true
   return false
 }
 
@@ -139,16 +145,21 @@ export function detectServerPluginRegistration(): ServerPluginInfo {
 export function detectTuiPluginRegistration(): TuiPluginInfo {
   const tuiJsonPath = join(getOpenCodeConfigDir({ binary: "opencode" }), "tui.json")
   if (!existsSync(tuiJsonPath)) {
-    return { registered: false, configPath: tuiJsonPath, exists: false }
+    return { registered: false, configPath: tuiJsonPath, exists: false, hasNamedTuiEntry: false }
   }
 
   try {
     const parsed = parseJsonc<TuiConfigShape>(readFileSync(tuiJsonPath, "utf-8"))
     const plugins = parsed.plugin ?? []
-    return { registered: plugins.some(isTuiPluginEntry), configPath: tuiJsonPath, exists: true }
+    return {
+      registered: plugins.some(isTuiPluginEntry),
+      configPath: tuiJsonPath,
+      exists: true,
+      hasNamedTuiEntry: plugins.some(isNamedTuiPluginEntry),
+    }
   } catch (error) {
     void error
-    return { registered: false, configPath: tuiJsonPath, exists: true }
+    return { registered: false, configPath: tuiJsonPath, exists: true, hasNamedTuiEntry: false }
   }
 }
 
@@ -172,7 +183,7 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
     }
   }
 
-  if (server.registered && server.packageExportsTui === false && tui.registered) {
+  if (server.registered && server.packageExportsTui === false && tui.hasNamedTuiEntry) {
     issues.push({
       title: "TUI plugin entry in tui.json is unresolvable",
       description:


### PR DESCRIPTION
## Summary

Fixes #4598 and #4303 by preventing doctor from recommending or blessing `oh-my-openagent/tui` when the actually registered installed package does not export `./tui`.

This supersedes #4655. That PR fixed the main symptom but Cubic found an actionable issue: package detection could choose the wrong package when canonical and legacy package folders both exist. This PR resolves that by deriving the package export status from the actual server plugin entry in `opencode.json`.

## Changes

- Read `package.json` exports for the registered server plugin entry (`oh-my-openagent`, `oh-my-opencode`, or file entry).
- If the package has no `./tui` export and `tui.json` lacks the TUI entry, pass with a clear “TUI subpath not shipped” message instead of recommending a broken entry.
- If the package has no `./tui` export and `tui.json` already contains the broken entry, warn and tell the user to remove it.
- Preserve legacy warning behavior when package metadata cannot be located.
- Add regression coverage for the mixed canonical/legacy install case from the #4655 review.

## QA

- Red repro: `PATH="$HOME/.bun/bin:$PATH" bun test src/cli/doctor/checks/tui-plugin-config.test.ts --bail` failed before the fix because doctor still warned to add an unshipped TUI entry.
- `PATH="$HOME/.bun/bin:$PATH" bun test src/cli/doctor/checks/tui-plugin-config.test.ts --bail` — 10 pass / 0 fail
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck` — pass
- `PATH="$HOME/.bun/bin:$PATH" bun run build` — pass

## Related

- Fixes #4598
- Also addresses #4303
- Supersedes #4655

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doctor now checks the server plugin package’s `exports` and only suggests or validates `.../tui` when `./tui` is shipped. Adds support for `file:` TUI entries and fixes wrong advice in mixed canonical/legacy installs; fixes #4598 and addresses #4303.

- **Bug Fixes**
  - Read `exports` from the package behind the registered server plugin in `opencode.json` (`oh-my-openagent`, `oh-my-opencode`, or `file:`).
  - If `./tui` isn’t exported and no TUI entry exists, pass with “TUI subpath not shipped”.
  - If `./tui` isn’t exported but a named TUI entry exists, warn and suggest removing it.
  - Treat `file:` TUI entries pointing to our package as valid when they export `./tui`; avoid false warnings.
  - Resolve canonical vs legacy folder conflicts by using the registered package; preserve legacy behavior when metadata is missing; add regression tests.

<sup>Written for commit 8fe5af71c1caed1e92f64fd0edb3dcd3b9ffe7b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

