### PR TITLE
fix(keyword-detector): avoid duplicate mode injection

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -29,6 +29,13 @@ function suppressComboStandalones(detected: DetectedKeyword[]): DetectedKeyword[
   return detected.filter((k) => k.type !== "ultrawork" && k.type !== "hyperplan")
 }
 
+function filterAlreadyInjectedKeywords(
+  detected: DetectedKeyword[],
+  text: string,
+): DetectedKeyword[] {
+  return detected.filter((keyword) => !text.includes(keyword.message))
+}
+
 export function createKeywordDetectorHook(
   ctx: PluginInput,
   _collector?: ContextCollector,
@@ -146,6 +153,12 @@ export function createKeywordDetectorHook(
           })
           return
         }
+      }
+
+      detectedKeywords = filterAlreadyInjectedKeywords(detectedKeywords, cleanText)
+      if (detectedKeywords.length === 0) {
+        log(`[keyword-detector] Skipping already injected keyword messages`, { sessionID: input.sessionID })
+        return
       }
 
       const hasUltrawork = detectedKeywords.some((k) => k.type === "ultrawork")

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -96,6 +96,41 @@ describe("keyword-detector message transform", () => {
     expect(textPart!.text).toContain("[search-mode]")
   })
 
+  test("should not prepend mode messages twice when an injected message is processed again", async () => {
+    const cases = [
+      { prompt: "search for the bug", marker: "[search-mode]" },
+      { prompt: "analyze the failing test", marker: "[analyze-mode]" },
+      { prompt: "team mode for this refactor", marker: "[team-mode]" },
+      { prompt: "hyperplan the migration", marker: "<hyperplan-mode>" },
+      { prompt: "ultrawork fix the flaky suite", marker: "<ultrawork-mode>" },
+    ]
+
+    for (const testCase of cases) {
+      // given - OpenCode can re-submit an already-mutated message after undo/resend
+      const collector = new ContextCollector()
+      const sessionID = `idempotent-${testCase.marker}`
+      getMainSessionSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(sessionID)
+      const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+      const output = {
+        message: {} as Record<string, unknown>,
+        parts: [{ type: "text", text: testCase.prompt }],
+      }
+
+      // when - keyword detection sees the same output twice
+      await hook["chat.message"]({ sessionID }, output)
+      await hook["chat.message"]({ sessionID }, output)
+
+      // then - the mode prompt remains idempotent
+      const textPart = output.parts.find(p => p.type === "text")
+      expect(textPart).toBeDefined()
+      const markerMatches = textPart!.text!.split(testCase.marker).length - 1
+      expect(markerMatches).toBe(1)
+      expect(textPart!.text).toContain(testCase.prompt)
+
+      getMainSessionSpy?.mockRestore()
+    }
+  })
+
   test("should tell analyze-mode agents to evaluate skills before delegating", async () => {
     // given - analyze mode keyword detection runs on a user investigation request
     const collector = new ContextCollector()


### PR DESCRIPTION
## Summary
- makes keyword mode prompt injection idempotent when OpenCode reprocesses an already-mutated message after undo/resend
- prevents duplicate banners for search, analyze, team, hyperplan, and ultrawork prompts
- replaces older related PRs #4261, #4332, and #4493 with the same narrow content-based approach on current `dev`

## QA
- Red repro before fix: processing the same keyword-mutated output twice added the same mode marker twice
- `PATH="$HOME/.bun/bin:$PATH" bun test src/hooks/keyword-detector/index.test.ts --bail`: pass, 48 tests
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`: pass
- `PATH="$HOME/.bun/bin:$PATH" bun run build`: pass

Fixes #4251

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes keyword mode injection idempotent so we don’t add duplicate mode banners when an already-mutated message is reprocessed (e.g., undo/resend). Applies to search, analyze, team, hyperplan, and ultrawork. Fixes #4251.

- **Bug Fixes**
  - Skip keywords already injected into the message; early-exit with a log when none remain.
  - Added a test to ensure only one mode marker remains after processing the same output twice.

<sup>Written for commit 068e40ce06d7952138ba49dfc8f1fb77249dbce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

