### PR TITLE
fix(ast-grep-mcp): reject non-file Windows shims

### DIFF
--- a/packages/ast-grep-mcp/src/sg-cli-path.test.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { executableCandidates, isValidBinary } from "./sg-cli-path"
+
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix))
+	temporaryDirectories.push(directory)
+	return directory
+}
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true })
+	}
+})
+
+describe("executableCandidates", () => {
+	it("adds Windows launcher extensions for extensionless ast-grep paths", () => {
+		expect(executableCandidates("C:\\omo\\node_modules\\@ast-grep\\cli\\sg", "win32")).toEqual([
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.cmd",
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.bat",
+		])
+	})
+
+	it("does not duplicate an existing Windows executable extension", () => {
+		expect(executableCandidates("C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe", "win32")).toEqual([
+			"C:\\omo\\node_modules\\@ast-grep\\cli\\sg.exe",
+		])
+	})
+
+	it("keeps non-Windows executable paths unchanged", () => {
+		expect(executableCandidates("/workspace/node_modules/@ast-grep/cli/sg", "linux")).toEqual([
+			"/workspace/node_modules/@ast-grep/cli/sg",
+		])
+	})
+
+	it("accepts small Windows command shims as valid executables", () => {
+		const directory = createTemporaryDirectory("omo-sg-cli-shim-")
+		const shimPath = join(directory, "sg.cmd")
+		writeFileSync(shimPath, "@echo off\r\nnode sg.js %*\r\n", "utf8")
+
+		expect(isValidBinary(shimPath)).toBe(true)
+	})
+
+	it("rejects tiny native executable candidates", () => {
+		const directory = createTemporaryDirectory("omo-sg-cli-native-")
+		const exePath = join(directory, "sg.exe")
+		writeFileSync(exePath, "not a binary", "utf8")
+
+		expect(isValidBinary(exePath)).toBe(false)
+	})
+})

--- a/packages/ast-grep-mcp/src/sg-cli-path.test.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -55,5 +55,13 @@ describe("executableCandidates", () => {
 		writeFileSync(exePath, "not a binary", "utf8")
 
 		expect(isValidBinary(exePath)).toBe(false)
+	})
+
+	it("rejects directories named like Windows command shims", () => {
+		const directory = createTemporaryDirectory("omo-sg-cli-directory-")
+		const shimDirectoryPath = join(directory, "sg.cmd")
+		mkdirSync(shimDirectoryPath)
+
+		expect(isValidBinary(shimDirectoryPath)).toBe(false)
 	})
 })

--- a/packages/ast-grep-mcp/src/sg-cli-path.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.ts
@@ -4,12 +4,42 @@ import { existsSync, statSync } from "fs"
 
 type Platform = "darwin" | "linux" | "win32" | "unsupported"
 
-function isValidBinary(filePath: string): boolean {
+const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const
+
+export function isValidBinary(filePath: string): boolean {
 	try {
-		return statSync(filePath).size > 10000
+		const size = statSync(filePath).size
+		const lowerPath = filePath.toLowerCase()
+		if (lowerPath.endsWith(".cmd") || lowerPath.endsWith(".bat")) {
+			return size > 0
+		}
+		return size > 10000
 	} catch {
 		return false
 	}
+}
+
+export function executableCandidates(filePath: string, platform: NodeJS.Platform = process.platform): string[] {
+	if (platform !== "win32") return [filePath]
+
+	const candidates = [filePath]
+	const lowerPath = filePath.toLowerCase()
+	if (WINDOWS_EXECUTABLE_EXTENSIONS.some((extension) => lowerPath.endsWith(extension))) {
+		return candidates
+	}
+	for (const extension of WINDOWS_EXECUTABLE_EXTENSIONS) {
+		candidates.push(`${filePath}${extension}`)
+	}
+	return candidates
+}
+
+function findValidExecutable(filePath: string): string | null {
+	for (const candidate of executableCandidates(filePath)) {
+		if (existsSync(candidate) && isValidBinary(candidate)) {
+			return candidate
+		}
+	}
+	return null
 }
 
 function getPlatformPackageName(): string | null {
@@ -30,16 +60,17 @@ function getPlatformPackageName(): string | null {
 }
 
 export function findSgCliPathSync(): string | null {
-	const binaryName = process.platform === "win32" ? "sg.exe" : "sg"
+	const binaryName = "sg"
 
 	try {
 		const require = createRequire(import.meta.url)
 		const cliPackageJsonPath = require.resolve("@ast-grep/cli/package.json")
 		const cliDirectory = dirname(cliPackageJsonPath)
 		const sgPath = join(cliDirectory, binaryName)
+		const validSgPath = findValidExecutable(sgPath)
 
-		if (existsSync(sgPath) && isValidBinary(sgPath)) {
-			return sgPath
+		if (validSgPath) {
+			return validSgPath
 		}
 	} catch {
 		// @ast-grep/cli not installed
@@ -51,11 +82,12 @@ export function findSgCliPathSync(): string | null {
 			const require = createRequire(import.meta.url)
 			const packageJsonPath = require.resolve(`${platformPackage}/package.json`)
 			const packageDirectory = dirname(packageJsonPath)
-			const astGrepBinaryName = process.platform === "win32" ? "ast-grep.exe" : "ast-grep"
+			const astGrepBinaryName = "ast-grep"
 			const binaryPath = join(packageDirectory, astGrepBinaryName)
+			const validBinaryPath = findValidExecutable(binaryPath)
 
-			if (existsSync(binaryPath) && isValidBinary(binaryPath)) {
-				return binaryPath
+			if (validBinaryPath) {
+				return validBinaryPath
 			}
 		} catch {
 			// Platform-specific package not installed

--- a/packages/ast-grep-mcp/src/sg-cli-path.ts
+++ b/packages/ast-grep-mcp/src/sg-cli-path.ts
@@ -8,7 +8,12 @@ const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const
 
 export function isValidBinary(filePath: string): boolean {
 	try {
-		const size = statSync(filePath).size
+		const stats = statSync(filePath)
+		if (!stats.isFile()) {
+			return false
+		}
+
+		const size = stats.size
 		const lowerPath = filePath.toLowerCase()
 		if (lowerPath.endsWith(".cmd") || lowerPath.endsWith(".bat")) {
 			return size > 0
@@ -59,6 +64,13 @@ function getPlatformPackageName(): string | null {
 	return platformMap[`${platform}-${arch}`] ?? null
 }
 
+function isModuleResolutionFailure(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.message.includes("Cannot find module") || error.message.includes("Cannot find package"))
+	)
+}
+
 export function findSgCliPathSync(): string | null {
 	const binaryName = "sg"
 
@@ -72,8 +84,10 @@ export function findSgCliPathSync(): string | null {
 		if (validSgPath) {
 			return validSgPath
 		}
-	} catch {
-		// @ast-grep/cli not installed
+	} catch (error) {
+		if (!isModuleResolutionFailure(error)) {
+			throw error
+		}
 	}
 
 	const platformPackage = getPlatformPackageName()
@@ -89,8 +103,10 @@ export function findSgCliPathSync(): string | null {
 			if (validBinaryPath) {
 				return validBinaryPath
 			}
-		} catch {
-			// Platform-specific package not installed
+		} catch (error) {
+			if (!isModuleResolutionFailure(error)) {
+				throw error
+			}
 		}
 	}
 


### PR DESCRIPTION
[sisyphus-dev] Replacement for #4287 after validating cubic's file-type concern, with #4287 preserved as the first commit and a focused follow-up fix.

## Summary
- Keep the Windows ast_grep executable shim resolution from #4287 for #4188/#4220.
- Reject directories named like `.cmd`/`.bat` launchers by requiring `stat.isFile()` before size validation.
- Narrow module-resolution catches so unexpected resolver failures rethrow.

## Links
- Fixes #4188
- Fixes #4220
- Supersedes #4287
- Reviewed alongside #4321, which changes behavior by disabling ast_grep when the CLI is missing.

## Verification
- `bun test packages/ast-grep-mcp/src/sg-cli-path.test.ts --bail`
- `bun /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/ast-grep-mcp/src/sg-cli-path.ts packages/ast-grep-mcp/src/sg-cli-path.test.ts`
- `bun run typecheck:packages`
- `bun run build:ast-grep-mcp`

## QA note
- The Windows failure is reproduced and verified through the path-resolution regression test that simulates Windows `.cmd` shim candidates.
- The local opencode-qa helper harness was also run; its dependency checks passed, but its bundled SQL-escape self-check currently reports an unrelated helper failure on this machine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows ast-grep CLI lookup by accepting `.cmd`/`.bat` shims and rejecting non-file shim paths. Ensures the correct binary is found for #4188 and #4220.

- **Bug Fixes**
  - Treat small `.cmd`/`.bat` launchers as valid executables; native binaries still require >10KB.
  - Require `stat.isFile()` to reject directories named like shims.
  - Add Windows candidate expansion for `sg`/`ast-grep` (`.exe`, `.cmd`, `.bat`) and pick the first valid file.
  - Only suppress module resolution errors for "Cannot find module/package"; rethrow other errors.
  - Add tests for candidate expansion and file validation in `@ast-grep/cli` lookup.

<sup>Written for commit f9ac671879ed60d227c76f9f66ed780f75f6ae75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

