### PR TITLE
test(background-agent): pin fast signal cleanup exit

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -89,6 +89,7 @@ describe("#given process cleanup registration", () => {
       const sigintListenersBefore = process.listeners("SIGINT")
       const setTimeoutSpy = spyOn(globalThis, "setTimeout")
       const clearTimeoutSpy = spyOn(globalThis, "clearTimeout")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       // Re-enable forced exit so we can verify setTimeout/clearTimeout are called
       __enableScheduledForcedExitForTesting()
 
@@ -109,9 +110,64 @@ describe("#given process cleanup registration", () => {
 
         expect(setTimeoutSpy).toHaveBeenCalledTimes(1)
         expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenLastCalledWith(0)
       } finally {
+        exitSpy.mockRestore()
         setTimeoutSpy.mockRestore()
         clearTimeoutSpy.mockRestore()
+        __disableScheduledForcedExitForTesting()
+        process.exitCode = 0
+      }
+    })
+
+    test("#when fast SIGINT cleanup finishes #then process exits after cleanup", async () => {
+      const sigintListenersBefore = process.listeners("SIGINT")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      __enableScheduledForcedExitForTesting()
+
+      try {
+        const shutdown = mock(() => {})
+        const manager = { shutdown }
+        registeredManagers.push(manager)
+
+        registerManagerForCleanup(manager)
+
+        const sigintListener = getNewListener("SIGINT", sigintListenersBefore)
+        sigintListener()
+        await flushMicrotasks()
+
+        expect(shutdown).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenLastCalledWith(0)
+      } finally {
+        exitSpy.mockRestore()
+        __disableScheduledForcedExitForTesting()
+        process.exitCode = 0
+      }
+    })
+
+    test("#when fast SIGTERM cleanup finishes #then process exits after cleanup", async () => {
+      const sigtermListenersBefore = process.listeners("SIGTERM")
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
+      __enableScheduledForcedExitForTesting()
+
+      try {
+        const shutdown = mock(() => {})
+        const manager = { shutdown }
+        registeredManagers.push(manager)
+
+        registerManagerForCleanup(manager)
+
+        const sigtermListener = getNewListener("SIGTERM", sigtermListenersBefore)
+        sigtermListener()
+        await flushMicrotasks()
+
+        expect(shutdown).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenCalledTimes(1)
+        expect(exitSpy).toHaveBeenLastCalledWith(0)
+      } finally {
+        exitSpy.mockRestore()
         __disableScheduledForcedExitForTesting()
         process.exitCode = 0
       }


### PR DESCRIPTION
[sisyphus-dev] Replacement for the non-merge-ready #4364/#4543/#4599 attempts around #4058.

## Summary
- Mock `process.exit` in the forced SIGINT cleanup test so Bun no longer exits mid-file with a false-green/no-summary run.
- Assert the after-cleanup path actually calls `process.exit(0)`.
- Add focused fast SIGINT and fast SIGTERM regression tests for the #4058 behavior already fixed on `dev`.

## Links
- Fixes #4058
- Supersedes #4364
- Supersedes #4543
- Supersedes #4599 for the narrow process-cleanup coverage piece

## Reproduction
- Current `dev` focused run printed only the first 2 process-cleanup tests and no `Ran N tests` summary before exiting. Evidence saved in `.omo/ulw-loop/evidence/issue-4058-dev-process-cleanup-baseline.txt`.

## Verification
- `bun test src/features/background-agent/process-cleanup.test.ts` -> 30 pass, 0 fail, 65 expect() calls, real completion summary.
- `bun test src/features/background-agent/ --bail` -> 605 pass, 0 fail.
- `bun run typecheck` -> pass.
- `bun /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/background-agent/process-cleanup.test.ts` -> pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes background-agent process cleanup tests by mocking process.exit and asserting exit(0) after cleanup. Adds focused regression tests for fast SIGINT and SIGTERM paths to cover the #4058 fix and prevent Bun from exiting mid-run.

<sup>Written for commit 3be563f9c7025b3a0f0c1de253b7d86fc7bd2025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

