### PR TITLE
fix(cli): dispatch run agents by id

### DIFF
--- a/src/cli/run/agent-resolver.ts
+++ b/src/cli/run/agent-resolver.ts
@@ -21,12 +21,11 @@ const normalizeAgentName = (agent?: string): ResolvedAgent | undefined => {
 
   const configKey = getAgentConfigKey(trimmed)
   const displayName = getAgentDisplayName(configKey)
-  const runtimeName = getAgentDisplayName(configKey)
   const isKnownAgent = displayName !== configKey
 
   return {
     configKey,
-    resolvedName: isKnownAgent ? runtimeName : trimmed,
+    resolvedName: isKnownAgent ? configKey : trimmed,
   }
 }
 
@@ -62,13 +61,12 @@ export const resolveRunAgent = (
     envAgent ??
     configAgent ?? {
       configKey: DEFAULT_AGENT,
-      resolvedName: getAgentDisplayName(DEFAULT_AGENT),
+      resolvedName: DEFAULT_AGENT,
     }
 
   if (isAgentDisabled(resolved.configKey, pluginConfig)) {
     const fallback = pickFallbackAgent(pluginConfig)
     const fallbackDisplayName = getAgentDisplayName(fallback)
-    const fallbackRuntimeName = getAgentDisplayName(fallback)
     const fallbackDisabled = isAgentDisabled(fallback, pluginConfig)
     if (fallbackDisabled) {
       console.log(
@@ -76,14 +74,14 @@ export const resolveRunAgent = (
           `Requested agent "${resolved.resolvedName}" is disabled and no enabled core agent was found. Proceeding with "${fallbackDisplayName}".`
         )
       )
-      return fallbackRuntimeName
+      return fallback
     }
     console.log(
       pc.yellow(
         `Requested agent "${resolved.resolvedName}" is disabled. Falling back to "${fallbackDisplayName}".`
       )
     )
-    return fallbackRuntimeName
+    return fallback
   }
 
   return resolved.resolvedName

--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -3,7 +3,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "../../config"
 import { resolveRunAgent } from "./agent-resolver"
-import { getAgentDisplayName } from "../../shared/agent-display-names"
 
 const createConfig = (overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOpenCodeConfig =>
   OhMyOpenCodeConfigSchema.parse(overrides)
@@ -32,7 +31,7 @@ describe("resolveRunAgent", () => {
     )
 
     // then
-    expect(agent).toBe(getAgentDisplayName("hephaestus"))
+    expect(agent).toBe("hephaestus")
   })
 
   it("uses env agent over config", () => {
@@ -44,7 +43,7 @@ describe("resolveRunAgent", () => {
     const agent = resolveRunAgent({ message: "test" }, config, env)
 
     // then
-    expect(agent).toBe(getAgentDisplayName("atlas"))
+    expect(agent).toBe("atlas")
   })
 
   it("uses config agent over default", () => {
@@ -55,7 +54,7 @@ describe("resolveRunAgent", () => {
     const agent = resolveRunAgent({ message: "test" }, config, {})
 
     // then
-    expect(agent).toBe(getAgentDisplayName("prometheus"))
+    expect(agent).toBe("prometheus")
   })
 
   it("falls back to sisyphus when none set", () => {
@@ -66,7 +65,7 @@ describe("resolveRunAgent", () => {
     const agent = resolveRunAgent({ message: "test" }, config, {})
 
     // then
-    expect(agent).toBe(getAgentDisplayName("sisyphus"))
+    expect(agent).toBe("sisyphus")
   })
 
   it("skips disabled sisyphus for next available core agent", () => {
@@ -77,10 +76,10 @@ describe("resolveRunAgent", () => {
     const agent = resolveRunAgent({ message: "test" }, config, {})
 
     // then
-    expect(agent).toBe(getAgentDisplayName("hephaestus"))
+    expect(agent).toBe("hephaestus")
   })
 
-  it("maps display-name style default_run_agent values to canonical runtime names", () => {
+  it("maps display-name style default_run_agent values to canonical prompt agent ids", () => {
     // given
     const config = createConfig({ default_run_agent: "Sisyphus - Ultraworker" })
 
@@ -88,7 +87,7 @@ describe("resolveRunAgent", () => {
     const agent = resolveRunAgent({ message: "test" }, config, {})
 
     // then
-    expect(agent).toBe(getAgentDisplayName("sisyphus"))
+    expect(agent).toBe("sisyphus")
   })
 })
 


### PR DESCRIPTION
[sisyphus-dev] Fixes #4670.

This changes `oh-my-openagent run` agent resolution so known agents are sent to OpenCode `promptAsync` as canonical agent ids (`sisyphus`, `hephaestus`, etc.) instead of UI display labels such as `Sisyphus - ultraworker`. Unknown custom agent names are still preserved.

QA:
- Red repro: `bun test src/cli/run/runner.test.ts --bail` failed before the fix because `resolveRunAgent()` returned `Hephaestus - Deep Agent` instead of `hephaestus`.
- `PATH="$HOME/.bun/bin:$PATH" bun test src/cli/run/runner.test.ts --bail`
- `PATH="$HOME/.bun/bin:$PATH" bun test src/cli/run --bail`
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- `PATH="$HOME/.bun/bin:$PATH" bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change `oh-my-openagent run` agent resolution to send canonical agent IDs (e.g., `sisyphus`, `hephaestus`) to `promptAsync` instead of display names. Unknown custom agents are preserved, and fallbacks now return IDs, fixing #4670.

<sup>Written for commit d4eb6f50ba99bd6a38d5441be7e8abf2a3c2f17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

