### PR TITLE
fix(runtime-fallback): mark synthetic continue as internal

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry.test.ts
@@ -99,4 +99,40 @@ describe("createAutoRetryHelpers", () => {
     expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
     expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
   })
+
+  test("#given compact-flushed session with no recoverable user parts #when auto-retry fires the synthetic continuation #then the injected prompt is marked synthetic and carries the internal initiator marker (#4085)", async () => {
+    // given - capture the actual parts forwarded to client.session.promptAsync
+    const promptCalls = { count: 0, lastBody: undefined as unknown }
+    const deps = createDeps(promptCalls)
+    // Post-compact case: messages() returns no user role entries, so
+    // getLastUserRetryPayload falls through to the synthetic "continue".
+    deps.ctx.client.session.messages = async () => ({ data: [] })
+    deps.ctx.client.session.promptAsync = async (args: unknown) => {
+      promptCalls.count += 1
+      promptCalls.lastBody = (args as { body?: unknown })?.body
+      return {}
+    }
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-compact-flushed"
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    deps.sessionStates.set(sessionID, state)
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+
+    // then
+    expect(promptCalls.count).toBe(1)
+    const body = promptCalls.lastBody as { parts?: ReadonlyArray<Record<string, unknown>> } | undefined
+    expect(body).toBeDefined()
+    const parts = body?.parts ?? []
+    expect(parts.length).toBe(1)
+    const firstPart = parts[0] ?? {}
+    expect(firstPart["type"]).toBe("text")
+    // Without the marker + synthetic flag, OMO's continuation/keyword-detector
+    // hooks treat this as a real user prompt and the TUI shows a bare "continue"
+    // that the user never typed (see #4085 / Discord report).
+    expect(firstPart["synthetic"]).toBe(true)
+    expect(String(firstPart["text"] ?? "")).toContain("OMO_INTERNAL_INITIATOR")
+  })
 })

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -17,6 +17,7 @@ import {
   releasePromptAsyncReservation,
 } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
+import { createInternalAgentContinuationTextPart } from "../../shared/internal-initiator-marker"
 
 const SESSION_TTL_MS = 30 * 60 * 1000
 
@@ -167,7 +168,12 @@ export function createAutoRetryHelpers(deps: HookDeps) {
                   hint: "This can occur when the working directory contains .git and messages are not yet persisted",
                 },
               )
-              return [{ type: "text" as const, text: "continue" }]
+              // Mark the synthetic fallback with the OMO internal initiator
+              // marker + `synthetic: true` so the TUI and OMO's other hooks
+              // (continuation, keyword-detector, etc.) classify it as a
+              // self-issued turn instead of rendering a bare "continue" the
+              // user never typed (#4085).
+              return [createInternalAgentContinuationTextPart("continue")]
             })()
       log(`[${HOOK_NAME}] Auto-retrying with fallback model (${source})`, {
         sessionID,


### PR DESCRIPTION
[sisyphus-dev] Replacement for #4534, preserving the original fix for #4085 while applying the repo style cleanup found during review.

Fixes #4085.
Supersedes #4534.

Verification run in an isolated worktree on current origin/dev:
- `bun test src/hooks/runtime-fallback/ src/shared/internal-initiator-marker.test.ts --bail` -> 225 pass / 0 fail
- `bun run typecheck` -> pass

Delegated gpt-5.5 high review found the runtime-fallback change invariant-preserving: it keeps dispatch through the existing internal prompt gate and only marks the synthetic fallback continuation as internal/synthetic so it is not visible as a user `continue` prompt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the synthetic "continue" sent by runtime-fallback auto-retry as internal and synthetic so it doesn’t appear as a user message and is classified as self-issued. Fixes #4085.

- **Bug Fixes**
  - When the session is compacted and no user parts are recoverable, auto-retry now uses `createInternalAgentContinuationTextPart("continue")`.
  - The injected part carries the `OMO_INTERNAL_INITIATOR` marker and `synthetic: true`, with a regression test verifying the payload sent to `client.session.promptAsync`.

<sup>Written for commit 5cd23dee63a3bb6ef774aa32fd9fd820f51e41e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

