### PR TITLE
fix(installer): keep WSL config on Linux home

### DIFF
--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -65,13 +65,21 @@ function isWindowsUserConfigRoot(pathValue: string): boolean {
   return /^[a-z]:\/users\//.test(normalizedPath) || /^\/mnt\/[a-z]\/users\//.test(normalizedPath)
 }
 
-function getWslLinuxHomeDir(): string | null {
+function getWindowsUserFromConfigRoot(pathValue: string): string | null {
+  const normalizedPath = pathValue.replaceAll("\\", "/")
+  const match = /^(?:[a-z]:|\/mnt\/[a-z])\/Users\/([^/]+)/i.exec(normalizedPath)
+  return match?.[1] ?? null
+}
+
+function getWslLinuxHomeDir(windowsConfigRoot?: string): string | null {
   const envHome = process.env.HOME?.trim()
   if (envHome && envHome.startsWith("/") && !isWindowsUserConfigRoot(envHome)) {
     return envHome
   }
 
-  const user = process.env.USER?.trim()
+  const user = process.env.USER?.trim() || process.env.LOGNAME?.trim() ||
+    process.env.SUDO_USER?.trim() ||
+    (windowsConfigRoot ? getWindowsUserFromConfigRoot(windowsConfigRoot)?.toLowerCase() : undefined)
   return user ? join("/home", user) : null
 }
 
@@ -80,7 +88,7 @@ function getCliDefaultConfigDir(): string {
   const shouldIgnoreWindowsXdg = envXdgConfig !== undefined && envXdgConfig.length > 0 &&
     isWslEnvironment() && isWindowsUserConfigRoot(envXdgConfig)
   const xdgConfig = shouldIgnoreWindowsXdg
-    ? join(getWslLinuxHomeDir() ?? homedir(), ".config")
+    ? join(getWslLinuxHomeDir(envXdgConfig) ?? "/home", ".config")
     : envXdgConfig || join(homedir(), ".config")
   return resolveConfigPath(join(xdgConfig, "opencode"))
 }

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -79,7 +79,7 @@ function getWslLinuxHomeDir(windowsConfigRoot?: string): string | null {
 
   const user = process.env.USER?.trim() || process.env.LOGNAME?.trim() ||
     process.env.SUDO_USER?.trim() ||
-    (windowsConfigRoot ? getWindowsUserFromConfigRoot(windowsConfigRoot)?.toLowerCase() : undefined)
+    (windowsConfigRoot ? getWindowsUserFromConfigRoot(windowsConfigRoot) : undefined)
   return user ? join("/home", user) : null
 }
 

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -55,8 +55,33 @@ function resolveConfigPath(pathValue: string): string {
   }
 }
 
+function isWslEnvironment(): boolean {
+  return process.platform === "linux" &&
+    (Boolean(process.env.WSL_DISTRO_NAME?.trim()) || Boolean(process.env.WSL_INTEROP?.trim()))
+}
+
+function isWindowsUserConfigRoot(pathValue: string): boolean {
+  const normalizedPath = pathValue.replaceAll("\\", "/").toLowerCase()
+  return /^[a-z]:\/users\//.test(normalizedPath) || /^\/mnt\/[a-z]\/users\//.test(normalizedPath)
+}
+
+function getWslLinuxHomeDir(): string | null {
+  const envHome = process.env.HOME?.trim()
+  if (envHome && envHome.startsWith("/") && !isWindowsUserConfigRoot(envHome)) {
+    return envHome
+  }
+
+  const user = process.env.USER?.trim()
+  return user ? join("/home", user) : null
+}
+
 function getCliDefaultConfigDir(): string {
-  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  const envXdgConfig = process.env.XDG_CONFIG_HOME?.trim()
+  const shouldIgnoreWindowsXdg = envXdgConfig !== undefined && envXdgConfig.length > 0 &&
+    isWslEnvironment() && isWindowsUserConfigRoot(envXdgConfig)
+  const xdgConfig = shouldIgnoreWindowsXdg
+    ? join(getWslLinuxHomeDir() ?? homedir(), ".config")
+    : envXdgConfig || join(homedir(), ".config")
   return resolveConfigPath(join(xdgConfig, "opencode"))
 }
 

--- a/src/shared/opencode-config-dir.wsl.test.ts
+++ b/src/shared/opencode-config-dir.wsl.test.ts
@@ -10,7 +10,9 @@ describe("opencode-config-dir WSL handling", () => {
     originalPlatform = process.platform
     originalEnv = {
       HOME: process.env.HOME,
+      LOGNAME: process.env.LOGNAME,
       OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+      SUDO_USER: process.env.SUDO_USER,
       USER: process.env.USER,
       WSL_DISTRO_NAME: process.env.WSL_DISTRO_NAME,
       WSL_INTEROP: process.env.WSL_INTEROP,
@@ -27,6 +29,24 @@ describe("opencode-config-dir WSL handling", () => {
         process.env[key] = value
       }
     }
+  })
+
+  test("#given WSL leaks Windows HOME and USER is missing #when resolving CLI config #then Linux home is inferred from XDG user", () => {
+    // given
+    Object.defineProperty(process, "platform", { value: "linux" })
+    process.env.WSL_DISTRO_NAME = "Ubuntu"
+    process.env.HOME = "C:\\Users\\Hanbin"
+    process.env.XDG_CONFIG_HOME = "C:\\Users\\Hanbin\\.config"
+    delete process.env.OPENCODE_CONFIG_DIR
+    delete process.env.USER
+    delete process.env.LOGNAME
+    delete process.env.SUDO_USER
+
+    // when
+    const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.14.48" })
+
+    // then
+    expect(result).toBe("/home/hanbin/.config/opencode")
   })
 
   test("#given WSL leaks a Windows config root through XDG_CONFIG_HOME #when resolving CLI config #then Linux HOME is used", () => {

--- a/src/shared/opencode-config-dir.wsl.test.ts
+++ b/src/shared/opencode-config-dir.wsl.test.ts
@@ -31,7 +31,7 @@ describe("opencode-config-dir WSL handling", () => {
     }
   })
 
-  test("#given WSL leaks Windows HOME and USER is missing #when resolving CLI config #then Linux home is inferred from XDG user", () => {
+  test("#given WSL leaks Windows HOME and USER is missing #when resolving CLI config #then Linux home preserves the inferred XDG user", () => {
     // given
     Object.defineProperty(process, "platform", { value: "linux" })
     process.env.WSL_DISTRO_NAME = "Ubuntu"
@@ -46,7 +46,7 @@ describe("opencode-config-dir WSL handling", () => {
     const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.14.48" })
 
     // then
-    expect(result).toBe("/home/hanbin/.config/opencode")
+    expect(result).toBe("/home/Hanbin/.config/opencode")
   })
 
   test("#given WSL leaks a Windows config root through XDG_CONFIG_HOME #when resolving CLI config #then Linux HOME is used", () => {

--- a/src/shared/opencode-config-dir.wsl.test.ts
+++ b/src/shared/opencode-config-dir.wsl.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import { getOpenCodeConfigDir } from "./opencode-config-dir"
+
+describe("opencode-config-dir WSL handling", () => {
+  let originalPlatform: NodeJS.Platform
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalPlatform = process.platform
+    originalEnv = {
+      HOME: process.env.HOME,
+      OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+      USER: process.env.USER,
+      WSL_DISTRO_NAME: process.env.WSL_DISTRO_NAME,
+      WSL_INTEROP: process.env.WSL_INTEROP,
+      XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    }
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform })
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  test("#given WSL leaks a Windows config root through XDG_CONFIG_HOME #when resolving CLI config #then Linux HOME is used", () => {
+    // given
+    Object.defineProperty(process, "platform", { value: "linux" })
+    process.env.WSL_DISTRO_NAME = "Ubuntu"
+    process.env.HOME = "/home/hanbin"
+    process.env.XDG_CONFIG_HOME = "C:\\Users\\Hanbin\\.config"
+    delete process.env.OPENCODE_CONFIG_DIR
+
+    // when
+    const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.14.48" })
+
+    // then
+    expect(result).toBe("/home/hanbin/.config/opencode")
+  })
+
+  test("#given WSL leaks a mounted Windows user config root #when resolving CLI config #then Linux HOME is used", () => {
+    // given
+    Object.defineProperty(process, "platform", { value: "linux" })
+    process.env.WSL_DISTRO_NAME = "Ubuntu"
+    process.env.HOME = "/home/hanbin"
+    process.env.XDG_CONFIG_HOME = "/mnt/c/Users/Hanbin/.config"
+    delete process.env.OPENCODE_CONFIG_DIR
+
+    // when
+    const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.14.48" })
+
+    // then
+    expect(result).toBe("/home/hanbin/.config/opencode")
+  })
+
+  test("#given WSL has an explicit OPENCODE_CONFIG_DIR #when resolving CLI config #then the explicit override wins", () => {
+    // given
+    Object.defineProperty(process, "platform", { value: "linux" })
+    process.env.WSL_DISTRO_NAME = "Ubuntu"
+    process.env.HOME = "/home/hanbin"
+    process.env.XDG_CONFIG_HOME = "C:\\Users\\Hanbin\\.config"
+    process.env.OPENCODE_CONFIG_DIR = "/tmp/opencode-profile"
+
+    // when
+    const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.14.48" })
+
+    // then
+    expect(result).toBe("/tmp/opencode-profile")
+  })
+})


### PR DESCRIPTION
## Summary

- ignore implicit Windows-style `XDG_CONFIG_HOME` roots when the CLI installer is running inside WSL
- fall back to the Linux-side `HOME` for `~/.config/opencode`
- keep explicit `OPENCODE_CONFIG_DIR` overrides intact

Fixes #3975

## QA

- `bun test src/shared/opencode-config-dir.wsl.test.ts src/shared/opencode-config-dir.test.ts --timeout 30000`
- `bun test src/shared/opencode-config-dir.wsl.test.ts src/shared/opencode-config-dir.test.ts src/cli/config-manager/write-omo-config.test.ts src/cli/config-manager/generate-omo-config.test.ts src/cli/config-manager/parse-opencode-config-file.test.ts src/cli/config-manager/plugin-detection.test.ts src/cli/cli-installer.test.ts src/cli/tui-installer.test.ts src/cli/cli-installer.platform.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/opencode-config-dir.ts src/shared/opencode-config-dir.wsl.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep CLI config under the Linux home in WSL by ignoring Windows-leaked `XDG_CONFIG_HOME` and inferring `/home/<user>` with correct casing when needed. Fixes #3975 and keeps explicit `OPENCODE_CONFIG_DIR` overrides.

- **Bug Fixes**
  - Detect WSL and ignore Windows-style `XDG_CONFIG_HOME` (e.g., `C:\Users\...`, `/mnt/c/Users/...`).
  - Resolve to `~/.config/opencode` on Linux; infer `/home/<user>` from leaked paths and preserve username casing when `HOME` is Windows and `USER` is missing.
  - Respect explicit `OPENCODE_CONFIG_DIR` overrides; added WSL-focused tests.

<sup>Written for commit a2974272c4ccafcd25196dca5e46efbfd3a1d17e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

