### PR TITLE
fix(background-agent): honor provider concurrency for fallback retries

### DIFF
--- a/src/features/background-agent/concurrency.test.ts
+++ b/src/features/background-agent/concurrency.test.ts
@@ -158,6 +158,51 @@ describe("ConcurrencyManager.getConcurrencyLimit", () => {
   })
 })
 
+describe("ConcurrencyManager.getConcurrencyKey", () => {
+  test("should use provider key when provider concurrency is configured", () => {
+    // given
+    const config: BackgroundTaskConfig = {
+      providerConcurrency: { anthropic: 1 }
+    }
+    const manager = new ConcurrencyManager(config)
+
+    // when
+    const firstKey = manager.getConcurrencyKey("anthropic/claude-sonnet-4-6")
+    const secondKey = manager.getConcurrencyKey("anthropic/claude-opus-4-7")
+
+    // then
+    expect(firstKey).toBe("anthropic")
+    expect(secondKey).toBe("anthropic")
+  })
+
+  test("should keep exact model key when model concurrency is configured", () => {
+    // given
+    const config: BackgroundTaskConfig = {
+      modelConcurrency: { "anthropic/claude-sonnet-4-6": 1 },
+      providerConcurrency: { anthropic: 1 }
+    }
+    const manager = new ConcurrencyManager(config)
+
+    // when
+    const key = manager.getConcurrencyKey("anthropic/claude-sonnet-4-6")
+
+    // then
+    expect(key).toBe("anthropic/claude-sonnet-4-6")
+  })
+
+  test("should keep exact model key when only default concurrency is configured", () => {
+    // given
+    const config: BackgroundTaskConfig = { defaultConcurrency: 1 }
+    const manager = new ConcurrencyManager(config)
+
+    // when
+    const key = manager.getConcurrencyKey("anthropic/claude-sonnet-4-6")
+
+    // then
+    expect(key).toBe("anthropic/claude-sonnet-4-6")
+  })
+})
+
 describe("ConcurrencyManager.acquire/release", () => {
   let manager: ConcurrencyManager
 

--- a/src/features/background-agent/concurrency.ts
+++ b/src/features/background-agent/concurrency.ts
@@ -38,6 +38,19 @@ export class ConcurrencyManager {
     return 5
   }
 
+  getConcurrencyKey(model: string): string {
+    if (this.config?.modelConcurrency?.[model] !== undefined) {
+      return model
+    }
+
+    const provider = model.split('/')[0]
+    if (provider && this.config?.providerConcurrency?.[provider] !== undefined) {
+      return provider
+    }
+
+    return model
+  }
+
   async acquire(model: string): Promise<void> {
     const limit = this.getConcurrencyLimit(model)
     if (limit === Infinity) {
@@ -78,7 +91,10 @@ export class ConcurrencyManager {
 
     // Try to hand off to a waiting entry (skip any settled entries from cancelWaiters)
     while (queue && queue.length > 0) {
-      const next = queue.shift()!
+      const next = queue.shift()
+      if (!next) {
+        continue
+      }
       if (!next.settled) {
         // Hand off the slot to this waiter (count stays the same)
         next.resolve()

--- a/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/src/features/background-agent/fallback-retry-handler.test.ts
@@ -66,6 +66,7 @@ function createMockConcurrencyManager(): ConcurrencyManager {
   return {
     release: mock(() => {}),
     acquire: mock(async () => {}),
+    getConcurrencyKey: mock((model: string) => model),
     getQueueLength: mock(() => 0),
     getActiveCount: mock(() => 0),
   } as never
@@ -243,6 +244,30 @@ describe("tryFallbackRetry", () => {
       expect(queue!.length).toBe(1)
       expect(queue![0].task).toBe(args.task)
       expect(args.processKey).toHaveBeenCalledWith(key)
+    })
+
+    test("queues fallback retry on provider key when provider concurrency is configured", async () => {
+      const args = createDefaultArgs({
+        model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+        concurrencyKey: "anthropic",
+        fallbackChain: [
+          { model: "claude-sonnet-4-6", providers: ["anthropic"], variant: undefined },
+        ],
+      })
+      args.concurrencyManager.getConcurrencyKey = mock((model: string) =>
+        model.startsWith("anthropic/") ? "anthropic" : model
+      )
+
+      await tryFallbackRetry(args)
+
+      expect(args.task.model).toEqual({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-6",
+        variant: undefined,
+      })
+      expect(args.queuesByKey.get("anthropic")).toHaveLength(1)
+      expect(args.queuesByKey.has("anthropic/claude-sonnet-4-6")).toBe(false)
+      expect(args.processKey).toHaveBeenCalledWith("anthropic")
     })
 
     test("preserves team identity and session callback in retry input", async () => {

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -201,7 +201,8 @@ export async function tryFallbackRetry(args: {
     )
   }
 
-  const key = task.model ? `${task.model.providerID}/${task.model.modelID}` : task.agent
+  const rawKey = task.model ? `${task.model.providerID}/${task.model.modelID}` : task.agent
+  const key = concurrencyManager.getConcurrencyKey(rawKey)
   const queue = queuesByKey.get(key) ?? []
   const retryInput: LaunchInput = {
     description: task.description,

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2714,6 +2714,39 @@ describe("BackgroundManager.resume concurrency key", () => {
     expect(concurrencyManager.getCount("external-key")).toBe(1)
     expect(task.concurrencyKey).toBe("external-key")
   })
+
+  test("should re-acquire persisted model group using provider concurrency key", async () => {
+    // given
+    manager.shutdown()
+    manager = createBackgroundManagerWithOptions({
+      config: { providerConcurrency: { anthropic: 1 } },
+    })
+    stubNotifyParentSession(manager)
+    const task = await manager.trackTask({
+      taskId: "task-1",
+      sessionId: "session-1",
+      parentSessionId: "parent-session",
+      description: "external task",
+      agent: "task",
+      concurrencyKey: "anthropic/claude-sonnet-4-6",
+    })
+
+    await tryCompleteTaskForTest(manager, task)
+    task.concurrencyGroup = "anthropic/claude-sonnet-4-6"
+
+    // when
+    await manager.resume({
+      sessionId: "session-1",
+      prompt: "resume",
+      parentSessionId: "parent-session-2",
+      parentMessageId: "msg-2",
+    })
+
+    // then
+    const concurrencyManager = getConcurrencyManager(manager)
+    expect(concurrencyManager.getCount("anthropic")).toBe(1)
+    expect(task.concurrencyKey).toBe("anthropic")
+  })
 })
 
 describe("BackgroundManager.resume promptAsync gate state", () => {
@@ -4397,6 +4430,45 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       expect(updatedTask1?.status).toBe("running")
       expect(updatedTask2?.status).toBe("running")
+    })
+
+    test("should respect provider concurrency across different models on the same provider", async () => {
+      // given
+      const config = { providerConcurrency: { anthropic: 1 } }
+      manager.shutdown()
+      manager = new BackgroundManager({ pluginContext: createPluginInput(mockClient), config: config })
+
+      const input1 = {
+        description: "Task 1",
+        prompt: "Do something",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-opus-4.7" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      const input2 = {
+        description: "Task 2",
+        prompt: "Do something else",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4.6" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      // when
+      const task1 = await manager.launch(input1)
+      const task2 = await manager.launch(input2)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // then
+      const updatedTask1 = manager.getTask(task1.id)
+      const updatedTask2 = manager.getTask(task2.id)
+
+      expect(updatedTask1?.status).toBe("running")
+      expect(updatedTask2?.status).toBe("pending")
+      expect(updatedTask1?.concurrencyKey).toBe("anthropic")
+      expect(updatedTask2?.concurrencyKey).toBeUndefined()
     })
   })
 

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1104,10 +1104,11 @@ The fallback retry session is now created and can be inspected directly.
   }
 
   private getConcurrencyKeyFromInput(input: LaunchInput): string {
-    if (input.model) {
-      return `${input.model.providerID}/${input.model.modelID}`
-    }
-    return input.agent
+    const modelKey = input.model
+      ? `${input.model.providerID}/${input.model.modelID}`
+      : input.agent
+
+    return this.concurrencyManager.getConcurrencyKey(modelKey)
   }
 
   /**
@@ -1136,7 +1137,9 @@ The fallback retry session is now created and can be inspected directly.
         existingTask.parentAgent = input.parentAgent
       }
       if (!existingTask.concurrencyGroup) {
-        existingTask.concurrencyGroup = input.concurrencyKey ?? existingTask.agent
+        existingTask.concurrencyGroup = input.concurrencyKey
+          ? this.concurrencyManager.getConcurrencyKey(input.concurrencyKey)
+          : existingTask.agent
       }
 
       if (existingTask.sessionId) {
@@ -1159,11 +1162,14 @@ The fallback retry session is now created and can be inspected directly.
       return existingTask
     }
 
-    const concurrencyGroup = input.concurrencyKey ?? input.agent ?? "task"
+    const concurrencyKey = input.concurrencyKey
+      ? this.concurrencyManager.getConcurrencyKey(input.concurrencyKey)
+      : undefined
+    const concurrencyGroup = concurrencyKey ?? input.agent ?? "task"
 
     // Acquire concurrency slot if a key is provided
-    if (input.concurrencyKey) {
-      await this.concurrencyManager.acquire(input.concurrencyKey)
+    if (concurrencyKey) {
+      await this.concurrencyManager.acquire(concurrencyKey)
     }
 
     const task: BackgroundTask = {
@@ -1181,7 +1187,7 @@ The fallback retry session is now created and can be inspected directly.
         lastUpdate: new Date(),
       },
       parentAgent: input.parentAgent,
-      concurrencyKey: input.concurrencyKey,
+      concurrencyKey,
       concurrencyGroup,
     }
 
@@ -1227,7 +1233,9 @@ The fallback retry session is now created and can be inspected directly.
     }
 
     // Re-acquire concurrency using the persisted concurrency group
-    const concurrencyKey = existingTask.concurrencyGroup ?? existingTask.agent
+    const concurrencyKey = this.concurrencyManager.getConcurrencyKey(
+      existingTask.concurrencyGroup ?? existingTask.agent,
+    )
     await this.concurrencyManager.acquire(concurrencyKey)
     existingTask.concurrencyKey = concurrencyKey
     existingTask.concurrencyGroup = concurrencyKey


### PR DESCRIPTION
## Summary
- preserves the original #4408 provider-concurrency scheduler fix as the first commit
- canonicalizes fallback retry queue keys through `ConcurrencyManager.getConcurrencyKey()`
- adds a regression proving fallback retries requeue on the provider key when `providerConcurrency` is configured

Supersedes #4408. Fixes #3968.

## QA
- `bun test src/features/background-agent/fallback-retry-handler.test.ts src/features/background-agent/concurrency.test.ts src/features/background-agent/manager.test.ts --bail` (235 pass)
- `bun test src/features/background-agent/fallback-retry-handler.test.ts --bail` (28 pass)
- `bun run typecheck`
- `git diff --check`

## Notes
- The previous PR fixed normal launch/resume paths, but fallback retries still queued under the exact fallback model key. This keeps fallback retries under the same provider-level cap as the rest of the background scheduler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces provider-level concurrency across model variants for background agents, including fallback retries and resumed tasks, by canonicalizing concurrency keys before queuing and acquiring slots. Fixes #3968.

- **Bug Fixes**
  - Added `ConcurrencyManager.getConcurrencyKey()` to return the provider key when `providerConcurrency` applies (keeps model key if a model limit exists).
  - Updated `BackgroundManager` to use the canonical key for acquire and resume, including persisted `concurrencyGroup` and explicit `concurrencyKey`.
  - Queues fallback retries under the canonical provider key so they share the same provider cap.
  - Tests cover key selection, provider caps across different models on the same provider, and resume behavior.

<sup>Written for commit ba6a7b92bf10f0e15be7994e4bb8819adc22eeee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

