### PR TITLE
fix(model-core): preserve thinking for kimi k2p models

### DIFF
--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -60,7 +60,9 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   },
   {
     family: "kimi",
-    includes: ["kimi", "k2"],
+    // Match "kimi" anywhere, or "k2" NOT followed by optional separator + "p" + digit.
+    // Excludes k2p6, k2-p6, k2.p6 from kimi-for-coding which support thinking (#4418).
+    pattern: /(?:kimi|k2(?![-.]?p\d))/,
     variants: ["low", "medium", "high"],
     supportsThinking: false,
   },

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -573,6 +573,27 @@ describe("resolveCompatibleModelSettings", () => {
     expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")
   })
 
+  test("preserves thinking for kimi-for-coding k2p model ids not matched by generic kimi heuristic", () => {
+    for (const modelID of ["k2p6", "k2-p6", "k2.p6"]) {
+      // given
+      const capabilities = getModelCapabilities({
+        providerID: "kimi-for-coding",
+        modelID,
+      })
+
+      // when
+      const result = resolveCompatibleModelSettings({
+        providerID: "kimi-for-coding",
+        modelID,
+        desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
+        capabilities,
+      })
+
+      // then
+      expect(result.thinking).toEqual({ type: "enabled", budgetTokens: 4096 })
+      expect(result.changes).toEqual([])
+    }
+  })
   test("clamps maxTokens to the model output limit", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",


### PR DESCRIPTION
[sisyphus-dev] Replacement simple-fix PR for #3945.

This supersedes #4541 while preserving its core fix direction. Current `dev` still treats `k2p6`-style Kimi model IDs as generic K2 non-thinking models, so `chat.params` strips `output.options.thinking` for `kimi-for-coding/k2p6`.

Changes:
- tighten the Kimi heuristic so generic `k2` still disables thinking, but `k2p6`, `k2-p6`, and `k2.p6` remain thinking-capable
- add regression coverage for the compact and separated K2P forms

Verification:
- `bun test packages/model-core/src/model-settings-compatibility.test.ts --bail` -> 65 pass / 0 fail
- `bun run typecheck` -> pass
- `git diff --check` -> pass

Fixes #3945. Supersedes #4541.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect disabling of thinking mode for Kimi K2P models by updating the heuristic so `k2p6` variants keep thinking enabled under `kimi-for-coding`. Prevents `chat.params` from stripping `output.options.thinking` for `k2p6`, `k2-p6`, and `k2.p6`.

- **Bug Fixes**
  - Tightened Kimi regex to match `kimi` or `k2` not followed by optional separator + `p` + digit, preserving thinking for K2P variants.
  - Added regression tests for `k2p6`, `k2-p6`, and `k2.p6` to ensure thinking remains enabled.

<sup>Written for commit 255fb45935146e27436fcea97a35a935cb8b9416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

