### PR TITLE
fix: auto-select single plan after start-work name miss

### DIFF
--- a/src/hooks/start-work/context-info-builder.test.ts
+++ b/src/hooks/start-work/context-info-builder.test.ts
@@ -169,6 +169,60 @@ describe("buildStartWorkContextInfo", () => {
     expect(clearSpy).toHaveBeenCalledTimes(0)
   })
 
+  test("auto-selects the only incomplete plan when explicit plan name misses", () => {
+    // given
+    const clearSpy = spyOn(boulderState, "clearBoulderState")
+    const actualPlanPath = writePlan("full-site-audit-fix-plan", "## TODOs\n- [ ] 1. Fix audit findings")
+
+    // when
+    const contextInfo = buildStartWorkContextInfo({
+      ctx: createPluginInput(),
+      explicitPlanName: "mot-vat-notifications-plan",
+      existingState: null,
+      sessionId: "session-current",
+      timestamp: "2026-05-11T00:00:00.000Z",
+      activeAgent: "atlas",
+      worktreePath: undefined,
+      worktreeBlock: "",
+    })
+
+    // then
+    expect(contextInfo).toContain("Auto-Selected Plan")
+    expect(contextInfo).toContain("full-site-audit-fix-plan")
+    expect(contextInfo).toContain(actualPlanPath)
+    expect(contextInfo).toContain("Only incomplete plan available")
+    expect(contextInfo).not.toContain("Plan Not Found")
+    expect(existsSync(getBoulderFilePath(testDirectory))).toBe(true)
+    expect(clearSpy).toHaveBeenCalledTimes(0)
+  })
+
+  test("asks for selection when explicit plan name misses with multiple incomplete plans", () => {
+    // given
+    const clearSpy = spyOn(boulderState, "clearBoulderState")
+    writePlan("first-candidate-plan", "## TODOs\n- [ ] 1. First task")
+    writePlan("second-candidate-plan", "## TODOs\n- [ ] 1. Second task")
+
+    // when
+    const contextInfo = buildStartWorkContextInfo({
+      ctx: createPluginInput(),
+      explicitPlanName: "unmatched-plan",
+      existingState: null,
+      sessionId: "session-current",
+      timestamp: "2026-05-11T00:00:00.000Z",
+      activeAgent: "atlas",
+      worktreePath: undefined,
+      worktreeBlock: "",
+    })
+
+    // then
+    expect(contextInfo).toContain("Plan Not Found")
+    expect(contextInfo).toContain("first-candidate-plan")
+    expect(contextInfo).toContain("second-candidate-plan")
+    expect(contextInfo).toContain("Ask the user which plan to work on")
+    expect(existsSync(getBoulderFilePath(testDirectory))).toBe(false)
+    expect(clearSpy).toHaveBeenCalledTimes(0)
+  })
+
   test("keeps existing works when explicit new plan is started", () => {
     // given
     writePlan("work-a", "## TODOs\n- [ ] 1. Work A")

--- a/src/hooks/start-work/context-info-builder.ts
+++ b/src/hooks/start-work/context-info-builder.ts
@@ -235,6 +235,25 @@ function buildExplicitPlanContext(params: {
   const allPlans = findPrometheusPlans(directory)
   const matchedPlan = findPlanByName(allPlans, explicitPlanName)
   if (!matchedPlan) {
+    const incompletePlans = allPlans.filter((planPath) => !getPlanProgress(planPath).isComplete)
+    if (incompletePlans.length === 1) {
+      createNewWorkOrInitialize({
+        directory,
+        planPath: incompletePlans[0],
+        sessionId,
+        activeAgent,
+        worktreePath,
+      })
+
+      return buildAutoSelectedPlanContextInfoOnly({
+        planPath: incompletePlans[0],
+        sessionId,
+        timestamp,
+        worktreeBlock,
+        reason: `Only incomplete plan available after "${explicitPlanName}" did not match any plan`,
+      })
+    }
+
     return buildMissingPlanContext(explicitPlanName, allPlans)
   }
 


### PR DESCRIPTION
## Summary
- Fixes #2926 by reusing the existing auto-select behavior when an explicit `/start-work <name>` misses and exactly one incomplete plan exists
- Preserves the current `Plan Not Found` / ask-user flow when more than one incomplete plan is available
- Replaces conflicted PR #3034 with a smaller current-dev patch

## Verification
- `bun test src/hooks/start-work/context-info-builder.test.ts src/hooks/start-work/index.test.ts`
- `bun run typecheck`
- `bun test`
- GPT-5.5 high review: MERGE-OK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects the only incomplete plan when `/start-work <name>` doesn’t match any plan, and starts work with it. Keeps the current “Plan Not Found” prompt when more than one incomplete plan exists.

<sup>Written for commit 7cac1e728f8bf693324d5ded7086a11fd191a876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

