### PR TITLE
fix(skill): avoid duplicate skill listings

### DIFF
--- a/src/tools/skill/async-description-refresh.test.ts
+++ b/src/tools/skill/async-description-refresh.test.ts
@@ -56,13 +56,14 @@ describe("skill tool - async native skill description refresh", () => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  it("updates description after async native skills resolve", async () => {
+  it("updates opt-in description after async native skills resolve", async () => {
     //#given
     let allCallCount = 0
     const tool = createFreshSkillTool({
       directory: testDir,
       skills: [createMockSkill("seeded-skill")],
       commands: [],
+      includeSkillsInDescription: true,
       nativeSkills: {
         async all() {
           allCallCount += 1

--- a/src/tools/skill/description-formatter.ts
+++ b/src/tools/skill/description-formatter.ts
@@ -3,6 +3,10 @@ import { sortByScopePriority } from "./scope-priority"
 import type { SkillInfo } from "./types"
 import type { CommandInfo } from "../slashcommand/types"
 
+interface CombinedDescriptionOptions {
+  includeSkills?: boolean
+}
+
 function formatSkillCommand(skill: SkillInfo): string {
   const lines = [
     "  <command>",
@@ -38,11 +42,19 @@ function formatSlashCommand(command: CommandInfo): string {
   return lines.join("\n")
 }
 
-export function formatCombinedDescription(skills?: SkillInfo[], commands?: CommandInfo[]): string {
-  const availableSkills = skills ?? []
+export function formatCombinedDescription(
+  skills?: SkillInfo[],
+  commands?: CommandInfo[],
+  options: CombinedDescriptionOptions = {}
+): string {
+  const availableSkills = options.includeSkills ? skills ?? [] : []
   const availableCommands = commands ?? []
 
   if (availableSkills.length === 0 && availableCommands.length === 0) {
+    if ((skills?.length ?? 0) > 0) {
+      return TOOL_DESCRIPTION_PREFIX
+    }
+
     return TOOL_DESCRIPTION_NO_SKILLS
   }
 
@@ -57,7 +69,7 @@ export function formatCombinedDescription(skills?: SkillInfo[], commands?: Comma
 
   return `${TOOL_DESCRIPTION_PREFIX}
 <available_items>
-Priority: project > user > opencode > builtin/plugin | Skills listed before commands
+Priority: project > user > opencode > builtin/plugin${options.includeSkills ? " | Skills listed before commands" : ""}
 Invoke via: skill(name="item-name") - omit leading slash for commands.
 ${availableItems.join("\n")}
 </available_items>`

--- a/src/tools/skill/tools.factory.test.ts
+++ b/src/tools/skill/tools.factory.test.ts
@@ -151,4 +151,52 @@ describe("createSkillTool", () => {
     expect(result).toContain("Seeded command body")
     expect(discoverCommandsSync.mock.calls.length).toBe(baselineDiscoverCommandsSyncCalls)
   })
+
+  it("lists commands but not skills in the default description", async () => {
+    // given
+    const command: CommandInfo = {
+      name: "seeded-command",
+      metadata: {
+        name: "seeded-command",
+        description: "Seeded command",
+      },
+      content: "Seeded command body",
+      scope: "project",
+    }
+
+    // when
+    const skillTool = await createSkillTool({
+      skills: [loadedSkill],
+      commands: [command],
+    })
+
+    // then
+    expect(skillTool.description).toContain("<available_items>")
+    expect(skillTool.description).toContain("<name>/seeded-command</name>")
+    expect(skillTool.description).not.toContain("<name>/lazy-skill</name>")
+  })
+
+  it("lists skills in the description when explicitly requested", async () => {
+    // given
+    const command: CommandInfo = {
+      name: "seeded-command",
+      metadata: {
+        name: "seeded-command",
+        description: "Seeded command",
+      },
+      content: "Seeded command body",
+      scope: "project",
+    }
+
+    // when
+    const skillTool = await createSkillTool({
+      skills: [loadedSkill],
+      commands: [command],
+      includeSkillsInDescription: true,
+    })
+
+    // then
+    expect(skillTool.description).toContain("<name>/lazy-skill</name>")
+    expect(skillTool.description).toContain("<name>/seeded-command</name>")
+  })
 })

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -70,7 +70,9 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
     // check already enforces the restriction at call time.
     const publicSkills = skills.filter((s) => !s.definition.agent)
     const skillInfos = publicSkills.map(loadedSkillToInfo)
-    cachedDescription = formatCombinedDescription(skillInfos, commands)
+    cachedDescription = formatCombinedDescription(skillInfos, commands, {
+      includeSkills: options.includeSkillsInDescription,
+    })
     return cachedDescription
   }
 
@@ -92,12 +94,16 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
       }
     }
 
-    cachedDescription = formatCombinedDescription(skillInfos, commandsForDescription)
+    cachedDescription = formatCombinedDescription(skillInfos, commandsForDescription, {
+      includeSkills: options.includeSkillsInDescription,
+    })
     if (needsAsyncRefresh) {
       void buildDescription(true)
     }
   } else if (options.commands !== undefined) {
-    cachedDescription = formatCombinedDescription([], options.commands)
+    cachedDescription = formatCombinedDescription([], options.commands, {
+      includeSkills: options.includeSkillsInDescription,
+    })
   }
 
   return tool({
@@ -117,7 +123,9 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
     async execute(args: SkillArgs, ctx?: ToolContext) {
       const skills = await getSkills(ctx)
       const commands = getCommands()
-      cachedDescription = formatCombinedDescription(skills.map(loadedSkillToInfo), commands)
+      cachedDescription = formatCombinedDescription(skills.map(loadedSkillToInfo), commands, {
+        includeSkills: options.includeSkillsInDescription,
+      })
 
       const requestedName = args.name.replace(/^\//, "")
       const matchedSkill = matchSkillByName(skills, requestedName)

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -49,4 +49,5 @@ export interface SkillLoadOptions {
     get(name: string): { name: string; description: string; location: string; content: string } | undefined | Promise<{ name: string; description: string; location: string; content: string } | undefined>
     dirs(): string[] | Promise<string[]>
   }
+  includeSkillsInDescription?: boolean
 }

--- a/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
+++ b/src/tools/skill/zauc-mocks-skill-tools/tools.test.ts
@@ -98,7 +98,7 @@ const mockContext: ToolContext = {
 }
 
 describe("skill tool - synchronous description", () => {
-  it("includes available_items immediately when skills are pre-provided", () => {
+  it("omits pre-provided skills from available_items by default", () => {
     // given
     const loadedSkills = [createMockSkill("test-skill")]
 
@@ -106,11 +106,11 @@ describe("skill tool - synchronous description", () => {
     const tool = createSkillTool({ skills: loadedSkills })
 
     // then
-    expect(tool.description).toContain("<available_items>")
-    expect(tool.description).toContain("test-skill")
+    expect(tool.description).not.toContain("<available_items>")
+    expect(tool.description).not.toContain("test-skill")
   })
 
-  it("includes all pre-provided skills in available_items immediately", () => {
+  it("includes all pre-provided skills in available_items when explicitly requested", () => {
     // given
     const loadedSkills = [
       createMockSkill("playwright"),
@@ -119,7 +119,10 @@ describe("skill tool - synchronous description", () => {
     ]
 
     // when
-    const tool = createSkillTool({ skills: loadedSkills })
+    const tool = createSkillTool({
+      skills: loadedSkills,
+      includeSkillsInDescription: true,
+    })
 
     // then
     expect(tool.description).toContain("<available_items>")
@@ -480,7 +483,11 @@ describe("skill tool - ordering and priority", () => {
     ]
 
     //#when: creating tool with both
-    const tool = createSkillTool({ skills, commands })
+    const tool = createSkillTool({
+      skills,
+      commands,
+      includeSkillsInDescription: true,
+    })
 
     //#then: skills should appear as <command> items with / prefix, listed before regular commands
     const desc = tool.description
@@ -502,7 +509,10 @@ describe("skill tool - ordering and priority", () => {
     ]
 
     //#when: creating tool
-    const tool = createSkillTool({ skills })
+    const tool = createSkillTool({
+      skills,
+      includeSkillsInDescription: true,
+    })
 
     //#then: should be sorted by priority
     const desc = tool.description
@@ -548,9 +558,9 @@ describe("skill tool - ordering and priority", () => {
     //#when: creating tool
     const tool = createSkillTool({ skills, commands })
 
-    //#then: should include priority info
+    //#then
     expect(tool.description).toContain("Priority: project > user > opencode > builtin/plugin")
-    expect(tool.description).toContain("Skills listed before commands")
+    expect(tool.description).not.toContain("Skills listed before commands")
   })
 
   it("uses <available_items> wrapper with unified command format", () => {
@@ -561,12 +571,12 @@ describe("skill tool - ordering and priority", () => {
     //#when: creating tool
     const tool = createSkillTool({ skills, commands })
 
-    //#then: should use unified wrapper with all items as commands
+    //#then
     expect(tool.description).toContain("<available_items>")
     expect(tool.description).toContain("</available_items>")
     expect(tool.description).not.toContain("<skill>")
     expect(tool.description).toContain("<command>")
-    expect(tool.description).toContain("/test-skill")
+    expect(tool.description).not.toContain("/test-skill")
     expect(tool.description).toContain("/test-cmd")
   })
 })
@@ -645,7 +655,10 @@ describe("skill tool - agent-restricted skill visibility in description", () => 
     ]
 
     // when: tool is created with these skills (as tool-registry would inject them)
-    const tool = createSkillTool({ skills: loadedSkills })
+    const tool = createSkillTool({
+      skills: loadedSkills,
+      includeSkillsInDescription: true,
+    })
 
     // then: oracle-only skill must NOT appear in the description
     expect(tool.description).toContain("public-skill")
@@ -657,7 +670,10 @@ describe("skill tool - agent-restricted skill visibility in description", () => 
     const loadedSkills = [createMockSkill("public-skill")]
 
     // when
-    const tool = createSkillTool({ skills: loadedSkills })
+    const tool = createSkillTool({
+      skills: loadedSkills,
+      includeSkillsInDescription: true,
+    })
 
     // then
     expect(tool.description).toContain("public-skill")
@@ -728,7 +744,7 @@ describe("skill tool - dynamic description cache invalidation", () => {
       expect(cachedError?.message).toContain('Skill or command "second-skill" not found.')
 
       clearSkillCache()
-      const refreshedTool = createSkillTool({})
+      const refreshedTool = createSkillTool({ includeSkillsInDescription: true })
 
       // when
       const refreshedResult = await refreshedTool.execute({ name: "second-skill" }, mockContext)
@@ -754,6 +770,7 @@ describe("skill tool - browserProvider forwarding", () => {
     const tool = createSkillTool({
       skills: [agentBrowserSkill],
       browserProvider: "agent-browser",
+      includeSkillsInDescription: true,
     })
 
     // when: executing skill("agent-browser")
@@ -771,6 +788,7 @@ describe("skill tool - browserProvider forwarding", () => {
     const tool = createSkillTool({
       skills: [agentBrowserSkill],
       browserProvider: "agent-browser",
+      includeSkillsInDescription: true,
     })
 
     // then
@@ -783,6 +801,7 @@ describe("skill tool - nativeSkills integration", () => {
     //#given
     const tool = createSkillTool({
       skills: [createMockSkill("seeded-skill")],
+      includeSkillsInDescription: true,
       nativeSkills: {
         all() {
           return [{


### PR DESCRIPTION
## Summary
- omit skill entries from OMO skill-tool `<available_items>` by default so OpenCode does not append a duplicate skill catalog
- keep slash commands visible in `<available_items>` and preserve `includeSkillsInDescription` as an explicit opt-in for legacy/test behavior
- add focused regression coverage plus a direct description smoke check

Fixes #3250. Supersedes #3603.

## Verification
- `bun test src/tools/skill/zauc-mocks-skill-tools/tools.test.ts src/tools/skill/tools.factory.test.ts src/tools/skill/async-description-refresh.test.ts --bail`
- `bun run typecheck`
- `git diff --check`
- description smoke: default includes command, omits unique skill; opt-in includes unique skill


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit skills from the skill tool `<available_items>` by default to prevent duplicate catalogs. Commands still appear; set `includeSkillsInDescription` to opt in to listing skills.

- **Migration**
  - If you rely on skills appearing in the description, pass `includeSkillsInDescription: true` to `createSkillTool`.
  - No changes to execution behavior; only the description output is affected.

<sup>Written for commit 18ba56ae85a05d728da09d958b17fbc859096644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

