### PR TITLE
fix(comment-checker): resolve PATH-only binary

### DIFF
--- a/src/hooks/comment-checker/cli.test.ts
+++ b/src/hooks/comment-checker/cli.test.ts
@@ -30,6 +30,35 @@ afterAll(() => { mock.restore() })
 
 describe("comment-checker CLI", () => {
   describe("lazy initialization", () => {
+    test("#given PATH-only binary #when resolving from PATH #then returns Bun.which result", async () => {
+      // given
+      const cliModule = await import(`./cli?path-only=${crypto.randomUUID()}`)
+      const calls: string[] = []
+
+      // when
+      const result = cliModule.resolveCommentCheckerPathFromPath("comment-checker.exe", (binary: string) => {
+        calls.push(binary)
+        return "C:\\tools\\comment-checker.exe"
+      })
+
+      // then
+      expect(result).toBe("C:\\tools\\comment-checker.exe")
+      expect(calls).toEqual(["comment-checker.exe"])
+    })
+
+    test("#given PATH lookup throws #when resolving from PATH #then returns null", async () => {
+      // given
+      const cliModule = await import(`./cli?path-error=${crypto.randomUUID()}`)
+
+      // when
+      const result = cliModule.resolveCommentCheckerPathFromPath("comment-checker", () => {
+        throw new Error("lookup failed")
+      })
+
+      // then
+      expect(result).toBeNull()
+    })
+
     test("getCommentCheckerPathSync should be lazy and callable", async () => {
       // given
       const cliModule = await import("./cli")
@@ -158,6 +187,7 @@ exit 2
         tool: "write",
         sessionID: "ses-1",
         filePath: "/tmp/a.ts",
+        newString: "// new comment",
         timestamp: Date.now(),
       }
       const firstCall = processWithCli({ tool: "write", sessionID: "ses-1", callID: "call-1" }, pendingCall, { output: "" }, "/fake", undefined, () => {}, { runCommentChecker: cliMocks.runCommentChecker })
@@ -183,15 +213,23 @@ exit 2
         startBackgroundInit: mock(() => {}),
       })
       const cliMocks = cliMockFactory()
-      const pendingCall: PendingCall = {
+      const firstPendingCall: PendingCall = {
         tool: "write",
-        sessionID: "ses-1",
+        sessionID: "ses-first",
         filePath: "/tmp/a.ts",
+        newString: "// new comment",
+        timestamp: Date.now(),
+      }
+      const secondPendingCall: PendingCall = {
+        tool: "write",
+        sessionID: "ses-second",
+        filePath: "/tmp/b.ts",
+        newString: "// another comment",
         timestamp: Date.now(),
       }
       // when
-      await processWithCli({ tool: "write", sessionID: "ses-1", callID: "call-1" }, pendingCall, { output: "" }, "/fake", undefined, () => {}, { runCommentChecker: cliMocks.runCommentChecker })
-      await processWithCli({ tool: "write", sessionID: "ses-2", callID: "call-2" }, pendingCall, { output: "" }, "/fake", undefined, () => {}, { runCommentChecker: cliMocks.runCommentChecker })
+      await processWithCli({ tool: "write", sessionID: "ses-first", callID: "call-1" }, firstPendingCall, { output: "" }, "/fake", undefined, () => {}, { runCommentChecker: cliMocks.runCommentChecker })
+      await processWithCli({ tool: "write", sessionID: "ses-second", callID: "call-2" }, secondPendingCall, { output: "" }, "/fake", undefined, () => {}, { runCommentChecker: cliMocks.runCommentChecker })
       // then
       expect(callCount).toBe(2)
     })

--- a/src/hooks/comment-checker/cli.ts
+++ b/src/hooks/comment-checker/cli.ts
@@ -25,9 +25,19 @@ function getBinaryName(): string {
   return process.platform === "win32" ? "comment-checker.exe" : "comment-checker"
 }
 
+export function resolveCommentCheckerPathFromPath(binaryName: string, which: (binary: string) => string | null = Bun.which): string | null {
+  try {
+    return which(binaryName)
+  } catch (error) {
+    debugLog("PATH lookup failed:", error)
+    return null
+  }
+}
+
 function findCommentCheckerPathSync(): string | null {
+  const binaryName = getBinaryName()
   const resolvedPath = resolveCommentCheckerBinary({
-    binaryName: getBinaryName(),
+    binaryName,
     cachedBinaryPath: getCachedBinaryPath(),
     existsSync,
     importMetaUrl: import.meta.url,
@@ -35,6 +45,12 @@ function findCommentCheckerPathSync(): string | null {
   if (resolvedPath !== null) {
     debugLog("resolved binary path:", resolvedPath)
     return resolvedPath
+  }
+
+  const pathBinary = resolveCommentCheckerPathFromPath(binaryName)
+  if (pathBinary !== null && existsSync(pathBinary)) {
+    debugLog("resolved PATH binary:", pathBinary)
+    return pathBinary
   }
 
   debugLog("no binary found in known locations")


### PR DESCRIPTION
[sisyphus-dev] Replacement fix for #3315.

## Summary
- make the runtime comment-checker resolver check PATH via Bun.which after cached/package-local lookup
- use the platform binary name, so Windows can resolve PATH-only comment-checker.exe the same way doctor does
- add focused resolver regressions and tighten existing semaphore fixtures so they exercise comment-checker execution instead of no-comment/dedupe skips

## QA
- `bun test src/hooks/comment-checker/cli.test.ts src/hooks/comment-checker/hook.before-after.test.ts src/hooks/comment-checker/hook.apply-patch.test.ts src/cli/doctor/checks/dependencies.test.ts --bail` -> 23 pass, 0 fail
- `git diff --check` -> clean
- `bun run typecheck` -> pass

Closes #3315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes comment-checker resolution when the binary is only on PATH by falling back to `Bun.which` after cached/local checks. Windows now resolves `comment-checker.exe` consistently with the doctor.

- **Bug Fixes**
  - Added PATH fallback via `resolveCommentCheckerPathFromPath` using `Bun.which`.
  - Use platform-specific binary name during lookup.
  - Expanded tests to cover PATH-only resolution and to exercise actual comment-checker execution.

<sup>Written for commit b25bac93931eb7f2ecc2964ac5ca8d9e669b6747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

