### PR TITLE
fix(ralph-loop): wait for pending background tasks

### DIFF
--- a/src/hooks/ralph-loop/background-task-activity.test.ts
+++ b/src/hooks/ralph-loop/background-task-activity.test.ts
@@ -1,0 +1,95 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { createRalphLoopHook } from "./index"
+import { clearState } from "./storage"
+
+type PromptCall = {
+	readonly sessionID: string
+	readonly text: string
+}
+
+type BackgroundTaskStatus = "pending" | "running"
+
+describe("ralph-loop background task activity", () => {
+	const testDirectory = join(tmpdir(), `ralph-loop-bg-activity-${Date.now()}`)
+	let promptCalls: PromptCall[]
+	let taskStatus: BackgroundTaskStatus
+
+	function createMockPluginInput() {
+		return unsafeTestValue<Parameters<typeof createRalphLoopHook>[0]>({
+			client: {
+				session: {
+					promptAsync: async (opts: { readonly path: { readonly id: string }; readonly body: { readonly parts: readonly [{ readonly text: string }] } }) => {
+						promptCalls.push({
+							sessionID: opts.path.id,
+							text: opts.body.parts[0].text,
+						})
+						return {}
+					},
+					messages: async () => ({ data: [] }),
+				},
+			},
+			directory: testDirectory,
+		})
+	}
+
+	function createHookWithBackgroundTask() {
+		return createRalphLoopHook(createMockPluginInput(), {
+			idleSettleMs: 0,
+			backgroundManager: {
+				getTasksByParentSession: () => [{ status: taskStatus }],
+			},
+		})
+	}
+
+	beforeEach(() => {
+		promptCalls = []
+		taskStatus = "pending"
+		if (!existsSync(testDirectory)) {
+			mkdirSync(testDirectory, { recursive: true })
+		}
+		clearState(testDirectory)
+	})
+
+	afterEach(() => {
+		clearState(testDirectory)
+		if (existsSync(testDirectory)) {
+			rmSync(testDirectory, { recursive: true, force: true })
+		}
+	})
+
+	test("#given a ralph loop has a pending background task #when the parent session idles #then continuation waits for the task", async () => {
+		// given
+		const hook = createHookWithBackgroundTask()
+		hook.startLoop("session-123", "Wait for the subagent")
+
+		// when
+		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
+
+		// then
+		expect(promptCalls).toHaveLength(0)
+		expect(hook.getState()?.iteration).toBe(1)
+	})
+
+	test("#given a ralph loop has a pending background task #when the parent session errors #then runtime retry waits for the task", async () => {
+		// given
+		const hook = createHookWithBackgroundTask()
+		hook.startLoop("session-123", "Wait for the subagent")
+
+		// when
+		await hook.event({
+			event: {
+				type: "session.error",
+				properties: { sessionID: "session-123", error: new Error("runtime") },
+			},
+		})
+
+		// then
+		expect(promptCalls).toHaveLength(0)
+		expect(hook.getState()?.iteration).toBe(1)
+	})
+})

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -34,12 +34,12 @@ function sleep(ms: number): Promise<void> {
 	return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }
 
-function hasRunningBackgroundTasks(
+function hasActiveBackgroundTasks(
 	backgroundManager: RalphLoopOptions["backgroundManager"],
 	sessionID: string,
 ): boolean {
 	return backgroundManager
-		? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+		? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "pending" || task.status === "running")
 		: false
 }
 
@@ -304,8 +304,8 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				if (hasRunningBackgroundTasks(options.backgroundManager, sessionID)) {
-					log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
+				if (hasActiveBackgroundTasks(options.backgroundManager, sessionID)) {
+					log(`[${HOOK_NAME}] Skipped: background tasks active`, { sessionID })
 					return
 				}
 
@@ -573,8 +573,8 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				if (hasRunningBackgroundTasks(options.backgroundManager, sessionID)) {
-					log(`[${HOOK_NAME}] Skipped runtime error retry: background tasks running`, { sessionID })
+				if (hasActiveBackgroundTasks(options.backgroundManager, sessionID)) {
+					log(`[${HOOK_NAME}] Skipped runtime error retry: background tasks active`, { sessionID })
 					return
 				}
 


### PR DESCRIPTION
[sisyphus-dev]

## Summary
- Treat `pending` background subagent tasks as active in the Ralph loop guard, alongside `running` tasks.
- Apply the guard to both parent `session.idle` continuation and non-abort `session.error` runtime retry.
- Add focused regressions for pending background tasks blocking both paths.

## Context
Issue #3362 describes ULW/Ralph loop continuing while the main session is waiting for a background subagent. The current Ralph guard only skipped `running` tasks, leaving queued `pending` tasks able to trigger another continuation.

This is a narrow replacement for the remaining Ralph-loop gap after earlier adjacent fixes. Replaces the unmerged direction from #3531 for this local path.

## Testing
- Red check before fix: `bun test ./src/hooks/ralph-loop/background-task-activity.test.ts` failed with both tests receiving 1 prompt instead of 0.
- `bun test ./src/hooks/ralph-loop/background-task-activity.test.ts` passed: 2 pass, 0 fail.
- `bun run typecheck` passed.
- `git diff --check` passed.
- `bun test ./src/hooks/ralph-loop` currently reports 143 pass / 6 fail. The failures reproduce in existing prompt-gate timing tests such as `index.test.ts --test-name-pattern 'new activity after an idle continuation'` and are not introduced by the pending-background guard.

Fixes #3362.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Ralph loop continuation while a background subagent task is pending or running, stopping duplicate prompts. Applies to idle continuation and runtime error retries to address #3362.

- **Bug Fixes**
  - Treat `pending` background tasks as active alongside `running` in the guard.
  - Apply the guard to `session.idle` and non-abort `session.error` paths with updated log messages.
  - Add focused tests to ensure both paths wait for background tasks.

<sup>Written for commit 338010ba34eda5662fadb46ac88016a004415dc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

