### PR TITLE
fix(model-core): preserve Anthropic hyphen model IDs

### DIFF
--- a/packages/model-core/src/provider-model-id-transform.test.ts
+++ b/packages/model-core/src/provider-model-id-transform.test.ts
@@ -6,18 +6,54 @@ import {
 } from "./provider-model-id-transform"
 
 describe("provider model ID transforms", () => {
-	test("keeps separate Anthropic API and display behavior", () => {
-		// #given an Anthropic model ID in config-display form
+	test("preserves hyphenated Anthropic IDs for direct API calls", () => {
+		// #given Anthropic model IDs in config-display form
 		const provider = "anthropic"
-		const model = "claude-opus-4-7"
+		const models = ["claude-haiku-4-5", "claude-opus-4-7"] as const
 
-		// #when both model-core transform variants are called
-		const apiResult = transformModelForProvider(provider, model)
-		const displayResult = transformModelForProviderDisplay(provider, model)
+		for (const model of models) {
+			// #when both model-core transform variants are called
+			const apiResult = transformModelForProvider(provider, model)
+			const displayResult = transformModelForProviderDisplay(provider, model)
 
-		// #then API calls use dotted Anthropic versions while display keeps hyphens
-		expect(apiResult).toBe("claude-opus-4.7")
-		expect(displayResult).toBe("claude-opus-4-7")
+			// #then direct Anthropic calls keep the strict provider model ID
+			expect(apiResult).toBe(model)
+			expect(displayResult).toBe(model)
+		}
+	})
+
+	test("keeps dotted Claude versions for gateway providers", () => {
+		// #given gateway providers that expect Claude version aliases
+		const scenarios = [
+			{
+				provider: "github-copilot",
+				model: "claude-haiku-4-5",
+				expected: "claude-haiku-4.5",
+			},
+			{
+				provider: "github-copilot",
+				model: "claude-opus-4-7",
+				expected: "claude-opus-4.7",
+			},
+			{
+				provider: "vercel",
+				model: "claude-haiku-4-5",
+				expected: "anthropic/claude-haiku-4.5",
+			},
+			{
+				provider: "vercel",
+				model: "anthropic/claude-opus-4-7",
+				expected: "anthropic/claude-opus-4.7",
+			},
+		] as const
+
+		for (const scenario of scenarios) {
+			// #when a gateway transform is applied
+			const result = transformModelForProvider(scenario.provider, scenario.model)
+
+			// #then the gateway receives its dotted Claude version form
+			expect(result).toBe(scenario.expected)
+		}
 	})
 
 	test("produces identical results for non-Anthropic providers", () => {

--- a/packages/model-core/src/provider-model-id-transform.ts
+++ b/packages/model-core/src/provider-model-id-transform.ts
@@ -27,7 +27,6 @@ function applyGatewayTransforms(model: string): string {
 function transformModelForProviderUsingAnthropicBehavior(
 	provider: string,
 	model: string,
-	directAnthropicTransform: (model: string) => string,
 ): string {
 	if (provider === "vercel") {
 		const slashIndex = model.indexOf("/")
@@ -53,26 +52,18 @@ function transformModelForProviderUsingAnthropicBehavior(
 			.replace(GEMINI_3_FLASH_PREVIEW, "gemini-3-flash-preview")
 	}
 	if (provider === "anthropic") {
-		return directAnthropicTransform(model)
+		return model
 	}
 	return model
 }
 
 export function transformModelForProvider(provider: string, model: string): string {
-	return transformModelForProviderUsingAnthropicBehavior(
-		provider,
-		model,
-		claudeVersionDot,
-	)
+	return transformModelForProviderUsingAnthropicBehavior(provider, model)
 }
 
 export function transformModelForProviderDisplay(
 	provider: string,
 	model: string,
 ): string {
-	return transformModelForProviderUsingAnthropicBehavior(
-		provider,
-		model,
-		(model) => model,
-	)
+	return transformModelForProviderUsingAnthropicBehavior(provider, model)
 }

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -304,7 +304,7 @@ describe("createBuiltinAgents with model overrides", () => {
 
       // #then
       expect(agents.sisyphus).toBeDefined()
-      expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4.7")
+      expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
     } finally {
       cacheSpy.mockRestore()
       fetchSpy.mockRestore()
@@ -1042,7 +1042,7 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
 
       // #then
       expect(agents.sisyphus).toBeDefined()
-      expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4.7")
+      expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
     } finally {
       cacheSpy.mockRestore()
       fetchSpy.mockRestore()

--- a/src/cli/provider-model-id-transform.test.ts
+++ b/src/cli/provider-model-id-transform.test.ts
@@ -352,11 +352,10 @@ describe("transformModelForProvider", () => {
     ] as const
 
     // #when both are called with the same anthropic claude input
-    // #then the CLI preserves hyphenated form for config output,
-    //       the shared runtime transform converts dash→dot for API calls
+    // #then both preserve hyphenated form for direct Anthropic calls
     expect(transformModelForProvider).not.toBe(transformRuntimeModelForProvider)
     expect(cliResult).toBe("claude-opus-4-7")
-    expect(runtimeResult).toBe("claude-opus-4.7")
+    expect(runtimeResult).toBe("claude-opus-4-7")
 
     for (const scenario of nonAnthropicScenarios) {
       expect(transformModelForProvider(scenario.provider, scenario.model)).toBe(

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -885,7 +885,7 @@ describe("BackgroundManager retry observability", () => {
     expect(notification).toContain("[BACKGROUND TASK RETRYING]")
     expect(notification).toContain("ses_retry_visibility")
     expect(notification).toContain("genai-proxy-openai/gpt-5.4-mini")
-    expect(notification).toContain("anthropic/claude-haiku-4.5")
+    expect(notification).toContain("anthropic/claude-haiku-4-5")
   })
 
   test("falls back to task parent agent when retrying wake cannot load parent messages", async () => {
@@ -6190,7 +6190,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     expect(task.attemptCount).toBe(1)
     expect(task.model).toEqual({
       providerID: "anthropic",
-      modelID: "claude-opus-4.7",
+      modelID: "claude-opus-4-7",
       variant: "max",
     })
     expect(task.concurrencyKey).toBeUndefined()
@@ -6228,7 +6228,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     expect(task.attemptCount).toBe(1)
     expect(task.model).toEqual({
       providerID: "anthropic",
-      modelID: "claude-opus-4.7",
+      modelID: "claude-opus-4-7",
       variant: "max",
     })
 
@@ -6273,7 +6273,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     expect(task.attemptCount).toBe(1)
     expect(task.model).toEqual({
       providerID: "anthropic",
-      modelID: "claude-opus-4.7",
+      modelID: "claude-opus-4-7",
       variant: "max",
     })
 

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -245,7 +245,7 @@ describe("resolveModelForDelegateTask", () => {
 				expect(result).toBeDefined()
 				expect(result).not.toHaveProperty("skipped")
 				const resolved = result as { model: string; variant?: string }
-				expect(resolved.model).toBe("anthropic/claude-haiku-4.5")
+				expect(resolved.model).toBe("anthropic/claude-haiku-4-5")
 			})
 
 			test("#then resolves first provider in entry that is connected", () => {


### PR DESCRIPTION
## Summary
- Preserve hyphenated Claude model IDs for direct Anthropic runtime calls so strict Meridian/opencode-with-claude proxies accept `claude-haiku-4-5`.
- Keep GitHub Copilot and Vercel gateway transforms on dotted Claude aliases.
- Update model-core, CLI comparison, background retry, agent, and delegate-task expectations to the direct-Anthropic hyphenated form.

## Links
Fixes #3562.
Supersedes the stale closed PR #3700; the fix moved from the old shared runtime file into `packages/model-core`.

## Verification
- `bun test packages/model-core/src/provider-model-id-transform.test.ts src/cli/provider-model-id-transform.test.ts src/tools/delegate-task/model-selection.test.ts src/features/background-agent/manager.test.ts src/agents/utils.test.ts` -> 310 pass / 0 fail
- `bun run typecheck` -> pass
- `git diff --check` -> pass
- `opencode --version` -> 1.14.41

Live Meridian/opencode-with-claude reproduction was not run because it requires external proxy credentials; the regression is pinned at the transform boundary that produced the rejected dotted ID.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves hyphenated Claude model IDs for direct `anthropic` calls while keeping dotted aliases for `github-copilot` and `vercel` gateways. Fixes proxy rejections of dotted IDs and aligns `model-core` transforms and tests to the hyphen form.

- **Bug Fixes**
  - Direct `anthropic` calls now keep `claude-haiku-4-5`/`claude-opus-4-7`.
  - Gateways keep dotted aliases: `github-copilot` (`claude-haiku-4.5`), `vercel` (`anthropic/claude-haiku-4.5`).
  - Simplified transform logic in `model-core`; updated CLI, background agent, agents, and delegate-task tests.

<sup>Written for commit 665396620ed69814706228133868c75998fce987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

