### PR TITLE
fix(look-at): extract thinking model answers

### DIFF
--- a/src/tools/look-at/assistant-message-extractor.test.ts
+++ b/src/tools/look-at/assistant-message-extractor.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+
+import { extractLatestAssistantOutcome, extractLatestAssistantText } from "./assistant-message-extractor"
+
+describe("assistant-message-extractor", () => {
+  test("returns plain assistant text from the newest assistant message", () => {
+    const text = extractLatestAssistantText([
+      { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "old answer" }] },
+      { info: { role: "assistant", time: { created: 2 } }, parts: [{ type: "text", text: "new answer" }] },
+    ])
+
+    expect(text).toBe("new answer")
+  })
+
+  test("prefers answer tags and strips thinking blocks from text parts", () => {
+    const text = extractLatestAssistantText([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [
+          {
+            type: "text",
+            text: "<think>private image reasoning</think>\n<answer>The chart shows revenue rising.</answer>",
+          },
+        ],
+      },
+    ])
+
+    expect(text).toBe("The chart shows revenue rising.")
+  })
+
+  test("strips thinking blocks when no answer tag is present", () => {
+    const text = extractLatestAssistantText([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [{ type: "text", text: "<think>private notes</think>\nVisible result" }],
+      },
+    ])
+
+    expect(text).toBe("Visible result")
+  })
+
+  test("uses reasoning parts when thinking models return no text part", () => {
+    const text = extractLatestAssistantText([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [{ type: "reasoning", text: "<answer>Detected two warning symbols.</answer>" }],
+      },
+    ])
+
+    expect(text).toBe("Detected two warning symbols.")
+  })
+
+  test("uses reasoning_content when text content is empty", () => {
+    const text = extractLatestAssistantText([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [{ type: "text", text: "", reasoning_content: "<answer>There are three columns.</answer>" }],
+      },
+    ])
+
+    expect(text).toBe("There are three columns.")
+  })
+
+  test("reads text from structured content arrays", () => {
+    const text = extractLatestAssistantText([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [{ type: "text", content: [{ type: "text", text: "<answer>Structured answer</answer>" }] }],
+      },
+    ])
+
+    expect(text).toBe("Structured answer")
+  })
+
+  test("preserves error and completion metadata while extracting text", () => {
+    const outcome = extractLatestAssistantOutcome([
+      {
+        info: { role: "assistant", time: { created: 1 } },
+        parts: [
+          { type: "text", text: "<answer>Recovered result</answer>" },
+          { type: "error", error: "ProviderError" },
+        ],
+      },
+    ])
+
+    expect(outcome).toEqual({
+      text: "Recovered result",
+      errorName: "ProviderError",
+      hasAssistant: true,
+      completed: true,
+    })
+  })
+})

--- a/src/tools/look-at/assistant-message-extractor.ts
+++ b/src/tools/look-at/assistant-message-extractor.ts
@@ -8,6 +8,9 @@ type MessageInfo = {
 type MessagePart = {
   type?: string
   text?: string
+  content?: unknown
+  reasoning?: string
+  reasoningContent?: string
 }
 
 type SessionMessage = {
@@ -38,6 +41,34 @@ function getCreatedTime(message: SessionMessage): number {
   return message.info?.time?.created ?? 0
 }
 
+function asText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined
+}
+
+function collectContentText(value: unknown): string[] {
+  const directText = asText(value)
+  if (directText) return [directText]
+
+  if (!Array.isArray(value)) return []
+
+  const texts: string[] = []
+  for (const block of value) {
+    if (!isObject(block)) continue
+    const text = asText(block["text"]) ?? asText(block["content"])
+    if (text) texts.push(text)
+  }
+  return texts
+}
+
+function normalizeThinkingText(text: string): string | null {
+  const answerMatches = [...text.matchAll(/<answer\b[^>]*>([\s\S]*?)<\/answer>/gi)]
+    .map((match) => match[1]?.trim())
+    .filter((value): value is string => Boolean(value))
+  const withoutThinking = text.replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, "").trim()
+  const normalized = answerMatches.length > 0 ? answerMatches.join("\n") : withoutThinking
+  return normalized.length > 0 ? normalized : null
+}
+
 function getTextParts(message: SessionMessage): MessagePart[] {
   if (!Array.isArray(message.parts)) return []
   return message.parts
@@ -45,8 +76,36 @@ function getTextParts(message: SessionMessage): MessagePart[] {
     .map((part) => ({
       type: typeof part["type"] === "string" ? part["type"] : undefined,
       text: typeof part["text"] === "string" ? part["text"] : undefined,
+      content: part["content"],
+      reasoning: typeof part["reasoning"] === "string" ? part["reasoning"] : undefined,
+      reasoningContent: typeof part["reasoning_content"] === "string" ? part["reasoning_content"] : undefined,
     }))
-    .filter((part) => part.type === "text" && Boolean(part.text))
+}
+
+function extractTextFromParts(parts: MessagePart[]): string | null {
+  const textCandidates: string[] = []
+  const reasoningCandidates: string[] = []
+
+  for (const part of parts) {
+    const contentTexts = collectContentText(part.content)
+    const directText = asText(part.text)
+
+    if (part.type === "text") {
+      if (directText) textCandidates.push(directText)
+      textCandidates.push(...contentTexts)
+    } else if (part.type === "reasoning" || part.type === "thinking") {
+      if (directText) reasoningCandidates.push(directText)
+      textCandidates.push(...contentTexts)
+    }
+
+    const reasoningText = asText(part.reasoningContent) ?? asText(part.reasoning)
+    if (reasoningText) reasoningCandidates.push(reasoningText)
+  }
+
+  const primaryText = textCandidates.map(normalizeThinkingText).filter((text): text is string => text !== null).join("\n")
+  if (primaryText) return primaryText
+
+  return reasoningCandidates.map(normalizeThinkingText).filter((text): text is string => text !== null).join("\n") || null
 }
 
 export function extractLatestAssistantText(messages: unknown): string | null {
@@ -80,8 +139,7 @@ export function extractLatestAssistantOutcome(messages: unknown): AssistantOutco
     return { text: null, errorName: null, hasAssistant, completed: false }
   }
 
-  const textParts = getTextParts(lastAssistantMessage)
-  const text = textParts.map((part) => part.text).join("\n") || null
+  const text = extractTextFromParts(getTextParts(lastAssistantMessage))
 
   const allParts = Array.isArray(lastAssistantMessage.parts) ? lastAssistantMessage.parts : []
   const errorPart = allParts.find((part): part is Record<string, unknown> =>


### PR DESCRIPTION
## Summary

Fixes #3648.

`look_at` previously treated the child multimodal-looker response as empty unless the latest assistant message had a non-empty `type: "text"` part with a direct `text` field. Thinking-mode vision models can return answer text inside `<answer>...</answer>`, include private reasoning in `<think>...</think>`, expose structured `content` arrays, or fall back to `reasoning` / `reasoning_content` shapes.

This keeps the fix local to the look_at message extractor:

- prefer `<answer>...</answer>` content when present
- strip `<think>...</think>` blocks from returned text
- read text from structured `content` arrays
- use reasoning/reasoning_content only when no primary text content is available
- preserve existing outcome metadata for errors/completion

## QA

```bash
bun test src/tools/look-at/assistant-message-extractor.test.ts src/tools/look-at/tools.test.ts src/tools/look-at/session-poller.test.ts
bun run typecheck
git diff --check
```

All passed locally in an isolated worktree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `look_at` extracting text from thinking-mode vision models so answers no longer appear empty. Parses `<answer>` content and structured parts while stripping `<think>` blocks to return clean, visible text.

- **Bug Fixes**
  - Prefer `<answer>...</answer>` and remove `<think>...</think>` from assistant text.
  - Read text from structured `content` arrays.
  - Fallback to `reasoning` / `reasoning_content` when no primary text exists.
  - Preserve outcome metadata (`errorName`, `completed`).
  - Added tests for extractor behavior.

<sup>Written for commit 793ba1909dbca476254b016e0a59ce5f160788e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

