### PR TITLE
Add local Claude reviewer lane for lazycodex

### DIFF
--- a/bin/lazycodex-local-claude-core.js
+++ b/bin/lazycodex-local-claude-core.js
@@ -1,0 +1,241 @@
+import { spawnSync } from "node:child_process";
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const DEFAULT_CLAUDE_TIMEOUT_MS = 180_000;
+
+export function parseLocalClaudeArgs(argv) {
+  const options = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") options.json = true;
+    else if (arg === "--diff") options.diff = true;
+    else if (arg === "--with-local-claude-review") options.withLocalClaudeReview = true;
+    else if (arg === "--claude-config-dir") options.claudeConfigDir = argv[++index];
+    else if (arg.startsWith("--claude-config-dir=")) options.claudeConfigDir = arg.slice("--claude-config-dir=".length);
+    else if (arg === "--claude-timeout-ms") options.claudeTimeoutMs = Number(argv[++index]);
+    else if (arg.startsWith("--claude-timeout-ms=")) options.claudeTimeoutMs = Number(arg.slice("--claude-timeout-ms=".length));
+    else if (arg === "--task") options.task = argv[++index];
+    else if (arg.startsWith("--task=")) options.task = arg.slice("--task=".length);
+    else if (arg === "--test-command") options.testCommand = argv[++index];
+    else if (arg.startsWith("--test-command=")) options.testCommand = arg.slice("--test-command=".length);
+    else options._.push(arg);
+  }
+  return options;
+}
+
+export function runCommand(command, args, options = {}) {
+  const started = Date.now();
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    maxBuffer: options.maxBuffer ?? 20 * 1024 * 1024,
+    shell: options.shell ?? false,
+    stdio: options.stdio ?? "pipe",
+    timeout: options.timeout,
+  });
+  return {
+    durationMs: Date.now() - started,
+    error: result.error?.message,
+    signal: result.signal,
+    status: result.status ?? (result.error ? 1 : 0),
+    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? "",
+  };
+}
+
+export function expandHome(value) {
+  return resolve(value.replace(/^~(?=$|\/)/, homedir()));
+}
+
+export function selectClaudeConfigDir(explicitConfigDir, env = process.env) {
+  if (explicitConfigDir) return expandHome(explicitConfigDir);
+  const configuredDirs = env.LAZYCODEX_CLAUDE_CONFIG_DIRS;
+  if (!configuredDirs) return null;
+  const dirs = configuredDirs.split(/[,:]/).map((item) => item.trim()).filter(Boolean).map(expandHome);
+  if (dirs.length === 0) return null;
+
+  const path = join(homedir(), ".local", "share", "lazycodex-claude", "state.json");
+  let nextIndex = 0;
+  try {
+    const state = JSON.parse(readFileSync(path, "utf8"));
+    if (Number.isInteger(state.nextClaudeConfigIndex)) nextIndex = state.nextClaudeConfigIndex;
+  } catch {
+    nextIndex = 0;
+  }
+
+  const selected = dirs[((nextIndex % dirs.length) + dirs.length) % dirs.length];
+  try {
+    mkdirSync(join(homedir(), ".local", "share", "lazycodex-claude"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ lastClaudeConfigDir: selected, nextClaudeConfigIndex: nextIndex + 1 }, null, 2));
+  } catch (error) {
+    ignoreBestEffortStateError(error);
+  }
+  return selected;
+}
+
+function ignoreBestEffortStateError(error) {
+  if (!(error instanceof Error)) throw error;
+  if (process.env.LAZYCODEX_CLAUDE_STATE_DEBUG === "1") console.error(`lazycodex: ${error.message}`);
+}
+
+export function claudeEnv(selectedConfigDir, env = process.env) {
+  const childEnv = { ...env };
+  delete childEnv.ANTHROPIC_API_KEY;
+  if (selectedConfigDir) childEnv.CLAUDE_CONFIG_DIR = selectedConfigDir;
+  return childEnv;
+}
+
+export function callClaude(prompt, options) {
+  const selectedConfigDir = selectClaudeConfigDir(options.claudeConfigDir);
+  const timeoutMs = Number.isFinite(options.claudeTimeoutMs) && options.claudeTimeoutMs > 0
+    ? options.claudeTimeoutMs
+    : DEFAULT_CLAUDE_TIMEOUT_MS;
+  const result = runCommand("claude", [
+    "-p",
+    prompt,
+    "--output-format",
+    "json",
+    "--max-turns",
+    "1",
+    "--permission-mode",
+    "plan",
+    "--tools",
+    "",
+    "--no-session-persistence",
+  ], {
+    env: claudeEnv(selectedConfigDir),
+    maxBuffer: 30 * 1024 * 1024,
+    timeout: timeoutMs,
+  });
+
+  let parsed = null;
+  if (result.stdout.trim()) {
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  return {
+    ...result,
+    claudeConfigDir: selectedConfigDir,
+    parsed,
+    text: parsed?.result ?? result.stdout,
+    timedOut: result.error === "spawnSync claude ETIMEDOUT",
+    timeoutMs,
+  };
+}
+
+export function collectDiff(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const unstagedStat = runCommand("git", ["diff", "--stat", "--no-ext-diff"], { cwd });
+  const stagedStat = runCommand("git", ["diff", "--cached", "--stat", "--no-ext-diff"], { cwd });
+  const unstagedDiff = runCommand("git", ["diff", "--no-ext-diff", "--no-color"], { cwd });
+  const stagedDiff = runCommand("git", ["diff", "--cached", "--no-ext-diff", "--no-color"], { cwd });
+  const untracked = collectUntrackedFiles(cwd);
+  const text = [
+    "## Staged diff",
+    stagedStat.stdout,
+    stagedDiff.stdout,
+    "## Unstaged diff",
+    unstagedStat.stdout,
+    unstagedDiff.stdout,
+    "## Untracked files",
+    untracked.text,
+  ].filter(Boolean).join("\n\n");
+  const maxChars = 24_000;
+  return {
+    chars: text.length,
+    stat: [stagedStat.stdout.trim(), unstagedStat.stdout.trim(), untracked.stat].filter(Boolean).join("\n"),
+    text: text.length > maxChars ? `${text.slice(0, maxChars)}\n\n[diff truncated at ${maxChars} chars]` : text,
+    truncated: text.length > maxChars,
+  };
+}
+
+function collectUntrackedFiles(cwd) {
+  const listed = runCommand("git", ["ls-files", "--others", "--exclude-standard", "-z"], { cwd });
+  if (listed.status !== 0 || !listed.stdout) return { stat: "", text: "" };
+  const files = listed.stdout.split("\0").filter(Boolean).slice(0, 10);
+  let remainingChars = 12_000;
+  const sections = [];
+  for (const file of files) {
+    const path = join(cwd, file);
+    const stat = lstatSync(path);
+    if (!stat.isFile()) continue;
+    if (stat.size > 64 * 1024) {
+      sections.push(`### ${file}\n[untracked file skipped: ${stat.size} bytes exceeds 65536 byte inline limit]`);
+      continue;
+    }
+    const content = readFileSync(path, "utf8");
+    const clipped = content.slice(0, Math.max(0, remainingChars));
+    remainingChars -= clipped.length;
+    sections.push(`### ${file}\n${clipped}${content.length > clipped.length ? "\n[untracked file truncated]" : ""}`);
+    if (remainingChars <= 0) break;
+  }
+  return {
+    stat: files.length > 0 ? `Untracked files: ${files.join(", ")}` : "",
+    text: sections.join("\n\n"),
+  };
+}
+
+export function buildReviewPrompt(task, diff) {
+  return `You are a read-only reviewer for a Codex/lazycodex workflow.
+Do not ask questions. Do not edit files. Do not suggest broad rewrites.
+
+Task:
+${task || "Review the current working tree diff."}
+
+Return strict JSON only:
+{
+  "summary": string,
+  "findings": [
+    {
+      "severity": "critical" | "high" | "medium" | "low",
+      "file": string,
+      "line": number | null,
+      "issue": string,
+      "minimal_fix": string,
+      "confidence": "low" | "medium" | "high"
+    }
+  ],
+  "quality_score": number,
+  "risk_score": number
+}
+
+Diff:
+${diff.text}`;
+}
+
+export function parseReviewJson(text) {
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const match = trimmed.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function hasValidReviewShape(value) {
+  return Boolean(value && typeof value === "object" && Array.isArray(value.findings));
+}
+
+export function summarizeChecks(output) {
+  const lines = `${output.stdout}\n${output.stderr}`.split(/\r?\n/).filter(Boolean);
+  const issueLines = lines.filter((line) => /\b(error|fail|failed|warning|warn|todo)\b/i.test(line));
+  return {
+    durationMs: output.durationMs,
+    issueLineCount: issueLines.length,
+    sample: issueLines.slice(0, 12),
+    status: output.status,
+  };
+}

--- a/bin/lazycodex-local-claude.js
+++ b/bin/lazycodex-local-claude.js
@@ -1,0 +1,210 @@
+import { resolve } from "node:path";
+import {
+  buildReviewPrompt,
+  callClaude,
+  collectDiff,
+  hasValidReviewShape,
+  parseLocalClaudeArgs,
+  parseReviewJson,
+  runCommand,
+  summarizeChecks,
+} from "./lazycodex-local-claude-core.js";
+
+const LOCAL_CLAUDE_COMMANDS = new Set(["claude-probe", "claude-review", "claude-benchmark"]);
+
+export function shouldHandleLazyCodexLocalClaude(invocationName, argv) {
+  if (invocationName !== "lazycodex" && invocationName !== "lazycodex-ai") return false;
+  const command = argv[0];
+  return shouldHandleLazyCodexStandaloneLocalClaude(invocationName, argv) ||
+    (command === "run" && argv.includes("--with-local-claude-review"));
+}
+
+export function shouldHandleLazyCodexStandaloneLocalClaude(invocationName, argv) {
+  if (invocationName !== "lazycodex" && invocationName !== "lazycodex-ai") return false;
+  return LOCAL_CLAUDE_COMMANDS.has(argv[0]);
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runProbe(options) {
+  const probe = callClaude("Reply with exactly: LOCAL_CLAUDE_OK", options);
+  const payload = {
+    apiKeyRemovedForClaudeCall: true,
+    claudeConfigDir: probe.claudeConfigDir,
+    claudeDurationMs: probe.parsed?.duration_ms ?? null,
+    durationMs: probe.durationMs,
+    modelUsage: probe.parsed?.modelUsage ?? null,
+    ok: probe.status === 0 && probe.text.includes("LOCAL_CLAUDE_OK"),
+    stderr: probe.stderr.trim(),
+    timedOut: probe.timedOut,
+    timeoutMs: probe.timeoutMs,
+    totalCostUsd: probe.parsed?.total_cost_usd ?? null,
+  };
+  if (options.json) printJson(payload);
+  else {
+    console.log(`local Claude probe: ${payload.ok ? "OK" : "FAILED"} (${payload.durationMs}ms)`);
+    console.log(`api key removed for call: ${payload.apiKeyRemovedForClaudeCall}`);
+    if (payload.totalCostUsd !== null) console.log(`reported cost/credit draw: $${payload.totalCostUsd}`);
+  }
+  return payload.ok ? 0 : 1;
+}
+
+function runReview(options) {
+  const diff = options.diff ? collectDiff() : { chars: 0, stat: "", text: "", truncated: false };
+  const review = callClaude(buildReviewPrompt(options.task, diff), options);
+  const parsedReview = parseReviewJson(review.text);
+  const reviewOk = review.status === 0 && hasValidReviewShape(parsedReview);
+  const payload = {
+    diff,
+    durationMs: review.durationMs,
+    ok: reviewOk,
+    parseError: reviewOk ? null : "Claude review output did not match the required JSON review shape.",
+    parseOk: reviewOk,
+    rawText: reviewOk ? undefined : review.text,
+    review: parsedReview,
+    stderr: review.stderr.trim(),
+    timedOut: review.timedOut,
+    timeoutMs: review.timeoutMs,
+    totalCostUsd: review.parsed?.total_cost_usd ?? null,
+  };
+  if (options.json) printJson(payload);
+  else if (reviewOk) {
+    console.log(`Claude review: OK (${payload.durationMs}ms)`);
+    console.log(`findings=${parsedReview.findings.length} quality=${parsedReview.quality_score ?? "n/a"} risk=${parsedReview.risk_score ?? "n/a"}`);
+    console.log(parsedReview.summary ?? "");
+  } else {
+    console.error(payload.parseError);
+    console.log(review.text);
+  }
+  return reviewOk ? 0 : 1;
+}
+
+function runBenchmark(options) {
+  const task = options.task || "Review current diff for concrete bugs and missing tests.";
+  const testCommand = options.testCommand || "git diff --check";
+  const diff = collectDiff();
+  const baselineStarted = Date.now();
+  const baselineCheck = runCommand(testCommand, [], { shell: true });
+  const baseline = {
+    checks: summarizeChecks(baselineCheck),
+    durationMs: Date.now() - baselineStarted,
+    mode: "codex_only_checks",
+    qualitySignals: { externalReviewerFindings: 0, staticIssueLines: summarizeChecks(baselineCheck).issueLineCount },
+  };
+
+  const augmentedStarted = Date.now();
+  const augmentedCheck = runCommand(testCommand, [], { shell: true });
+  const review = callClaude(buildReviewPrompt(task, diff), options);
+  const parsedReview = parseReviewJson(review.text);
+  const reviewOk = review.status === 0 && hasValidReviewShape(parsedReview);
+  const findings = reviewOk ? parsedReview.findings : [];
+  const augmented = {
+    checks: summarizeChecks(augmentedCheck),
+    claude: {
+      claudeDurationMs: review.parsed?.duration_ms ?? null,
+      durationMs: review.durationMs,
+      parseError: reviewOk ? null : "Claude review output did not match the required JSON review shape.",
+      parseOk: reviewOk,
+      status: review.status,
+      timedOut: review.timedOut,
+      timeoutMs: review.timeoutMs,
+      totalCostUsd: review.parsed?.total_cost_usd ?? null,
+    },
+    durationMs: Date.now() - augmentedStarted,
+    mode: "codex_checks_plus_local_claude_review",
+    qualitySignals: {
+      externalReviewerFindings: findings.length,
+      highOrCriticalFindings: findings.filter((finding) => ["critical", "high"].includes(String(finding.severity))).length,
+      qualityScore: reviewOk ? parsedReview.quality_score ?? null : null,
+      riskScore: reviewOk ? parsedReview.risk_score ?? null : null,
+      staticIssueLines: summarizeChecks(augmentedCheck).issueLineCount,
+    },
+    rawText: reviewOk ? undefined : review.text,
+    review: parsedReview,
+  };
+
+  const payload = {
+    augmented,
+    baseline,
+    comparison: {
+      addedHighOrCriticalFindings: augmented.qualitySignals.highOrCriticalFindings,
+      addedReviewerFindings: augmented.qualitySignals.externalReviewerFindings,
+      elapsedDeltaMs: augmented.durationMs - baseline.durationMs,
+      elapsedRatio: baseline.durationMs > 0 ? Number((augmented.durationMs / baseline.durationMs).toFixed(2)) : null,
+    },
+    diff: { chars: diff.chars, stat: diff.stat, truncated: diff.truncated },
+    task,
+    testCommand,
+  };
+  if (options.json) printJson(payload);
+  else {
+    console.log(`Baseline: ${baseline.durationMs}ms, static issue lines=${baseline.qualitySignals.staticIssueLines}`);
+    console.log(`Claude-augmented: ${augmented.durationMs}ms, reviewer findings=${augmented.qualitySignals.externalReviewerFindings}`);
+    console.log(`Delta: ${payload.comparison.elapsedDeltaMs}ms (${payload.comparison.elapsedRatio}x)`);
+  }
+  return baselineCheck.status === 0 && augmentedCheck.status === 0 && reviewOk ? 0 : 1;
+}
+
+function parseRunWithLocalClaudeArgs(argv) {
+  const options = { _: [], delegateArgs: [], reviewCwd: process.cwd() };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--with-local-claude-review") options.withLocalClaudeReview = true;
+    else if (arg === "--claude-config-dir") options.claudeConfigDir = argv[++index];
+    else if (arg.startsWith("--claude-config-dir=")) options.claudeConfigDir = arg.slice("--claude-config-dir=".length);
+    else if (arg === "--claude-timeout-ms") options.claudeTimeoutMs = Number(argv[++index]);
+    else if (arg.startsWith("--claude-timeout-ms=")) options.claudeTimeoutMs = Number(arg.slice("--claude-timeout-ms=".length));
+    else {
+      options._.push(arg);
+      options.delegateArgs.push(arg);
+    }
+  }
+  options.reviewCwd = resolveRunDirectory(options.delegateArgs);
+  return options;
+}
+
+function resolveRunDirectory(delegateArgs) {
+  for (let index = 0; index < delegateArgs.length; index += 1) {
+    const arg = delegateArgs[index];
+    if (arg === "--directory" || arg === "-d") return resolveDirectory(delegateArgs[index + 1]);
+    if (arg.startsWith("--directory=")) return resolveDirectory(arg.slice("--directory=".length));
+  }
+  return process.cwd();
+}
+
+function resolveDirectory(value) {
+  return value ? resolve(value) : process.cwd();
+}
+
+function runWithLocalClaudeReview(options, runDelegate) {
+  const runResult = runDelegate(["run", ...options.delegateArgs]);
+  if (runResult.signal) return runResult.signalExitCode;
+  if ((runResult.status ?? 1) !== 0) return runResult.status ?? 1;
+
+  const review = callClaude(buildReviewPrompt(options._.join(" "), collectDiff({ cwd: options.reviewCwd })), options);
+  const parsedReview = parseReviewJson(review.text);
+  const reviewOk = review.status === 0 && hasValidReviewShape(parsedReview);
+  console.log("\n--- local Claude read-only review ---");
+  if (reviewOk) console.log(JSON.stringify(parsedReview, null, 2));
+  else {
+    console.error("lazycodex: local Claude review did not return the required JSON review shape.");
+    console.log(review.text);
+  }
+  return reviewOk ? review.status : 1;
+}
+
+export function runLazyCodexLocalClaude(argv, runDelegate) {
+  const command = argv[0];
+  if (command === "run") {
+    const runOptions = parseRunWithLocalClaudeArgs(argv.slice(1));
+    if (runOptions.withLocalClaudeReview) return runWithLocalClaudeReview(runOptions, runDelegate);
+    return 1;
+  }
+  const options = parseLocalClaudeArgs(argv.slice(1));
+  if (command === "claude-probe") return runProbe(options);
+  if (command === "claude-review") return runReview(options);
+  if (command === "claude-benchmark") return runBenchmark(options);
+  return 1;
+}

--- a/bin/lazycodex-local-claude.test.ts
+++ b/bin/lazycodex-local-claude.test.ts
@@ -1,0 +1,343 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getPlatformPackageCandidates } from "./platform.js";
+
+const testRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(testRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("lazycodex local Claude reviewer", () => {
+  test("runs claude-probe through local Claude without forwarding ANTHROPIC_API_KEY", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture();
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-probe", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: "must-not-reach-claude",
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const payload = JSON.parse(result.stdout);
+    const claudeEnv = JSON.parse(await readFile(join(fixture.captureDir, "claude-env.json"), "utf8"));
+    const claudeArgs = JSON.parse(await readFile(join(fixture.captureDir, "claude-args.json"), "utf8"));
+    expect(result.status).toBe(0);
+    expect(payload.ok).toBe(true);
+    expect(payload.apiKeyRemovedForClaudeCall).toBe(true);
+    expect(claudeEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(claudeArgs).toContain("--permission-mode");
+    expect(claudeArgs).toContain("plan");
+    expect(claudeArgs).toContain("--tools");
+    expect(claudeArgs).toContain("--no-session-persistence");
+  });
+
+  test("runs standalone claude-probe without installed platform packages", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ platformPackages: false });
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-probe", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.ok).toBe(true);
+  });
+
+  test("fails claude-review when Claude returns malformed review JSON", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ claudeResult: "this is not review json" });
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-review", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(1);
+    expect(payload.ok).toBe(false);
+    expect(payload.parseOk).toBe(false);
+    expect(payload.parseError).toContain("required JSON review shape");
+  });
+
+  test("does not run Claude review when delegated lazycodex run fails", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ platformStatus: 42 });
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "run", "--with-local-claude-review", "do work"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const platformArgs = (await readFile(join(fixture.captureDir, "platform-args"), "utf8")).trim().split("\n");
+    expect(result.status).toBe(42);
+    expect(platformArgs).toEqual(["run", "do work"]);
+    expect(result.stdout).not.toContain("local Claude read-only review");
+  });
+
+  test("reviews the delegated run directory and preserves run flags", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ claudeResult: validReviewResult() });
+    const wrapperRepo = await createCommittedRepo(fixture.root, "wrapper-repo", "WRAPPER_DIFF_MARKER");
+    const targetRepo = await createCommittedRepo(fixture.root, "target-repo", "TARGET_DIFF_MARKER");
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [
+      fixture.lazycodexBin,
+      "run",
+      "--with-local-claude-review",
+      "--json",
+      "--directory",
+      targetRepo,
+      "do work",
+    ], {
+      cwd: wrapperRepo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const platformArgs = (await readFile(join(fixture.captureDir, "platform-args"), "utf8")).trim().split("\n");
+    const claudeArgs = JSON.parse(await readFile(join(fixture.captureDir, "claude-args.json"), "utf8"));
+    expect(result.status).toBe(0);
+    expect(platformArgs).toEqual(["run", "--json", "--directory", targetRepo, "do work"]);
+    expect(claudeArgs[1]).toContain("TARGET_DIFF_MARKER");
+    expect(claudeArgs[1]).not.toContain("WRAPPER_DIFF_MARKER");
+  });
+
+  test("reports benchmark metrics when Claude returns a valid review", async () => {
+    // #given
+    const review = JSON.stringify({
+      findings: [
+        {
+          confidence: "high",
+          file: "bin/lazycodex-local-claude.js",
+          issue: "sample issue",
+          line: 1,
+          minimal_fix: "sample fix",
+          severity: "high",
+        },
+      ],
+      quality_score: 8,
+      risk_score: 2,
+      summary: "sample review",
+    });
+    const fixture = await createLocalClaudeFixture({ claudeResult: review });
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-benchmark", "--test-command", "true", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.baseline.checks.status).toBe(0);
+    expect(payload.augmented.checks.status).toBe(0);
+    expect(payload.augmented.claude.parseOk).toBe(true);
+    expect(payload.augmented.qualitySignals.externalReviewerFindings).toBe(1);
+    expect(payload.augmented.qualitySignals.highOrCriticalFindings).toBe(1);
+  });
+
+  test("includes staged and untracked content in review diffs", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ claudeResult: validReviewResult() });
+    const repo = await createCommittedRepo(fixture.root, "diff-repo", "BASELINE_MARKER");
+    await writeFile(join(repo, "tracked.txt"), "STAGED_MARKER\n");
+    spawnSync("git", ["add", "tracked.txt"], { cwd: repo });
+    await writeFile(join(repo, "new-file.txt"), "UNTRACKED_MARKER\n");
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-review", "--diff", "--json"], {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const claudeArgs = JSON.parse(await readFile(join(fixture.captureDir, "claude-args.json"), "utf8"));
+    expect(result.status).toBe(0);
+    expect(claudeArgs[1]).toContain("STAGED_MARKER");
+    expect(claudeArgs[1]).toContain("UNTRACKED_MARKER");
+  });
+
+  test("does not follow untracked symlinks outside the repo", async () => {
+    // #given
+    const fixture = await createLocalClaudeFixture({ claudeResult: validReviewResult() });
+    const repo = await createCommittedRepo(fixture.root, "symlink-repo", "BASELINE_MARKER");
+    const outsideSecret = join(fixture.root, "outside-secret.txt");
+    await writeFile(outsideSecret, "OUTSIDE_SECRET_MARKER\n");
+    await symlink(outsideSecret, join(repo, "linked-secret"));
+    const nodePath = Bun.which("node") ?? "node";
+
+    // #when
+    const result = spawnSync(nodePath, [fixture.lazycodexBin, "claude-review", "--diff", "--json"], {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CAPTURE_DIR: fixture.captureDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    // #then
+    const claudeArgs = JSON.parse(await readFile(join(fixture.captureDir, "claude-args.json"), "utf8"));
+    expect(result.status).toBe(0);
+    expect(claudeArgs[1]).not.toContain("OUTSIDE_SECRET_MARKER");
+  });
+});
+
+async function createLocalClaudeFixture(options: { readonly claudeResult?: string; readonly platformPackages?: boolean; readonly platformStatus?: number } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "lazycodex-local-claude-"));
+  testRoots.push(root);
+
+  const binDir = join(root, "bin");
+  const fakeBinDir = join(root, "fake-bin");
+  const captureDir = join(root, "capture");
+  await mkdir(binDir, { recursive: true });
+  await mkdir(fakeBinDir, { recursive: true });
+  await mkdir(captureDir, { recursive: true });
+
+  await cp(fileURLToPath(new URL("./oh-my-opencode.js", import.meta.url)), join(binDir, "lazycodex"));
+  await cp(fileURLToPath(new URL("./platform.js", import.meta.url)), join(binDir, "platform.js"));
+  await cp(fileURLToPath(new URL("./lazycodex-local-claude.js", import.meta.url)), join(binDir, "lazycodex-local-claude.js"));
+  await cp(fileURLToPath(new URL("./lazycodex-local-claude-core.js", import.meta.url)), join(binDir, "lazycodex-local-claude-core.js"));
+  await writeFile(join(root, "package.json"), JSON.stringify({ name: "lazycodex", type: "module" }));
+  if (options.platformPackages !== false) await writePlatformPackages(root, options.platformStatus ?? 0);
+  await writeFakeClaude(fakeBinDir, options.claudeResult ?? "LOCAL_CLAUDE_OK");
+
+  return {
+    captureDir,
+    fakeBinDir,
+    lazycodexBin: join(binDir, "lazycodex"),
+    root,
+  };
+}
+
+async function createCommittedRepo(root: string, name: string, marker: string): Promise<string> {
+  const repo = join(root, name);
+  await mkdir(repo, { recursive: true });
+  spawnSync("git", ["init"], { cwd: repo });
+  await writeFile(join(repo, "tracked.txt"), "baseline\n");
+  spawnSync("git", ["add", "tracked.txt"], { cwd: repo });
+  spawnSync("git", ["-c", "user.name=Test User", "-c", "user.email=test@example.com", "commit", "-m", "init"], { cwd: repo });
+  await writeFile(join(repo, "tracked.txt"), `${marker}\n`);
+  return repo;
+}
+
+function validReviewResult(): string {
+  return JSON.stringify({
+    findings: [
+      {
+        confidence: "high",
+        file: "bin/lazycodex-local-claude.js",
+        issue: "sample issue",
+        line: 1,
+        minimal_fix: "sample fix",
+        severity: "high",
+      },
+    ],
+    quality_score: 8,
+    risk_score: 2,
+    summary: "sample review",
+  });
+}
+
+async function writeFakeClaude(fakeBinDir: string, resultText: string): Promise<void> {
+  const fakeClaude = join(fakeBinDir, "claude");
+  await writeFile(
+    fakeClaude,
+    [
+      "#!/usr/bin/env node",
+      'import { writeFileSync } from "node:fs";',
+      'writeFileSync(`${process.env.CAPTURE_DIR}/claude-env.json`, JSON.stringify({ ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? undefined, CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? undefined }));',
+      'writeFileSync(`${process.env.CAPTURE_DIR}/claude-args.json`, JSON.stringify(process.argv.slice(2)));',
+      `process.stdout.write(${JSON.stringify(JSON.stringify({ duration_ms: 10, result: resultText, total_cost_usd: 0 }))});`,
+      "",
+    ].join("\n"),
+  );
+  await chmod(fakeClaude, 0o755);
+}
+
+async function writePlatformPackages(root: string, status: number): Promise<void> {
+  const packages = getPlatformPackageCandidates({
+    arch: process.arch,
+    libcFamily: process.platform === "linux" ? "glibc" : undefined,
+    packageBaseName: "oh-my-openagent",
+    platform: process.platform,
+  });
+  for (const packageName of packages) {
+    const binaryPath = join(root, "node_modules", packageName, "bin", "oh-my-opencode.js");
+    await mkdir(dirname(binaryPath), { recursive: true });
+    await writeFile(
+      binaryPath,
+      [
+        "#!/usr/bin/env node",
+        'import { writeFileSync } from "node:fs";',
+        'writeFileSync(`${process.env.CAPTURE_DIR}/platform-args`, `${process.argv.slice(2).join("\\n")}\\n`);',
+        `process.exit(${status});`,
+        "",
+      ].join("\n"),
+    );
+    await chmod(binaryPath, 0o755);
+  }
+
+  if (process.platform === "linux") {
+    const detectLibcPath = join(root, "node_modules", "detect-libc", "index.js");
+    await mkdir(dirname(detectLibcPath), { recursive: true });
+    await writeFile(detectLibcPath, 'exports.familySync = () => "glibc";\n');
+  }
+}

--- a/bin/oh-my-opencode.js
+++ b/bin/oh-my-opencode.js
@@ -8,6 +8,11 @@ import { createRequire } from "node:module";
 import { basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  runLazyCodexLocalClaude,
+  shouldHandleLazyCodexLocalClaude,
+  shouldHandleLazyCodexStandaloneLocalClaude,
+} from "./lazycodex-local-claude.js";
+import {
   getPlatformPackageCandidates,
   getBinaryPath,
   getPackageBareName,
@@ -95,6 +100,39 @@ function getWrapperPackageRoot() {
   return fileURLToPath(new URL("..", import.meta.url));
 }
 
+function runResolvedBinary(resolvedBinaries, childEnv, args) {
+  for (let index = 0; index < resolvedBinaries.length; index += 1) {
+    const currentBinary = resolvedBinaries[index];
+    const hasFallback = index < resolvedBinaries.length - 1;
+    const result = spawnSync(process.execPath, [currentBinary.binPath, ...args], {
+      stdio: "inherit",
+      env: childEnv,
+    });
+
+    if (result.error) {
+      if (hasFallback) {
+        continue;
+      }
+
+      console.error(`\noh-my-opencode: Failed to execute binary.`);
+      console.error(`Error: ${result.error.message}\n`);
+      return { status: 2 };
+    }
+
+    if (result.signal === "SIGILL" && hasFallback) {
+      continue;
+    }
+
+    if (result.signal) {
+      return { signal: result.signal, signalExitCode: getSignalExitCode(result.signal) };
+    }
+
+    return { status: result.status ?? 1 };
+  }
+
+  return { status: 1 };
+}
+
 /**
  * Determine which bin name the user invoked us with (oh-my-opencode, oh-my-openagent, omo, lazycodex).
  * Propagated to the compiled CLI binary via OMO_INVOCATION_NAME so it can route accordingly
@@ -118,10 +156,16 @@ function getInvocationName(wrapperPackageName) {
 
 function main() {
   const { platform, arch } = process;
-  const libcFamily = getLibcFamily();
   const wrapperPackageName = getWrapperPackageName();
   const invocationName = getInvocationName(wrapperPackageName);
+  const args = process.argv.slice(2);
 
+  if (shouldHandleLazyCodexStandaloneLocalClaude(invocationName, args)) {
+    const status = runLazyCodexLocalClaude(args, () => ({ status: 127 }));
+    process.exit(status);
+  }
+
+  const libcFamily = getLibcFamily();
   const packageBaseName = resolvePlatformPackageBaseName(wrapperPackageName);
   const avx2Supported = supportsAvx2();
   
@@ -164,36 +208,16 @@ function main() {
     OMO_WRAPPER_PACKAGE_ROOT: getWrapperPackageRoot(),
   };
 
-  for (let index = 0; index < resolvedBinaries.length; index += 1) {
-    const currentBinary = resolvedBinaries[index];
-    const hasFallback = index < resolvedBinaries.length - 1;
-    const result = spawnSync(process.execPath, [currentBinary.binPath, ...process.argv.slice(2)], {
-      stdio: "inherit",
-      env: childEnv,
-    });
-
-    if (result.error) {
-      if (hasFallback) {
-        continue;
-      }
-
-      console.error(`\noh-my-opencode: Failed to execute binary.`);
-      console.error(`Error: ${result.error.message}\n`);
-      process.exit(2);
-    }
-
-    if (result.signal === "SIGILL" && hasFallback) {
-      continue;
-    }
-
-    if (result.signal) {
-      process.exit(getSignalExitCode(result.signal));
-    }
-
-    process.exit(result.status ?? 1);
+  if (shouldHandleLazyCodexLocalClaude(invocationName, args)) {
+    const status = runLazyCodexLocalClaude(args, (delegateArgs) => runResolvedBinary(resolvedBinaries, childEnv, delegateArgs));
+    process.exit(status);
   }
 
-  process.exit(1);
+  const result = runResolvedBinary(resolvedBinaries, childEnv, args);
+  if (result.signal) {
+    process.exit(result.signalExitCode);
+  }
+  process.exit(result.status ?? 1);
 }
 
 main();

--- a/bin/oh-my-opencode.test.ts
+++ b/bin/oh-my-opencode.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { chmod, cp, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getPlatformPackageCandidates } from "./platform.js";
 
@@ -26,7 +26,7 @@ describe("lazycodex bin wrapper", () => {
       env: {
         ...process.env,
         CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
       },
     });
 
@@ -34,7 +34,7 @@ describe("lazycodex bin wrapper", () => {
     expect(result.status).toBe(23);
     expect((await readFile(join(fixture.captureDir, "env"), "utf8")).trim()).toBe("lazycodex");
     expect(await canonicalizePackageRootCapture(fixture)).toBe(await realpath(fixture.root));
-    expect(await realpath((await readFile(join(fixture.captureDir, "exec-path"), "utf8")).trim())).toBe(await realpath(nodePath));
+    expect(nodeExecutableName((await readFile(join(fixture.captureDir, "exec-path"), "utf8")).trim())).toBe("node");
     expect((await readFile(join(fixture.captureDir, "args"), "utf8")).trim().split("\n")).toEqual([
       "install",
       "--no-tui",
@@ -52,7 +52,7 @@ describe("lazycodex bin wrapper", () => {
       env: {
         ...process.env,
         CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
       },
     });
 
@@ -77,7 +77,7 @@ describe("lazycodex bin wrapper", () => {
       env: {
         ...process.env,
         CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
       },
     });
 
@@ -102,7 +102,7 @@ describe("lazycodex bin wrapper", () => {
       env: {
         ...process.env,
         CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
+        PATH: `${fixture.fakeBinDir}:${process.env.PATH ?? ""}`,
       },
     });
 
@@ -133,6 +133,8 @@ async function createLazyCodexFixture(options: { packageName?: string; wrapperFi
   const wrapperFileName = options.wrapperFileName ?? "lazycodex";
   const wrapperBin = join(binDir, wrapperFileName);
   await cp(fileURLToPath(new URL("./oh-my-opencode.js", import.meta.url)), wrapperBin);
+  await cp(fileURLToPath(new URL("./lazycodex-local-claude.js", import.meta.url)), join(binDir, "lazycodex-local-claude.js"));
+  await cp(fileURLToPath(new URL("./lazycodex-local-claude-core.js", import.meta.url)), join(binDir, "lazycodex-local-claude-core.js"));
   if (wrapperFileName !== "lazycodex") {
     await symlink(wrapperFileName, join(binDir, "lazycodex"));
   }
@@ -166,6 +168,10 @@ async function createLazyCodexFixture(options: { packageName?: string; wrapperFi
 
 async function canonicalizePackageRootCapture(fixture: { readonly captureDir: string }): Promise<string> {
   return realpath((await readFile(join(fixture.captureDir, "wrapper-root"), "utf8")).trim());
+}
+
+function nodeExecutableName(execPath: string): string {
+  return basename(execPath).replace(/\.exe$/, "");
 }
 
 async function writePlatformPackages(root: string): Promise<void> {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -150,6 +150,37 @@ bunx oh-my-openagent run <message>
 
 ---
 
+## lazycodex local Claude reviewer
+
+The `lazycodex` and `lazycodex-ai` bin aliases include an optional local Claude
+reviewer lane. It uses the installed `claude -p` CLI session, removes
+`ANTHROPIC_API_KEY` from the child environment, and leaves account loading to
+the configured local Claude CLI session.
+
+### Usage
+
+```bash
+lazycodex claude-probe --json
+lazycodex claude-review --diff --task "Review this change" --json
+lazycodex claude-benchmark --task "Review this change" --test-command "git diff --check" --json
+lazycodex run --with-local-claude-review "Implement the requested change"
+```
+
+Claude review calls add `--permission-mode plan`, `--tools ""`, and
+`--no-session-persistence`. Multiple local Claude profiles can be selected with
+`--claude-config-dir` or with a best-effort round-robin pool:
+
+```bash
+export LAZYCODEX_CLAUDE_CONFIG_DIRS="$HOME/.claude-max-a:$HOME/.claude-max-b"
+```
+
+`claude-benchmark` compares deterministic local checks against the same checks
+plus a local Claude review. It is not a full A/B test of two independent coding
+sessions. The local Claude lane is not a Codex native subagent; it is an
+external reviewer process launched by the `lazycodex` wrapper.
+
+---
+
 ## get-local-version
 
 Shows local plugin version state and update status.


### PR DESCRIPTION
## Summary
- Add `lazycodex` / `lazycodex-ai` local Claude commands: `claude-probe`, `claude-review`, and `claude-benchmark`.
- Add `lazycodex run --with-local-claude-review` as a reviewer gate after a successful delegated run.
- Use the installed local `claude -p` CLI session while removing `ANTHROPIC_API_KEY` from the child environment.
- Add local Claude safety controls: `--permission-mode plan`, `--tools ""`, and `--no-session-persistence`.
- Include staged, unstaged, and bounded untracked regular-file content in review diffs while skipping untracked symlinks.
- Document profile selection through `--claude-config-dir` and `LAZYCODEX_CLAUDE_CONFIG_DIRS`.

## Notes
This is not a Codex native subagent implementation. It is an external reviewer process launched by the `lazycodex` wrapper so users can reuse a locally logged-in Claude CLI subscription without requiring an Anthropic API key.

`claude-benchmark` compares deterministic local checks against the same checks plus a local Claude review. It is not a full A/B test of two independent coding sessions.

## Verification
- `bun test bin/lazycodex-local-claude.test.ts bin/oh-my-opencode.test.ts bin/platform.test.ts` -> 36 pass, 0 fail.
- `node --check bin/oh-my-opencode.js && node --check bin/lazycodex-local-claude.js && node --check bin/lazycodex-local-claude-core.js` -> pass.
- `git diff --check` -> pass.
- `git diff --cached --check` -> pass.

## Not Tested
- Full repository Bun test/typecheck suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local Claude reviewer lane to `lazycodex`, enabling read‑only reviews via the installed `claude -p` CLI without using an API key. Introduces `claude-*` commands and an optional `run --with-local-claude-review` quality gate.

- **New Features**
  - New commands: `claude-probe`, `claude-review`, `claude-benchmark` (compares baseline checks vs checks + local review).
  - Run gate: `lazycodex run --with-local-claude-review` runs a review after a successful delegated run.
  - Uses the local Claude CLI session; strips `ANTHROPIC_API_KEY`; enforces `--permission-mode plan`, `--tools ""`, `--no-session-persistence`.
  - Diff input includes staged, unstaged, and small untracked files; skips untracked symlinks; applies truncation limits.
  - Profile selection via `--claude-config-dir` or round‑robin `LAZYCODEX_CLAUDE_CONFIG_DIRS`.
  - Wrapper updates route `lazycodex`/`lazycodex-ai` requests to the local lane when invoked; docs updated and tests added.

<sup>Written for commit bf8458ed80a19bd2972c7bcc8cd713e1e2c43854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

