### PR TITLE
fix(codex): set installer model defaults

### DIFF
--- a/packages/omo-codex/plugin/test/aggregate.test.mjs
+++ b/packages/omo-codex/plugin/test/aggregate.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const mcpPackageManifestPaths = ["../../lsp-tools-mcp/package.json", "../../ast-grep-mcp/package.json", "../../git-bash-mcp/package.json"];
+const mcpPackageManifestExists = await Promise.all(mcpPackageManifestPaths.map(exists));
 
 async function readJson(relativePath) {
 	return JSON.parse(await readFile(join(root, relativePath), "utf8"));
@@ -250,25 +252,29 @@ test("#given aggregate MCP config #when inspected #then code MCPs reference pack
 	assert.deepEqual(componentLocalMcpSources, []);
 });
 
-test("#given package-level MCP CLIs #when package metadata is inspected #then bin names use the omo prefix", async () => {
-	// given
-	const lspPackageJson = await readJson("../../lsp-tools-mcp/package.json");
-	const astGrepPackageJson = await readJson("../../ast-grep-mcp/package.json");
-	const gitBashPackageJson = await readJson("../../git-bash-mcp/package.json");
+test(
+	"#given package-level MCP CLIs #when package metadata is inspected #then bin names use the omo prefix",
+	{ skip: mcpPackageManifestExists.some((exists) => !exists) },
+	async () => {
+		// given
+		const [lspPackageJson, astGrepPackageJson, gitBashPackageJson] = await Promise.all(
+			mcpPackageManifestPaths.map((path) => readJson(path)),
+		);
 
-	// when
-	const binNames = [
-		...Object.keys(lspPackageJson.bin ?? {}),
-		...Object.keys(astGrepPackageJson.bin ?? {}),
-		...Object.keys(gitBashPackageJson.bin ?? {}),
-	].sort();
+		// when
+		const binNames = [
+			...Object.keys(lspPackageJson.bin ?? {}),
+			...Object.keys(astGrepPackageJson.bin ?? {}),
+			...Object.keys(gitBashPackageJson.bin ?? {}),
+		].sort();
 
-	// then
-	assert.deepEqual(binNames, ["omo-ast-grep", "omo-git-bash", "omo-lsp"]);
-	for (const name of binNames) {
-		assert.match(name, /^omo-/);
-	}
-});
+		// then
+		assert.deepEqual(binNames, ["omo-ast-grep", "omo-git-bash", "omo-lsp"]);
+		for (const name of binNames) {
+			assert.match(name, /^omo-/);
+		}
+	},
+);
 
 test("#given aggregate plugin build script #when inspected #then hook status and telemetry sync run before workspace builds", async () => {
 	// given

--- a/packages/omo-codex/scripts/install-config-reasoning.test.mjs
+++ b/packages/omo-codex/scripts/install-config-reasoning.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { updateCodexConfig } from "./install/config.mjs";
 
-test("#given empty Codex config #when script installer updates config #then sets default model and reasoning defaults", async () => {
+test("#given empty Codex config #when script installer updates config #then sets worker model and reasoning defaults", async () => {
 	// given
 	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-reasoning-"));
 	const configPath = join(root, "config.toml");
@@ -22,8 +22,8 @@ test("#given empty Codex config #when script installer updates config #then sets
 
 	// then
 	const content = await readFile(configPath, "utf8");
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.4"/);
+	assert.match(content, /model_context_window = 1000000/);
 	assert.match(content, /model_reasoning_effort = "high"/);
 	assert.match(content, /plan_mode_reasoning_effort = "xhigh"/);
 });
@@ -35,7 +35,7 @@ test("#given existing model and reasoning config #when script installer updates 
 	await writeFile(
 		configPath,
 		[
-			'model = "gpt-5.4"',
+			'model = "gpt-5.5"',
 			"model_context_window = 272000",
 			'model_reasoning_effort = "low"',
 			'plan_mode_reasoning_effort = "medium"',
@@ -61,11 +61,11 @@ test("#given existing model and reasoning config #when script installer updates 
 	assert.equal(content.match(/^model_context_window\s*=/gm)?.length, 1);
 	assert.equal(content.match(/^model_reasoning_effort\s*=/gm)?.length, 1);
 	assert.equal(content.match(/^plan_mode_reasoning_effort\s*=/gm)?.length, 1);
-	assert.match(content, /model = "gpt-5\.5"/);
-	assert.match(content, /model_context_window = 400000/);
+	assert.match(content, /model = "gpt-5\.4"/);
+	assert.match(content, /model_context_window = 1000000/);
 	assert.match(content, /model_reasoning_effort = "high"/);
 	assert.match(content, /plan_mode_reasoning_effort = "xhigh"/);
-	assert.doesNotMatch(content, /model = "gpt-5\.4"/);
+	assert.doesNotMatch(content, /model = "gpt-5\.5"/);
 	assert.doesNotMatch(content, /model_context_window = 272000/);
 	assert.doesNotMatch(content, /model_reasoning_effort = "low"/);
 	assert.doesNotMatch(content, /plan_mode_reasoning_effort = "medium"/);

--- a/packages/omo-codex/scripts/install/reasoning-config.mjs
+++ b/packages/omo-codex/scripts/install/reasoning-config.mjs
@@ -1,7 +1,7 @@
 import { replaceOrInsertRootSetting } from "./toml-editor.mjs";
 
-const DEFAULT_MODEL = "gpt-5.5";
-const DEFAULT_MODEL_CONTEXT_WINDOW = 400_000;
+const DEFAULT_MODEL = "gpt-5.4";
+const DEFAULT_MODEL_CONTEXT_WINDOW = 1_000_000;
 const DEFAULT_MODE_REASONING_EFFORT = "high";
 const PLAN_MODE_REASONING_EFFORT = "xhigh";
 

--- a/src/cli/install-codex/codex-config-reasoning.test.ts
+++ b/src/cli/install-codex/codex-config-reasoning.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path"
 import { updateCodexConfig } from "./codex-config-toml"
 
 describe("codex-config-reasoning", () => {
-  test("#given empty Codex config #when updating config #then sets default model and reasoning defaults", async () => {
+  test("#given empty Codex config #when updating config #then sets worker model and reasoning defaults", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-reasoning-"))
     const configPath = join(root, "config.toml")
@@ -24,8 +24,8 @@ describe("codex-config-reasoning", () => {
 
     // then
     const content = await readFile(configPath, "utf8")
-    expect(content).toContain('model = "gpt-5.5"')
-    expect(content).toContain("model_context_window = 400000")
+    expect(content).toContain('model = "gpt-5.4"')
+    expect(content).toContain("model_context_window = 1000000")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).toContain('plan_mode_reasoning_effort = "xhigh"')
   })
@@ -37,7 +37,7 @@ describe("codex-config-reasoning", () => {
     await writeFile(
       configPath,
       [
-        'model = "gpt-5.4"',
+        'model = "gpt-5.5"',
         "model_context_window = 272000",
         'model_reasoning_effort = "low"',
         'plan_mode_reasoning_effort = "medium"',
@@ -63,11 +63,11 @@ describe("codex-config-reasoning", () => {
     expect(content.match(/^model_context_window\s*=/gm)).toHaveLength(1)
     expect(content.match(/^model_reasoning_effort\s*=/gm)).toHaveLength(1)
     expect(content.match(/^plan_mode_reasoning_effort\s*=/gm)).toHaveLength(1)
-    expect(content).toContain('model = "gpt-5.5"')
-    expect(content).toContain("model_context_window = 400000")
+    expect(content).toContain('model = "gpt-5.4"')
+    expect(content).toContain("model_context_window = 1000000")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).toContain('plan_mode_reasoning_effort = "xhigh"')
-    expect(content).not.toContain('model = "gpt-5.4"')
+    expect(content).not.toContain('model = "gpt-5.5"')
     expect(content).not.toContain("model_context_window = 272000")
     expect(content).not.toContain('model_reasoning_effort = "low"')
     expect(content).not.toContain('plan_mode_reasoning_effort = "medium"')

--- a/src/cli/install-codex/codex-config-reasoning.ts
+++ b/src/cli/install-codex/codex-config-reasoning.ts
@@ -1,8 +1,8 @@
 import { replaceOrInsertRootSetting } from "./toml-section-editor"
 
 const DEFAULT_MODE_REASONING_EFFORT = "high"
-const DEFAULT_MODEL = "gpt-5.5"
-const DEFAULT_MODEL_CONTEXT_WINDOW = 400_000
+const DEFAULT_MODEL = "gpt-5.4"
+const DEFAULT_MODEL_CONTEXT_WINDOW = 1_000_000
 const PLAN_MODE_REASONING_EFFORT = "xhigh"
 
 export function ensureCodexReasoningConfig(config: string): string {


### PR DESCRIPTION
## Summary
Set Codex installer defaults to the worker model `gpt-5.4` with a 1,000,000 token context window while preserving high default reasoning and xhigh Plan-mode reasoning. Also hardens lazycodex aggregate compatibility checks around reviewer model defaults and MCP package metadata availability.

## Changes
- Add `model = "gpt-5.4"` and `model_context_window = 1000000` defaults to both Codex installer config paths.
- Extend root and script installer tests to cover fresh configs, stale model/context replacement, duplicate-key prevention, and adjacent `[features]` preservation.
- Assert reviewer agent prompts keep `gpt-5.5` plus `xhigh` reasoning and avoid retired `gpt-5.2` defaults.
- Keep aggregate MCP bin-name checks active when package manifests are present, with a guarded skip for sparse checkout/worktree environments.

## Testing
- `bun test src/cli/install-codex/codex-config-reasoning.test.ts packages/omo-codex/scripts/install-config-reasoning.test.mjs && node --test packages/omo-codex/plugin/test/aggregate.test.mjs` ✅
- `bun run typecheck` ✅
- `bun run test:codex` ✅
- `bun run build` ✅

## Related Issues
None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Codex installer defaults to `gpt-5.4` with a 1,000,000-token context window, keeping high default reasoning and xhigh Plan-mode reasoning. Also hardens aggregate compatibility checks and ulw-loop completion handling.

- **Bug Fixes**
  - Installer config: set `model = "gpt-5.4"` and `model_context_window = 1000000`; keep `model_reasoning_effort = "high"` and `plan_mode_reasoning_effort = "xhigh"`. Tests cover fresh configs, replacing stale values without duplicates, and preserving adjacent `[features]`.
  - MCP checks: validate CLI bin names only when package manifests exist; add a guarded skip for sparse checkout/worktree setups and use `fileURLToPath` in tests.
  - ulw-loop: accept aggregate completion when the active task’s Codex objective maps to the ulw-loop brief and evidence shows completion; adds a test for this path.
  - Reviewer/docs: keep reviewer on `gpt-5.5` with `xhigh`; remove references to retired `gpt-5.2` and `gpt-5.3-codex`.

<sup>Written for commit f6704aeb515c9d498f92bacd87858119a73872c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

