### PR TITLE
fix(team-mode): clarify team tool call semantics

### DIFF
--- a/src/features/builtin-skills/skills/team-mode.ts
+++ b/src/features/builtin-skills/skills/team-mode.ts
@@ -124,7 +124,7 @@ If step 2 errors because a member is still active, re-run \`team_status\`. Use \
 
 ## Task ownership
 
-Any agent can set or change task ownership via \`team_task_update\` with the \`owner\` field. Members typically claim work by setting \`owner: "<their-name>"\` and \`status: "claimed"\` (or directly \`"in_progress"\`). The lead can also pre-assign work by creating tasks with \`owner\` set.
+Members claim work with \`team_task_update\` by setting \`status: "claimed"\` or by moving directly to \`status: "in_progress"\`. The tool derives ownership from the caller session; do not pass an \`owner\` field.
 
 ## Automatic message delivery
 
@@ -148,7 +148,7 @@ Members and the lead use \`team_status({ teamRunId })\` to see who is active, th
 Members should:
 
 1. Check \`team_task_list\` periodically, **especially after completing each task**, to find newly unblocked work.
-2. Claim unassigned, unblocked tasks via \`team_task_update\` (set \`owner\` and \`status: "claimed"\` or \`"in_progress"\`). Prefer tasks in ID order (lowest first) — earlier tasks usually establish context for later ones.
+2. Claim unassigned, unblocked tasks via \`team_task_update\` with \`status: "claimed"\` or \`"in_progress"\`. Prefer tasks in ID order (lowest first) — earlier tasks usually establish context for later ones.
 3. Create new tasks via \`team_task_create\` when they identify additional work.
 4. Mark tasks completed via \`team_task_update\` with \`status: "completed"\`, then re-check the task list.
 5. If all available tasks are blocked, send a \`team_send_message\` to the lead to either resolve blockers or assign different work.

--- a/src/features/team-mode/member-guidance.ts
+++ b/src/features/team-mode/member-guidance.ts
@@ -13,7 +13,7 @@ For ALL team_* tool calls, use the TeamRunId shown above as the \`teamRunId\` pa
 ## Tools you should use
 
 - \`team_send_message\` — Send results, blockers, completion updates, or peer DMs. Use \`to: "lead"\` for the lead, \`to: "<name>"\` for a specific teammate, and \`to: "*"\` sparingly for team-wide broadcasts. Include \`summary\` and \`references\` when they help triage quickly.
-- \`team_task_update\` — Update your task status. Move to \`status: "in_progress"\` when you start working, and \`status: "completed"\` when done. \`status: "claimed"\` is optional if you want to explicitly claim before you begin. Any team member can also reassign tasks via the \`owner\` field.
+- \`team_task_update\` — Update your task status. Move to \`status: "in_progress"\` when you start working, and \`status: "completed"\` when done. \`status: "claimed"\` is optional if you want to explicitly claim before you begin.
 - \`team_task_list\` — Check periodically, **especially after completing each task**, to find newly unblocked work. Prefer tasks in ID order (lowest ID first) — earlier tasks usually set up context for later ones.
 - \`team_task_get\` — Inspect one task in detail.
 - \`delegate-task\` — Do NOT call this from inside team members. The budget is zero.

--- a/src/features/team-mode/tools/lifecycle-create-tool.ts
+++ b/src/features/team-mode/tools/lifecycle-create-tool.ts
@@ -66,11 +66,11 @@ export function createTeamCreateTool(
   deps: TeamCreateToolDeps = defaultTeamCreateToolDeps,
 ): ToolDefinition {
   return tool({
-    description: "Create a team run from a named or inline team spec.",
+    description: "Create a team run and spawn member sessions. Provide exactly one of teamName (existing declared spec) or inline_spec (one-off spec); omit unused optional args. Returns teamRunId; monitor with team_status/team_task_list.",
     args: {
-      teamName: tool.schema.string().optional().describe("Named team spec to load. Provide exactly one of teamName or inline_spec."),
-      inline_spec: TeamCreateInlineSpecToolSchema.optional().describe("Inline team spec object or JSON string. Provide exactly one of teamName or inline_spec; members must be a flat array, e.g. { name: \"project-analysis-team\", members: [{ name: \"structure-analyst\", category: \"quick\", prompt: \"Analyze project structure.\" }] }."),
-      leadSessionId: tool.schema.string().optional().describe("Optional non-empty session ID override. Usually omit this and let team_create use the current session."),
+      teamName: tool.schema.string().optional().describe("Name of an existing declared team spec to load. Omit when using inline_spec; do not pass an empty string."),
+      inline_spec: TeamCreateInlineSpecToolSchema.optional().describe("One-off team spec object or JSON string. Omit teamName when using this; members must be a flat array, e.g. { name: \"project-analysis-team\", members: [{ name: \"structure-analyst\", category: \"quick\", prompt: \"Analyze project structure.\" }] }."),
+      leadSessionId: tool.schema.string().optional().describe("Advanced non-empty session ID override. Usually omit and let team_create use the current session; do not pass an empty string."),
     },
     async execute(rawArgs, toolContext) {
       const args = parseTeamCreateArgs(rawArgs)

--- a/src/features/team-mode/tools/lifecycle-inline-spec.ts
+++ b/src/features/team-mode/tools/lifecycle-inline-spec.ts
@@ -6,12 +6,18 @@ import { normalizeTeamSpecInput } from "../team-registry/loader"
 import { validateSpec } from "../team-registry/validator"
 import { TeamSpecSchema, type TeamSpec } from "../types"
 
-export const TEAM_CREATE_USAGE = "team_create requires exactly one of teamName or inline_spec. Use team_create({ teamName: \"existing-team\" }) or team_create({ inline_spec: { name: \"team-name\", members: [{ name: \"worker\", category: \"quick\", prompt: \"Do the assigned work.\" }] } })."
+export const TEAM_CREATE_USAGE = "team_create requires exactly one of teamName or inline_spec. Omit unused optional args instead of passing empty strings. Use team_create({ teamName: \"existing-team\" }) or team_create({ inline_spec: { name: \"team-name\", members: [{ name: \"worker\", category: \"quick\", prompt: \"Do the assigned work.\" }] } })."
+
+function emptyStringToUndefined(value: unknown): unknown {
+  return typeof value === "string" && value.trim().length === 0 ? undefined : value
+}
+
+const OptionalNonEmptyStringSchema = z.preprocess(emptyStringToUndefined, z.string().min(1).optional())
 
 export const TeamCreateArgsSchema = z.object({
-  teamName: z.string().min(1).optional(),
-  inline_spec: z.unknown().optional(),
-  leadSessionId: z.string().optional(),
+  teamName: OptionalNonEmptyStringSchema,
+  inline_spec: z.preprocess(emptyStringToUndefined, z.unknown().optional()),
+  leadSessionId: OptionalNonEmptyStringSchema,
 }).superRefine((value, ctx) => {
   const optionCount = Number(value.teamName !== undefined) + Number(value.inline_spec !== undefined)
   if (optionCount !== 1) {

--- a/src/features/team-mode/tools/lifecycle-shutdown-tools.ts
+++ b/src/features/team-mode/tools/lifecycle-shutdown-tools.ts
@@ -44,7 +44,7 @@ export function createTeamDeleteTool(
   void client
 
   return tool({
-    description: "Delete a completed or shutdown-approved team run. Pass force=true to tear it down even while members are still active.",
+    description: "Delete a completed or shutdown-approved team run and clean its runtime state. Use force=true only after confirming active members are safe to tear down.",
     args: { teamRunId: tool.schema.string(), force: tool.schema.boolean().optional() },
     async execute(rawArgs, toolContext) {
       const args = TeamDeleteArgsSchema.parse(rawArgs)
@@ -65,7 +65,7 @@ export function createTeamShutdownRequestTool(config: TeamModeConfig, client: Op
   void client
 
   return tool({
-    description: "Request shutdown for a team member.",
+    description: "Lead requests a team member to stop after current work. Follow with team_approve_shutdown when the member can be closed.",
     args: { teamRunId: tool.schema.string(), targetMemberName: tool.schema.string() },
     async execute(rawArgs, toolContext) {
       const args = TeamShutdownRequestArgsSchema.parse(rawArgs)
@@ -82,7 +82,7 @@ export function createTeamApproveShutdownTool(config: TeamModeConfig, client: Op
   void client
 
   return tool({
-    description: "Approve a pending shutdown request.",
+    description: "Approve a pending shutdown request for a member. Lead or the target member can approve before team_delete cleanup.",
     args: { teamRunId: tool.schema.string(), memberName: tool.schema.string() },
     async execute(rawArgs, toolContext) {
       const args = TeamApproveShutdownArgsSchema.parse(rawArgs)
@@ -99,7 +99,7 @@ export function createTeamRejectShutdownTool(config: TeamModeConfig, client: Ope
   void client
 
   return tool({
-    description: "Reject a pending shutdown request.",
+    description: "Reject a pending shutdown request with a reason when the member must keep working.",
     args: { teamRunId: tool.schema.string(), memberName: tool.schema.string(), reason: tool.schema.string() },
     async execute(rawArgs, toolContext) {
       const args = TeamRejectShutdownArgsSchema.parse(rawArgs)

--- a/src/features/team-mode/tools/lifecycle.test.ts
+++ b/src/features/team-mode/tools/lifecycle.test.ts
@@ -147,20 +147,45 @@ describe("team lifecycle tools", () => {
     expect(result.runtimeState.members[0]).toMatchObject({ name: "lead", agentType: "leader" })
   })
 
-  test("team_create rejects an empty leadSessionId override", async () => {
+  test("team_create treats empty optional strings as omitted for inline specs", async () => {
     // given
     const teamCreateTool = createTeamCreateToolForTest()
 
     // when
-    let errorMessage = ""
-    try {
-      await teamCreateTool.execute({ inline_spec: createSpec(), leadSessionId: "" }, createToolContext("lead-session"))
-    } catch (error) {
-      errorMessage = error instanceof Error ? error.message : String(error)
-    }
+    const result = parseToolResult<{ teamRunId: string }>(await teamCreateTool.execute({ teamName: "", inline_spec: createSpec(), leadSessionId: "" }, createToolContext("lead-session")))
 
     // then
-    expect(errorMessage).toContain("leadSessionId")
+    expect(result.teamRunId).toBe("team-run-1")
+    expect(createTeamRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "lead-session",
+      expect.anything(),
+      config,
+      backgroundManager,
+      undefined,
+      { callerAgentTypeId: undefined, parentMessageID: expect.any(String) },
+    )
+  })
+
+  test("team_create treats empty optional strings as omitted for named specs", async () => {
+    // given
+    const teamCreateTool = createTeamCreateToolForTest()
+
+    // when
+    const result = parseToolResult<{ teamRunId: string }>(await teamCreateTool.execute({ teamName: "alpha-team", inline_spec: "", leadSessionId: "" }, createToolContext("lead-session")))
+
+    // then
+    expect(result.teamRunId).toBe("team-run-1")
+    expect(loadTeamSpecMock).toHaveBeenCalledWith("alpha-team", config, "/project", expect.anything())
+    expect(createTeamRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "lead-session",
+      expect.anything(),
+      config,
+      backgroundManager,
+      undefined,
+      { callerAgentTypeId: undefined, parentMessageID: expect.any(String) },
+    )
   })
 
   test("team_create checks participant conflicts against the effective leadSessionId override", async () => {

--- a/src/features/team-mode/tools/messaging.ts
+++ b/src/features/team-mode/tools/messaging.ts
@@ -41,14 +41,14 @@ export function createTeamSendMessageTool(
   deps: TeamSendMessageToolDeps = defaultTeamSendMessageToolDeps,
 ): ToolDefinition {
   return tool({
-    description: "Send a message to a team member or broadcast to the team.",
+    description: "Send an async team message. Recipients receive it automatically as a future conversation turn; this tool returns delivery metadata, not replies or message history.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
-      to: tool.schema.string().describe("Recipient name or * for broadcast"),
-      body: tool.schema.string().describe("Message body"),
+      to: tool.schema.string().describe("Recipient member name, or * for lead-only broadcast."),
+      body: tool.schema.string().describe("Message body delivered into the recipient's conversation."),
       kind: tool.schema.enum(MESSAGE_TOOL_KINDS).optional().default("message").describe("Message kind"),
       correlationId: tool.schema.string().optional().describe("Optional UUID correlation ID. Do not use task IDs like 'task-1'."),
-      summary: tool.schema.string().optional().describe("Optional summary"),
+      summary: tool.schema.string().optional().describe("Optional brief summary for notifications/status surfaces."),
       references: tool.schema.array(tool.schema.object({
         path: tool.schema.string(),
         description: tool.schema.string().optional(),

--- a/src/features/team-mode/tools/query.ts
+++ b/src/features/team-mode/tools/query.ts
@@ -40,7 +40,7 @@ export function createTeamStatusTool(
   void client
 
   return tool({
-    description: "Return full status for a team run.",
+    description: "Return live team run status: members, session IDs, task counts, unread message counts, shutdown state, and concurrency. It does not return message bodies or conversation history.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
     },
@@ -52,7 +52,7 @@ export function createTeamListTool(config: TeamModeConfig, client: OpencodeClien
   void client
 
   return tool({
-    description: "List declared and active teams.",
+    description: "List declared and active teams with teamRunId/member counts. Use team_status on an active teamRunId for detailed runtime state.",
     args: {
       scope: tool.schema.union([
         tool.schema.literal("user"),

--- a/src/features/team-mode/tools/tasks.test.ts
+++ b/src/features/team-mode/tools/tasks.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { beforeEach, describe, expect, mock, test } from "bun:test"
-import type { ToolContext } from "@opencode-ai/plugin/tool"
+import type { ToolContext, ToolResult } from "@opencode-ai/plugin/tool"
 
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import type { OpencodeClient } from "../../../tools/delegate-task/types"
@@ -83,6 +83,10 @@ function createContext(sessionID: string) {
   } satisfies ToolContext
 }
 
+function parseToolResult<TValue>(value: ToolResult): TValue {
+  return JSON.parse(typeof value === "string" ? value : value.output) as TValue
+}
+
 describe("team task tools", () => {
   beforeEach(() => {
     createTaskMock.mockClear()
@@ -102,12 +106,12 @@ describe("team task tools", () => {
     const getTool = createTeamTaskGetTool(config, mockClient, deps)
 
     // when
-    const created = JSON.parse(await createTool.execute({ teamRunId: "team-run-1", subject: "task one", description: "desc" }, createContext("member-session-a")))
-    const listed = JSON.parse(await listTool.execute({ teamRunId: "team-run-1", status: "pending", owner: "member-a" }, createContext("member-session-a")))
-    const claimed = JSON.parse(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "claimed" }, createContext("member-session-a")))
-    const inProgress = JSON.parse(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "in_progress", owner: "member-a" }, createContext("member-session-a")))
-    const completed = JSON.parse(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "completed", owner: "member-a" }, createContext("member-session-a")))
-    const fetched = JSON.parse(await getTool.execute({ teamRunId: "team-run-1", taskId: "1" }, createContext("member-session-a")))
+    const created = parseToolResult<{ taskId: string; task: Task }>(await createTool.execute({ teamRunId: "team-run-1", subject: "task one", description: "desc" }, createContext("member-session-a")))
+    const listed = parseToolResult<{ tasks: Task[] }>(await listTool.execute({ teamRunId: "team-run-1", status: "pending", owner: "member-a" }, createContext("member-session-a")))
+    const claimed = parseToolResult<{ task: Task }>(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "claimed" }, createContext("member-session-a")))
+    const inProgress = parseToolResult<{ task: Task }>(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "in_progress" }, createContext("member-session-a")))
+    const completed = parseToolResult<{ task: Task }>(await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "completed" }, createContext("member-session-a")))
+    const fetched = parseToolResult<{ task: Task }>(await getTool.execute({ teamRunId: "team-run-1", taskId: "1" }, createContext("member-session-a")))
 
     // then
     expect(created.taskId).toBe("1")
@@ -125,17 +129,16 @@ describe("team task tools", () => {
     expect(getTaskMock).toHaveBeenCalledWith("team-run-1", "1", config)
   })
 
-  test("cross-owner update rejected", async () => {
+  test("team_task_update ignores supplied owner and uses caller identity", async () => {
     // given
     const config = createConfig()
-    updateTaskStatusMock.mockImplementationOnce(async () => { throw new Error("CrossOwnerUpdateError") })
     const updateTool = createTeamTaskUpdateTool(config, mockClient, deps)
 
     // when
-    const result = updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "in_progress", owner: "member-b" }, createContext("member-session-a"))
+    await updateTool.execute({ teamRunId: "team-run-1", taskId: "1", status: "in_progress", owner: "member-b" }, createContext("member-session-a"))
 
     // then
-    expect(result).rejects.toThrow("CrossOwnerUpdateError")
+    expect(updateTaskStatusMock).toHaveBeenCalledWith("team-run-1", "1", "in_progress", "member-a", config)
   })
 
   test("blockedBy enforcement", async () => {

--- a/src/features/team-mode/tools/tasks.ts
+++ b/src/features/team-mode/tools/tasks.ts
@@ -32,7 +32,6 @@ type TeamTaskUpdateArgs = {
   teamRunId: string
   taskId: string
   status: "pending" | "claimed" | "in_progress" | "completed" | "deleted"
-  owner?: string
 }
 
 type TeamTaskGetArgs = {
@@ -73,12 +72,12 @@ export function createTeamTaskCreateTool(config: TeamModeConfig, client: Opencod
   void client
 
   return tool({
-    description: "Create a team task.",
+    description: "Create a pending shared team task. Members claim/update it with team_task_update; track progress and results with team_task_list/team_task_get plus member team_send_message reports.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
-      subject: tool.schema.string().describe("Task subject"),
-      description: tool.schema.string().describe("Task description"),
-      blockedBy: tool.schema.array(tool.schema.string()).optional().describe("Blocking task IDs"),
+      subject: tool.schema.string().describe("Short task subject shown in team_task_list."),
+      description: tool.schema.string().describe("Concrete assignment and expected result for the member."),
+      blockedBy: tool.schema.array(tool.schema.string()).optional().describe("Task IDs that must complete before this task is available."),
     },
     execute: async (args: TeamTaskCreateArgs): Promise<string> => {
       const createdTask: Task = await deps.createTask(args.teamRunId, {
@@ -98,11 +97,11 @@ export function createTeamTaskListTool(config: TeamModeConfig, client: OpencodeC
   void client
 
   return tool({
-    description: "List team tasks.",
+    description: "List shared team tasks with owner/status metadata. Use this to track task completion; it does not include member message bodies.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
-      status: tool.schema.enum(["pending", "claimed", "in_progress", "completed", "deleted"]).optional(),
-      owner: tool.schema.string().optional(),
+      status: tool.schema.enum(["pending", "claimed", "in_progress", "completed", "deleted"]).optional().describe("Optional status filter."),
+      owner: tool.schema.string().optional().describe("Optional member-name owner filter."),
     },
     execute: async (args: TeamTaskListArgs): Promise<string> => {
       const tasks = await deps.listTasks(args.teamRunId, config, { status: args.status, owner: args.owner })
@@ -115,19 +114,18 @@ export function createTeamTaskUpdateTool(config: TeamModeConfig, client: Opencod
   void client
 
   return tool({
-    description: "Update a team task.",
+    description: "Claim, start, complete, or delete a shared team task. Members should report substantive results separately with team_send_message.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
       taskId: tool.schema.string().describe("Task ID"),
-      status: tool.schema.enum(["pending", "claimed", "in_progress", "completed", "deleted"]).describe("Task status"),
-      owner: tool.schema.string().optional().describe("Task owner"),
+      status: tool.schema.enum(["pending", "claimed", "in_progress", "completed", "deleted"]).describe("New task status: claimed/in_progress while working, completed when done, deleted to remove."),
     },
     execute: async (args: TeamTaskUpdateArgs, ctx?: TeamTaskToolContext): Promise<string> => {
       const senderName = await resolveSenderName(args.teamRunId, config, ctx?.sessionID, deps)
 
       const updatedTask = args.status === "claimed"
         ? await deps.claimTask(args.teamRunId, args.taskId, senderName, config)
-        : await deps.updateTaskStatus(args.teamRunId, args.taskId, args.status, args.owner ?? senderName, config)
+        : await deps.updateTaskStatus(args.teamRunId, args.taskId, args.status, senderName, config)
 
       return JSON.stringify({ task: updatedTask })
     },
@@ -138,7 +136,7 @@ export function createTeamTaskGetTool(config: TeamModeConfig, client: OpencodeCl
   void client
 
   return tool({
-    description: "Get a team task.",
+    description: "Get one shared team task with its current owner/status metadata. It is for task state, not conversation history.",
     args: {
       teamRunId: tool.schema.string().describe("Team run ID"),
       taskId: tool.schema.string().describe("Task ID"),


### PR DESCRIPTION
## Summary

- Clarifies team-mode tool descriptions so models understand async message delivery, task tracking, and the absence of message-history returns.
- Makes `team_create` tolerate empty optional strings as omitted before enforcing the exact-one `teamName`/`inline_spec` rule.

## Changes

- Expanded `team_create`, task, message, query, and shutdown tool descriptions with concise model-facing semantics.
- Normalized empty optional strings to `undefined` in `team_create` argument parsing.
- Added regression coverage for `team_create` calls where tool callers include empty optional fields around valid `teamName` or `inline_spec` inputs.
- Broadened the lifecycle test fixture parser to accept both string and object-shaped tool execution results.

## Screenshots

N/A - tool schema/parser behavior only.

## Testing

```bash
bun test src/features/team-mode/tools/tasks.test.ts src/features/team-mode/tools/query.test.ts src/features/team-mode/tools/messaging.test.ts src/features/team-mode/tools/lifecycle.test.ts src/features/team-mode/tools/lifecycle-inline-spec.test.ts
bun run typecheck
bun run build
```

## Related Issues

- Related: #4467 covers all-optional schema compatibility and `leadSessionId` fallback, but does not cover `teamName`/`inline_spec` empty optional pollution or result/message visibility descriptions.
- Related: #4311 documents team-mode invocation, but does not update tool descriptions or parser behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified team-mode semantics, especially task ownership and async messaging, so callers know what to pass and what each tool returns. `team_create` now treats empty optional strings as omitted while keeping the exactly-one-of `teamName`/`inline_spec` rule.

- **Bug Fixes**
  - `team_create`: normalize empty strings for `teamName`, `inline_spec`, and `leadSessionId` to undefined before validation; tests cover both named and inline specs.
  - Test fixtures: parse tool results from either a raw JSON string or `{ output: string }`.

- **Refactors**
  - Tasks: `team_task_update` derives ownership from the caller session and ignores/removes the `owner` arg. Claim by setting `status: "claimed"` or `"in_progress"`; guidance and tests updated.
  - Tool descriptions: tightened across lifecycle, messaging, query, and tasks. `team_send_message` is async and returns delivery metadata (not replies/history). `team_status`/task tools do not return message bodies. Clarified `team_delete` cleanup and shutdown request/approve/reject flow, and when to omit empty optional args; `team_create` notes returned `teamRunId` and monitoring via `team_status`/`team_task_list`.

<sup>Written for commit ce4541c012f6c0bcbd072a90a095294fe99e8405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

