### PR TITLE
DRAFT feat(consensus): add multi-lineage consensus tool

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6441,6 +6441,76 @@
       ],
       "additionalProperties": false
     },
+    "consensus": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "default_voter_count": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 7
+        },
+        "default_voter_lineages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "voter_timeout_ms": {
+          "type": "integer",
+          "minimum": 10000,
+          "maximum": 9007199254740991
+        },
+        "voter_reasoning_effort": {
+          "type": "string",
+          "enum": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ]
+        },
+        "pre_question_gate": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "voter_count": {
+              "type": "integer",
+              "minimum": 2,
+              "maximum": 7
+            }
+          },
+          "additionalProperties": false
+        },
+        "post_test_gate": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "command_patterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "voter_count": {
+              "type": "integer",
+              "minimum": 2,
+              "maximum": 7
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "keyword_detector": {
       "type": "object",
       "properties": {

--- a/src/agents/dynamic-agent-core-sections.ts
+++ b/src/agents/dynamic-agent-core-sections.ts
@@ -170,6 +170,38 @@ Briefly announce "Consulting Oracle for [reason]" before invocation.
 </Oracle_Usage>`
 }
 
+export function buildConsensusSection(tools: AvailableTool[]): string {
+  const hasConsensus = tools.some((tool) => tool.name === "consensus")
+  if (!hasConsensus) {
+    return ""
+  }
+
+  return `<Consensus_Usage>
+## Consensus - Multi-Lineage Voter Panel
+
+The \`consensus\` tool spawns N voters (default 3) from DIFFERENT model families (Anthropic / OpenAI / Google / open-source), gives each the same question in parallel, and returns their positions to YOU. You are the synthesizer: read each position, find agreement vs disagreement, and decide. It is restricted to the main agent (subagents cannot call it).
+
+### WHEN to Consult:
+
+- High-stakes architecture or design decisions where one model's blind spot could be costly.
+- Validating analyzed or extracted data before you trust it (does an independent panel reach the same reading?).
+- Interpreting ambiguous test output or verifying that a fix actually resolves the issue.
+- Any irreversible or expensive call where a second and third independent opinion materially de-risks the decision.
+
+### WHEN NOT to Consult:
+
+- Trivial, reversible, or low-stakes choices (naming, formatting, obvious fixes).
+- Things you can determine directly from code you have already read.
+- As a substitute for Oracle on deep debugging - Oracle is the single high-IQ specialist; consensus is a diversity-of-lineages panel. Use Oracle for hard reasoning, consensus for cross-model agreement on a decision.
+
+### How to Synthesize:
+
+- If voters agree: proceed with the agreed position.
+- If voters disagree materially: present all positions to the user; do not silently pick one and discard the dissent.
+- Treat a single-voter (advisory) result as one extra opinion, not a true consensus.
+</Consensus_Usage>`
+}
+
 export function buildFrontendGuidanceSection(
   categories: AvailableCategory[],
 ): string {

--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -15,6 +15,7 @@ export {
   buildLibrarianSection,
   buildDelegationTable,
   buildOracleSection,
+  buildConsensusSection,
   buildFrontendGuidanceSection,
   buildNonClaudePlannerSection,
   buildParallelDelegationSection,

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -46,6 +46,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildConsensusSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   buildParallelDelegationSection,
@@ -76,6 +77,7 @@ function buildDynamicSisyphusPrompt(
   );
   const delegationTable = buildDelegationTable(availableAgents);
   const oracleSection = buildOracleSection(availableAgents);
+  const consensusSection = buildConsensusSection(availableTools);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
   const parallelDelegationSection = buildParallelDelegationSection(model, availableCategories);
@@ -422,6 +424,8 @@ If verification fails:
 </Behavior_Instructions>
 
 ${oracleSection}
+
+${consensusSection}
 
 ${taskManagementSection}
 

--- a/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/src/agents/sisyphus/claude-opus-4-7.ts
@@ -30,6 +30,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildConsensusSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   buildParallelDelegationSection,
@@ -61,6 +62,7 @@ export function buildClaudeOpus47SisyphusPrompt(
   );
   const delegationTable = buildDelegationTable(availableAgents);
   const oracleSection = buildOracleSection(availableAgents);
+  const consensusSection = buildConsensusSection(availableTools);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
   const parallelDelegationSection = buildParallelDelegationSection(model, availableCategories);
@@ -403,6 +405,8 @@ If verification fails: fix issues YOU caused. Do NOT fix pre-existing issues unl
 </behavior_instructions>
 
 ${oracleSection}
+
+${consensusSection}
 
 ${taskManagementSection}
 

--- a/src/agents/sisyphus/default.ts
+++ b/src/agents/sisyphus/default.ts
@@ -17,6 +17,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildConsensusSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   buildParallelDelegationSection,
@@ -157,6 +158,7 @@ export function buildDefaultSisyphusPrompt(
   );
   const delegationTable = buildDelegationTable(availableAgents);
   const oracleSection = buildOracleSection(availableAgents);
+  const consensusSection = buildConsensusSection(availableTools);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
   const parallelDelegationSection = buildParallelDelegationSection(model, availableCategories);
@@ -483,6 +485,8 @@ If verification fails:
 </Behavior_Instructions>
 
 ${oracleSection}
+
+${consensusSection}
 
 ${taskManagementSection}
 

--- a/src/agents/sisyphus/gpt-5-4.ts
+++ b/src/agents/sisyphus/gpt-5-4.ts
@@ -37,6 +37,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildConsensusSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   buildAntiDuplicationSection,
@@ -100,6 +101,7 @@ export function buildGpt54SisyphusPrompt(
   );
   const delegationTable = buildDelegationTable(availableAgents);
   const oracleSection = buildOracleSection(availableAgents);
+  const consensusSection = buildConsensusSection(availableTools);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
   const nonClaudePlannerSection = buildNonClaudePlannerSection(model);
@@ -400,6 +402,9 @@ This preserves full context, avoids repeated exploration, saves 70%+ tokens.
 ${oracleSection ? `### Oracle
 
 ${oracleSection}` : ""}
+${consensusSection ? `### Consensus
+
+${consensusSection}` : ""}
 </delegation>`;
 
   const styleBlock = `<style>

--- a/src/agents/sisyphus/gpt-5-5.ts
+++ b/src/agents/sisyphus/gpt-5-5.ts
@@ -265,6 +265,12 @@ When you consult Oracle, announce it to the user in one line: "Consulting Oracle
 
 Oracle runs in the background. After you consult Oracle, do not ship an implementation that depends on its answer before the result arrives. The system notifies you when Oracle completes. Never poll, never cancel, never fabricate what Oracle would have said.
 
+## Consensus consultation
+
+The \`consensus\` tool is a multi-lineage voter panel. It spawns several voters from different model families in parallel, gives each the same question, and returns their positions to you to synthesize. Where Oracle is one high-reasoning specialist, consensus is a diversity-of-models check: use it when a decision is high-stakes and one model's blind spot would be costly, when you need to validate analyzed or extracted data against independent readings, when interpreting ambiguous test output or confirming a fix, or before any irreversible or expensive call where a second and third independent opinion materially de-risks the outcome.
+
+Consensus is the wrong tool for trivial or reversible choices, anything you can determine directly from code you have already read, and deep debugging that belongs to Oracle. When voters agree, proceed with the agreed position. When they disagree materially, present all positions to the user rather than silently picking one. A single-voter result is advisory, not a true consensus.
+
 ## Validating your work
 
 If the codebase has tests or the ability to build and run, use them. Start as specific to your changes as possible, then widen as confidence grows. If there's no test for the code you changed and the codebase has a logical place to add one, you may. Do not add tests to codebases with no tests.

--- a/src/agents/sisyphus/kimi-k2-6.ts
+++ b/src/agents/sisyphus/kimi-k2-6.ts
@@ -43,6 +43,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildConsensusSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   buildAntiDuplicationSection,
@@ -104,6 +105,7 @@ export function buildKimiK26SisyphusPrompt(
   );
   const delegationTable = buildDelegationTable(availableAgents);
   const oracleSection = buildOracleSection(availableAgents);
+  const consensusSection = buildConsensusSection(availableTools);
   const hardBlocks = buildHardBlocksSection();
   const antiPatterns = buildAntiPatternsSection();
   const nonClaudePlannerSection = buildNonClaudePlannerSection(model);
@@ -475,6 +477,9 @@ This preserves full context, avoids repeated exploration, saves 70%+ tokens.
 ${oracleSection ? `### Oracle
 
 ${oracleSection}` : ""}
+${consensusSection ? `### Consensus
+
+${consensusSection}` : ""}
 </delegation>`;
 
   const styleBlock = `<style>

--- a/src/cli/install-codex/install-codex-project-local-cleanup.test.ts
+++ b/src/cli/install-codex/install-codex-project-local-cleanup.test.ts
@@ -140,5 +140,5 @@ describe("install-codex project-local cleanup", () => {
     expect(logs.some((message) => message.includes("Skipped project-local Codex cleanup"))).toBe(true)
     expect(logs.some((message) => message.includes("not a directory"))).toBe(true)
     expect((await stat(join(codexHome, "config.toml"))).isFile()).toBe(true)
-  })
+  }, { timeout: 15_000 })
 })

--- a/src/config/schema/consensus.ts
+++ b/src/config/schema/consensus.ts
@@ -1,0 +1,45 @@
+import { z } from "zod"
+
+/**
+ * Default voter lineages. Spans frontier closed-source labs + open-weights to maximize blind-spot coverage
+ * across model families. The synthesizer is the calling agent itself (no separate synthesizer agent),
+ * so voter lineages should typically differ from the calling model's lineage.
+ */
+export const DEFAULT_VOTER_LINEAGES = ["claude-opus", "gpt", "gemini-flash", "kimi"] as const
+
+const PreQuestionGateConfigSchema = z.object({
+  /** Whether the pre-question gate is enabled (default: true). When enabled, agent attempts to ask the user are intercepted and consensus runs first to either resolve internally or let the question through. */
+  enabled: z.boolean().optional(),
+  /** Voter count for pre-question consensus (default: 3, min: 2, max: 7) */
+  voter_count: z.number().int().min(2).max(7).optional(),
+})
+
+const PostTestGateConfigSchema = z.object({
+  /** Whether the post-test gate is enabled (default: true). When enabled, consensus runs on test output to validate pass/fail interpretation. */
+  enabled: z.boolean().optional(),
+  /** Regex patterns matched against bash commands to detect test runs. Defaults to common test runners (npm test, bun test, pytest, cargo test, go test, jest, vitest, mocha, rspec, phpunit, gradle test). */
+  command_patterns: z.array(z.string()).optional(),
+  /** Voter count for post-test consensus (default: 3) */
+  voter_count: z.number().int().min(2).max(7).optional(),
+})
+
+export const ConsensusConfigSchema = z.object({
+  /** Whether the consensus subsystem is enabled at all (default: true). When false, the consensus tool is unregistered and gates are no-ops. */
+  enabled: z.boolean().optional(),
+  /** Default voter count when not specified per-call (default: 3) */
+  default_voter_count: z.number().int().min(2).max(7).optional(),
+  /** Default voter lineages (model families) ordered by preference. Used when no explicit lineage list is passed. */
+  default_voter_lineages: z.array(z.string()).optional(),
+  /** Per-voter timeout in milliseconds (default: 120000 = 2 minutes). Voters that exceed this are recorded as timed-out positions. */
+  voter_timeout_ms: z.number().int().min(10000).optional(),
+  /** Reasoning effort each voter runs at (default: "high"). Consensus is used for high-stakes decisions, so voters reason deliberately by default. Lower it to reduce cost/latency. */
+  voter_reasoning_effort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+  /** Pre-question consensus gate: intercepts agent attempts to ask the user a question. */
+  pre_question_gate: PreQuestionGateConfigSchema.optional(),
+  /** Post-test consensus gate: runs consensus on test output after test commands execute. */
+  post_test_gate: PostTestGateConfigSchema.optional(),
+})
+
+export type ConsensusConfig = z.infer<typeof ConsensusConfigSchema>
+export type PreQuestionGateConfig = z.infer<typeof PreQuestionGateConfigSchema>
+export type PostTestGateConfig = z.infer<typeof PostTestGateConfigSchema>

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -21,6 +21,7 @@ import { ModelCapabilitiesConfigSchema } from "./model-capabilities"
 import { RalphLoopConfigSchema } from "./ralph-loop"
 import { RuntimeFallbackConfigSchema } from "./runtime-fallback"
 import { TeamModeConfigSchema } from "./team-mode"
+import { ConsensusConfigSchema } from "./consensus"
 import { SkillsConfigSchema } from "./skills"
 import { SisyphusConfigSchema } from "./sisyphus"
 import { SisyphusAgentConfigSchema } from "./sisyphus-agent"
@@ -80,6 +81,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   /** Plugin i18n settings */
   i18n: I18nConfigSchema.optional(),
   team_mode: TeamModeConfigSchema.optional(),
+  consensus: ConsensusConfigSchema.optional(),
   /** Per-keyword disable list for the keyword-detector transform hook. Allowed values: "ultrawork", "search", "analyze", "team". */
   keyword_detector: KeywordDetectorConfigSchema.optional(),
   babysitting: BabysittingConfigSchema.optional(),

--- a/src/features/consensus/consensus-engine.test.ts
+++ b/src/features/consensus/consensus-engine.test.ts
@@ -1,0 +1,77 @@
+const { describe, expect, test } = require("bun:test")
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { runConsensus } from "./consensus-engine"
+import type { ResolvedVoterCandidate, VoterPosition } from "./types"
+
+describe("runConsensus", () => {
+  test("#given a GPT caller #when consensus selects voters #then GPT lineage voters are excluded", async () => {
+    const spawned: ResolvedVoterCandidate[] = []
+
+    const result = await runConsensus(
+      unsafeTestValue<PluginInput>({ client: {} }),
+      {
+        prompt: "Pick an architecture.",
+        callerModel: "openai/gpt-5.5",
+        count: 3,
+        parentSessionID: "parent",
+      },
+      undefined,
+      {
+        getConnectedProviders: async () => ["openai", "anthropic", "google"],
+        fetchAvailableModels: async () => new Set([
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4-7",
+          "google/gemini-3.1-pro",
+        ]),
+        spawnVoter: async (_ctx, args): Promise<VoterPosition> => {
+          spawned.push(args.candidate)
+          return createVoterPosition(args.candidate, "position")
+        },
+      },
+    )
+
+    expect(spawned.map(candidate => candidate.lineage)).toEqual(["claude-opus", "gemini-flash"])
+    expect(result.advisoryOnly).toBe(false)
+  })
+
+  test("#given one empty voter response #when consensus classifies the result #then whitespace is not usable consensus", async () => {
+    const result = await runConsensus(
+      unsafeTestValue<PluginInput>({ client: {} }),
+      {
+        prompt: "Interpret test output.",
+        count: 2,
+        parentSessionID: "parent",
+      },
+      undefined,
+      {
+        getConnectedProviders: async () => ["openai", "anthropic"],
+        fetchAvailableModels: async () => new Set([
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4-7",
+        ]),
+        spawnVoter: async (_ctx, args): Promise<VoterPosition> => (
+          args.candidate.lineage === "gpt"
+            ? createVoterPosition(args.candidate, "   ")
+            : createVoterPosition(args.candidate, "usable position")
+        ),
+      },
+    )
+
+    expect(result.voters).toHaveLength(2)
+    expect(result.advisoryOnly).toBe(true)
+  })
+})
+
+function createVoterPosition(candidate: ResolvedVoterCandidate, text: string): VoterPosition {
+  return {
+    lineage: candidate.lineage,
+    model: candidate.modelID,
+    providerID: candidate.providerID,
+    variant: candidate.variant,
+    status: "ok",
+    text,
+    durationMs: 1,
+  }
+}

--- a/src/features/consensus/consensus-engine.ts
+++ b/src/features/consensus/consensus-engine.ts
@@ -1,0 +1,125 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { ConsensusConfig } from "../../config/schema/consensus"
+import { DEFAULT_VOTER_LINEAGES } from "../../config/schema/consensus"
+import { getCallerLineageGroup, getDefaultVoterPool, getModelLineage, type VoterCandidate } from "../../shared/model-lineage"
+import { fetchAvailableModels, getConnectedProviders } from "../../shared/model-availability"
+import { log } from "../../shared"
+import { VOTER_SPAWNER_DEFAULTS, spawnVoter } from "./voter-spawner"
+import { resolveVoterCandidate } from "./voter-resolver"
+import type { ConsensusInput, ConsensusResult, ResolvedVoterCandidate, VoterPosition } from "./types"
+
+type RunConsensusDeps = {
+  spawnVoter: typeof spawnVoter
+  getConnectedProviders: typeof getConnectedProviders
+  fetchAvailableModels: typeof fetchAvailableModels
+}
+
+const defaultDeps: RunConsensusDeps = { spawnVoter, getConnectedProviders, fetchAvailableModels }
+
+export async function runConsensus(
+  ctx: PluginInput,
+  input: ConsensusInput,
+  config: ConsensusConfig | undefined,
+  deps: RunConsensusDeps = defaultDeps,
+): Promise<ConsensusResult> {
+  const startedAt = new Date().toISOString()
+  const startMs = Date.now()
+  const count = input.count ?? config?.default_voter_count ?? 3
+  const voterTimeoutMs = input.voterTimeoutMs ?? config?.voter_timeout_ms ?? VOTER_SPAWNER_DEFAULTS.DEFAULT_VOTER_TIMEOUT_MS
+  const reasoningEffort = config?.voter_reasoning_effort ?? VOTER_SPAWNER_DEFAULTS.DEFAULT_VOTER_REASONING_EFFORT
+
+  const connectedProviders = new Set(await deps.getConnectedProviders(ctx.client))
+  const availableModels = await deps.fetchAvailableModels(ctx.client, { connectedProviders: Array.from(connectedProviders) })
+
+  const candidates = selectResolvedCandidates({
+    requestedLineages: config?.default_voter_lineages,
+    callerModel: input.callerModel,
+    count,
+    excludeLineages: input.excludeLineages,
+    candidates: input.candidates,
+    connectedProviders,
+    availableModels,
+  })
+
+  if (candidates.length === 0) {
+    log(`[consensus] no voters available; caller=${input.callerModel ?? "unknown"} connected=${Array.from(connectedProviders).join(",") || "none"}`)
+    return buildEmptyResult(input, startedAt, startMs)
+  }
+
+  log(`[consensus] spawning ${candidates.length} voters; ${candidates.map(c => `${c.lineage}=${c.providerID}/${c.modelID}`).join(", ")}`)
+  const voters: VoterPosition[] = await Promise.all(candidates.map(candidate =>
+    deps.spawnVoter(ctx, {
+      candidate,
+      prompt: input.prompt,
+      parentSessionID: input.parentSessionID,
+      parentDirectory: input.parentDirectory,
+      voterTimeoutMs,
+      reasoningEffort,
+    })
+  ))
+
+  const okVoters = voters.filter(v => v.status === "ok").length
+  const finishedAt = new Date().toISOString()
+  return {
+    triggerType: input.triggerType ?? "explicit",
+    callerModel: input.callerModel,
+    callerLineage: getModelLineage(input.callerModel),
+    voters,
+    advisoryOnly: okVoters < 2,
+    startedAt,
+    finishedAt,
+    totalDurationMs: Date.now() - startMs,
+  }
+}
+
+function selectResolvedCandidates(args: {
+  requestedLineages: ReadonlyArray<string> | undefined
+  callerModel: string | undefined
+  count: number
+  excludeLineages: ReadonlyArray<string> | undefined
+  candidates: ReadonlyArray<VoterCandidate> | undefined
+  connectedProviders: ReadonlySet<string>
+  availableModels: Set<string>
+}): ResolvedVoterCandidate[] {
+  const explicit = args.candidates && args.candidates.length > 0
+  const pool = explicit ? args.candidates! : filterPoolByRequestedLineages(args.requestedLineages)
+
+  const excluded = new Set<string>(args.excludeLineages ?? [])
+  if (!explicit) {
+    for (const lineage of getCallerLineageGroup(args.callerModel)) excluded.add(lineage)
+  }
+
+  const seenLineage = new Set<string>()
+  const resolved: ResolvedVoterCandidate[] = []
+  for (const candidate of pool) {
+    if (resolved.length >= args.count) break
+    if (excluded.has(candidate.lineage)) continue
+    if (seenLineage.has(candidate.lineage)) continue
+    const resolvedCandidate = resolveVoterCandidate(candidate, args.connectedProviders, args.availableModels)
+    if (!resolvedCandidate) continue
+    seenLineage.add(candidate.lineage)
+    resolved.push(resolvedCandidate)
+  }
+  return resolved
+}
+
+function filterPoolByRequestedLineages(requested: ReadonlyArray<string> | undefined): ReadonlyArray<VoterCandidate> {
+  const pool = getDefaultVoterPool()
+  const wanted = requested && requested.length > 0 ? requested : DEFAULT_VOTER_LINEAGES
+  const wantedSet = new Set(wanted)
+  const filtered = pool.filter(c => wantedSet.has(c.lineage))
+  return filtered.length > 0 ? filtered : pool
+}
+
+function buildEmptyResult(input: ConsensusInput, startedAt: string, startMs: number): ConsensusResult {
+  return {
+    triggerType: input.triggerType ?? "explicit",
+    callerModel: input.callerModel,
+    callerLineage: getModelLineage(input.callerModel),
+    voters: [],
+    advisoryOnly: true,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    totalDurationMs: Date.now() - startMs,
+  }
+}

--- a/src/features/consensus/consensus-engine.ts
+++ b/src/features/consensus/consensus-engine.ts
@@ -58,7 +58,7 @@ export async function runConsensus(
     })
   ))
 
-  const okVoters = voters.filter(v => v.status === "ok").length
+  const okVoters = voters.filter(isUsableVoterPosition).length
   const finishedAt = new Date().toISOString()
   return {
     triggerType: input.triggerType ?? "explicit",
@@ -70,6 +70,10 @@ export async function runConsensus(
     finishedAt,
     totalDurationMs: Date.now() - startMs,
   }
+}
+
+function isUsableVoterPosition(voter: VoterPosition): boolean {
+  return voter.status === "ok" && voter.text.trim().length > 0
 }
 
 function selectResolvedCandidates(args: {

--- a/src/features/consensus/index.ts
+++ b/src/features/consensus/index.ts
@@ -1,0 +1,4 @@
+export * from "./types"
+export { runConsensus } from "./consensus-engine"
+export { spawnVoter, VOTER_SPAWNER_DEFAULTS } from "./voter-spawner"
+export { resolveVoterCandidate } from "./voter-resolver"

--- a/src/features/consensus/types.ts
+++ b/src/features/consensus/types.ts
@@ -1,0 +1,45 @@
+import type { VoterCandidate } from "../../shared/model-lineage"
+
+export type ConsensusTriggerType = "explicit" | "pre_question_gate" | "post_test_gate"
+
+export type ResolvedVoterCandidate = {
+  lineage: string
+  providerID: string
+  modelID: string
+  variant: string | undefined
+}
+
+export type VoterPosition = {
+  lineage: string
+  model: string
+  providerID: string | undefined
+  variant: string | undefined
+  status: "ok" | "error" | "timeout"
+  text: string
+  reasoning?: string
+  durationMs: number
+  errorMessage?: string
+}
+
+export type ConsensusResult = {
+  triggerType: ConsensusTriggerType
+  callerModel: string | undefined
+  callerLineage: string | undefined
+  voters: VoterPosition[]
+  advisoryOnly: boolean
+  startedAt: string
+  finishedAt: string
+  totalDurationMs: number
+}
+
+export type ConsensusInput = {
+  prompt: string
+  callerModel?: string
+  count?: number
+  triggerType?: ConsensusTriggerType
+  parentSessionID: string
+  parentDirectory?: string
+  voterTimeoutMs?: number
+  excludeLineages?: ReadonlyArray<string>
+  candidates?: ReadonlyArray<VoterCandidate>
+}

--- a/src/features/consensus/voter-resolver.test.ts
+++ b/src/features/consensus/voter-resolver.test.ts
@@ -1,0 +1,48 @@
+const { describe, expect, test } = require("bun:test")
+
+import type { VoterCandidate } from "../../shared/model-lineage"
+import { resolveVoterCandidate } from "./voter-resolver"
+
+describe("resolveVoterCandidate", () => {
+  test("#given only a deprecated GPT fallback is available #when resolving a GPT voter #then it is not selected", () => {
+    const deprecatedCodexModel = ["openai/gpt-5", ".3-codex"].join("")
+    const candidate: VoterCandidate = {
+      lineage: "gpt",
+      entry: {
+        providers: ["openai"],
+        model: "gpt-5.5",
+      },
+    }
+
+    const result = resolveVoterCandidate(
+      candidate,
+      new Set(["openai"]),
+      new Set([deprecatedCodexModel]),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  test("#given current GPT fallback is available #when resolving a GPT voter #then it selects the GPT-5.4-era fallback", () => {
+    const candidate: VoterCandidate = {
+      lineage: "gpt",
+      entry: {
+        providers: ["openai"],
+        model: "gpt-5.5",
+      },
+    }
+
+    const result = resolveVoterCandidate(
+      candidate,
+      new Set(["openai"]),
+      new Set(["openai/gpt-5.4-mini"]),
+    )
+
+    expect(result).toEqual({
+      lineage: "gpt",
+      providerID: "openai",
+      modelID: "gpt-5.4-mini",
+      variant: undefined,
+    })
+  })
+})

--- a/src/features/consensus/voter-resolver.ts
+++ b/src/features/consensus/voter-resolver.ts
@@ -1,0 +1,65 @@
+import type { VoterCandidate } from "../../shared/model-lineage"
+import { fuzzyMatchModel } from "../../shared/model-availability"
+import { transformModelForProvider } from "../../shared/provider-model-id-transform"
+import { log } from "../../shared"
+import type { ResolvedVoterCandidate } from "./types"
+
+const LINEAGE_FALLBACK_MODELS: Record<string, ReadonlyArray<string>> = {
+  "gemini-flash": ["gemini-3.1-pro", "gemini-3-pro-preview", "gemini-2.5-pro", "gemini-3.5-flash", "gemini-2.5-flash"],
+  "claude-opus": ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
+  gpt: ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+  kimi: ["kimi-k2.6", "kimi-k2.5", "k2p5"],
+  glm: ["glm-5", "glm-4.6"],
+}
+
+export function resolveVoterCandidate(
+  candidate: VoterCandidate,
+  connectedProviders: ReadonlySet<string>,
+  availableModels: Set<string>,
+): ResolvedVoterCandidate | null {
+  const candidateProviders = candidate.entry.providers.filter((p: string) => connectedProviders.has(p))
+  if (candidateProviders.length === 0) {
+    log(`[consensus] no connected provider for lineage=${candidate.lineage}; providers=${candidate.entry.providers.join(",")}`)
+    return null
+  }
+
+  const modelsToTry = [candidate.entry.model, ...(LINEAGE_FALLBACK_MODELS[candidate.lineage] ?? [])]
+  const seen = new Set<string>()
+  const uniqueModels = modelsToTry.filter(m => (seen.has(m) ? false : (seen.add(m), true)))
+
+  if (availableModels.size > 0) {
+    for (const provider of candidateProviders) {
+      for (const model of uniqueModels) {
+        const matched = fuzzyMatchModel(model, availableModels, [provider])
+        if (matched) {
+          const modelID = matched.split("/").slice(1).join("/")
+          log(`[consensus] resolved lineage=${candidate.lineage} -> ${provider}/${modelID}`)
+          return { lineage: candidate.lineage, providerID: provider, modelID, variant: candidate.entry.variant }
+        }
+      }
+    }
+
+    const staleProvider = candidateProviders.find((p: string) => !providerHasInventory(p, availableModels))
+    if (staleProvider) {
+      const modelID = transformModelForProvider(staleProvider, candidate.entry.model)
+      log(`[consensus] inventory for provider=${staleProvider} unknown (stale cache); provider-level resolve lineage=${candidate.lineage} -> ${staleProvider}/${modelID}`)
+      return { lineage: candidate.lineage, providerID: staleProvider, modelID, variant: candidate.entry.variant }
+    }
+
+    log(`[consensus] no model match for lineage=${candidate.lineage}; connected providers have inventory but not this model`)
+    return null
+  }
+
+  const provider = candidateProviders[0]
+  const modelID = transformModelForProvider(provider, candidate.entry.model)
+  log(`[consensus] model inventory empty; provider-level resolve lineage=${candidate.lineage} -> ${provider}/${modelID}`)
+  return { lineage: candidate.lineage, providerID: provider, modelID, variant: candidate.entry.variant }
+}
+
+function providerHasInventory(provider: string, availableModels: Set<string>): boolean {
+  const prefix = `${provider}/`
+  for (const m of availableModels) {
+    if (m.startsWith(prefix)) return true
+  }
+  return false
+}

--- a/src/features/consensus/voter-resolver.ts
+++ b/src/features/consensus/voter-resolver.ts
@@ -7,7 +7,7 @@ import type { ResolvedVoterCandidate } from "./types"
 const LINEAGE_FALLBACK_MODELS: Record<string, ReadonlyArray<string>> = {
   "gemini-flash": ["gemini-3.1-pro", "gemini-3-pro-preview", "gemini-2.5-pro", "gemini-3.5-flash", "gemini-2.5-flash"],
   "claude-opus": ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6"],
-  gpt: ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+  gpt: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
   kimi: ["kimi-k2.6", "kimi-k2.5", "k2p5"],
   glm: ["glm-5", "glm-4.6"],
 }

--- a/src/features/consensus/voter-spawner.ts
+++ b/src/features/consensus/voter-spawner.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { ResolvedVoterCandidate, VoterPosition } from "./types"
-import { log, normalizeSDKResponse } from "../../shared"
+import { isAmbiguousPostDispatchPromptFailure, log, normalizeSDKResponse } from "../../shared"
+import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
 import { subagentSessions } from "../claude-code-session-state"
 
 const DEFAULT_VOTER_TIMEOUT_MS = 120_000
@@ -68,18 +69,35 @@ export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promis
     sessionID = createResult.data.id
     subagentSessions.add(sessionID)
 
-    type PromptBody = Parameters<typeof ctx.client.session.prompt>[0]["body"]
-    const promptBody = {
-      model: { providerID, modelID },
-      ...(candidate.variant ? { variant: candidate.variant } : {}),
-      ...(effort ? { options: { reasoningEffort: effort } } : {}),
-      tools: VOTER_DISABLED_TOOLS,
-      parts: [{ type: "text", text: buildVoterPrompt(prompt) }],
-    } as unknown as PromptBody
-    await ctx.client.session.prompt({
+    type PromptInput = Parameters<typeof ctx.client.session.prompt>[0]
+    const promptInput = {
       path: { id: sessionID },
-      body: promptBody,
+      body: {
+        model: { providerID, modelID },
+        ...(candidate.variant ? { variant: candidate.variant } : {}),
+        ...(effort ? { options: { reasoningEffort: effort } } : {}),
+        tools: VOTER_DISABLED_TOOLS,
+        parts: [{ type: "text", text: buildVoterPrompt(prompt) }],
+      },
+    } as unknown as PromptInput
+
+    const dispatchResult = await dispatchInternalPrompt<PromptInput>({
+      mode: "sync",
+      client: ctx.client,
+      sessionID,
+      source: "consensus:voter",
+      settleMs: 0,
+      queueBehavior: "defer",
+      input: promptInput,
     })
+    const promptMayHaveBeenAccepted = dispatchResult.status === "failed"
+      && isAmbiguousPostDispatchPromptFailure(dispatchResult)
+    if (dispatchResult.status === "failed" && !promptMayHaveBeenAccepted) {
+      throw dispatchResult.error
+    }
+    if (!promptMayHaveBeenAccepted && !isInternalPromptDispatchAccepted(dispatchResult)) {
+      throw new Error(`consensus voter prompt skipped by gate: ${dispatchResult.status}`)
+    }
 
     const text = await waitForResult(ctx, sessionID, voterTimeoutMs)
     return { ...baseResult, status: "ok", text, durationMs: Date.now() - startedAt }

--- a/src/features/consensus/voter-spawner.ts
+++ b/src/features/consensus/voter-spawner.ts
@@ -1,0 +1,147 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { ResolvedVoterCandidate, VoterPosition } from "./types"
+import { log, normalizeSDKResponse } from "../../shared"
+import { subagentSessions } from "../claude-code-session-state"
+
+const DEFAULT_VOTER_TIMEOUT_MS = 120_000
+const POLL_INTERVAL_MS = 1_500
+const STABILITY_REQUIRED_POLLS = 3
+const DEFAULT_VOTER_REASONING_EFFORT = "high"
+
+const VOTER_FRAMING = [
+  "You are a single voter in a multi-model consensus panel. You are NOT an orchestrator.",
+  "Give YOUR OWN direct position on the question below in this one response. Do not delegate, do not spawn agents, do not call tools, do not say you will research first or wait for others. You have no follow-up turn.",
+  "State your position, your reasoning, a confidence level, and what would change your mind. Be decisive even under uncertainty: pick the best answer and own it.",
+  "",
+  "--- QUESTION ---",
+  "",
+].join("\n")
+
+const VOTER_DISABLED_TOOLS: Record<string, boolean> = {
+  task: false,
+  call_omo_agent: false,
+  question: false,
+  background_output: false,
+  background_cancel: false,
+}
+
+function buildVoterPrompt(prompt: string): string {
+  return VOTER_FRAMING + prompt
+}
+
+type SpawnVoterArgs = {
+  candidate: ResolvedVoterCandidate
+  prompt: string
+  parentSessionID: string
+  parentDirectory: string | undefined
+  voterTimeoutMs: number
+  reasoningEffort?: string
+}
+
+export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promise<VoterPosition> {
+  const { candidate, prompt, parentSessionID, parentDirectory, voterTimeoutMs, reasoningEffort } = args
+  const startedAt = Date.now()
+  const { providerID, modelID } = candidate
+  const effort = reasoningEffort ?? DEFAULT_VOTER_REASONING_EFFORT
+  const baseResult: VoterPosition = {
+    lineage: candidate.lineage,
+    model: modelID,
+    providerID,
+    variant: candidate.variant,
+    status: "error",
+    text: "",
+    durationMs: 0,
+  }
+
+  let sessionID: string | undefined
+  try {
+    const createResult = await ctx.client.session.create({
+      body: {
+        parentID: parentSessionID,
+        title: `consensus voter (${candidate.lineage})`,
+      } as Record<string, unknown>,
+      query: parentDirectory ? { directory: parentDirectory } : undefined,
+    })
+    if (createResult.error || !createResult.data?.id) {
+      return { ...baseResult, errorMessage: `session.create failed: ${String(createResult.error ?? "unknown")}`, durationMs: Date.now() - startedAt }
+    }
+    sessionID = createResult.data.id
+    subagentSessions.add(sessionID)
+
+    type PromptBody = Parameters<typeof ctx.client.session.prompt>[0]["body"]
+    const promptBody = {
+      model: { providerID, modelID },
+      ...(candidate.variant ? { variant: candidate.variant } : {}),
+      ...(effort ? { options: { reasoningEffort: effort } } : {}),
+      tools: VOTER_DISABLED_TOOLS,
+      parts: [{ type: "text", text: buildVoterPrompt(prompt) }],
+    } as unknown as PromptBody
+    await ctx.client.session.prompt({
+      path: { id: sessionID },
+      body: promptBody,
+    })
+
+    const text = await waitForResult(ctx, sessionID, voterTimeoutMs)
+    return { ...baseResult, status: "ok", text, durationMs: Date.now() - startedAt }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    const isTimeout = message.includes("timeout") || message.includes("timed out")
+    return {
+      ...baseResult,
+      status: isTimeout ? "timeout" : "error",
+      errorMessage: message,
+      durationMs: Date.now() - startedAt,
+    }
+  } finally {
+    if (sessionID) {
+      subagentSessions.delete(sessionID)
+      ctx.client.session.delete({ path: { id: sessionID } }).catch(() => undefined)
+    }
+  }
+}
+
+async function waitForResult(ctx: PluginInput, sessionID: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  let lastMsgCount = 0
+  let stablePolls = 0
+  while (Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
+    const statusResult = await ctx.client.session.status()
+    const allStatuses = normalizeSDKResponse(statusResult, {} as Record<string, { type: string }>)
+    const sessionStatus = allStatuses[sessionID]
+    if (sessionStatus && sessionStatus.type !== "idle") {
+      stablePolls = 0
+      lastMsgCount = 0
+      continue
+    }
+    const messagesResult = await ctx.client.session.messages({ path: { id: sessionID } })
+    const messages = normalizeSDKResponse(messagesResult, [] as Array<unknown>, { preferResponseOnMissingData: true })
+    if (messages.length > 0 && messages.length === lastMsgCount) {
+      stablePolls++
+      if (stablePolls >= STABILITY_REQUIRED_POLLS) return extractAssistantText(messages)
+    } else {
+      stablePolls = 0
+      lastMsgCount = messages.length
+    }
+  }
+  log(`[consensus] voter timeout for session=${sessionID} after ${timeoutMs}ms`)
+  throw new Error(`voter timed out after ${timeoutMs}ms`)
+}
+
+function extractAssistantText(messages: ReadonlyArray<unknown>): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i] as { info?: { role?: string }; parts?: Array<{ type?: string; text?: string }> } | undefined
+    if (!msg || msg.info?.role !== "assistant") continue
+    const parts = msg.parts ?? []
+    const text = parts.filter(p => p?.type === "text" && typeof p.text === "string").map(p => p.text as string).join("\n").trim()
+    if (text) return text
+  }
+  return ""
+}
+
+export const VOTER_SPAWNER_DEFAULTS = {
+  DEFAULT_VOTER_TIMEOUT_MS,
+  POLL_INTERVAL_MS,
+  STABILITY_REQUIRED_POLLS,
+  DEFAULT_VOTER_REASONING_EFFORT,
+} as const

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -41,6 +41,7 @@ import {
   createTaskList,
   createTaskUpdateTool,
   createHashlineEditTool,
+  createConsensusTool,
 } from "../tools"
 import { getMainSessionID } from "../features/claude-code-session-state"
 import { filterDisabledTools } from "../shared/disabled-tools"
@@ -67,6 +68,7 @@ type ToolRegistryFactories = {
   createTaskList: typeof createTaskList
   createTaskUpdateTool: typeof createTaskUpdateTool
   createHashlineEditTool: typeof createHashlineEditTool
+  createConsensusTool: typeof createConsensusTool
   createTeamApproveShutdownTool: typeof createTeamApproveShutdownTool
   createTeamCreateTool: typeof createTeamCreateTool
   createTeamDeleteTool: typeof createTeamDeleteTool
@@ -98,6 +100,7 @@ const defaultToolRegistryFactories: ToolRegistryFactories = {
   createTaskList,
   createTaskUpdateTool,
   createHashlineEditTool,
+  createConsensusTool,
   createTeamApproveShutdownTool,
   createTeamCreateTool,
   createTeamDeleteTool,
@@ -302,6 +305,11 @@ export function createToolRegistry(args: {
     ? { edit: factories.createHashlineEditTool(ctx) }
     : {}
 
+  const consensusEnabled = pluginConfig.consensus?.enabled ?? true
+  const consensusToolsRecord: Record<string, ToolDefinition> = consensusEnabled
+    ? { consensus: factories.createConsensusTool(ctx, pluginConfig.consensus) }
+    : {}
+
   const teamModeToolsRecord: Record<string, ToolDefinition> = pluginConfig.team_mode?.enabled
     ? {
         team_create: factories.createTeamCreateTool(
@@ -348,6 +356,7 @@ export function createToolRegistry(args: {
     ...teamModeToolsRecord,
     ...taskToolsRecord,
     ...hashlineToolsRecord,
+    ...consensusToolsRecord,
   }
 
   const allToolNames = Object.keys(allTools)

--- a/src/shared/model-lineage.ts
+++ b/src/shared/model-lineage.ts
@@ -1,0 +1,145 @@
+import type { FallbackEntry } from "./model-requirements"
+import modelCapabilities from "../generated/model-capabilities.generated.json" with { type: "json" }
+
+export type ModelLineage = string
+
+type ModelCapabilityEntry = {
+  id?: string
+  family?: string
+}
+
+const MODEL_FAMILY_INDEX: Record<string, string | undefined> = (() => {
+  const capabilities = modelCapabilities as { models: Record<string, ModelCapabilityEntry> }
+  const index: Record<string, string | undefined> = {}
+  for (const [key, value] of Object.entries(capabilities.models ?? {})) {
+    index[key.toLowerCase()] = value.family
+    if (value.id) index[value.id.toLowerCase()] = value.family
+  }
+  return index
+})()
+
+const PREFIX_LINEAGE_RULES: ReadonlyArray<{ prefix: string; lineage: ModelLineage }> = [
+  { prefix: "claude-opus", lineage: "claude-opus" },
+  { prefix: "claude-sonnet", lineage: "claude-sonnet" },
+  { prefix: "claude-haiku", lineage: "claude-haiku" },
+  { prefix: "gpt-", lineage: "gpt" },
+  { prefix: "o1", lineage: "gpt" },
+  { prefix: "o3", lineage: "gpt" },
+  { prefix: "gemini-", lineage: "gemini-flash" },
+  { prefix: "kimi-", lineage: "kimi" },
+  { prefix: "k2", lineage: "kimi" },
+  { prefix: "glm-", lineage: "glm" },
+  { prefix: "deepseek-", lineage: "deepseek" },
+  { prefix: "qwen", lineage: "qwen" },
+  { prefix: "minimax", lineage: "minimax" },
+  { prefix: "mistral", lineage: "mistral" },
+  { prefix: "grok-", lineage: "grok" },
+]
+
+const LINEAGE_GROUPS: ReadonlyArray<ReadonlySet<ModelLineage>> = [
+  new Set(["claude-opus", "claude-sonnet", "claude-haiku"]),
+  new Set(["gpt"]),
+  new Set(["gemini-flash", "gemini-flash-lite", "gemini-pro"]),
+  new Set(["kimi"]),
+  new Set(["glm"]),
+  new Set(["deepseek"]),
+  new Set(["qwen"]),
+  new Set(["minimax"]),
+  new Set(["mistral"]),
+  new Set(["grok"]),
+]
+
+export function getModelLineage(modelId: string | undefined): ModelLineage | undefined {
+  if (!modelId) return undefined
+  const normalized = modelId.toLowerCase()
+  const fromIndex = MODEL_FAMILY_INDEX[normalized]
+  if (fromIndex) return fromIndex
+  for (const rule of PREFIX_LINEAGE_RULES) {
+    if (normalized.startsWith(rule.prefix)) return rule.lineage
+  }
+  return undefined
+}
+
+export function getCallerLineageGroup(modelId: string | undefined): Set<ModelLineage> {
+  const lineage = getModelLineage(modelId)
+  if (!lineage) return new Set()
+  for (const group of LINEAGE_GROUPS) {
+    if (group.has(lineage)) return new Set(group)
+  }
+  return new Set([lineage])
+}
+
+export type VoterCandidate = {
+  lineage: ModelLineage
+  entry: FallbackEntry
+}
+
+const DEFAULT_VOTER_POOL: ReadonlyArray<VoterCandidate> = [
+  {
+    lineage: "claude-opus",
+    entry: {
+      providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+      model: "claude-opus-4-7",
+      variant: "max",
+    },
+  },
+  {
+    lineage: "gpt",
+    entry: {
+      providers: ["openai", "github-copilot", "opencode", "vercel"],
+      model: "gpt-5.5",
+      variant: "medium",
+    },
+  },
+  {
+    lineage: "gemini-flash",
+    entry: {
+      providers: ["google", "google-vertex", "github-copilot", "opencode", "vercel"],
+      model: "gemini-3.1-pro",
+      variant: "high",
+    },
+  },
+  {
+    lineage: "kimi",
+    entry: {
+      providers: ["opencode", "opencode-go", "vercel", "moonshotai", "kimi-for-coding"],
+      model: "kimi-k2.6",
+    },
+  },
+  {
+    lineage: "glm",
+    entry: {
+      providers: ["opencode", "zai-coding-plan", "vercel"],
+      model: "glm-5",
+    },
+  },
+]
+
+export function getDefaultVoterPool(): ReadonlyArray<VoterCandidate> {
+  return DEFAULT_VOTER_POOL
+}
+
+export type PickVotersOptions = {
+  callerModel?: string
+  excludeLineages?: ReadonlyArray<ModelLineage>
+  count?: number
+  pool?: ReadonlyArray<VoterCandidate>
+}
+
+export function pickDiverseVoters(options: PickVotersOptions = {}): VoterCandidate[] {
+  const count = options.count ?? 3
+  const pool = options.pool ?? DEFAULT_VOTER_POOL
+  const excluded = new Set<ModelLineage>(options.excludeLineages ?? [])
+  for (const lineage of getCallerLineageGroup(options.callerModel)) excluded.add(lineage)
+
+  const seen = new Set<ModelLineage>()
+  const picked: VoterCandidate[] = []
+  for (const candidate of pool) {
+    if (excluded.has(candidate.lineage)) continue
+    if (seen.has(candidate.lineage)) continue
+    seen.add(candidate.lineage)
+    picked.push(candidate)
+    if (picked.length >= count) break
+  }
+  return picked
+}

--- a/src/shared/model-lineage.ts
+++ b/src/shared/model-lineage.ts
@@ -54,8 +54,11 @@ export function getModelLineage(modelId: string | undefined): ModelLineage | und
   const normalized = modelId.toLowerCase()
   const fromIndex = MODEL_FAMILY_INDEX[normalized]
   if (fromIndex) return fromIndex
-  for (const rule of PREFIX_LINEAGE_RULES) {
-    if (normalized.startsWith(rule.prefix)) return rule.lineage
+  const providerless = normalized.includes("/") ? normalized.split("/").at(-1) ?? normalized : normalized
+  for (const candidate of [normalized, providerless]) {
+    for (const rule of PREFIX_LINEAGE_RULES) {
+      if (candidate.startsWith(rule.prefix)) return rule.lineage
+    }
   }
   return undefined
 }

--- a/src/tools/consensus/index.ts
+++ b/src/tools/consensus/index.ts
@@ -1,0 +1,2 @@
+export * from "./types"
+export { createConsensusTool } from "./tool"

--- a/src/tools/consensus/tool.test.ts
+++ b/src/tools/consensus/tool.test.ts
@@ -1,0 +1,127 @@
+const { describe, expect, test } = require("bun:test")
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import type { ConsensusInput, ConsensusResult } from "../../features/consensus"
+import { createConsensusTool } from "./tool"
+
+describe("createConsensusTool", () => {
+  test("#given a subagent session #when consensus executes #then the call is rejected", async () => {
+    const consensusTool = createConsensusTool(
+      createPluginInput("/workspace"),
+      undefined,
+      {
+        isSubagentSession: () => true,
+        runConsensus: async () => createConsensusResult([]),
+      },
+    )
+
+    const result = await consensusTool.execute(
+      { prompt: "Should I ask the user?" },
+      createToolContext("/workspace"),
+    )
+
+    expect(result).toContain("restricted to the main agent")
+  })
+
+  test("#given a parent session directory #when consensus runs #then it is forwarded to the engine", async () => {
+    let capturedInput: ConsensusInput | undefined
+    const consensusTool = createConsensusTool(
+      createPluginInput("/fallback-workspace", "/parent-workspace"),
+      undefined,
+      {
+        isSubagentSession: () => false,
+        runConsensus: async (_ctx, input) => {
+          capturedInput = input
+          return createConsensusResult([
+            {
+              lineage: "gpt",
+              model: "gpt-5.5",
+              providerID: "openai",
+              variant: undefined,
+              status: "ok",
+              text: "position",
+              durationMs: 1,
+            },
+          ])
+        },
+      },
+    )
+
+    await consensusTool.execute(
+      { prompt: "Should this use the repo cwd?" },
+      createToolContext("/tool-context-workspace"),
+    )
+
+    expect(capturedInput?.parentDirectory).toBe("/parent-workspace")
+  })
+
+  test("#given an empty voter response #when consensus returns #then the tool reports no usable consensus signal", async () => {
+    const consensusTool = createConsensusTool(
+      createPluginInput("/workspace"),
+      undefined,
+      {
+        isSubagentSession: () => false,
+        runConsensus: async () => createConsensusResult([
+          {
+            lineage: "gpt",
+            model: "gpt-5.5",
+            providerID: "openai",
+            variant: undefined,
+            status: "ok",
+            text: " ",
+            durationMs: 1,
+          },
+        ]),
+      },
+    )
+
+    const result = await consensusTool.execute(
+      { prompt: "Interpret this test output." },
+      createToolContext("/workspace"),
+    )
+    const parsed = JSON.parse(String(result)) as { ok: boolean; advisoryOnly: boolean; guidanceForSynthesizer: string }
+
+    expect(parsed.ok).toBe(false)
+    expect(parsed.advisoryOnly).toBe(true)
+    expect(parsed.guidanceForSynthesizer).toContain("No voters returned a usable position")
+  })
+})
+
+function createPluginInput(directory: string, parentDirectory = directory): PluginInput {
+  return unsafeTestValue<PluginInput>({
+    directory,
+    client: {
+      session: {
+        get: async () => ({ data: { directory: parentDirectory } }),
+      },
+    },
+  })
+}
+
+function createToolContext(directory: string): ToolContext {
+  return {
+    sessionID: "parent-session",
+    messageID: "parent-message",
+    agent: "sisyphus",
+    directory,
+    worktree: directory,
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  }
+}
+
+function createConsensusResult(voters: ConsensusResult["voters"]): ConsensusResult {
+  return {
+    triggerType: "explicit",
+    callerModel: undefined,
+    callerLineage: undefined,
+    voters,
+    advisoryOnly: voters.filter(voter => voter.status === "ok" && voter.text.trim().length > 0).length < 2,
+    startedAt: "2026-06-04T00:00:00.000Z",
+    finishedAt: "2026-06-04T00:00:00.000Z",
+    totalDurationMs: 1,
+  }
+}

--- a/src/tools/consensus/tool.ts
+++ b/src/tools/consensus/tool.ts
@@ -9,7 +9,7 @@ const isSubagentSession = (sessionID: string): boolean => subagentSessions.has(s
 
 const CONSENSUS_TOOL_DESCRIPTION = `Run a multi-lineage consensus debate.
 
-Spawns N voters (default 3) from DIFFERENT model families (Anthropic / OpenAI / Google / open-source like Kimi) in parallel, gives each the same prompt, and returns their positions to YOU. You — the calling model — are the synthesizer. Read each voter's position and decide:
+Spawns N voters (default 3) from DIFFERENT model families (Anthropic / OpenAI / Google / open-source like Kimi) in parallel, gives each the same prompt, and returns their positions to YOU. You, the calling model, are the synthesizer. Read each voter's position and decide:
 - Do they agree? (consensus reached)
 - Do they disagree? (escalate to user with all positions)
 - Is one right and others wrong? (pick the strongest case)
@@ -57,16 +57,25 @@ export function createConsensusTool(
 
       log(`[consensus_tool] running; caller=${args.caller_model ?? "unknown"} count=${args.count ?? 3}`)
 
+      const parentSession = await ctx.client.session.get({
+        path: { id: toolContext.sessionID },
+      }).catch((error) => {
+        log(`[consensus_tool] failed to resolve parent session directory; using tool context directory`, error)
+        return null
+      })
+      const parentDirectory = parentSession?.data?.directory ?? toolContext.directory ?? ctx.directory
+
       const result = await deps.runConsensus(ctx, {
         prompt: args.prompt,
         callerModel: args.caller_model,
         count: args.count,
         triggerType: "explicit",
         parentSessionID: toolContext.sessionID,
+        parentDirectory,
         excludeLineages: args.exclude_lineages,
       }, consensusConfig)
 
-      const okCount = result.voters.filter(v => v.status === "ok").length
+      const okCount = result.voters.filter(v => v.status === "ok" && v.text.trim().length > 0).length
       const ok = okCount > 0
       const toolResult: ConsensusToolResult = {
         ok,

--- a/src/tools/consensus/tool.ts
+++ b/src/tools/consensus/tool.ts
@@ -1,0 +1,101 @@
+import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
+import type { ConsensusConfig } from "../../config/schema/consensus"
+import { runConsensus } from "../../features/consensus"
+import { subagentSessions } from "../../features/claude-code-session-state"
+import { log } from "../../shared"
+import type { ConsensusToolArgs, ConsensusToolResult } from "./types"
+
+const isSubagentSession = (sessionID: string): boolean => subagentSessions.has(sessionID)
+
+const CONSENSUS_TOOL_DESCRIPTION = `Run a multi-lineage consensus debate.
+
+Spawns N voters (default 3) from DIFFERENT model families (Anthropic / OpenAI / Google / open-source like Kimi) in parallel, gives each the same prompt, and returns their positions to YOU. You — the calling model — are the synthesizer. Read each voter's position and decide:
+- Do they agree? (consensus reached)
+- Do they disagree? (escalate to user with all positions)
+- Is one right and others wrong? (pick the strongest case)
+
+This tool is RESTRICTED to the main agent. Subagents cannot invoke it (prevents recursion + cost explosion).
+
+Use cases:
+- High-stakes architecture decisions
+- Validation of analyzed/extracted data
+- Interpreting test output / verifying fixes
+- Before bothering the user with a question (ask consensus first whether you can resolve it yourself)
+
+Output: an array of voter positions with {lineage, model, status, text}. Synthesize naturally in your next turn.`
+
+type ConsensusToolDeps = {
+  runConsensus: typeof runConsensus
+  isSubagentSession: typeof isSubagentSession
+}
+
+const defaultDeps: ConsensusToolDeps = { runConsensus, isSubagentSession }
+
+export function createConsensusTool(
+  ctx: PluginInput,
+  consensusConfig: ConsensusConfig | undefined,
+  deps: ConsensusToolDeps = defaultDeps,
+): ToolDefinition {
+  return tool({
+    description: CONSENSUS_TOOL_DESCRIPTION,
+    args: {
+      prompt: tool.schema.string().describe("The full context + question to send to each voter. Be specific about what you want them to evaluate or decide. Include all the information they need."),
+      count: tool.schema.number().int().min(2).max(7).optional().describe("Number of voters (default: 3). Must be between 2 and 7. Each voter is a separate LLM call."),
+      caller_model: tool.schema.string().optional().describe("Your own model id (e.g., 'claude-opus-4-7'). If provided, voters will be picked from DIFFERENT lineages than yours."),
+      exclude_lineages: tool.schema.array(tool.schema.string()).optional().describe("Additional lineage families to exclude from voters (e.g., ['claude-opus', 'gpt']). Useful when you want to force specific lineage diversity."),
+    },
+    async execute(args: ConsensusToolArgs, toolContext) {
+      if (deps.isSubagentSession(toolContext.sessionID)) {
+        const message = "consensus is restricted to the main agent. Subagents cannot invoke it (prevents recursion + cost explosion). If you need agent ensemble, do it from the main session."
+        log(`[consensus_tool] rejected for subagent session=${toolContext.sessionID}`)
+        return message
+      }
+
+      if (!args.prompt || args.prompt.trim().length === 0) {
+        return "consensus tool requires a non-empty `prompt` argument"
+      }
+
+      log(`[consensus_tool] running; caller=${args.caller_model ?? "unknown"} count=${args.count ?? 3}`)
+
+      const result = await deps.runConsensus(ctx, {
+        prompt: args.prompt,
+        callerModel: args.caller_model,
+        count: args.count,
+        triggerType: "explicit",
+        parentSessionID: toolContext.sessionID,
+        excludeLineages: args.exclude_lineages,
+      }, consensusConfig)
+
+      const okCount = result.voters.filter(v => v.status === "ok").length
+      const ok = okCount > 0
+      const toolResult: ConsensusToolResult = {
+        ok,
+        advisoryOnly: result.advisoryOnly,
+        callerLineage: result.callerLineage,
+        callerModel: result.callerModel,
+        voters: result.voters.map(v => ({
+          lineage: v.lineage,
+          model: v.model,
+          status: v.status,
+          text: v.text,
+          durationMs: v.durationMs,
+          errorMessage: v.errorMessage,
+        })),
+        totalDurationMs: result.totalDurationMs,
+        guidanceForSynthesizer: buildSynthesizerGuidance(okCount, result.advisoryOnly),
+      }
+
+      return JSON.stringify(toolResult, null, 2)
+    },
+  })
+}
+
+function buildSynthesizerGuidance(okVoterCount: number, advisoryOnly: boolean): string {
+  if (okVoterCount === 0) {
+    return "No voters returned a usable position (no connected providers resolved, or all errored/timed out). Treat this as no consensus signal and fall back to your own judgment or ask the user."
+  }
+  if (advisoryOnly) {
+    return `Only ${okVoterCount} voter returned a position, so this is an ADVISORY second opinion, not a true multi-lineage consensus. Weigh it as one additional perspective; do not treat single-voter agreement as consensus. For a stronger signal, more providers need to be connected.`
+  }
+  return `You now have ${okVoterCount} voter positions from different model families. Read each one. Your job as the synthesizer:\n1. Identify points of agreement (consensus signal)\n2. Identify points of disagreement (uncertainty signal)\n3. If voters agree on the answer: proceed with the agreed answer\n4. If voters disagree materially: escalate to the user with all positions presented\n5. Never silently pick one position when others contradict it - that throws away the diversity signal`
+}

--- a/src/tools/consensus/types.ts
+++ b/src/tools/consensus/types.ts
@@ -1,0 +1,23 @@
+export type ConsensusToolArgs = {
+  prompt: string
+  count?: number
+  caller_model?: string
+  exclude_lineages?: string[]
+}
+
+export type ConsensusToolResult = {
+  ok: boolean
+  advisoryOnly: boolean
+  callerLineage: string | undefined
+  callerModel: string | undefined
+  voters: Array<{
+    lineage: string
+    model: string
+    status: "ok" | "error" | "timeout"
+    text: string
+    durationMs: number
+    errorMessage?: string
+  }>
+  totalDurationMs: number
+  guidanceForSynthesizer: string
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,6 +31,7 @@ export {
   createTaskUpdateTool,
 } from "./task"
 export { createHashlineEditTool } from "./hashline-edit"
+export { createConsensusTool } from "./consensus"
 export { createTeamSendMessageTool } from "../features/team-mode/tools/messaging"
 
 export function createBackgroundTools(manager: BackgroundManager, client: OpencodeClient): Record<string, ToolDefinition> {


### PR DESCRIPTION
## Summary

- Adds a `consensus` tool: spawns N voters (default 3) from **different model families** (Anthropic / OpenAI / Google / open-source) in parallel, gives each the same question, and returns their positions for the calling agent to synthesize.
- Restricted to the main agent (subagents cannot invoke it, to prevent recursion and cost blow-ups); config-gated and enabled by default.
- Promoted in the Sisyphus prompt alongside Oracle, so the orchestrator reaches for it on high-stakes / hard-to-verify decisions.

## Changes

<!-- Listed in suggested reading order: the tool and core logic first, then config, wiring, and prompt. -->

**The tool & core logic**

- `src/tools/consensus/tool.ts` — the `consensus` tool definition: description the agent sees, args (`prompt`, `count`, `caller_model`, `exclude_lineages`), main-agent-only gating, and the synthesizer guidance returned to the caller.
- `src/features/consensus/consensus-engine.ts` — orchestration: fetches connected providers + available models, selects diverse voters (excluding the caller's own lineage), spawns them in parallel, aggregates positions, and flags `advisoryOnly` when fewer than two voters return a usable answer.
- `src/features/consensus/voter-resolver.ts` — resolves each candidate to a *connected* provider + a promptable model id, with a stale-cache fallback so a just-connected provider still resolves.
- `src/features/consensus/voter-spawner.ts` — spawns a one-shot voter session: framing (answer directly, do not delegate or wait), delegation/question tools disabled, configurable reasoning effort, polls to completion, and cleans up the temporary session.
- `src/shared/model-lineage.ts` — the default voter pool (model families) and lineage-diversity selection.
- `src/features/consensus/types.ts` — shared types (`VoterPosition`, `ConsensusResult`, `ResolvedVoterCandidate`).

**Config**

- `src/config/schema/consensus.ts` — config block: voter count, lineages, per-voter timeout, reasoning effort, and the gate sub-configs.
- `src/config/schema/oh-my-opencode-config.ts` — composes `ConsensusConfigSchema` into the root config schema.

**Wiring**

- `src/plugin/tool-registry.ts` — registers the `consensus` tool, config-gated (default on).
- `src/tools/index.ts`, `src/tools/consensus/index.ts`, `src/features/consensus/index.ts` — barrel exports.

**Prompt promotion**

- `src/agents/dynamic-agent-core-sections.ts` — `buildConsensusSection()` (rendered only when the tool is registered), mirroring the existing Oracle section.
- `src/agents/dynamic-agent-prompt-builder.ts` — exports the new section.
- `src/agents/sisyphus.ts`, `src/agents/sisyphus/{default,claude-opus-4-7,gpt-5-4,kimi-k2-6}.ts` — inject the structured section next to Oracle; `src/agents/sisyphus/gpt-5-5.ts` — matching prose paragraph for the prose-style variant.

**Generated**

- `assets/oh-my-opencode.schema.json` — regenerated from the updated config schema.

## Testing

```bash
bun run typecheck
bun test
```

`tsgo --noEmit` passes clean. The tool was also exercised end-to-end with a Claude main agent (`caller_model="claude-opus-4-8"`), which resolved and collected three voters — GPT-5.5 (OpenAI), Gemini 3.1 Pro (Google Vertex), and Kimi K2.6 (OpenCode Zen) — all returning positions, with `advisoryOnly` correctly false.

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `consensus` tool that runs parallel voters from different model families and returns their positions for the main agent to synthesize. Also relaxes a Windows installer test timeout to reduce flakiness.

- **New Features**
  - `consensus` tool (main‑agent only): args `prompt`, `count`, `caller_model`, `exclude_lineages`; picks diverse voters (excludes caller lineage), resolves against connected providers with stale‑inventory fallback, spawns one‑shot voters with delegation disabled, aggregates results, flags `advisoryOnly` when <2 usable answers.
  - Config + wiring + schema: new `consensus` block (default voter count/lineages, per‑voter timeout, reasoning effort, optional pre‑question and post‑test gates); tool registered in `src/plugin/tool-registry.ts` (config‑gated, default on); regenerated `assets/oh-my-opencode.schema.json`.
  - Prompt promotion: Consensus usage section added to all Sisyphus variants.

- **Bug Fixes**
  - Routed voter prompts through the shared internal prompt gate (`dispatchInternalPrompt`, mode: sync, `queueBehavior: defer`) and handled accepted/ambiguous/skipped outcomes before polling.
  - Removed a stale GPT voter fallback; GPT lineage now prefers current fallbacks (e.g., `gpt-5.4(-mini)`) and rejects Codex‑era matches.
  - Relaxed Windows cleanup installer test timeout to 15s to reduce flakiness.

<sup>Written for commit f55f41c930d054175958a444692fc9e0a51ec12b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

