### PR TITLE
Preserve existing Codex agent TOMLs on reinstall

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/README.md
+++ b/packages/omo-codex/plugin/components/ultrawork/README.md
@@ -37,7 +37,7 @@ Codex passes the prompt payload on stdin. When the pattern `\b(?:ultrawork|ulw)\
 
 If a prior `UserPromptSubmit` hook output in transcript JSONL already contains `<ultrawork-mode>`, the hook suppresses itself so the same directive is not injected repeatedly. Plain transcript text containing `<ultrawork-mode>` is ignored unless it comes from hook output.
 
-Bundled agent role TOMLs in `agents/` ship to `CODEX_HOME/agents/` at install time, not via a runtime hook. The installer creates a symlink on Linux / macOS and a file copy on Windows (because symlinks require admin privileges or Developer Mode). For the public marketplace, the source is the stable installed-marketplace snapshot, not the versioned plugin cache, so agent role configs remain valid when Codex replaces `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/` during auto-update. Both code paths overwrite stale files and write a `.installed-agents.json` manifest next to the source root for clean uninstall tracking.
+Bundled agent role TOMLs in `agents/` ship to `CODEX_HOME/agents/` at install time, not via a runtime hook. The installer creates a symlink on Linux / macOS and a file copy on Windows (because symlinks require admin privileges or Developer Mode). For the public marketplace, the source is the stable installed-marketplace snapshot, not the versioned plugin cache, so agent role configs remain valid when Codex replaces `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/` during auto-update. On update, existing `CODEX_HOME/agents/*.toml` files are preserved as user-owned files and omitted from `.installed-agents.json`; only newly installed agent files are listed for clean uninstall tracking.
 
 ## Smoke test
 

--- a/packages/omo-codex/scripts/install-agent-links.test.mjs
+++ b/packages/omo-codex/scripts/install-agent-links.test.mjs
@@ -102,3 +102,48 @@ test(
 		assert.equal(await readFile(join(snapshotRoot, ".codex-marketplace-install.json"), "utf8"), '{"source_type":"git"}\n');
 	},
 );
+
+test(
+	"#given existing symlinked agent was customized #when installing locally again #then preserves the customized TOML",
+	{ skip: process.platform === "win32" ? "Windows copies agent files instead of symlinking them" : false },
+	async () => {
+		const repoRoot = await makeTempDir();
+		const codexHome = await makeTempDir();
+		const codexPackageRoot = join(repoRoot, "packages", "omo-codex");
+		const pluginRoot = join(codexPackageRoot, "plugin");
+		const agentsRoot = join(pluginRoot, "components", "ultrawork", "agents");
+
+		await writeJson(join(codexPackageRoot, "marketplace.json"), {
+			name: "sisyphuslabs",
+			plugins: [{ name: "omo", source: "./plugins/omo" }],
+		});
+		await writePluginAt(pluginRoot, "omo", "0.1.0");
+		await mkdir(agentsRoot, { recursive: true });
+		await writeFile(join(agentsRoot, "plan.toml"), 'name = "plan"\nmodel_reasoning_effort = "xhigh"\n');
+
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+		const agentPath = join(codexHome, "agents", "plan.toml");
+		await writeFile(agentPath, 'name = "plan"\nmodel_reasoning_effort = "high"\n');
+		await writeFile(join(agentsRoot, "plan.toml"), 'name = "plan"\nmodel_reasoning_effort = "xhigh"\ndescription = "new default"\n');
+
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+
+		assert.equal((await lstat(agentPath)).isSymbolicLink(), false);
+		assert.equal(await readFile(agentPath, "utf8"), 'name = "plan"\nmodel_reasoning_effort = "high"\n');
+		const snapshotPluginPath = join(codexHome, ".tmp", "marketplaces", "sisyphuslabs", "plugins", "omo");
+		const installedAgents = JSON.parse(await readFile(join(snapshotPluginPath, ".installed-agents.json"), "utf8"));
+		assert.deepEqual(installedAgents.agents, []);
+	},
+);

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -31,6 +31,7 @@ import { formatLazyCodexInstallHelp, parseLazyCodexInstallCliArgs } from "./inst
 import { runDelegatedOmoCommand } from "./install/delegated-command.mjs";
 import { shouldBuildSourcePackages } from "./install/source-package-build.mjs";
 import { runLazyCodexManualUpdate } from "../plugin/scripts/auto-update.mjs";
+import { materializeExistingCodexAgentFiles } from "./install/preserve-existing-agents.mjs";
 
 const LEGACY_CODEX_PLUGIN_MARKETPLACE = ["code", "yeongyu", "codex", "plugins"].join("-");
 const SISYPHUS_LEGACY_CACHE_MARKETPLACES = ["lazycodex", LEGACY_CODEX_PLUGIN_MARKETPLACE];
@@ -106,6 +107,7 @@ export async function installMarketplaceLocally(options = {}) {
 		installed.push(plugin);
 	}
 
+	await materializeExistingCodexAgentFiles(codexHome);
 	const agentSourceRoots = await agentSourceRootsForInstall({ codexHome, marketplace, installed, pluginSources });
 	for (const plugin of installed) {
 		const pluginRoot = agentSourceRoots.get(plugin.name) ?? plugin.path;

--- a/packages/omo-codex/scripts/install/agents.mjs
+++ b/packages/omo-codex/scripts/install/agents.mjs
@@ -1,5 +1,5 @@
 import { basename, join } from "node:path";
-import { copyFile, lstat, mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { copyFile, lstat, mkdir, readdir, symlink, writeFile } from "node:fs/promises";
 
 import { exists } from "./utils.mjs";
 
@@ -17,14 +17,12 @@ export async function linkCachedPluginAgents({ codexHome, pluginRoot, platform =
 	const linked = [];
 	for (const agentPath of bundledAgents) {
 		const linkPath = join(agentsDir, basename(agentPath));
-		if (platform === "win32") {
-			await replaceWithCopy(linkPath, agentPath);
-		} else {
-			await replaceWithSymlink(linkPath, agentPath);
-		}
-		linked.push({ name: basename(agentPath), path: linkPath, target: agentPath });
+		const installed = platform === "win32"
+			? await copyIfMissing(linkPath, agentPath)
+			: await symlinkIfMissing(linkPath, agentPath);
+		linked.push({ name: basename(agentPath), path: linkPath, target: installed.target, managed: installed.managed });
 	}
-	await writeManifest(pluginRoot, linked.map((entry) => entry.path));
+	await writeManifest(pluginRoot, linked.filter((entry) => entry.managed).map((entry) => entry.path));
 	return linked;
 }
 
@@ -48,23 +46,25 @@ async function discoverBundledAgents(pluginRoot) {
 	return agents;
 }
 
-async function replaceWithSymlink(linkPath, target) {
-	await prepareReplacement(linkPath);
+async function symlinkIfMissing(linkPath, target) {
+	if (await existingAgentFile(linkPath)) return { target: linkPath, managed: false };
 	await symlink(target, linkPath);
+	return { target, managed: true };
 }
 
-async function replaceWithCopy(linkPath, target) {
-	await prepareReplacement(linkPath);
+async function copyIfMissing(linkPath, target) {
+	if (await existingAgentFile(linkPath)) return { target: linkPath, managed: false };
 	await copyFile(target, linkPath);
+	return { target, managed: true };
 }
 
-async function prepareReplacement(linkPath) {
-	if (!(await lstatExists(linkPath))) return;
+async function existingAgentFile(linkPath) {
+	if (!(await lstatExists(linkPath))) return false;
 	const entryStat = await lstat(linkPath);
 	if (entryStat.isDirectory() && !entryStat.isSymbolicLink()) {
 		throw new Error(`${linkPath} already exists and is a directory; refusing to replace`);
 	}
-	await rm(linkPath, { force: true });
+	return true;
 }
 
 async function writeManifest(pluginRoot, agentPaths) {

--- a/packages/omo-codex/scripts/install/preserve-existing-agents.mjs
+++ b/packages/omo-codex/scripts/install/preserve-existing-agents.mjs
@@ -1,0 +1,35 @@
+import { lstat, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { exists } from "./utils.mjs";
+
+export async function materializeExistingCodexAgentFiles(codexHome) {
+	const agentsDir = join(codexHome, "agents");
+	if (!(await exists(agentsDir))) return [];
+
+	const materialized = [];
+	const entries = await readdir(agentsDir, { withFileTypes: true });
+	for (const entry of entries) {
+		if (!entry.name.endsWith(".toml")) continue;
+		const agentPath = join(agentsDir, entry.name);
+		const stat = await lstat(agentPath);
+		if (!stat.isSymbolicLink()) continue;
+
+		const content = await readExistingSymlinkContent(agentPath);
+		await rm(agentPath, { force: true });
+		if (content === null) continue;
+
+		await writeFile(agentPath, content);
+		materialized.push(agentPath);
+	}
+	return materialized.sort();
+}
+
+async function readExistingSymlinkContent(path) {
+	try {
+		return await readFile(path, "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
+	}
+}

--- a/src/cli/install-codex/install-codex.ts
+++ b/src/cli/install-codex/install-codex.ts
@@ -13,6 +13,7 @@ import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource
 import { defaultRunCommand } from "./codex-process"
 import { repairProjectLocalCodexArtifactsBestEffort } from "./codex-project-local-cleanup-best-effort"
 import type { CodexInstallOptions, CodexInstallResult, CodexMarketplaceSource, InstalledPlugin, MarketplaceManifest } from "./types"
+import { materializeExistingCodexAgentFiles } from "./preserve-existing-codex-agents"
 
 const SISYPHUS_LEGACY_CACHE_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
 
@@ -79,6 +80,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
     installed.push(plugin)
   }
 
+  await materializeExistingCodexAgentFiles(codexHome)
   const agentSourceRoots = await agentSourceRootsForInstall({
     codexHome,
     marketplace,

--- a/src/cli/install-codex/link-cached-plugin-agents.test.ts
+++ b/src/cli/install-codex/link-cached-plugin-agents.test.ts
@@ -81,41 +81,36 @@ describe("linkCachedPluginAgents", () => {
     }
   })
 
-  test("replaces stale regular files (legacy sync-agents.py copies) with symlinks on unix", async () => {
+  test("preserves existing regular agent TOMLs on unix", async () => {
     // given
     const { codexHome, pluginRoot } = await makeFixture()
     const agentsDir = join(codexHome, "agents")
     await mkdir(agentsDir, { recursive: true })
-    await writeFile(
-      join(agentsDir, "explorer.toml"),
-      "# stale broken copy with no `name` field, from old sync-agents.py\nmodel = \"old\"\n",
-    )
+    await writeFile(join(agentsDir, "explorer.toml"), 'name = "explorer"\nmodel_reasoning_effort = "high"\n')
 
     // when
-    await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "linux" })
+    const linked = await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "linux" })
 
     // then
-    const linkStat = await lstat(join(agentsDir, "explorer.toml"))
-    expect(linkStat.isSymbolicLink()).toBe(true)
-    expect(await readlink(join(agentsDir, "explorer.toml"))).toBe(
-      join(pluginRoot, "components", "ultrawork", "agents", "explorer.toml"),
-    )
+    const explorer = linked.find((entry) => entry.name === "explorer.toml")
+    expect(explorer?.managed).toBe(false)
+    expect((await lstat(join(agentsDir, "explorer.toml"))).isSymbolicLink()).toBe(false)
+    expect(await readFile(join(agentsDir, "explorer.toml"), "utf8")).toContain('model_reasoning_effort = "high"')
   })
 
-  test("overwrites stale copies on Windows", async () => {
+  test("preserves existing regular agent TOMLs on Windows", async () => {
     // given
     const { codexHome, pluginRoot } = await makeFixture()
     const agentsDir = join(codexHome, "agents")
     await mkdir(agentsDir, { recursive: true })
-    await writeFile(join(agentsDir, "explorer.toml"), "# stale broken copy\n")
+    await writeFile(join(agentsDir, "explorer.toml"), 'name = "explorer"\nmodel_reasoning_effort = "high"\n')
 
     // when
     await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "win32" })
 
     // then
     const content = await readFile(join(agentsDir, "explorer.toml"), "utf8")
-    expect(content).toContain('name = "explorer"')
-    expect(content).not.toContain("stale broken copy")
+    expect(content).toContain('model_reasoning_effort = "high"')
   })
 
   test("writes a manifest under the plugin cache listing installed agent paths for clean uninstall", async () => {
@@ -179,6 +174,27 @@ describe("linkCachedPluginAgents", () => {
       await readFile(join(pluginRoot, ".installed-agents.json"), "utf8"),
     ) as { agents: string[] }
     expect(manifest.agents).toEqual([])
+  })
+
+  test("omits preserved user agent TOMLs from the cleanup manifest", async () => {
+    // given
+    const { codexHome, pluginRoot } = await makeFixture()
+    const agentsDir = join(codexHome, "agents")
+    await mkdir(agentsDir, { recursive: true })
+    await writeFile(join(agentsDir, "explorer.toml"), 'name = "explorer"\nmodel_reasoning_effort = "high"\n')
+
+    // when
+    const linked = await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "linux" })
+
+    // then
+    expect(linked.find((entry) => entry.name === "explorer.toml")?.managed).toBe(false)
+    const manifest = JSON.parse(
+      await readFile(join(pluginRoot, ".installed-agents.json"), "utf8"),
+    ) as { agents: string[] }
+    expect(manifest.agents.sort()).toEqual([
+      join(codexHome, "agents", "librarian.toml"),
+      join(codexHome, "agents", "planner.toml"),
+    ])
   })
 
   test("auto-detects host platform when platform parameter is omitted", async () => {

--- a/src/cli/install-codex/link-cached-plugin-agents.ts
+++ b/src/cli/install-codex/link-cached-plugin-agents.ts
@@ -1,4 +1,4 @@
-import { copyFile, lstat, mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises"
+import { copyFile, lstat, mkdir, readdir, symlink, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
 
 const MANIFEST_FILE = ".installed-agents.json"
@@ -7,6 +7,7 @@ export interface LinkedAgent {
   readonly name: string
   readonly path: string
   readonly target: string
+  readonly managed: boolean
 }
 
 type LinkPlatform = NodeJS.Platform
@@ -27,16 +28,14 @@ export async function linkCachedPluginAgents(input: {
   const linked: LinkedAgent[] = []
   for (const agentPath of bundledAgents) {
     const linkPath = join(agentsDir, basename(agentPath))
-    if (platform === "win32") {
-      await replaceWithCopy(linkPath, agentPath)
-    } else {
-      await replaceWithSymlink(linkPath, agentPath)
-    }
-    linked.push({ name: basename(agentPath), path: linkPath, target: agentPath })
+    const installed = platform === "win32"
+      ? await copyIfMissing(linkPath, agentPath)
+      : await symlinkIfMissing(linkPath, agentPath)
+    linked.push({ name: basename(agentPath), path: linkPath, target: installed.target, managed: installed.managed })
   }
   await writeManifest(
     input.pluginRoot,
-    linked.map((entry) => entry.path),
+    linked.filter((entry) => entry.managed).map((entry) => entry.path),
   )
   return linked
 }
@@ -60,23 +59,25 @@ async function discoverBundledAgents(pluginRoot: string): Promise<readonly strin
   return agents
 }
 
-async function replaceWithSymlink(linkPath: string, target: string): Promise<void> {
-  await prepareReplacement(linkPath)
+async function symlinkIfMissing(linkPath: string, target: string): Promise<{ readonly target: string; readonly managed: boolean }> {
+  if (await existingAgentFile(linkPath)) return { target: linkPath, managed: false }
   await symlink(target, linkPath)
+  return { target, managed: true }
 }
 
-async function replaceWithCopy(linkPath: string, target: string): Promise<void> {
-  await prepareReplacement(linkPath)
+async function copyIfMissing(linkPath: string, target: string): Promise<{ readonly target: string; readonly managed: boolean }> {
+  if (await existingAgentFile(linkPath)) return { target: linkPath, managed: false }
   await copyFile(target, linkPath)
+  return { target, managed: true }
 }
 
-async function prepareReplacement(linkPath: string): Promise<void> {
-  if (!(await exists(linkPath))) return
+async function existingAgentFile(linkPath: string): Promise<boolean> {
+  if (!(await exists(linkPath))) return false
   const entryStat = await lstat(linkPath)
   if (entryStat.isDirectory() && !entryStat.isSymbolicLink()) {
     throw new Error(`${linkPath} already exists and is a directory; refusing to replace`)
   }
-  await rm(linkPath, { force: true })
+  return true
 }
 
 async function writeManifest(pluginRoot: string, agentPaths: readonly string[]): Promise<void> {

--- a/src/cli/install-codex/preserve-existing-codex-agents.test.ts
+++ b/src/cli/install-codex/preserve-existing-codex-agents.test.ts
@@ -1,0 +1,31 @@
+/// <reference path="../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { materializeExistingCodexAgentFiles } from "./preserve-existing-codex-agents"
+
+describe("materializeExistingCodexAgentFiles", () => {
+  test("converts existing agent symlinks into regular files with their current content", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-preserve-agents-"))
+    const codexHome = join(root, "codex")
+    const agentsDir = join(codexHome, "agents")
+    const snapshotAgent = join(root, "snapshot", "plan.toml")
+    await mkdir(agentsDir, { recursive: true })
+    await mkdir(join(root, "snapshot"), { recursive: true })
+    await writeFile(snapshotAgent, 'name = "plan"\nmodel_reasoning_effort = "high"\n')
+    await symlink(snapshotAgent, join(agentsDir, "plan.toml"))
+
+    // when
+    const materialized = await materializeExistingCodexAgentFiles(codexHome)
+    await writeFile(snapshotAgent, 'name = "plan"\nmodel_reasoning_effort = "xhigh"\n')
+
+    // then
+    expect(materialized).toEqual([join(agentsDir, "plan.toml")])
+    expect((await lstat(join(agentsDir, "plan.toml"))).isSymbolicLink()).toBe(false)
+    expect(await readFile(join(agentsDir, "plan.toml"), "utf8")).toBe('name = "plan"\nmodel_reasoning_effort = "high"\n')
+  })
+})

--- a/src/cli/install-codex/preserve-existing-codex-agents.ts
+++ b/src/cli/install-codex/preserve-existing-codex-agents.ts
@@ -1,0 +1,42 @@
+import { lstat, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+export async function materializeExistingCodexAgentFiles(codexHome: string): Promise<readonly string[]> {
+  const agentsDir = join(codexHome, "agents")
+  if (!(await exists(agentsDir))) return []
+
+  const materialized: string[] = []
+  const entries = await readdir(agentsDir, { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.name.endsWith(".toml")) continue
+    const agentPath = join(agentsDir, entry.name)
+    const stat = await lstat(agentPath)
+    if (!stat.isSymbolicLink()) continue
+
+    const content = await readExistingSymlinkContent(agentPath)
+    await rm(agentPath, { force: true })
+    if (content === null) continue
+
+    await writeFile(agentPath, content)
+    materialized.push(agentPath)
+  }
+  return materialized.sort()
+}
+
+async function readExistingSymlinkContent(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8")
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null
+    throw error
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Preserve existing `CODEX_HOME/agents/*.toml` files instead of replacing them during Codex/LazyCodex reinstalls.
- Materialize existing Unix symlinked agent TOMLs into regular user-owned files before refreshing the stable marketplace snapshot, so local edits survive snapshot rewrites.
- Keep preserved user files out of `.installed-agents.json` so cleanup does not delete them, while still registering their `[agents.*]` config entries.
- Mirror the behavior in the packaged `packages/omo-codex/scripts` installer path and update ultrawork docs.

Refs code-yeongyu/lazycodex#18.

## Verification

- `bun run typecheck`
- `bun test src/cli/install-codex/link-cached-plugin-agents.test.ts src/cli/install-codex/preserve-existing-codex-agents.test.ts`
- `node --test packages/omo-codex/scripts/install-agent-links.test.mjs`

## Notes

`bun run test:codex` currently stops before reaching the Codex tests because `build:lsp-tools-mcp` runs `npm --prefix packages/lsp-tools-mcp ci`, but that package has no `package-lock.json` in this checkout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves existing agent TOMLs in `CODEX_HOME/agents` during Codex/LazyCodex reinstalls and marketplace updates so local edits aren’t overwritten. Converts old Unix symlinked agents to user-owned files and only installs missing agents.

- Bug Fixes
  - Materialize existing symlinked `*.toml` into regular files before refreshing the marketplace snapshot.
  - Install agents only if missing: symlink on Unix, copy on Windows; never overwrite existing user files.
  - Record only managed agent files in `.installed-agents.json` so preserved user files aren’t deleted on cleanup.
  - Applied in both the CLI installer and `packages/omo-codex/scripts`; updated ultrawork docs and added tests.

<sup>Written for commit 1f981f7b8d61274125bddd69133eadcfb339b41a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

