### PR TITLE
fix(model-core): extend kimi-thinking heuristic to match k2p* models

### DIFF
--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -56,7 +56,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     includes: ["kimi-thinking", "k2-thinking", "k2-think"],
     // Matches models with -thinking/-think suffix, OR k2p* models (k2p5, k2p6, k2-p6, k2.p6)
     // which are kimi-for-coding provider models that support thinking (#3945, #4418, #4707).
-    pattern: /(?:kimi|k2)(?:.*-(?:thinking|think)|[-.]?p\d)/,
+    pattern: /(?:kimi.*-(?:thinking|think)|k2(?:.*-(?:thinking|think)|[-.]?p\d))/,
     variants: ["low", "medium", "high"],
     supportsThinking: true,
   },

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -54,7 +54,9 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "kimi-thinking",
     includes: ["kimi-thinking", "k2-thinking", "k2-think"],
-    pattern: /(?:kimi|k2).*-(?:thinking|think)/,
+    // Matches models with -thinking/-think suffix, OR k2p* models (k2p5, k2p6, k2-p6, k2.p6)
+    // which are kimi-for-coding provider models that support thinking (#3945, #4418, #4707).
+    pattern: /(?:kimi|k2)(?:.*-(?:thinking|think)|[-.]?p\d)/,
     variants: ["low", "medium", "high"],
     supportsThinking: true,
   },

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -631,6 +631,18 @@ describe("resolveCompatibleModelSettings", () => {
     }
   })
 
+  test("does not classify kimi-p style IDs as kimi-thinking", () => {
+    // given
+    const capabilities = getModelCapabilities({
+      providerID: "kimi-for-coding",
+      modelID: "kimi-p6",
+    })
+
+    // then
+    expect(capabilities.family).not.toBe("kimi-thinking")
+    expect(capabilities.supportsThinking).not.toBe(true)
+  })
+
   test("clamps maxTokens to the model output limit", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -594,6 +594,43 @@ describe("resolveCompatibleModelSettings", () => {
       expect(result.changes).toEqual([])
     }
   })
+  test("resolves variant for k2p models via kimi-thinking heuristic family", () => {
+    for (const modelID of ["k2p5", "k2p6", "k2-p6", "k2.p6"]) {
+      // given
+      const capabilities = getModelCapabilities({
+        providerID: "kimi-for-coding",
+        modelID,
+      })
+
+      // when
+      const result = resolveCompatibleModelSettings({
+        providerID: "kimi-for-coding",
+        modelID,
+        desired: { variant: "high" },
+        capabilities,
+      })
+
+      // then
+      expect(result.variant).toBe("high")
+      expect(result.changes).toEqual([])
+    }
+  })
+
+  test("detects k2p models as kimi-thinking family with thinking and variants", () => {
+    for (const modelID of ["k2p5", "k2p6", "k2-p6", "k2.p6"]) {
+      // given
+      const capabilities = getModelCapabilities({
+        providerID: "kimi-for-coding",
+        modelID,
+      })
+
+      // then: kimi-thinking heuristic family should detect thinking support
+      expect(capabilities.supportsThinking).toBe(true)
+      expect(capabilities.family).toBe("kimi-thinking")
+      expect(capabilities.variants).toEqual(["low", "medium", "high"])
+    }
+  })
+
   test("clamps maxTokens to the model output limit", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",


### PR DESCRIPTION
## Problem

After #4681 correctly excluded `k2p6` from the generic `kimi` family (which has `supportsThinking: false`), k2p* models from `kimi-for-coding` fall through all three capability detection stages:

1. No alias rule matches
2. No snapshot entry exists (bundled snapshot is stale since April 17, see #3945 #4707)
3. `kimi-thinking` heuristic does not match (requires `-thinking` or `-think` suffix); `kimi` does not match either (excluded by #4681 negative lookahead)

Result: `resolutionMode = "unknown"`, variant and reasoningEffort are silently deleted from requests.

## Fix

Extend the `kimi-thinking` heuristic pattern to also match k2p* model IDs, instead of creating a new family. The `kimi-thinking` family already has the correct properties (`supportsThinking: true`, `variants: ["low", "medium", "high"]`), and models.dev already classifies both k2p5 and k2p6 under `family: "kimi-thinking"`.

```diff
- pattern: /(?:kimi|k2).*-(?:thinking|think)/
+ pattern: /(?:kimi|k2)(?:.*-(?:thinking|think)|[-.]?p\d)/
```

This matches:
- `kimi-k2-thinking`, `k2-thinking`, `k2-think` (existing behavior, suffix-based)
- `k2p5`, `k2p6`, `k2-p6`, `k2.p6` (new, kimi-for-coding thinking models)

And does NOT match:
- `k2-v2`, `k2.6` (volcengine/generic K2 without thinking)
- `kimi-k2.5` (falls through to `kimi` family with `supportsThinking: false`)

Since the registry is ordered (`kimi-thinking` before `kimi`), k2p* models are now classified as `kimi-thinking` with correct thinking support and variants, instead of falling through to "unknown".

## Changes

- **`model-capability-heuristics.ts`**: Extend `kimi-thinking` pattern to `/(?:kimi|k2)(?:.*-(?:thinking|think)|[-.]?p\d)/`
- **`model-settings-compatibility.test.ts`**: Add two regression tests verifying variant resolution and capability detection for all k2p* ID forms

## Testing

```
bun test packages/model-core/src/ --bail
262 pass / 0 fail
```

## Related

- Closes #4707
- Related to #3945 (original thinking display bug)
- Related to #4681 (k2p6 regex exclusion, which this complements)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the `kimi-thinking` heuristic to match `k2p*` models from `kimi-for-coding` while avoiding `kimi-p*` misclassification. `k2p*` models are now correctly treated as thinking models with proper variants, preventing unknown resolution and preserving variant and `reasoningEffort`.

- **Bug Fixes**
  - Narrowed regex to `/(?:kimi.*-(?:thinking|think)|k2(?:.*-(?:thinking|think)|[-.]?p\d))/` to include `k2p5`, `k2p6`, `k2-p6`, `k2.p6` and exclude `kimi-p*`.
  - Added regression tests for `k2p*` variant detection and a negative test for `kimi-p6`.

<sup>Written for commit 8f144ce63b35f50aa6ab3bf4a84649be05c6689c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

