### PR TITLE
fix(model-core): prefer metadata over heuristic for supportsThinking

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -332,7 +332,7 @@ describe("getModelCapabilities", () => {
     })
   })
 
-  test("marks MiniMax M2.7 as not supporting thinking despite snapshot reasoning", () => {
+  test("prefers snapshot reasoning over heuristic supportsThinking for MiniMax M2.7", () => {
     // given
     const modelID = "minimax-m2.7"
 
@@ -343,9 +343,9 @@ describe("getModelCapabilities", () => {
       bundledSnapshot,
     })
 
-    // then
-    expect(result.supportsThinking).toBe(false)
-    expect(result.diagnostics.supportsThinking.source).toBe("heuristic")
+    // then: snapshot reasoning metadata should win over heuristic fallback
+    expect(result.supportsThinking).toBe(true)
+    expect(result.diagnostics.supportsThinking.source).toBe("bundled-snapshot")
   })
 
   test("marks non-thinking Kimi K2.6 as not supporting thinking", () => {
@@ -424,5 +424,51 @@ describe("getModelCapabilities", () => {
       expect(result.diagnostics.resolutionMode).toBe("snapshot-backed")
       expect(result.diagnostics.snapshot.source).toBe("bundled-snapshot")
     }
+  })
+
+  test("prefers snapshot reasoning over heuristic supportsThinking: false", () => {
+    // given: a model matching the kimi heuristic (supportsThinking: false) but with reasoning: true in snapshot
+    const capabilities = getModelCapabilities({
+      providerID: "moonshotai",
+      modelID: "kimi-k2.5",
+      bundledSnapshot: {
+        generatedAt: "test",
+        sourceUrl: "test",
+        models: {
+          "kimi-k2.5": {
+            id: "kimi-k2.5",
+            family: "kimi",
+            reasoning: true,
+            temperature: true,
+            modalities: { input: ["text"], output: ["text"] },
+            limit: { context: 262144, output: 32768 },
+          },
+        },
+      },
+    })
+
+    // then: snapshot metadata should win over heuristic fallback
+    expect(capabilities.supportsThinking).toBe(true)
+    expect(capabilities.diagnostics.supportsThinking.source).toBe("bundled-snapshot")
+  })
+
+  test("prefers runtime thinking over heuristic supportsThinking: false", () => {
+    // given: a model matching the kimi heuristic but runtime reports thinking
+    findProviderModelMetadataSpy = spyOn(
+      connectedProvidersCache,
+      "findProviderModelMetadata",
+    ).mockReturnValue(undefined)
+
+    const capabilities = getModelCapabilities({
+      providerID: "moonshotai",
+      modelID: "kimi-k2.5",
+      runtimeModel: {
+        reasoning: true,
+      },
+    })
+
+    // then: runtime metadata should win over heuristic fallback
+    expect(capabilities.supportsThinking).toBe(true)
+    expect(capabilities.diagnostics.supportsThinking.source).toBe("runtime")
   })
 })

--- a/packages/model-core/src/model-capabilities/get-model-capabilities.ts
+++ b/packages/model-core/src/model-capabilities/get-model-capabilities.ts
@@ -67,12 +67,12 @@ export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCap
 	const supportsThinkingSource: ModelCapabilitiesDiagnostics["supportsThinking"]["source"] =
 		override?.supportsThinking !== undefined
 			? "override"
-			: heuristicFamily?.supportsThinking !== undefined
-			? "heuristic"
 			: runtimeThinking !== undefined
 			? "runtime"
 			: snapshotEntry?.reasoning !== undefined
 			? snapshotSource
+			: heuristicFamily?.supportsThinking !== undefined
+			? "heuristic"
 			: "none"
 	const supportsTemperatureSource: ModelCapabilitiesDiagnostics["supportsTemperature"]["source"] =
 		runtimeTemperature !== undefined
@@ -110,7 +110,7 @@ export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCap
 		variants: runtimeVariants ?? override?.variants ?? heuristicFamily?.variants,
 		reasoningEfforts: override?.reasoningEfforts ?? heuristicFamily?.reasoningEfforts,
 		reasoning: runtimeReasoning ?? snapshotEntry?.reasoning,
-		supportsThinking: override?.supportsThinking ?? heuristicFamily?.supportsThinking ?? runtimeThinking ?? snapshotEntry?.reasoning,
+		supportsThinking: override?.supportsThinking ?? runtimeThinking ?? snapshotEntry?.reasoning ?? heuristicFamily?.supportsThinking,
 		supportsTemperature: runtimeTemperature ?? override?.supportsTemperature ?? snapshotEntry?.temperature,
 		supportsTopP: runtimeTopP ?? override?.supportsTopP,
 		maxOutputTokens: runtimeMaxOutputTokens ?? snapshotEntry?.limit?.output,


### PR DESCRIPTION
## Problem

The `supportsThinking` field in `getModelCapabilities()` evaluates heuristic family metadata **before** runtime and snapshot metadata:

```typescript
supportsThinking: override?.supportsThinking
  ?? heuristicFamily?.supportsThinking    // heuristic BEFORE snapshot
  ?? runtimeThinking
  ?? snapshotEntry?.reasoning             // snapshot is the LAST fallback
```

This makes fallback data override authoritative model metadata. For example, `kimi-k2.5` has `reasoning: true` in the models.dev snapshot, but the generic `kimi` heuristic has `supportsThinking: false`, so the model is incorrectly classified as non-thinking. The same issue affects the `minimax` family.

The `family` field uses the correct order — snapshot before heuristic:
```typescript
family: snapshotEntry?.family ?? heuristicFamily?.family
```

## Fix

Reorder the `supportsThinking` resolution chain to use heuristic only as the last fallback:

```typescript
supportsThinking: override?.supportsThinking
  ?? runtimeThinking                     // runtime metadata
  ?? snapshotEntry?.reasoning            // snapshot metadata
  ?? heuristicFamily?.supportsThinking   // heuristic LAST (true fallback)
```

The matching diagnostics `supportsThinkingSource` is updated in sync.

## Changes

- **`get-model-capabilities.ts`**: Swap heuristic and metadata positions in both the value resolution chain and the `supportsThinkingSource` diagnostics
- **`model-capabilities.test.ts`**: Update MiniMax M2.7 test to reflect correct snapshot-over-heuristic behavior; add two new tests verifying snapshot and runtime metadata take precedence over heuristic

## Testing

```
bun test packages/model-core/src/ --bail
262 pass / 0 fail
```

## Why separate from #4716

#4716 only fixes the stale snapshot fallback for k2p* models (heuristic-level fix). This PR fixes the broader architectural issue so refreshed snapshots and runtime metadata are always respected for all model families.

## Related

- Closes #4718
- Related to #3945 (original thinking display bug)
- Related to #4681 (k2p6 heuristic exclusion)
- Related to #4707 (k2p6 capability unknown)
- Related to #4716 (k2p heuristic fallback fix)
- Related to #4717 (snapshot auto-refresh broken)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `supportsThinking` precedence in `model-core` to prioritize runtime and snapshot metadata over heuristic defaults. Prevents misclassifying models with reasoning metadata as non-thinking (e.g., `minimax-m2.7`, `kimi-k2.5`).

- **Bug Fixes**
  - Set order to: override > runtime > snapshot > heuristic for `supportsThinking`.
  - Update `supportsThinkingSource` diagnostics to match.
  - Update `minimax-m2.7` test to reflect snapshot winning; add tests confirming snapshot/runtime beat heuristic for `kimi-k2.5`.

<sup>Written for commit b4337b653e00d5d8212b874955d8b96bbf2895e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

