### PR TITLE
fix(claude-code-plugin-loader): replace all CLAUDE_PLUGIN_ROOT occurrences (fixes #4709)

### DIFF
--- a/src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts
+++ b/src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts
@@ -13,6 +13,17 @@ describe("resolvePluginPath", () => {
     // then
     expect(result).toBe("/tmp/plugin-root/dist/index.js")
   })
+
+  test("#given a path referencing the placeholder multiple times #when resolving the path #then it replaces every occurrence", () => {
+    // given
+    const path = 'bash "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/run.py" --quiet'
+
+    // when
+    const result = resolvePluginPath(path, "/tmp/plugin-root")
+
+    // then
+    expect(result).toBe('bash "/tmp/plugin-root/hooks/launcher.sh" "/tmp/plugin-root/hooks/run.py" --quiet')
+  })
 })
 
 describe("resolvePluginPaths", () => {

--- a/src/features/claude-code-plugin-loader/plugin-path-resolver.ts
+++ b/src/features/claude-code-plugin-loader/plugin-path-resolver.ts
@@ -1,7 +1,7 @@
 const CLAUDE_PLUGIN_ROOT_VAR = "${CLAUDE_PLUGIN_ROOT}"
 
 export function resolvePluginPath(path: string, pluginRoot: string): string {
-  return path.replace(CLAUDE_PLUGIN_ROOT_VAR, pluginRoot)
+  return path.replaceAll(CLAUDE_PLUGIN_ROOT_VAR, pluginRoot)
 }
 
 export function resolvePluginPaths<T>(obj: T, pluginRoot: string): T {


### PR DESCRIPTION
## Summary
`resolvePluginPath()` only resolved the **first** `${CLAUDE_PLUGIN_ROOT}` in a string, so plugin hook commands that reference the placeholder more than once kept the later occurrences unresolved and broke every Bash tool call. Switched the single replace to `replaceAll`.

## Root Cause
`src/features/claude-code-plugin-loader/plugin-path-resolver.ts:4` used `String.prototype.replace` with a **string** pattern:

```ts
return path.replace(CLAUDE_PLUGIN_ROOT_VAR, pluginRoot)  // first match only
```

A string-pattern `.replace()` rewrites only the first match. Real plugins (e.g. `alexgreensh/token-optimizer`) put two `${CLAUDE_PLUGIN_ROOT}` references in one hook command (`bash "${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/run.py" ...`). The second occurrence survived resolution, the spawned shell expanded the leftover `${CLAUDE_PLUGIN_ROOT}` to an empty string, and every PreToolUse/PostToolUse Bash call failed with `python3: can't open file '/hooks/run.py'`.

## Changes
| File | Change |
|------|--------|
| `src/features/claude-code-plugin-loader/plugin-path-resolver.ts` | `.replace()` → `.replaceAll()` so every `${CLAUDE_PLUGIN_ROOT}` is resolved |
| `src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts` | Added regression test for a command containing two placeholders |

## Reproduction (before fix)
~~~
INPUT : bash "${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/run.py" --quiet
OUTPUT: bash "/Users/me/.claude/plugins/cache/x/5.8.9/hooks/python-launcher.sh" "${CLAUDE_PLUGIN_ROOT}/hooks/run.py" --quiet
LEFTOVER PLACEHOLDER PRESENT: true   <-- second occurrence not replaced
~~~

## Verification (after fix)
~~~
OUTPUT: bash "/Users/me/.claude/plugins/cache/x/5.8.9/hooks/python-launcher.sh" "/Users/me/.claude/plugins/cache/x/5.8.9/hooks/run.py" --quiet
LEFTOVER PLACEHOLDER PRESENT: false  <-- all occurrences replaced

bun test src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts
 4 pass  0 fail
~~~

## Test
- Regression test: `plugin-path-resolver.test.ts` (newly added multi-occurrence case)
- Module suite: `bun test src/features/claude-code-plugin-loader/` — 54 pass. One unrelated pre-existing failure in `discovery.test.ts` (`#when multiple non-'unknown' semver siblings are present`) reproduces on a clean `upstream/dev` tree without this change (Windows temp-path parsing); not touched here.
- Typecheck: `bun run typecheck` — exit code 0, clean.

Fixes #4709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed path resolution in `claude-code-plugin-loader` to replace all `${CLAUDE_PLUGIN_ROOT}` occurrences so multi-reference hook commands resolve correctly and Bash tool calls no longer fail.

- **Bug Fixes**
  - Use `.replaceAll()` in `resolvePluginPath` to replace every placeholder.
  - Add a regression test for a command containing two `${CLAUDE_PLUGIN_ROOT}` references.

<sup>Written for commit 4c0ea569baaf826a38ce428d629e8331a09ce372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

