### PR TITLE
fix(session-manager): list all sessions when directory is server root (fixes #4704)

### DIFF
--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -415,6 +415,26 @@ describe("session-manager storage - getMainSessions", () => {
     // then
     expect(sessions.length).toBe(2)
   })
+
+  test("getMainSessions returns all main sessions when directory is the server root sentinel", async () => {
+    // given
+    const projectA = "proj_aaa"
+    const projectB = "proj_bbb"
+    const now = Date.now()
+
+    createSessionMetadata(projectA, "ses_projA", { directory: "/path/to/projectA", updated: now })
+    createSessionMetadata(projectB, "ses_projB", { directory: "/path/to/projectB", updated: now - 1000 })
+
+    createMessageForSession("ses_projA", "msg_001", now)
+    createMessageForSession("ses_projB", "msg_001", now - 1000)
+
+    // when
+    const sessions = await storage.getMainSessions({ directory: "/" })
+
+    // then
+    expect(sessions.length).toBe(2)
+    expect(sessions.map((s) => s.id).sort()).toEqual(["ses_projA", "ses_projB"])
+  })
 })
 
 describe("session-manager storage - SDK path (beta mode)", () => {

--- a/src/tools/session-manager/storage.ts
+++ b/src/tools/session-manager/storage.ts
@@ -9,6 +9,14 @@ export interface GetMainSessionsOptions {
   directory?: string
 }
 
+// In multi-project server mode (opencode web / opencode serve) ctx.directory is the
+// filesystem root "/", which never matches a stored session.directory. Treat it as
+// "no project filter" so every session is listed instead of silently dropping all of them.
+function normalizeProjectFilter(directory?: string): string | undefined {
+  if (directory === "/") return undefined
+  return directory
+}
+
 function mergeSessionMetadataLists(
   sdkSessions: SessionMetadata[],
   fileSessions: SessionMetadata[],
@@ -42,10 +50,11 @@ export function resetStorageClient(): void {
 }
 
 export async function getMainSessions(options: GetMainSessionsOptions): Promise<SessionMetadata[]> {
+  const directory = normalizeProjectFilter(options.directory)
   if (isSqliteBackend() && sdkClient) {
     try {
-      const sdkSessions = await getSdkMainSessions(sdkClient, options.directory)
-      const fileSessions = await getFileMainSessions(options.directory)
+      const sdkSessions = await getSdkMainSessions(sdkClient, directory)
+      const fileSessions = await getFileMainSessions(directory)
       return mergeSessionMetadataLists(sdkSessions, fileSessions)
     } catch (error) {
       if (!shouldFallbackFromSdkError(error)) throw error
@@ -53,7 +62,7 @@ export async function getMainSessions(options: GetMainSessionsOptions): Promise<
     }
   }
 
-  return getFileMainSessions(options.directory)
+  return getFileMainSessions(directory)
 }
 
 export async function getAllSessions(): Promise<string[]> {


### PR DESCRIPTION
## Summary
`session_list` returned an empty list in `opencode web` / `opencode serve`, so the web sidebar showed no sessions at all. In multi-project server mode the directory filter dropped every session. Normalized the root sentinel so all sessions are listed.

## Root Cause
`session_list` passes `ctx.directory` as the project filter (`src/tools/session-manager/tools.ts`). In multi-project server mode (`opencode web` / `opencode serve`) `ctx.directory` is the filesystem root `"/"`. Both filter sites compare with strict equality:

- `src/tools/session-manager/sdk-storage.ts`: `mainSessions.filter((s) => s.directory === directory)`
- `src/tools/session-manager/file-storage.ts`: `if (directory && meta.directory !== directory) continue`

Stored sessions keep their real project path (e.g. `D:\root\project`, `/home/user/project`), which never equals `"/"`, so **all** main sessions were filtered out. `session_search` was unaffected because it uses `getAllSessions()` with no directory filter — which is why search found sessions while the sidebar stayed empty.

## Fix
Normalize the `"/"` root sentinel to an absent filter at the single chokepoint `getMainSessions()` in `storage.ts`. Both the SDK and file paths then fall through to their already-tested "no directory = return all sessions" behavior. One small change covers both code paths and adds no new heuristic to the filter sites.

## Changes
| File | Change |
|------|--------|
| `src/tools/session-manager/storage.ts` | Add `normalizeProjectFilter()`; map `"/"` -> `undefined` before delegating to SDK/file lookups |
| `src/tools/session-manager/storage.test.ts` | Regression test: `getMainSessions({ directory: "/" })` returns all sessions |

## Reproduction (before fix)
~~~
getMainSessions({ directory: "/" }) on 2 stored sessions (dirs: /path/to/projectA, /path/to/projectB)
Expected: 2
Received: 0   <-- all sessions filtered out, empty sidebar
~~~

## Verification (after fix)
~~~
bun test src/tools/session-manager/storage.test.ts -t "server root sentinel"
 1 pass  0 fail

bun test src/tools/session-manager/
 57 pass  0 fail
~~~

## Test
- Regression test: `storage.test.ts` (newly added root-sentinel case; fails before the fix with `Received: 0`, passes after)
- Module suite: `bun test src/tools/session-manager/` — 57 pass, 0 fail
- Typecheck: `bun run typecheck` — exit code 0, clean

Fixes #4704

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty sessions in the web sidebar for multi-project server mode by treating `'/'` as no project filter so all sessions are listed. Fixes #4704.

- **Bug Fixes**
  - Normalize the server root sentinel `'/'` to `undefined` in `getMainSessions()` via `normalizeProjectFilter()`, covering both SDK and file storage paths.
  - Add regression test to ensure `getMainSessions({ directory: "/" })` returns all main sessions.

<sup>Written for commit 0bd6c0f52eeabce99beff41fb2f584a34abd9aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

