### PR TITLE
fix(background-agent): defer parent wakes during active assistant turns

### DIFF
--- a/.github/workflows/lazycodex-label.yml
+++ b/.github/workflows/lazycodex-label.yml
@@ -22,11 +22,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          if gh label view "$LABEL_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh label edit "$LABEL_NAME" --repo "$GITHUB_REPOSITORY" --color "7C3AED" --description "LazyCodex and omo-codex related work"
-          else
-            gh label create "$LABEL_NAME" --repo "$GITHUB_REPOSITORY" --color "7C3AED" --description "LazyCodex and omo-codex related work"
+          if gh label create "$LABEL_NAME" --repo "$GITHUB_REPOSITORY" --color "7C3AED" --description "LazyCodex and omo-codex related work" 2>/tmp/lazycodex-label-error.log; then
+            exit 0
           fi
+
+          if grep -qi "already exists" /tmp/lazycodex-label-error.log; then
+            gh label edit "$LABEL_NAME" --repo "$GITHUB_REPOSITORY" --color "7C3AED" --description "LazyCodex and omo-codex related work"
+            exit 0
+          fi
+
+          cat /tmp/lazycodex-label-error.log >&2
+          exit 1
 
   label-pull-request:
     runs-on: ubuntu-latest

--- a/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -167,7 +167,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     }
   })
 
-  test("#given stale completed unknown assistant turn has only step metadata #when flushing pending wake #then parent wake bypasses the second prompt gate check", async () => {
+  test("#given stale completed unknown assistant turn has only step metadata #when flushing pending wake #then wake stays pending", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -237,8 +237,8 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-completed-unknown")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(false)
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(true)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -8,7 +8,7 @@ import { ParentWakeNotifier } from "./parent-wake-notifier"
 type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
 
 describe("ParentWakeNotifier — assistant history deferral", () => {
-  test("#given stale unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake dispatches after defer max without second gate check", async () => {
+  test("#given stale unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake keeps deferring", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -66,7 +66,7 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-stale-text", pendingWake)
 
       // then
-      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: true })
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -21,7 +21,7 @@ import {
   type ParentWakePromptContext,
   type PendingParentWake,
 } from "./parent-wake-dedupe"
-import { getParentWakeMessageActivityAt, getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
+import { getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
 
 type OpencodeClient = PluginInput["client"]
 type ParentWakeNotifierClient = PromptDispatchClient & {
@@ -420,52 +420,6 @@ export class ParentWakeNotifier {
     return message.info?.role ?? message.role
   }
 
-  private getParentWakeMessageFinish(message: ParentWakeSessionMessage): string | undefined {
-    return message.info?.finish ?? message.finish
-  }
-
-  private parentWakePartIsWaitingOnTool(part: NonNullable<ParentWakeSessionMessage["parts"]>[number]): boolean {
-    if (
-      part.type !== "tool"
-      && part.type !== "tool_use"
-      && part.type !== "tool-call"
-      && part.type !== "tool-invocation"
-    ) {
-      return false
-    }
-
-    const status = part.state?.status
-    return status === "pending" || status === "running"
-  }
-
-  private latestAssistantToolWaitState(messages: ParentWakeSessionMessage[]): {
-    waiting: boolean
-    activityAt?: number
-  } {
-    for (let index = messages.length - 1; index >= 0; index--) {
-      const message = messages[index]
-      if (!message) {
-        continue
-      }
-      const role = this.getParentWakeMessageRole(message)
-      if (role === "assistant") {
-        const waiting = this.getParentWakeMessageFinish(message) === "tool-calls"
-          || message.parts?.some((part) => this.parentWakePartIsWaitingOnTool(part)) === true
-        const activityAt = getParentWakeMessageActivityAt(message)
-        return waiting
-          ? { waiting: true, activityAt }
-          : { waiting: false, activityAt }
-      }
-      if (role === "user") {
-        if (isSyntheticOrInternalUserMessage(message)) {
-          continue
-        }
-        return { waiting: false }
-      }
-    }
-    return { waiting: false }
-  }
-
   private parentWakeMessageHasOutput(message: ParentWakeSessionMessage): boolean {
     const role = this.getParentWakeMessageRole(message)
     if (role !== "assistant" && role !== "tool") {
@@ -556,7 +510,6 @@ export class ParentWakeNotifier {
     }
     const latestAssistantBlocksPrompt = latestAssistantTurnBlocksInternalPrompt(messages)
     const latestAssistantHasUnansweredQuestion = latestAssistantTurnHasUnansweredQuestion(messages)
-    const toolWaitState = this.latestAssistantToolWaitState(messages)
     if (!latestAssistantBlocksPrompt) {
       delete wake.toolCallDeferralStartedAt
       return { defer: false, skipPromptGateToolStateCheck: false }
@@ -568,36 +521,6 @@ export class ParentWakeNotifier {
         sessionID,
       })
       return { defer: true, skipPromptGateToolStateCheck: false }
-    }
-    const latestToolWaitAgeMs = toolWaitState.activityAt === undefined
-      ? 0
-      : now - toolWaitState.activityAt
-    const deferAge = now - wake.toolCallDeferralStartedAt
-    const latestAssistantActivityAgeMs = toolWaitState.activityAt === undefined
-      ? deferAge
-      : now - toolWaitState.activityAt
-    if (
-      wake.shouldReply
-      && toolWaitState.waiting
-      && deferAge >= this.options.toolCallDeferMaxMs
-      && latestToolWaitAgeMs >= this.options.toolCallDeferMaxMs
-    ) {
-      log("[background-agent] Sending parent wake after stale tool-call deferral window:", {
-        sessionID,
-      })
-      return { defer: false, skipPromptGateToolStateCheck: true }
-    }
-    if (
-      !toolWaitState.waiting
-      && deferAge >= this.options.toolCallDeferMaxMs
-      && latestAssistantActivityAgeMs >= this.options.toolCallDeferMaxMs
-    ) {
-      log("[background-agent] Sending parent wake after stale assistant-text deferral window:", {
-        sessionID,
-        deferAgeMs: deferAge,
-        latestAssistantActivityAgeMs,
-      })
-      return { defer: false, skipPromptGateToolStateCheck: true }
     }
     log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
       sessionID,


### PR DESCRIPTION
## Summary
Fixes duplicated same-parent assistant responses observed in OpenCode session `ses_16f3db45cffejXikhjWw3yz5G6` after the synthetic `[BACKGROUND TASK COMPLETED] [ALL BACKGROUND TASKS COMPLETE]` parent wake. The duplicated replies came from a stale parent-wake escape hatch that bypassed the shared prompt gate while the latest assistant turn still blocked internal prompts.

## Changes
- Removes the background-agent parent-wake stale assistant/tool-call bypass that returned `skipPromptGateToolStateCheck: true`.
- Keeps parent wakes pending while `latestAssistantTurnBlocksInternalPrompt()` says the latest assistant turn is still unsafe for internal prompt injection.
- Updates regression tests so stale assistant-text and completed-unknown assistant-turn cases stay deferred instead of forking another parent response.

## Evidence
- Investigated target session export/timeline for `ses_16f3db45cffejXikhjWw3yz5G6`.
- Cross-checked `../opencode` prompt durability behavior: `promptAsync` can return before the prompt is durably accepted, with later failures surfacing on session events.
- Related duplicate-response issues used as context: #4167, #4505, #4256, #4638.

## Testing
- RED: `bun test src/features/background-agent/parent-wake-history-deferral.test.ts -t "stale unfinished assistant text"` failed with `{ defer: false, skipPromptGateToolStateCheck: true }` before the fix.
- GREEN focused parent-wake suite: `bun test src/features/background-agent/parent-wake-history-deferral.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-assistant-blocking.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/shared/prompt-async-gate/pending-tool-turn.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun test`
- Manual QA through the parent-wake/OpenCode-like CLI surface: stale assistant turn produced `promptAsyncCalls: 0` and left the wake pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers parent wakes during active assistant turns to stop duplicate assistant replies after synthetic background-task wakes. Removes a stale bypass that skipped the shared prompt gate; also makes the LazyCodex label workflow idempotent.

- **Bug Fixes**
  - Removed the parent-wake escape hatch that set `skipPromptGateToolStateCheck: true`.
  - Keep wakes pending while `latestAssistantTurnBlocksInternalPrompt()` is true; removed time-based flushes and tool-wait scanning.
  - Updated tests to ensure wakes stay pending and no extra prompts are dispatched.
  - CI: Make LazyCodex label creation idempotent by creating first, editing on “already exists,” and failing otherwise.

<sup>Written for commit 3599f6a5e44b4d76d70c64efdefcb4e1aa7006cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

