### PR TITLE
fix(background-agent): requeue empty parent wakes

### DIFF
--- a/src/features/background-agent/empty-assistant-turn.ts
+++ b/src/features/background-agent/empty-assistant-turn.ts
@@ -1,0 +1,49 @@
+import { isRecord } from "./error-classifier"
+
+type AssistantTurnInfo = {
+  readonly role?: unknown
+  readonly finish?: unknown
+  readonly tokens?: unknown
+}
+
+function getTokenCount(tokens: unknown, key: "input" | "output" | "reasoning"): number | undefined {
+  const tokenRecord = isRecord(tokens) ? tokens : undefined
+  if (!tokenRecord) {
+    return undefined
+  }
+  const value = tokenRecord[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function getCacheTokenCount(tokens: unknown, key: "write" | "read"): number | undefined {
+  const tokenRecord = isRecord(tokens) ? tokens : undefined
+  const cacheRecord = isRecord(tokenRecord?.cache) ? tokenRecord.cache : undefined
+  if (!cacheRecord) {
+    return undefined
+  }
+  const value = cacheRecord[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function allTokenCountsIndicateNoProgress(tokens: unknown): boolean {
+  const coreCounts = [
+    getTokenCount(tokens, "input"),
+    getTokenCount(tokens, "output"),
+    getTokenCount(tokens, "reasoning"),
+  ]
+  const cacheCounts = [
+    getCacheTokenCount(tokens, "write"),
+    getCacheTokenCount(tokens, "read"),
+  ]
+  const cachePresent = cacheCounts.some((count) => count !== undefined)
+  return coreCounts.every((count) => count === 0)
+    && (!cachePresent || cacheCounts.every((count) => count === 0))
+}
+
+export function isEmptyNoProgressAssistantTurnInfo(info: unknown): info is AssistantTurnInfo {
+  const infoRecord = isRecord(info) ? info : undefined
+  return !!infoRecord
+    && infoRecord.role === "assistant"
+    && infoRecord.finish === "unknown"
+    && allTokenCountsIndicateNoProgress(infoRecord.tokens)
+}

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1496,15 +1496,7 @@ The fallback retry session is now created and can be inspected directly.
       if (isEmptyNoProgressAssistantTurnInfo(info)) {
         const dispatchedWake = this.parentWakeNotifier.getDispatchedParentWakes().get(sessionID)
         if (dispatchedWake) {
-          this.clearDispatchedParentWake(sessionID)
-          this.queuePendingParentWake(
-            sessionID,
-            dispatchedWake.notifications.join("\n\n"),
-            dispatchedWake.promptContext,
-            dispatchedWake.shouldReply,
-            0,
-          )
-          log("[background-agent] Requeued dispatched parent wake after empty assistant turn:", { sessionID })
+          this.parentWakeNotifier.requeueDispatchedParentWakeAfterEmptyAssistantTurn(sessionID)
           return
         }
       }

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -68,6 +68,7 @@ import {
   isAbortedSessionError,
   isRecord,
 } from "./error-classifier"
+import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
 import { tryFallbackRetry } from "./fallback-retry-handler"
 import {
   type CircuitBreakerSettings,
@@ -1492,6 +1493,21 @@ The fallback retry session is now created and can be inspected directly.
       const sessionID = resolveMessageEventSessionID(props)
       const role = (info as Record<string, unknown>)["role"]
       if (!sessionID) return
+      if (isEmptyNoProgressAssistantTurnInfo(info)) {
+        const dispatchedWake = this.parentWakeNotifier.getDispatchedParentWakes().get(sessionID)
+        if (dispatchedWake) {
+          this.clearDispatchedParentWake(sessionID)
+          this.queuePendingParentWake(
+            sessionID,
+            dispatchedWake.notifications.join("\n\n"),
+            dispatchedWake.promptContext,
+            dispatchedWake.shouldReply,
+            0,
+          )
+          log("[background-agent] Requeued dispatched parent wake after empty assistant turn:", { sessionID })
+          return
+        }
+      }
       this.clearDispatchedParentWake(sessionID)
       this.parentWakeNotifier.recordParentSessionActivity(sessionID)
 

--- a/src/features/background-agent/parent-wake-dedupe.ts
+++ b/src/features/background-agent/parent-wake-dedupe.ts
@@ -13,6 +13,7 @@ export type PendingParentWake = {
   shouldReply: boolean
   dispatchedAt?: number
   toolCallDeferralStartedAt?: number
+  allowEmptyAssistantTurnRetry?: boolean
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -34,6 +35,9 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     ...(wake.dispatchedAt !== undefined ? { dispatchedAt: wake.dispatchedAt } : {}),
     ...(wake.toolCallDeferralStartedAt !== undefined
       ? { toolCallDeferralStartedAt: wake.toolCallDeferralStartedAt }
+      : {}),
+    ...(wake.allowEmptyAssistantTurnRetry !== undefined
+      ? { allowEmptyAssistantTurnRetry: wake.allowEmptyAssistantTurnRetry }
       : {}),
   }
 }

--- a/src/features/background-agent/parent-wake-empty-turn-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-empty-turn-requeue.test.ts
@@ -32,6 +32,11 @@ type BackgroundManagerInternals = {
   readonly flushPendingParentWake: (sessionID: string) => Promise<void>
 }
 
+type SessionMessageForTest = {
+  readonly info: Record<string, unknown>
+  readonly parts?: readonly Record<string, unknown>[]
+}
+
 const EMPTY_UNKNOWN_ASSISTANT_INFO = {
   id: "msg-empty",
   sessionID: "parent-session-empty-wake",
@@ -53,7 +58,7 @@ afterEach(() => {
   releaseAllPromptAsyncReservationsForTesting()
 })
 
-function createManager(): {
+function createManager(sessionMessages: readonly SessionMessageForTest[] = []): {
   readonly manager: BackgroundManager
   readonly internals: BackgroundManagerInternals
   readonly promptCalls: PromptCall[]
@@ -62,7 +67,7 @@ function createManager(): {
   const client = unsafeTestValue<PluginInput["client"]>({
     session: {
       status: async () => ({ data: { "parent-session-empty-wake": { type: "idle" } } }),
-      messages: async () => ({ data: [] }),
+      messages: async () => ({ data: sessionMessages }),
       promptAsync: async (args: PromptCall) => {
         promptCalls.push(args)
         return {}
@@ -80,6 +85,21 @@ function createManager(): {
     internals: unsafeTestValue<BackgroundManagerInternals>(manager),
     promptCalls,
   }
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  expect(predicate()).toBe(true)
+}
+
+function waitForPendingWake(internals: BackgroundManagerInternals, sessionID: string): Promise<void> {
+  return waitUntil(() => internals.parentWakeNotifier.getPendingParentWakes().has(sessionID), 600)
 }
 
 describe("isEmptyNoProgressAssistantTurnInfo", () => {
@@ -168,12 +188,89 @@ describe("BackgroundManager parent wake empty-turn recovery", () => {
         info: EMPTY_UNKNOWN_ASSISTANT_INFO,
       },
     })
-    await Promise.resolve()
+    await waitForPendingWake(internals, sessionID)
 
     // then
     expect(internals.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
     expect(internals.parentWakeNotifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([
       notification,
     ])
+  })
+
+  test("#given dispatched parent wake has coalesced notifications #when OpenCode records an empty assistant turn #then notification slots are preserved", async () => {
+    // given
+    const { manager, internals, promptCalls } = createManager()
+    managerUnderTest = manager
+    const sessionID = "parent-session-empty-wake"
+    const firstNotification = "<system-reminder>first</system-reminder>"
+    const secondNotification = "<system-reminder>second</system-reminder>"
+    internals.queuePendingParentWake(sessionID, firstNotification, { agent: "sisyphus" }, true, 0)
+    internals.queuePendingParentWake(sessionID, secondNotification, { agent: "sisyphus" }, true, 0)
+    await internals.flushPendingParentWake(sessionID)
+    expect(promptCalls).toHaveLength(1)
+    expect(internals.parentWakeNotifier.getDispatchedParentWakes().get(sessionID)?.notifications).toEqual([
+      firstNotification,
+      secondNotification,
+    ])
+
+    // when
+    manager.handleEvent({
+      type: "message.updated",
+      properties: {
+        sessionID,
+        info: EMPTY_UNKNOWN_ASSISTANT_INFO,
+      },
+    })
+    await waitForPendingWake(internals, sessionID)
+
+    // then
+    expect(internals.parentWakeNotifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([
+      firstNotification,
+      secondNotification,
+    ])
+  })
+
+  test("#given parent history contains the empty assistant turn #when idle flushes the requeued wake #then one retry prompt is delivered", async () => {
+    // given
+    const sessionID = "parent-session-empty-wake"
+    const notification = "<system-reminder>done</system-reminder>"
+    const sessionMessages: SessionMessageForTest[] = []
+    const completedEmptyHistory: readonly SessionMessageForTest[] = [
+      {
+        info: { role: "user", time: { created: 1000 } },
+        parts: [{ type: "text", text: notification }],
+      },
+      {
+        info: {
+          ...EMPTY_UNKNOWN_ASSISTANT_INFO,
+          time: { created: 2000, completed: 3000 },
+        },
+        parts: [{ type: "step-finish", reason: "unknown", tokens: EMPTY_UNKNOWN_ASSISTANT_INFO.tokens }],
+      },
+    ]
+    const { manager, internals, promptCalls } = createManager(sessionMessages)
+    managerUnderTest = manager
+    internals.queuePendingParentWake(sessionID, notification, { agent: "sisyphus" }, true, 0)
+    await internals.flushPendingParentWake(sessionID)
+    expect(promptCalls).toHaveLength(1)
+    sessionMessages.push(...completedEmptyHistory)
+
+    manager.handleEvent({
+      type: "message.updated",
+      properties: {
+        sessionID,
+        info: EMPTY_UNKNOWN_ASSISTANT_INFO,
+      },
+    })
+    await waitForPendingWake(internals, sessionID)
+
+    // when
+    manager.handleEvent({ type: "session.idle", properties: { sessionID } })
+    await internals.flushPendingParentWake(sessionID)
+    await waitUntil(() => promptCalls.length === 2, 4_000)
+
+    // then
+    expect(promptCalls).toHaveLength(2)
+    expect(JSON.stringify(promptCalls[1]?.body.parts)).toContain(notification)
   })
 })

--- a/src/features/background-agent/parent-wake-empty-turn-requeue.test.ts
+++ b/src/features/background-agent/parent-wake-empty-turn-requeue.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
+import { BackgroundManager } from "./manager"
+
+type PromptCall = {
+  readonly path: { readonly id: string }
+  readonly body: Record<string, unknown>
+}
+
+type PendingParentWakeForTest = {
+  readonly notifications: string[]
+}
+
+type ParentWakeInternals = {
+  readonly getPendingParentWakes: () => Map<string, PendingParentWakeForTest>
+  readonly getDispatchedParentWakes: () => Map<string, PendingParentWakeForTest>
+}
+
+type BackgroundManagerInternals = {
+  readonly parentWakeNotifier: ParentWakeInternals
+  readonly queuePendingParentWake: (
+    sessionID: string,
+    notification: string,
+    promptContext: Record<string, unknown>,
+    shouldReply: boolean,
+    delayMs?: number,
+  ) => void
+  readonly flushPendingParentWake: (sessionID: string) => Promise<void>
+}
+
+const EMPTY_UNKNOWN_ASSISTANT_INFO = {
+  id: "msg-empty",
+  sessionID: "parent-session-empty-wake",
+  role: "assistant",
+  finish: "unknown",
+  tokens: {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cache: { write: 0, read: 0 },
+  },
+} as const
+
+let managerUnderTest: BackgroundManager | undefined
+
+afterEach(() => {
+  managerUnderTest?.shutdown()
+  managerUnderTest = undefined
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+function createManager(): {
+  readonly manager: BackgroundManager
+  readonly internals: BackgroundManagerInternals
+  readonly promptCalls: PromptCall[]
+} {
+  const promptCalls: PromptCall[] = []
+  const client = unsafeTestValue<PluginInput["client"]>({
+    session: {
+      status: async () => ({ data: { "parent-session-empty-wake": { type: "idle" } } }),
+      messages: async () => ({ data: [] }),
+      promptAsync: async (args: PromptCall) => {
+        promptCalls.push(args)
+        return {}
+      },
+      abort: async () => ({}),
+    },
+  })
+  const pluginContext = unsafeTestValue<PluginInput>({
+    client,
+    directory: tmpdir(),
+  })
+  const manager = new BackgroundManager({ pluginContext })
+  return {
+    manager,
+    internals: unsafeTestValue<BackgroundManagerInternals>(manager),
+    promptCalls,
+  }
+}
+
+describe("isEmptyNoProgressAssistantTurnInfo", () => {
+  test("#given zero-token unknown assistant info #when classified #then it is treated as empty no-progress", () => {
+    // given
+    const info = EMPTY_UNKNOWN_ASSISTANT_INFO
+
+    // when
+    const result = isEmptyNoProgressAssistantTurnInfo(info)
+
+    // then
+    expect(result).toBe(true)
+  })
+
+  test("#given non-empty or non-assistant message updates #when classified #then they are not treated as empty no-progress", () => {
+    // given
+    const falseCases: readonly unknown[] = [
+      { ...EMPTY_UNKNOWN_ASSISTANT_INFO, tokens: { ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens, input: 1 } },
+      { ...EMPTY_UNKNOWN_ASSISTANT_INFO, tokens: { ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens, output: 1 } },
+      {
+        ...EMPTY_UNKNOWN_ASSISTANT_INFO,
+        tokens: {
+          ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens,
+          cache: { ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens.cache, read: 1 },
+        },
+      },
+      {
+        ...EMPTY_UNKNOWN_ASSISTANT_INFO,
+        tokens: {
+          ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens,
+          cache: { ...EMPTY_UNKNOWN_ASSISTANT_INFO.tokens.cache, write: 1 },
+        },
+      },
+      { ...EMPTY_UNKNOWN_ASSISTANT_INFO, finish: "stop" },
+      { ...EMPTY_UNKNOWN_ASSISTANT_INFO, role: "user" },
+      { role: "assistant", finish: "unknown" },
+      undefined,
+    ]
+
+    // when
+    const results = falseCases.map(isEmptyNoProgressAssistantTurnInfo)
+
+    // then
+    expect(results).toEqual(falseCases.map(() => false))
+  })
+
+  test("#given zero-token unknown assistant info without cache counts #when classified #then it is still treated as empty no-progress", () => {
+    // given
+    const info = {
+      id: "msg-empty-no-cache",
+      sessionID: "parent-session-empty-wake",
+      role: "assistant",
+      finish: "unknown",
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+      },
+    } as const
+
+    // when
+    const result = isEmptyNoProgressAssistantTurnInfo(info)
+
+    // then
+    expect(result).toBe(true)
+  })
+})
+
+describe("BackgroundManager parent wake empty-turn recovery", () => {
+  test("#given dispatched parent wake #when OpenCode records a zero-token empty unknown assistant turn #then the wake is requeued", async () => {
+    // given
+    const { manager, internals, promptCalls } = createManager()
+    managerUnderTest = manager
+    const sessionID = "parent-session-empty-wake"
+    const notification = "<system-reminder>done</system-reminder>"
+    internals.queuePendingParentWake(sessionID, notification, { agent: "sisyphus" }, true, 0)
+    await internals.flushPendingParentWake(sessionID)
+    expect(promptCalls).toHaveLength(1)
+    expect(internals.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)).toBe(true)
+
+    // when
+    manager.handleEvent({
+      type: "message.updated",
+      properties: {
+        sessionID,
+        info: EMPTY_UNKNOWN_ASSISTANT_INFO,
+      },
+    })
+    await Promise.resolve()
+
+    // then
+    expect(internals.parentWakeNotifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
+    expect(internals.parentWakeNotifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([
+      notification,
+    ])
+  })
+})

--- a/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -334,4 +334,79 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       releaseAllPromptAsyncReservationsForTesting()
     }
   })
+
+  test("#given old assistant turn has recent state-level tool activity #when checking parent wake history #then stale tool escape stays deferred", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "tool-calls",
+                time: { created: 80_000 },
+              },
+              parts: [
+                {
+                  type: "tool",
+                  tool: "bash",
+                  state: { status: "running", time: { updated: 99_500 } },
+                },
+              ],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-fresh-tool-state-activity": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-fresh-tool-state-activity",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-tool-state-activity")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"](
+        "parent-fresh-tool-state-activity",
+        pendingWake,
+      )
+
+      // then
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
 })

--- a/src/features/background-agent/parent-wake-history-state.ts
+++ b/src/features/background-agent/parent-wake-history-state.ts
@@ -1,0 +1,96 @@
+import {
+  messageCompleted,
+  messageFinish,
+  messageHasUnresolvedTool,
+  messageHasWaitingTool,
+  messageIsSyntheticOrInternalUser,
+  messageRole,
+} from "../../shared/prompt-async-gate/prompt-message-state"
+import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
+import { isRecord } from "./error-classifier"
+import { getParentWakeMessageCreatedAt } from "./parent-wake-message-activity"
+import type { PendingParentWake } from "./parent-wake-dedupe"
+
+export function latestAssistantTurnIsCompletedEmptyNoProgress(messages: readonly unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      const info = isRecord(message) && isRecord(message.info) ? message.info : message
+      return messageCompleted(message) && isEmptyNoProgressAssistantTurnInfo(info)
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+export function latestAssistantTurnHasToolBlock(messages: readonly unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      return messageFinish(message) === "tool-calls"
+        || messageHasWaitingTool(message)
+        || messageHasUnresolvedTool(message)
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+export function latestAssistantTurnHasFreshToolActivity(
+  messages: readonly unknown[],
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      if (!isRecord(message) || !Array.isArray(message.parts)) {
+        return false
+      }
+      const createdAt = getParentWakeMessageCreatedAt(message)
+      if (createdAt !== undefined && now - createdAt <= maxAgeMs) {
+        return true
+      }
+      return message.parts.some((part) => partHasFreshToolActivity(part, now, maxAgeMs))
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+export function createEmptyAssistantTurnRetryDedupeKey(wake: PendingParentWake): string {
+  return [
+    "background-agent-parent-wake-empty-retry",
+    ...wake.notifications,
+    JSON.stringify(wake.promptContext),
+    wake.shouldReply ? "reply" : "silent",
+  ].join("\u0000")
+}
+
+function partHasFreshToolActivity(part: unknown, now: number, maxAgeMs: number): boolean {
+  if (!isRecord(part)) {
+    return false
+  }
+  return timeHasFreshActivity(part.time, now, maxAgeMs) || timeHasFreshActivity(
+    isRecord(part.state) ? part.state.time : undefined,
+    now,
+    maxAgeMs,
+  )
+}
+
+function timeHasFreshActivity(time: unknown, now: number, maxAgeMs: number): boolean {
+  if (!isRecord(time)) {
+    return false
+  }
+  const values = [time.start, time.end, time.created, time.updated]
+  return values.some((value) => typeof value === "number" && Number.isFinite(value) && now - value <= maxAgeMs)
+}

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -13,7 +13,17 @@ import {
   latestAssistantTurnBlocksInternalPrompt,
   latestAssistantTurnHasUnansweredQuestion,
 } from "../../shared/prompt-async-gate/pending-tool-turn"
+import {
+  messageCompleted,
+  messageFinish,
+  messageHasUnresolvedTool,
+  messageHasWaitingTool,
+  messageIsSyntheticOrInternalUser,
+  messageRole,
+} from "../../shared/prompt-async-gate/prompt-message-state"
 import type { PluginInput } from "@opencode-ai/plugin"
+import { isRecord } from "./error-classifier"
+import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
 import {
   cloneParentWake,
   isRedundantParentWake,
@@ -186,6 +196,7 @@ export class ParentWakeNotifier {
       return
     }
 
+    const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
     if (toolWaitDecision.defer) {
       this.schedulePendingParentWakeFlush(sessionID)
@@ -225,6 +236,7 @@ export class ParentWakeNotifier {
         client: this.deps.client,
         sessionID,
         source: "background-agent-parent-wake",
+        ...(emptyAssistantTurnRetry ? { dedupeKey: createEmptyAssistantTurnRetryDedupeKey(latestWake) } : {}),
         settleMs: 0,
         queueBehavior: "defer",
         checkStatus: true,
@@ -277,6 +289,7 @@ export class ParentWakeNotifier {
         return
       }
       log("[background-agent] Sent deferred parent wake:", { sessionID })
+      delete latestWake.allowEmptyAssistantTurnRetry
       this.trackDispatchedParentWake(sessionID, latestWake, dispatchStartedAt)
     } catch (error) {
       this.requeueWake(sessionID, latestWake)
@@ -318,6 +331,20 @@ export class ParentWakeNotifier {
       sessionID,
       reason,
     })
+    return true
+  }
+
+  requeueDispatchedParentWakeAfterEmptyAssistantTurn(sessionID: string): boolean {
+    const wake = this.dispatchedParentWakes.get(sessionID)
+    if (!wake) {
+      return false
+    }
+
+    this.clearDispatchedParentWake(sessionID)
+    wake.allowEmptyAssistantTurnRetry = true
+    this.requeueWake(sessionID, wake)
+    this.schedulePendingParentWakeFlush(sessionID, 0)
+    log("[background-agent] Requeued dispatched parent wake after empty assistant turn:", { sessionID })
     return true
   }
 
@@ -512,15 +539,29 @@ export class ParentWakeNotifier {
     const latestAssistantHasUnansweredQuestion = latestAssistantTurnHasUnansweredQuestion(messages)
     if (!latestAssistantBlocksPrompt) {
       delete wake.toolCallDeferralStartedAt
+      delete wake.allowEmptyAssistantTurnRetry
       return { defer: false, skipPromptGateToolStateCheck: false }
     }
     const now = Date.now()
     wake.toolCallDeferralStartedAt ??= now
+    if (wake.allowEmptyAssistantTurnRetry && latestAssistantTurnIsCompletedEmptyNoProgress(messages)) {
+      log("[background-agent] Retrying parent wake after completed empty assistant turn:", { sessionID })
+      return { defer: false, skipPromptGateToolStateCheck: true }
+    }
     if (latestAssistantHasUnansweredQuestion) {
       log("[background-agent] Deferred parent wake because latest assistant question awaits user response:", {
         sessionID,
       })
       return { defer: true, skipPromptGateToolStateCheck: false }
+    }
+    if (
+      now - wake.toolCallDeferralStartedAt >= this.options.toolCallDeferMaxMs
+      && latestAssistantTurnHasToolBlock(messages)
+      && !latestAssistantTurnHasFreshToolActivity(messages, now, this.options.toolCallDeferMaxMs)
+    ) {
+      delete wake.toolCallDeferralStartedAt
+      log("[background-agent] Retrying parent wake after stale tool-call deferral:", { sessionID })
+      return { defer: false, skipPromptGateToolStateCheck: true }
     }
     log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
       sessionID,
@@ -559,8 +600,78 @@ export class ParentWakeNotifier {
       pendingWake.shouldReply = pendingWake.shouldReply || latestWake.shouldReply
       pendingWake.promptContext = latestWake.promptContext
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
+      pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
       return
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))
   }
+}
+
+function latestAssistantTurnIsCompletedEmptyNoProgress(messages: unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      const info = isRecord(message) && isRecord(message.info) ? message.info : message
+      return messageCompleted(message) && isEmptyNoProgressAssistantTurnInfo(info)
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+function latestAssistantTurnHasToolBlock(messages: unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      return messageFinish(message) === "tool-calls"
+        || messageHasWaitingTool(message)
+        || messageHasUnresolvedTool(message)
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+function latestAssistantTurnHasFreshToolActivity(messages: unknown[], now: number, maxAgeMs: number): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    const role = messageRole(message)
+    if (role === "assistant") {
+      if (!isRecord(message) || !Array.isArray(message.parts)) {
+        return false
+      }
+      const createdAt = getParentWakeMessageCreatedAt(message)
+      if (createdAt !== undefined && now - createdAt <= maxAgeMs) {
+        return true
+      }
+      return message.parts.some((part) => partHasFreshToolActivity(part, now, maxAgeMs))
+    }
+    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+      return false
+    }
+  }
+  return false
+}
+
+function createEmptyAssistantTurnRetryDedupeKey(wake: PendingParentWake): string {
+  return [
+    "background-agent-parent-wake-empty-retry",
+    ...wake.notifications,
+    JSON.stringify(wake.promptContext),
+    wake.shouldReply ? "reply" : "silent",
+  ].join("\u0000")
+}
+
+function partHasFreshToolActivity(part: unknown, now: number, maxAgeMs: number): boolean {
+  if (!isRecord(part) || !isRecord(part.time)) {
+    return false
+  }
+  const values = [part.time.start, part.time.end, part.time.created, part.time.updated]
+  return values.some((value) => typeof value === "number" && Number.isFinite(value) && now - value <= maxAgeMs)
 }

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -14,16 +14,15 @@ import {
   latestAssistantTurnHasUnansweredQuestion,
 } from "../../shared/prompt-async-gate/pending-tool-turn"
 import {
-  messageCompleted,
-  messageFinish,
-  messageHasUnresolvedTool,
-  messageHasWaitingTool,
   messageIsSyntheticOrInternalUser,
-  messageRole,
 } from "../../shared/prompt-async-gate/prompt-message-state"
 import type { PluginInput } from "@opencode-ai/plugin"
-import { isRecord } from "./error-classifier"
-import { isEmptyNoProgressAssistantTurnInfo } from "./empty-assistant-turn"
+import {
+  createEmptyAssistantTurnRetryDedupeKey,
+  latestAssistantTurnHasFreshToolActivity,
+  latestAssistantTurnHasToolBlock,
+  latestAssistantTurnIsCompletedEmptyNoProgress,
+} from "./parent-wake-history-state"
 import {
   cloneParentWake,
   isRedundantParentWake,
@@ -605,73 +604,4 @@ export class ParentWakeNotifier {
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))
   }
-}
-
-function latestAssistantTurnIsCompletedEmptyNoProgress(messages: unknown[]): boolean {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index]
-    const role = messageRole(message)
-    if (role === "assistant") {
-      const info = isRecord(message) && isRecord(message.info) ? message.info : message
-      return messageCompleted(message) && isEmptyNoProgressAssistantTurnInfo(info)
-    }
-    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
-      return false
-    }
-  }
-  return false
-}
-
-function latestAssistantTurnHasToolBlock(messages: unknown[]): boolean {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index]
-    const role = messageRole(message)
-    if (role === "assistant") {
-      return messageFinish(message) === "tool-calls"
-        || messageHasWaitingTool(message)
-        || messageHasUnresolvedTool(message)
-    }
-    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
-      return false
-    }
-  }
-  return false
-}
-
-function latestAssistantTurnHasFreshToolActivity(messages: unknown[], now: number, maxAgeMs: number): boolean {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index]
-    const role = messageRole(message)
-    if (role === "assistant") {
-      if (!isRecord(message) || !Array.isArray(message.parts)) {
-        return false
-      }
-      const createdAt = getParentWakeMessageCreatedAt(message)
-      if (createdAt !== undefined && now - createdAt <= maxAgeMs) {
-        return true
-      }
-      return message.parts.some((part) => partHasFreshToolActivity(part, now, maxAgeMs))
-    }
-    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
-      return false
-    }
-  }
-  return false
-}
-
-function createEmptyAssistantTurnRetryDedupeKey(wake: PendingParentWake): string {
-  return [
-    "background-agent-parent-wake-empty-retry",
-    ...wake.notifications,
-    JSON.stringify(wake.promptContext),
-    wake.shouldReply ? "reply" : "silent",
-  ].join("\u0000")
-}
-
-function partHasFreshToolActivity(part: unknown, now: number, maxAgeMs: number): boolean {
-  if (!isRecord(part) || !isRecord(part.time)) {
-    return false
-  }
-  const values = [part.time.start, part.time.end, part.time.created, part.time.updated]
-  return values.some((value) => typeof value === "number" && Number.isFinite(value) && now - value <= maxAgeMs)
 }


### PR DESCRIPTION
## Summary
Fixes a missed background-completion wake when OpenCode accepts a parent wake but then records an empty assistant turn (`finish: "unknown"` with all token counts at zero). In that case OMO now puts the dispatched wake back into the pending queue instead of treating it as delivered.

## Changes
- Add a narrow classifier for zero-token, no-progress assistant updates.
- Requeue only the matching dispatched parent wake after that empty assistant update.
- Add regression coverage for the empty-turn recovery path and false-positive cases.

## Evidence
- Inspected live session `ses_16ef72bd9ffeapf8DsJeFXPv39`: final assistant message has `finish: "unknown"`, zero input/output/reasoning/cache tokens, and only `step-finish`.
- Inspected local `../opencode` source at `2a33addd290cba71a408a133a6780b311a0d3459`: `prompt_async` returns immediately and late outcomes arrive through message/status/error events.
- Related regression context: PR #4725 fixed duplicate parent wakes by deferring active-turn injections; this patch covers the inverse empty-consumed-wake case without broadening duplicate retries.

## Testing
- `bun test src/features/background-agent/parent-wake-empty-turn-requeue.test.ts`
- `bun test src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-activity-window.test.ts src/features/background-agent/parent-wake-assistant-blocking.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`

## QA Notes
ULW evidence recorded in `.omo/ulw-loop/019e9119-7922-7222-a10b-22cbb09f1c08/ledger.jsonl`; tmux cleanup receipts are in `.omo/ulw-loop/evidence/background-completion-session/` in the working investigation tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requeues dispatched parent wakes when an assistant turn is empty (finish: "unknown" with zero tokens) and prevents duplicate retries with a stable dedupe key. Also respects recent tool state activity so we don’t retry while tools are still active.

- **Bug Fixes**
  - Detects zero-token, unknown-finish assistant updates and requeues only the matching dispatched parent wake, with a stable retry `dedupeKey`.
  - Skips prompt-gate deferral when the latest assistant history is a completed empty turn so the retry flushes immediately.
  - Defers while tools have fresh state activity; retries after stale tool-call deferrals with no recent activity.
  - Added targeted tests for recovery, coalesced notifications, and tool-activity deferral.

<sup>Written for commit 8f333aaa67eb02e834b837e0288ce100a795ffd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

