### PR TITLE
feat: add Sparkshell runtime awareness

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/sparkshell-awareness.ts
+++ b/packages/omo-codex/plugin/components/rules/src/sparkshell-awareness.ts
@@ -1,0 +1,51 @@
+type RuntimeEnv = Readonly<Record<string, string | undefined>>;
+
+const SPARKSHELL_AWARENESS_MARKER = "## Sparkshell Runtime";
+
+export const SPARKSHELL_AWARENESS_DEDUP_KEY = "__omo_sparkshell_awareness__";
+
+export function isCodexAppServerActive(env: RuntimeEnv = process.env): boolean {
+	const originator = env["CODEX_INTERNAL_ORIGINATOR_OVERRIDE"]?.toLowerCase() ?? "";
+	const bundleIdentifier = env["__CFBundleIdentifier"]?.toLowerCase() ?? "";
+	const shellActive = isTruthy(env["CODEX_SHELL"]);
+
+	return (
+		shellActive &&
+		(originator.includes("codex desktop") ||
+			originator.includes("codex app") ||
+			bundleIdentifier === "com.openai.codex")
+	);
+}
+
+export function getSparkShellRuntimeAwareness(env: RuntimeEnv = process.env): string {
+	const override = env["OMO_SPARKSHELL_AWARENESS"] ?? env["LAZYCODEX_SPARKSHELL_AWARENESS"];
+	if (isFalsy(override)) {
+		return "";
+	}
+	if (!isTruthy(override) && !isCodexAppServerActive(env)) {
+		return "";
+	}
+
+	return [
+		SPARKSHELL_AWARENESS_MARKER,
+		"",
+		"- Codex app server context is active, so Sparkshell is available for shell-native inspection and bounded verification.",
+		"- Use `omo sparkshell <command>` for direct argv execution. Use `omo sparkshell --shell '<command>'` only when shell metacharacters are required.",
+		"- Use `omo sparkshell --tmux-pane <pane-id> --tail-lines 400` to summarize a tmux pane. Tail lines must stay between 100 and 1000.",
+		"- Fallback boundaries are visible in output. `OMO_SPARKSHELL_BIN` selects a native sidecar path; `OMX_SPARKSHELL_BIN` is accepted for compatibility.",
+	].join("\n");
+}
+
+function isTruthy(value: string | undefined): boolean {
+	if (value === undefined) {
+		return false;
+	}
+	return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function isFalsy(value: string | undefined): boolean {
+	if (value === undefined) {
+		return false;
+	}
+	return ["0", "false", "no", "off"].includes(value.trim().toLowerCase());
+}

--- a/packages/omo-codex/plugin/components/rules/src/static-injection.ts
+++ b/packages/omo-codex/plugin/components/rules/src/static-injection.ts
@@ -4,6 +4,7 @@ import { formatAdditionalContextOutput } from "./hook-output.js";
 import { completePostCompactRecovery, hydrateEngineState, persistEngineState } from "./persistent-cache.js";
 import { withPostCompactBudget } from "./post-compact-budget.js";
 import { createRulesEngine } from "./rules-engine-factory.js";
+import { getSparkShellRuntimeAwareness, SPARKSHELL_AWARENESS_DEDUP_KEY } from "./sparkshell-awareness.js";
 import { filterRulesAlreadyInTranscript } from "./transcript-rule-filter.js";
 import type { TranscriptSearchOptions } from "./transcript-search.js";
 
@@ -42,7 +43,10 @@ export function runStaticInjection(
 		},
 		transcriptSearchOptions,
 	);
-	if (rules.length === 0) {
+	const sparkshellAwareness = engine.state.staticDedup.has(SPARKSHELL_AWARENESS_DEDUP_KEY)
+		? ""
+		: getSparkShellRuntimeAwareness(options.env);
+	if (rules.length === 0 && sparkshellAwareness.length === 0) {
 		persistEngineState(engine, cachePath, completedPostCompactChannel);
 		return "";
 	}
@@ -51,6 +55,13 @@ export function runStaticInjection(
 	for (const rule of rules) {
 		engine.markStaticInjected(rule);
 	}
+	if (sparkshellAwareness.length > 0) {
+		engine.state.staticDedup.add(SPARKSHELL_AWARENESS_DEDUP_KEY);
+	}
 	persistEngineState(engine, cachePath, completedPostCompactChannel);
-	return formatAdditionalContextOutput(eventName, block);
+	return formatAdditionalContextOutput(eventName, combineStaticContext(block, sparkshellAwareness));
+}
+
+function combineStaticContext(...blocks: readonly string[]): string {
+	return blocks.filter((block) => block.trim().length > 0).join("\n\n");
 }

--- a/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/sparkshell-awareness.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runSessionStartHook, runUserPromptSubmitHook } from "../src/codex-hook.js";
+import { formatAdditionalContextOutput } from "../src/hook-output.js";
+
+type HookOutput = {
+	readonly hookSpecificOutput?: {
+		readonly additionalContext?: string;
+	};
+};
+
+function parseAdditionalContext(output: string): string {
+	expect(output.trim().length).toBeGreaterThan(0);
+	const parsed = parseHookOutput(JSON.parse(output));
+	return parsed.hookSpecificOutput?.additionalContext ?? "";
+}
+
+function parseHookOutput(value: unknown): HookOutput {
+	if (typeof value !== "object" || value === null) {
+		return {};
+	}
+	const record = value;
+	if (!("hookSpecificOutput" in record)) {
+		return {};
+	}
+	const hookSpecificOutput = record.hookSpecificOutput;
+	if (typeof hookSpecificOutput !== "object" || hookSpecificOutput === null) {
+		return {};
+	}
+	if (!("additionalContext" in hookSpecificOutput)) {
+		return { hookSpecificOutput: {} };
+	}
+	const additionalContext = hookSpecificOutput.additionalContext;
+	if (typeof additionalContext !== "string") {
+		return { hookSpecificOutput: {} };
+	}
+	return {
+		hookSpecificOutput: {
+			additionalContext,
+		},
+	};
+}
+
+describe("Codex Sparkshell awareness", () => {
+	it("#given active Codex app server env #when SessionStart runs #then emits Sparkshell guidance", async () => {
+		// given
+		const env = {
+			CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+			CODEX_SHELL: "1",
+			CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+		};
+
+		// when
+		const output = await runSessionStartHook(
+			{
+				session_id: "session-sparkshell-active",
+				transcript_path: null,
+				cwd: process.cwd(),
+				hook_event_name: "SessionStart",
+				model: "gpt-5.5",
+				permission_mode: "default",
+				source: "startup",
+			},
+			{ env },
+		);
+
+		// then
+		expect(parseAdditionalContext(output)).toContain("omo sparkshell <command>");
+	});
+
+	it("#given inactive env #when SessionStart runs #then emits no Sparkshell guidance", async () => {
+		// given
+		const env = {
+			CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+		};
+
+		// when
+		const output = await runSessionStartHook(
+			{
+				session_id: "session-sparkshell-inactive",
+				transcript_path: null,
+				cwd: process.cwd(),
+				hook_event_name: "SessionStart",
+				model: "gpt-5.5",
+				permission_mode: "default",
+				source: "startup",
+			},
+			{ env },
+		);
+
+		// then
+		expect(output).toBe("");
+	});
+
+	it("#given explicit force-on env #when SessionStart runs #then emits Sparkshell guidance", async () => {
+		// given
+		const env = {
+			OMO_SPARKSHELL_AWARENESS: "1",
+			CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+		};
+
+		// when
+		const output = await runSessionStartHook(
+			{
+				session_id: "session-sparkshell-force-on",
+				transcript_path: null,
+				cwd: process.cwd(),
+				hook_event_name: "SessionStart",
+				model: "gpt-5.5",
+				permission_mode: "default",
+				source: "startup",
+			},
+			{ env },
+		);
+
+		// then
+		expect(parseAdditionalContext(output)).toContain("omo sparkshell <command>");
+	});
+
+	it("#given explicit force-off env with active Codex app context #when SessionStart runs #then emits no Sparkshell guidance", async () => {
+		// given
+		const env = {
+			OMO_SPARKSHELL_AWARENESS: "0",
+			CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+			CODEX_SHELL: "1",
+			CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+		};
+
+		// when
+		const output = await runSessionStartHook(
+			{
+				session_id: "session-sparkshell-force-off",
+				transcript_path: null,
+				cwd: process.cwd(),
+				hook_event_name: "SessionStart",
+				model: "gpt-5.5",
+				permission_mode: "default",
+				source: "startup",
+			},
+			{ env },
+		);
+
+		// then
+		expect(output).toBe("");
+	});
+
+	it("#given Sparkshell awareness already emitted for a session #when UserPromptSubmit runs #then emits no duplicate guidance", async () => {
+		// given
+		const pluginDataRoot = mkdtempSync(join(tmpdir(), "codex-sparkshell-awareness-"));
+		const env = {
+			CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+			CODEX_SHELL: "1",
+			CODEX_RULES_ENABLED_SOURCES: ".omo/rules",
+		};
+		try {
+			const firstOutput = await runSessionStartHook(
+				{
+					session_id: "session-sparkshell-dedupe",
+					transcript_path: null,
+					cwd: process.cwd(),
+					hook_event_name: "SessionStart",
+					model: "gpt-5.5",
+					permission_mode: "default",
+					source: "startup",
+				},
+				{ env, pluginDataRoot },
+			);
+			expect(parseAdditionalContext(firstOutput)).toContain("omo sparkshell <command>");
+
+			// when
+			const secondOutput = await runUserPromptSubmitHook(
+				{
+					session_id: "session-sparkshell-dedupe",
+					turn_id: "turn-1",
+					transcript_path: null,
+					cwd: process.cwd(),
+					hook_event_name: "UserPromptSubmit",
+					model: "gpt-5.5",
+					permission_mode: "default",
+					prompt: "continue",
+				},
+				{ env, pluginDataRoot },
+			);
+
+			// then
+			expect(secondOutput).toBe("");
+		} finally {
+			rmSync(pluginDataRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("#given explicit force-on env #when hook output is formatted #then awareness remains valid hook JSON", () => {
+		// given
+		const context = [
+			"## Sparkshell Runtime",
+			"",
+			"- Use `omo sparkshell <command>` for shell-native inspection.",
+		].join("\n");
+
+		// when
+		const output = formatAdditionalContextOutput("SessionStart", context);
+
+		// then
+		expect(parseAdditionalContext(output)).toContain("## Sparkshell Runtime");
+	});
+});

--- a/src/cli/cli-program.test.ts
+++ b/src/cli/cli-program.test.ts
@@ -74,3 +74,17 @@ test("program configures explicit '-h, --help' help option for consistent help-f
   expect(programBlock).not.toBeNull()
   expect(programBlock?.[1]).toContain('.helpOption("-h, --help", "Display help for command")')
 })
+
+test("program registers sparkshell as a runtime command", async () => {
+  // given
+  const cliProgramSource = await readFile(
+    path.resolve(import.meta.dir, "cli-program.ts"),
+    "utf-8",
+  )
+
+  // when
+  const registersRuntimeCommands = cliProgramSource.includes("configureRuntimeCommands(program)")
+
+  // then
+  expect(registersRuntimeCommands).toBe(true)
+})

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -4,10 +4,8 @@ import { configureCleanupCommand, resolveCleanupPlatform } from "./cleanup-comma
 import { run } from "./run"
 import { getLocalVersion } from "./get-local-version"
 import { doctor, resolveDoctorTarget } from "./doctor"
-import { refreshModelCapabilities } from "./refresh-model-capabilities"
 import { createMcpOAuthCommand } from "./mcp-oauth"
-import { boulder } from "./boulder"
-import { codexUlwLoop } from "./codex-ulw-loop"
+import { configureRuntimeCommands } from "./runtime-commands"
 import type { InstallArgs } from "./types"
 import type { RunOptions } from "./run"
 import type { GetLocalVersionOptions } from "./get-local-version/types"
@@ -239,52 +237,7 @@ Examples:
     process.exit(exitCode)
   })
 
-program
-  .command("refresh-model-capabilities")
-  .description("Refresh the cached models.dev-based model capabilities snapshot")
-  .option("-d, --directory <path>", "Working directory to read oh-my-opencode config from")
-  .option("--source-url <url>", "Override the models.dev source URL")
-  .option("--json", "Output refresh summary as JSON")
-  .action(async (options) => {
-    const exitCode = await refreshModelCapabilities({
-      directory: options.directory,
-      sourceUrl: options.sourceUrl,
-      json: options.json ?? false,
-    })
-    process.exit(exitCode)
-  })
-
-program
-  .command("version")
-  .description("Show version information")
-  .action(() => {
-    console.log(`oh-my-opencode v${VERSION}`)
-  })
-
-program
-  .command("boulder")
-  .description("Show boulder progress, elapsed time, and per-task statistics")
-  .option("-d, --directory <path>", "Working directory")
-  .option("-w, --work-id <id>", "Filter to a specific work")
-  .option("--json", "Output as JSON")
-  .action(async (options) => {
-    const exitCode = await boulder({
-      directory: options.directory,
-      workId: options.workId,
-      json: options.json ?? false,
-    })
-    process.exit(exitCode)
-  })
-
-program
-  .command("ulw-loop [args...]")
-  .allowUnknownOption()
-  .passThroughOptions()
-  .description("Run the Codex LazyCodex ulw-loop CLI")
-  .action(async (args: string[] = []) => {
-    const exitCode = await codexUlwLoop(args)
-    process.exit(exitCode)
-  })
+configureRuntimeCommands(program)
 
 program.addCommand(createMcpOAuthCommand())
 

--- a/src/cli/runtime-commands.ts
+++ b/src/cli/runtime-commands.ts
@@ -1,0 +1,69 @@
+import type { Command } from "commander"
+
+import { boulder } from "./boulder"
+import { codexUlwLoop } from "./codex-ulw-loop"
+import { refreshModelCapabilities } from "./refresh-model-capabilities"
+import { runSparkShell } from "./sparkshell"
+import packageJson from "../../package.json" with { type: "json" }
+
+const VERSION = packageJson.version
+
+export function configureRuntimeCommands(program: Command): void {
+  program
+    .command("refresh-model-capabilities")
+    .description("Refresh the cached models.dev-based model capabilities snapshot")
+    .option("-d, --directory <path>", "Working directory to read oh-my-opencode config from")
+    .option("--source-url <url>", "Override the models.dev source URL")
+    .option("--json", "Output refresh summary as JSON")
+    .action(async (options: { readonly directory?: string; readonly sourceUrl?: string; readonly json?: boolean }) => {
+      const exitCode = await refreshModelCapabilities({
+        directory: options.directory,
+        sourceUrl: options.sourceUrl,
+        json: options.json ?? false,
+      })
+      process.exit(exitCode)
+    })
+
+  program
+    .command("sparkshell [args...]")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .description("Run Sparkshell shell-native inspection with explicit raw fallback")
+    .action(async (args: string[] = []) => {
+      const exitCode = await runSparkShell(args)
+      process.exit(exitCode)
+    })
+
+  program
+    .command("version")
+    .description("Show version information")
+    .action(() => {
+      console.log(`oh-my-opencode v${VERSION}`)
+    })
+
+  program
+    .command("boulder")
+    .description("Show boulder progress, elapsed time, and per-task statistics")
+    .option("-d, --directory <path>", "Working directory")
+    .option("-w, --work-id <id>", "Filter to a specific work")
+    .option("--json", "Output as JSON")
+    .action(async (options: { readonly directory?: string; readonly workId?: string; readonly json?: boolean }) => {
+      const exitCode = await boulder({
+        directory: options.directory,
+        workId: options.workId,
+        json: options.json ?? false,
+      })
+      process.exit(exitCode)
+    })
+
+  program
+    .command("ulw-loop [args...]")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .description("Run the Codex LazyCodex ulw-loop CLI")
+    .action(async (args: string[] = []) => {
+      const exitCode = await codexUlwLoop(args)
+      process.exit(exitCode)
+    })
+}

--- a/src/cli/sparkshell-parse.ts
+++ b/src/cli/sparkshell-parse.ts
@@ -1,0 +1,187 @@
+export const SPARKSHELL_USAGE = [
+  "Usage: omo sparkshell <command> [args...]",
+  "   or: omo sparkshell [--json] [--budget <chars>] <command> [args...]",
+  "   or: omo sparkshell --shell '<shell command>'",
+  "   or: omo sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]",
+  "Runs Sparkshell with a native sidecar when configured, otherwise falls back to raw command execution.",
+  "Shell metacharacters are interpreted only with explicit --shell opt-in.",
+  "Environment: OMO_SPARKSHELL_BIN selects the native sidecar path. OMX_SPARKSHELL_BIN is accepted for compatibility.",
+].join("\n")
+
+export type SparkShellFallbackInvocation =
+  | { readonly kind: "command"; readonly argv: readonly string[] }
+  | { readonly kind: "tmux-pane"; readonly argv: readonly string[] }
+
+type RuntimeEnv = Readonly<Record<string, string | undefined>>
+
+type StripResult = {
+  readonly args: readonly string[]
+}
+
+export function resolveFallbackShellArgv(
+  script: string,
+  options: {
+    readonly platform?: NodeJS.Platform
+    readonly env?: RuntimeEnv
+    readonly commandExists?: (command: string) => boolean
+  } = {},
+): readonly string[] {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const commandExists = options.commandExists ?? (() => false)
+
+  if (platform !== "win32") {
+    return ["sh", "-lc", script]
+  }
+  if (commandExists("pwsh")) {
+    return ["pwsh", "-NoLogo", "-NoProfile", "-Command", script]
+  }
+  if (commandExists("powershell.exe")) {
+    return ["powershell.exe", "-NoLogo", "-NoProfile", "-Command", script]
+  }
+  return [env["ComSpec"]?.trim() || "cmd.exe", "/d", "/s", "/c", script]
+}
+
+export function parseSparkShellFallbackInvocation(
+  rawArgs: readonly string[],
+  options: {
+    readonly platform?: NodeJS.Platform
+    readonly env?: RuntimeEnv
+    readonly commandExists?: (command: string) => boolean
+  } = {},
+): SparkShellFallbackInvocation {
+  const args = stripSparkShellOptions(rawArgs).args
+  if (args.length === 0) {
+    throw new Error(`Missing command to run.\n${SPARKSHELL_USAGE}`)
+  }
+
+  if (args[0] === "--shell") {
+    const script = args[1]
+    if (!script) {
+      throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`)
+    }
+    return { kind: "command", argv: resolveFallbackShellArgv(script, options) }
+  }
+
+  if (args[0]?.startsWith("--shell=")) {
+    const script = args[0].slice("--shell=".length)
+    if (script.trim().length === 0) {
+      throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`)
+    }
+    return { kind: "command", argv: resolveFallbackShellArgv(script, options) }
+  }
+
+  if (args[0] === "--tmux-pane" || args[0]?.startsWith("--tmux-pane=")) {
+    return parseTmuxPaneInvocation(args)
+  }
+
+  return { kind: "command", argv: args }
+}
+
+export function hasTopLevelSparkShellHelpFlag(args: readonly string[]): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]
+    if (token === "--") {
+      return false
+    }
+    if (token === "--help" || token === "-h") {
+      return true
+    }
+    if (token === "--json") {
+      continue
+    }
+    if (token === "--budget") {
+      const next = args[index + 1]
+      if (!next || next.startsWith("-")) {
+        return false
+      }
+      index += 1
+      continue
+    }
+    if (token?.startsWith("--budget=")) {
+      continue
+    }
+    return false
+  }
+  return false
+}
+
+function parseTmuxPaneInvocation(args: readonly string[]): SparkShellFallbackInvocation {
+  let paneId: string | undefined
+  let tailLines = 200
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]
+    if (token === "--tmux-pane") {
+      const next = args[index + 1]
+      if (!next || next.startsWith("-")) {
+        throw new Error(`--tmux-pane requires a pane id.\n${SPARKSHELL_USAGE}`)
+      }
+      paneId = next
+      index += 1
+      continue
+    }
+    if (token?.startsWith("--tmux-pane=")) {
+      paneId = token.slice("--tmux-pane=".length).trim()
+      if (paneId.length === 0) {
+        throw new Error(`--tmux-pane requires a pane id.\n${SPARKSHELL_USAGE}`)
+      }
+      continue
+    }
+    if (token === "--tail-lines") {
+      const next = args[index + 1]
+      tailLines = parseTailLines(next)
+      index += 1
+      continue
+    }
+    if (token?.startsWith("--tail-lines=")) {
+      tailLines = parseTailLines(token.slice("--tail-lines=".length))
+      continue
+    }
+    throw new Error(`tmux pane mode does not accept an additional command.\n${SPARKSHELL_USAGE}`)
+  }
+
+  if (!paneId || paneId.trim().length === 0) {
+    throw new Error(`--tmux-pane requires a pane id.\n${SPARKSHELL_USAGE}`)
+  }
+  return {
+    kind: "tmux-pane",
+    argv: ["tmux", "capture-pane", "-p", "-t", paneId, "-S", `-${tailLines}`],
+  }
+}
+
+function stripSparkShellOptions(args: readonly string[]): StripResult {
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]
+    if (token === "--") {
+      return { args: args.slice(index + 1) }
+    }
+    if (token === "--json") {
+      continue
+    }
+    if (token === "--budget") {
+      const next = args[index + 1]
+      if (!next || next.startsWith("-")) {
+        throw new Error(`--budget requires a numeric value.\n${SPARKSHELL_USAGE}`)
+      }
+      index += 1
+      continue
+    }
+    if (token?.startsWith("--budget=")) {
+      continue
+    }
+    return { args: args.slice(index) }
+  }
+  return { args: [] }
+}
+
+function parseTailLines(rawValue: string | undefined): number {
+  if (!rawValue || rawValue.startsWith("-")) {
+    throw new Error(`--tail-lines requires a numeric value.\n${SPARKSHELL_USAGE}`)
+  }
+  const parsed = Number.parseInt(rawValue, 10)
+  if (!Number.isSafeInteger(parsed) || parsed < 100 || parsed > 1000) {
+    throw new Error(`--tail-lines must be an integer between 100 and 1000.\n${SPARKSHELL_USAGE}`)
+  }
+  return parsed
+}

--- a/src/cli/sparkshell.test.ts
+++ b/src/cli/sparkshell.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test"
+import { resolve } from "node:path"
+
+import {
+  parseSparkShellFallbackInvocation,
+  resolveFallbackShellArgv,
+  runSparkShell,
+  SPARKSHELL_USAGE,
+  type SparkShellSpawnResult,
+} from "./sparkshell"
+
+const REPO_ROOT = resolve(import.meta.dir, "../..")
+const textDecoder = new TextDecoder()
+
+describe("sparkshell CLI", () => {
+  test("#given no args #when running Sparkshell #then usage explains the command surface", async () => {
+    // given
+    const stderr: string[] = []
+
+    // when
+    const exitCode = await runSparkShell([], {
+      writeStderr: (value: string) => {
+        stderr.push(value)
+      },
+    })
+
+    // then
+    expect(exitCode).toBe(1)
+    expect(stderr.join("")).toContain("Usage: omo sparkshell <command> [args...]")
+    expect(SPARKSHELL_USAGE).toContain("--tmux-pane")
+  })
+
+  test("#given direct argv #when native sidecar is absent #then falls back to raw command execution", async () => {
+    // given
+    const calls: string[][] = []
+
+    // when
+    const exitCode = await runSparkShell(["git", "status"], {
+      env: {},
+      writeStderr: () => {},
+      spawn: (command: string, args: readonly string[]): SparkShellSpawnResult => {
+        calls.push([command, ...args])
+        return { status: 0 }
+      },
+    })
+
+    // then
+    expect(exitCode).toBe(0)
+    expect(calls).toEqual([["git", "status"]])
+  })
+
+  test("#given command-owned options #when native sidecar is absent #then preserves argv after the command boundary", async () => {
+    // given
+    const calls: string[][] = []
+
+    // when
+    const exitCode = await runSparkShell(["--json", "rg", "--json", "Sparkshell"], {
+      env: {},
+      writeStderr: () => {},
+      spawn: (command: string, args: readonly string[]): SparkShellSpawnResult => {
+        calls.push([command, ...args])
+        return { status: 0 }
+      },
+    })
+
+    // then
+    expect(exitCode).toBe(0)
+    expect(calls).toEqual([["rg", "--json", "Sparkshell"]])
+  })
+
+  test("#given command-owned help flag #when native sidecar is absent #then does not show Sparkshell usage", async () => {
+    // given
+    const calls: string[][] = []
+    const stdout: string[] = []
+
+    // when
+    const exitCode = await runSparkShell(["printf", "%s", "--help"], {
+      env: {},
+      writeStdout: (value: string) => {
+        stdout.push(value)
+      },
+      writeStderr: () => {},
+      spawn: (command: string, args: readonly string[]): SparkShellSpawnResult => {
+        calls.push([command, ...args])
+        return { status: 0 }
+      },
+    })
+
+    // then
+    expect(exitCode).toBe(0)
+    expect(stdout.join("")).not.toContain("Usage: omo sparkshell")
+    expect(calls).toEqual([["printf", "%s", "--help"]])
+  })
+
+  test("#given top-level Sparkshell options before command-owned help #when CLI runs #then Commander does not intercept help", () => {
+    for (const topLevelArgs of [["--json"], ["--budget", "100"]]) {
+      // when
+      const result = Bun.spawnSync({
+        cmd: ["bun", "src/cli/index.ts", "sparkshell", ...topLevelArgs, "printf", "%s", "--help"],
+        cwd: REPO_ROOT,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      // then
+      expect(result.exitCode).toBe(0)
+      expect(textDecoder.decode(result.stdout)).toBe("--help")
+      expect(textDecoder.decode(result.stderr)).toContain("native sidecar unavailable")
+    }
+  })
+
+  test("#given command-owned tmux flag #when parsing fallback invocation #then preserves it as raw argv", () => {
+    // given
+    const args = ["printf", "%s", "--tmux-pane"]
+
+    // when
+    const invocation = parseSparkShellFallbackInvocation(args)
+
+    // then
+    expect(invocation).toEqual({
+      kind: "command",
+      argv: ["printf", "%s", "--tmux-pane"],
+    })
+  })
+
+  test("#given explicit shell script #when resolving fallback argv #then uses platform shell", () => {
+    // given
+    const script = "printf '%s' hello && printf '%s' world"
+
+    // when
+    const argv = resolveFallbackShellArgv(script, { platform: "linux" })
+
+    // then
+    expect(argv).toEqual(["sh", "-lc", script])
+  })
+
+  test("#given tmux pane mode #when parsing fallback invocation #then builds capture-pane argv with tail lines", () => {
+    // given
+    const args = ["--tmux-pane", "%12", "--tail-lines", "400"]
+
+    // when
+    const invocation = parseSparkShellFallbackInvocation(args)
+
+    // then
+    expect(invocation).toEqual({
+      kind: "tmux-pane",
+      argv: ["tmux", "capture-pane", "-p", "-t", "%12", "-S", "-400"],
+    })
+  })
+
+  test("#given native sidecar override #when running Sparkshell #then delegates original args to sidecar", async () => {
+    // given
+    const calls: string[][] = []
+
+    // when
+    const exitCode = await runSparkShell(["--json", "git", "status"], {
+      env: { OMO_SPARKSHELL_BIN: "/tmp/omo-sparkshell" },
+      spawn: (command: string, args: readonly string[]): SparkShellSpawnResult => {
+        calls.push([command, ...args])
+        return { status: 7 }
+      },
+    })
+
+    // then
+    expect(exitCode).toBe(7)
+    expect(calls).toEqual([["/tmp/omo-sparkshell", "--json", "git", "status"]])
+  })
+})

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -1,0 +1,152 @@
+import { spawnSync } from "node:child_process"
+import { constants as osConstants } from "node:os"
+import { isAbsolute, resolve } from "node:path"
+import {
+  hasTopLevelSparkShellHelpFlag,
+  parseSparkShellFallbackInvocation,
+  SPARKSHELL_USAGE,
+  type SparkShellFallbackInvocation,
+} from "./sparkshell-parse"
+
+export const SPARKSHELL_BIN_ENV = "OMO_SPARKSHELL_BIN"
+export const LEGACY_SPARKSHELL_BIN_ENV = "OMX_SPARKSHELL_BIN"
+
+export {
+  parseSparkShellFallbackInvocation,
+  resolveFallbackShellArgv,
+  SPARKSHELL_USAGE,
+} from "./sparkshell-parse"
+
+export type SparkShellSpawnResult = {
+  readonly status?: number | null
+  readonly signal?: string | null
+  readonly stdout?: string
+  readonly stderr?: string
+  readonly error?: Error
+}
+
+export type SparkShellSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd: string; readonly env: RuntimeEnv },
+) => SparkShellSpawnResult
+
+type RuntimeEnv = Readonly<Record<string, string | undefined>>
+
+export type SparkShellRunOptions = {
+  readonly cwd?: string
+  readonly env?: RuntimeEnv
+  readonly platform?: NodeJS.Platform
+  readonly spawn?: SparkShellSpawn
+  readonly writeStdout?: (value: string) => void
+  readonly writeStderr?: (value: string) => void
+  readonly commandExists?: (command: string) => boolean
+}
+
+export async function runSparkShell(args: readonly string[], options: SparkShellRunOptions = {}): Promise<number> {
+  const env = options.env ?? process.env
+  const writeStdout = options.writeStdout ?? ((value: string) => process.stdout.write(value))
+  const writeStderr = options.writeStderr ?? ((value: string) => process.stderr.write(value))
+  const cwd = options.cwd ?? process.cwd()
+
+  if (hasTopLevelSparkShellHelpFlag(args)) {
+    writeStdout(`${SPARKSHELL_USAGE}\n`)
+    return 0
+  }
+
+  if (args.length === 0) {
+    writeStderr(`Missing command to run.\n${SPARKSHELL_USAGE}\n`)
+    return 1
+  }
+
+  const nativeBinaryPath = resolveNativeBinaryOverride(env, cwd)
+  const spawn = options.spawn ?? defaultSpawn
+  if (nativeBinaryPath.length > 0) {
+    return runSpawnedCommand(spawn, nativeBinaryPath, args, { cwd, env }, writeStdout, writeStderr)
+  }
+
+  let invocation: SparkShellFallbackInvocation
+  try {
+    invocation = parseSparkShellFallbackInvocation(args, {
+      platform: options.platform,
+      env,
+      commandExists: options.commandExists ?? defaultCommandExists,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    writeStderr(`${message}\n`)
+    return 1
+  }
+
+  writeStderr("[sparkshell] native sidecar unavailable; falling back to raw command execution without summary support.\n")
+  const [command, ...commandArgs] = invocation.argv
+  if (command === undefined) {
+    writeStderr(`Missing command to run.\n${SPARKSHELL_USAGE}\n`)
+    return 1
+  }
+  return runSpawnedCommand(spawn, command, commandArgs, { cwd, env }, writeStdout, writeStderr)
+}
+
+function resolveNativeBinaryOverride(env: RuntimeEnv, cwd: string): string {
+  const override = env[SPARKSHELL_BIN_ENV]?.trim() || env[LEGACY_SPARKSHELL_BIN_ENV]?.trim() || ""
+  if (override.length === 0) {
+    return ""
+  }
+  return isAbsolute(override) || /^[A-Za-z]:[\\/]/.test(override) ? override : resolve(cwd, override)
+}
+
+function runSpawnedCommand(
+  spawn: SparkShellSpawn,
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd: string; readonly env: RuntimeEnv },
+  writeStdout: (value: string) => void,
+  writeStderr: (value: string) => void,
+): number {
+  const result = spawn(command, args, options)
+  if (result.stdout && result.stdout.length > 0) {
+    writeStdout(result.stdout)
+  }
+  if (result.stderr && result.stderr.length > 0) {
+    writeStderr(result.stderr)
+  }
+  if (result.error) {
+    writeStderr(`[sparkshell] failed to launch ${command}: ${result.error.message}\n`)
+    return 1
+  }
+  if (typeof result.status === "number") {
+    return result.status
+  }
+  return signalExitCode(result.signal)
+}
+
+function signalExitCode(signal: string | null | undefined): number {
+  if (!signal) {
+    return 1
+  }
+  const signalNumber = Object.entries(osConstants.signals).find(([name]) => name === signal)?.[1]
+  return typeof signalNumber === "number" && Number.isFinite(signalNumber) ? 128 + signalNumber : 1
+}
+
+function defaultCommandExists(command: string): boolean {
+  const result = spawnSync(command, ["--version"], {
+    stdio: "ignore",
+  })
+  return result.error === undefined
+}
+
+function defaultSpawn(command: string, args: readonly string[], options: { readonly cwd: string; readonly env: RuntimeEnv }): SparkShellSpawnResult {
+  const result = spawnSync(command, [...args], {
+    cwd: options.cwd,
+    env: { ...process.env, ...options.env },
+    stdio: "inherit",
+    encoding: "utf8",
+  })
+  return {
+    status: result.status,
+    signal: result.signal,
+    error: result.error,
+    stdout: typeof result.stdout === "string" ? result.stdout : undefined,
+    stderr: typeof result.stderr === "string" ? result.stderr : undefined,
+  }
+}

--- a/src/plugin/sparkshell-awareness.test.ts
+++ b/src/plugin/sparkshell-awareness.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+
+import { createSystemTransformHandler } from "./system-transform"
+
+describe("OpenCode Sparkshell awareness system transform", () => {
+  test("#given active Codex app server env #when system transform runs #then appends Sparkshell guidance", async () => {
+    // given
+    const handler = createSystemTransformHandler(
+      undefined,
+      undefined,
+      {
+        CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+        CODEX_SHELL: "1",
+      },
+    )
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler(
+      {
+        sessionID: "session-sparkshell-active",
+        model: { id: "gpt-5.5", providerID: "openai" },
+      },
+      output,
+    )
+
+    // then
+    expect(output.system.join("\n")).toContain("omo sparkshell <command>")
+  })
+
+  test("#given inactive env #when system transform runs #then leaves system prompt unchanged", async () => {
+    // given
+    const handler = createSystemTransformHandler(undefined, undefined, {})
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler(
+      {
+        sessionID: "session-sparkshell-inactive",
+        model: { id: "gpt-5.5", providerID: "openai" },
+      },
+      output,
+    )
+
+    // then
+    expect(output.system).toEqual(["base system prompt"])
+  })
+
+  test("#given explicit force-on env #when system transform runs #then appends Sparkshell guidance", async () => {
+    // given
+    const handler = createSystemTransformHandler(undefined, undefined, {
+      OMO_SPARKSHELL_AWARENESS: "1",
+    })
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler(
+      {
+        sessionID: "session-sparkshell-force-on",
+        model: { id: "gpt-5.5", providerID: "openai" },
+      },
+      output,
+    )
+
+    // then
+    expect(output.system.join("\n")).toContain("omo sparkshell <command>")
+  })
+
+  test("#given explicit force-off env with active Codex app context #when system transform runs #then leaves system prompt unchanged", async () => {
+    // given
+    const handler = createSystemTransformHandler(undefined, undefined, {
+      OMO_SPARKSHELL_AWARENESS: "0",
+      CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+      CODEX_SHELL: "1",
+    })
+    const output = { system: ["base system prompt"] }
+
+    // when
+    await handler(
+      {
+        sessionID: "session-sparkshell-force-off",
+        model: { id: "gpt-5.5", providerID: "openai" },
+      },
+      output,
+    )
+
+    // then
+    expect(output.system).toEqual(["base system prompt"])
+  })
+
+  test("#given preexisting Sparkshell marker #when system transform runs #then does not duplicate guidance", async () => {
+    // given
+    const handler = createSystemTransformHandler(
+      undefined,
+      undefined,
+      {
+        CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+        CODEX_SHELL: "1",
+      },
+    )
+    const output = { system: ["## Sparkshell Runtime\n\nexisting guidance"] }
+
+    // when
+    await handler(
+      {
+        sessionID: "session-sparkshell-dedupe",
+        model: { id: "gpt-5.5", providerID: "openai" },
+      },
+      output,
+    )
+
+    // then
+    expect(output.system).toEqual(["## Sparkshell Runtime\n\nexisting guidance"])
+  })
+})

--- a/src/plugin/system-transform.ts
+++ b/src/plugin/system-transform.ts
@@ -1,15 +1,28 @@
 import type { DefaultModeConfig } from "../config/schema/default-mode"
+import {
+  getSparkShellRuntimeAwareness,
+  hasSparkShellRuntimeAwareness,
+} from "../shared/sparkshell-awareness"
 
 const ULTRAWORK_MODE_TAG = "<ultrawork-mode>"
 
 export function createSystemTransformHandler(
   defaultMode?: DefaultModeConfig,
   getUltraworkMessage?: (agentName?: string, modelID?: string) => string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
 ): (
   input: { sessionID?: string; model: { id: string; providerID: string; [key: string]: unknown } },
   output: { system: string[] },
 ) => Promise<void> {
   return async (input, output): Promise<void> => {
+    const sparkshellAwareness = getSparkShellRuntimeAwareness(env)
+    if (
+      sparkshellAwareness.length > 0 &&
+      !output.system.some(hasSparkShellRuntimeAwareness)
+    ) {
+      output.system.push(sparkshellAwareness)
+    }
+
     if (!defaultMode?.ultrawork || !getUltraworkMessage) return
 
     // Avoid re-injecting if the ultrawork prompt is already in the system prompt

--- a/src/shared/sparkshell-awareness.test.ts
+++ b/src/shared/sparkshell-awareness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  getSparkShellRuntimeAwareness,
+  isCodexAppServerActive,
+} from "./sparkshell-awareness"
+
+describe("sparkshell runtime awareness", () => {
+  test("#given Codex Desktop originator env #when detecting app server activation #then returns active", () => {
+    // given
+    const env = {
+      CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+      CODEX_SHELL: "1",
+    }
+
+    // when
+    const active = isCodexAppServerActive(env)
+
+    // then
+    expect(active).toBe(true)
+  })
+
+  test("#given inactive environment #when resolving runtime awareness #then returns empty context", () => {
+    // given
+    const env = {
+      CODEX_SHELL: "1",
+    }
+
+    // when
+    const context = getSparkShellRuntimeAwareness(env)
+
+    // then
+    expect(context).toBe("")
+  })
+
+  test("#given explicit force-off env #when Codex Desktop is present #then returns empty context", () => {
+    // given
+    const env = {
+      OMO_SPARKSHELL_AWARENESS: "0",
+      CODEX_INTERNAL_ORIGINATOR_OVERRIDE: "Codex Desktop",
+      CODEX_SHELL: "1",
+    }
+
+    // when
+    const context = getSparkShellRuntimeAwareness(env)
+
+    // then
+    expect(context).toBe("")
+  })
+
+  test("#given explicit force-on env #when Codex Desktop is absent #then returns Sparkshell guidance", () => {
+    // given
+    const env = {
+      OMO_SPARKSHELL_AWARENESS: "1",
+    }
+
+    // when
+    const context = getSparkShellRuntimeAwareness(env)
+
+    // then
+    expect(context).toContain("omo sparkshell <command>")
+    expect(context).toContain("--tmux-pane")
+    expect(context).toContain("OMO_SPARKSHELL_BIN")
+  })
+})

--- a/src/shared/sparkshell-awareness.ts
+++ b/src/shared/sparkshell-awareness.ts
@@ -1,0 +1,52 @@
+type RuntimeEnv = Readonly<Record<string, string | undefined>>
+
+const SPARKSHELL_AWARENESS_MARKER = "## Sparkshell Runtime"
+
+export function isCodexAppServerActive(env: RuntimeEnv = process.env): boolean {
+  const originator = env["CODEX_INTERNAL_ORIGINATOR_OVERRIDE"]?.toLowerCase() ?? ""
+  const bundleIdentifier = env["__CFBundleIdentifier"]?.toLowerCase() ?? ""
+  const shellActive = isTruthy(env["CODEX_SHELL"])
+
+  return shellActive && (
+    originator.includes("codex desktop") ||
+    originator.includes("codex app") ||
+    bundleIdentifier === "com.openai.codex"
+  )
+}
+
+export function getSparkShellRuntimeAwareness(env: RuntimeEnv = process.env): string {
+  const override = env["OMO_SPARKSHELL_AWARENESS"] ?? env["LAZYCODEX_SPARKSHELL_AWARENESS"]
+  if (isFalsy(override)) {
+    return ""
+  }
+  if (!isTruthy(override) && !isCodexAppServerActive(env)) {
+    return ""
+  }
+
+  return [
+    SPARKSHELL_AWARENESS_MARKER,
+    "",
+    "- Codex app server context is active, so Sparkshell is available for shell-native inspection and bounded verification.",
+    "- Use `omo sparkshell <command>` for direct argv execution. Use `omo sparkshell --shell '<command>'` only when shell metacharacters are required.",
+    "- Use `omo sparkshell --tmux-pane <pane-id> --tail-lines 400` to summarize a tmux pane. Tail lines must stay between 100 and 1000.",
+    "- Fallback boundaries are visible in output. `OMO_SPARKSHELL_BIN` selects a native sidecar path; `OMX_SPARKSHELL_BIN` is accepted for compatibility.",
+  ].join("\n")
+}
+
+export function hasSparkShellRuntimeAwareness(value: string): boolean {
+  return value.includes(SPARKSHELL_AWARENESS_MARKER)
+}
+
+function isTruthy(value: string | undefined): boolean {
+  if (value === undefined) {
+    return false
+  }
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase())
+}
+
+function isFalsy(value: string | undefined): boolean {
+  if (value === undefined) {
+    return false
+  }
+  return ["0", "false", "no", "off"].includes(value.trim().toLowerCase())
+}


### PR DESCRIPTION
## Summary

- Add `omo sparkshell` with direct argv execution, explicit `--shell`, explicit `--tmux-pane`, visible raw fallback, and native sidecar override via `OMO_SPARKSHELL_BIN` / compatible `OMX_SPARKSHELL_BIN`.
- Inject Sparkshell runtime awareness in OpenCode system transforms when Codex Desktop/app shell context is active or explicitly forced on.
- Inject/dedupe Sparkshell awareness in the Codex Light rules component static context under the same active/override contract.

## Verification

- `bun test src/cli/sparkshell.test.ts src/plugin/sparkshell-awareness.test.ts src/shared/sparkshell-awareness.test.ts src/cli/cli-program.test.ts`
- `npm --workspaces=false run test -- test/sparkshell-awareness.test.ts test/codex-hook.test.ts` in `packages/omo-codex/plugin/components/rules`
- `bun run typecheck`
- `bun run build`
- `bun test`
- `bun run test:codex`
- LSP diagnostics on changed production files: no diagnostics
- tmux manual QA artifacts captured under `.omo/qa-artifacts/`:
  - raw fallback and native sidecar override
  - command-owned `--json`, `--help`, and `--tmux-pane` boundary preservation
  - OpenCode active/inactive awareness
  - Codex hook active/inactive awareness
- `codex-ultrawork-reviewer`: unconditional approval after blocker fixes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `omo sparkshell` runtime command and injects Sparkshell runtime awareness into OpenCode and Codex contexts. Improves CLI ergonomics with explicit modes, safe fallbacks, and deduped guidance.

- **New Features**
  - `omo sparkshell` supports direct argv, `--shell '<command>'`, and `--tmux-pane <pane-id> --tail-lines <100-1000>`.
  - Native sidecar override via `OMO_SPARKSHELL_BIN` (also `OMX_SPARKSHELL_BIN`); falls back to raw execution with a visible notice when unavailable.
  - Sparkshell awareness is injected when the Codex Desktop/app shell context is active, or when `OMO_SPARKSHELL_AWARENESS` is set; force-off is respected and duplicates are avoided.

- **Refactors**
  - Runtime commands moved to `src/cli/runtime-commands.ts` and registered in the CLI program.
  - Shared awareness helpers added (`src/shared/sparkshell-awareness.ts`) and static injection with dedupe in `packages/omo-codex` rules.
  - Tests cover CLI parsing and fallback, tmux capture, help boundary handling, and awareness injection/deduping.

<sup>Written for commit 13078930098a3da7035cd6a64c897e0c47ed979a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

