### PR TITLE
fix(background-agent): record active parent wakes without replies

### DIFF
--- a/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -108,7 +108,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake active turn events", () => {
-  test("#when background task completes during active parent turn #then parent wake stays deferred", async () => {
+  test("#when background task completes during active parent turn #then parent wake is recorded without forking a reply", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -130,11 +130,12 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when duplicate background completions overlap an active parent turn #then one coalesced wake dispatches after idle", async () => {
+  test("#when duplicate background completions overlap an active parent turn #then one coalesced admit-only wake is recorded", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -168,23 +169,13 @@ describe("BackgroundManager parent wake active turn events", () => {
     ])
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
-
-    // when
-    sessionStatuses["parent-1"] = { type: "idle" }
-    await Promise.all([
-      flushPendingParentWakeForTest(manager, "parent-1"),
-      flushPendingParentWakeForTest(manager, "parent-1"),
-    ])
-
-    // then
     expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
     expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when background task fails during active parent turn #then parent wake stays deferred", async () => {
+  test("#when background task fails during active parent turn #then parent wake is recorded without forking a reply", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -207,11 +198,12 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when parent reasoning delta is newer than stale idle state #then background completion does not fork a reply", async () => {
+  test("#when parent reasoning delta is newer than stale idle state #then background completion records an admit-only wake", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -241,11 +233,12 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when parent idle event follows fresh reasoning delta #then background completion still does not fork a reply", async () => {
+  test("#when parent idle event follows fresh reasoning delta #then background completion still records an admit-only wake", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -276,7 +269,8 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 })

--- a/src/features/background-agent/parent-wake-activity-window.test.ts
+++ b/src/features/background-agent/parent-wake-activity-window.test.ts
@@ -91,7 +91,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake activity window", () => {
-  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then parent prompt stays deferred", async () => {
+  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -120,8 +120,9 @@ describe("BackgroundManager parent wake activity window", () => {
       await flushPendingParentWakeForTest(manager, "parent-1")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
     } finally {
       Date.now = originalDateNow
     }

--- a/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -19,7 +19,7 @@ type PromptAsyncCall = {
 type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
 
 describe("ParentWakeNotifier — assistant turn blocking", () => {
-  test("#given notifier sees an unfinished assistant but prompt gate message fetch fails #when flushing pending wake #then the wake stays pending", async () => {
+  test("#given notifier sees an unfinished assistant but prompt gate message fetch fails #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const promptAsyncCalls: PromptAsyncCall[] = []
     let messageReads = 0
@@ -77,15 +77,16 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     await notifier.flushPendingParentWake("parent-local-unknown")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-local-unknown")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-local-unknown")).toBe(false)
     expect(messageReads).toBe(1)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given stale completed assistant question tool has no real user answer #when flushing pending wake #then wake stays pending", async () => {
+  test("#given stale completed assistant question tool has no real user answer #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -158,8 +159,9 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-question-unanswered")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-question-unanswered")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-question-unanswered")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -167,7 +169,7 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
     }
   })
 
-  test("#given stale completed unknown assistant turn has only step metadata #when flushing pending wake #then wake stays pending", async () => {
+  test("#given stale completed unknown assistant turn has only step metadata #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -237,8 +239,9 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       await notifier.flushPendingParentWake("parent-completed-unknown")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -140,7 +140,7 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
     }
   })
 
-  test("#given stale deferral but fresh unfinished assistant text #when flushing parent wake #then parent wake stays queued without dispatch", async () => {
+  test("#given stale deferral but fresh unfinished assistant text #when flushing parent wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -200,8 +200,8 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       await notifier.flushPendingParentWake("parent-fresh-text-flush")
 
       // then
-      expect(promptAsyncCallCount).toBe(0)
-      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
+      expect(promptAsyncCallCount).toBe(1)
+      expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/src/features/background-agent/parent-wake-non-error-retry.test.ts
+++ b/src/features/background-agent/parent-wake-non-error-retry.test.ts
@@ -133,7 +133,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
     }
   })
 
-  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake stays queued and the retry timer is restored", async () => {
+  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake is recorded without a reply", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionMessagesImpl: async (attempt) => {
@@ -161,13 +161,8 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
       await notifier.flushPendingParentWake(sessionID)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
-      expect(notifier.getPendingParentWakeTimers().has(sessionID)).toBe(true)
-
-      await notifier.flushPendingParentWake(sessionID)
-
       expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
     } finally {
       notifier.shutdown()

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -150,7 +150,14 @@ export class ParentWakeNotifier {
       await settleAfterSessionIdle()
 
       if (await this.isSessionActive(sessionID)) {
-        this.schedulePendingParentWakeFlush(sessionID)
+        const latestWake = this.pendingQueue.getWake(sessionID)
+        if (latestWake) {
+          await this.sendParentWakePrompt(sessionID, latestWake, {
+            emptyAssistantTurnRetry: false,
+            toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+            forceNoReply: true,
+          })
+        }
         return
       }
     }
@@ -160,13 +167,21 @@ export class ParentWakeNotifier {
       return
     }
     if (sessionActive) {
-      this.schedulePendingParentWakeFlush(sessionID)
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry: false,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
       return
     }
 
     if (this.hasRecentParentSessionActivity(sessionID)) {
-      this.schedulePendingParentWakeFlush(sessionID)
-      log("[background-agent] Deferred parent wake because parent session activity is still fresh:", {
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry: false,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
         sessionID,
       })
       return
@@ -175,19 +190,27 @@ export class ParentWakeNotifier {
     const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
     if (toolWaitDecision.defer) {
-      this.schedulePendingParentWakeFlush(sessionID)
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
       return
     }
 
     if (await this.isUserMessageInProgress(sessionID)) {
-      // The user just sent a new message into the parent session. Dispatching
-      // a parent-wake right now would race their prompt and, on Electron-hosted
+      // The user just sent a new message into the parent session. Starting a
+      // reply-producing parent-wake right now would race their prompt and, on Electron-hosted
       // OpenCode (macOS arm64), has been observed to crash the sidecar via
       // @parcel/watcher TSFN callbacks firing into a torn-down JS env.
-      // The user's own message will drive the model; the queued notifications
-      // will be re-flushed on the next idle. See issue #4120.
-      this.schedulePendingParentWakeFlush(sessionID)
-      log("[background-agent] Deferred parent wake because user message just arrived:", {
+      // Store the wake as noReply so the user's own turn can consume it without
+      // forking another assistant turn. See issue #4120.
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
         sessionID,
       })
       return
@@ -200,6 +223,21 @@ export class ParentWakeNotifier {
       return
     }
 
+    await this.sendParentWakePrompt(sessionID, latestWake, {
+      emptyAssistantTurnRetry,
+      toolWaitDecision,
+    })
+  }
+
+  private async sendParentWakePrompt(
+    sessionID: string,
+    latestWake: PendingParentWake,
+    options: {
+      readonly emptyAssistantTurnRetry: boolean
+      readonly toolWaitDecision: ToolWaitDeferralDecision
+      readonly forceNoReply?: boolean
+    },
+  ): Promise<void> {
     this.pendingQueue.deleteWake(sessionID)
 
     await sendParentWakePrompt({
@@ -207,8 +245,9 @@ export class ParentWakeNotifier {
       directory: this.deps.directory,
       sessionID,
       latestWake,
-      emptyAssistantTurnRetry,
-      toolWaitDecision,
+      ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
+      emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
+      toolWaitDecision: options.toolWaitDecision,
       getDispatchedWake: () => this.dispatchedTracker.getWake(sessionID),
       hasRecordedPromptAfterDispatch: (wake) =>
         this.sessionInspector.hasRecordedPromptMessageAfterDispatchedWake(sessionID, wake),

--- a/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -15,6 +15,7 @@ type ParentWakePromptDispatchInput = {
   readonly directory: string
   readonly sessionID: string
   readonly latestWake: PendingParentWake
+  readonly forceNoReply?: boolean
   readonly emptyAssistantTurnRetry: boolean
   readonly toolWaitDecision: ToolWaitDeferralDecision
   readonly getDispatchedWake: () => PendingParentWake | undefined
@@ -39,12 +40,12 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         : {}),
       settleMs: 0,
       queueBehavior: "defer",
-      checkStatus: true,
-      checkToolState: !input.toolWaitDecision.skipPromptGateToolStateCheck,
+      checkStatus: input.forceNoReply !== true,
+      checkToolState: input.forceNoReply !== true && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       input: {
         path: { id: input.sessionID },
         body: {
-          noReply: !input.latestWake.shouldReply,
+          noReply: input.forceNoReply === true || !input.latestWake.shouldReply,
           ...input.latestWake.promptContext,
           parts: [createInternalAgentTextPart(notificationContent)],
         },

--- a/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -71,7 +71,7 @@ function createNotifier(args: {
 }
 
 describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
-  test("#given user message was created exactly at the race-window boundary #when flushing pending wake #then dispatch is still deferred", async () => {
+  test("#given user message was created exactly at the race-window boundary #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 10_000
@@ -98,8 +98,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-boundary")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -220,7 +221,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given all-complete wake arrives while prior assistant turn is still streaming #when the parent status is stale-idle #then the wake stays pending", async () => {
+  test("#given all-complete wake arrives while prior assistant turn is still streaming #when the parent status is stale-idle #then the wake is recorded without forking a reply", async () => {
     // given
     const sessionMessages: SessionMessageStub[] = [
       {
@@ -260,14 +261,15 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-stale-idle")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(false)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given latest message is a user message just added #when flushing pending wake #then dispatch is deferred (no promptAsync)", async () => {
+  test("#given latest message is a user message just added #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionMessages: [
@@ -297,8 +299,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(0)
-    expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
@@ -444,7 +447,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given stale all-complete wake and gate sees a repaired user tail #when latest assistant is still waiting on tools #then no parent reply is forked", async () => {
+  test("#given stale all-complete wake and gate sees a repaired user tail #when latest assistant is still waiting on tools #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -521,8 +524,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-repaired-tail")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -530,7 +534,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     }
   })
 
-  test("#given internal user tail follows a waiting assistant #when flushing pending wake #then parent wake remains deferred", async () => {
+  test("#given internal user tail follows a waiting assistant #when flushing pending wake #then parent wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -572,8 +576,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-tools")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -581,7 +586,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     }
   })
 
-  test("#given only an internal user tail is fresh #when flushing pending wake #then parent wake remains deferred", async () => {
+  test("#given only an internal user tail is fresh #when flushing pending wake #then parent wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -615,8 +620,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()
@@ -624,7 +630,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     }
   })
 
-  test("#given mixed real user tail is fresh #when flushing pending wake #then user race guard still defers", async () => {
+  test("#given mixed real user tail is fresh #when flushing pending wake #then wake is recorded without forking a reply", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -661,8 +667,9 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-mixed-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(0)
-      expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(false)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()


### PR DESCRIPTION
## Summary
Fixes duplicated parent wake handling when background tasks complete while the parent session is already in an active assistant turn. Active wakes are now admitted durably with `noReply`, preserving the wake message without starting a duplicate assistant reply loop.

## Changes
- Route active/history-blocked/fresh-user parent wakes through forced no-reply prompt dispatch.
- Bypass active status/tool-state gates only for forced no-reply wake admission.
- Add regression coverage proving active wake admission records once and clears pending wake state.

## Testing
- `bun test src/features/background-agent/parent-wake*.test.ts`
- `bun test src/features/background-agent`
- `bun run typecheck`
- `bun run build`
- Manual isolated OpenCode QA for `prompt_async` with `noReply`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate assistant replies by admitting parent wakes as no-reply prompts when the parent session is active or within race/deferral windows. Wakes are recorded once and processed on the next turn.

- **Bug Fixes**
  - Route active, history-deferred, and fresh user-message wakes through `prompt_async` with `noReply`.
  - Add a `forceNoReply` path that bypasses status/tool-state checks, records once, clears pending, and coalesces duplicates.
  - Expand regression tests for active turns, activity window, history deferral, non-Error retry, and user-message race cases.

<sup>Written for commit 6e3565ebf39165769ad431f3529becf13117650d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

