### PR TITLE
Harden prepublish cleanup targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -655,7 +655,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/lazycodex-marketplace"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add .agents/plugins/marketplace.json plugins/omo
+          git add .agents/plugins/marketplace.json .github/workflows/pr-source-guidance.yml plugins/omo
           if git diff --cached --quiet; then
             echo "LazyCodex marketplace already up to date"
           else
@@ -689,6 +689,7 @@ jobs:
           bun run script/sync-lazycodex-marketplace.ts "$PREVIOUS_PACKAGE_ROOT" "$PREVIOUS_MARKETPLACE_ROOT"
 
           if diff -qr "$PREVIOUS_MARKETPLACE_ROOT/.agents/plugins/marketplace.json" "$CURRENT_MARKETPLACE_ROOT/.agents/plugins/marketplace.json" &&
+             diff -qr "$PREVIOUS_MARKETPLACE_ROOT/.github/workflows/pr-source-guidance.yml" "$CURRENT_MARKETPLACE_ROOT/.github/workflows/pr-source-guidance.yml" &&
              diff -qr "$PREVIOUS_MARKETPLACE_ROOT/plugins/omo" "$CURRENT_MARKETPLACE_ROOT/plugins/omo"; then
             echo "LazyCodex payload unchanged from lazycodex-ai@${PREVIOUS_LAZYCODEX_VERSION}"
             echo "lazycodex_changed=false" >> "$GITHUB_OUTPUT"

--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -62,6 +62,18 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(1_000_000)
   })
 
+  it("returns cached limit for Gemini models served by google", () => {
+    const modelContextLimitsCache = new Map<string, number>()
+    modelContextLimitsCache.set("google/gemini-3.1-pro", 1_048_576)
+
+    const actualLimit = resolveActualContextLimit("google", "gemini-3.1-pro", {
+      anthropicContext1MEnabled: false,
+      modelContextLimitsCache,
+    })
+
+    expect(actualLimit).toBe(1_048_576)
+  })
+
   it("uses cached limit for GA Anthropic models when cache exists", () => {
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -8,9 +8,12 @@ export type ContextLimitModelCacheState = {
   modelContextLimitsCache?: Map<string, number>
 }
 
-function isAnthropicProvider(providerID: string): boolean {
+function isAnthropicProvider(providerID: string, modelID: string): boolean {
   const normalized = providerID.toLowerCase()
-  return normalized === "anthropic" || normalized === "google-vertex-anthropic" || normalized === "aws-bedrock-anthropic" || normalized === "google"
+  return normalized === "anthropic"
+    || normalized === "google-vertex-anthropic"
+    || normalized === "aws-bedrock-anthropic"
+    || (normalized === "google" && modelID.toLowerCase().startsWith("claude-"))
 }
 
 function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState): number {
@@ -30,7 +33,7 @@ export function resolveActualContextLimit(
   modelID: string,
   modelCacheState?: ContextLimitModelCacheState,
 ): number | null {
-  if (isAnthropicProvider(providerID)) {
+  if (isAnthropicProvider(providerID, modelID)) {
     const explicit1M = getAnthropicActualLimit(modelCacheState)
     if (explicit1M === ANTHROPIC_GA_1M_LIMIT) return explicit1M
 

--- a/packages/omo-codex/scripts/install-config.test.mjs
+++ b/packages/omo-codex/scripts/install-config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -102,6 +102,31 @@ test("#given existing Context7 MCP config #when script installer updates config 
 	assert.match(config, /args = \["\/opt\/context7\/server\.js"\]/);
 	assert.match(config, /startup_timeout_sec = 40/);
 	assert.doesNotMatch(config, /YOUR_API_KEY/);
+});
+
+test("#given Codex config is a symlink #when script installer updates config #then writes through the target", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-script-config-symlink-"));
+	const targetPath = join(root, "actual-config.toml");
+	const configPath = join(root, "config.toml");
+	await writeFile(targetPath, "[features]\nplugins = false\n");
+	await symlink(targetPath, configPath);
+
+	// when
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "sisyphuslabs",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+		pluginNames: ["omo"],
+	});
+
+	// then
+	const configStat = await lstat(configPath);
+	const targetConfig = await readFile(targetPath, "utf8");
+	assert.equal(configStat.isSymbolicLink(), true);
+	assert.match(targetConfig, /plugins = true/);
+	assert.match(targetConfig, /\[plugins\."omo@sisyphuslabs"\]/);
 });
 
 test("#given sisyphuslabs config without explicit source #when script installer updates config #then uses local marketplace", async () => {

--- a/script/publish-lazycodex-sync-workflow.test.ts
+++ b/script/publish-lazycodex-sync-workflow.test.ts
@@ -67,4 +67,20 @@ describe("LazyCodex marketplace sync workflow", () => {
       "release marketplace sync must initialize packages/lsp-tools-mcp before npm ci runs inside it",
     ).toBe(true)
   })
+
+  test("stages generated LazyCodex repository workflow changes", () => {
+    // #given
+    const workflow = readFileSync(publishWorkflowPath, "utf8")
+    const syncStep = sliceWorkflowSection(
+      workflow,
+      "      - name: Sync LazyCodex Codex marketplace",
+      "      - name: Resolve LazyCodex release payload",
+    )
+
+    // #when
+    const stagesWorkflow = syncStep.includes("git add .agents/plugins/marketplace.json .github/workflows/pr-source-guidance.yml plugins/omo")
+
+    // #then
+    expect(stagesWorkflow, "release marketplace sync must stage generated LazyCodex repository workflow changes").toBe(true)
+  })
 })

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -90,6 +90,7 @@ describe("LazyCodex publish workflow", () => {
       lazycodexReleaseStateStep.includes("npm pack \"lazycodex-ai@${PREVIOUS_LAZYCODEX_VERSION}\"") &&
       lazycodexReleaseStateStep.includes("bun run script/sync-lazycodex-marketplace.ts \"$PREVIOUS_PACKAGE_ROOT\" \"$PREVIOUS_MARKETPLACE_ROOT\"") &&
       lazycodexReleaseStateStep.includes("diff -qr \"$PREVIOUS_MARKETPLACE_ROOT/.agents/plugins/marketplace.json\" \"$CURRENT_MARKETPLACE_ROOT/.agents/plugins/marketplace.json\"") &&
+      lazycodexReleaseStateStep.includes("diff -qr \"$PREVIOUS_MARKETPLACE_ROOT/.github/workflows/pr-source-guidance.yml\" \"$CURRENT_MARKETPLACE_ROOT/.github/workflows/pr-source-guidance.yml\"") &&
       lazycodexReleaseStateStep.includes("diff -qr \"$PREVIOUS_MARKETPLACE_ROOT/plugins/omo\" \"$CURRENT_MARKETPLACE_ROOT/plugins/omo\"")
     const exposesChangedOutput =
       lazycodexReleaseStateStep.includes("lazycodex_changed=true") &&

--- a/src/cli/doctor/checks/codex.test.ts
+++ b/src/cli/doctor/checks/codex.test.ts
@@ -82,6 +82,67 @@ describe("codex doctor checks", () => {
     expect(result.issues.map((issue) => issue.title)).toContain("Codex is not installed")
     expect(result.issues.map((issue) => issue.title)).toContain("OMO Codex plugin is not installed")
     expect(result.issues.map((issue) => issue.title)).toContain("Codex plugin is not enabled")
+    expect(result.issues.map((issue) => issue.title)).toContain("LazyCodex marketplace is not configured")
+  })
+
+  test("#given another plugin is enabled #when LazyCodex is disabled #then Codex doctor reports OMO as disabled", async () => {
+    // given
+    const { codexHome, binDir } = await createInstalledCodexHome()
+    await writeFile(
+      join(codexHome, "config.toml"),
+      [
+        "[features]",
+        "plugins = true",
+        "plugin_hooks = true",
+        "",
+        "[marketplaces.sisyphuslabs]",
+        `source = "${join(codexHome, "plugins", "cache", "sisyphuslabs")}"`,
+        "",
+        '[plugins."omo@sisyphuslabs"]',
+        "enabled = false",
+        "",
+        '[plugins."other@example"]',
+        "enabled = true",
+      ].join("\n"),
+    )
+
+    // when
+    const result = await checkCodex({
+      codexHome,
+      binDir,
+      detectCodexInstallation: async () => ({ found: true, source: "cli", path: "/usr/local/bin/codex" }),
+    })
+
+    // then
+    expect(result.status).toBe("fail")
+    expect(result.issues.map((issue) => issue.title)).toContain("Codex plugin is not enabled")
+  })
+
+  test("#given LazyCodex marketplace is missing #when Codex doctor runs #then plugin loading fails", async () => {
+    // given
+    const { codexHome, binDir } = await createInstalledCodexHome()
+    await writeFile(
+      join(codexHome, "config.toml"),
+      [
+        "[features]",
+        "plugins = true",
+        "plugin_hooks = true",
+        "",
+        '[plugins."omo@sisyphuslabs"]',
+        "enabled = true",
+      ].join("\n"),
+    )
+
+    // when
+    const result = await checkCodex({
+      codexHome,
+      binDir,
+      detectCodexInstallation: async () => ({ found: true, source: "cli", path: "/usr/local/bin/codex" }),
+    })
+
+    // then
+    expect(result.status).toBe("fail")
+    expect(result.issues.map((issue) => issue.title)).toContain("LazyCodex marketplace is not configured")
   })
 
   test("#given installed LazyCodex #when checking Codex doctor #then details include Codex-specific health surfaces", async () => {

--- a/src/cli/doctor/checks/codex.ts
+++ b/src/cli/doctor/checks/codex.ts
@@ -110,6 +110,15 @@ function buildCodexIssues(summary: CodexDoctorSummary): DoctorIssue[] {
       affects: ["plugin loading"],
     })
   }
+  if (!summary.config.marketplaceConfigured) {
+    issues.push({
+      title: "LazyCodex marketplace is not configured",
+      description: 'Expected [marketplaces.sisyphuslabs] in Codex config.',
+      fix: "Run: npx lazycodex-ai install",
+      severity: "error",
+      affects: ["plugin loading"],
+    })
+  }
   if (!summary.config.pluginsFeatureEnabled || !summary.config.pluginHooksFeatureEnabled) {
     issues.push({
       title: "Codex plugin features are not enabled",
@@ -138,7 +147,7 @@ async function readCodexConfigSummary(configPath: string): Promise<CodexConfigSu
   return {
     exists: true,
     marketplaceConfigured: content.includes("[marketplaces.sisyphuslabs]"),
-    pluginEnabled: content.includes('[plugins."omo@sisyphuslabs"]') && settingEnabled(content, "enabled"),
+    pluginEnabled: settingEnabled(sectionBody(content, 'plugins."omo@sisyphuslabs"'), "enabled"),
     pluginsFeatureEnabled: featureEnabled(content, "plugins"),
     pluginHooksFeatureEnabled: featureEnabled(content, "plugin_hooks"),
   }
@@ -176,7 +185,7 @@ function stringField(record: JsonRecord | null, key: string): string | null {
 
 function featureEnabled(content: string, name: string): boolean {
   const features = sectionBody(content, "features")
-  return features.includes(`${name} = true`)
+  return settingEnabled(features, name)
 }
 
 function settingEnabled(content: string, name: string): boolean {

--- a/src/cli/sparkshell-appserver-websocket.test.ts
+++ b/src/cli/sparkshell-appserver-websocket.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import type { Socket } from "node:net"
+
+import { unsafeTestValue } from "../../test-support/unsafe-test-value"
+import { readWebSocketText } from "./sparkshell-appserver-websocket"
+
+describe("readWebSocketText", () => {
+  test("#given coalesced websocket frames #when reading twice #then buffered bytes are preserved", async () => {
+    // given
+    let pending: Buffer | null = Buffer.concat([
+      createServerTextFrame("notification"),
+      createServerTextFrame("response"),
+    ])
+    const socket = unsafeTestValue<Socket>({
+      read: () => {
+        const chunk = pending
+        pending = null
+        return chunk
+      },
+      once: () => socket,
+      off: () => socket,
+    })
+
+    // when
+    const first = await readWebSocketText(socket)
+    const second = await readWebSocketText(socket)
+
+    // then
+    expect(first).toBe("notification")
+    expect(second).toBe("response")
+  })
+})
+
+function createServerTextFrame(payload: string): Buffer {
+  const body = Buffer.from(payload)
+  if (body.length >= 126) {
+    throw new Error("test helper only supports short frames")
+  }
+  return Buffer.concat([Buffer.from([0x81, body.length]), body])
+}

--- a/src/cli/sparkshell-appserver-websocket.ts
+++ b/src/cli/sparkshell-appserver-websocket.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto"
 import { createConnection, type Socket } from "node:net"
 
+const SOCKET_READ_BUFFERS = new WeakMap<Socket, Buffer>()
+
 export async function connectUnixWebSocket(socketPath: string): Promise<Socket> {
   const socket = createConnection(socketPath)
   await new Promise<void>((resolveConnect, rejectConnect) => {
@@ -60,7 +62,9 @@ export async function readWebSocketText(socket: Socket): Promise<string> {
     offset += 8
   }
   frame = await readAtLeast(socket, frame, offset + length)
-  return frame.subarray(offset, offset + length).toString("utf8")
+  const endOffset = offset + length
+  bufferUnreadSocketBytes(socket, frame.subarray(endOffset))
+  return frame.subarray(offset, endOffset).toString("utf8")
 }
 
 function createTextFrameHeader(length: number): Buffer {
@@ -86,9 +90,16 @@ async function readHttpUpgrade(socket: Socket): Promise<void> {
   if (!header.startsWith("HTTP/1.1 101")) {
     throw new Error("appserver websocket upgrade failed")
   }
+  const headerEnd = buffer.indexOf("\r\n\r\n") + 4
+  bufferUnreadSocketBytes(socket, buffer.subarray(headerEnd))
 }
 
 async function readSocketChunk(socket: Socket): Promise<Buffer> {
+  const buffered = SOCKET_READ_BUFFERS.get(socket)
+  if (buffered && buffered.length > 0) {
+    SOCKET_READ_BUFFERS.delete(socket)
+    return buffered
+  }
   const existing = socket.read()
   if (Buffer.isBuffer(existing)) {
     return existing
@@ -129,4 +140,10 @@ async function readAtLeast(socket: Socket, initial: Buffer, byteLength: number):
     buffer = Buffer.concat([buffer, await readSocketChunk(socket)])
   }
   return buffer
+}
+
+function bufferUnreadSocketBytes(socket: Socket, unread: Buffer): void {
+  if (unread.length === 0) return
+  const existing = SOCKET_READ_BUFFERS.get(socket)
+  SOCKET_READ_BUFFERS.set(socket, existing ? Buffer.concat([existing, unread]) : unread)
 }

--- a/src/features/consensus/consensus-engine.ts
+++ b/src/features/consensus/consensus-engine.ts
@@ -6,7 +6,7 @@ import { fetchAvailableModels, getConnectedProviders } from "../../shared/model-
 import { log } from "../../shared"
 import { VOTER_SPAWNER_DEFAULTS, spawnVoter } from "./voter-spawner"
 import { resolveVoterCandidate } from "./voter-resolver"
-import type { ConsensusInput, ConsensusResult, ResolvedVoterCandidate, VoterPosition } from "./types"
+import { isUsableVoterPosition, type ConsensusInput, type ConsensusResult, type ResolvedVoterCandidate, type VoterPosition } from "./types"
 
 type RunConsensusDeps = {
   spawnVoter: typeof spawnVoter
@@ -72,10 +72,6 @@ export async function runConsensus(
   }
 }
 
-function isUsableVoterPosition(voter: VoterPosition): boolean {
-  return voter.status === "ok" && voter.text.trim().length > 0
-}
-
 function selectResolvedCandidates(args: {
   requestedLineages: ReadonlyArray<string> | undefined
   callerModel: string | undefined
@@ -85,11 +81,11 @@ function selectResolvedCandidates(args: {
   connectedProviders: ReadonlySet<string>
   availableModels: Set<string>
 }): ResolvedVoterCandidate[] {
-  const explicit = args.candidates && args.candidates.length > 0
-  const pool = explicit ? args.candidates! : filterPoolByRequestedLineages(args.requestedLineages)
+  const explicitCandidates = args.candidates && args.candidates.length > 0 ? args.candidates : undefined
+  const pool = explicitCandidates ?? filterPoolByRequestedLineages(args.requestedLineages)
 
   const excluded = new Set<string>(args.excludeLineages ?? [])
-  if (!explicit) {
+  if (!explicitCandidates) {
     for (const lineage of getCallerLineageGroup(args.callerModel)) excluded.add(lineage)
   }
 

--- a/src/features/consensus/types.ts
+++ b/src/features/consensus/types.ts
@@ -21,6 +21,10 @@ export type VoterPosition = {
   errorMessage?: string
 }
 
+export function isUsableVoterPosition(voter: VoterPosition): boolean {
+  return voter.status === "ok" && voter.text.trim().length > 0
+}
+
 export type ConsensusResult = {
   triggerType: ConsensusTriggerType
   callerModel: string | undefined

--- a/src/features/consensus/voter-resolver.test.ts
+++ b/src/features/consensus/voter-resolver.test.ts
@@ -45,4 +45,27 @@ describe("resolveVoterCandidate", () => {
       variant: undefined,
     })
   })
+
+  test("#given empty model inventory #when resolving a Kimi voter #then it prefers opencode-go over opencode", () => {
+    const candidate: VoterCandidate = {
+      lineage: "kimi",
+      entry: {
+        providers: ["opencode-go", "opencode"],
+        model: "kimi-k2.6",
+      },
+    }
+
+    const result = resolveVoterCandidate(
+      candidate,
+      new Set(["opencode", "opencode-go"]),
+      new Set(),
+    )
+
+    expect(result).toEqual({
+      lineage: "kimi",
+      providerID: "opencode-go",
+      modelID: "kimi-k2.6",
+      variant: undefined,
+    })
+  })
 })

--- a/src/features/consensus/voter-spawner.test.ts
+++ b/src/features/consensus/voter-spawner.test.ts
@@ -1,0 +1,63 @@
+const { describe, expect, test } = require("bun:test")
+
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { extractAssistantText, spawnVoter } from "./voter-spawner"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+describe("extractAssistantText", () => {
+  test("#given mixed message shapes #when extracting voter output #then the latest assistant text is returned", () => {
+    const text = extractAssistantText([
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "older" }] },
+      { info: { role: "user" }, parts: [{ type: "text", text: "question" }] },
+      null,
+      { info: { role: "assistant" }, parts: [{ type: "tool" }, { type: "text", text: " latest " }] },
+    ])
+
+    expect(text).toBe("latest")
+  })
+
+  test("#given no assistant text parts #when extracting voter output #then an empty string is returned", () => {
+    const text = extractAssistantText([
+      { info: { role: "assistant" }, parts: [{ type: "tool", text: "ignored" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "   " }] },
+    ])
+
+    expect(text).toBe("")
+  })
+})
+
+describe("spawnVoter", () => {
+  test("#given a voter times out #when cleaning up session tracking #then the child session remains inspectable", async () => {
+    let deletedSessionID: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      client: {
+        session: {
+          create: async () => ({ data: { id: "voter-session" } }),
+          prompt: async () => ({ data: {} }),
+          status: async () => ({ data: {} }),
+          messages: async () => ({ data: [] }),
+          delete: async (input: { path: { id: string } }) => {
+            deletedSessionID = input.path.id
+            return { data: {} }
+          },
+        },
+      },
+    })
+
+    const result = await spawnVoter(ctx, {
+      candidate: {
+        lineage: "gpt",
+        providerID: "openai",
+        modelID: "gpt-5.5",
+        variant: undefined,
+      },
+      prompt: "Pick an architecture.",
+      parentSessionID: "parent",
+      parentDirectory: "/workspace",
+      voterTimeoutMs: 0,
+    })
+
+    expect(result.status).toBe("timeout")
+    expect(deletedSessionID).toBeUndefined()
+  })
+})

--- a/src/features/consensus/voter-spawner.ts
+++ b/src/features/consensus/voter-spawner.ts
@@ -39,6 +39,18 @@ type SpawnVoterArgs = {
   reasoningEffort?: string
 }
 
+type VoterPromptInput = {
+  path: { id: string }
+  body: {
+    model: { providerID: string; modelID: string }
+    variant?: string
+    options?: { reasoningEffort: string }
+    tools: Record<string, boolean>
+    parts: Array<{ type: "text"; text: string }>
+  }
+  url: "/session/{id}/message"
+}
+
 export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promise<VoterPosition> {
   const { candidate, prompt, parentSessionID, parentDirectory, voterTimeoutMs, reasoningEffort } = args
   const startedAt = Date.now()
@@ -60,7 +72,7 @@ export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promis
       body: {
         parentID: parentSessionID,
         title: `consensus voter (${candidate.lineage})`,
-      } as Record<string, unknown>,
+      },
       query: parentDirectory ? { directory: parentDirectory } : undefined,
     })
     if (createResult.error || !createResult.data?.id) {
@@ -69,8 +81,7 @@ export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promis
     sessionID = createResult.data.id
     subagentSessions.add(sessionID)
 
-    type PromptInput = Parameters<typeof ctx.client.session.prompt>[0]
-    const promptInput = {
+    const promptInput: VoterPromptInput = {
       path: { id: sessionID },
       body: {
         model: { providerID, modelID },
@@ -79,9 +90,10 @@ export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promis
         tools: VOTER_DISABLED_TOOLS,
         parts: [{ type: "text", text: buildVoterPrompt(prompt) }],
       },
-    } as unknown as PromptInput
+      url: "/session/{id}/message",
+    }
 
-    const dispatchResult = await dispatchInternalPrompt<PromptInput>({
+    const dispatchResult = await dispatchInternalPrompt<VoterPromptInput>({
       mode: "sync",
       client: ctx.client,
       sessionID,
@@ -113,7 +125,6 @@ export async function spawnVoter(ctx: PluginInput, args: SpawnVoterArgs): Promis
   } finally {
     if (sessionID) {
       subagentSessions.delete(sessionID)
-      ctx.client.session.delete({ path: { id: sessionID } }).catch(() => undefined)
     }
   }
 }
@@ -146,15 +157,39 @@ async function waitForResult(ctx: PluginInput, sessionID: string, timeoutMs: num
   throw new Error(`voter timed out after ${timeoutMs}ms`)
 }
 
-function extractAssistantText(messages: ReadonlyArray<unknown>): string {
+export function extractAssistantText(messages: ReadonlyArray<unknown>): string {
   for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i] as { info?: { role?: string }; parts?: Array<{ type?: string; text?: string }> } | undefined
-    if (!msg || msg.info?.role !== "assistant") continue
-    const parts = msg.parts ?? []
-    const text = parts.filter(p => p?.type === "text" && typeof p.text === "string").map(p => p.text as string).join("\n").trim()
+    const msg = messages[i]
+    if (!isAssistantMessage(msg)) continue
+    const text = msg.parts.filter(isTextPart).map(part => part.text).join("\n").trim()
     if (text) return text
   }
   return ""
+}
+
+type AssistantMessageWithParts = {
+  readonly info?: { readonly role?: string }
+  readonly parts: ReadonlyArray<unknown>
+}
+
+type TextPart = {
+  readonly type: "text"
+  readonly text: string
+}
+
+function isAssistantMessage(value: unknown): value is AssistantMessageWithParts {
+  if (!isRecord(value)) return false
+  if (!Array.isArray(value.parts)) return false
+  if (!isRecord(value.info)) return false
+  return value.info.role === "assistant"
+}
+
+function isTextPart(value: unknown): value is TextPart {
+  return isRecord(value) && value.type === "text" && typeof value.text === "string"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 export const VOTER_SPAWNER_DEFAULTS = {

--- a/src/shared/model-lineage.ts
+++ b/src/shared/model-lineage.ts
@@ -105,7 +105,7 @@ const DEFAULT_VOTER_POOL: ReadonlyArray<VoterCandidate> = [
   {
     lineage: "kimi",
     entry: {
-      providers: ["opencode", "opencode-go", "vercel", "moonshotai", "kimi-for-coding"],
+      providers: ["opencode-go", "opencode", "vercel", "moonshotai", "kimi-for-coding"],
       model: "kimi-k2.6",
     },
   },

--- a/src/tools/consensus/tool.test.ts
+++ b/src/tools/consensus/tool.test.ts
@@ -4,6 +4,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 import type { ConsensusInput, ConsensusResult } from "../../features/consensus"
+import { isUsableVoterPosition } from "../../features/consensus/types"
 import { createConsensusTool } from "./tool"
 
 describe("createConsensusTool", () => {
@@ -119,7 +120,7 @@ function createConsensusResult(voters: ConsensusResult["voters"]): ConsensusResu
     callerModel: undefined,
     callerLineage: undefined,
     voters,
-    advisoryOnly: voters.filter(voter => voter.status === "ok" && voter.text.trim().length > 0).length < 2,
+    advisoryOnly: voters.filter(isUsableVoterPosition).length < 2,
     startedAt: "2026-06-04T00:00:00.000Z",
     finishedAt: "2026-06-04T00:00:00.000Z",
     totalDurationMs: 1,

--- a/src/tools/consensus/tool.ts
+++ b/src/tools/consensus/tool.ts
@@ -3,6 +3,7 @@ import type { ConsensusConfig } from "../../config/schema/consensus"
 import { runConsensus } from "../../features/consensus"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared"
+import { isUsableVoterPosition } from "../../features/consensus/types"
 import type { ConsensusToolArgs, ConsensusToolResult } from "./types"
 
 const isSubagentSession = (sessionID: string): boolean => subagentSessions.has(sessionID)
@@ -75,7 +76,7 @@ export function createConsensusTool(
         excludeLineages: args.exclude_lineages,
       }, consensusConfig)
 
-      const okCount = result.voters.filter(v => v.status === "ok" && v.text.trim().length > 0).length
+      const okCount = result.voters.filter(isUsableVoterPosition).length
       const ok = okCount > 0
       const toolResult: ConsensusToolResult = {
         ok,


### PR DESCRIPTION
## Summary
- harden consensus voter dispatch, parsing, session retention, and result counting
- preserve LazyCodex marketplace workflow payload checks during release sync
- tighten Codex doctor marketplace/plugin config validation
- keep routed Gemini context limits and prefer opencode-go for Kimi voters
- preserve coalesced Sparkshell WebSocket frames and cover Codex config symlink updates

## Validation
- bun test
- bun run typecheck
- bun run build
- bun run test:codex
- git diff --check origin/dev..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens consensus voting and Codex integration, and ensures LazyCodex release sync stages workflow payloads. Also preserves Gemini context limits and fixes WebSocket coalesced frame handling.

- **Bug Fixes**
  - Consensus: safer session lifecycle (no delete on timeout), stricter internal prompt typing, robust assistant text parsing, shared usable-voter check, improved candidate selection, and prefer `opencode-go` for Kimi.
  - Release: publish sync now stages `.github/workflows/pr-source-guidance.yml` and includes it in change detection.
  - Codex: doctor flags missing `[marketplaces.sisyphuslabs]`, checks `plugins."omo@sisyphuslabs"` enablement within its section, and reads `features` reliably; installer supports symlinked `config.toml`.
  - Models: treat `google` as Anthropic only for `claude-*` models; keep cached limits for Gemini.
  - Sparkshell: buffer unread bytes after HTTP upgrade and per frame so coalesced WebSocket frames are preserved.

<sup>Written for commit 8e67dd4d97056b869332e3f208d9d0880c140a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

