### PR TITLE
refactor(utils): remove duplicate JSONC BOM stripping

### DIFF
--- a/packages/utils/src/jsonc-parser.ts
+++ b/packages/utils/src/jsonc-parser.ts
@@ -31,9 +31,6 @@ function stripBom(content: string): string {
 }
 
 export function parseJsonc<T = unknown>(content: string): T {
-  // Strip UTF-8 BOM if present (Windows UTF-8 with BOM files)
-  content = content.replace(/^\uFEFF/, "")
-
   const errors: ParseError[] = []
   const result = parse(stripBom(content), errors, {
     allowTrailingComma: true,


### PR DESCRIPTION
## Summary
Removes redundant UTF-8 BOM stripping from `parseJsonc` so JSONC parsing has one shared normalization path through `stripBom`.

## Changes
- Deleted the extra `content.replace(/^\uFEFF/, "")` call from `parseJsonc`.
- Kept existing BOM behavior covered by current parser, safe parser, and file-read tests.

## Testing
- `bun test packages/utils/src/jsonc-parser.test.ts`
- `bun run --cwd packages/utils test`
- `bun run --cwd packages/utils typecheck`
- `bun run typecheck:packages`
- `bun -e 'import { parseJsonc } from "./packages/utils/src/jsonc-parser.ts"; const parsed = parseJsonc<{ readonly key: string }>("\uFEFF{ // comment\n \"key\": \"value\",\n}"); console.log(parsed.key)'`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate UTF-8 BOM stripping in parseJsonc so JSONC input is normalized once via stripBom. Simplifies the parser and keeps existing BOM handling unchanged.

<sup>Written for commit 9e87a0528ee706eef0a3f6a0c00b0a30f7a14d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

