### PR TITLE
Remove unused agents-md-core utils dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@oh-my-opencode/rules-engine": "workspace:*",
-        "@oh-my-opencode/utils": "workspace:*",
       },
     },
     "packages/ast-grep-core": {

--- a/packages/agents-md-core/package.json
+++ b/packages/agents-md-core/package.json
@@ -16,7 +16,6 @@
     "test": "bun test src/*.test.ts"
   },
   "dependencies": {
-    "@oh-my-opencode/rules-engine": "workspace:*",
-    "@oh-my-opencode/utils": "workspace:*"
+    "@oh-my-opencode/rules-engine": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary
Remove the unused `@oh-my-opencode/utils` dependency from `@oh-my-opencode/agents-md-core` and refresh the Bun lockfile package entry.

## Changes
- Removed `@oh-my-opencode/utils` from `packages/agents-md-core/package.json`.
- Removed the matching workspace dependency from `bun.lock`.

## Testing
- `rg "@oh-my-opencode/utils" packages/agents-md-core`
- `bun run --cwd packages/agents-md-core test`
- `bun run --cwd packages/agents-md-core typecheck`
- `bun -e 'const mod = await import("@oh-my-opencode/agents-md-core"); const required = ["AGENTS_FILENAME", "resolveFilePath", "formatAgentsMdContextBlock", "getSessionCache", "processFilePathForAgentsInjection"]; for (const key of required) { if (!(key in mod)) throw new Error(`missing ${key}`); } console.log(required.join(","));'`\n- `bun run typecheck:packages`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `@oh-my-opencode/utils` from `@oh-my-opencode/agents-md-core` and cleaned up `bun.lock`. Reduces workspace noise and avoids installing an unused package; no functional changes.

- **Dependencies**
  - Dropped `@oh-my-opencode/utils` from `packages/agents-md-core/package.json` and removed the matching entry from `bun.lock`.

<sup>Written for commit 4e947dc6281eeaae8ea98d27006a430762776728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

