### PR TITLE
hashline-core: remove unused edit primitive import

### DIFF
--- a/packages/hashline-core/src/edit-operation-primitives.ts
+++ b/packages/hashline-core/src/edit-operation-primitives.ts
@@ -3,7 +3,6 @@ import {
   restoreLeadingIndent,
   stripInsertAnchorEcho,
   stripInsertBeforeEcho,
-  stripInsertBoundaryEcho,
   stripRangeBoundaryEcho,
   toNewLines,
 } from "./edit-text-normalization"

--- a/packages/hashline-core/src/validation.test.ts
+++ b/packages/hashline-core/src/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { computeLineHash, computeLegacyLineHash } from "./hash-computation"
-import { parseLineRef, validateLineRef, validateLineRefs } from "./validation"
+import { HashlineMismatchError, parseLineRef, validateLineRef, validateLineRefs } from "./validation"
 
 describe("parseLineRef", () => {
   it("parses valid LINE#ID reference", () => {
@@ -114,6 +114,31 @@ describe("validateLineRef", () => {
 
     //#when / #then
     expect(() => validateLineRef(lines, "1#ZZ")).toThrow(/>>>\s+1#[ZPMQVRWSNKTXJBYH]{2}\|/)
+  })
+
+  it("keeps mismatch constructor parameters as observable error fields", () => {
+    //#given
+    const lines = ["function hello() {"]
+    let capturedError: HashlineMismatchError | undefined
+
+    //#when
+    try {
+      validateLineRef(lines, "1#ZZ")
+    } catch (error) {
+      if (!(error instanceof HashlineMismatchError)) {
+        throw error
+      }
+      capturedError = error
+    }
+
+    //#then
+    if (capturedError === undefined) {
+      throw new Error("Expected HashlineMismatchError")
+    }
+    expect(Object.hasOwn(capturedError, "mismatches")).toBe(true)
+    expect(Object.hasOwn(capturedError, "fileLines")).toBe(true)
+    expect(Object.keys(capturedError)).toContain("mismatches")
+    expect(Object.keys(capturedError)).toContain("fileLines")
   })
 
   it("accepts legacy hashes for indented lines", () => {


### PR DESCRIPTION
## Summary
Removes the unused `stripInsertBoundaryEcho` import from `hashline-core` edit primitives. Adds a characterization test showing `HashlineMismatchError` constructor parameter properties are observable own enumerable fields, so those noUnused diagnostics are intentionally left unchanged to preserve runtime shape.

## Changes
- Removed the confirmed unused import from `packages/hashline-core/src/edit-operation-primitives.ts`.
- Added a `HashlineMismatchError` shape characterization test in `packages/hashline-core/src/validation.test.ts`.

## Testing
- `bun test packages/hashline-core`
- `bun run typecheck:packages`
- `bun run build`
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/hashline-core/src/validation.test.ts packages/hashline-core/src/edit-operation-primitives.ts`
- Manual QA: Bun driver imported `packages/hashline-core/src/index.ts`, applied a hashline replace edit, and verified stale-hash validation still throws `HashlineMismatchError` with `mismatches` and `fileLines` own fields.

## Notes
Scoped noUnused rerun now reports only `HashlineMismatchError` private parameter properties (`mismatches`, `fileLines`), which are preserved because the characterization test proves they are observable at runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unused `stripInsertBoundaryEcho` import in `hashline-core` edit primitives. Added a test that proves `HashlineMismatchError` exposes `mismatches` and `fileLines` as own enumerable fields, so the private constructor parameters are kept despite noUnused warnings.

<sup>Written for commit eee15c9c59a21fb0408a517c81ed9d35fbb30fc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

