### PR TITLE
perf(boulder-state): scan session work once

### DIFF
--- a/packages/boulder-state/src/read-state.test.ts
+++ b/packages/boulder-state/src/read-state.test.ts
@@ -171,6 +171,56 @@ describe("getWorkForSession", () => {
     expect(work?.work_id).toBe("first")
   })
 
+  test("#given matching works with invalid sort times #when reading by session #then first inserted work is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, createState([
+      createWork({
+        workId: "first-invalid",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "not-a-date",
+        updatedAt: "also-not-a-date",
+      }),
+      createWork({
+        workId: "second-invalid",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "still-not-a-date",
+        updatedAt: "nope",
+      }),
+    ]))
+
+    // when
+    const work = getWorkForSession(directory, "sess-a")
+
+    // then
+    expect(work?.work_id).toBe("first-invalid")
+  })
+
+  test("#given valid and invalid matching work times #when reading by session #then valid time wins", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, createState([
+      createWork({
+        workId: "invalid",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "not-a-date",
+        updatedAt: "also-not-a-date",
+      }),
+      createWork({
+        workId: "valid",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:00:00.000Z",
+        updatedAt: "2026-06-05T02:00:00.000Z",
+      }),
+    ]))
+
+    // when
+    const work = getWorkForSession(directory, "sess-a")
+
+    // then
+    expect(work?.work_id).toBe("valid")
+  })
+
   test("#given no matching work but matching mirror session #when reading by session #then mirror work is returned", () => {
     // given
     const directory = createTempDirectory()

--- a/packages/boulder-state/src/read-state.test.ts
+++ b/packages/boulder-state/src/read-state.test.ts
@@ -1,12 +1,12 @@
-/// <reference path="../../../../bun-test.d.ts" />
+/// <reference path="../../../bun-test.d.ts" />
 
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
 
-import type { BoulderState, BoulderWorkState } from "../types"
-import { getWorkForSession, readBoulderState } from "./read-state"
+import type { BoulderState, BoulderWorkState } from "./types"
+import { getWorkForSession, readBoulderState } from "./storage/read-state"
 
 function createTempDirectory(): string {
   return mkdtempSync(join(tmpdir(), "boulder-read-state-"))

--- a/packages/boulder-state/src/storage/read-state.test.ts
+++ b/packages/boulder-state/src/storage/read-state.test.ts
@@ -1,0 +1,194 @@
+/// <reference path="../../../../bun-test.d.ts" />
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+import type { BoulderState, BoulderWorkState } from "../types"
+import { getWorkForSession, readBoulderState } from "./read-state"
+
+function createTempDirectory(): string {
+  return mkdtempSync(join(tmpdir(), "boulder-read-state-"))
+}
+
+function writeState(directory: string, state: BoulderState): void {
+  const boulderDirectory = join(directory, ".omo")
+  mkdirSync(boulderDirectory, { recursive: true })
+  writeFileSync(join(boulderDirectory, "boulder.json"), JSON.stringify(state), "utf-8")
+}
+
+function createWork(input: {
+  readonly workId: string
+  readonly sessionIds: readonly string[]
+  readonly startedAt: string
+  readonly updatedAt?: string
+}): BoulderWorkState {
+  return {
+    work_id: input.workId,
+    active_plan: `.omo/plans/${input.workId}.md`,
+    plan_name: input.workId,
+    status: "active",
+    started_at: input.startedAt,
+    ...(input.updatedAt !== undefined ? { updated_at: input.updatedAt } : {}),
+    session_ids: [...input.sessionIds],
+  }
+}
+
+function createState(works: readonly BoulderWorkState[]): BoulderState {
+  const firstWork = works[0]
+  if (!firstWork) {
+    throw new Error("test state requires at least one work")
+  }
+
+  return {
+    schema_version: 2,
+    active_work_id: firstWork.work_id,
+    works: Object.fromEntries(works.map((work) => [work.work_id, work])),
+    active_plan: firstWork.active_plan,
+    plan_name: firstWork.plan_name,
+    status: firstWork.status,
+    started_at: firstWork.started_at,
+    updated_at: firstWork.updated_at,
+    session_ids: [...firstWork.session_ids],
+    session_origins: {},
+    task_sessions: {},
+  }
+}
+
+describe("readBoulderState", () => {
+  test("#given no boulder file #when reading state #then null is returned", () => {
+    // given
+    const directory = createTempDirectory()
+
+    // when
+    const state = readBoulderState(directory)
+
+    // then
+    expect(state).toBeNull()
+  })
+
+  test("#given malformed state json #when reading state #then null is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    const boulderDirectory = join(directory, ".omo")
+    mkdirSync(boulderDirectory, { recursive: true })
+    writeFileSync(join(boulderDirectory, "boulder.json"), "{not-json", "utf-8")
+
+    // when
+    const state = readBoulderState(directory)
+
+    // then
+    expect(state).toBeNull()
+  })
+
+  test("#given non-object state json #when reading state #then null is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    const boulderDirectory = join(directory, ".omo")
+    mkdirSync(boulderDirectory, { recursive: true })
+    writeFileSync(join(boulderDirectory, "boulder.json"), "[]", "utf-8")
+
+    // when
+    const state = readBoulderState(directory)
+
+    // then
+    expect(state).toBeNull()
+  })
+})
+
+describe("getWorkForSession", () => {
+  test("#given multiple works for one session #when reading by session #then newest updated work is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, createState([
+      createWork({
+        workId: "older",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:00:00.000Z",
+        updatedAt: "2026-06-05T02:00:00.000Z",
+      }),
+      createWork({
+        workId: "newest",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:30:00.000Z",
+        updatedAt: "2026-06-05T03:00:00.000Z",
+      }),
+    ]))
+
+    // when
+    const work = getWorkForSession(directory, "sess-a")
+
+    // then
+    expect(work?.work_id).toBe("newest")
+  })
+
+  test("#given matching works without updated times #when reading by session #then newest started work is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, createState([
+      createWork({
+        workId: "older-start",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:00:00.000Z",
+      }),
+      createWork({
+        workId: "newer-start",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T02:00:00.000Z",
+      }),
+    ]))
+
+    // when
+    const work = getWorkForSession(directory, "opencode:sess-a")
+
+    // then
+    expect(work?.work_id).toBe("newer-start")
+  })
+
+  test("#given matching works with identical sort times #when reading by session #then first inserted work is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, createState([
+      createWork({
+        workId: "first",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:00:00.000Z",
+        updatedAt: "2026-06-05T02:00:00.000Z",
+      }),
+      createWork({
+        workId: "second",
+        sessionIds: ["opencode:sess-a"],
+        startedAt: "2026-06-05T01:30:00.000Z",
+        updatedAt: "2026-06-05T02:00:00.000Z",
+      }),
+    ]))
+
+    // when
+    const work = getWorkForSession(directory, "sess-a")
+
+    // then
+    expect(work?.work_id).toBe("first")
+  })
+
+  test("#given no matching work but matching mirror session #when reading by session #then mirror work is returned", () => {
+    // given
+    const directory = createTempDirectory()
+    writeState(directory, {
+      schema_version: 2,
+      active_plan: ".omo/plans/mirror.md",
+      plan_name: "mirror",
+      status: "active",
+      started_at: "2026-06-05T01:00:00.000Z",
+      session_ids: ["opencode:sess-a"],
+      session_origins: { "opencode:sess-a": "direct" },
+      task_sessions: {},
+    })
+
+    // when
+    const work = getWorkForSession(directory, "sess-a")
+
+    // then
+    expect(work?.work_id).toBe("mirror-legacy")
+  })
+})

--- a/packages/boulder-state/src/storage/read-state.ts
+++ b/packages/boulder-state/src/storage/read-state.ts
@@ -147,12 +147,23 @@ export function getWorkForSession(directory: string, sessionId: string): Boulder
   }
 
   const normalizedSessionId = normalizeSessionId(sessionId)
-  const works = getBoulderWorks(state)
-    .filter((work) => work.session_ids.includes(normalizedSessionId))
-    .sort((left, right) => (parseIsoToMs(right.updated_at ?? right.started_at) ?? 0) - (parseIsoToMs(left.updated_at ?? left.started_at) ?? 0))
+  let newestWork: BoulderWorkState | null = null
+  let newestWorkMs = 0
 
-  if (works.length > 0) {
-    return works[0] ?? null
+  for (const work of getBoulderWorks(state)) {
+    if (!work.session_ids.includes(normalizedSessionId)) {
+      continue
+    }
+
+    const workMs = parseIsoToMs(work.updated_at ?? work.started_at) ?? 0
+    if (!newestWork || workMs > newestWorkMs) {
+      newestWork = work
+      newestWorkMs = workMs
+    }
+  }
+
+  if (newestWork) {
+    return newestWork
   }
 
   return state.session_ids.includes(normalizedSessionId) ? buildWorkFromMirror(state) : null


### PR DESCRIPTION
## Summary
Optimizes boulder-state session work lookup by selecting the newest matching work in a single pass instead of filtering and sorting all matches. Adds characterization coverage for current newest-selection, tie, mirror fallback, and malformed state behavior.

## Changes
- Add read-state characterization tests for missing, malformed, and non-object state files.
- Cover getWorkForSession newest updated/start fallback selection, equal timestamp tie behavior, bare session normalization, and mirror fallback.
- Replace filter/sort selection with a single-pass best-match scan while preserving first-match tie behavior.

## Testing
- `bun test packages/boulder-state/src/storage/read-state.test.ts` ✅
- `bun run --cwd packages/boulder-state typecheck` ✅
- `bun test packages/boulder-state/src/storage/read-state.test.ts packages/boulder-state/test/normalize-session-id.test.ts` ✅
- `bun run typecheck:packages` ✅
- Manual Bun temp-file driver: wrote `.omo/boulder.json` and read `newest` ✅

## Notes
- `bun run --cwd packages/boulder-state test` currently fails because the existing script glob `src/*.test.ts` does not match nested test files. Left unchanged to keep this PR scoped to read-state and tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `boulder-state` session work lookup to select the newest matching work in a single pass. Added characterization tests for state reading, selection rules, and invalid timestamp handling, wired into the package test script.

- **Refactors**
  - Replaced filter/sort with single-pass scan using `updated_at` or `started_at`.
  - Preserved first-match behavior on equal or invalid times; valid times win when present.
  - Returned mirror work when no direct session match is found.

<sup>Written for commit 04c617fe5d11447c982a092ddc16820e63f2ec20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

