### PR TITLE
perf(codex-rules): dedupe parsed globs with Set

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/rules/parser.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules/parser.ts
@@ -72,6 +72,7 @@ function parseYamlFrontmatter(yamlContent: string): RuleFrontmatter {
 	const lines = yamlContent.replace(/\r\n/g, "\n").split("\n");
 	const frontmatter: RuleFrontmatter = {};
 	const globValues: string[] = [];
+	const seenGlobs = new Set<string>();
 	let lineIndex = 0;
 
 	while (lineIndex < lines.length) {
@@ -107,7 +108,10 @@ function parseYamlFrontmatter(yamlContent: string): RuleFrontmatter {
 		if (key === "globs" || key === "paths" || key === "applyTo") {
 			const parsed = parseGlobValue(rawValue, lines, lineIndex);
 			for (const glob of parsed.values) {
-				if (!globValues.includes(glob)) globValues.push(glob);
+				if (!seenGlobs.has(glob)) {
+					seenGlobs.add(glob);
+					globValues.push(glob);
+				}
 			}
 			lineIndex += parsed.consumed;
 			continue;

--- a/packages/omo-codex/plugin/components/rules/test/parser.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/parser.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRule } from "../src/rules/parser.js";
+
+describe("parseRule", () => {
+	it("#given duplicate glob aliases #when parsing frontmatter #then first-seen order is preserved", () => {
+		// given
+		const content = [
+			"---",
+			'globs: ["src/**/*.ts", "test/**/*.ts", "src/**/*.ts"]',
+			"paths:",
+			"  - test/**/*.ts",
+			"  - packages/**/*.ts",
+			"applyTo: packages/**/*.ts, docs/**/*.md, src/**/*.ts",
+			"---",
+			"",
+			"Prefer strict TypeScript.",
+		].join("\n");
+
+		// when
+		const parsed = parseRule(content);
+
+		// then
+		expect(parsed.frontmatter.globs).toEqual(["src/**/*.ts", "test/**/*.ts", "packages/**/*.ts", "docs/**/*.md"]);
+	});
+});


### PR DESCRIPTION
## Summary
Replace the rules frontmatter parser's duplicate glob membership check with an insertion-ordered `Set`, avoiding repeated linear `includes()` scans while preserving emitted glob order.

## Changes
- Add a parser characterization test for duplicate `globs` / `paths` / `applyTo` aliases.
- Preserve first-seen glob ordering while using a `Set` for dedupe membership.

## Testing
- `npm test -- test/parser.test.ts` ✅
- `npm run typecheck` ✅
- `npx biome check src/rules/parser.ts test/parser.test.ts` ✅
- `npm run build && npm test` ✅
- Manual QA: built `dist/cli.js hook post-tool-use` against a temporary `.omo/rules` fixture with duplicate glob aliases ✅
- `npm run check` ⚠️ blocked by pre-existing Biome formatting issue in `src/rules/constants.ts`
- `bun run test:codex` ⚠️ blocked by `packages/lsp-tools-mcp` missing `package-lock.json` while the script runs `npm ci`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the rules frontmatter parser by deduping glob patterns with an insertion-ordered `Set`, eliminating repeated array `includes()` scans. Preserves first-seen order and dedupes across `globs`, `paths`, and `applyTo`; adds a test to lock in this behavior.

<sup>Written for commit a78da12189dad388ef690dfed0b16f04039b2b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

