### PR TITLE
test(omo-codex): consolidate Python migration coverage

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/codex-hook.test.ts
@@ -31,6 +31,28 @@ describe("codex ultrawork hook", () => {
 		expect(parsed.hookSpecificOutput.additionalContext).toMatch(/First user-visible line this turn MUST be exactly:/);
 	});
 
+	it("#given Windows cwd #when hook sees ultrawork prompt #then emits directive as Codex hook JSON", () => {
+		// given
+		const payload = {
+			cwd: "C:\\Users\\codex\\project",
+			hook_event_name: "UserPromptSubmit",
+			model: "gpt-5.5",
+			permission_mode: "default",
+			prompt: "please ulw this change",
+			session_id: "s",
+			transcript_path: null,
+			turn_id: "t",
+		};
+
+		// when
+		const output = runUserPromptSubmitHook(payload);
+		const parsed = parseHookOutput(output);
+
+		// then
+		expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+		expect(parsed.hookSpecificOutput.additionalContext).toMatch(/^<ultrawork-mode>/);
+	});
+
 	it("#given transcript already contains ultrawork directive #when hook sees ultrawork prompt #then it does not repeat directive", () => {
 		// given
 		const payload = {

--- a/packages/omo-codex/src/python-migration-cross-platform.test.ts
+++ b/packages/omo-codex/src/python-migration-cross-platform.test.ts
@@ -2,44 +2,21 @@ import { describe, expect, it } from "bun:test"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
-import { runUserPromptSubmitHook } from "../plugin/components/ultrawork/src/codex-hook"
-
 const repoRoot = join(import.meta.dir, "..", "..", "..")
 
 describe("omo-codex Python migration cross-platform behavior", () => {
-  it("handles empty inventory, malformed input, and Windows paths without Python", () => {
+  it("keeps aggregate hook commands Node-based and platform-neutral", () => {
     // given
     const aggregateHooks = readJson(join(repoRoot, "packages/omo-codex/plugin/hooks/hooks.json"))
-    const componentHooks = readJson(join(repoRoot, "packages/omo-codex/plugin/components/ultrawork/hooks/hooks.json"))
-    const hookCommands = collectHookCommands([aggregateHooks, componentHooks])
 
     // when
-    const outputs = [
-      runUserPromptSubmitHook(undefined),
-      runUserPromptSubmitHook({ hook_event_name: "UserPromptSubmit", prompt: "" }),
-      runUserPromptSubmitHook({ hook_event_name: "UserPromptSubmit", prompt: "refactor ulw_helper.ts" }),
-      runUserPromptSubmitHook({
-        cwd: "C:\\Users\\codex\\project",
-        hook_event_name: "UserPromptSubmit",
-        model: "gpt-5.5",
-        permission_mode: "default",
-        prompt: "please ulw this",
-        session_id: "s",
-        transcript_path: null,
-        turn_id: "t",
-      }),
-    ]
-    const ultraworkOutput = parseHookOutput(outputs[3])
+    const hookCommands = collectHookCommands([aggregateHooks])
 
     // then
     expect(hookCommands).not.toContainEqual(expect.stringMatching(/\bpython3?\b/i))
     expect(hookCommands).toContain('node "${PLUGIN_ROOT}/components/ultrawork/dist/cli.js" hook user-prompt-submit')
-    expect(hookCommands).toContain('node "${PLUGIN_ROOT}/dist/cli.js" hook user-prompt-submit')
-    expect(outputs[0]).toBe("")
-    expect(outputs[1]).toBe("")
-    expect(outputs[2]).toBe("")
-    expect(ultraworkOutput.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit")
-    expect(ultraworkOutput.hookSpecificOutput.additionalContext).toStartWith("<ultrawork-mode>")
+    expect(hookCommands.every((command) => command.startsWith("node "))).toBe(true)
+    expect(hookCommands.every((command) => !command.includes("\\"))).toBe(true)
   })
 })
 
@@ -61,27 +38,4 @@ function collectHookCommandsFromValue(value: unknown): readonly string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-interface UserPromptSubmitHookOutput {
-  readonly hookSpecificOutput: {
-    readonly hookEventName: "UserPromptSubmit"
-    readonly additionalContext: string
-  }
-}
-
-function parseHookOutput(output: string): UserPromptSubmitHookOutput {
-  const parsed: unknown = JSON.parse(output)
-  if (!isUserPromptSubmitHookOutput(parsed)) throw new TypeError("Expected UserPromptSubmit hook output")
-  return parsed
-}
-
-function isUserPromptSubmitHookOutput(value: unknown): value is UserPromptSubmitHookOutput {
-  if (!isRecord(value)) return false
-  const hookSpecificOutput = value["hookSpecificOutput"]
-  return (
-    isRecord(hookSpecificOutput) &&
-    hookSpecificOutput["hookEventName"] === "UserPromptSubmit" &&
-    typeof hookSpecificOutput["additionalContext"] === "string"
-  )
 }

--- a/packages/omo-codex/src/python-migration-regression.test.ts
+++ b/packages/omo-codex/src/python-migration-regression.test.ts
@@ -3,30 +3,26 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
 const repoRoot = join(import.meta.dir, "..", "..", "..")
-const ultraworkRoot = join(repoRoot, "packages/omo-codex/plugin/components/ultrawork")
+const aggregatePluginRoot = join(repoRoot, "packages/omo-codex/plugin")
 
 describe("omo-codex Python migration regression", () => {
-  it("keeps package scripts and plugin packaging Python-free", () => {
+  it("keeps aggregate plugin packaging Python-free", () => {
     // given
-    const componentPackage = readJson(join(ultraworkRoot, "package.json"))
-    const aggregateHooks = readFileSync(join(repoRoot, "packages/omo-codex/plugin/hooks/hooks.json"), "utf8")
-    const componentHooks = readFileSync(join(ultraworkRoot, "hooks/hooks.json"), "utf8")
-    const aggregateTest = readFileSync(join(repoRoot, "packages/omo-codex/plugin/test/aggregate.test.mjs"), "utf8")
+    const aggregatePackage = readJson(join(aggregatePluginRoot, "package.json"))
+    const aggregateHooks = readFileSync(join(aggregatePluginRoot, "hooks/hooks.json"), "utf8")
+    const aggregateTest = readFileSync(join(aggregatePluginRoot, "test/aggregate.test.mjs"), "utf8")
 
     // when
-    const packagedFiles = isRecord(componentPackage) && Array.isArray(componentPackage["files"])
-      ? componentPackage["files"]
+    const scripts = isRecord(aggregatePackage) && isRecord(aggregatePackage["scripts"]) ? aggregatePackage["scripts"] : {}
+    const workspaces = isRecord(aggregatePackage) && Array.isArray(aggregatePackage["workspaces"])
+      ? aggregatePackage["workspaces"]
       : []
-    const scripts = isRecord(componentPackage) && isRecord(componentPackage["scripts"]) ? componentPackage["scripts"] : {}
-    const bin = isRecord(componentPackage) && isRecord(componentPackage["bin"]) ? componentPackage["bin"] : {}
 
     // then
-    expect(scripts["build"]).toBe("tsc -p tsconfig.build.json")
-    expect(scripts["test"]).toBe("vitest --run")
-    expect(bin["omo-ultrawork"]).toBe("./dist/cli.js")
-    expect(packagedFiles).toContain("dist")
-    expect(packagedFiles).not.toContain("hooks/ultrawork-detector.py")
-    expect(`${aggregateHooks}\n${componentHooks}\n${aggregateTest}`).not.toMatch(/\bpython3?\b|ultrawork-detector\.py/)
+    expect(scripts["build"]).toContain("node scripts/build-components.mjs")
+    expect(scripts["test"]).toBe("node --test test/*.test.mjs")
+    expect(workspaces).toContain("components/ultrawork")
+    expect(`${aggregateHooks}\n${aggregateTest}`).not.toMatch(/\bpython3?\b|ultrawork-detector\.py/)
   })
 })
 

--- a/packages/omo-codex/src/python-migration-regression.test.ts
+++ b/packages/omo-codex/src/python-migration-regression.test.ts
@@ -8,6 +8,7 @@ const aggregatePluginRoot = join(repoRoot, "packages/omo-codex/plugin")
 describe("omo-codex Python migration regression", () => {
   it("keeps aggregate plugin packaging Python-free", () => {
     // given
+    const aggregatePackageText = readFileSync(join(aggregatePluginRoot, "package.json"), "utf8")
     const aggregatePackage = readJson(join(aggregatePluginRoot, "package.json"))
     const aggregateHooks = readFileSync(join(aggregatePluginRoot, "hooks/hooks.json"), "utf8")
     const aggregateTest = readFileSync(join(aggregatePluginRoot, "test/aggregate.test.mjs"), "utf8")
@@ -22,7 +23,7 @@ describe("omo-codex Python migration regression", () => {
     expect(scripts["build"]).toContain("node scripts/build-components.mjs")
     expect(scripts["test"]).toBe("node --test test/*.test.mjs")
     expect(workspaces).toContain("components/ultrawork")
-    expect(`${aggregateHooks}\n${aggregateTest}`).not.toMatch(/\bpython3?\b|ultrawork-detector\.py/)
+    expect(`${aggregatePackageText}\n${aggregateHooks}\n${aggregateTest}`).not.toMatch(/\bpython3?\b|ultrawork-detector\.py/)
   })
 })
 


### PR DESCRIPTION
## Summary
Consolidates overlapping Python migration tests so each ownership layer asserts its own contract without losing behavior.

## Assertion Map
Before:
- `python-migration-inventory.test.ts`: all Python files under `packages/omo-codex` are classified and match the retained allowlist.
- `python-migration-regression.test.ts`: ultrawork package scripts, bin, packaged files, component hook command, aggregate hook JSON, and aggregate test remain Python-free.
- `python-migration-cross-platform.test.ts`: aggregate and component hook commands are not Python, aggregate/component ultrawork commands exist, malformed/empty/identifier prompts are quiet, and Windows cwd emits `<ultrawork-mode>` JSON.
- `ultrawork/package-smoke.test.ts`: ultrawork package metadata, bin, files, shebang, and component hook command are Node-based and Python-free.
- `ultrawork/codex-hook.test.ts`: ultrawork hook behavior for prompt emission, malformed input, empty input, identifier boundaries, transcript dedupe, and context-pressure quiet paths.

After:
- Inventory test remains unchanged and still owns the no-unclassified-Python invariant.
- Migration regression now owns only aggregate plugin packaging: aggregate scripts, ultrawork workspace registration, aggregate hooks, and aggregate tests stay Python-free.
- Migration cross-platform now owns only aggregate hook commands: aggregate ultrawork command is Node dist CLI, all aggregate commands are Node-based, and commands avoid backslash paths.
- Ultrawork package-smoke remains the owner for component package metadata, bin, packaged files, shebang, and component hook command coverage.
- Ultrawork codex-hook now additionally owns the Windows cwd behavior, preserving the removed migration hook-behavior assertion in the component behavior suite.

## Testing
- `bun test packages/omo-codex/src/python-migration-*.test.ts` ✅
- `bun run --cwd packages/omo-codex test` ✅
- `npm --prefix packages/omo-codex/plugin run --workspace components/ultrawork test` ✅
- `npm --prefix packages/omo-codex/plugin test` ✅
- `npm --prefix packages/omo-codex/plugin run --workspace components/ultrawork build` ✅
- `bun run typecheck` ✅
- `bun run test:codex` ✅ after initializing `packages/lsp-tools-mcp` submodule

## Manual QA
- Built ultrawork hook CLI emitted `UserPromptSubmit`, `additionalContext.startsWith("<ultrawork-mode>") === true`, and printed `<ultrawork-mode>` as the JSON context prefix.
- Aggregate hook inspection found `node "${PLUGIN_ROOT}/components/ultrawork/dist/cli.js" hook user-prompt-submit` and `nodeBased=true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates Python migration tests in `packages/omo-codex` to remove overlap and give each suite a clear contract. Preserves behavior and adds checks that aggregate package scripts are Node-based and Python-free.

- Refactors
  - Regression now only checks aggregate plugin packaging: `package.json` scripts (build/test), workspaces, hooks, and tests are Node-based and contain no Python.
  - Cross-platform now only verifies aggregate hook commands are Node-based, use the dist CLI, and avoid backslash paths.
  - `components/ultrawork` codex-hook tests add the Windows cwd case emitting `<ultrawork-mode>` JSON for `UserPromptSubmit`.
  - Inventory test unchanged; ultrawork package-smoke keeps ownership of component package metadata and hook command coverage.

<sup>Written for commit cfc1e5c3345f432488b0bfc6bef6291fb2a09e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

