### PR TITLE
Fix background concurrency key normalization and launch raw limits

### DIFF
--- a/src/features/background-agent/concurrency-normalized-key.test.ts
+++ b/src/features/background-agent/concurrency-normalized-key.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import type { BackgroundTaskConfig } from "../../config/schema"
+import { ConcurrencyManager } from "./concurrency"
+
+describe("ConcurrencyManager normalized acquire/release keys", () => {
+  test("should release a raw model acquisition through the normalized provider key", async () => {
+    // given
+    const rawModel = "anthropic/claude-sonnet-4-6"
+    const config: BackgroundTaskConfig = {
+      providerConcurrency: { anthropic: 1 },
+    }
+    const manager = new ConcurrencyManager(config)
+    const normalizedKey = manager.getConcurrencyKey(rawModel)
+
+    // when
+    await manager.acquire(rawModel)
+    manager.release(normalizedKey)
+    const countAfterRelease = manager.getCount(normalizedKey)
+    const reacquire = manager.acquire(rawModel, "next-task").then(
+      () => "acquired",
+      () => "cancelled",
+    )
+    const countAfterReacquire = manager.getCount(normalizedKey)
+    const queueLengthAfterReacquire = manager.getQueueLength(normalizedKey)
+    if (queueLengthAfterReacquire > 0) {
+      manager.cancelWaiters(normalizedKey)
+      await reacquire
+    } else if (countAfterReacquire === 0) {
+      manager.cancelWaiters(rawModel)
+      await reacquire
+    }
+
+    // then
+    expect(normalizedKey).toBe("anthropic")
+    expect(countAfterRelease).toBe(0)
+    expect(countAfterReacquire).toBe(1)
+    expect(queueLengthAfterReacquire).toBe(0)
+
+    manager.release(normalizedKey)
+    await reacquire
+  })
+})

--- a/src/features/background-agent/concurrency-normalized-key.test.ts
+++ b/src/features/background-agent/concurrency-normalized-key.test.ts
@@ -39,4 +39,33 @@ describe("ConcurrencyManager normalized acquire/release keys", () => {
     manager.release(normalizedKey)
     await reacquire
   })
+
+  test("should resolve the limit from the raw model before storing by provider key", async () => {
+    // given
+    const rawModel = "anthropic/claude-sonnet-4-6"
+    const config: BackgroundTaskConfig = {
+      modelConcurrency: { anthropic: 99 },
+      providerConcurrency: { anthropic: 1 },
+    }
+    const manager = new ConcurrencyManager(config)
+    const normalizedKey = manager.getConcurrencyKey(rawModel)
+    await manager.acquire(rawModel)
+
+    // when
+    const secondAcquire = manager.acquire(rawModel, "second-task").then(
+      () => "acquired",
+      () => "cancelled",
+    )
+    const countAfterSecondAcquire = manager.getCount(normalizedKey)
+    const queueLengthAfterSecondAcquire = manager.getQueueLength(normalizedKey)
+
+    // then
+    expect(normalizedKey).toBe("anthropic")
+    expect(countAfterSecondAcquire).toBe(1)
+    expect(queueLengthAfterSecondAcquire).toBe(1)
+
+    manager.cancelWaiters(normalizedKey)
+    await secondAcquire
+    manager.release(normalizedKey)
+  })
 })

--- a/src/features/background-agent/concurrency.ts
+++ b/src/features/background-agent/concurrency.ts
@@ -53,19 +53,20 @@ export class ConcurrencyManager {
   }
 
   async acquire(model: string, taskId?: string): Promise<void> {
-    const limit = this.getConcurrencyLimit(model)
+    const key = this.getConcurrencyKey(model)
+    const limit = this.getConcurrencyLimit(key)
     if (limit === Infinity) {
       return
     }
 
-    const current = this.counts.get(model) ?? 0
+    const current = this.counts.get(key) ?? 0
     if (current < limit) {
-      this.counts.set(model, current + 1)
+      this.counts.set(key, current + 1)
       return
     }
 
     return new Promise<void>((resolve, reject) => {
-      const queue = this.queues.get(model) ?? []
+      const queue = this.queues.get(key) ?? []
 
       const entry: QueueEntry = {
         taskId,
@@ -79,17 +80,18 @@ export class ConcurrencyManager {
       }
 
       queue.push(entry)
-      this.queues.set(model, queue)
+      this.queues.set(key, queue)
     })
   }
 
   release(model: string): void {
-    const limit = this.getConcurrencyLimit(model)
+    const key = this.getConcurrencyKey(model)
+    const limit = this.getConcurrencyLimit(key)
     if (limit === Infinity) {
       return
     }
 
-    const queue = this.queues.get(model)
+    const queue = this.queues.get(key)
 
     // Try to hand off to a waiting entry (skip any settled entries from cancelWaiters)
     while (queue && queue.length > 0) {
@@ -105,9 +107,9 @@ export class ConcurrencyManager {
     }
 
     // No handoff occurred - decrement the count to free the slot
-    const current = this.counts.get(model) ?? 0
+    const current = this.counts.get(key) ?? 0
     if (current > 0) {
-      this.counts.set(model, current - 1)
+      this.counts.set(key, current - 1)
     }
   }
 

--- a/src/features/background-agent/concurrency.ts
+++ b/src/features/background-agent/concurrency.ts
@@ -54,7 +54,7 @@ export class ConcurrencyManager {
 
   async acquire(model: string, taskId?: string): Promise<void> {
     const key = this.getConcurrencyKey(model)
-    const limit = this.getConcurrencyLimit(key)
+    const limit = this.getConcurrencyLimit(model)
     if (limit === Infinity) {
       return
     }
@@ -86,11 +86,6 @@ export class ConcurrencyManager {
 
   release(model: string): void {
     const key = this.getConcurrencyKey(model)
-    const limit = this.getConcurrencyLimit(key)
-    if (limit === Infinity) {
-      return
-    }
-
     const queue = this.queues.get(key)
 
     // Try to hand off to a waiting entry (skip any settled entries from cancelWaiters)

--- a/src/features/background-agent/constants.ts
+++ b/src/features/background-agent/constants.ts
@@ -46,6 +46,7 @@ export interface Todo {
 
 export interface QueueItem {
   attemptID: string
+  rawConcurrencyKey?: string
   task: BackgroundTask
   input: LaunchInput
 }

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -227,7 +227,7 @@ export async function tryFallbackRetry(args: {
     await abortWithTimeout(client, previousSessionID).catch(() => {})
   }
 
-  queue.push({ task, input: retryInput, attemptID: nextAttempt.attemptId })
+  queue.push({ task, input: retryInput, attemptID: nextAttempt.attemptId, rawConcurrencyKey: rawKey })
   queuesByKey.set(key, queue)
   processKey(key)
   return true

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -4470,6 +4470,51 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       expect(updatedTask1?.concurrencyKey).toBe("anthropic")
       expect(updatedTask2?.concurrencyKey).toBeUndefined()
     })
+
+    test("should resolve limits from raw model keys while queueing by provider key", async () => {
+      // given
+      const config = {
+        modelConcurrency: { anthropic: 99 },
+        providerConcurrency: { anthropic: 1 },
+      }
+      manager.shutdown()
+      manager = new BackgroundManager({ pluginContext: createPluginInput(mockClient), config })
+
+      const input1 = {
+        description: "Task 1",
+        prompt: "Do something",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-opus-4.7" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      const input2 = {
+        description: "Task 2",
+        prompt: "Do something else",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4.6" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      // when
+      const task1 = await manager.launch(input1)
+      const task2 = await manager.launch(input2)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // then
+      const updatedTask1 = manager.getTask(task1.id)
+      const updatedTask2 = manager.getTask(task2.id)
+      const concurrencyManager = getConcurrencyManager(manager)
+
+      expect(updatedTask1?.status).toBe("running")
+      expect(updatedTask2?.status).toBe("pending")
+      expect(updatedTask1?.concurrencyKey).toBe("anthropic")
+      expect(updatedTask2?.concurrencyKey).toBeUndefined()
+      expect(concurrencyManager.getCount("anthropic")).toBe(1)
+      expect(concurrencyManager.getQueueLength("anthropic")).toBe(1)
+    })
   })
 
   describe("TTL uses queuedAt for pending, startedAt for running", () => {

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -4515,6 +4515,56 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       expect(concurrencyManager.getCount("anthropic")).toBe(1)
       expect(concurrencyManager.getQueueLength("anthropic")).toBe(1)
     })
+
+    test("should remove cancelled pending model task from provider queue", async () => {
+      // given
+      const config = { providerConcurrency: { anthropic: 1 } }
+      manager.shutdown()
+      manager = new BackgroundManager({ pluginContext: createPluginInput(mockClient), config })
+
+      const input1 = {
+        description: "Task 1",
+        prompt: "Do something",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-opus-4.7" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      const input2 = {
+        description: "Task 2",
+        prompt: "Do something else",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4.6" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      const input3 = {
+        description: "Task 3",
+        prompt: "Do a third thing",
+        agent: "test-agent",
+        model: { providerID: "anthropic", modelID: "claude-haiku-4.5" },
+        parentSessionId: "parent-session",
+        parentMessageId: "parent-message",
+      }
+
+      await manager.launch(input1)
+      await manager.launch(input2)
+      const task3 = await manager.launch(input3)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // when
+      const cancelled = await manager.cancelTask(task3.id, { abortSession: false, skipNotification: true })
+
+      // then
+      const providerQueue = getQueuesByKey(manager).get("anthropic")
+      const providerQueuedTaskIds = providerQueue?.map(item => item.task.id) ?? []
+      expect(cancelled).toBe(true)
+      expect(providerQueuedTaskIds).not.toContain(task3.id)
+      expect(getQueuesByKey(manager).get("anthropic/claude-haiku-4.5")).toBeUndefined()
+      expect(manager.getTask(task3.id)?.status).toBe("cancelled")
+    })
   })
 
   describe("TTL uses queuedAt for pending, startedAt for running", () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1135,6 +1135,12 @@ The fallback retry session is now created and can be inspected directly.
     return modelKey
   }
 
+  private getRawConcurrencyKeyFromTask(task: Pick<BackgroundTask, "model" | "agent">): string {
+    return task.model
+      ? `${task.model.providerID}/${task.model.modelID}`
+      : task.agent
+  }
+
   /**
    * Track a task created elsewhere (e.g., from task) for notification tracking.
    * This allows tasks created by other tools to receive the same toast/prompt notifications.
@@ -2296,9 +2302,8 @@ The task was re-queued on a fallback model after a retryable failure.
     const reason = options?.reason
 
     if (task.status === "pending") {
-      const key = task.model
-        ? `${task.model.providerID}/${task.model.modelID}`
-        : task.agent
+      const rawKey = this.getRawConcurrencyKeyFromTask(task)
+      const key = this.concurrencyManager.getConcurrencyKey(rawKey)
       const queue = this.queuesByKey.get(key)
       if (queue) {
         const index = queue.findIndex(item => item.task.id === taskId)
@@ -2310,7 +2315,7 @@ The task was re-queued on a fallback model after a retryable failure.
         }
       }
       this.rollbackPreStartDescendantReservation(task)
-      this.concurrencyManager.cancelWaiter(key, taskId)
+      this.concurrencyManager.cancelWaiter(rawKey, taskId)
       log("[background-agent] Cancelled pending task:", { taskId, key })
     }
 
@@ -2738,9 +2743,7 @@ The task was re-queued on a fallback model after a retryable failure.
           this.idleDeferralTimers.delete(taskId)
         }
         if (wasPending) {
-          const key = task.model
-            ? `${task.model.providerID}/${task.model.modelID}`
-            : task.agent
+          const key = this.concurrencyManager.getConcurrencyKey(this.getRawConcurrencyKeyFromTask(task))
           const queue = this.queuesByKey.get(key)
           if (queue) {
             const index = queue.findIndex((item) => item.task.id === taskId)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -606,9 +606,10 @@ export class BackgroundManager {
       }
 
       // Add to queue
-      const key = this.getConcurrencyKeyFromInput(input)
+      const rawConcurrencyKey = this.getRawConcurrencyKeyFromInput(input)
+      const key = this.concurrencyManager.getConcurrencyKey(rawConcurrencyKey)
       const queue = this.queuesByKey.get(key) ?? []
-      queue.push({ task, input, attemptID: firstAttempt.attemptId })
+      queue.push({ task, input, attemptID: firstAttempt.attemptId, rawConcurrencyKey })
       this.queuesByKey.set(key, queue)
 
       log("[background-agent] Task queued:", { taskId: task.id, key, queueLength: queue.length })
@@ -657,7 +658,7 @@ export class BackgroundManager {
         }
 
         try {
-          await this.concurrencyManager.acquire(key, item.task.id)
+          await this.concurrencyManager.acquire(item.rawConcurrencyKey ?? key, item.task.id)
         } catch (error) {
           if (item.task.status === "cancelled" || item.task.status === "error" || item.task.status === "interrupt") {
             this.rollbackPreStartDescendantReservation(item.task)
@@ -1123,11 +1124,15 @@ The fallback retry session is now created and can be inspected directly.
   }
 
   private getConcurrencyKeyFromInput(input: LaunchInput): string {
+    return this.concurrencyManager.getConcurrencyKey(this.getRawConcurrencyKeyFromInput(input))
+  }
+
+  private getRawConcurrencyKeyFromInput(input: LaunchInput): string {
     const modelKey = input.model
       ? `${input.model.providerID}/${input.model.modelID}`
       : input.agent
 
-    return this.concurrencyManager.getConcurrencyKey(modelKey)
+    return modelKey
   }
 
   /**


### PR DESCRIPTION
## Summary
Follow-up to #3968. `ConcurrencyManager.acquire()` and `release()` now canonicalize raw provider/model inputs through `getConcurrencyKey()` once at the boundary, so provider-level concurrency uses the same counts and queue bucket on acquire and release.

## Changes
- Key `acquire()` counts and queues by the normalized concurrency key.
- Key `release()` handoff and decrement logic by the same normalized concurrency key.
- Add a focused regression test for raw model acquire plus normalized provider release.

## Testing
- RED: `bun test src/features/background-agent/concurrency-normalized-key.test.ts` failed on current `dev` with `Expected: 0, Received: 1` for the raw model count after normalized release.
- GREEN: `bun test src/features/background-agent/concurrency-normalized-key.test.ts src/features/background-agent/concurrency.test.ts src/features/background-agent/concurrency-cancel-waiter.test.ts` passed: 29 tests, 50 expects.
- Manual QA: Bun driver acquired `anthropic/claude-sonnet-4-6`, released `anthropic`, reacquired raw model, then released to final provider count 0.
- `bun run typecheck` passed.
- `bun test` passed.
- `bun run build` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider-level concurrency by normalizing slot keys while preserving raw-model limit resolution, and ensure pending queues are cleaned under the normalized provider key. `acquire()` resolves limits from the raw model; counts, queues, handoffs, and `release()` use the provider key to keep state in sync.

- **Bug Fixes**
  - Normalize keys via `getConcurrencyKey()` at `acquire()`/`release()` boundaries; store counts/queues under the provider key while resolving limits from the raw key.
  - Preserve raw launch/retry limits: store `rawConcurrencyKey` on background/fallback queue items and pass it to `acquire()`.
  - Clean pending queues: cancelling a pending model task removes it from the normalized provider queue and cancels the waiter via the raw key to avoid stale entries.

<sup>Written for commit bfecef1ea24dd548e620f271128666a9c709e698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

