### PR TITLE
Fix normalized background queue cancellation

### DIFF
--- a/src/features/background-agent/concurrency.test.ts
+++ b/src/features/background-agent/concurrency.test.ts
@@ -393,9 +393,68 @@ describe("ConcurrencyManager.acquire/release", () => {
     manager.release("anthropic/claude-sonnet-4-6")
     await waitPromise
   })
+
 })
 
 describe("ConcurrencyManager.cleanup", () => {
+  test("cancelWaiter should cancel a raw model waiter stored under a normalized provider key", async () => {
+    // given
+    const rawKey = "anthropic/claude-sonnet-4-6"
+    const config: BackgroundTaskConfig = {
+      providerConcurrency: { anthropic: 1 },
+    }
+    const manager = new ConcurrencyManager(config)
+    await manager.acquire(rawKey, "running-task")
+
+    const errors: Error[] = []
+    const waiter = manager.acquire(rawKey, "queued-task").catch((error: Error) => {
+      errors.push(error)
+    })
+    await Promise.resolve()
+
+    // when
+    const cancelled = manager.cancelWaiter(rawKey, "queued-task")
+    await waiter
+
+    // then
+    expect(cancelled).toBe(true)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("queued-task")
+    expect(manager.getQueueLength(rawKey)).toBe(0)
+
+    manager.release(rawKey)
+  })
+
+  test("cancelWaiters should cancel all raw model waiters stored under a normalized provider key", async () => {
+    // given
+    const rawKey = "anthropic/claude-sonnet-4-6"
+    const config: BackgroundTaskConfig = {
+      providerConcurrency: { anthropic: 1 },
+    }
+    const manager = new ConcurrencyManager(config)
+    await manager.acquire(rawKey, "running-task")
+
+    const errors: Error[] = []
+    const firstWaiter = manager.acquire(rawKey, "queued-task-1").catch((error: Error) => {
+      errors.push(error)
+    })
+    const secondWaiter = manager.acquire(rawKey, "queued-task-2").catch((error: Error) => {
+      errors.push(error)
+    })
+    await Promise.resolve()
+
+    // when
+    manager.cancelWaiters(rawKey)
+    await Promise.all([firstWaiter, secondWaiter])
+
+    // then
+    expect(errors).toHaveLength(2)
+    expect(errors.every((error) => error.message.includes(rawKey))).toBe(true)
+    expect(manager.getQueueLength(rawKey)).toBe(0)
+
+    manager.release(rawKey)
+  })
+
   test("cancelWaiters should reject all pending acquires", async () => {
     // given
     const config: BackgroundTaskConfig = { defaultConcurrency: 1 }

--- a/src/features/background-agent/concurrency.ts
+++ b/src/features/background-agent/concurrency.ts
@@ -113,7 +113,8 @@ export class ConcurrencyManager {
    * Returns true if a matching waiter was found and cancelled.
    */
   cancelWaiter(model: string, taskId: string): boolean {
-    const queue = this.queues.get(model)
+    const key = this.getConcurrencyKey(model)
+    const queue = this.queues.get(key)
     if (!queue) return false
 
     const index = queue.findIndex(entry => entry.taskId === taskId && !entry.settled)
@@ -124,7 +125,7 @@ export class ConcurrencyManager {
     entry.rawReject(new Error(`Concurrency queue cancelled for task: ${taskId}`))
     queue.splice(index, 1)
     if (queue.length === 0) {
-      this.queues.delete(model)
+      this.queues.delete(key)
     }
     return true
   }
@@ -133,7 +134,8 @@ export class ConcurrencyManager {
    * Cancel all waiting acquires for a model. Used during cleanup.
    */
   cancelWaiters(model: string): void {
-    const queue = this.queues.get(model)
+    const key = this.getConcurrencyKey(model)
+    const queue = this.queues.get(key)
     if (queue) {
       for (const entry of queue) {
         if (!entry.settled) {
@@ -141,7 +143,7 @@ export class ConcurrencyManager {
           entry.rawReject(new Error(`Concurrency queue cancelled for model: ${model}`))
         }
       }
-      this.queues.delete(model)
+      this.queues.delete(key)
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize `cancelWaiter()` / `cancelWaiters()` through `getConcurrencyKey()` so provider-level queues can be cancelled with raw model IDs
- keep `acquire()` / `release()` ownership in #4755 (`fix/concurrency-manager-normalized-key`)
- add regression coverage for raw model waiters stored under normalized provider keys

## Stack / merge order
This PR is intentionally stacked on top of #4755 and targets `fix/concurrency-manager-normalized-key`, not `dev`. Do not merge it independently before #4755; #4755 owns the root `acquire()` / `release()` normalization follow-up to #3968.

## Verification
- `bun test src/features/background-agent/concurrency.test.ts src/features/background-agent/concurrency-normalized-key.test.ts`
- `git diff fix/concurrency-manager-normalized-key..fix/background-agent-normalized-queue-cancel -- src/features/background-agent/concurrency.ts | git apply --check`
- temporary clean worktree at `fix/concurrency-manager-normalized-key` + `git merge --no-ff --no-commit fix/background-agent-normalized-queue-cancel` exited 0 with no conflicts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix background concurrency queue cancellation when cancelling by raw model ID. `cancelWaiter` and `cancelWaiters` now normalize keys via `getConcurrencyKey`, reliably cancel provider-level queues, clean up empty queues, and include tests for single and bulk cancellation of raw model waiters.

<sup>Written for commit ad9a102820bf5fe4a68ec79d1bbe238f37081fb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

