### PR TITLE
refactor(codex-comment-checker): split apply patch extraction

### DIFF
--- a/packages/omo-codex/plugin/components/comment-checker/src/apply-patch.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/apply-patch.ts
@@ -1,0 +1,188 @@
+import type { CommentCheckRequest } from "./core.js";
+import { getString, isRecord } from "./core-values.js";
+
+type ApplyPatchAccumulator = {
+	operation: "add" | "delete" | "update";
+	filePath: string;
+	movePath?: string;
+	oldLines: string[];
+	newLines: string[];
+};
+
+type ApplyPatchFileMetadata = {
+	filePath: string;
+	movePath?: string;
+	before: string;
+	after: string;
+	type?: string;
+};
+
+export function extractApplyPatchRequests(event: {
+	details?: unknown;
+	input: Record<string, unknown>;
+	toolName: string;
+}): CommentCheckRequest[] {
+	const metadataRequests = extractApplyPatchMetadataRequests(event.details, event.toolName);
+	if (metadataRequests.length > 0) return metadataRequests;
+
+	const patch = getString(event.input, ["input", "patch", "command"]);
+	if (!patch) return [];
+	return parseApplyPatchRequests(patch, event.toolName);
+}
+
+export function parseApplyPatchRequests(patch: string, sourceToolName = "apply_patch"): CommentCheckRequest[] {
+	const requests: CommentCheckRequest[] = [];
+	let current: ApplyPatchAccumulator | undefined;
+
+	const flush = (): void => {
+		if (!current) return;
+		if (current.operation === "add") {
+			const content = joinPatchLines(current.newLines);
+			if (content.length > 0) {
+				requests.push({
+					sourceToolName,
+					toolName: "Write",
+					filePath: current.filePath,
+					toolInput: {
+						file_path: current.filePath,
+						content,
+					},
+				});
+			}
+		}
+		if (current.operation === "update") {
+			const newString = joinPatchLines(current.newLines);
+			if (newString.length > 0) {
+				const filePath = current.movePath ?? current.filePath;
+				requests.push({
+					sourceToolName,
+					toolName: "Edit",
+					filePath,
+					toolInput: {
+						file_path: filePath,
+						old_string: joinPatchLines(current.oldLines),
+						new_string: newString,
+					},
+				});
+			}
+		}
+		current = undefined;
+	};
+
+	for (const line of patch.split(/\r?\n/)) {
+		if (line === "*** Begin Patch" || line === "*** End Patch") continue;
+		if (line.startsWith("*** Add File: ")) {
+			flush();
+			current = makeAccumulator("add", line.slice("*** Add File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Update File: ")) {
+			flush();
+			current = makeAccumulator("update", line.slice("*** Update File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Delete File: ")) {
+			flush();
+			current = makeAccumulator("delete", line.slice("*** Delete File: ".length).trim());
+			continue;
+		}
+		if (line.startsWith("*** Move to: ")) {
+			if (current?.operation === "update") current.movePath = line.slice("*** Move to: ".length).trim();
+			continue;
+		}
+		if (!current) continue;
+		if (line.startsWith("@@")) continue;
+		if (current.operation === "add") {
+			if (line.startsWith("+")) current.newLines.push(line.slice(1));
+			continue;
+		}
+		if (current.operation === "update") {
+			if (line.startsWith("+")) current.newLines.push(line.slice(1));
+			if (line.startsWith("-")) current.oldLines.push(line.slice(1));
+		}
+	}
+
+	flush();
+	return requests;
+}
+
+function extractApplyPatchMetadataRequests(details: unknown, sourceToolName: string): CommentCheckRequest[] {
+	const metadataFiles = getApplyPatchMetadataFiles(details);
+	if (metadataFiles.length === 0) return [];
+
+	const requests: CommentCheckRequest[] = [];
+	for (const file of metadataFiles) {
+		if (file.type === "delete") continue;
+		const filePath = file.movePath ?? file.filePath;
+		if (file.before.length === 0) {
+			requests.push({
+				sourceToolName,
+				toolName: "Write",
+				filePath,
+				toolInput: {
+					file_path: filePath,
+					content: file.after,
+				},
+			});
+			continue;
+		}
+		requests.push({
+			sourceToolName,
+			toolName: "Edit",
+			filePath,
+			toolInput: {
+				file_path: filePath,
+				old_string: file.before,
+				new_string: file.after,
+			},
+		});
+	}
+	return requests;
+}
+
+function getApplyPatchMetadataFiles(details: unknown): ApplyPatchFileMetadata[] {
+	if (!isRecord(details)) return [];
+	const direct = readApplyPatchMetadataFiles(details["files"]);
+	if (direct.length > 0) return direct;
+	const resultDetails = details["result"];
+	const result = isRecord(resultDetails) ? readApplyPatchMetadataFiles(resultDetails["files"]) : [];
+	if (result.length > 0) return result;
+	const metadataDetails = details["metadata"];
+	const metadata = isRecord(metadataDetails) ? readApplyPatchMetadataFiles(metadataDetails["files"]) : [];
+	return metadata;
+}
+
+function readApplyPatchMetadataFiles(value: unknown): ApplyPatchFileMetadata[] {
+	if (!Array.isArray(value)) return [];
+	const files: ApplyPatchFileMetadata[] = [];
+	for (const item of value) {
+		if (!isRecord(item)) continue;
+		const filePath = getString(item, ["filePath", "file_path", "path"]);
+		const movePath = getString(item, ["movePath", "move_path"]);
+		const before = getString(item, ["before", "old", "oldString", "old_string"]);
+		const after = getString(item, ["after", "new", "newString", "new_string"]);
+		const type = getString(item, ["type", "operation"]);
+		if (!filePath || before === undefined || after === undefined) continue;
+		files.push({
+			filePath,
+			before,
+			after,
+			...(movePath === undefined ? {} : { movePath }),
+			...(type === undefined ? {} : { type }),
+		});
+	}
+	return files;
+}
+
+function makeAccumulator(operation: ApplyPatchAccumulator["operation"], filePath: string): ApplyPatchAccumulator {
+	return {
+		operation,
+		filePath,
+		oldLines: [],
+		newLines: [],
+	};
+}
+
+function joinPatchLines(lines: string[]): string {
+	return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}

--- a/packages/omo-codex/plugin/components/comment-checker/src/core-values.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/core-values.ts
@@ -1,0 +1,11 @@
+export function getString(input: Record<string, unknown>, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = input[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/omo-codex/plugin/components/comment-checker/src/core.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/core.ts
@@ -1,3 +1,9 @@
+import { extractApplyPatchRequests as extractApplyPatchRequestsFromPatch } from "./apply-patch.js";
+import { getString, isRecord } from "./core-values.js";
+
+export { parseApplyPatchRequests } from "./apply-patch.js";
+export { isRecord } from "./core-values.js";
+
 export type TextContent = {
 	type: "text";
 	text: string;
@@ -48,22 +54,6 @@ export type ToolResultLike = {
 	content?: ToolResultContent[];
 	isError?: boolean;
 	details?: unknown;
-};
-
-type ApplyPatchAccumulator = {
-	operation: "add" | "delete" | "update";
-	filePath: string;
-	movePath?: string;
-	oldLines: string[];
-	newLines: string[];
-};
-
-type ApplyPatchFileMetadata = {
-	filePath: string;
-	movePath?: string;
-	before: string;
-	after: string;
-	type?: string;
 };
 
 export function extractCommentCheckRequests(event: ToolResultLike): CommentCheckRequest[] {
@@ -159,165 +149,7 @@ function extractMultiEditRequest(event: ToolResultLike): CommentCheckRequest[] {
 }
 
 function extractApplyPatchRequests(event: ToolResultLike): CommentCheckRequest[] {
-	const metadataRequests = extractApplyPatchMetadataRequests(event.details, event.toolName);
-	if (metadataRequests.length > 0) return metadataRequests;
-
-	const patch = getString(event.input, ["input", "patch", "command"]);
-	if (!patch) return [];
-	return parseApplyPatchRequests(patch, event.toolName);
-}
-
-function extractApplyPatchMetadataRequests(details: unknown, sourceToolName: string): CommentCheckRequest[] {
-	const metadataFiles = getApplyPatchMetadataFiles(details);
-	if (metadataFiles.length === 0) return [];
-
-	const requests: CommentCheckRequest[] = [];
-	for (const file of metadataFiles) {
-		if (file.type === "delete") continue;
-		const filePath = file.movePath ?? file.filePath;
-		if (file.before.length === 0) {
-			requests.push({
-				sourceToolName,
-				toolName: "Write",
-				filePath,
-				toolInput: {
-					file_path: filePath,
-					content: file.after,
-				},
-			});
-			continue;
-		}
-		requests.push({
-			sourceToolName,
-			toolName: "Edit",
-			filePath,
-			toolInput: {
-				file_path: filePath,
-				old_string: file.before,
-				new_string: file.after,
-			},
-		});
-	}
-	return requests;
-}
-
-function getApplyPatchMetadataFiles(details: unknown): ApplyPatchFileMetadata[] {
-	if (!isRecord(details)) return [];
-	const direct = readApplyPatchMetadataFiles(details["files"]);
-	if (direct.length > 0) return direct;
-	const resultDetails = details["result"];
-	const result = isRecord(resultDetails) ? readApplyPatchMetadataFiles(resultDetails["files"]) : [];
-	if (result.length > 0) return result;
-	const metadataDetails = details["metadata"];
-	const metadata = isRecord(metadataDetails) ? readApplyPatchMetadataFiles(metadataDetails["files"]) : [];
-	return metadata;
-}
-
-function readApplyPatchMetadataFiles(value: unknown): ApplyPatchFileMetadata[] {
-	if (!Array.isArray(value)) return [];
-	const files: ApplyPatchFileMetadata[] = [];
-	for (const item of value) {
-		if (!isRecord(item)) continue;
-		const filePath = getString(item, ["filePath", "file_path", "path"]);
-		const movePath = getString(item, ["movePath", "move_path"]);
-		const before = getString(item, ["before", "old", "oldString", "old_string"]);
-		const after = getString(item, ["after", "new", "newString", "new_string"]);
-		const type = getString(item, ["type", "operation"]);
-		if (!filePath || before === undefined || after === undefined) continue;
-		files.push({
-			filePath,
-			before,
-			after,
-			...(movePath === undefined ? {} : { movePath }),
-			...(type === undefined ? {} : { type }),
-		});
-	}
-	return files;
-}
-
-export function parseApplyPatchRequests(patch: string, sourceToolName = "apply_patch"): CommentCheckRequest[] {
-	const requests: CommentCheckRequest[] = [];
-	let current: ApplyPatchAccumulator | undefined;
-
-	const flush = (): void => {
-		if (!current) return;
-		if (current.operation === "add") {
-			const content = joinPatchLines(current.newLines);
-			if (content.length > 0) {
-				requests.push({
-					sourceToolName,
-					toolName: "Write",
-					filePath: current.filePath,
-					toolInput: {
-						file_path: current.filePath,
-						content,
-					},
-				});
-			}
-		}
-		if (current.operation === "update") {
-			const newString = joinPatchLines(current.newLines);
-			if (newString.length > 0) {
-				const filePath = current.movePath ?? current.filePath;
-				requests.push({
-					sourceToolName,
-					toolName: "Edit",
-					filePath,
-					toolInput: {
-						file_path: filePath,
-						old_string: joinPatchLines(current.oldLines),
-						new_string: newString,
-					},
-				});
-			}
-		}
-		current = undefined;
-	};
-
-	for (const line of patch.split(/\r?\n/)) {
-		if (line === "*** Begin Patch" || line === "*** End Patch") continue;
-		if (line.startsWith("*** Add File: ")) {
-			flush();
-			current = makeAccumulator("add", line.slice("*** Add File: ".length).trim());
-			continue;
-		}
-		if (line.startsWith("*** Update File: ")) {
-			flush();
-			current = makeAccumulator("update", line.slice("*** Update File: ".length).trim());
-			continue;
-		}
-		if (line.startsWith("*** Delete File: ")) {
-			flush();
-			current = makeAccumulator("delete", line.slice("*** Delete File: ".length).trim());
-			continue;
-		}
-		if (line.startsWith("*** Move to: ")) {
-			if (current?.operation === "update") current.movePath = line.slice("*** Move to: ".length).trim();
-			continue;
-		}
-		if (!current) continue;
-		if (line.startsWith("@@")) continue;
-		if (current.operation === "add") {
-			if (line.startsWith("+")) current.newLines.push(line.slice(1));
-			continue;
-		}
-		if (current.operation === "update") {
-			if (line.startsWith("+")) current.newLines.push(line.slice(1));
-			if (line.startsWith("-")) current.oldLines.push(line.slice(1));
-		}
-	}
-
-	flush();
-	return requests;
-}
-
-function makeAccumulator(operation: ApplyPatchAccumulator["operation"], filePath: string): ApplyPatchAccumulator {
-	return {
-		operation,
-		filePath,
-		oldLines: [],
-		newLines: [],
-	};
+	return extractApplyPatchRequestsFromPatch(event);
 }
 
 function getEdits(value: unknown): CheckerEdit[] {
@@ -342,20 +174,4 @@ function getContentText(content: ToolResultContent[] | undefined): string {
 		.filter((block): block is TextContent => block.type === "text")
 		.map((block) => block.text)
 		.join("\n");
-}
-
-function getString(input: Record<string, unknown>, keys: string[]): string | undefined {
-	for (const key of keys) {
-		const value = input[key];
-		if (typeof value === "string") return value;
-	}
-	return undefined;
-}
-
-function joinPatchLines(lines: string[]): string {
-	return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
 }

--- a/packages/omo-codex/plugin/components/comment-checker/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/test/codex-hook.test.ts
@@ -94,6 +94,151 @@ describe("extractCodexCommentCheckRequests", () => {
 		]);
 	});
 
+	it("#given apply_patch metadata files #when extracting #then metadata takes priority over raw patch text", () => {
+		const requests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_input: {
+					command: [
+						"*** Begin Patch",
+						"*** Update File: src/raw.ts",
+						"@@",
+						"-const raw = 1;",
+						"+const raw = 2;",
+						"*** End Patch",
+					].join("\n"),
+				},
+				tool_response: {
+					files: [
+						{
+							filePath: "src/new.ts",
+							before: "",
+							after: "// explains new\nconst value = 1;\n",
+						},
+						{
+							file_path: "src/old.ts",
+							move_path: "src/moved.ts",
+							old: "const value = 1;\n",
+							new: "// explains moved\nconst value = 2;\n",
+						},
+						{
+							path: "src/deleted.ts",
+							before: "const deleted = true;\n",
+							after: "",
+							type: "delete",
+						},
+					],
+				},
+			}),
+		);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Write",
+				filePath: "src/new.ts",
+				toolInput: {
+					file_path: "src/new.ts",
+					content: "// explains new\nconst value = 1;\n",
+				},
+			},
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Edit",
+				filePath: "src/moved.ts",
+				toolInput: {
+					file_path: "src/moved.ts",
+					old_string: "const value = 1;\n",
+					new_string: "// explains moved\nconst value = 2;\n",
+				},
+			},
+		]);
+	});
+
+	it("#given nested apply_patch metadata #when extracting #then result and metadata containers are supported", () => {
+		const resultRequests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_response: {
+					result: {
+						files: [{ filePath: "src/result.ts", before: "", after: "const result = true;\n" }],
+					},
+				},
+			}),
+		);
+		const metadataRequests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_response: {
+					metadata: {
+						files: [{ filePath: "src/metadata.ts", before: "", after: "const metadata = true;\n" }],
+					},
+				},
+			}),
+		);
+
+		expect(resultRequests[0]?.filePath).toBe("src/result.ts");
+		expect(metadataRequests[0]?.filePath).toBe("src/metadata.ts");
+	});
+
+	it("#given apply_patch add move and delete hunks #when extracting from raw patch #then add and move are checked while delete is ignored", () => {
+		const requests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_input: {
+					command: [
+						"*** Begin Patch",
+						"*** Add File: src/added.ts",
+						"+// explains add",
+						"+const added = true;",
+						"*** Update File: src/original.ts",
+						"*** Move to: src/renamed.ts",
+						"@@",
+						"-const original = true;",
+						"+// explains rename",
+						"+const renamed = true;",
+						"*** Delete File: src/deleted.ts",
+						"*** End Patch",
+					].join("\n"),
+				},
+			}),
+		);
+
+		expect(requests).toEqual([
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Write",
+				filePath: "src/added.ts",
+				toolInput: {
+					file_path: "src/added.ts",
+					content: "// explains add\nconst added = true;\n",
+				},
+			},
+			{
+				sourceToolName: "apply_patch",
+				toolName: "Edit",
+				filePath: "src/renamed.ts",
+				toolInput: {
+					file_path: "src/renamed.ts",
+					old_string: "const original = true;\n",
+					new_string: "// explains rename\nconst renamed = true;\n",
+				},
+			},
+		]);
+	});
+
+	it("#given failed tool response #when extracting #then no comment-check request is emitted", () => {
+		const textFailureRequests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_response: "failed to apply patch",
+			}),
+		);
+		const structuredFailureRequests = extractCodexCommentCheckRequests(
+			postToolUseInput({
+				tool_response: { is_error: true, text: "Success. Updated files." },
+			}),
+		);
+
+		expect(textFailureRequests).toEqual([]);
+		expect(structuredFailureRequests).toEqual([]);
+	});
+
 	it("#given unsupported post tool event #when extracting #then returns no requests", () => {
 		const requests = extractCodexCommentCheckRequests(
 			postToolUseInput({


### PR DESCRIPTION
## Summary
- keep `core.ts` as the Codex hook routing facade and move apply_patch metadata/raw patch extraction into `apply-patch.ts`
- move small shared value readers into `core-values.ts` while preserving existing public re-exports from `core.ts`
- add characterization tests for metadata priority, nested metadata containers, raw add/move/delete hunks, and failed tool responses

## LOC evidence
- `core.ts`: 328 pure LOC before, 157 pure LOC after
- new `apply-patch.ts`: 174 pure LOC
- new `core-values.ts`: 10 pure LOC
- all touched production files stay under the 250 pure LOC target

## Smart rebase
- fetched `origin/dev` before commit restore and again before push
- pre-push rebase selected `dev`; branch was 1 ahead / 0 behind, rebase was a no-op

## Validation
- `cd packages/omo-codex/plugin/components/comment-checker && npm run typecheck`
- `npm test -- test/codex-hook.test.ts test/codex-hook-newline.test.ts test/runner.test.ts`
- `npm run check`
- `npm test`
- `npm pack --dry-run`
- manual hook QA via `node --input-type=module` importing `dist/codex-hook.js`, verifying apply_patch extraction and Codex blocking JSON

## Root compatibility
- prior to publishing this branch, root `bun run test:codex` passed after root install/submodule init; final Node segment reported 184 pass / 0 fail


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split apply_patch extraction into its own module and kept `core.ts` as the Codex hook facade. This reduces complexity and preserves the public API while adding coverage for edge cases.

- **Refactors**
  - Moved apply_patch metadata and raw patch parsing to `apply-patch.ts`; `core.ts` now delegates.
  - Extracted shared helpers to `core-values.ts` and preserved existing re-exports from `core.ts`.
  - Added characterization tests: metadata over raw patch, nested metadata containers, raw add/move parsed (delete ignored), and no requests on failed tool responses.

<sup>Written for commit 9f18a0150ace703dec644bd979bcbae5d8a55809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

