### PR TITLE
refactor(codex): split auto update state helpers

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update-state.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update-state.mjs
@@ -1,0 +1,78 @@
+import { appendFile, mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DEFAULT_LOCK_STALE_MS = 10 * 60 * 1_000;
+
+export function resolveStatePath(env) {
+	if (env.LAZYCODEX_AUTO_UPDATE_STATE_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_STATE_PATH;
+	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
+	return join(dataRoot, "auto-update.json");
+}
+
+export function resolveLogPath(env) {
+	if (env.LAZYCODEX_AUTO_UPDATE_LOG_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_LOG_PATH;
+	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
+	return join(dataRoot, "auto-update.log");
+}
+
+export function resolveLockPath(env, statePath) {
+	if (env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH;
+	return `${statePath}.lock`;
+}
+
+export async function acquireLock(lockPath, now, staleMs = DEFAULT_LOCK_STALE_MS) {
+	await mkdir(dirname(lockPath), { recursive: true });
+	try {
+		const handle = await open(lockPath, "wx");
+		await handle.writeFile(`${now}\n`);
+		await handle.close();
+		return {
+			release: () => rm(lockPath, { force: true }),
+		};
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+		if (!(await removeStaleLock(lockPath, now, staleMs))) return null;
+		return acquireLock(lockPath, now, 0);
+	}
+}
+
+export async function readState(statePath) {
+	try {
+		const raw = await readFile(statePath, "utf8");
+		const parsed = JSON.parse(raw);
+		return typeof parsed === "object" && parsed !== null ? parsed : {};
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return {};
+		return {};
+	}
+}
+
+export async function writeState(statePath, state) {
+	await mkdir(dirname(statePath), { recursive: true });
+	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export async function appendUpdateLog(env, now, event, details = {}) {
+	const logPath = resolveLogPath(env);
+	await mkdir(dirname(logPath), { recursive: true });
+	const entry = {
+		timestamp: new Date(now).toISOString(),
+		event,
+		...details,
+	};
+	await appendFile(logPath, `${JSON.stringify(entry)}\n`);
+}
+
+async function removeStaleLock(lockPath, now, staleMs) {
+	if (staleMs <= 0) return false;
+	try {
+		const lockStat = await stat(lockPath);
+		if (now - lockStat.mtimeMs < staleMs) return false;
+		await rm(lockPath, { force: true });
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+		throw error;
+	}
+}

--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -2,15 +2,21 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { appendFile, mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+	DEFAULT_LOCK_STALE_MS,
+	acquireLock,
+	appendUpdateLog,
+	readState,
+	resolveLockPath,
+	resolveStatePath,
+	writeState,
+} from "./auto-update-state.mjs";
 import { migrateCodexConfig } from "./migrate-codex-config.mjs";
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETRY_INTERVAL_MS = 30 * 60 * 1_000;
-const DEFAULT_LOCK_STALE_MS = 10 * 60 * 1_000;
 const DEFAULT_UPDATE_COMMAND = "npx";
 const DEFAULT_UPDATE_ARGS = ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"];
 const INSTALLED_VERSION_FILE = "lazycodex-install.json";
@@ -100,7 +106,8 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 		return { started: false, reason: plan.reason };
 	}
 
-	const lock = await acquireLock(resolveLockPath(env, statePath), now, env);
+	const lockStaleMs = parsePositiveInteger(env.LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS, DEFAULT_LOCK_STALE_MS);
+	const lock = await acquireLock(resolveLockPath(env, statePath), now, lockStaleMs);
 	if (lock === null) {
 		await appendUpdateLog(env, now, "locked");
 		return { started: false, reason: "locked" };
@@ -225,23 +232,6 @@ function compareVersions(left, right) {
 	return 0;
 }
 
-function resolveStatePath(env) {
-	if (env.LAZYCODEX_AUTO_UPDATE_STATE_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_STATE_PATH;
-	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
-	return join(dataRoot, "auto-update.json");
-}
-
-function resolveLogPath(env) {
-	if (env.LAZYCODEX_AUTO_UPDATE_LOG_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_LOG_PATH;
-	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
-	return join(dataRoot, "auto-update.log");
-}
-
-function resolveLockPath(env, statePath) {
-	if (env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH?.trim()) return env.LAZYCODEX_AUTO_UPDATE_LOCK_PATH;
-	return `${statePath}.lock`;
-}
-
 function resolveInstalledVersionPath(env, pluginRoot) {
 	if (env.LAZYCODEX_INSTALLED_VERSION_PATH?.trim()) return env.LAZYCODEX_INSTALLED_VERSION_PATH;
 	return join(pluginRoot, INSTALLED_VERSION_FILE);
@@ -257,63 +247,6 @@ function readVersionManifest(path) {
 		if (error instanceof Error) return undefined;
 		throw error;
 	}
-}
-
-async function acquireLock(lockPath, now, env) {
-	await mkdir(dirname(lockPath), { recursive: true });
-	const staleMs = parsePositiveInteger(env.LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS, DEFAULT_LOCK_STALE_MS);
-	try {
-		const handle = await open(lockPath, "wx");
-		await handle.writeFile(`${now}\n`);
-		await handle.close();
-		return {
-			release: () => rm(lockPath, { force: true }),
-		};
-	} catch (error) {
-		if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-		if (!(await removeStaleLock(lockPath, now, staleMs))) return null;
-		return acquireLock(lockPath, now, { ...env, LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS: "0" });
-	}
-}
-
-async function removeStaleLock(lockPath, now, staleMs) {
-	if (staleMs <= 0) return false;
-	try {
-		const lockStat = await stat(lockPath);
-		if (now - lockStat.mtimeMs < staleMs) return false;
-		await rm(lockPath, { force: true });
-		return true;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
-		throw error;
-	}
-}
-
-async function readState(statePath) {
-	try {
-		const raw = await readFile(statePath, "utf8");
-		const parsed = JSON.parse(raw);
-		return typeof parsed === "object" && parsed !== null ? parsed : {};
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return {};
-		return {};
-	}
-}
-
-async function writeState(statePath, state) {
-	await mkdir(dirname(statePath), { recursive: true });
-	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
-}
-
-async function appendUpdateLog(env, now, event, details = {}) {
-	const logPath = resolveLogPath(env);
-	await mkdir(dirname(logPath), { recursive: true });
-	const entry = {
-		timestamp: new Date(now).toISOString(),
-		event,
-		...details,
-	};
-	await appendFile(logPath, `${JSON.stringify(entry)}\n`);
 }
 
 function parsePositiveInteger(value, fallback) {

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -1,10 +1,22 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { resolveAutoUpdatePlan, resolveLazyCodexUpdatePlan, runAutoUpdateCheck } from "../scripts/auto-update.mjs";
+
+function autoUpdateEnv(root, extra = {}) {
+	return {
+		CODEX_HOME: join(root, "codex-home"),
+		LAZYCODEX_CURRENT_VERSION: "1.0.0",
+		LAZYCODEX_LATEST_VERSION: "1.0.1",
+		LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
+		LAZYCODEX_AUTO_UPDATE_STATE_PATH: join(root, "state.json"),
+		LAZYCODEX_AUTO_UPDATE_LOG_PATH: join(root, "auto-update.log"),
+		...extra,
+	};
+}
 
 test("#given auto update is disabled #when resolving plan #then no command is scheduled", () => {
 	const plan = resolveAutoUpdatePlan({
@@ -113,34 +125,26 @@ test("#given installed lazycodex version snapshot #when resolving auto update pl
 test("#given test command override #when running check #then records state and launches command", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-"));
 	const logPath = join(root, "spawn.log");
-	const updateLogPath = join(root, "auto-update.log");
-	const statePath = join(root, "state.json");
-	const codexHome = join(root, "codex-home");
+	const env = autoUpdateEnv(root, {
+		LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
+		LAZYCODEX_AUTO_UPDATE_COMMAND: process.execPath,
+		LAZYCODEX_AUTO_UPDATE_ARGS_JSON: JSON.stringify(["-e", `require("node:fs").writeFileSync(${JSON.stringify(logPath)}, "ok")`]),
+		LAZYCODEX_AUTO_UPDATE_WAIT: "1",
+	});
 
 	const result = await runAutoUpdateCheck({
-		env: {
-			CODEX_HOME: codexHome,
-			LAZYCODEX_CURRENT_VERSION: "1.0.0",
-			LAZYCODEX_LATEST_VERSION: "1.0.1",
-			LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
-			LAZYCODEX_AUTO_UPDATE_STATE_PATH: statePath,
-			LAZYCODEX_AUTO_UPDATE_LOG_PATH: updateLogPath,
-			LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
-			LAZYCODEX_AUTO_UPDATE_COMMAND: process.execPath,
-			LAZYCODEX_AUTO_UPDATE_ARGS_JSON: JSON.stringify(["-e", `require("node:fs").writeFileSync(${JSON.stringify(logPath)}, "ok")`]),
-			LAZYCODEX_AUTO_UPDATE_WAIT: "1",
-		},
+		env,
 		now: 123_456,
 	});
 
 	assert.equal(result.started, true);
-	assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), {
+	assert.deepEqual(JSON.parse(await readFile(env.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8")), {
 		lastCheckedAt: 123_456,
 		lastAttemptedAt: 123_456,
 		lastStatus: "success",
 	});
 	assert.equal(await readFile(logPath, "utf8"), "ok");
-	const updateLog = (await readFile(updateLogPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+	const updateLog = (await readFile(env.LAZYCODEX_AUTO_UPDATE_LOG_PATH, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
 	assert.deepEqual(updateLog, [
 		{
 			timestamp: "1970-01-01T00:02:03.456Z",
@@ -154,25 +158,16 @@ test("#given test command override #when running check #then records state and l
 			status: 0,
 		},
 	]);
-	assert.match(await readFile(join(codexHome, "config.toml"), "utf8"), /model = "gpt-5\.5"/);
+	assert.match(await readFile(join(env.CODEX_HOME, "config.toml"), "utf8"), /model = "gpt-5\.5"/);
 });
 
 test("#given failed waited update #when retry window passes #then next update is not blocked by success throttle", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-retry-"));
-	const statePath = join(root, "state.json");
-	const updateLogPath = join(root, "auto-update.log");
 	const successPath = join(root, "success.log");
-	const codexHome = join(root, "codex-home");
-	const baseEnv = {
-		CODEX_HOME: codexHome,
-		LAZYCODEX_CURRENT_VERSION: "1.0.0",
-		LAZYCODEX_LATEST_VERSION: "1.0.1",
-		LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
-		LAZYCODEX_AUTO_UPDATE_STATE_PATH: statePath,
-		LAZYCODEX_AUTO_UPDATE_LOG_PATH: updateLogPath,
+	const baseEnv = autoUpdateEnv(root, {
 		LAZYCODEX_AUTO_UPDATE_WAIT: "1",
 		LAZYCODEX_AUTO_UPDATE_COMMAND: process.execPath,
-	};
+	});
 
 	const failed = await runAutoUpdateCheck({
 		env: {
@@ -183,7 +178,7 @@ test("#given failed waited update #when retry window passes #then next update is
 	});
 	assert.equal(failed.started, true);
 	assert.equal(failed.status, 1);
-	assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), {
+	assert.deepEqual(JSON.parse(await readFile(baseEnv.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8")), {
 		lastAttemptedAt: 123_456,
 		lastStatus: "failed",
 	});
@@ -203,30 +198,51 @@ test("#given failed waited update #when retry window passes #then next update is
 
 test("#given active lock #when running check #then skips concurrent update", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-lock-"));
-	const statePath = join(root, "state.json");
 	const lockPath = join(root, "state.json.lock");
-	const updateLogPath = join(root, "auto-update.log");
-	const codexHome = join(root, "codex-home");
 	await writeFile(lockPath, "locked\n");
 
 	const result = await runAutoUpdateCheck({
-		env: {
-			CODEX_HOME: codexHome,
-			LAZYCODEX_CURRENT_VERSION: "1.0.0",
-			LAZYCODEX_LATEST_VERSION: "1.0.1",
-			LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
-			LAZYCODEX_AUTO_UPDATE_STATE_PATH: statePath,
-			LAZYCODEX_AUTO_UPDATE_LOG_PATH: updateLogPath,
+		env: autoUpdateEnv(root, {
 			LAZYCODEX_AUTO_UPDATE_LOCK_PATH: lockPath,
 			LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
 			LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS: "600000",
-		},
+		}),
 		now: 123_456,
 	});
 
 	assert.equal(result.started, false);
 	assert.equal(result.reason, "locked");
-	assert.match(await readFile(join(codexHome, "config.toml"), "utf8"), /model_context_window = 400000/);
+	assert.match(await readFile(join(root, "codex-home", "config.toml"), "utf8"), /model_context_window = 400000/);
+});
+
+test("#given stale lock #when running check #then removes lock and runs update", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-auto-update-stale-lock-"));
+	const lockPath = join(root, "state.json.lock");
+	const successPath = join(root, "success.log");
+	await writeFile(lockPath, "locked\n");
+	await utimes(lockPath, new Date(0), new Date(0));
+	const env = autoUpdateEnv(root, {
+		LAZYCODEX_AUTO_UPDATE_LOCK_PATH: lockPath,
+		LAZYCODEX_AUTO_UPDATE_INTERVAL_MS: "0",
+		LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS: "600000",
+		LAZYCODEX_AUTO_UPDATE_WAIT: "1",
+		LAZYCODEX_AUTO_UPDATE_COMMAND: process.execPath,
+		LAZYCODEX_AUTO_UPDATE_ARGS_JSON: JSON.stringify(["-e", `require("node:fs").writeFileSync(${JSON.stringify(successPath)}, "ok")`]),
+	});
+
+	const result = await runAutoUpdateCheck({
+		env,
+		now: 1_000_000,
+	});
+
+	assert.equal(result.started, true);
+	assert.equal(result.status, 0);
+	assert.equal(await readFile(successPath, "utf8"), "ok");
+	assert.deepEqual(JSON.parse(await readFile(env.LAZYCODEX_AUTO_UPDATE_STATE_PATH, "utf8")), {
+		lastCheckedAt: 1_000_000,
+		lastAttemptedAt: 1_000_000,
+		lastStatus: "success",
+	});
 });
 
 test("#given throttled updater and stale Codex config #when running check #then config migration still runs", async () => {


### PR DESCRIPTION
## Summary
- keep `scripts/auto-update.mjs` focused on update planning/orchestration
- extract state path, log writing, lock acquisition, and stale-lock cleanup into `scripts/auto-update-state.mjs`
- add a stale-lock characterization test while trimming repeated env setup so the test file stays at the 250 pure LOC ceiling

## LOC evidence
- `auto-update.mjs`: 298 pure LOC before, 239 pure LOC after
- new `auto-update-state.mjs`: 69 pure LOC
- `auto-update.test.mjs`: 250 pure LOC after adding stale-lock coverage and removing duplicated env setup

## Smart rebase
- fresh worktree started from `origin/dev`
- rebased once when `origin/dev` advanced to `290c4fb2f` before commit
- rebased committed branch onto `origin/dev` after `6b4589062` landed
- final pre-push fetch/rebase was a no-op: 1 ahead / 0 behind

## Validation
- `cd packages/omo-codex/plugin && node --test test/auto-update.test.mjs`
- `npm test` in `packages/omo-codex/plugin`
- `npm run build` in `packages/omo-codex/plugin`
- manual CLI QA: executed `node scripts/auto-update.mjs` with temp state/log paths and waited update command; verified exit 0, command side effect, success state, and start/finish log entries
- `bun run test:codex` from repo root: PASS, final Node segment 185 pass / 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split auto-update state and lock helpers into a dedicated module so `scripts/auto-update.mjs` focuses on planning and orchestration. Added explicit stale-lock handling and tests; behavior unchanged and code size reduced.

- **Refactors**
  - Extracted state path/log path, log append, state read/write, lock acquisition, and stale-lock cleanup to `scripts/auto-update-state.mjs`.
  - Updated `scripts/auto-update.mjs` to use helpers and parse `LAZYCODEX_AUTO_UPDATE_LOCK_STALE_MS`.
  - Added a stale-lock test and an `autoUpdateEnv` helper to dedupe test setup.

<sup>Written for commit b2c873bb78e90bb82d1c5f897169fc2d094b024d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

