### PR TITLE
Fix LazyCodex Codex cache activation on Windows

### DIFF
--- a/bin/oh-my-opencode.test.ts
+++ b/bin/oh-my-opencode.test.ts
@@ -23,11 +23,7 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.lazycodexBin, "install", "--no-tui"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
-      },
+      env: createWrapperTestEnv(fixture),
     });
 
     // #then
@@ -49,11 +45,7 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.lazycodexBin, "install", "--no-tui"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
-      },
+      env: createWrapperTestEnv(fixture),
     });
 
     // #then
@@ -74,11 +66,7 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.wrapperBin, "install", "--no-tui"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
-      },
+      env: createWrapperTestEnv(fixture),
     });
 
     // #then
@@ -99,11 +87,7 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.wrapperBin, "install", "--no-tui"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
-      },
+      env: createWrapperTestEnv(fixture),
     });
 
     // #then
@@ -124,13 +108,12 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.lazycodexBin, "update", "--dry-run"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
+      env: createWrapperTestEnv(fixture, {
         CAPTURE_DIR: fixture.captureDir,
         LAZYCODEX_CURRENT_VERSION: "1.0.0",
         LAZYCODEX_LATEST_VERSION: "1.0.1",
         PATH: fixture.fakeBinDir,
-      },
+      }),
     });
 
     // #then
@@ -149,11 +132,7 @@ describe("lazycodex bin wrapper", () => {
     // #when
     const result = spawnSync(nodePath, [fixture.lazycodexBin, "uninstall", "--dry-run", "--project", "/tmp/lazycodex-qa"], {
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CAPTURE_DIR: fixture.captureDir,
-        PATH: fixture.fakeBinDir,
-      },
+      env: createWrapperTestEnv(fixture),
     });
 
     // #then
@@ -166,6 +145,19 @@ describe("lazycodex bin wrapper", () => {
     ]);
   });
 });
+
+function createWrapperTestEnv(
+  fixture: { readonly captureDir: string; readonly fakeBinDir: string },
+  overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  const { OMO_INVOCATION_NAME: _invocationName, OMO_WRAPPER_PACKAGE_ROOT: _wrapperPackageRoot, ...baseEnv } = process.env;
+  return {
+    ...baseEnv,
+    CAPTURE_DIR: fixture.captureDir,
+    PATH: fixture.fakeBinDir,
+    ...overrides,
+  };
+}
 
 async function createLazyCodexFixture(options: { packageName?: string; wrapperFileName?: string } = {}) {
   const root = await mkdtemp(join(tmpdir(), "lazycodex-bin-wrapper-"));

--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { migrateCodexConfig } from "./migrate-codex-config.mjs";
+import { resolveSpawnCommand } from "./spawn-command.mjs";
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETRY_INTERVAL_MS = 30 * 60 * 1_000;
@@ -108,7 +109,7 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 	try {
 		await appendUpdateLog(env, now, "started", { command: plan.command, args: plan.args });
 		if (env.LAZYCODEX_AUTO_UPDATE_WAIT === "1") {
-			const result = spawnSync(plan.command, plan.args, {
+			const result = spawnSync(resolveSpawnCommand(plan.command), plan.args, {
 				env: plan.env,
 				stdio: "ignore",
 			});
@@ -120,7 +121,7 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 			return { started: true, status };
 		}
 
-		const child = spawn(plan.command, plan.args, {
+		const child = spawn(resolveSpawnCommand(plan.command), plan.args, {
 			env: plan.env,
 			stdio: "ignore",
 			detached: true,
@@ -170,7 +171,7 @@ function resolveCurrentVersion(env) {
 
 function resolveLatestVersion(env) {
 	if (env.LAZYCODEX_LATEST_VERSION?.trim()) return env.LAZYCODEX_LATEST_VERSION.trim();
-	const result = spawnSync("npm", ["view", "lazycodex-ai", "version", "--silent"], {
+	const result = spawnSync(resolveSpawnCommand("npm"), ["view", "lazycodex-ai", "version", "--silent"], {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
 	});
@@ -181,7 +182,7 @@ function resolveLatestVersion(env) {
 
 function defaultRunCommandForManualUpdate(command, args, options) {
 	return new Promise((resolve, reject) => {
-		const child = spawn(command, args, {
+		const child = spawn(resolveSpawnCommand(command), args, {
 			cwd: options.cwd,
 			env: options.env,
 			stdio: "inherit",

--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { migrateCodexConfig } from "./migrate-codex-config.mjs";
-import { resolveSpawnCommand } from "./spawn-command.mjs";
+import { resolveSpawnInvocation } from "./spawn-command.mjs";
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETRY_INTERVAL_MS = 30 * 60 * 1_000;
@@ -109,7 +109,8 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 	try {
 		await appendUpdateLog(env, now, "started", { command: plan.command, args: plan.args });
 		if (env.LAZYCODEX_AUTO_UPDATE_WAIT === "1") {
-			const result = spawnSync(resolveSpawnCommand(plan.command), plan.args, {
+			const invocation = resolveSpawnInvocation(plan.command, plan.args);
+			const result = spawnSync(invocation.command, invocation.args, {
 				env: plan.env,
 				stdio: "ignore",
 			});
@@ -121,7 +122,8 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 			return { started: true, status };
 		}
 
-		const child = spawn(resolveSpawnCommand(plan.command), plan.args, {
+		const invocation = resolveSpawnInvocation(plan.command, plan.args);
+		const child = spawn(invocation.command, invocation.args, {
 			env: plan.env,
 			stdio: "ignore",
 			detached: true,
@@ -171,7 +173,8 @@ function resolveCurrentVersion(env) {
 
 function resolveLatestVersion(env) {
 	if (env.LAZYCODEX_LATEST_VERSION?.trim()) return env.LAZYCODEX_LATEST_VERSION.trim();
-	const result = spawnSync(resolveSpawnCommand("npm"), ["view", "lazycodex-ai", "version", "--silent"], {
+	const invocation = resolveSpawnInvocation("npm", ["view", "lazycodex-ai", "version", "--silent"]);
+	const result = spawnSync(invocation.command, invocation.args, {
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
 	});
@@ -182,7 +185,8 @@ function resolveLatestVersion(env) {
 
 function defaultRunCommandForManualUpdate(command, args, options) {
 	return new Promise((resolve, reject) => {
-		const child = spawn(resolveSpawnCommand(command), args, {
+		const invocation = resolveSpawnInvocation(command, args);
+		const child = spawn(invocation.command, invocation.args, {
 			cwd: options.cwd,
 			env: options.env,
 			stdio: "inherit",

--- a/packages/omo-codex/plugin/scripts/spawn-command.mjs
+++ b/packages/omo-codex/plugin/scripts/spawn-command.mjs
@@ -1,0 +1,7 @@
+const WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"]);
+
+export function resolveSpawnCommand(command, platform = process.platform) {
+	if (platform !== "win32") return command;
+	if (!WINDOWS_CMD_SHIM_COMMANDS.has(command.toLowerCase())) return command;
+	return `${command}.cmd`;
+}

--- a/packages/omo-codex/plugin/scripts/spawn-command.mjs
+++ b/packages/omo-codex/plugin/scripts/spawn-command.mjs
@@ -1,7 +1,11 @@
 const WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"]);
 
-export function resolveSpawnCommand(command, platform = process.platform) {
-	if (platform !== "win32") return command;
-	if (!WINDOWS_CMD_SHIM_COMMANDS.has(command.toLowerCase())) return command;
-	return `${command}.cmd`;
+export function resolveSpawnInvocation(command, args, platform = process.platform) {
+	const invocation = { command, args: Array.from(args) };
+	if (platform !== "win32") return invocation;
+	if (!WINDOWS_CMD_SHIM_COMMANDS.has(command.toLowerCase())) return invocation;
+	return {
+		command: "cmd.exe",
+		args: ["/d", "/s", "/c", `${command}.cmd`, ...invocation.args],
+	};
 }

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { resolveAutoUpdatePlan, resolveLazyCodexUpdatePlan, runAutoUpdateCheck } from "../scripts/auto-update.mjs";
+import { resolveSpawnCommand } from "../scripts/spawn-command.mjs";
 
 test("#given auto update is disabled #when resolving plan #then no command is scheduled", () => {
 	const plan = resolveAutoUpdatePlan({
@@ -27,6 +28,13 @@ test("#given stale state #when resolving plan #then installer update command is 
 	assert.equal(plan.shouldRun, true);
 	assert.deepEqual(plan.command, "npx");
 	assert.deepEqual(plan.args, ["--yes", "lazycodex-ai@latest", "install", "--no-tui", "--codex-autonomous"]);
+});
+
+test("#given Windows npm shims #when resolving spawn commands #then cmd shims are used", () => {
+	assert.equal(resolveSpawnCommand("npm", "win32"), "npm.cmd");
+	assert.equal(resolveSpawnCommand("npx", "win32"), "npx.cmd");
+	assert.equal(resolveSpawnCommand("node", "win32"), "node");
+	assert.equal(resolveSpawnCommand("npx", "darwin"), "npx");
 });
 
 test("#given current version #when resolving update plan #then skips installer", () => {

--- a/packages/omo-codex/plugin/test/auto-update.test.mjs
+++ b/packages/omo-codex/plugin/test/auto-update.test.mjs
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { resolveAutoUpdatePlan, resolveLazyCodexUpdatePlan, runAutoUpdateCheck } from "../scripts/auto-update.mjs";
-import { resolveSpawnCommand } from "../scripts/spawn-command.mjs";
+import { resolveSpawnInvocation } from "../scripts/spawn-command.mjs";
 
 test("#given auto update is disabled #when resolving plan #then no command is scheduled", () => {
 	const plan = resolveAutoUpdatePlan({
@@ -31,10 +31,22 @@ test("#given stale state #when resolving plan #then installer update command is 
 });
 
 test("#given Windows npm shims #when resolving spawn commands #then cmd shims are used", () => {
-	assert.equal(resolveSpawnCommand("npm", "win32"), "npm.cmd");
-	assert.equal(resolveSpawnCommand("npx", "win32"), "npx.cmd");
-	assert.equal(resolveSpawnCommand("node", "win32"), "node");
-	assert.equal(resolveSpawnCommand("npx", "darwin"), "npx");
+	assert.deepEqual(resolveSpawnInvocation("npm", ["install"], "win32"), {
+		command: "cmd.exe",
+		args: ["/d", "/s", "/c", "npm.cmd", "install"],
+	});
+	assert.deepEqual(resolveSpawnInvocation("npx", ["--yes", "lazycodex-ai@latest"], "win32"), {
+		command: "cmd.exe",
+		args: ["/d", "/s", "/c", "npx.cmd", "--yes", "lazycodex-ai@latest"],
+	});
+	assert.deepEqual(resolveSpawnInvocation("node", ["script.mjs"], "win32"), {
+		command: "node",
+		args: ["script.mjs"],
+	});
+	assert.deepEqual(resolveSpawnInvocation("npx", ["--yes"], "darwin"), {
+		command: "npx",
+		args: ["--yes"],
+	});
 });
 
 test("#given current version #when resolving update plan #then skips installer", () => {

--- a/packages/omo-codex/scripts/install-cache-copy.test.mjs
+++ b/packages/omo-codex/scripts/install-cache-copy.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -27,4 +27,36 @@ test("#given source plugin has a stale npm lockfile #when caching plugin #then l
 
 	// then
 	await assert.rejects(stat(join(installed.path, "package-lock.json")));
+});
+
+test("#given existing cache #when npm install fails #then previous active cache is preserved", async () => {
+	// given
+	const root = await makeTempDir();
+	const codexHome = join(root, "codex-home");
+	const sourceRoot = join(root, "plugin");
+	const cacheRoot = join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0");
+	await mkdir(sourceRoot, { recursive: true });
+	await mkdir(cacheRoot, { recursive: true });
+	await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }));
+	await writeFile(join(cacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }));
+
+	// when
+	await assert.rejects(
+		installCachedPlugin({
+			codexHome,
+			marketplaceName: "debug",
+			name: "omo",
+			sourcePath: sourceRoot,
+			version: "0.1.0",
+			runCommand: async (_command, args) => {
+				if (args.join(" ") === "install --omit=dev") throw new Error("spawn npm ENOENT");
+			},
+		}),
+		/spawn npm ENOENT/,
+	);
+
+	// then
+	assert.equal(await readFile(join(cacheRoot, "package.json"), "utf8"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }));
+	const cacheParentEntries = await readdir(join(codexHome, "plugins", "cache", "debug", "omo"));
+	assert.deepEqual(cacheParentEntries, ["0.1.0"]);
 });

--- a/packages/omo-codex/scripts/install-cache-copy.test.mjs
+++ b/packages/omo-codex/scripts/install-cache-copy.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
 import test from "node:test";
 
 import { installCachedPlugin } from "./install/cache.mjs";
@@ -53,6 +53,40 @@ test("#given existing cache #when npm install fails #then previous active cache 
 			},
 		}),
 		/spawn npm ENOENT/,
+	);
+
+	// then
+	assert.equal(await readFile(join(cacheRoot, "package.json"), "utf8"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }));
+	const cacheParentEntries = await readdir(join(codexHome, "plugins", "cache", "debug", "omo"));
+	assert.deepEqual(cacheParentEntries, ["0.1.0"]);
+});
+
+test("#given existing cache #when final promotion fails #then previous active cache is restored", async () => {
+	// given
+	const root = await makeTempDir();
+	const codexHome = join(root, "codex-home");
+	const sourceRoot = join(root, "plugin");
+	const cacheRoot = join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0");
+	await mkdir(sourceRoot, { recursive: true });
+	await mkdir(cacheRoot, { recursive: true });
+	await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }));
+	await writeFile(join(cacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }));
+
+	// when
+	await assert.rejects(
+		installCachedPlugin({
+			codexHome,
+			marketplaceName: "debug",
+			name: "omo",
+			sourcePath: sourceRoot,
+			version: "0.1.0",
+			runCommand: async () => undefined,
+			renameDirectory: async (fromPath, toPath) => {
+				if (toPath === cacheRoot && basename(fromPath).startsWith(".tmp-")) throw new Error("rename final failed");
+				await rename(fromPath, toPath);
+			},
+		}),
+		/rename final failed/,
 	);
 
 	// then

--- a/packages/omo-codex/scripts/install-packaged-local.test.mjs
+++ b/packages/omo-codex/scripts/install-packaged-local.test.mjs
@@ -58,10 +58,13 @@ test("#given packaged lazycodex adapter #when installing locally #then uses bund
 
 	assert.deepEqual(result.installed.map((plugin) => `${plugin.name}@${plugin.version}`), ["omo@0.1.2"]);
 	assert.equal(pluginCacheRoot, join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.1.2"));
-	assert.deepEqual(
-		commands.map(([command, args, cwd]) => [command, args, cwd]),
-		[["npm", "install --omit=dev", pluginCacheRoot]],
-	);
+	assert.equal(commands.length, 1);
+	const installCommand = commands[0];
+	assert.notEqual(installCommand, undefined);
+	const [command, args, cwd] = installCommand;
+	assert.equal(command, "npm");
+	assert.equal(args, "install --omit=dev");
+	assert.equal(cwd.startsWith(join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", ".tmp-0.1.2-")), true);
 	assert.deepEqual(cachedMcp.mcpServers.lsp.args, [cachedLspCli, "mcp"]);
 	assert.equal((await stat(cachedLspCli)).isFile(), true);
 	assert.notEqual(cachedMcp.mcpServers.lsp.args[0], join(lspRuntimeRoot, "dist", "cli.js"));

--- a/packages/omo-codex/scripts/install/cache.mjs
+++ b/packages/omo-codex/scripts/install/cache.mjs
@@ -13,10 +13,20 @@ export async function installCachedPlugin({ buildSource = true, codexHome, marke
 	}
 
 	const targetPath = join(codexHome, "plugins", "cache", marketplaceName, name, version);
-	await replaceDirectory(sourcePath, targetPath, shouldCopyPluginPath);
-	await rewriteCachedPackageLocalFileDependencies(targetPath, sourcePath);
-	await maybeRunNpmInstall(targetPath, runCommand, ["install", "--omit=dev"]);
-	await rewriteCachedMcpManifest(targetPath, sourcePath);
+	const tempPath = createTempSiblingPath(targetPath);
+	await rm(tempPath, { recursive: true, force: true });
+	try {
+		await copyDirectory(sourcePath, tempPath, shouldCopyPluginPath);
+		await rewriteCachedPackageLocalFileDependencies(tempPath, sourcePath);
+		await maybeRunNpmInstall(tempPath, runCommand, ["install", "--omit=dev"]);
+		await rewriteCachedMcpManifest(tempPath, sourcePath);
+		await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
+		await rm(targetPath, { recursive: true, force: true });
+		await rename(tempPath, targetPath);
+	} catch (error) {
+		await rm(tempPath, { recursive: true, force: true });
+		throw error;
+	}
 	return { name, version, path: targetPath };
 }
 
@@ -78,16 +88,16 @@ async function maybeRunNpmBuild(cwd, runCommand) {
 	await runCommand("npm", ["run", "build"], { cwd });
 }
 
-async function replaceDirectory(sourcePath, targetPath, filter) {
+function createTempSiblingPath(targetPath) {
+	return join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`);
+}
+
+async function copyDirectory(sourcePath, targetPath, filter) {
 	await mkdir(dirname(targetPath), { recursive: true });
-	const tempPath = join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`);
-	await rm(tempPath, { recursive: true, force: true });
-	await cp(sourcePath, tempPath, {
+	await cp(sourcePath, targetPath, {
 		recursive: true,
 		filter: (source) => filter(source, sourcePath),
 	});
-	await rm(targetPath, { recursive: true, force: true });
-	await rename(tempPath, targetPath);
 }
 
 async function discoverPackageBins(root) {
@@ -192,6 +202,30 @@ export async function rewriteCachedMcpManifest(pluginRoot, sourceRoot = pluginRo
 		const nextArgs = await Promise.all(
 			server.args.map((arg) => rewriteRuntimeArg({ arg, pluginRoot, serverName, sourceRoot })),
 		);
+		if (nextArgs.some((value, index) => value !== server.args[index])) {
+			server.args = nextArgs;
+			changed = true;
+		}
+	}
+	if (changed) await writeFile(manifestPath, `${JSON.stringify(parsed, null, "\t")}\n`);
+}
+
+async function rewriteCachedManifestRoot(pluginRoot, fromRoot, toRoot) {
+	const manifestPath = join(pluginRoot, ".mcp.json");
+	if (!(await exists(manifestPath))) return;
+	const raw = await readFile(manifestPath, "utf8");
+	const parsed = JSON.parse(raw);
+	if (!isRecord(parsed) || !isRecord(parsed.mcpServers)) return;
+	let changed = false;
+	for (const server of Object.values(parsed.mcpServers)) {
+		if (!isRecord(server) || !Array.isArray(server.args)) continue;
+		const nextArgs = server.args.map((arg) => {
+			if (typeof arg !== "string") return arg;
+			if (arg === fromRoot) return toRoot;
+			const prefix = `${fromRoot}${sep}`;
+			if (!arg.startsWith(prefix)) return arg;
+			return `${toRoot}${arg.slice(fromRoot.length)}`;
+		});
 		if (nextArgs.some((value, index) => value !== server.args[index])) {
 			server.args = nextArgs;
 			changed = true;

--- a/packages/omo-codex/scripts/install/cache.mjs
+++ b/packages/omo-codex/scripts/install/cache.mjs
@@ -6,7 +6,7 @@ import { exists, isRecord } from "./utils.mjs";
 import { COMMAND_SHIM_MARKER } from "./command-shim.mjs";
 import { removeLegacyCodexComponentBins } from "./legacy-bins.mjs";
 
-export async function installCachedPlugin({ buildSource = true, codexHome, marketplaceName, name, runCommand, sourcePath, version }) {
+export async function installCachedPlugin({ buildSource = true, codexHome, marketplaceName, name, renameDirectory = rename, runCommand, sourcePath, version }) {
 	if (buildSource) {
 		await maybeRunNpmInstall(sourcePath, runCommand);
 		await maybeRunNpmBuild(sourcePath, runCommand);
@@ -21,8 +21,7 @@ export async function installCachedPlugin({ buildSource = true, codexHome, marke
 		await maybeRunNpmInstall(tempPath, runCommand, ["install", "--omit=dev"]);
 		await rewriteCachedMcpManifest(tempPath, sourcePath);
 		await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
-		await rm(targetPath, { recursive: true, force: true });
-		await rename(tempPath, targetPath);
+		await promoteDirectory(tempPath, targetPath, renameDirectory);
 	} catch (error) {
 		await rm(tempPath, { recursive: true, force: true });
 		throw error;
@@ -92,12 +91,39 @@ function createTempSiblingPath(targetPath) {
 	return join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`);
 }
 
+function createBackupSiblingPath(targetPath) {
+	return join(dirname(targetPath), `.backup-${basename(targetPath)}-${process.pid}-${Date.now()}`);
+}
+
 async function copyDirectory(sourcePath, targetPath, filter) {
 	await mkdir(dirname(targetPath), { recursive: true });
 	await cp(sourcePath, targetPath, {
 		recursive: true,
 		filter: (source) => filter(source, sourcePath),
 	});
+}
+
+async function promoteDirectory(tempPath, targetPath, renameDirectory) {
+	const backupPath = createBackupSiblingPath(targetPath);
+	await rm(backupPath, { recursive: true, force: true });
+	let backupMoved = false;
+	try {
+		if (await exists(targetPath)) {
+			await renameDirectory(targetPath, backupPath);
+			backupMoved = true;
+		}
+		await renameDirectory(tempPath, targetPath);
+	} catch (error) {
+		if (backupMoved) await restoreBackupDirectory(backupPath, targetPath, renameDirectory);
+		throw error;
+	}
+	if (backupMoved) await rm(backupPath, { recursive: true, force: true });
+}
+
+async function restoreBackupDirectory(backupPath, targetPath, renameDirectory) {
+	if (!(await exists(backupPath))) return;
+	await rm(targetPath, { recursive: true, force: true });
+	await renameDirectory(backupPath, targetPath);
 }
 
 async function discoverPackageBins(root) {

--- a/packages/omo-codex/scripts/install/process.mjs
+++ b/packages/omo-codex/scripts/install/process.mjs
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
+import { resolveSpawnCommand } from "../../plugin/scripts/spawn-command.mjs";
 
 export async function defaultRunCommand(command, args, options) {
 	await new Promise((resolvePromise, reject) => {
-		const child = spawn(command, args, {
+		const child = spawn(resolveSpawnCommand(command), args, {
 			cwd: options.cwd,
 			stdio: "inherit",
 		});

--- a/packages/omo-codex/scripts/install/process.mjs
+++ b/packages/omo-codex/scripts/install/process.mjs
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
-import { resolveSpawnCommand } from "../../plugin/scripts/spawn-command.mjs";
+import { resolveSpawnInvocation } from "../../plugin/scripts/spawn-command.mjs";
 
 export async function defaultRunCommand(command, args, options) {
 	await new Promise((resolvePromise, reject) => {
-		const child = spawn(resolveSpawnCommand(command), args, {
+		const invocation = resolveSpawnInvocation(command, args);
+		const child = spawn(invocation.command, invocation.args, {
 			cwd: options.cwd,
 			stdio: "inherit",
 		});

--- a/src/cli/install-codex/codex-cache.test.ts
+++ b/src/cli/install-codex/codex-cache.test.ts
@@ -2,7 +2,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, readlink, stat, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, readFile, readlink, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { installCachedPlugin, linkCachedPluginBins, rewriteCachedMcpManifest } from "./codex-cache"
@@ -120,6 +120,36 @@ describe("codex-cache", () => {
 
     // then
     await expect(stat(join(installed.path, "package-lock.json"))).rejects.toThrow()
+  })
+
+  test("#given existing cache #when npm install fails #then previous active cache is preserved", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-install-fail-"))
+    const codexHome = join(root, "codex-home")
+    const sourceRoot = join(root, "plugin")
+    const cacheRoot = join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0")
+    await mkdir(sourceRoot, { recursive: true })
+    await mkdir(cacheRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+    await writeFile(join(cacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
+
+    // when
+    await expect(
+      installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async (_command, args) => {
+          if (args.join(" ") === "install --omit=dev") throw new Error("spawn npm ENOENT")
+        },
+      }),
+    ).rejects.toThrow("spawn npm ENOENT")
+
+    // then
+    expect(await readFile(join(cacheRoot, "package.json"), "utf8")).toBe(JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
+    expect(await readdir(join(codexHome, "plugins", "cache", "debug", "omo"))).toEqual(["0.1.0"])
   })
 
   test("#given source plugin has built component runtimes #when caching plugin #then component dist files are preserved for hooks", async () => {

--- a/src/cli/install-codex/codex-cache.test.ts
+++ b/src/cli/install-codex/codex-cache.test.ts
@@ -2,9 +2,9 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readdir, readFile, readlink, stat, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, readFile, readlink, rename, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { installCachedPlugin, linkCachedPluginBins, rewriteCachedMcpManifest } from "./codex-cache"
 
 describe("codex-cache", () => {
@@ -146,6 +146,38 @@ describe("codex-cache", () => {
         },
       }),
     ).rejects.toThrow("spawn npm ENOENT")
+
+    // then
+    expect(await readFile(join(cacheRoot, "package.json"), "utf8")).toBe(JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
+    expect(await readdir(join(codexHome, "plugins", "cache", "debug", "omo"))).toEqual(["0.1.0"])
+  })
+
+  test("#given existing cache #when final promotion fails #then previous active cache is restored", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-promote-fail-"))
+    const codexHome = join(root, "codex-home")
+    const sourceRoot = join(root, "plugin")
+    const cacheRoot = join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0")
+    await mkdir(sourceRoot, { recursive: true })
+    await mkdir(cacheRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+    await writeFile(join(cacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
+
+    // when
+    await expect(
+      installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async () => undefined,
+        renameDirectory: async (fromPath, toPath) => {
+          if (toPath === cacheRoot && basename(fromPath).startsWith(".tmp-")) throw new Error("rename final failed")
+          await rename(fromPath, toPath)
+        },
+      }),
+    ).rejects.toThrow("rename final failed")
 
     // then
     expect(await readFile(join(cacheRoot, "package.json"), "utf8")).toBe(JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))

--- a/src/cli/install-codex/codex-cache.ts
+++ b/src/cli/install-codex/codex-cache.ts
@@ -24,11 +24,21 @@ export async function installCachedPlugin(input: {
   }
 
   const targetPath = join(input.codexHome, "plugins", "cache", input.marketplaceName, input.name, input.version)
-  await replaceDirectory(input.sourcePath, targetPath)
-  await rewriteCachedPackageLocalFileDependencies(targetPath, input.sourcePath)
-  await copyBundledMcpRuntimeDists({ pluginRoot: targetPath, sourceRoot: input.sourcePath })
-  await maybeRunNpmInstall(targetPath, input.runCommand, ["install", "--omit=dev"])
-  await rewriteCachedMcpManifest(targetPath, input.sourcePath)
+  const tempPath = createTempSiblingPath(targetPath)
+  await rm(tempPath, { recursive: true, force: true })
+  try {
+    await copyDirectory(input.sourcePath, tempPath)
+    await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
+    await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
+    await maybeRunNpmInstall(tempPath, input.runCommand, ["install", "--omit=dev"])
+    await rewriteCachedMcpManifest(tempPath, input.sourcePath)
+    await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
+    await rm(targetPath, { recursive: true, force: true })
+    await rename(tempPath, targetPath)
+  } catch (error) {
+    await rm(tempPath, { recursive: true, force: true })
+    throw error
+  }
   return { name: input.name, version: input.version, path: targetPath }
 }
 
@@ -125,6 +135,32 @@ export async function rewriteCachedMcpManifest(pluginRoot: string, sourceRoot = 
   if (changed) await writeFile(manifestPath, `${JSON.stringify(parsed, null, "\t")}\n`)
 }
 
+async function rewriteCachedManifestRoot(pluginRoot: string, fromRoot: string, toRoot: string): Promise<void> {
+  const manifestPath = join(pluginRoot, ".mcp.json")
+  if (!(await exists(manifestPath))) return
+  const raw = await readFile(manifestPath, "utf8")
+  const parsed: unknown = JSON.parse(raw)
+  if (!isRecord(parsed) || !isRecord(parsed.mcpServers)) return
+  let changed = false
+  for (const server of Object.values(parsed.mcpServers)) {
+    if (!isRecord(server)) continue
+    const currentArgs = server.args
+    if (!Array.isArray(currentArgs)) continue
+    const nextArgs = currentArgs.map((arg) => {
+      if (typeof arg !== "string") return arg
+      if (arg === fromRoot) return toRoot
+      const prefix = `${fromRoot}${sep}`
+      if (!arg.startsWith(prefix)) return arg
+      return `${toRoot}${arg.slice(fromRoot.length)}`
+    })
+    if (nextArgs.some((value, index) => value !== currentArgs[index])) {
+      server.args = nextArgs
+      changed = true
+    }
+  }
+  if (changed) await writeFile(manifestPath, `${JSON.stringify(parsed, null, "\t")}\n`)
+}
+
 async function maybeRunNpmInstall(cwd: string, runCommand: RunCommand, args: readonly string[] = ["install"]): Promise<void> {
   if (!(await exists(join(cwd, "package.json")))) return
   await runCommand("npm", args, { cwd })
@@ -139,13 +175,13 @@ async function maybeRunNpmBuild(cwd: string, runCommand: RunCommand): Promise<vo
   await runCommand("npm", ["run", "build"], { cwd })
 }
 
-async function replaceDirectory(sourcePath: string, targetPath: string): Promise<void> {
+function createTempSiblingPath(targetPath: string): string {
+  return join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`)
+}
+
+async function copyDirectory(sourcePath: string, targetPath: string): Promise<void> {
   await mkdir(dirname(targetPath), { recursive: true })
-  const tempPath = join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`)
-  await rm(tempPath, { recursive: true, force: true })
-  await cp(sourcePath, tempPath, { recursive: true, filter: (source) => shouldCopyPluginPath(source, sourcePath) })
-  await rm(targetPath, { recursive: true, force: true })
-  await rename(tempPath, targetPath)
+  await cp(sourcePath, targetPath, { recursive: true, filter: (source) => shouldCopyPluginPath(source, sourcePath) })
 }
 
 async function discoverPackageBins(root: string): Promise<readonly { name: string; target: string }[]> {

--- a/src/cli/install-codex/codex-cache.ts
+++ b/src/cli/install-codex/codex-cache.ts
@@ -8,12 +8,14 @@ import { resolveCachedRuntimePath } from "./codex-cache-paths"
 import type { InstalledPlugin, RunCommand } from "./types"
 
 type LinkPlatform = NodeJS.Platform
+type RenameDirectory = (fromPath: string, toPath: string) => Promise<void>
 
 export async function installCachedPlugin(input: {
   readonly buildSource?: boolean
   readonly codexHome: string
   readonly marketplaceName: string
   readonly name: string
+  readonly renameDirectory?: RenameDirectory
   readonly sourcePath: string
   readonly version: string
   readonly runCommand: RunCommand
@@ -33,8 +35,7 @@ export async function installCachedPlugin(input: {
     await maybeRunNpmInstall(tempPath, input.runCommand, ["install", "--omit=dev"])
     await rewriteCachedMcpManifest(tempPath, input.sourcePath)
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
-    await rm(targetPath, { recursive: true, force: true })
-    await rename(tempPath, targetPath)
+    await promoteDirectory(tempPath, targetPath, input.renameDirectory ?? rename)
   } catch (error) {
     await rm(tempPath, { recursive: true, force: true })
     throw error
@@ -179,9 +180,36 @@ function createTempSiblingPath(targetPath: string): string {
   return join(dirname(targetPath), `.tmp-${basename(targetPath)}-${process.pid}-${Date.now()}`)
 }
 
+function createBackupSiblingPath(targetPath: string): string {
+  return join(dirname(targetPath), `.backup-${basename(targetPath)}-${process.pid}-${Date.now()}`)
+}
+
 async function copyDirectory(sourcePath: string, targetPath: string): Promise<void> {
   await mkdir(dirname(targetPath), { recursive: true })
   await cp(sourcePath, targetPath, { recursive: true, filter: (source) => shouldCopyPluginPath(source, sourcePath) })
+}
+
+async function promoteDirectory(tempPath: string, targetPath: string, renameDirectory: RenameDirectory): Promise<void> {
+  const backupPath = createBackupSiblingPath(targetPath)
+  await rm(backupPath, { recursive: true, force: true })
+  let backupMoved = false
+  try {
+    if (await exists(targetPath)) {
+      await renameDirectory(targetPath, backupPath)
+      backupMoved = true
+    }
+    await renameDirectory(tempPath, targetPath)
+  } catch (error) {
+    if (backupMoved) await restoreBackupDirectory(backupPath, targetPath, renameDirectory)
+    throw error
+  }
+  if (backupMoved) await rm(backupPath, { recursive: true, force: true })
+}
+
+async function restoreBackupDirectory(backupPath: string, targetPath: string, renameDirectory: RenameDirectory): Promise<void> {
+  if (!(await exists(backupPath))) return
+  await rm(targetPath, { recursive: true, force: true })
+  await renameDirectory(backupPath, targetPath)
 }
 
 async function discoverPackageBins(root: string): Promise<readonly { name: string; target: string }[]> {

--- a/src/cli/install-codex/install-codex-packaged.test.ts
+++ b/src/cli/install-codex/install-codex-packaged.test.ts
@@ -118,7 +118,12 @@ test("#given packaged lazycodex tarball layout #when installing Codex plugin #th
   expect(cachedComponentPackage.version).toBe("4.5.12")
   expect(cachedHooks.hooks.PostToolUse[0].hooks[0].statusMessage).toBe("LazyCodex(4.5.12): Checking Comments")
   expect(cachedComponentHooks.hooks.UserPromptSubmit[0].hooks[0].statusMessage).toBe("LazyCodex(4.5.12): Checking Ulw-Loop Steering")
-  expect(commands).toEqual([["npm", "install --omit=dev", pluginPath]])
+  expect(commands).toHaveLength(1)
+  const installCommand = commands[0]
+  if (installCommand === undefined) throw new Error("missing cached plugin npm install command")
+  expect(installCommand[0]).toBe("npm")
+  expect(installCommand[1]).toBe("install --omit=dev")
+  expect(installCommand[2].startsWith(join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", ".tmp-4.5.12-"))).toBe(true)
   expect(cachedMcp.mcpServers.lsp.cwd).toBeUndefined()
   expect(cachedMcp.mcpServers.lsp.args).toEqual([cachedLspCli, "mcp"])
   expect(cachedMcp.mcpServers.lsp.args[0]).not.toBe(join(lspRuntimeRoot, "dist", "cli.js"))


### PR DESCRIPTION
## Summary
- stage Codex plugin cache installs in a sibling temp directory, then activate only after npm install and MCP rewrites succeed
- preserve the previous active cache when npm install fails, including Windows npm ENOENT cases
- resolve npm/npx through .cmd shims for Windows updater and script-installer subprocesses
- isolate lazycodex wrapper tests from the parent OMO invocation environment

## Validation
- bun run typecheck
- bun test
- bun run build
- bun run test:codex
- manual temp CODEX_HOME install smoke verified ast_grep, git_bash, and lsp MCP args point inside the installed plugin cache and files exist

Related: code-yeongyu/lazycodex#25
Related: code-yeongyu/lazycodex#27

Reported by @jelitz and @sjh0728-somansa.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex plugin cache activation on Windows by staging installs in a temp dir, promoting only after `npm install` and MCP rewrites succeed, and backing up/restoring the previous cache on failures. Ensures all `npm`/`npx` calls use Windows `cmd.exe` shims and keeps MCP config pointing at the final cache.

- Bug Fixes
  - Stage plugin cache to a sibling temp dir; promote only after install and MCP rewrites. Previous cache is preserved on install failures and restored on promotion failures.
  - Use Windows `.cmd` shims through `cmd.exe` via a new `resolveSpawnInvocation` helper in the installer and auto-update (including version checks).
  - Rewrite `.mcp.json` paths when promoting temp → final so MCP args reference the installed cache.
  - Tests updated: preserve/restore cache on failure, assert temp install cwd, Windows `cmd.exe` shim resolution, and isolated wrapper env.

<sup>Written for commit d6ed3805e02a1a62f987298426c384b52684afb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

