### PR TITLE
refactor(codex): split config migration helpers

### DIFF
--- a/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config.mjs
@@ -1,44 +1,19 @@
 #!/usr/bin/env node
 
-import { lstat, mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const FALLBACK_CATALOG = {
-	version: "fallback.gpt-5.5-400k",
-	current: {
-		model: "gpt-5.5",
-		model_context_window: 400_000,
-		model_reasoning_effort: "high",
-		plan_mode_reasoning_effort: "xhigh",
-	},
-	roles: {
-		default: {
-			model: "gpt-5.5",
-			model_context_window: 400_000,
-			model_reasoning_effort: "high",
-			plan_mode_reasoning_effort: "xhigh",
-		},
-		verifier: { model: "gpt-5.5", model_reasoning_effort: "xhigh" },
-		worker: { model: "gpt-5.5", model_reasoning_effort: "high" },
-	},
-	managedProfiles: [
-		{
-			version: "legacy.gpt-5.5-1m",
-			match: {
-				model: "gpt-5.5",
-				model_context_window: 1_000_000,
-				model_reasoning_effort: "high",
-				plan_mode_reasoning_effort: "xhigh",
-			},
-		},
-		{ version: "legacy.gpt-5.5-272k", match: { model: "gpt-5.5", model_context_window: 272_000 } },
-	],
-};
+import { FALLBACK_CATALOG, readModelCatalog } from "./migrate-codex-config/catalog.mjs";
+import { configPaths } from "./migrate-codex-config/config-paths.mjs";
+import { ensureCodexReasoningConfig as applyReasoningProfile, readRootSettings } from "./migrate-codex-config/root-settings.mjs";
+import { readState, resolveStatePath, writeState } from "./migrate-codex-config/state.mjs";
 
-const MANAGED_KEYS = ["model", "model_context_window", "model_reasoning_effort", "plan_mode_reasoning_effort"];
+export { readModelCatalog } from "./migrate-codex-config/catalog.mjs";
+
+export function ensureCodexReasoningConfig(config, profile = FALLBACK_CATALOG.current) {
+	return applyReasoningProfile(config, profile);
+}
 
 export async function migrateCodexConfig({ env = process.env, cwd = process.cwd() } = {}) {
 	const catalog = await readModelCatalog(env);
@@ -74,24 +49,6 @@ export async function migrateConfigFile(configPath, { catalog = FALLBACK_CATALOG
 	return { changed: true, written: catalog.current, managed: true };
 }
 
-export function ensureCodexReasoningConfig(config, profile = FALLBACK_CATALOG.current) {
-	let next = replaceOrInsertRootSetting(config, "model", JSON.stringify(profile.model));
-	next = replaceOrInsertRootSetting(next, "model_context_window", profile.model_context_window.toString());
-	next = replaceOrInsertRootSetting(next, "model_reasoning_effort", JSON.stringify(profile.model_reasoning_effort));
-	next = replaceOrInsertRootSetting(next, "plan_mode_reasoning_effort", JSON.stringify(profile.plan_mode_reasoning_effort));
-	return next;
-}
-
-export async function readModelCatalog(env = process.env) {
-	const catalogPath = env.LAZYCODEX_MODEL_CATALOG_PATH?.trim() || join(dirname(fileURLToPath(import.meta.url)), "..", "model-catalog.json");
-	try {
-		return parseCatalog(JSON.parse(await readFile(catalogPath, "utf8"))) ?? FALLBACK_CATALOG;
-	} catch (error) {
-		if (error instanceof Error) return FALLBACK_CATALOG;
-		throw error;
-	}
-}
-
 function shouldApplyCatalog(config, catalog, previousState) {
 	const current = readRootSettings(config);
 	if (Object.keys(current).length === 0) return { apply: true, reason: "empty" };
@@ -113,79 +70,8 @@ function matchesProfile(current, profile) {
 	return true;
 }
 
-function readRootSettings(config) {
-	const settings = {};
-	for (const line of config.split(/\n/)) {
-		if (isSectionHeader(line)) break;
-		for (const key of MANAGED_KEYS) {
-			if (!isRootSetting(line, key)) continue;
-			const value = parseTomlScalar(line.slice(line.indexOf("=") + 1));
-			if (value !== undefined) settings[key] = value;
-		}
-	}
-	return settings;
-}
-
-function parseTomlScalar(value) {
-	const trimmed = value.trim();
-	if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-		try {
-			return JSON.parse(trimmed);
-		} catch (error) {
-			if (error instanceof SyntaxError) return undefined;
-			throw error;
-		}
-	}
-	const numeric = Number(trimmed);
-	return Number.isFinite(numeric) ? numeric : undefined;
-}
-
-function parseCatalog(value) {
-	if (!isRecord(value) || !isRecord(value.current) || !Array.isArray(value.managedProfiles)) return null;
-	if (typeof value.version !== "string" || !isReasoningProfile(value.current)) return null;
-	const managedProfiles = [];
-	for (const profile of value.managedProfiles) {
-		if (!isRecord(profile) || typeof profile.version !== "string" || !isRecord(profile.match)) return null;
-		managedProfiles.push({ version: profile.version, match: profile.match });
-	}
-	return { version: value.version, current: value.current, managedProfiles, roles: isRecord(value.roles) ? value.roles : {} };
-}
-
-function isReasoningProfile(value) {
-	return (
-		isRecord(value) &&
-		typeof value.model === "string" &&
-		typeof value.model_context_window === "number" &&
-		typeof value.model_reasoning_effort === "string" &&
-		typeof value.plan_mode_reasoning_effort === "string"
-	);
-}
-
 function isRecord(value) {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-async function configPaths({ env, cwd }) {
-	const codexHome = resolve(env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
-	const paths = new Set([join(codexHome, "config.toml")]);
-	for (const projectConfig of projectConfigPaths({ cwd, stopAt: homedir() })) {
-		if (!(await isRegularFile(projectConfig))) continue;
-		if (!(await isRegularDirectory(dirname(projectConfig)))) continue;
-		paths.add(projectConfig);
-	}
-	return [...paths];
-}
-
-function projectConfigPaths({ cwd, stopAt }) {
-	const paths = [];
-	let current = resolve(cwd);
-	const stop = resolve(stopAt);
-	while (true) {
-		paths.push(join(current, ".codex", "config.toml"));
-		if (current === stop || current === dirname(current)) break;
-		current = dirname(current);
-	}
-	return paths;
 }
 
 async function readConfig(configPath) {
@@ -195,80 +81,6 @@ async function readConfig(configPath) {
 		if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
 		throw error;
 	}
-}
-
-function resolveStatePath(env) {
-	if (env.LAZYCODEX_MODEL_CATALOG_STATE_PATH?.trim()) return env.LAZYCODEX_MODEL_CATALOG_STATE_PATH;
-	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
-	return join(dataRoot, "model-catalog-state.json");
-}
-
-async function readState(statePath) {
-	try {
-		const parsed = JSON.parse(await readFile(statePath, "utf8"));
-		return isRecord(parsed) ? parsed : {};
-	} catch (error) {
-		if (error instanceof Error) return {};
-		throw error;
-	}
-}
-
-async function writeState(statePath, state) {
-	await mkdir(dirname(statePath), { recursive: true });
-	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
-}
-
-async function isRegularFile(path) {
-	try {
-		return (await lstat(path)).isFile();
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-		throw error;
-	}
-}
-
-async function isRegularDirectory(path) {
-	try {
-		return (await lstat(path)).isDirectory();
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-		throw error;
-	}
-}
-
-function replaceOrInsertRootSetting(config, key, value) {
-	const lines = config.split(/\n/);
-	const output = [];
-	let replaced = false;
-	let inserted = false;
-	for (const line of lines) {
-		if (!inserted && isSectionHeader(line)) {
-			if (!replaced) output.push(`${key} = ${value}`);
-			inserted = true;
-		}
-		if (isRootSetting(line, key)) {
-			if (!replaced) {
-				output.push(`${key} = ${value}`);
-				replaced = true;
-			}
-			continue;
-		}
-		output.push(line);
-	}
-	if (!replaced && !inserted) output.push(`${key} = ${value}`);
-	return output.join("\n");
-}
-
-function isSectionHeader(line) {
-	const trimmed = line.trim();
-	return trimmed.startsWith("[") && trimmed.endsWith("]");
-}
-
-function isRootSetting(line, key) {
-	const trimmed = line.trimStart();
-	if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false;
-	const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
-	return match?.[1] === key;
 }
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/catalog.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/catalog.mjs
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const FALLBACK_CATALOG = {
+	version: "fallback.gpt-5.5-400k",
+	current: {
+		model: "gpt-5.5",
+		model_context_window: 400_000,
+		model_reasoning_effort: "high",
+		plan_mode_reasoning_effort: "xhigh",
+	},
+	roles: {
+		default: {
+			model: "gpt-5.5",
+			model_context_window: 400_000,
+			model_reasoning_effort: "high",
+			plan_mode_reasoning_effort: "xhigh",
+		},
+		verifier: { model: "gpt-5.5", model_reasoning_effort: "xhigh" },
+		worker: { model: "gpt-5.5", model_reasoning_effort: "high" },
+	},
+	managedProfiles: [
+		{
+			version: "legacy.gpt-5.5-1m",
+			match: {
+				model: "gpt-5.5",
+				model_context_window: 1_000_000,
+				model_reasoning_effort: "high",
+				plan_mode_reasoning_effort: "xhigh",
+			},
+		},
+		{ version: "legacy.gpt-5.5-272k", match: { model: "gpt-5.5", model_context_window: 272_000 } },
+	],
+};
+
+export async function readModelCatalog(env = process.env) {
+	const catalogPath =
+		env.LAZYCODEX_MODEL_CATALOG_PATH?.trim() || join(dirname(fileURLToPath(import.meta.url)), "..", "model-catalog.json");
+	try {
+		return parseCatalog(JSON.parse(await readFile(catalogPath, "utf8"))) ?? FALLBACK_CATALOG;
+	} catch (error) {
+		if (error instanceof Error) return FALLBACK_CATALOG;
+		throw error;
+	}
+}
+
+function parseCatalog(value) {
+	if (!isRecord(value) || !isRecord(value.current) || !Array.isArray(value.managedProfiles)) return null;
+	if (typeof value.version !== "string" || !isReasoningProfile(value.current)) return null;
+	const managedProfiles = [];
+	for (const profile of value.managedProfiles) {
+		if (!isRecord(profile) || typeof profile.version !== "string" || !isRecord(profile.match)) return null;
+		managedProfiles.push({ version: profile.version, match: profile.match });
+	}
+	return { version: value.version, current: value.current, managedProfiles, roles: isRecord(value.roles) ? value.roles : {} };
+}
+
+function isReasoningProfile(value) {
+	return (
+		isRecord(value) &&
+		typeof value.model === "string" &&
+		typeof value.model_context_window === "number" &&
+		typeof value.model_reasoning_effort === "string" &&
+		typeof value.plan_mode_reasoning_effort === "string"
+	);
+}
+
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/config-paths.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/config-paths.mjs
@@ -1,0 +1,44 @@
+import { lstat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export async function configPaths({ env, cwd }) {
+	const codexHome = resolve(env.CODEX_HOME?.trim() || join(homedir(), ".codex"));
+	const paths = new Set([join(codexHome, "config.toml")]);
+	for (const projectConfig of projectConfigPaths({ cwd, stopAt: homedir() })) {
+		if (!(await isRegularFile(projectConfig))) continue;
+		if (!(await isRegularDirectory(dirname(projectConfig)))) continue;
+		paths.add(projectConfig);
+	}
+	return [...paths];
+}
+
+function projectConfigPaths({ cwd, stopAt }) {
+	const paths = [];
+	let current = resolve(cwd);
+	const stop = resolve(stopAt);
+	while (true) {
+		paths.push(join(current, ".codex", "config.toml"));
+		if (current === stop || current === dirname(current)) break;
+		current = dirname(current);
+	}
+	return paths;
+}
+
+async function isRegularFile(path) {
+	try {
+		return (await lstat(path)).isFile();
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function isRegularDirectory(path) {
+	try {
+		return (await lstat(path)).isDirectory();
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
@@ -1,0 +1,71 @@
+export const MANAGED_KEYS = ["model", "model_context_window", "model_reasoning_effort", "plan_mode_reasoning_effort"];
+
+export function ensureCodexReasoningConfig(config, profile) {
+	let next = replaceOrInsertRootSetting(config, "model", JSON.stringify(profile.model));
+	next = replaceOrInsertRootSetting(next, "model_context_window", profile.model_context_window.toString());
+	next = replaceOrInsertRootSetting(next, "model_reasoning_effort", JSON.stringify(profile.model_reasoning_effort));
+	next = replaceOrInsertRootSetting(next, "plan_mode_reasoning_effort", JSON.stringify(profile.plan_mode_reasoning_effort));
+	return next;
+}
+
+export function readRootSettings(config) {
+	const settings = {};
+	for (const line of config.split(/\n/)) {
+		if (isSectionHeader(line)) break;
+		for (const key of MANAGED_KEYS) {
+			if (!isRootSetting(line, key)) continue;
+			const value = parseTomlScalar(line.slice(line.indexOf("=") + 1));
+			if (value !== undefined) settings[key] = value;
+		}
+	}
+	return settings;
+}
+
+function parseTomlScalar(value) {
+	const trimmed = value.trim();
+	if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		try {
+			return JSON.parse(trimmed);
+		} catch (error) {
+			if (error instanceof SyntaxError) return undefined;
+			throw error;
+		}
+	}
+	const numeric = Number(trimmed);
+	return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function replaceOrInsertRootSetting(config, key, value) {
+	const lines = config.split(/\n/);
+	const output = [];
+	let replaced = false;
+	let inserted = false;
+	for (const line of lines) {
+		if (!inserted && isSectionHeader(line)) {
+			if (!replaced) output.push(`${key} = ${value}`);
+			inserted = true;
+		}
+		if (isRootSetting(line, key)) {
+			if (!replaced) {
+				output.push(`${key} = ${value}`);
+				replaced = true;
+			}
+			continue;
+		}
+		output.push(line);
+	}
+	if (!replaced && !inserted) output.push(`${key} = ${value}`);
+	return output.join("\n");
+}
+
+function isSectionHeader(line) {
+	const trimmed = line.trim();
+	return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+function isRootSetting(line, key) {
+	const trimmed = line.trimStart();
+	if (trimmed.startsWith("#") || trimmed.startsWith("[")) return false;
+	const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+	return match?.[1] === key;
+}

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/root-settings.mjs
@@ -40,12 +40,14 @@ function replaceOrInsertRootSetting(config, key, value) {
 	const output = [];
 	let replaced = false;
 	let inserted = false;
+	let inRoot = true;
 	for (const line of lines) {
-		if (!inserted && isSectionHeader(line)) {
+		const sectionHeader = isSectionHeader(line);
+		if (inRoot && !inserted && sectionHeader) {
 			if (!replaced) output.push(`${key} = ${value}`);
 			inserted = true;
 		}
-		if (isRootSetting(line, key)) {
+		if (inRoot && isRootSetting(line, key)) {
 			if (!replaced) {
 				output.push(`${key} = ${value}`);
 				replaced = true;
@@ -53,6 +55,7 @@ function replaceOrInsertRootSetting(config, key, value) {
 			continue;
 		}
 		output.push(line);
+		if (sectionHeader) inRoot = false;
 	}
 	if (!replaced && !inserted) output.push(`${key} = ${value}`);
 	return output.join("\n");

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/state.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/state.mjs
@@ -1,0 +1,28 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export function resolveStatePath(env) {
+	if (env.LAZYCODEX_MODEL_CATALOG_STATE_PATH?.trim()) return env.LAZYCODEX_MODEL_CATALOG_STATE_PATH;
+	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
+	return join(dataRoot, "model-catalog-state.json");
+}
+
+export async function readState(statePath) {
+	try {
+		const parsed = JSON.parse(await readFile(statePath, "utf8"));
+		return isRecord(parsed) ? parsed : {};
+	} catch (error) {
+		if (error instanceof Error) return {};
+		throw error;
+	}
+}
+
+export async function writeState(statePath, state) {
+	await mkdir(dirname(statePath), { recursive: true });
+	await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/scripts/migrate-codex-config/state.mjs
+++ b/packages/omo-codex/plugin/scripts/migrate-codex-config/state.mjs
@@ -3,7 +3,8 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 export function resolveStatePath(env) {
-	if (env.LAZYCODEX_MODEL_CATALOG_STATE_PATH?.trim()) return env.LAZYCODEX_MODEL_CATALOG_STATE_PATH;
+	const explicitStatePath = env.LAZYCODEX_MODEL_CATALOG_STATE_PATH?.trim();
+	if (explicitStatePath) return explicitStatePath;
 	const dataRoot = env.PLUGIN_DATA?.trim() || join(homedir(), ".local", "share", "lazycodex");
 	return join(dataRoot, "model-catalog-state.json");
 }

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -134,6 +134,29 @@ test("#given model catalog is unavailable and stale 272k config #when migrating 
 	assert.match(content, /model_context_window = 400000/);
 });
 
+test("#given model catalog is malformed and stale config #when migrating #then fallback catalog still upgrades it", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-malformed-catalog-"));
+	const codexHome = join(root, "codex-home");
+	const catalogPath = join(root, "model-catalog.json");
+	await mkdir(codexHome, { recursive: true });
+	await writeFile(catalogPath, "{not-json");
+	await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.5"\nmodel_context_window = 272000\n');
+
+	const result = await migrateCodexConfig({
+		env: {
+			CODEX_HOME: codexHome,
+			LAZYCODEX_MODEL_CATALOG_PATH: catalogPath,
+			LAZYCODEX_MODEL_CATALOG_STATE_PATH: join(root, "model-state.json"),
+		},
+		cwd: root,
+	});
+
+	const content = await readFile(join(codexHome, "config.toml"), "utf8");
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
+	assert.match(content, /model = "gpt-5\.5"/);
+	assert.match(content, /model_context_window = 400000/);
+});
+
 test("#given user-customized Codex model config #when migrating #then user values are preserved", async () => {
 	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-custom-"));
 	const codexHome = join(root, "codex-home");
@@ -160,6 +183,26 @@ test("#given user-customized Codex model config #when migrating #then user value
 	assert.match(content, /model_context_window = 123456/);
 	assert.match(content, /model_reasoning_effort = "medium"/);
 	assert.match(content, /plan_mode_reasoning_effort = "medium"/);
+});
+
+test("#given managed config state is malformed #when migrating #then migration ignores stale state safely", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-malformed-state-"));
+	const codexHome = join(root, "codex-home");
+	const statePath = join(root, "model-state.json");
+	await mkdir(codexHome, { recursive: true });
+	await writeFile(statePath, "[broken-json");
+	await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.5"\nmodel_context_window = 272000\n');
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: statePath },
+		cwd: root,
+	});
+
+	const content = await readFile(join(codexHome, "config.toml"), "utf8");
+	const state = JSON.parse(await readFile(statePath, "utf8"));
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
+	assert.match(content, /model_context_window = 400000/);
+	assert.equal(state.files[join(codexHome, "config.toml")].managed, true);
 });
 
 test("#given managed catalog state #when catalog version advances #then only previously managed config is updated", async () => {

--- a/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
+++ b/packages/omo-codex/plugin/test/migrate-codex-config.test.mjs
@@ -32,6 +32,29 @@ test("#given stale root reasoning config #when ensuring config #then replaces st
 	assert.match(result, /\[features\]/);
 });
 
+test("#given section settings reuse managed root keys #when ensuring config #then section settings are preserved", () => {
+	const result = ensureCodexReasoningConfig(
+		[
+			'model = "gpt-5.5"',
+			"model_context_window = 272000",
+			"",
+			"[model_providers.openai]",
+			'model = "provider-scoped-value"',
+			"model_context_window = 123456",
+			"",
+			"[profiles.review]",
+			'model_reasoning_effort = "medium"',
+			'plan_mode_reasoning_effort = "medium"',
+			"",
+		].join("\n"),
+	);
+
+	assert.match(result, /^model = "gpt-5\.5"$/m);
+	assert.match(result, /^model_context_window = 400000$/m);
+	assert.match(result, /\[model_providers\.openai\]\nmodel = "provider-scoped-value"\nmodel_context_window = 123456/);
+	assert.match(result, /\[profiles\.review\]\nmodel_reasoning_effort = "medium"\nplan_mode_reasoning_effort = "medium"/);
+});
+
 test("#given project .codex is a symlink #when migrating #then project config is skipped", async (t) => {
 	if (!(await canCreateSymlink("dir"))) t.skip("symbolic links are unavailable in this environment");
 
@@ -202,6 +225,23 @@ test("#given managed config state is malformed #when migrating #then migration i
 	const state = JSON.parse(await readFile(statePath, "utf8"));
 	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
 	assert.match(content, /model_context_window = 400000/);
+	assert.equal(state.files[join(codexHome, "config.toml")].managed, true);
+});
+
+test("#given managed config state path has surrounding whitespace #when migrating #then trimmed state path is used", async () => {
+	const root = await mkdtemp(join(tmpdir(), "lazycodex-config-trimmed-state-"));
+	const codexHome = join(root, "codex-home");
+	const statePath = join(root, "model-state.json");
+	await mkdir(codexHome, { recursive: true });
+	await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.5"\nmodel_context_window = 272000\n');
+
+	const result = await migrateCodexConfig({
+		env: { CODEX_HOME: codexHome, LAZYCODEX_MODEL_CATALOG_STATE_PATH: `  ${statePath}  ` },
+		cwd: root,
+	});
+
+	const state = JSON.parse(await readFile(statePath, "utf8"));
+	assert.deepEqual(result.changed, [join(codexHome, "config.toml")]);
 	assert.equal(state.files[join(codexHome, "config.toml")].managed, true);
 });
 


### PR DESCRIPTION
## Summary
Refactors `packages/omo-codex/plugin/scripts/migrate-codex-config.mjs` into cohesive helper modules while preserving the public script entrypoint and import surface.

## Changes
- Extracts model catalog parsing/fallback handling, config path discovery, root TOML setting edits, and migration state persistence into focused modules.
- Keeps `migrate-codex-config.mjs` as the CLI/public orchestrator and preserves exported `migrateCodexConfig`, `migrateConfigFile`, `ensureCodexReasoningConfig`, and `readModelCatalog`.
- Adds characterization tests for malformed model catalog JSON and malformed managed state JSON.

## Testing
- `node --test packages/omo-codex/plugin/test/migrate-codex-config.test.mjs`
- `npm ci` in `packages/omo-codex/plugin`
- `npm test` in `packages/omo-codex/plugin` (83 pass, 1 skip)
- `git submodule update --init packages/lsp-tools-mcp`
- `bun run build:lsp-tools-mcp`
- `bun install` at repo root to provide workspace deps
- `npm run build` in `packages/omo-codex/plugin`
- Manual QA: temp `CODEX_HOME` + temp project `.codex/config.toml`, ran `node packages/omo-codex/plugin/scripts/migrate-codex-config.mjs` from temp project and verified both configs upgraded plus state file entries
- `git diff --check`

## Notes
- `migrate-codex-config.mjs` drops from 252 pure LOC to 79; extracted helper files are 66, 40, 65, and 24 pure LOC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `migrate-codex-config.mjs` into focused helper modules while keeping the CLI entrypoint and exported API the same. Improves readability, testability, and preserves section-scoped settings during migration.

- **Refactors**
  - Extracted helpers: `catalog.mjs`, `config-paths.mjs`, `root-settings.mjs`, `state.mjs`.
  - `migrate-codex-config.mjs` stays as the CLI/orchestrator and still exports `migrateCodexConfig`, `migrateConfigFile`, `ensureCodexReasoningConfig`, `readModelCatalog`.

- **Bug Fixes**
  - Update only root keys and preserve provider/profile sections when applying managed settings.
  - Fall back to `FALLBACK_CATALOG` when the model catalog JSON is missing or malformed.
  - Ignore malformed managed state JSON and proceed safely; write back valid state.
  - Trim whitespace in `LAZYCODEX_MODEL_CATALOG_STATE_PATH` before use.

<sup>Written for commit 5a28619cacab354861ecace8e4c161ece2eb464c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Pre-existing bugfix note
Cubic identified two migration behaviors that were already present in the original monolithic `migrate-codex-config.mjs` on `origin/dev` before this split: section-local settings with managed root key names could be dropped by `replaceOrInsertRootSetting`, and `LAZYCODEX_MODEL_CATALOG_STATE_PATH` was checked with `trim()` but returned untrimmed.

The follow-up commit keeps the split explicit and adds regression coverage for both pre-existing bugs: section-level settings are preserved, and whitespace-padded state-path env values resolve to the trimmed path.
