### PR TITLE
refactor(plugin): split event facade

### DIFF
--- a/src/plugin/event-compaction-agent.test.ts
+++ b/src/plugin/event-compaction-agent.test.ts
@@ -53,8 +53,10 @@ describe("createEventHandler compaction agent filtering", () => {
     _resetForTesting()
     clearSessionModel("ses_compaction_poisoning")
     clearSessionModel("ses_compaction_model_poisoning")
+    clearSessionModel("ses_compaction_trim_poisoning")
     clearSessionPromptParams("ses_compaction_poisoning")
     clearSessionPromptParams("ses_compaction_model_poisoning")
+    clearSessionPromptParams("ses_compaction_trim_poisoning")
   })
 
   it("does not overwrite the stored session agent with compaction", async () => {
@@ -99,6 +101,38 @@ describe("createEventHandler compaction agent filtering", () => {
             sessionID,
             role: "user",
             agent: "compaction",
+            providerID: "anthropic",
+            modelID: "claude-opus-4-1",
+            time: { created: Date.now() },
+          },
+        },
+      },
+    }
+
+    // when
+    await eventHandler(input)
+
+    // then
+    expect(getSessionModel(sessionID)).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+  })
+
+  it("does not overwrite the stored session model with whitespace around compaction marker", async () => {
+    // given
+    const sessionID = "ses_compaction_trim_poisoning"
+    setSessionModel(sessionID, { providerID: "openai", modelID: "gpt-5" })
+    const eventHandler = createMinimalEventHandler()
+    const input: Parameters<ReturnType<typeof createEventHandler>>[0] = {
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg-compaction-trim",
+            sessionID,
+            role: "user",
+            agent: " compaction ",
             providerID: "anthropic",
             modelID: "claude-opus-4-1",
             time: { created: Date.now() },

--- a/src/plugin/event-error-utils.test.ts
+++ b/src/plugin/event-error-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test"
+
+import { extractErrorMessage } from "./event"
+import { resolveFallbackAgentName } from "./event-error-utils"
+
+describe("event error utilities", () => {
+  it("#given nested string error payload #when extracting message #then returns the nested provider message", () => {
+    // given
+    const error = { data: { error: "quota exhausted for model" }, message: "top-level wrapper" }
+
+    // when
+    const message = extractErrorMessage(error)
+
+    // then
+    expect(message).toBe("quota exhausted for model")
+  })
+
+  it("#given mixed-case GPT model error #when resolving fallback agent #then chooses hephaestus", () => {
+    // given
+    const sessionID = "ses_uppercase_gpt"
+
+    // when
+    const agentName = resolveFallbackAgentName({
+      sessionID,
+      mainSessionID: sessionID,
+      message: "All credentials for model GPT-5.5 are cooling down",
+    })
+
+    // then
+    expect(agentName).toBe("hephaestus")
+  })
+})

--- a/src/plugin/event-error-utils.ts
+++ b/src/plugin/event-error-utils.ts
@@ -1,0 +1,78 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeFallbackModelID(modelID: string): string {
+  return modelID
+    .replace(/-thinking$/i, "")
+    .replace(/-max$/i, "")
+    .replace(/-high$/i, "");
+}
+
+export function extractErrorName(error: unknown): string | undefined {
+  if (isRecord(error) && typeof error.name === "string") return error.name;
+  if (error instanceof Error) return error.name;
+  return undefined;
+}
+
+export function extractErrorMessage(error: unknown): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+
+  if (isRecord(error)) {
+    const candidates: unknown[] = [
+      error.data,
+      isRecord(error.data) ? error.data.error : undefined,
+      error.error,
+      error.cause,
+      error,
+    ];
+
+    for (const candidate of candidates) {
+      if (isRecord(candidate) && typeof candidate.message === "string" && candidate.message.length > 0) {
+        return candidate.message;
+      }
+    }
+  }
+
+  if (error instanceof Error) return error.message;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function extractProviderModelFromErrorMessage(message: string): { providerID?: string; modelID?: string } {
+  const lower = message.toLowerCase();
+
+  const providerModel = lower.match(/model\s+not\s+found:\s*([a-z0-9_-]+)\s*\/\s*([a-z0-9._-]+)/i);
+  if (providerModel) {
+    return {
+      providerID: providerModel[1],
+      modelID: providerModel[2],
+    };
+  }
+
+  const modelOnly = lower.match(/unknown\s+provider\s+for\s+model\s+([a-z0-9._-]+)/i);
+  if (modelOnly) {
+    return {
+      modelID: modelOnly[1],
+    };
+  }
+
+  return {};
+}
+
+export function resolveFallbackAgentName(params: {
+  currentAgent?: string;
+  sessionID: string;
+  mainSessionID?: string;
+  message: string;
+}): string | undefined {
+  if (params.currentAgent) return params.currentAgent;
+  if (params.sessionID !== params.mainSessionID) return undefined;
+  if (params.message.includes("gpt-5")) return "hephaestus";
+  return "sisyphus";
+}

--- a/src/plugin/event-error-utils.ts
+++ b/src/plugin/event-error-utils.ts
@@ -29,6 +29,9 @@ export function extractErrorMessage(error: unknown): string {
     ];
 
     for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.length > 0) {
+        return candidate;
+      }
       if (isRecord(candidate) && typeof candidate.message === "string" && candidate.message.length > 0) {
         return candidate.message;
       }
@@ -73,6 +76,6 @@ export function resolveFallbackAgentName(params: {
 }): string | undefined {
   if (params.currentAgent) return params.currentAgent;
   if (params.sessionID !== params.mainSessionID) return undefined;
-  if (params.message.includes("gpt-5")) return "hephaestus";
+  if (params.message.toLowerCase().includes("gpt-5")) return "hephaestus";
   return "sisyphus";
 }

--- a/src/plugin/event-hook-dispatcher.ts
+++ b/src/plugin/event-hook-dispatcher.ts
@@ -1,0 +1,69 @@
+import type { CreatedHooks } from "../create-hooks";
+import { log } from "../shared/logger";
+import { resolveMessageEventSessionID, resolveSessionEventID } from "../shared/event-session-id";
+import { isRecord } from "./event-error-utils";
+import type { EventInput, EventHookRunner } from "./event-types";
+
+export function getEventSessionID(input: EventInput): string | undefined {
+  const properties = input.event.properties;
+  if (input.event.type.startsWith("session.")) {
+    return resolveSessionEventID(properties);
+  }
+  if (input.event.type.startsWith("message.") || input.event.type.startsWith("tool.")) {
+    return resolveMessageEventSessionID(properties);
+  }
+  const record: Record<string, unknown> | undefined = isRecord(properties) ? properties : undefined;
+  const sessionID = record?.sessionID;
+  return typeof sessionID === "string" && sessionID.length > 0 ? sessionID : undefined;
+}
+
+export function createEventHookRunner(): EventHookRunner {
+  return async (hookName, handler, input): Promise<void> => {
+    if (!handler) return;
+
+    try {
+      await Promise.resolve(handler(input));
+    } catch (error) {
+      log("[event] hook execution failed", {
+        hook: hookName,
+        eventType: input.event.type,
+        sessionID: getEventSessionID(input),
+        error: error instanceof Error ? error : String(error),
+      });
+    }
+  };
+}
+
+export function createEventHookDispatcher(hooks: CreatedHooks, runEventHookSafely: EventHookRunner) {
+  return async (input: EventInput): Promise<void> => {
+    await runEventHookSafely("autoUpdateChecker", hooks.autoUpdateChecker?.event, input);
+    await runEventHookSafely("legacyPluginToast", hooks.legacyPluginToast?.event, input);
+    await runEventHookSafely("claudeCodeHooks", hooks.claudeCodeHooks?.event, input);
+    await runEventHookSafely("backgroundNotificationHook", hooks.backgroundNotificationHook?.event, input);
+    await runEventHookSafely("sessionNotification", hooks.sessionNotification, input);
+    await runEventHookSafely("todoContinuationEnforcer", hooks.todoContinuationEnforcer?.handler, input);
+    await runEventHookSafely("unstableAgentBabysitter", hooks.unstableAgentBabysitter?.event, input);
+    await runEventHookSafely("preemptiveCompaction", hooks.preemptiveCompaction?.event, input);
+    await runEventHookSafely("directoryAgentsInjector", hooks.directoryAgentsInjector?.event, input);
+    await runEventHookSafely("directoryReadmeInjector", hooks.directoryReadmeInjector?.event, input);
+    await runEventHookSafely("rulesInjector", hooks.rulesInjector?.event, input);
+    await runEventHookSafely("hephaestusAgentsMdInjector", hooks.hephaestusAgentsMdInjector?.event, input);
+    await runEventHookSafely("thinkMode", hooks.thinkMode?.event, input);
+    await runEventHookSafely(
+      "anthropicContextWindowLimitRecovery",
+      hooks.anthropicContextWindowLimitRecovery?.event,
+      input,
+    );
+    await runEventHookSafely("runtimeFallback", hooks.runtimeFallback?.event, input);
+    await runEventHookSafely("agentUsageReminder", hooks.agentUsageReminder?.event, input);
+    await runEventHookSafely("categorySkillReminder", hooks.categorySkillReminder?.event, input);
+    await runEventHookSafely("interactiveBashSession", hooks.interactiveBashSession?.event, input);
+    await runEventHookSafely("ralphLoop", hooks.ralphLoop?.event, input);
+    await runEventHookSafely("stopContinuationGuard", hooks.stopContinuationGuard?.event, input);
+    await runEventHookSafely("compactionContextInjector", hooks.compactionContextInjector?.event, input);
+    await runEventHookSafely("compactionTodoPreserver", hooks.compactionTodoPreserver?.event, input);
+    await runEventHookSafely("writeExistingFileGuard", hooks.writeExistingFileGuard?.event, input);
+    await runEventHookSafely("atlasHook", hooks.atlasHook?.handler, input);
+    await runEventHookSafely("autoSlashCommand", hooks.autoSlashCommand?.event, input);
+  };
+}

--- a/src/plugin/event-model-fallback-state.ts
+++ b/src/plugin/event-model-fallback-state.ts
@@ -1,0 +1,241 @@
+import type { OhMyOpenCodeConfig } from "../config";
+import { resolveRegisteredAgentName } from "../features/claude-code-session-state";
+import type { ModelFallbackHook } from "../hooks/model-fallback/hook";
+import { setSessionFallbackChain } from "../hooks/model-fallback/hook";
+import { getRawFallbackModels } from "../hooks/runtime-fallback/fallback-models";
+import {
+  dispatchInternalPrompt,
+  isInternalPromptDispatchAccepted,
+  releasePromptAsyncReservation,
+} from "../hooks/shared/prompt-async-gate";
+import { createInternalAgentContinuationTextPart } from "../shared";
+import { getAgentConfigKey } from "../shared/agent-display-names";
+import { readConnectedProvidersCache } from "../shared/connected-providers-cache";
+import { buildFallbackChainFromModels } from "../shared/fallback-chain-from-models";
+import { isAmbiguousPostDispatchPromptFailure } from "../shared/prompt-failure-classifier";
+import { getSessionModel } from "../shared/session-model-state";
+import { log } from "../shared/logger";
+import type { PluginEventContext } from "./event-types";
+
+export type FallbackContinuationContext = {
+  agentName?: string;
+  providerID?: string;
+  dedupeProviderID?: string;
+  modelID?: string;
+};
+
+type FallbackContinuationDedupeKeys = {
+  modelKey?: string;
+  providerModelKey?: string;
+};
+
+type FallbackContinuationDedupeState = {
+  modelKeys: Set<string>;
+  providerModelKeys: Set<string>;
+  providerlessModelKeys: Set<string>;
+};
+
+export function applyUserConfiguredFallbackChain(
+  modelFallback: Pick<ModelFallbackHook, "setSessionFallbackChain"> | null | undefined,
+  sessionID: string,
+  agentName: string,
+  currentProviderID: string,
+  pluginConfig: OhMyOpenCodeConfig,
+): void {
+  const agentKey = getAgentConfigKey(agentName);
+  const rawFallbackModels = getRawFallbackModels(sessionID, agentKey, pluginConfig);
+  if (!rawFallbackModels || rawFallbackModels.length === 0) return;
+
+  const fallbackChain = buildFallbackChainFromModels(rawFallbackModels, currentProviderID);
+
+  if (fallbackChain && fallbackChain.length > 0 && modelFallback) {
+    setSessionFallbackChain(modelFallback, sessionID, fallbackChain);
+  }
+}
+
+export function createModelFallbackContinuationController(args: {
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  lastKnownModelBySession: Map<string, { providerID: string; modelID: string }>;
+  continuationsInFlight: Set<string>;
+  lastDispatchedContinuationKeys: Map<string, FallbackContinuationDedupeState>;
+}) {
+  const { pluginConfig, pluginContext, lastKnownModelBySession, continuationsInFlight } = args;
+  const lastDispatchedContinuationKeys = args.lastDispatchedContinuationKeys;
+
+  const resolveFallbackProviderID = (sessionID: string, providerHint?: string): string => {
+    const normalizedProviderHint = providerHint?.trim();
+    if (normalizedProviderHint) return normalizedProviderHint;
+
+    const sessionModel = getSessionModel(sessionID);
+    if (sessionModel?.providerID) return sessionModel.providerID;
+
+    const lastKnownModel = lastKnownModelBySession.get(sessionID);
+    if (lastKnownModel?.providerID) return lastKnownModel.providerID;
+
+    const connectedProvider = readConnectedProvidersCache()?.[0];
+    if (connectedProvider) return connectedProvider;
+
+    return "opencode";
+  };
+
+  const getFallbackContinuationKeys = (
+    fallbackContext?: FallbackContinuationContext,
+  ): FallbackContinuationDedupeKeys => {
+    const agentKey = fallbackContext?.agentName
+      ? getAgentConfigKey(fallbackContext.agentName).trim().toLowerCase()
+      : "";
+    const providerID = fallbackContext?.dedupeProviderID?.trim().toLowerCase() ?? "";
+    const modelID = fallbackContext?.modelID?.trim().toLowerCase() ?? "";
+
+    if (!agentKey || !modelID) return {};
+
+    return {
+      modelKey: `${agentKey}:${modelID}`,
+      ...(providerID ? { providerModelKey: `${agentKey}:${providerID}:${modelID}` } : {}),
+    };
+  };
+
+  const getDedupeState = (sessionID: string): FallbackContinuationDedupeState => {
+    const existingState = lastDispatchedContinuationKeys.get(sessionID);
+    if (existingState) return existingState;
+
+    const state = {
+      modelKeys: new Set<string>(),
+      providerModelKeys: new Set<string>(),
+      providerlessModelKeys: new Set<string>(),
+    };
+    lastDispatchedContinuationKeys.set(sessionID, state);
+    return state;
+  };
+
+  const wasAlreadyDispatched = (
+    state: FallbackContinuationDedupeState | undefined,
+    keys: FallbackContinuationDedupeKeys,
+  ): boolean => {
+    if (!state || !keys.modelKey) return false;
+    if (!keys.providerModelKey) return state.modelKeys.has(keys.modelKey);
+    return state.providerModelKeys.has(keys.providerModelKey) || state.providerlessModelKeys.has(keys.modelKey);
+  };
+
+  const shouldSkipFallbackContinuation = (
+    sessionID: string,
+    source: string,
+    fallbackContext?: FallbackContinuationContext,
+  ): boolean => {
+    const fallbackKeys = getFallbackContinuationKeys(fallbackContext);
+
+    if (continuationsInFlight.has(sessionID)) {
+      log("[event] model-fallback continuation skipped because one is already in flight", { sessionID, source });
+      return true;
+    }
+
+    const lastDispatchedKeys = lastDispatchedContinuationKeys.get(sessionID);
+    if (wasAlreadyDispatched(lastDispatchedKeys, fallbackKeys)) {
+      log("[event] model-fallback continuation skipped because matching fallback was already dispatched", {
+        sessionID,
+        source,
+      });
+      return true;
+    }
+
+    return false;
+  };
+
+  const markDispatched = (sessionID: string, fallbackContext?: FallbackContinuationContext): void => {
+    const fallbackKeys = getFallbackContinuationKeys(fallbackContext);
+    if (!fallbackKeys.modelKey) return;
+
+    const dispatchedKeys = getDedupeState(sessionID);
+    dispatchedKeys.modelKeys.add(fallbackKeys.modelKey);
+    if (fallbackKeys.providerModelKey) {
+      dispatchedKeys.providerModelKeys.add(fallbackKeys.providerModelKey);
+    } else {
+      dispatchedKeys.providerlessModelKeys.add(fallbackKeys.modelKey);
+    }
+  };
+
+  const autoContinueAfterFallback = async (
+    sessionID: string,
+    source: string,
+    fallbackContext?: FallbackContinuationContext,
+  ): Promise<void> => {
+    if (shouldSkipFallbackContinuation(sessionID, source, fallbackContext)) return;
+
+    continuationsInFlight.add(sessionID);
+    let dispatched = false;
+    try {
+      try {
+        await pluginContext.client.session.abort({ path: { id: sessionID } });
+      } catch (error) {
+        log("[event] model-fallback abort failed", {
+          sessionID,
+          source,
+          error: error instanceof Error ? error : String(error),
+        });
+        return;
+      }
+      releasePromptAsyncReservation(sessionID, `model-fallback-abort:${source}`, {
+        reservedBy: [`model-fallback:${source}`, `model-fallback:${source}:sync`],
+        reservedByPrefix: "model-fallback:",
+      });
+
+      const launchAgent = fallbackContext?.agentName
+        ? resolveRegisteredAgentName(fallbackContext.agentName)
+        : undefined;
+      const launchModel = fallbackContext?.providerID && fallbackContext?.modelID
+        ? { providerID: fallbackContext.providerID, modelID: fallbackContext.modelID }
+        : undefined;
+      const agentConfigKey = fallbackContext?.agentName ? getAgentConfigKey(fallbackContext.agentName) : undefined;
+      const agentSettings = agentConfigKey
+        ? pluginConfig.agents?.[agentConfigKey as keyof NonNullable<typeof pluginConfig.agents>]
+        : undefined;
+      const launchVariant = (agentSettings as { variant?: string } | undefined)?.variant;
+      const promptBody = {
+        path: { id: sessionID },
+        body: {
+          ...(launchAgent ? { agent: launchAgent } : {}),
+          ...(launchModel ? { model: launchModel } : {}),
+          ...(launchVariant ? { variant: launchVariant } : {}),
+          parts: [createInternalAgentContinuationTextPart("continue")],
+        },
+        query: { directory: pluginContext.directory },
+      };
+
+      const mode = typeof pluginContext.client.session.promptAsync === "function" ? "async" : "sync";
+      const promptResult = await dispatchInternalPrompt({
+        mode,
+        client: pluginContext.client,
+        sessionID,
+        source: mode === "async" ? `model-fallback:${source}` : `model-fallback:${source}:sync`,
+        queueBehavior: "defer",
+        input: promptBody,
+      });
+      if (isInternalPromptDispatchAccepted(promptResult)) {
+        dispatched = true;
+      } else if (promptResult.status === "failed") {
+        if (isAmbiguousPostDispatchPromptFailure(promptResult)) dispatched = true;
+        log(`[event] model-fallback ${mode === "async" ? "promptAsync" : "prompt"} failed`, {
+          sessionID,
+          source,
+          error: promptResult.error,
+        });
+      } else {
+        log(`[event] model-fallback ${mode === "async" ? "promptAsync" : "prompt"} skipped by gate`, {
+          sessionID,
+          source,
+          status: promptResult.status,
+        });
+      }
+    } finally {
+      if (dispatched) markDispatched(sessionID, fallbackContext);
+      continuationsInFlight.delete(sessionID);
+    }
+  };
+
+  return {
+    autoContinueAfterFallback,
+    resolveFallbackProviderID,
+    shouldSkipFallbackContinuation,
+  };
+}

--- a/src/plugin/event-model-fallback.ts
+++ b/src/plugin/event-model-fallback.ts
@@ -1,0 +1,233 @@
+import type { OhMyOpenCodeConfig } from "../config";
+import { getMainSessionID, getSessionAgent } from "../features/claude-code-session-state";
+import {
+  clearPendingModelFallback,
+  clearSessionFallbackChain,
+  setPendingModelFallback,
+  type ModelFallbackHook,
+} from "../hooks/model-fallback/hook";
+import { shouldRetryError } from "../shared/model-error-classifier";
+import { extractRetryAttempt, normalizeRetryStatusMessage } from "../shared/retry-status-utils";
+import {
+  extractErrorMessage,
+  extractErrorName,
+  extractProviderModelFromErrorMessage,
+  normalizeFallbackModelID,
+  resolveFallbackAgentName,
+} from "./event-error-utils";
+import {
+  applyUserConfiguredFallbackChain,
+  createModelFallbackContinuationController,
+  type FallbackContinuationContext,
+} from "./event-model-fallback-state";
+import type { PluginEventContext } from "./event-types";
+
+export function createModelFallbackEventHandler(args: {
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  modelFallback: ModelFallbackHook | null | undefined;
+  isModelFallbackEnabled: boolean;
+  isRuntimeFallbackEnabled: boolean;
+  shouldAutoRetrySession: (sessionID: string) => boolean;
+  isSessionStopped: (sessionID: string) => boolean;
+}) {
+  const lastHandledModelErrorMessageID = new Map<string, string>();
+  const lastHandledRetryStatusKey = new Map<string, string>();
+  const lastKnownModelBySession = new Map<string, { providerID: string; modelID: string }>();
+  const continuationsInFlight = new Set<string>();
+  const lastDispatchedContinuationKeys = new Map<
+    string,
+    {
+      modelKeys: Set<string>;
+      providerModelKeys: Set<string>;
+      providerlessModelKeys: Set<string>;
+    }
+  >();
+  const continuation = createModelFallbackContinuationController({
+    pluginConfig: args.pluginConfig,
+    pluginContext: args.pluginContext,
+    lastKnownModelBySession,
+    continuationsInFlight,
+    lastDispatchedContinuationKeys,
+  });
+
+  const clearSession = (sessionID: string): void => {
+    lastHandledModelErrorMessageID.delete(sessionID);
+    lastHandledRetryStatusKey.delete(sessionID);
+    lastKnownModelBySession.delete(sessionID);
+    continuationsInFlight.delete(sessionID);
+    lastDispatchedContinuationKeys.delete(sessionID);
+    if (args.modelFallback) {
+      clearPendingModelFallback(args.modelFallback, sessionID);
+      clearSessionFallbackChain(args.modelFallback, sessionID);
+    }
+  };
+
+  const clearRetryDedupeAfterIdle = (sessionID: string): void => {
+    lastHandledRetryStatusKey.delete(sessionID);
+    lastDispatchedContinuationKeys.delete(sessionID);
+  };
+
+  const setLastKnownModel = (sessionID: string, model: { providerID: string; modelID: string }): void => {
+    lastKnownModelBySession.set(sessionID, model);
+  };
+
+  const applyFallback = async (
+    sessionID: string,
+    source: string,
+    agentName: string,
+    currentProvider: string,
+    currentModel: string,
+    shouldAutoContinue: boolean,
+    fallbackContext: FallbackContinuationContext,
+  ): Promise<void> => {
+    if (shouldAutoContinue && continuation.shouldSkipFallbackContinuation(sessionID, source, fallbackContext)) return;
+
+    applyUserConfiguredFallbackChain(args.modelFallback, sessionID, agentName, currentProvider, args.pluginConfig);
+    const setFallback = args.modelFallback
+      ? setPendingModelFallback(args.modelFallback, sessionID, agentName, currentProvider, currentModel)
+      : false;
+
+    if (setFallback && shouldAutoContinue) {
+      await continuation.autoContinueAfterFallback(sessionID, source, fallbackContext);
+    }
+  };
+
+  const shouldHandleModelFallback = (): boolean => {
+    return args.isModelFallbackEnabled && !args.isRuntimeFallbackEnabled;
+  };
+
+  const handleAssistantMessageUpdated = async (params: {
+    sessionID: string;
+    info: Record<string, unknown>;
+    agent?: string;
+  }): Promise<boolean> => {
+    if (!shouldHandleModelFallback()) return false;
+
+    const assistantMessageID = params.info.id as string | undefined;
+    const assistantError = params.info.error;
+    if (!assistantMessageID || !assistantError) return false;
+
+    const lastHandled = lastHandledModelErrorMessageID.get(params.sessionID);
+    if (lastHandled === assistantMessageID) return true;
+
+    const errorName = extractErrorName(assistantError);
+    const errorMessage = extractErrorMessage(assistantError);
+    if (!shouldRetryError({ name: errorName, message: errorMessage })) return false;
+
+    const agentName = resolveFallbackAgentName({
+      currentAgent: params.agent ?? getSessionAgent(params.sessionID),
+      sessionID: params.sessionID,
+      mainSessionID: getMainSessionID(),
+      message: errorMessage,
+    });
+    if (!agentName) return false;
+
+    const providerHint = params.info.providerID as string | undefined;
+    const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, providerHint);
+    const rawModel = (params.info.modelID as string | undefined) ?? "claude-opus-4-7";
+    const currentModel = normalizeFallbackModelID(rawModel);
+    const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: providerHint, modelID: currentModel };
+    const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);
+
+    await applyFallback(
+      params.sessionID,
+      "message.updated",
+      agentName,
+      currentProvider,
+      currentModel,
+      shouldAutoContinue,
+      fallbackContext,
+    );
+    if (shouldAutoContinue) lastHandledModelErrorMessageID.set(params.sessionID, assistantMessageID);
+    return false;
+  };
+
+  const handleSessionStatus = async (params: {
+    sessionID: string;
+    status?: { type?: string; attempt?: number; message?: string; next?: number };
+  }): Promise<boolean> => {
+    if (params.status?.type === "idle") clearRetryDedupeAfterIdle(params.sessionID);
+    if (params.status?.type !== "retry" || !shouldHandleModelFallback()) return false;
+
+    const retryMessage = typeof params.status.message === "string" ? params.status.message : "";
+    const parsedForKey = extractProviderModelFromErrorMessage(retryMessage);
+    const retryAttempt = extractRetryAttempt(params.status.attempt, retryMessage);
+    const retryKey = `${retryAttempt}:${parsedForKey.providerID ?? ""}/${parsedForKey.modelID ?? ""}:${normalizeRetryStatusMessage(retryMessage)}`;
+    if (lastHandledRetryStatusKey.get(params.sessionID) === retryKey) return true;
+    lastHandledRetryStatusKey.set(params.sessionID, retryKey);
+
+    if (!shouldRetryError({ name: undefined, message: retryMessage })) return false;
+
+    const agentName = resolveFallbackAgentName({
+      currentAgent: getSessionAgent(params.sessionID),
+      sessionID: params.sessionID,
+      mainSessionID: getMainSessionID(),
+      message: retryMessage,
+    });
+    if (!agentName) return false;
+
+    const parsed = extractProviderModelFromErrorMessage(retryMessage);
+    const lastKnown = lastKnownModelBySession.get(params.sessionID);
+    const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, parsed.providerID);
+    const currentModel = normalizeFallbackModelID(parsed.modelID ?? lastKnown?.modelID ?? "claude-opus-4-7");
+    const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: parsed.providerID, modelID: currentModel };
+    const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);
+
+    await applyFallback(
+      params.sessionID,
+      "session.status",
+      agentName,
+      currentProvider,
+      currentModel,
+      shouldAutoContinue,
+      fallbackContext,
+    );
+    return false;
+  };
+
+  const handleSessionError = async (params: {
+    sessionID: string;
+    errorMessage: string;
+    errorName?: string;
+    props?: Record<string, unknown>;
+  }): Promise<void> => {
+    if (!shouldHandleModelFallback() || !shouldRetryError({ name: params.errorName, message: params.errorMessage })) return;
+
+    const agentName = resolveFallbackAgentName({
+      currentAgent: getSessionAgent(params.sessionID),
+      sessionID: params.sessionID,
+      mainSessionID: getMainSessionID(),
+      message: params.errorMessage,
+    });
+    if (!agentName) return;
+
+    const parsed = extractProviderModelFromErrorMessage(params.errorMessage);
+    const providerHint = (params.props?.providerID as string | undefined) || parsed.providerID;
+    const currentProvider = continuation.resolveFallbackProviderID(params.sessionID, providerHint);
+    const currentModel = normalizeFallbackModelID(
+      (params.props?.modelID as string | undefined) || parsed.modelID || "claude-opus-4-7",
+    );
+    const fallbackContext = { agentName, providerID: currentProvider, dedupeProviderID: providerHint, modelID: currentModel };
+    const shouldAutoContinue = args.shouldAutoRetrySession(params.sessionID) && !args.isSessionStopped(params.sessionID);
+
+    await applyFallback(
+      params.sessionID,
+      "session.error",
+      agentName,
+      currentProvider,
+      currentModel,
+      shouldAutoContinue,
+      fallbackContext,
+    );
+  };
+
+  return {
+    clearRetryDedupeAfterIdle,
+    clearSession,
+    handleAssistantMessageUpdated,
+    handleSessionError,
+    handleSessionStatus,
+    setLastKnownModel,
+  };
+}

--- a/src/plugin/event-session-lifecycle.ts
+++ b/src/plugin/event-session-lifecycle.ts
@@ -30,7 +30,7 @@ export const TMUX_ACTIVITY_EVENT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 export function isCompactionAgent(agent: string): boolean {
-  return agent.toLowerCase() === "compaction";
+  return agent.trim().toLowerCase() === "compaction";
 }
 
 export async function dispatchOpenClawSessionEvent(args: {

--- a/src/plugin/event-session-lifecycle.ts
+++ b/src/plugin/event-session-lifecycle.ts
@@ -1,0 +1,158 @@
+import {
+  clearSessionAgent,
+  getMainSessionID,
+  setMainSession,
+  subagentSessions,
+  syncSubagentSessions,
+  updateSessionAgent,
+} from "../features/claude-code-session-state";
+import {
+  clearBackgroundOutputConsumptionsForParentSession,
+  clearBackgroundOutputConsumptionsForTaskSession,
+  restoreBackgroundOutputConsumption,
+} from "../shared/background-output-consumption";
+import { resetMessageCursor } from "../shared";
+import { clearSessionModel, setSessionModel } from "../shared/session-model-state";
+import { clearSessionPromptParams } from "../shared/session-prompt-params-state";
+import { deleteSessionTools } from "../shared/session-tools-store";
+import { dispatchOpenClawEvent } from "../openclaw/runtime-dispatch";
+import { resolveMessageEventSessionID, resolveSessionEventID } from "../shared/event-session-id";
+import type { OhMyOpenCodeConfig } from "../config";
+import type { Managers } from "../create-managers";
+import type { FirstMessageVariantGate, PluginEventContext } from "./event-types";
+
+export const TMUX_ACTIVITY_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "message.updated",
+  "message.part.updated",
+  "message.part.delta",
+  "message.part.removed",
+  "message.removed",
+]);
+
+export function isCompactionAgent(agent: string): boolean {
+  return agent.toLowerCase() === "compaction";
+}
+
+export async function dispatchOpenClawSessionEvent(args: {
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  managers: Managers;
+  rawEvent: string;
+  sessionID: string;
+}): Promise<void> {
+  if (!args.pluginConfig.openclaw) return;
+
+  await dispatchOpenClawEvent({
+    config: args.pluginConfig.openclaw,
+    rawEvent: args.rawEvent,
+    context: {
+      sessionId: args.sessionID,
+      projectPath: args.pluginContext.directory,
+      tmuxPaneId: args.managers.tmuxSessionManager.getTrackedPaneId?.(args.sessionID) ?? process.env.TMUX_PANE,
+    },
+  });
+}
+
+export async function handleSessionCreatedEvent(args: {
+  event: { type: string; properties?: unknown };
+  props?: Record<string, unknown>;
+  tmuxIntegrationEnabled: boolean;
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  managers: Managers;
+  firstMessageVariantGate: FirstMessageVariantGate;
+}): Promise<void> {
+  const sessionInfo = args.props?.info as { id?: string; title?: string; parentID?: string } | undefined;
+  const sessionID = resolveSessionEventID(args.props);
+  const isSubagentSession = !!sessionInfo?.parentID || !!sessionID && subagentSessions.has(sessionID);
+
+  if (!isSubagentSession) setMainSession(sessionID);
+  args.firstMessageVariantGate.markSessionCreated(sessionInfo);
+
+  if (args.tmuxIntegrationEnabled && !isSubagentSession) {
+    await args.managers.tmuxSessionManager.onSessionCreated(
+      args.event as {
+        type: string;
+        properties?: { info?: { id?: string; parentID?: string; title?: string } };
+      },
+    );
+  }
+
+  if (sessionID && !isSubagentSession) {
+    await dispatchOpenClawSessionEvent({ ...args, rawEvent: args.event.type, sessionID });
+  }
+}
+
+export async function handleSessionDeletedEvent(args: {
+  props?: Record<string, unknown>;
+  tmuxIntegrationEnabled: boolean;
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  managers: Managers;
+  firstMessageVariantGate: FirstMessageVariantGate;
+  clearModelFallbackSession: (sessionID: string) => void;
+  clearUserAbortRecovery: (sessionID: string) => void;
+}): Promise<void> {
+  const sessionID = resolveSessionEventID(args.props);
+  if (sessionID === getMainSessionID()) setMainSession(undefined);
+  if (!sessionID) return;
+
+  const wasSyncSubagentSession = syncSubagentSessions.has(sessionID);
+  clearSessionAgent(sessionID);
+  args.clearModelFallbackSession(sessionID);
+  args.clearUserAbortRecovery(sessionID);
+  resetMessageCursor(sessionID);
+  clearBackgroundOutputConsumptionsForParentSession(sessionID);
+  clearBackgroundOutputConsumptionsForTaskSession(sessionID);
+  args.firstMessageVariantGate.clear(sessionID);
+  clearSessionModel(sessionID);
+  clearSessionPromptParams(sessionID);
+  syncSubagentSessions.delete(sessionID);
+  await dispatchOpenClawSessionEvent({ ...args, rawEvent: "session.deleted", sessionID });
+  if (wasSyncSubagentSession) subagentSessions.delete(sessionID);
+  deleteSessionTools(sessionID);
+  await args.managers.skillMcpManager.disconnectSession(sessionID);
+  if (args.tmuxIntegrationEnabled) await args.managers.tmuxSessionManager.onSessionDeleted({ sessionID });
+}
+
+export function handleMessageRemovedEvent(props?: Record<string, unknown>): void {
+  const messageID = props?.messageID as string | undefined;
+  const sessionID = resolveMessageEventSessionID(props);
+  restoreBackgroundOutputConsumption(sessionID, messageID);
+}
+
+export function handleMessageUpdatedSessionState(args: {
+  props?: Record<string, unknown>;
+  noteSessionModel: (sessionID: string, model: { providerID: string; modelID: string }) => void;
+  clearUserAbortRecovery: (sessionID: string) => void;
+  noteAssistantError: (sessionID: string, error: unknown) => void;
+}): {
+  info: Record<string, unknown> | undefined;
+  sessionID: string | undefined;
+  agent: string | undefined;
+  role: string | undefined;
+} {
+  const info = args.props?.info as Record<string, unknown> | undefined;
+  const sessionID = resolveMessageEventSessionID(args.props);
+  const agent = info?.agent as string | undefined;
+  const role = info?.role as string | undefined;
+
+  if (sessionID && role === "user") {
+    const isCompactionMessage = agent ? isCompactionAgent(agent) : false;
+    if (agent && !isCompactionMessage) {
+      updateSessionAgent(sessionID, agent);
+    }
+    const providerID = info?.providerID as string | undefined;
+    const modelID = info?.modelID as string | undefined;
+    if (providerID && modelID && !isCompactionMessage) {
+      args.noteSessionModel(sessionID, { providerID, modelID });
+      setSessionModel(sessionID, { providerID, modelID });
+    }
+    args.clearUserAbortRecovery(sessionID);
+  }
+  if (sessionID && role === "assistant") {
+    args.noteAssistantError(sessionID, info?.error);
+  }
+
+  return { info, sessionID, agent, role };
+}

--- a/src/plugin/event-session-recovery.ts
+++ b/src/plugin/event-session-recovery.ts
@@ -1,0 +1,68 @@
+import { getMainSessionID } from "../features/claude-code-session-state";
+import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../hooks/shared/prompt-async-gate";
+import { createInternalAgentContinuationTextPart } from "../shared";
+import { log } from "../shared/logger";
+import { isAmbiguousPostDispatchPromptFailure } from "../shared/prompt-failure-classifier";
+import type { CreatedHooks } from "../create-hooks";
+import type { PluginEventContext } from "./event-types";
+
+export async function handleRecoverableSessionError(args: {
+  hooks: CreatedHooks;
+  pluginContext: PluginEventContext;
+  sessionID?: string;
+  messageID?: string;
+  error: unknown;
+}): Promise<boolean> {
+  if (!args.hooks.sessionRecovery?.isRecoverableError(args.error)) return false;
+
+  const recovered = await args.hooks.sessionRecovery.handleSessionRecovery({
+    id: args.messageID,
+    role: "assistant",
+    sessionID: args.sessionID,
+    error: args.error,
+  });
+
+  if (
+    recovered &&
+    args.sessionID &&
+    args.sessionID === getMainSessionID() &&
+    !args.hooks.stopContinuationGuard?.isStopped(args.sessionID)
+  ) {
+    await args.pluginContext.client.session
+      .summarize({
+        path: { id: args.sessionID },
+        body: { auto: true },
+        query: { directory: args.pluginContext.directory },
+      })
+      .catch((err: unknown) => {
+        log("[event] compaction before recovery continue failed:", { sessionID: args.sessionID, error: err });
+      });
+
+    const promptResult = await dispatchInternalPrompt({
+      mode: "sync",
+      client: args.pluginContext.client,
+      sessionID: args.sessionID,
+      source: "session-recovery:post-compaction-continue",
+      queueBehavior: "defer",
+      input: {
+        path: { id: args.sessionID },
+        body: { parts: [createInternalAgentContinuationTextPart("continue")] },
+        query: { directory: args.pluginContext.directory },
+      },
+    });
+    if (promptResult.status === "failed") {
+      if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
+        log("[event] recovery continue prompt may have been accepted before ambiguous failure", {
+          sessionID: args.sessionID,
+          error: promptResult.error,
+        });
+      } else {
+        log("[event] recovery continue prompt failed", { sessionID: args.sessionID, error: promptResult.error });
+      }
+    } else if (!isInternalPromptDispatchAccepted(promptResult)) {
+      log("[event] recovery continue prompt skipped by gate", { sessionID: args.sessionID, status: promptResult.status });
+    }
+  }
+
+  return true;
+}

--- a/src/plugin/event-team-handlers.test.ts
+++ b/src/plugin/event-team-handlers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+
+import { createEventTeamHandlers } from "./event-team-handlers"
+import { unsafeTestValue } from "../../test-support/unsafe-test-value"
+
+describe("createEventTeamHandlers", () => {
+  it("#given team mode without promptAsync #when creating handlers #then idle wake hint handler is still installed", () => {
+    // given
+    const pluginConfig = unsafeTestValue({
+      team_mode: {
+        enabled: true,
+      },
+    })
+    const pluginContext = unsafeTestValue({
+      directory: "/tmp",
+      client: {
+        session: {},
+      },
+    })
+    const managers = unsafeTestValue({
+      tmuxSessionManager: {},
+      backgroundManager: {},
+    })
+
+    // when
+    const handlers = createEventTeamHandlers({ pluginConfig, pluginContext, managers })
+
+    // then
+    expect(handlers.teamIdleWakeHint).toBeFunction()
+  })
+})

--- a/src/plugin/event-team-handlers.ts
+++ b/src/plugin/event-team-handlers.ts
@@ -1,0 +1,38 @@
+import { createTeamIdleWakeHint } from "../hooks/team-session-events/team-idle-wake-hint";
+import { createTeamLeadOrphanHandler } from "../hooks/team-session-events/team-lead-orphan-handler";
+import { createTeamMemberErrorHandler } from "../hooks/team-session-events/team-member-error-handler";
+import { createTeamMemberStatusHandler } from "../hooks/team-session-events/team-member-status-handler";
+import { buildTeamIdleWakeHintClient } from "./build-team-idle-wake-hint-client";
+import type { OhMyOpenCodeConfig } from "../config";
+import type { Managers } from "../create-managers";
+import type { PluginEventContext } from "./event-types";
+
+export function createEventTeamHandlers(args: {
+  pluginConfig: OhMyOpenCodeConfig;
+  pluginContext: PluginEventContext;
+  managers: Managers;
+}) {
+  const teamModeConfig = args.pluginConfig.team_mode?.enabled ? args.pluginConfig.team_mode : undefined;
+  const teamLeadOrphanHandler = teamModeConfig
+    ? createTeamLeadOrphanHandler(teamModeConfig, args.managers.tmuxSessionManager, args.managers.backgroundManager)
+    : undefined;
+  const teamMemberErrorHandler = teamModeConfig
+    ? createTeamMemberErrorHandler(teamModeConfig, { client: args.pluginContext.client })
+    : undefined;
+  const teamMemberStatusHandler = teamModeConfig
+    ? createTeamMemberStatusHandler(teamModeConfig)
+    : undefined;
+  const teamIdleWakeHint = teamModeConfig && typeof args.pluginContext.client.session?.promptAsync === "function"
+    ? createTeamIdleWakeHint({
+        directory: args.pluginContext.directory,
+        client: buildTeamIdleWakeHintClient(args.pluginContext.client),
+      }, teamModeConfig)
+    : undefined;
+
+  return {
+    teamIdleWakeHint,
+    teamLeadOrphanHandler,
+    teamMemberErrorHandler,
+    teamMemberStatusHandler,
+  };
+}

--- a/src/plugin/event-team-handlers.ts
+++ b/src/plugin/event-team-handlers.ts
@@ -22,7 +22,7 @@ export function createEventTeamHandlers(args: {
   const teamMemberStatusHandler = teamModeConfig
     ? createTeamMemberStatusHandler(teamModeConfig)
     : undefined;
-  const teamIdleWakeHint = teamModeConfig && typeof args.pluginContext.client.session?.promptAsync === "function"
+  const teamIdleWakeHint = teamModeConfig
     ? createTeamIdleWakeHint({
         directory: args.pluginContext.directory,
         client: buildTeamIdleWakeHintClient(args.pluginContext.client),

--- a/src/plugin/event-types.ts
+++ b/src/plugin/event-types.ts
@@ -1,4 +1,4 @@
-import type { CreatedHooks } from "../create-hooks";
+import type { Event } from "@opencode-ai/sdk";
 import type { PluginContext } from "./types";
 
 export type FirstMessageVariantGate = {
@@ -6,7 +6,7 @@ export type FirstMessageVariantGate = {
   clear: (sessionID: string) => void;
 };
 
-export type EventInput = Parameters<NonNullable<NonNullable<CreatedHooks["writeExistingFileGuard"]>["event"]>>[0];
+export type EventInput = { event: Event };
 
 type InternalTextPart = {
   type: "text";

--- a/src/plugin/event-types.ts
+++ b/src/plugin/event-types.ts
@@ -1,0 +1,56 @@
+import type { CreatedHooks } from "../create-hooks";
+import type { PluginContext } from "./types";
+
+export type FirstMessageVariantGate = {
+  markSessionCreated: (sessionInfo: { id?: string; title?: string; parentID?: string } | undefined) => void;
+  clear: (sessionID: string) => void;
+};
+
+export type EventInput = Parameters<NonNullable<NonNullable<CreatedHooks["writeExistingFileGuard"]>["event"]>>[0];
+
+type InternalTextPart = {
+  type: "text";
+  text: string;
+  synthetic?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+type InternalPromptInput = {
+  path: { id: string };
+  body: {
+    parts: InternalTextPart[];
+    agent?: string;
+    model?: { providerID: string; modelID: string };
+    variant?: string;
+  };
+  query: { directory: string };
+};
+
+export type PluginEventContext = PluginContext & {
+  directory: string;
+  client: {
+    session: {
+      abort: (input: { path: { id: string } }) => Promise<unknown>;
+      promptAsync?: (input: InternalPromptInput) => Promise<unknown>;
+      prompt: (input: InternalPromptInput) => Promise<unknown>;
+      summarize: {
+        (input: {
+          path: { id: string };
+          body: { providerID: string; modelID: string; auto?: boolean };
+          query: { directory: string };
+        }): Promise<unknown>;
+        (input: {
+          path: { id: string };
+          body: { auto: boolean };
+          query: { directory: string };
+        }): Promise<unknown>;
+      };
+    };
+  };
+};
+
+export type EventHookRunner = (
+  hookName: string,
+  handler: ((input: EventInput) => unknown | Promise<unknown>) | null | undefined,
+  input: EventInput,
+) => Promise<void>;

--- a/src/plugin/event.model-fallback.test.ts
+++ b/src/plugin/event.model-fallback.test.ts
@@ -628,6 +628,89 @@ describe("createEventHandler - model fallback", () => {
     expect(promptCalls).toEqual([sessionID])
   })
 
+  test("re-handles the same retry key after session recovers through session.idle", async () => {
+    //#given
+    const sessionID = "ses_status_retry_real_idle_reset"
+    setMainSession(sessionID)
+    const modelFallback = createModelFallbackHook()
+    clearPendingModelFallback(modelFallback, sessionID)
+    const { handler, abortCalls, promptCalls } = createHandler({ hooks: { modelFallback } })
+    const chatMessageHandler = createChatMessageHandler({
+      ctx: unsafeTestValue({
+        client: {
+          tui: {
+            showToast: async () => ({}),
+          },
+        },
+      }),
+      pluginConfig: unsafeTestValue({}),
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+      },
+      hooks: unsafeTestValue({
+        modelFallback,
+        stopContinuationGuard: null,
+        keywordDetector: null,
+        claudeCodeHooks: null,
+        autoSlashCommand: null,
+        startWork: null,
+        ralphLoop: null,
+      }),
+    })
+    const retryStatus = {
+      type: "session.status",
+      properties: {
+        sessionID,
+        status: {
+          type: "retry",
+          attempt: 1,
+          message:
+            "All credentials for model claude-opus-4-7-thinking are cooling down [retrying in ~5 days attempt #1]",
+          next: 300,
+        },
+      },
+    }
+
+    await handler({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_user_status_idle_reset",
+            sessionID,
+            role: "user",
+            modelID: "claude-opus-4-7-thinking",
+            providerID: "anthropic",
+            agent: "Sisyphus - Ultraworker",
+          },
+        },
+      },
+    })
+
+    //#when
+    await handler({ event: retryStatus })
+    await chatMessageHandler(
+      {
+        sessionID,
+        agent: "sisyphus",
+        model: { providerID: "anthropic", modelID: "claude-opus-4-7-thinking" },
+      },
+      { message: {}, parts: [] },
+    )
+    await handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID },
+      },
+    })
+    await handler({ event: retryStatus })
+
+    //#then
+    expect(abortCalls).toEqual([sessionID, sessionID])
+    expect(promptCalls).toEqual([sessionID, sessionID])
+  })
+
   test("does not leave stale pending fallback when a providerless duplicate arrives after fallback was applied", async () => {
     //#given
     const sessionID = "ses_model_fallback_duplicate_surface"

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -1889,4 +1889,83 @@ describe("createEventHandler - session recovery compaction", () => {
 		expect(runtimeFallbackCalls).toHaveLength(1)
 		expect(runtimeFallbackCalls[0]?.event.type).toBe("session.error")
 	})
+
+	it("preserves hook fan-out order while isolating individual hook failures", async () => {
+		const calls: string[] = []
+
+		const eventHandler = createEventHandler({
+			ctx: asEventHandlerContext({
+				directory: "/tmp",
+				client: {
+					session: {
+						abort: async () => ({}),
+						prompt: async () => ({}),
+					},
+				},
+			}),
+			pluginConfig: asPluginConfig({}),
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: createEventHandlerManagers(),
+			hooks: createEventHandlerHooks({
+				autoUpdateChecker: {
+					event: async () => {
+						calls.push("autoUpdateChecker")
+					},
+				},
+				legacyPluginToast: {
+					event: async () => {
+						calls.push("legacyPluginToast")
+						throw new Error("toast failed")
+					},
+				},
+				claudeCodeHooks: {
+					event: async () => {
+						calls.push("claudeCodeHooks")
+					},
+				},
+				backgroundNotificationHook: {
+					event: async () => {
+						calls.push("backgroundNotificationHook")
+					},
+				},
+				sessionNotification: async () => {
+					calls.push("sessionNotification")
+				},
+				runtimeFallback: {
+					event: async () => {
+						calls.push("runtimeFallback")
+					},
+				},
+				writeExistingFileGuard: {
+					event: async () => {
+						calls.push("writeExistingFileGuard")
+					},
+				},
+				stopContinuationGuard: { isStopped: () => false },
+			}),
+		})
+
+		await eventHandler(asEventHandlerInput({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID: "ses_hook_order",
+					error: { name: "Error", message: "retry me" },
+				},
+			},
+		}))
+
+		expect(calls).toEqual([
+			"autoUpdateChecker",
+			"legacyPluginToast",
+			"claudeCodeHooks",
+			"backgroundNotificationHook",
+			"sessionNotification",
+			"runtimeFallback",
+			"writeExistingFileGuard",
+		])
+	})
 })

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -1,175 +1,33 @@
-import type { OhMyOpenCodeConfig } from "../config";
 import type { PluginInput } from "@opencode-ai/plugin";
-import type { PluginContext } from "./types";
-
-import {
-  clearSessionAgent,
-  getMainSessionID,
-  getSessionAgent,
-  resolveRegisteredAgentName,
-  setMainSession,
-  subagentSessions,
-  syncSubagentSessions,
-  updateSessionAgent,
-} from "../features/claude-code-session-state";
-import {
-  clearPendingModelFallback,
-  clearSessionFallbackChain,
-  setSessionFallbackChain,
-  setPendingModelFallback,
-  type ModelFallbackHook,
-} from "../hooks/model-fallback/hook";
-import { getRawFallbackModels } from "../hooks/runtime-fallback/fallback-models";
-import {
-  clearBackgroundOutputConsumptionsForParentSession,
-  clearBackgroundOutputConsumptionsForTaskSession,
-  restoreBackgroundOutputConsumption,
-} from "../shared/background-output-consumption";
-import { createInternalAgentContinuationTextPart, resetMessageCursor } from "../shared";
-import { getAgentConfigKey } from "../shared/agent-display-names";
-import { readConnectedProvidersCache } from "../shared/connected-providers-cache";
-import { invalidateContextWindowUsageCache } from "../shared/dynamic-truncator";
-import { log } from "../shared/logger";
-import { isAmbiguousPostDispatchPromptFailure } from "../shared/prompt-failure-classifier";
-import { shouldRetryError } from "../shared/model-error-classifier";
-import { buildFallbackChainFromModels } from "../shared/fallback-chain-from-models";
-import { extractRetryAttempt, normalizeRetryStatusMessage } from "../shared/retry-status-utils";
-import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state";
-import { clearSessionPromptParams } from "../shared/session-prompt-params-state";
-import { deleteSessionTools } from "../shared/session-tools-store";
-import { dispatchOpenClawEvent } from "../openclaw/runtime-dispatch";
-import { createTeamIdleWakeHint } from "../hooks/team-session-events/team-idle-wake-hint";
-import { buildTeamIdleWakeHintClient } from "./build-team-idle-wake-hint-client";
-import { createTeamLeadOrphanHandler } from "../hooks/team-session-events/team-lead-orphan-handler";
-import { createTeamMemberErrorHandler } from "../hooks/team-session-events/team-member-error-handler";
-import { createTeamMemberStatusHandler } from "../hooks/team-session-events/team-member-status-handler";
-import {
-  dispatchInternalPrompt,
-  isInternalPromptDispatchAccepted,
-  releasePromptAsyncReservation,
-} from "../hooks/shared/prompt-async-gate";
-
+import type { OhMyOpenCodeConfig } from "../config";
 import type { CreatedHooks } from "../create-hooks";
 import type { Managers } from "../create-managers";
-import { pruneRecentSyntheticIdles } from "./recent-synthetic-idles";
+import type { PluginContext } from "./types";
+
+import { getMainSessionID, subagentSessions, syncSubagentSessions } from "../features/claude-code-session-state";
+import { invalidateContextWindowUsageCache } from "../shared/dynamic-truncator";
+import { resolveSessionEventID } from "../shared/event-session-id";
+import { log } from "../shared/logger";
 import { normalizeSessionStatusToIdle } from "./session-status-normalizer";
-import { resolveMessageEventSessionID, resolveSessionEventID } from "../shared/event-session-id";
+import { pruneRecentSyntheticIdles } from "./recent-synthetic-idles";
 import { createUserAbortInterruptedRecoveryGuard } from "./user-abort-interrupted-recovery-guard";
+import { extractErrorMessage, extractErrorName } from "./event-error-utils";
+import { createEventHookDispatcher, createEventHookRunner, getEventSessionID } from "./event-hook-dispatcher";
+import { createModelFallbackEventHandler } from "./event-model-fallback";
+import {
+  dispatchOpenClawSessionEvent,
+  handleMessageRemovedEvent,
+  handleMessageUpdatedSessionState,
+  handleSessionCreatedEvent,
+  handleSessionDeletedEvent,
+  TMUX_ACTIVITY_EVENT_TYPES,
+} from "./event-session-lifecycle";
+import { handleRecoverableSessionError } from "./event-session-recovery";
+import { createEventTeamHandlers } from "./event-team-handlers";
+import type { EventInput, FirstMessageVariantGate, PluginEventContext } from "./event-types";
 
-type FirstMessageVariantGate = {
-  markSessionCreated: (sessionInfo: { id?: string; title?: string; parentID?: string } | undefined) => void;
-  clear: (sessionID: string) => void;
-};
+export { extractErrorMessage } from "./event-error-utils";
 
-type FallbackContinuationDedupeKeys = {
-  modelKey?: string;
-  providerModelKey?: string;
-};
-
-type FallbackContinuationDedupeState = {
-  modelKeys: Set<string>;
-  providerModelKeys: Set<string>;
-  providerlessModelKeys: Set<string>;
-};
-
-type FallbackContinuationContext = {
-  agentName?: string;
-  providerID?: string;
-  dedupeProviderID?: string;
-  modelID?: string;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function normalizeFallbackModelID(modelID: string): string {
-  return modelID
-    .replace(/-thinking$/i, "")
-    .replace(/-max$/i, "")
-    .replace(/-high$/i, "");
-}
-
-function extractErrorName(error: unknown): string | undefined {
-  if (isRecord(error) && typeof error.name === "string") return error.name;
-  if (error instanceof Error) return error.name;
-  return undefined;
-}
-
-export function extractErrorMessage(error: unknown): string {
-  if (!error) return "";
-  if (typeof error === "string") return error;
-
-  if (isRecord(error)) {
-    const candidates: unknown[] = [
-      error.data,
-      isRecord(error.data) ? error.data.error : undefined,
-      error.error,
-      error.cause,
-      error,
-    ];
-
-    for (const candidate of candidates) {
-      if (isRecord(candidate) && typeof candidate.message === "string" && candidate.message.length > 0) {
-        return candidate.message;
-      }
-    }
-  }
-
-  if (error instanceof Error) return error.message;
-
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-function extractProviderModelFromErrorMessage(message: string): { providerID?: string; modelID?: string } {
-  const lower = message.toLowerCase();
-
-  const providerModel = lower.match(/model\s+not\s+found:\s*([a-z0-9_-]+)\s*\/\s*([a-z0-9._-]+)/i);
-  if (providerModel) {
-    return {
-      providerID: providerModel[1],
-      modelID: providerModel[2],
-    };
-  }
-
-  const modelOnly = lower.match(/unknown\s+provider\s+for\s+model\s+([a-z0-9._-]+)/i);
-  if (modelOnly) {
-    return {
-      modelID: modelOnly[1],
-    };
-  }
-
-  return {};
-}
-function applyUserConfiguredFallbackChain(
-  modelFallback: Pick<ModelFallbackHook, "setSessionFallbackChain"> | null | undefined,
-  sessionID: string,
-  agentName: string,
-  currentProviderID: string,
-  pluginConfig: OhMyOpenCodeConfig,
-): void {
-  const agentKey = getAgentConfigKey(agentName);
-  const rawFallbackModels = getRawFallbackModels(sessionID, agentKey, pluginConfig);
-  if (!rawFallbackModels || rawFallbackModels.length === 0) return;
-
-  const fallbackChain = buildFallbackChainFromModels(rawFallbackModels, currentProviderID);
-
-  if (fallbackChain && fallbackChain.length > 0) {
-    if (modelFallback) {
-      setSessionFallbackChain(modelFallback, sessionID, fallbackChain);
-    }
-  }
-}
-
-function isCompactionAgent(agent: string): boolean {
-  return agent.toLowerCase() === "compaction";
-}
-
-type EventInput = Parameters<NonNullable<NonNullable<CreatedHooks["writeExistingFileGuard"]>["event"]>>[0];
 export function createEventHandler(args: {
   ctx: PluginContext;
   pluginConfig: OhMyOpenCodeConfig;
@@ -179,219 +37,52 @@ export function createEventHandler(args: {
 }): (input: EventInput) => Promise<void> {
   const { ctx, pluginConfig, firstMessageVariantGate, managers, hooks } = args;
   const tmuxIntegrationEnabled = pluginConfig.tmux?.enabled ?? false;
-  const pluginContext = ctx as PluginContext & {
-    directory: string;
-    client: {
-      session: {
-        abort: (input: { path: { id: string } }) => Promise<unknown>;
-        promptAsync?: (input: {
-          path: { id: string };
-          body: {
-            parts: Array<{
-              type: "text";
-              text: string;
-              synthetic?: boolean;
-              metadata?: Record<string, unknown>;
-            }>;
-            agent?: string;
-            model?: { providerID: string; modelID: string };
-            variant?: string;
-          };
-          query: { directory: string };
-        }) => Promise<unknown>;
-        prompt: (input: {
-          path: { id: string };
-          body: {
-            parts: Array<{
-              type: "text";
-              text: string;
-              synthetic?: boolean;
-              metadata?: Record<string, unknown>;
-            }>;
-            agent?: string;
-            model?: { providerID: string; modelID: string };
-            variant?: string;
-          };
-          query: { directory: string };
-        }) => Promise<unknown>;
-        summarize: {
-          (input: {
-            path: { id: string };
-            body: { providerID: string; modelID: string; auto?: boolean };
-            query: { directory: string };
-          }): Promise<unknown>;
-          (input: {
-            path: { id: string };
-            body: { auto: boolean };
-            query: { directory: string };
-          }): Promise<unknown>;
-        };
-      };
-    };
-  };
+  const pluginContext = ctx as PluginEventContext;
   const isRuntimeFallbackEnabled =
     hooks.runtimeFallback !== null &&
     hooks.runtimeFallback !== undefined &&
-    (typeof args.pluginConfig.runtime_fallback === "boolean"
-      ? args.pluginConfig.runtime_fallback
-      : (args.pluginConfig.runtime_fallback?.enabled ?? false));
-
-  const isModelFallbackEnabled =
-    hooks.modelFallback !== null && hooks.modelFallback !== undefined;
-  const modelFallback = hooks.modelFallback;
-
-  // Avoid triggering multiple abort+continue cycles for the same failing assistant message.
-  const lastHandledModelErrorMessageID = new Map<string, string>();
-  const lastHandledRetryStatusKey = new Map<string, string>();
-  const lastKnownModelBySession = new Map<string, { providerID: string; modelID: string }>();
-  const modelFallbackContinuationsInFlight = new Set<string>();
-  const lastDispatchedModelFallbackContinuationKeys = new Map<string, FallbackContinuationDedupeState>();
+    (typeof pluginConfig.runtime_fallback === "boolean"
+      ? pluginConfig.runtime_fallback
+      : (pluginConfig.runtime_fallback?.enabled ?? false));
+  const isModelFallbackEnabled = hooks.modelFallback !== null && hooks.modelFallback !== undefined;
   const userAbortInterruptedRecoveryGuard = createUserAbortInterruptedRecoveryGuard();
-
-  const resolveFallbackProviderID = (sessionID: string, providerHint?: string): string => {
-    const normalizedProviderHint = providerHint?.trim();
-    if (normalizedProviderHint) {
-      return normalizedProviderHint;
-    }
-
-    const sessionModel = getSessionModel(sessionID);
-    if (sessionModel?.providerID) {
-      return sessionModel.providerID;
-    }
-
-    const lastKnownModel = lastKnownModelBySession.get(sessionID);
-    if (lastKnownModel?.providerID) {
-      return lastKnownModel.providerID;
-    }
-
-    const connectedProvider = readConnectedProvidersCache()?.[0];
-    if (connectedProvider) {
-      return connectedProvider;
-    }
-
-    return "opencode";
-  };
-
-  const getEventSessionID = (input: EventInput): string | undefined => {
-    const properties = input.event.properties;
-    if (input.event.type.startsWith("session.")) {
-      return resolveSessionEventID(properties);
-    }
-    if (input.event.type.startsWith("message.") || input.event.type.startsWith("tool.")) {
-      return resolveMessageEventSessionID(properties);
-    }
-    const record: Record<string, unknown> | undefined = isRecord(properties) ? properties : undefined;
-    const sessionID = record?.sessionID;
-    return typeof sessionID === "string" && sessionID.length > 0 ? sessionID : undefined;
-  };
-
-  const runEventHookSafely = async (
-    hookName: string,
-    handler: ((input: EventInput) => unknown | Promise<unknown>) | null | undefined,
-    input: EventInput,
-  ): Promise<void> => {
-    if (!handler) return;
-
-    try {
-      await Promise.resolve(handler(input));
-    } catch (error) {
-      log("[event] hook execution failed", {
-        hook: hookName,
-        eventType: input.event.type,
-        sessionID: getEventSessionID(input),
-        error,
-      });
-    }
-  };
-
-  const dispatchToHooks = async (input: EventInput): Promise<void> => {
-    await runEventHookSafely("autoUpdateChecker", hooks.autoUpdateChecker?.event, input);
-    await runEventHookSafely("legacyPluginToast", hooks.legacyPluginToast?.event, input);
-    await runEventHookSafely("claudeCodeHooks", hooks.claudeCodeHooks?.event, input);
-    await runEventHookSafely("backgroundNotificationHook", hooks.backgroundNotificationHook?.event, input);
-    await runEventHookSafely("sessionNotification", hooks.sessionNotification, input);
-    await runEventHookSafely("todoContinuationEnforcer", hooks.todoContinuationEnforcer?.handler, input);
-    await runEventHookSafely("unstableAgentBabysitter", hooks.unstableAgentBabysitter?.event, input);
-    await runEventHookSafely("preemptiveCompaction", hooks.preemptiveCompaction?.event, input);
-    await runEventHookSafely("directoryAgentsInjector", hooks.directoryAgentsInjector?.event, input);
-    await runEventHookSafely("directoryReadmeInjector", hooks.directoryReadmeInjector?.event, input);
-    await runEventHookSafely("rulesInjector", hooks.rulesInjector?.event, input);
-    await runEventHookSafely("hephaestusAgentsMdInjector", hooks.hephaestusAgentsMdInjector?.event, input);
-    await runEventHookSafely("thinkMode", hooks.thinkMode?.event, input);
-    await runEventHookSafely(
-      "anthropicContextWindowLimitRecovery",
-      hooks.anthropicContextWindowLimitRecovery?.event,
-      input,
-    );
-    await runEventHookSafely("runtimeFallback", hooks.runtimeFallback?.event, input);
-    await runEventHookSafely("agentUsageReminder", hooks.agentUsageReminder?.event, input);
-    await runEventHookSafely("categorySkillReminder", hooks.categorySkillReminder?.event, input);
-    await runEventHookSafely("interactiveBashSession", hooks.interactiveBashSession?.event, input as EventInput);
-    await runEventHookSafely("ralphLoop", hooks.ralphLoop?.event, input);
-    await runEventHookSafely("stopContinuationGuard", hooks.stopContinuationGuard?.event, input);
-    await runEventHookSafely("compactionContextInjector", hooks.compactionContextInjector?.event, input);
-    await runEventHookSafely("compactionTodoPreserver", hooks.compactionTodoPreserver?.event, input);
-    await runEventHookSafely("writeExistingFileGuard", hooks.writeExistingFileGuard?.event, input);
-    await runEventHookSafely("atlasHook", hooks.atlasHook?.handler, input);
-    await runEventHookSafely("autoSlashCommand", hooks.autoSlashCommand?.event, input);
-  };
-
+  const runEventHookSafely = createEventHookRunner();
+  const dispatchToHooks = createEventHookDispatcher(hooks, runEventHookSafely);
   const recentSyntheticIdles = new Map<string, number>();
   const recentRealIdles = new Map<string, number>();
   const recentAnyIdles = new Map<string, number>();
-  const DEDUP_WINDOW_MS = 500;
-  const teamModeConfig = pluginConfig.team_mode?.enabled ? pluginConfig.team_mode : undefined;
-  const teamLeadOrphanHandler = teamModeConfig
-    ? createTeamLeadOrphanHandler(teamModeConfig, managers.tmuxSessionManager, managers.backgroundManager)
-    : undefined;
-  const teamMemberErrorHandler = teamModeConfig
-    ? createTeamMemberErrorHandler(teamModeConfig, { client: pluginContext.client })
-    : undefined;
-  const teamMemberStatusHandler = teamModeConfig
-    ? createTeamMemberStatusHandler(teamModeConfig)
-    : undefined;
-  const teamIdleWakeHint = teamModeConfig && typeof pluginContext.client.session?.promptAsync === "function"
-    ? createTeamIdleWakeHint({
-        directory: pluginContext.directory,
-        client: buildTeamIdleWakeHintClient(pluginContext.client),
-      }, teamModeConfig)
-    : undefined;
-  const TMUX_ACTIVITY_EVENT_TYPES = new Set([
-    "message.updated",
-    "message.part.updated",
-    "message.part.delta",
-    "message.part.removed",
-    "message.removed",
-  ]);
+  const dedupWindowMs = 500;
+  const teamHandlers = createEventTeamHandlers({ pluginConfig, pluginContext, managers });
 
   const shouldAutoRetrySession = (sessionID: string): boolean => {
     if (syncSubagentSessions.has(sessionID)) return true;
     const mainSessionID = getMainSessionID();
     if (mainSessionID) return sessionID === mainSessionID;
-    // Headless runs (or resumed sessions) may not emit session.created, so mainSessionID can be unset.
-    // In that case, treat any non-subagent session as the "main" interactive session.
     return !subagentSessions.has(sessionID);
   };
 
+  const modelFallbackHandler = createModelFallbackEventHandler({
+    pluginConfig,
+    pluginContext,
+    modelFallback: hooks.modelFallback,
+    isModelFallbackEnabled,
+    isRuntimeFallbackEnabled,
+    shouldAutoRetrySession,
+    isSessionStopped: (sessionID) => hooks.stopContinuationGuard?.isStopped(sessionID) ?? false,
+  });
+
   const shouldDispatchIdleEvent = (sessionID: string, now: number): boolean => {
     const lastDispatchedAt = recentAnyIdles.get(sessionID);
-    if (lastDispatchedAt !== undefined && now - lastDispatchedAt < DEDUP_WINDOW_MS) {
-      return false;
-    }
-
+    if (lastDispatchedAt !== undefined && now - lastDispatchedAt < dedupWindowMs) return false;
     recentAnyIdles.set(sessionID, now);
     return true;
   };
 
   const recoverInterruptedToolResultsOnIdleEvent = async (input: EventInput): Promise<boolean> => {
-    if (input.event.type !== "session.idle") {
-      return false;
-    }
+    if (input.event.type !== "session.idle") return false;
 
     const sessionID = getEventSessionID(input);
-    if (!sessionID || !hooks.sessionRecovery?.handleInterruptedToolResultsOnIdle) {
-      return false;
-    }
+    if (!sessionID || !hooks.sessionRecovery?.handleInterruptedToolResultsOnIdle) return false;
     if (userAbortInterruptedRecoveryGuard.shouldSkipRecovery(sessionID)) {
       log("[event] interrupted tool recovery skipped after user abort", { sessionID });
       return false;
@@ -402,185 +93,30 @@ export function createEventHandler(args: {
 
   const dispatchIdleOnlyHooks = async (input: EventInput): Promise<void> => {
     managers.tmuxSessionManager?.onEvent?.(input.event);
-    await runEventHookSafely("teamIdleWakeHint", teamIdleWakeHint, input);
-    await runEventHookSafely("teamMemberStatusHandler", teamMemberStatusHandler, input);
+    await runEventHookSafely("teamIdleWakeHint", teamHandlers.teamIdleWakeHint, input);
+    await runEventHookSafely("teamMemberStatusHandler", teamHandlers.teamMemberStatusHandler, input);
   };
 
-  const getFallbackContinuationKeys = (fallbackContext?: FallbackContinuationContext): FallbackContinuationDedupeKeys => {
-    const agentKey = fallbackContext?.agentName
-      ? getAgentConfigKey(fallbackContext.agentName).trim().toLowerCase()
-      : "";
-    const providerID = fallbackContext?.dedupeProviderID?.trim().toLowerCase() ?? "";
-    const modelID = fallbackContext?.modelID?.trim().toLowerCase() ?? "";
-
-    if (!agentKey || !modelID) {
-      return {};
-    }
-
-    return {
-      modelKey: `${agentKey}:${modelID}`,
-      ...(providerID ? { providerModelKey: `${agentKey}:${providerID}:${modelID}` } : {}),
-    };
-  };
-
-  const getFallbackContinuationDedupeState = (sessionID: string): FallbackContinuationDedupeState => {
-    const existingState = lastDispatchedModelFallbackContinuationKeys.get(sessionID);
-    if (existingState) {
-      return existingState;
-    }
-
-    const state = {
-      modelKeys: new Set<string>(),
-      providerModelKeys: new Set<string>(),
-      providerlessModelKeys: new Set<string>(),
-    };
-    lastDispatchedModelFallbackContinuationKeys.set(sessionID, state);
-    return state;
-  };
-
-  const wasFallbackContinuationAlreadyDispatched = (
-    state: FallbackContinuationDedupeState | undefined,
-    keys: FallbackContinuationDedupeKeys,
-  ): boolean => {
-    if (!state || !keys.modelKey) {
-      return false;
-    }
-
-    if (!keys.providerModelKey) {
-      return state.modelKeys.has(keys.modelKey);
-    }
-
-    return state.providerModelKeys.has(keys.providerModelKey) || state.providerlessModelKeys.has(keys.modelKey);
-  };
-
-  const shouldSkipFallbackContinuation = (
-    sessionID: string,
-    source: string,
-    fallbackContext?: FallbackContinuationContext,
-  ): boolean => {
-    const fallbackKeys = getFallbackContinuationKeys(fallbackContext);
-
-    if (modelFallbackContinuationsInFlight.has(sessionID)) {
-      log("[event] model-fallback continuation skipped because one is already in flight", { sessionID, source });
-      return true;
-    }
-
-    const lastDispatchedKeys = lastDispatchedModelFallbackContinuationKeys.get(sessionID);
-    if (wasFallbackContinuationAlreadyDispatched(lastDispatchedKeys, fallbackKeys)) {
-      log("[event] model-fallback continuation skipped because matching fallback was already dispatched", {
-        sessionID,
-        source,
-      });
-      return true;
-    }
-
-    return false;
-  };
-
-  const autoContinueAfterFallback = async (
-    sessionID: string,
-    source: string,
-    fallbackContext?: FallbackContinuationContext,
-  ): Promise<void> => {
-    const fallbackKeys = getFallbackContinuationKeys(fallbackContext);
-
-    if (shouldSkipFallbackContinuation(sessionID, source, fallbackContext)) {
+  const dispatchSyntheticIdle = async (syntheticIdle: EventInput): Promise<void> => {
+    const sessionID = (syntheticIdle.event.properties as Record<string, unknown>)?.sessionID as string;
+    const now = Date.now();
+    const emittedAt = recentRealIdles.get(sessionID);
+    if (emittedAt !== undefined && now - emittedAt < dedupWindowMs) {
+      recentRealIdles.delete(sessionID);
       return;
     }
+    recentSyntheticIdles.set(sessionID, now);
+    if (!shouldDispatchIdleEvent(sessionID, now)) return;
 
-    modelFallbackContinuationsInFlight.add(sessionID);
-    let dispatched = false;
-    try {
-      try {
-        await pluginContext.client.session.abort({ path: { id: sessionID } });
-      } catch (error) {
-        log("[event] model-fallback abort failed", { sessionID, source, error });
-        return;
-      }
-      releasePromptAsyncReservation(sessionID, `model-fallback-abort:${source}`, {
-        reservedBy: [`model-fallback:${source}`, `model-fallback:${source}:sync`],
-        reservedByPrefix: "model-fallback:",
-      });
-
-      const launchAgent = fallbackContext?.agentName
-        ? resolveRegisteredAgentName(fallbackContext.agentName)
-        : undefined;
-      const launchModel = fallbackContext?.providerID && fallbackContext?.modelID
-        ? { providerID: fallbackContext.providerID, modelID: fallbackContext.modelID }
-        : undefined;
-
-      const agentConfigKey = fallbackContext?.agentName
-        ? getAgentConfigKey(fallbackContext.agentName)
-        : undefined;
-      const agentSettings = agentConfigKey
-        ? pluginConfig.agents?.[agentConfigKey as keyof NonNullable<typeof pluginConfig.agents>]
-        : undefined;
-      const launchVariant = (agentSettings as { variant?: string } | undefined)?.variant;
-
-      const promptBody = {
-        path: { id: sessionID },
-        body: {
-          ...(launchAgent ? { agent: launchAgent } : {}),
-          ...(launchModel ? { model: launchModel } : {}),
-          ...(launchVariant ? { variant: launchVariant } : {}),
-          parts: [createInternalAgentContinuationTextPart("continue")],
-        },
-        query: { directory: pluginContext.directory },
-      };
-
-      if (typeof pluginContext.client.session.promptAsync === "function") {
-        const promptResult = await dispatchInternalPrompt({
-          mode: "async",
-          client: pluginContext.client,
-          sessionID,
-          source: `model-fallback:${source}`,
-          queueBehavior: "defer",
-          input: promptBody,
-        });
-        if (isInternalPromptDispatchAccepted(promptResult)) {
-          dispatched = true;
-        } else if (promptResult.status === "failed") {
-          if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
-            dispatched = true;
-          }
-          const error = promptResult.error;
-          log("[event] model-fallback promptAsync failed", { sessionID, source, error });
-        } else {
-          log("[event] model-fallback promptAsync skipped by gate", { sessionID, source, status: promptResult.status });
-        }
-        return;
-      }
-
-      const promptResult = await dispatchInternalPrompt({
-        mode: "sync",
-        client: pluginContext.client,
-        sessionID,
-        source: `model-fallback:${source}:sync`,
-        queueBehavior: "defer",
-        input: promptBody,
-      });
-      if (isInternalPromptDispatchAccepted(promptResult)) {
-        dispatched = true;
-      } else if (promptResult.status === "failed") {
-        if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
-          dispatched = true;
-        }
-        log("[event] model-fallback prompt failed", { sessionID, source, error: promptResult.error });
-      } else {
-        log("[event] model-fallback prompt skipped by gate", { sessionID, source, status: promptResult.status });
-      }
-    } finally {
-      if (dispatched && fallbackKeys.modelKey) {
-        const dispatchedKeys = getFallbackContinuationDedupeState(sessionID);
-        dispatchedKeys.modelKeys.add(fallbackKeys.modelKey);
-        if (fallbackKeys.providerModelKey) {
-          dispatchedKeys.providerModelKeys.add(fallbackKeys.providerModelKey);
-        } else {
-          dispatchedKeys.providerlessModelKeys.add(fallbackKeys.modelKey);
-        }
-      }
-      modelFallbackContinuationsInFlight.delete(sessionID);
-    }
+    await dispatchToHooks(syntheticIdle);
+    await dispatchOpenClawSessionEvent({
+      pluginConfig,
+      pluginContext,
+      managers,
+      rawEvent: "session.idle",
+      sessionID,
+    });
+    await dispatchIdleOnlyHooks(syntheticIdle);
   };
 
   return async (input): Promise<void> => {
@@ -589,66 +125,29 @@ export function createEventHandler(args: {
       recentRealIdles,
       recentAnyIdles,
       now: Date.now(),
-      dedupWindowMs: DEDUP_WINDOW_MS,
+      dedupWindowMs,
     });
-    const syntheticIdle = normalizeSessionStatusToIdle(input);
+    const syntheticIdle = normalizeSessionStatusToIdle(input) as EventInput | undefined;
 
     if (input.event.type === "session.idle") {
       const sessionID = getEventSessionID(input);
       if (sessionID) {
         const now = Date.now();
         const emittedAt = recentSyntheticIdles.get(sessionID);
-        if (emittedAt !== undefined && now - emittedAt < DEDUP_WINDOW_MS) {
-          recentSyntheticIdles.delete(sessionID);
-        }
+        if (emittedAt !== undefined && now - emittedAt < dedupWindowMs) recentSyntheticIdles.delete(sessionID);
       }
-      const recovered = await recoverInterruptedToolResultsOnIdleEvent(input);
-      if (recovered) {
-        return;
-      }
+      if (await recoverInterruptedToolResultsOnIdleEvent(input)) return;
       if (sessionID) {
         const now = Date.now();
         recentRealIdles.set(sessionID, now);
-        if (!shouldDispatchIdleEvent(sessionID, now)) {
-          return;
-        }
+        if (!shouldDispatchIdleEvent(sessionID, now)) return;
       }
-    } else if (syntheticIdle) {
-      const recovered = await recoverInterruptedToolResultsOnIdleEvent(syntheticIdle as EventInput);
-      if (recovered) {
-        return;
-      }
+    } else if (syntheticIdle && await recoverInterruptedToolResultsOnIdleEvent(syntheticIdle)) {
+      return;
     }
 
     await dispatchToHooks(input);
-
-    if (syntheticIdle) {
-      const sessionID = (syntheticIdle.event.properties as Record<string, unknown>)?.sessionID as string;
-      const now = Date.now();
-      const emittedAt = recentRealIdles.get(sessionID);
-      if (emittedAt !== undefined && now - emittedAt < DEDUP_WINDOW_MS) {
-        recentRealIdles.delete(sessionID);
-        return;
-      }
-      recentSyntheticIdles.set(sessionID, now);
-      if (!shouldDispatchIdleEvent(sessionID, now)) {
-        return;
-      }
-      const syntheticIdleInput = syntheticIdle as EventInput;
-      await dispatchToHooks(syntheticIdleInput);
-      if (pluginConfig.openclaw) {
-        await dispatchOpenClawEvent({
-          config: pluginConfig.openclaw,
-          rawEvent: "session.idle",
-          context: {
-            sessionId: sessionID,
-            projectPath: pluginContext.directory,
-            tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
-          },
-        });
-      }
-      await dispatchIdleOnlyHooks(syntheticIdleInput);
-    }
+    if (syntheticIdle) await dispatchSyntheticIdle(syntheticIdle);
 
     const { event } = input;
     const props = event.properties as Record<string, unknown> | undefined;
@@ -658,207 +157,67 @@ export function createEventHandler(args: {
     }
 
     if (event.type === "session.created") {
-      const sessionInfo = props?.info as { id?: string; title?: string; parentID?: string } | undefined;
-      const sessionID = resolveSessionEventID(props);
-      const isSubagentSession = !!sessionInfo?.parentID || !!sessionID && subagentSessions.has(sessionID);
-
-      if (!isSubagentSession) {
-        setMainSession(sessionID);
-      }
-
-      firstMessageVariantGate.markSessionCreated(sessionInfo);
-
-      // Subagent sessions are registered by the specialized background/delegate callbacks.
-      if (tmuxIntegrationEnabled && !isSubagentSession) {
-        await managers.tmuxSessionManager.onSessionCreated(
-          event as {
-            type: string;
-            properties?: {
-              info?: { id?: string; parentID?: string; title?: string };
-            };
-          },
-        );
-      }
-
-      // Skip subagent sessions — they are dispatched by specialized callbacks
-      // in create-managers.ts (async) and tool-registry.ts (sync)
-      if (pluginConfig.openclaw && sessionID && !isSubagentSession) {
-        await dispatchOpenClawEvent({
-          config: pluginConfig.openclaw,
-          rawEvent: event.type,
-          context: {
-            sessionId: sessionID,
-            projectPath: pluginContext.directory,
-            tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
-          },
-        });
-      }
+      await handleSessionCreatedEvent({
+        event,
+        props,
+        tmuxIntegrationEnabled,
+        pluginConfig,
+        pluginContext,
+        managers,
+        firstMessageVariantGate,
+      });
     }
 
     if (event.type === "session.deleted") {
-      const sessionID = resolveSessionEventID(props);
-      if (sessionID === getMainSessionID()) {
-        setMainSession(undefined);
-      }
-
-      if (sessionID) {
-        const wasSyncSubagentSession = syncSubagentSessions.has(sessionID);
-        clearSessionAgent(sessionID);
-        lastHandledModelErrorMessageID.delete(sessionID);
-        lastHandledRetryStatusKey.delete(sessionID);
-        lastKnownModelBySession.delete(sessionID);
-        modelFallbackContinuationsInFlight.delete(sessionID);
-        lastDispatchedModelFallbackContinuationKeys.delete(sessionID);
-        userAbortInterruptedRecoveryGuard.clear(sessionID);
-        if (modelFallback) {
-          clearPendingModelFallback(modelFallback, sessionID);
-          clearSessionFallbackChain(modelFallback, sessionID);
-        }
-        resetMessageCursor(sessionID);
-        clearBackgroundOutputConsumptionsForParentSession(sessionID);
-        clearBackgroundOutputConsumptionsForTaskSession(sessionID);
-        firstMessageVariantGate.clear(sessionID);
-        clearSessionModel(sessionID);
-        clearSessionPromptParams(sessionID);
-        syncSubagentSessions.delete(sessionID);
-        if (pluginConfig.openclaw) {
-          await dispatchOpenClawEvent({
-            config: pluginConfig.openclaw,
-            rawEvent: event.type,
-            context: {
-              sessionId: sessionID,
-              projectPath: pluginContext.directory,
-              tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
-            },
-          });
-        }
-        if (wasSyncSubagentSession) {
-          subagentSessions.delete(sessionID);
-        }
-        deleteSessionTools(sessionID);
-        await managers.skillMcpManager.disconnectSession(sessionID);
-        if (tmuxIntegrationEnabled) {
-          await managers.tmuxSessionManager.onSessionDeleted({
-            sessionID,
-          });
-        }
-      }
-
-      await runEventHookSafely("teamLeadOrphanHandler", teamLeadOrphanHandler, input);
-      await runEventHookSafely("teamMemberStatusHandler", teamMemberStatusHandler, input);
+      await handleSessionDeletedEvent({
+        props,
+        tmuxIntegrationEnabled,
+        pluginConfig,
+        pluginContext,
+        managers,
+        firstMessageVariantGate,
+        clearModelFallbackSession: modelFallbackHandler.clearSession,
+        clearUserAbortRecovery: (sessionID) => userAbortInterruptedRecoveryGuard.clear(sessionID),
+      });
+      await runEventHookSafely("teamLeadOrphanHandler", teamHandlers.teamLeadOrphanHandler, input);
+      await runEventHookSafely("teamMemberStatusHandler", teamHandlers.teamMemberStatusHandler, input);
     }
 
-    if (event.type === "message.removed") {
-      const messageID = props?.messageID as string | undefined;
-      const sessionID = resolveMessageEventSessionID(props);
-      restoreBackgroundOutputConsumption(sessionID, messageID);
-    }
-
-    if (event.type === "session.idle" && pluginConfig.openclaw) {
-      const sessionID = resolveSessionEventID(props);
-      if (sessionID) {
-        await dispatchOpenClawEvent({
-          config: pluginConfig.openclaw,
-          rawEvent: event.type,
-          context: {
-            sessionId: sessionID,
-            projectPath: pluginContext.directory,
-            tmuxPaneId: managers.tmuxSessionManager.getTrackedPaneId?.(sessionID) ?? process.env.TMUX_PANE,
-          },
-        });
-      }
-    }
+    if (event.type === "message.removed") handleMessageRemovedEvent(props);
 
     if (event.type === "session.idle") {
+      const sessionID = resolveSessionEventID(props);
+      if (sessionID) {
+        await dispatchOpenClawSessionEvent({ pluginConfig, pluginContext, managers, rawEvent: event.type, sessionID });
+      }
       await dispatchIdleOnlyHooks(input);
     }
 
     if (event.type === "message.updated") {
-      const info = props?.info as Record<string, unknown> | undefined;
-      const sessionID = resolveMessageEventSessionID(props);
-      const agent = info?.agent as string | undefined;
-      const role = info?.role as string | undefined;
-      const finish = info?.finish;
-      if (sessionID && ((typeof finish === "string" && finish.length > 0) || finish === true)) {
-        invalidateContextWindowUsageCache(pluginContext as PluginInput, sessionID);
+      const state = handleMessageUpdatedSessionState({
+        props,
+        noteSessionModel: modelFallbackHandler.setLastKnownModel,
+        clearUserAbortRecovery: (sessionID) => userAbortInterruptedRecoveryGuard.clear(sessionID),
+        noteAssistantError: (sessionID, error) => {
+          userAbortInterruptedRecoveryGuard.noteSessionError(sessionID, extractErrorName(error));
+        },
+      });
+      if (state.sessionID && ((typeof state.info?.finish === "string" && state.info.finish.length > 0) || state.info?.finish === true)) {
+        invalidateContextWindowUsageCache(pluginContext as PluginInput, state.sessionID);
       }
-      if (sessionID && role === "user") {
-        const isCompactionMessage = agent ? isCompactionAgent(agent) : false;
-        if (agent && !isCompactionMessage) {
-          updateSessionAgent(sessionID, agent);
-        }
-        const providerID = info?.providerID as string | undefined;
-        const modelID = info?.modelID as string | undefined;
-        if (providerID && modelID && !isCompactionMessage) {
-          lastKnownModelBySession.set(sessionID, { providerID, modelID });
-          setSessionModel(sessionID, { providerID, modelID });
-        }
-        userAbortInterruptedRecoveryGuard.clear(sessionID);
-      }
-      if (sessionID && role === "assistant") {
-        userAbortInterruptedRecoveryGuard.noteSessionError(sessionID, extractErrorName(info?.error));
-      }
-
-      // Model fallback: in practice, API/model failures often surface as assistant message errors.
-      // session.error events are not guaranteed for all providers, so we also observe message.updated.
-      if (sessionID && role === "assistant" && !isRuntimeFallbackEnabled && isModelFallbackEnabled) {
+      if (state.sessionID && state.role === "assistant") {
         try {
-          const assistantMessageID = info?.id as string | undefined;
-          const assistantError = info?.error;
-          if (assistantMessageID && assistantError) {
-            const lastHandled = lastHandledModelErrorMessageID.get(sessionID);
-            if (lastHandled === assistantMessageID) {
-              return;
-            }
-
-            const errorName = extractErrorName(assistantError);
-            const errorMessage = extractErrorMessage(assistantError);
-            const errorInfo = { name: errorName, message: errorMessage };
-
-            if (shouldRetryError(errorInfo)) {
-              // Prefer the agent/model/provider from the assistant message payload.
-              let agentName = agent ?? getSessionAgent(sessionID);
-              if (!agentName && sessionID === getMainSessionID()) {
-                if (errorMessage.includes("claude-opus") || errorMessage.includes("opus")) {
-                  agentName = "sisyphus";
-                } else if (errorMessage.includes("gpt-5")) {
-                  agentName = "hephaestus";
-                } else {
-                  agentName = "sisyphus";
-                }
-              }
-
-              if (agentName) {
-                const providerHint = info?.providerID as string | undefined;
-                const currentProvider = resolveFallbackProviderID(sessionID, providerHint);
-                const rawModel = (info?.modelID as string | undefined) ?? "claude-opus-4-7";
-                const currentModel = normalizeFallbackModelID(rawModel);
-                const fallbackContext = {
-                  agentName,
-                  providerID: currentProvider,
-                  dedupeProviderID: providerHint,
-                  modelID: currentModel,
-                };
-                const shouldAutoContinue = shouldAutoRetrySession(sessionID) &&
-                  !hooks.stopContinuationGuard?.isStopped(sessionID);
-
-                if (!shouldAutoContinue || !shouldSkipFallbackContinuation(sessionID, "message.updated", fallbackContext)) {
-                  applyUserConfiguredFallbackChain(modelFallback, sessionID, agentName, currentProvider, args.pluginConfig);
-
-                  const setFallback = modelFallback
-                    ? setPendingModelFallback(modelFallback, sessionID, agentName, currentProvider, currentModel)
-                    : false;
-
-                  if (setFallback && shouldAutoContinue) {
-                    lastHandledModelErrorMessageID.set(sessionID, assistantMessageID);
-                    await autoContinueAfterFallback(sessionID, "message.updated", fallbackContext);
-                  }
-                }
-              }
-            }
-          }
+          const shouldStop = await modelFallbackHandler.handleAssistantMessageUpdated({
+            sessionID: state.sessionID,
+            info: state.info ?? {},
+            agent: state.agent,
+          });
+          if (shouldStop) return;
         } catch (err) {
-          log("[event] model-fallback error in message.updated:", { sessionID, error: err });
+          log("[event] model-fallback error in message.updated:", {
+            sessionID: state.sessionID,
+            error: err instanceof Error ? err : String(err),
+          });
         }
       }
     }
@@ -866,70 +225,14 @@ export function createEventHandler(args: {
     if (event.type === "session.status") {
       const sessionID = resolveSessionEventID(props);
       const status = props?.status as { type?: string; attempt?: number; message?: string; next?: number } | undefined;
-
-      // Retry dedupe lifecycle: set key when a retry status is handled, clear it after recovery
-      // (non-retry idle) so future failures with the same key can trigger fallback again.
-      if (sessionID && status?.type === "idle") {
-        lastHandledRetryStatusKey.delete(sessionID);
-        lastDispatchedModelFallbackContinuationKeys.delete(sessionID);
-      }
-
-      if (sessionID && status?.type === "retry" && isModelFallbackEnabled && !isRuntimeFallbackEnabled) {
+      if (sessionID) {
         try {
-          const retryMessage = typeof status.message === "string" ? status.message : "";
-          const parsedForKey = extractProviderModelFromErrorMessage(retryMessage);
-          const retryAttempt = extractRetryAttempt(status.attempt, retryMessage);
-          // Deduplicate countdown updates for the same retry attempt/model.
-          // Messages like "retrying in 7m 56s" change every second but should only trigger once.
-          const retryKey = `${retryAttempt}:${parsedForKey.providerID ?? ""}/${parsedForKey.modelID ?? ""}:${normalizeRetryStatusMessage(retryMessage)}`;
-          if (lastHandledRetryStatusKey.get(sessionID) === retryKey) {
-            return;
-          }
-          lastHandledRetryStatusKey.set(sessionID, retryKey);
-
-          const errorInfo = { name: undefined as string | undefined, message: retryMessage };
-          if (shouldRetryError(errorInfo)) {
-            let agentName = getSessionAgent(sessionID);
-            if (!agentName && sessionID === getMainSessionID()) {
-              if (retryMessage.includes("claude-opus") || retryMessage.includes("opus")) {
-                agentName = "sisyphus";
-              } else if (retryMessage.includes("gpt-5")) {
-                agentName = "hephaestus";
-              } else {
-                agentName = "sisyphus";
-              }
-            }
-
-            if (agentName) {
-              const parsed = extractProviderModelFromErrorMessage(retryMessage);
-              const lastKnown = lastKnownModelBySession.get(sessionID);
-              const currentProvider = resolveFallbackProviderID(sessionID, parsed.providerID);
-              let currentModel = parsed.modelID ?? lastKnown?.modelID ?? "claude-opus-4-7";
-              currentModel = normalizeFallbackModelID(currentModel);
-              const fallbackContext = {
-                agentName,
-                providerID: currentProvider,
-                dedupeProviderID: parsed.providerID,
-                modelID: currentModel,
-              };
-              const shouldAutoContinue = shouldAutoRetrySession(sessionID) &&
-                !hooks.stopContinuationGuard?.isStopped(sessionID);
-
-              if (!shouldAutoContinue || !shouldSkipFallbackContinuation(sessionID, "session.status", fallbackContext)) {
-                applyUserConfiguredFallbackChain(modelFallback, sessionID, agentName, currentProvider, args.pluginConfig);
-
-                const setFallback = modelFallback
-                  ? setPendingModelFallback(modelFallback, sessionID, agentName, currentProvider, currentModel)
-                  : false;
-
-                if (setFallback && shouldAutoContinue) {
-                  await autoContinueAfterFallback(sessionID, "session.status", fallbackContext);
-                }
-              }
-            }
-          }
+          if (await modelFallbackHandler.handleSessionStatus({ sessionID, status })) return;
         } catch (err) {
-          log("[event] model-fallback error in session.status:", { sessionID, error: err });
+          log("[event] model-fallback error in session.status:", {
+            sessionID,
+            error: err instanceof Error ? err : String(err),
+          });
         }
       }
     }
@@ -938,112 +241,29 @@ export function createEventHandler(args: {
       try {
         const sessionID = resolveSessionEventID(props);
         const error = props?.error;
-
         const errorName = extractErrorName(error);
         const errorMessage = extractErrorMessage(error);
-        const errorInfo = { name: errorName, message: errorMessage };
-        if (sessionID) {
-          userAbortInterruptedRecoveryGuard.noteSessionError(sessionID, errorName);
-        }
+        if (sessionID) userAbortInterruptedRecoveryGuard.noteSessionError(sessionID, errorName);
 
-        // First, try session recovery for internal errors (thinking blocks, tool results, etc.)
-        if (hooks.sessionRecovery?.isRecoverableError(error)) {
-          const messageInfo = {
-            id: props?.messageID as string | undefined,
-            role: "assistant" as const,
-            sessionID,
-            error,
-          };
-          const recovered = await hooks.sessionRecovery.handleSessionRecovery(messageInfo);
-
-          if (
-            recovered &&
-            sessionID &&
-            sessionID === getMainSessionID() &&
-            !hooks.stopContinuationGuard?.isStopped(sessionID)
-          ) {
-            // Trigger compaction before sending "continue" to avoid double-sending continuation
-            await pluginContext.client.session
-              .summarize({
-                path: { id: sessionID },
-                body: { auto: true },
-                query: { directory: pluginContext.directory },
-              })
-              .catch((err: unknown) => {
-                log("[event] compaction before recovery continue failed:", { sessionID, error: err });
-              });
-
-            const promptResult = await dispatchInternalPrompt({
-              mode: "sync",
-              client: pluginContext.client,
-              sessionID,
-              source: "session-recovery:post-compaction-continue",
-              queueBehavior: "defer",
-              input: {
-                path: { id: sessionID },
-                body: { parts: [createInternalAgentContinuationTextPart("continue")] },
-                query: { directory: pluginContext.directory },
-              },
-            });
-            if (promptResult.status === "failed") {
-              if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
-                log("[event] recovery continue prompt may have been accepted before ambiguous failure", { sessionID, error: promptResult.error });
-              } else {
-                log("[event] recovery continue prompt failed", { sessionID, error: promptResult.error });
-              }
-            } else if (!isInternalPromptDispatchAccepted(promptResult)) {
-              log("[event] recovery continue prompt skipped by gate", { sessionID, status: promptResult.status });
-            }
-          }
-        }
-        // Second, try model fallback for model errors (rate limit, quota, provider issues, etc.)
-        else if (sessionID && shouldRetryError(errorInfo) && !isRuntimeFallbackEnabled && isModelFallbackEnabled) {
-          let agentName = getSessionAgent(sessionID);
-
-          if (!agentName && sessionID === getMainSessionID()) {
-            if (errorMessage.includes("claude-opus") || errorMessage.includes("opus")) {
-              agentName = "sisyphus";
-            } else if (errorMessage.includes("gpt-5")) {
-              agentName = "hephaestus";
-            } else {
-              agentName = "sisyphus";
-            }
-          }
-
-          if (agentName) {
-            const parsed = extractProviderModelFromErrorMessage(errorMessage);
-            const providerHint = (props?.providerID as string | undefined) || parsed.providerID;
-            const currentProvider = resolveFallbackProviderID(sessionID, providerHint);
-            let currentModel = (props?.modelID as string) || parsed.modelID || "claude-opus-4-7";
-            currentModel = normalizeFallbackModelID(currentModel);
-            const fallbackContext = {
-              agentName,
-              providerID: currentProvider,
-              dedupeProviderID: providerHint,
-              modelID: currentModel,
-            };
-            const shouldAutoContinue = shouldAutoRetrySession(sessionID) &&
-              !hooks.stopContinuationGuard?.isStopped(sessionID);
-
-            if (!shouldAutoContinue || !shouldSkipFallbackContinuation(sessionID, "session.error", fallbackContext)) {
-              applyUserConfiguredFallbackChain(modelFallback, sessionID, agentName, currentProvider, args.pluginConfig);
-
-              const setFallback = modelFallback
-                ? setPendingModelFallback(modelFallback, sessionID, agentName, currentProvider, currentModel)
-                : false;
-
-              if (setFallback && shouldAutoContinue) {
-                await autoContinueAfterFallback(sessionID, "session.error", fallbackContext);
-              }
-            }
-          }
+        const recovered = await handleRecoverableSessionError({
+          hooks,
+          pluginContext,
+          sessionID,
+          messageID: props?.messageID as string | undefined,
+          error,
+        });
+        if (!recovered && sessionID) {
+          await modelFallbackHandler.handleSessionError({ sessionID, errorName, errorMessage, props });
         }
       } catch (err) {
         const sessionID = resolveSessionEventID(props);
-        log("[event] model-fallback error in session.error:", { sessionID, error: err });
+        log("[event] model-fallback error in session.error:", {
+          sessionID,
+          error: err instanceof Error ? err : String(err),
+        });
       }
 
-      await runEventHookSafely("teamMemberErrorHandler", teamMemberErrorHandler, input);
+      await runEventHookSafely("teamMemberErrorHandler", teamHandlers.teamMemberErrorHandler, input);
     }
   };
 }

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -132,6 +132,7 @@ export function createEventHandler(args: {
     if (input.event.type === "session.idle") {
       const sessionID = getEventSessionID(input);
       if (sessionID) {
+        modelFallbackHandler.clearRetryDedupeAfterIdle(sessionID);
         const now = Date.now();
         const emittedAt = recentSyntheticIdles.get(sessionID);
         if (emittedAt !== undefined && now - emittedAt < dedupWindowMs) recentSyntheticIdles.delete(sessionID);


### PR DESCRIPTION
## Summary
- split `src/plugin/event.ts` into focused helpers for hook dispatch, model fallback, session lifecycle, recovery, team handlers, and shared event types
- keep `createEventHandler` as the facade while preserving existing session/OpenClaw/tmux behavior
- add characterization coverage for hook fan-out order and isolated hook failures

## Verification
- `bun test src/plugin/event.test.ts src/plugin/event.model-fallback.test.ts src/plugin/event.model-fallback-2941.test.ts src/plugin/event.model-fallback-pin-agent.test.ts src/plugin/event-abort-interrupted-recovery.test.ts src/plugin/event-compaction-agent.test.ts src/plugin/fallback.cliproxyapi-matrix.test.ts src/tools/call-omo-agent/reused-sync-session-delete-cleanup.test.ts src/tools/background-task/create-background-output.undo.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic event facade into focused modules to improve clarity and reliability, while keeping `createEventHandler` behavior the same. Also improved error parsing and fallback selection, and ensured hooks run in order with isolated failures.

- **Refactors**
  - Extracted focused modules: `event-hook-dispatcher`, `event-model-fallback(-state)`, `event-session-lifecycle`, `event-session-recovery`, `event-team-handlers`, `event-error-utils`, and `event-types`.
  - Added safe hook fan-out with `createEventHookRunner` and a dispatcher that preserves order and isolates individual hook failures.
  - Moved model fallback into `createModelFallbackEventHandler` with dedupe, controlled auto-continue, and user-configured fallback chains; clears retry dedupe on `session.idle`.
  - Centralized session lifecycle: OpenClaw dispatch, tmux activity events, cleanup, background output handling, and agent/model tracking.
  - Consolidated recovery into `handleRecoverableSessionError`, including compaction + continue via internal prompt.
  - Kept idle-event dedupe and synthetic idle path, now routed through a slimmer flow.

- **Bug Fixes**
  - Trimmed compaction agent markers (e.g. " compaction ") to prevent session model overwrite.
  - Improved error parsing and provider/model extraction; resolves nested provider messages and mixed-case GPT model names for fallback agent selection.
  - Team idle wake hint is now installed even when `promptAsync` is unavailable.

<sup>Written for commit 697ddff1b9b5b00ea9323e1df02d86364e9ce0bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up Verification
- Addressed the 6 issues identified by cubic in follow-up commit `697ddff1b`.
- Local verification: focused event/fallback suite (71 pass), `bun run typecheck`, no-excuse audit, `git diff --check`, pure LOC check, and event facade import smoke.
- Existing `codex-compatibility` failure is unrelated and was reproduced from fresh `origin/dev` (lazycodex bin-name mismatch: expected `omo-lsp`, actual `lsp-tools-mcp`).