### PR TITLE
Refactor parent wake notifier flush flow

### DIFF
--- a/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/src/features/background-agent/parent-wake-flush-runner.ts
@@ -1,0 +1,170 @@
+import { log } from "../../shared"
+import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
+import { isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
+import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
+import type { ParentWakePendingQueue } from "./parent-wake-pending-queue"
+import { sendParentWakePrompt } from "./parent-wake-prompt-dispatch"
+import type { ToolWaitDeferralDecision } from "./parent-wake-session-history"
+import type { ParentWakeSessionInspector } from "./parent-wake-session-inspector"
+import type { ParentWakeNotifierDeps } from "./parent-wake-notifier-types"
+
+type ParentWakeFlushRunnerDeps = {
+  readonly notifierDeps: ParentWakeNotifierDeps
+  readonly pendingQueue: ParentWakePendingQueue
+  readonly dispatchedTracker: ParentWakeDispatchedTracker
+  readonly sessionInspector: ParentWakeSessionInspector
+}
+
+export class ParentWakeFlushRunner {
+  constructor(private readonly deps: ParentWakeFlushRunnerDeps) {}
+
+  async flushPendingParentWake(sessionID: string): Promise<void> {
+    if (!this.deps.pendingQueue.hasWake(sessionID)) {
+      this.clearPendingParentWakeTimer(sessionID)
+      return
+    }
+
+    const sessionActive = await this.isSessionActive(sessionID)
+    this.clearPendingParentWakeTimer(sessionID)
+    if (!sessionActive) {
+      await settleAfterSessionIdle()
+
+      if (await this.isSessionActive(sessionID)) {
+        const latestWake = this.deps.pendingQueue.getWake(sessionID)
+        if (latestWake) {
+          await this.sendParentWakePrompt(sessionID, latestWake, {
+            emptyAssistantTurnRetry: false,
+            toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+            forceNoReply: true,
+          })
+        }
+        return
+      }
+    }
+
+    const latestWake = this.deps.pendingQueue.getWake(sessionID)
+    if (!latestWake) {
+      return
+    }
+    if (sessionActive) {
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry: false,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      return
+    }
+
+    if (this.hasRecentParentSessionActivity(sessionID)) {
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry: false,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
+        sessionID,
+      })
+      return
+    }
+
+    const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
+    const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
+    if (toolWaitDecision.defer) {
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      return
+    }
+
+    if (await this.isUserMessageInProgress(sessionID)) {
+      // The user just sent a new message into the parent session. Starting a
+      // reply-producing parent-wake right now would race their prompt and, on Electron-hosted
+      // OpenCode (macOS arm64), has been observed to crash the sidecar via
+      // @parcel/watcher TSFN callbacks firing into a torn-down JS env.
+      // Store the wake as noReply so the user's own turn can consume it without
+      // forking another assistant turn. See issue #4120.
+      await this.sendParentWakePrompt(sessionID, latestWake, {
+        emptyAssistantTurnRetry,
+        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+        forceNoReply: true,
+      })
+      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
+        sessionID,
+      })
+      return
+    }
+
+    const dispatchedWake = this.deps.dispatchedTracker.getWake(sessionID)
+    if (dispatchedWake && isRedundantParentWake(latestWake, dispatchedWake)) {
+      this.deps.pendingQueue.deleteWake(sessionID)
+      log("[background-agent] Suppressed duplicate parent wake already dispatched:", { sessionID })
+      return
+    }
+
+    await this.sendParentWakePrompt(sessionID, latestWake, {
+      emptyAssistantTurnRetry,
+      toolWaitDecision,
+    })
+  }
+
+  schedulePendingParentWakeFlush(sessionID: string, delayMs?: number): void {
+    this.deps.pendingQueue.scheduleFlush(sessionID, () => this.flushPendingParentWake(sessionID), delayMs)
+  }
+
+  clearPendingParentWakeTimer(sessionID: string): void {
+    this.deps.pendingQueue.clearTimer(sessionID)
+  }
+
+  private async sendParentWakePrompt(
+    sessionID: string,
+    latestWake: PendingParentWake,
+    options: {
+      readonly emptyAssistantTurnRetry: boolean
+      readonly toolWaitDecision: ToolWaitDeferralDecision
+      readonly forceNoReply?: boolean
+    },
+  ): Promise<void> {
+    this.deps.pendingQueue.deleteWake(sessionID)
+
+    await sendParentWakePrompt({
+      client: this.deps.notifierDeps.client,
+      directory: this.deps.notifierDeps.directory,
+      sessionID,
+      latestWake,
+      ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
+      emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
+      toolWaitDecision: options.toolWaitDecision,
+      getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
+      hasRecordedPromptAfterDispatch: (wake) =>
+        this.deps.sessionInspector.hasRecordedPromptMessageAfterDispatchedWake(sessionID, wake),
+      trackDispatchedWake: (wake, dispatchedAt) => this.deps.dispatchedTracker.trackWake(sessionID, wake, dispatchedAt),
+      requeueWake: (wake) => this.requeueWake(sessionID, wake),
+      scheduleFlush: (delayMs) => this.schedulePendingParentWakeFlush(sessionID, delayMs),
+    })
+  }
+
+  private async isSessionActive(sessionID: string): Promise<boolean> {
+    return isOpenCodeSessionActive(this.deps.notifierDeps.client, sessionID)
+  }
+
+  private hasRecentParentSessionActivity(sessionID: string): boolean {
+    return this.deps.sessionInspector.hasRecentActivity(sessionID)
+  }
+
+  private async isUserMessageInProgress(sessionID: string): Promise<boolean> {
+    return this.deps.sessionInspector.isUserMessageInProgress(sessionID)
+  }
+
+  private async shouldDeferParentWakeForSessionHistory(
+    sessionID: string,
+    wake: PendingParentWake,
+  ): Promise<ToolWaitDeferralDecision> {
+    return this.deps.sessionInspector.shouldDeferForHistory(sessionID, wake)
+  }
+
+  private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
+    this.deps.pendingQueue.requeueWake(sessionID, latestWake)
+  }
+}

--- a/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/src/features/background-agent/parent-wake-notifier-types.ts
@@ -1,0 +1,48 @@
+import type { PromptDispatchClient, PromptMessagesQuery } from "../../shared/prompt-async-gate/types"
+import type { ParentWakePromptContext } from "./parent-wake-dedupe"
+
+type ParentWakePromptBody = ParentWakePromptContext & {
+  readonly noReply?: boolean
+  readonly parts: { readonly type: "text"; readonly text: string }[]
+}
+
+type ParentWakePromptAsyncInput = {
+  readonly path: { readonly id: string }
+  readonly body: ParentWakePromptBody
+  readonly query: { readonly directory: string }
+}
+
+export type ParentWakeNotifierClient = PromptDispatchClient & {
+  readonly session: NonNullable<PromptDispatchClient["session"]> & {
+    readonly messages: (input: {
+      readonly path: { readonly id: string }
+      readonly query: PromptMessagesQuery
+    }) => Promise<unknown>
+    readonly promptAsync: (input: ParentWakePromptAsyncInput) => Promise<unknown>
+  }
+}
+
+export type ParentWakeNotifierDeps = {
+  readonly client: ParentWakeNotifierClient
+  readonly directory: string
+  readonly enqueueNotificationForParent: (
+    parentSessionID: string | undefined,
+    operation: () => Promise<void>,
+  ) => Promise<void>
+}
+
+export type ParentWakeNotifierOptions = {
+  readonly pendingRetryMs: number
+  readonly acceptedMessageSkewMs: number
+  readonly toolCallDeferMaxMs: number
+  readonly failureRequeueWindowMs: number
+  /**
+   * If the latest message in the parent session is a `user` message added
+   * within this window, the parent-wake injection is deferred. Prevents the
+   * race where a parent-wake `dispatchInternalPrompt` collides with a fresh
+   * user prompt, which on macOS/Electron has triggered native SIGABRT crashes
+   * inside OpenCode's `@parcel/watcher` TSFN callback path. See issue #4120.
+   */
+  readonly userMessageInProgressWindowMs: number
+  readonly parentSessionActivityInProgressWindowMs?: number
+}

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -1,77 +1,29 @@
 import { log } from "../../shared"
-import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
-import type { PromptDispatchClient, PromptMessagesQuery } from "../../shared/prompt-async-gate/types"
-import {
-  isRedundantParentWake,
-  type ParentWakePromptContext,
-  type PendingParentWake,
-} from "./parent-wake-dedupe"
+import { settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
+import type { ParentWakePromptContext, PendingParentWake } from "./parent-wake-dedupe"
 import { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
+import { ParentWakeFlushRunner } from "./parent-wake-flush-runner"
 import { ParentWakePendingQueue } from "./parent-wake-pending-queue"
-import {
-  type ToolWaitDeferralDecision,
-} from "./parent-wake-session-history"
+import type { ToolWaitDeferralDecision } from "./parent-wake-session-history"
 import { ParentWakeSessionInspector } from "./parent-wake-session-inspector"
-import { sendParentWakePrompt } from "./parent-wake-prompt-dispatch"
+import type { ParentWakeNotifierDeps, ParentWakeNotifierOptions } from "./parent-wake-notifier-types"
 import {
   handleDispatchedParentWakeWindowElapsed,
   logParentWakeWindowRecoveryError,
   rescheduleParentWakeWindowRecoveryAfterError,
 } from "./parent-wake-window-recovery"
 
-type ParentWakePromptBody = ParentWakePromptContext & {
-  readonly noReply?: boolean
-  readonly parts: { readonly type: "text"; readonly text: string }[]
-}
-
-type ParentWakePromptAsyncInput = {
-  readonly path: { readonly id: string }
-  readonly body: ParentWakePromptBody
-  readonly query: { readonly directory: string }
-}
-
-type ParentWakeNotifierClient = PromptDispatchClient & {
-  readonly session: NonNullable<PromptDispatchClient["session"]> & {
-    readonly messages: (input: {
-      readonly path: { readonly id: string }
-      readonly query: PromptMessagesQuery
-    }) => Promise<unknown>
-    readonly promptAsync: (input: ParentWakePromptAsyncInput) => Promise<unknown>
-  }
-}
-
 export type { ParentWakePromptContext, PendingParentWake } from "./parent-wake-dedupe"
-
-type ParentWakeNotifierDeps = {
-  client: ParentWakeNotifierClient
-  directory: string
-  enqueueNotificationForParent: (parentSessionID: string | undefined, operation: () => Promise<void>) => Promise<void>
-}
-
-type ParentWakeNotifierOptions = {
-  pendingRetryMs: number
-  acceptedMessageSkewMs: number
-  toolCallDeferMaxMs: number
-  failureRequeueWindowMs: number
-  /**
-   * If the latest message in the parent session is a `user` message added
-   * within this window, the parent-wake injection is deferred. Prevents the
-   * race where a parent-wake `dispatchInternalPrompt` collides with a fresh
-   * user prompt, which on macOS/Electron has triggered native SIGABRT crashes
-   * inside OpenCode's `@parcel/watcher` TSFN callback path. See issue #4120.
-   */
-  userMessageInProgressWindowMs: number
-  parentSessionActivityInProgressWindowMs?: number
-}
 
 export class ParentWakeNotifier {
   private readonly pendingQueue: ParentWakePendingQueue
   private readonly dispatchedTracker: ParentWakeDispatchedTracker
   private readonly sessionInspector: ParentWakeSessionInspector
+  private readonly flushRunner: ParentWakeFlushRunner
 
   constructor(
-    private readonly deps: ParentWakeNotifierDeps,
-    private readonly options: ParentWakeNotifierOptions,
+    deps: ParentWakeNotifierDeps,
+    options: ParentWakeNotifierOptions,
   ) {
     this.pendingQueue = new ParentWakePendingQueue({
       pendingRetryMs: options.pendingRetryMs,
@@ -104,6 +56,12 @@ export class ParentWakeNotifier {
       toolCallDeferMaxMs: options.toolCallDeferMaxMs,
       userMessageInProgressWindowMs: options.userMessageInProgressWindowMs,
       parentSessionActivityInProgressWindowMs: options.parentSessionActivityInProgressWindowMs,
+    })
+    this.flushRunner = new ParentWakeFlushRunner({
+      notifierDeps: deps,
+      pendingQueue: this.pendingQueue,
+      dispatchedTracker: this.dispatchedTracker,
+      sessionInspector: this.sessionInspector,
     })
   }
 
@@ -139,122 +97,7 @@ export class ParentWakeNotifier {
   }
 
   async flushPendingParentWake(sessionID: string): Promise<void> {
-    if (!this.pendingQueue.hasWake(sessionID)) {
-      this.clearPendingParentWakeTimer(sessionID)
-      return
-    }
-
-    const sessionActive = await this.isSessionActive(sessionID)
-    this.clearPendingParentWakeTimer(sessionID)
-    if (!sessionActive) {
-      await settleAfterSessionIdle()
-
-      if (await this.isSessionActive(sessionID)) {
-        const latestWake = this.pendingQueue.getWake(sessionID)
-        if (latestWake) {
-          await this.sendParentWakePrompt(sessionID, latestWake, {
-            emptyAssistantTurnRetry: false,
-            toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-            forceNoReply: true,
-          })
-        }
-        return
-      }
-    }
-
-    const latestWake = this.pendingQueue.getWake(sessionID)
-    if (!latestWake) {
-      return
-    }
-    if (sessionActive) {
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry: false,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-      })
-      return
-    }
-
-    if (this.hasRecentParentSessionActivity(sessionID)) {
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry: false,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-      })
-      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
-        sessionID,
-      })
-      return
-    }
-
-    const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
-    const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
-    if (toolWaitDecision.defer) {
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-      })
-      return
-    }
-
-    if (await this.isUserMessageInProgress(sessionID)) {
-      // The user just sent a new message into the parent session. Starting a
-      // reply-producing parent-wake right now would race their prompt and, on Electron-hosted
-      // OpenCode (macOS arm64), has been observed to crash the sidecar via
-      // @parcel/watcher TSFN callbacks firing into a torn-down JS env.
-      // Store the wake as noReply so the user's own turn can consume it without
-      // forking another assistant turn. See issue #4120.
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-      })
-      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
-        sessionID,
-      })
-      return
-    }
-
-    const dispatchedWake = this.dispatchedTracker.getWake(sessionID)
-    if (dispatchedWake && isRedundantParentWake(latestWake, dispatchedWake)) {
-      this.pendingQueue.deleteWake(sessionID)
-      log("[background-agent] Suppressed duplicate parent wake already dispatched:", { sessionID })
-      return
-    }
-
-    await this.sendParentWakePrompt(sessionID, latestWake, {
-      emptyAssistantTurnRetry,
-      toolWaitDecision,
-    })
-  }
-
-  private async sendParentWakePrompt(
-    sessionID: string,
-    latestWake: PendingParentWake,
-    options: {
-      readonly emptyAssistantTurnRetry: boolean
-      readonly toolWaitDecision: ToolWaitDeferralDecision
-      readonly forceNoReply?: boolean
-    },
-  ): Promise<void> {
-    this.pendingQueue.deleteWake(sessionID)
-
-    await sendParentWakePrompt({
-      client: this.deps.client,
-      directory: this.deps.directory,
-      sessionID,
-      latestWake,
-      ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
-      emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
-      toolWaitDecision: options.toolWaitDecision,
-      getDispatchedWake: () => this.dispatchedTracker.getWake(sessionID),
-      hasRecordedPromptAfterDispatch: (wake) =>
-        this.sessionInspector.hasRecordedPromptMessageAfterDispatchedWake(sessionID, wake),
-      trackDispatchedWake: (wake, dispatchedAt) => this.dispatchedTracker.trackWake(sessionID, wake, dispatchedAt),
-      requeueWake: (wake) => this.requeueWake(sessionID, wake),
-      scheduleFlush: (delayMs) => this.schedulePendingParentWakeFlush(sessionID, delayMs),
-    })
+    await this.flushRunner.flushPendingParentWake(sessionID)
   }
 
   clearDispatchedParentWake(sessionID: string): void {
@@ -303,11 +146,11 @@ export class ParentWakeNotifier {
   }
 
   schedulePendingParentWakeFlush(sessionID: string, delayMs?: number): void {
-    this.pendingQueue.scheduleFlush(sessionID, () => this.flushPendingParentWake(sessionID), delayMs)
+    this.flushRunner.schedulePendingParentWakeFlush(sessionID, delayMs)
   }
 
   clearPendingParentWakeTimer(sessionID: string): void {
-    this.pendingQueue.clearTimer(sessionID)
+    this.flushRunner.clearPendingParentWakeTimer(sessionID)
   }
 
   shutdown(): void {
@@ -316,16 +159,8 @@ export class ParentWakeNotifier {
     this.sessionInspector.shutdown()
   }
 
-  private async isSessionActive(sessionID: string): Promise<boolean> {
-    return isOpenCodeSessionActive(this.deps.client, sessionID)
-  }
-
-  private hasRecentParentSessionActivity(sessionID: string): boolean {
-    return this.sessionInspector.hasRecentActivity(sessionID)
-  }
-
-  private async isUserMessageInProgress(sessionID: string): Promise<boolean> {
-    return this.sessionInspector.isUserMessageInProgress(sessionID)
+  private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
+    this.pendingQueue.requeueWake(sessionID, latestWake)
   }
 
   private async shouldDeferParentWakeForSessionHistory(
@@ -333,9 +168,5 @@ export class ParentWakeNotifier {
     wake: PendingParentWake,
   ): Promise<ToolWaitDeferralDecision> {
     return this.sessionInspector.shouldDeferForHistory(sessionID, wake)
-  }
-
-  private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
-    this.pendingQueue.requeueWake(sessionID, latestWake)
   }
 }


### PR DESCRIPTION
## Summary
Extracts the parent wake flush decision flow out of `ParentWakeNotifier` into a dedicated `ParentWakeFlushRunner` while keeping `ParentWakeNotifier` as the facade used by the rest of background-agent.

## Changes
- Moves notifier client/dependency/option typing into `parent-wake-notifier-types.ts`.
- Moves pending-wake flush/send orchestration into `parent-wake-flush-runner.ts`.
- Keeps existing notifier facade methods and test-visible history deferral delegate intact.
- Leaves `src/features/background-agent/manager.ts` and tmux manager untouched.

## LOC
- `parent-wake-notifier.ts`: 295 pure LOC on `origin/dev` -> 150 pure LOC.
- `parent-wake-flush-runner.ts`: 144 pure LOC.
- `parent-wake-notifier-types.ts`: 43 pure LOC.

## Testing
- `bun test src/features/background-agent/parent-wake-user-message-race.test.ts src/features/background-agent/parent-wake-same-source-requeue.test.ts src/features/background-agent/parent-wake-assistant-blocking.test.ts src/features/background-agent/parent-wake-history-deferral.test.ts src/features/background-agent/parent-wake-late-error-recovery.test.ts src/features/background-agent/parent-wake-non-error-retry.test.ts src/features/background-agent/parent-wake-final-notification-merge.test.ts src/features/background-agent/parent-wake-assistant-error-history.test.ts` ✅
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/background-agent/parent-wake-notifier.ts src/features/background-agent/parent-wake-flush-runner.ts src/features/background-agent/parent-wake-notifier-types.ts` ✅
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

## Branch Overlap Note
The stale `refactor/background-manager-ai-slop-cleanup-tdd` branch touches parent-wake files, but it predates the current parent-wake organization on `dev` and has no open PR. If that branch is revived, its parent-wake changes should be rewritten against current `dev` rather than merged as-is.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the parent-wake flush logic by extracting it from `parent-wake-notifier.ts` into `ParentWakeFlushRunner` for clearer orchestration and easier maintenance. `ParentWakeNotifier` keeps the same facade and behavior.

- **Refactors**
  - Added `parent-wake-flush-runner.ts` to own pending-wake flush/send orchestration and timer management.
  - Added `parent-wake-notifier-types.ts` to centralize client/deps/options typing.
  - Updated `parent-wake-notifier.ts` to delegate flush flow to the runner; public API and test-visible hooks unchanged.
  - Left `src/features/background-agent/manager.ts` and tmux manager untouched.

<sup>Written for commit 384b2c5da16e3660c2841f47d039b3ebf30dd8d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

