### PR TITLE
Refactor delegate sync task executor

### DIFF
--- a/src/tools/delegate-task/sync-completion-message.ts
+++ b/src/tools/delegate-task/sync-completion-message.ts
@@ -1,0 +1,68 @@
+import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
+import type { ParentContext } from "./executor-types"
+import { formatDuration } from "./time-formatter"
+import type { DelegatedModelConfig, DelegateTaskArgs } from "./types"
+
+function formatModelID(model: DelegatedModelConfig | ParentContext["model"] | undefined): string | undefined {
+  return model ? `${model.providerID}/${model.modelID}` : undefined
+}
+
+export function buildRecoveredSyncTaskCompletion(input: {
+  readonly activeSessionID: string
+  readonly agentToUse: string
+  readonly args: DelegateTaskArgs
+  readonly effectiveCategoryModel: DelegatedModelConfig | undefined
+  readonly parentContext: ParentContext
+  readonly startTime: Date
+  readonly textContent: string
+}): string {
+  const duration = formatDuration(input.startTime)
+  const actualModelStr = formatModelID(input.effectiveCategoryModel)
+  const parentModelStr = formatModelID(input.parentContext.model)
+  let modelRoutingNote = ""
+  if (actualModelStr && parentModelStr && actualModelStr !== parentModelStr) {
+    modelRoutingNote = `\n⚠️  Model fallback used: requested ${parentModelStr}, executed ${actualModelStr}`
+  }
+
+  return `Task completed in ${duration}.\n\n---\n\n${input.textContent || "(No text output)"}${modelRoutingNote}\n\n${buildTaskMetadataBlock({
+    sessionId: input.activeSessionID,
+    taskId: input.activeSessionID,
+    agent: input.agentToUse,
+    category: input.args.category,
+  })}`
+}
+
+export function buildSyncTaskCompletion(input: {
+  readonly activeSessionID: string
+  readonly agentToUse: string
+  readonly args: DelegateTaskArgs
+  readonly effectiveCategoryModel: DelegatedModelConfig | undefined
+  readonly parentContext: ParentContext
+  readonly startTime: Date
+  readonly textContent: string
+}): string {
+  const duration = formatDuration(input.startTime)
+  const actualModelStr = formatModelID(input.effectiveCategoryModel)
+  const parentModelStr = formatModelID(input.parentContext.model)
+  let modelRoutingNote = ""
+  if (actualModelStr && parentModelStr && actualModelStr !== parentModelStr) {
+    modelRoutingNote = `\n⚠️  Model routing: parent used ${parentModelStr}, this subagent used ${actualModelStr} (via category: ${input.args.category ?? "unknown"})`
+  } else if (actualModelStr) {
+    modelRoutingNote = `\nModel: ${actualModelStr}${input.args.category ? ` (category: ${input.args.category})` : ""}`
+  }
+
+  return `Task completed in ${duration}.
+
+Agent: ${input.agentToUse}${input.args.category ? ` (category: ${input.args.category})` : ""}${modelRoutingNote}
+
+---
+
+${input.textContent || "(No text output)"}
+
+${buildTaskMetadataBlock({
+    sessionId: input.activeSessionID,
+    taskId: input.activeSessionID,
+    agent: input.agentToUse,
+    category: input.args.category,
+  })}`
+}

--- a/src/tools/delegate-task/sync-poll-error-recovery.ts
+++ b/src/tools/delegate-task/sync-poll-error-recovery.ts
@@ -1,0 +1,25 @@
+export function shouldAttemptPollErrorRecovery(pollError: string): boolean {
+  const trimmed = pollError.trim()
+
+  if (trimmed.length === 0) {
+    return false
+  }
+
+  if (/\bMessageAbortedError\b/u.test(trimmed)) {
+    return true
+  }
+
+  if (/\bDOMException\b/u.test(trimmed) && /\bAbortError\b/u.test(trimmed)) {
+    return true
+  }
+
+  if (/\bAbortError\b/u.test(trimmed) && !/\bTask aborted\b/u.test(trimmed)) {
+    return true
+  }
+
+  if (/^the operation was aborted\.?$/iu.test(trimmed)) {
+    return true
+  }
+
+  return false
+}

--- a/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -1,0 +1,63 @@
+import { setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
+import {
+  clearDelegatedChildSessionBootstrap,
+  registerDelegatedChildSessionBootstrap,
+} from "../../shared/delegated-child-session-bootstrap"
+import { log } from "../../shared/logger"
+import { SessionCategoryRegistry } from "../../shared/session-category-registry"
+import type { ExecutorContext, ParentContext } from "./executor-types"
+import { buildTaskPrompt } from "./prompt-builder"
+import { buildSyncPromptTools } from "./sync-prompt-sender"
+import type { DelegateTaskArgs } from "./types"
+
+export async function registerSyncSessionSideEffects(input: {
+  readonly args: DelegateTaskArgs
+  readonly executorCtx: ExecutorContext
+  readonly sessionID: string
+  readonly parentContext: ParentContext
+  readonly agentToUse: string
+  readonly fallbackChain: import("../../shared/model-requirements").FallbackEntry[] | undefined
+  readonly systemContent: string | undefined
+}): Promise<void> {
+  subagentSessions.add(input.sessionID)
+  syncSubagentSessions.add(input.sessionID)
+  setSessionAgent(input.sessionID, input.agentToUse)
+  registerDelegatedChildSessionBootstrap({
+    sessionID: input.sessionID,
+    promptText: buildTaskPrompt(input.args.prompt, input.agentToUse, input.executorCtx.sisyphusAgentConfig?.tdd),
+    fallbackChain: input.fallbackChain,
+    category: input.args.category,
+    system: input.systemContent,
+    tools: buildSyncPromptTools(input.agentToUse),
+    modelFallbackControllerAccessor: input.executorCtx.modelFallbackControllerAccessor,
+  })
+
+  if (input.executorCtx.onSyncSessionCreated) {
+    log("[task] Invoking onSyncSessionCreated callback", {
+      sessionID: input.sessionID,
+      parentID: input.parentContext.sessionID,
+    })
+    try {
+      await input.executorCtx.onSyncSessionCreated({
+        sessionID: input.sessionID,
+        parentID: input.parentContext.sessionID,
+        title: input.args.description,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? String(error) : String(error)
+      log("[task] onSyncSessionCreated callback failed", { error: message })
+    }
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+}
+
+export function cleanupSyncSessionSideEffects(
+  sessionID: string,
+  executorCtx: Pick<ExecutorContext, "modelFallbackControllerAccessor">
+): void {
+  subagentSessions.delete(sessionID)
+  syncSubagentSessions.delete(sessionID)
+  clearDelegatedChildSessionBootstrap(sessionID)
+  executorCtx.modelFallbackControllerAccessor?.clearSessionFallbackChain(sessionID)
+  SessionCategoryRegistry.remove(sessionID)
+}

--- a/src/tools/delegate-task/sync-spawn-reservation.ts
+++ b/src/tools/delegate-task/sync-spawn-reservation.ts
@@ -1,0 +1,49 @@
+import { log } from "../../shared/logger"
+import type { ExecutorContext, ParentContext } from "./executor-types"
+
+export interface SyncSpawnReservation {
+  readonly spawnContext: {
+    readonly rootSessionID: string
+    readonly parentDepth: number
+    readonly childDepth: number
+  }
+  readonly reservation: Awaited<ReturnType<ExecutorContext["manager"]["reserveSubagentSpawn"]>> | undefined
+}
+
+export async function reserveSyncSubagentSpawn(
+  executorCtx: Pick<ExecutorContext, "manager">,
+  parentContext: Pick<ParentContext, "sessionID">
+): Promise<SyncSpawnReservation> {
+  const { manager } = executorCtx
+  const reservation = typeof manager?.reserveSubagentSpawn === "function"
+    ? await manager.reserveSubagentSpawn(parentContext.sessionID)
+    : undefined
+
+  if (reservation?.spawnContext) {
+    return {
+      spawnContext: reservation.spawnContext,
+      reservation,
+    }
+  }
+
+  if (typeof manager?.assertCanSpawn === "function") {
+    return {
+      spawnContext: await manager.assertCanSpawn(parentContext.sessionID),
+      reservation,
+    }
+  }
+
+  log(
+    "[task] WARNING: BackgroundManager has no spawn enforcement methods (reserveSubagentSpawn / assertCanSpawn). " +
+    "Depth limits cannot be enforced for this task. This indicates an old SDK or a misconfiguration.",
+    { parentSessionID: parentContext.sessionID }
+  )
+  return {
+    spawnContext: {
+      rootSessionID: parentContext.sessionID,
+      parentDepth: 0,
+      childDepth: 1,
+    },
+    reservation,
+  }
+}

--- a/src/tools/delegate-task/sync-task-metadata.ts
+++ b/src/tools/delegate-task/sync-task-metadata.ts
@@ -1,0 +1,33 @@
+import { publishToolMetadata } from "../../features/tool-metadata-store"
+import type { ParentContext } from "./executor-types"
+import { resolveMetadataModel } from "./resolve-metadata-model"
+import type { DelegatedModelConfig, DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+
+export async function publishSyncTaskMetadata(input: {
+  readonly args: DelegateTaskArgs
+  readonly ctx: ToolContextWithMetadata
+  readonly currentSessionID: string
+  readonly currentModel: DelegatedModelConfig | undefined
+  readonly parentContext: ParentContext
+  readonly agentToUse: string
+  readonly spawnDepth: number
+}): Promise<void> {
+  await publishToolMetadata(input.ctx, {
+    title: input.args.description,
+    metadata: {
+      prompt: input.args.prompt,
+      agent: input.agentToUse,
+      category: input.args.category,
+      ...(input.args.requested_subagent_type !== undefined ? { requested_subagent_type: input.args.requested_subagent_type } : {}),
+      load_skills: input.args.load_skills,
+      description: input.args.description,
+      run_in_background: input.args.run_in_background,
+      taskId: input.currentSessionID,
+      sessionId: input.currentSessionID,
+      sync: true,
+      spawnDepth: input.spawnDepth,
+      command: input.args.command,
+      model: resolveMetadataModel(input.currentModel, input.parentContext.model),
+    },
+  })
+}

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -1,51 +1,17 @@
-import { setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
-import { publishToolMetadata } from "../../features/tool-metadata-store"
-import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 import type { ModelFallbackState } from "../../hooks/model-fallback/hook"
-import {
-  clearDelegatedChildSessionBootstrap,
-  registerDelegatedChildSessionBootstrap,
-} from "../../shared/delegated-child-session-bootstrap"
-import { log } from "../../shared/logger"
 import { shouldRetryError } from "../../shared/model-error-classifier"
-import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { formatDetailedError } from "./error-formatting"
 import type { ExecutorContext, ParentContext } from "./executor-types"
-import { buildTaskPrompt } from "./prompt-builder"
-import { resolveMetadataModel } from "./resolve-metadata-model"
-import { buildSyncPromptTools } from "./sync-prompt-sender"
+import { buildRecoveredSyncTaskCompletion, buildSyncTaskCompletion } from "./sync-completion-message"
+import { shouldAttemptPollErrorRecovery } from "./sync-poll-error-recovery"
+import { reserveSyncSubagentSpawn } from "./sync-spawn-reservation"
 import { type SyncTaskDeps, syncTaskDeps } from "./sync-task-deps"
 import { getNextSyncFallbackModel, retrySyncPromptWithFallbacks } from "./sync-task-fallback"
-import { formatDuration } from "./time-formatter"
+import { publishSyncTaskMetadata } from "./sync-task-metadata"
+import { cleanupSyncSessionSideEffects, registerSyncSessionSideEffects } from "./sync-session-lifecycle"
 import type { DelegatedModelConfig, DelegateTaskArgs, ToolContextWithMetadata } from "./types"
-
-function shouldAttemptPollErrorRecovery(pollError: string): boolean {
-  const trimmed = pollError.trim()
-
-  if (trimmed.length === 0) {
-    return false
-  }
-
-  if (/\bMessageAbortedError\b/u.test(trimmed)) {
-    return true
-  }
-
-  if (/\bDOMException\b/u.test(trimmed) && /\bAbortError\b/u.test(trimmed)) {
-    return true
-  }
-
-  if (/\bAbortError\b/u.test(trimmed) && !/\bTask aborted\b/u.test(trimmed)) {
-    return true
-  }
-
-  if (/^the operation was aborted\.?$/iu.test(trimmed)) {
-    return true
-  }
-
-  return false
-}
 
 export async function executeSyncTask(
   args: DelegateTaskArgs,
@@ -59,7 +25,7 @@ export async function executeSyncTask(
   fallbackChain?: import("../../shared/model-requirements").FallbackEntry[],
   deps: SyncTaskDeps = syncTaskDeps
 ): Promise<string> {
-  const { manager, client, directory, onSyncSessionCreated, syncPollTimeoutMs } = executorCtx
+  const { manager, client, directory, syncPollTimeoutMs } = executorCtx
   const hasActiveChildBackgroundTasks = manager?.hasActiveChildTasks?.bind(manager)
   const toastManager = getTaskToastManager()
   let taskId: string | undefined
@@ -69,28 +35,9 @@ export async function executeSyncTask(
     | undefined
 
   try {
-    if (typeof manager?.reserveSubagentSpawn === "function") {
-      spawnReservation = await manager.reserveSubagentSpawn(parentContext.sessionID)
-    }
-
-    // Only default to childDepth: 1 for legacy managers that cannot enforce spawn depth.
-    let spawnContext: { rootSessionID: string; parentDepth: number; childDepth: number }
-    if (spawnReservation?.spawnContext) {
-      spawnContext = spawnReservation.spawnContext
-    } else if (typeof manager?.assertCanSpawn === "function") {
-      spawnContext = await manager.assertCanSpawn(parentContext.sessionID)
-    } else {
-      log(
-        "[task] WARNING: BackgroundManager has no spawn enforcement methods (reserveSubagentSpawn / assertCanSpawn). " +
-        "Depth limits cannot be enforced for this task. This indicates an old SDK or a misconfiguration.",
-        { parentSessionID: parentContext.sessionID }
-      )
-      spawnContext = {
-        rootSessionID: parentContext.sessionID,
-        parentDepth: 0,
-        childDepth: 1,
-      }
-    }
+    const spawn = await reserveSyncSubagentSpawn(executorCtx, parentContext)
+    spawnReservation = spawn.reservation
+    const { spawnContext } = spawn
 
     const createSessionResult = await deps.createSyncSession(client, {
       parentSessionID: parentContext.sessionID,
@@ -111,32 +58,15 @@ export async function executeSyncTask(
 
     const registerSyncSession = async (newSessionID: string): Promise<void> => {
       syncSessionID = newSessionID
-      subagentSessions.add(newSessionID)
-      syncSubagentSessions.add(newSessionID)
-      setSessionAgent(newSessionID, agentToUse)
-      registerDelegatedChildSessionBootstrap({
+      await registerSyncSessionSideEffects({
+        args,
+        executorCtx,
         sessionID: newSessionID,
-        promptText: buildTaskPrompt(args.prompt, agentToUse, executorCtx.sisyphusAgentConfig?.tdd),
+        parentContext,
+        agentToUse,
         fallbackChain,
-        category: args.category,
-        system: systemContent,
-        tools: buildSyncPromptTools(agentToUse),
-        modelFallbackControllerAccessor: executorCtx.modelFallbackControllerAccessor,
+        systemContent,
       })
-
-      if (onSyncSessionCreated) {
-        log("[task] Invoking onSyncSessionCreated callback", { sessionID: newSessionID, parentID: parentContext.sessionID })
-        try {
-          await onSyncSessionCreated({
-            sessionID: newSessionID,
-            parentID: parentContext.sessionID,
-            title: args.description,
-          })
-        } catch (error) {
-          log("[task] onSyncSessionCreated callback failed", { error: String(error) })
-        }
-        await new Promise(r => setTimeout(r, 200))
-      }
     }
 
     const publishSyncMetadata = async (
@@ -144,23 +74,14 @@ export async function executeSyncTask(
       currentModel: DelegatedModelConfig | undefined,
       spawnDepth: number,
     ): Promise<void> => {
-      await publishToolMetadata(ctx, {
-        title: args.description,
-        metadata: {
-          prompt: args.prompt,
-          agent: agentToUse,
-          category: args.category,
-          ...(args.requested_subagent_type !== undefined ? { requested_subagent_type: args.requested_subagent_type } : {}),
-          load_skills: args.load_skills,
-          description: args.description,
-          run_in_background: args.run_in_background,
-          taskId: currentSessionID,
-          sessionId: currentSessionID,
-          sync: true,
-          spawnDepth,
-          command: args.command,
-          model: resolveMetadataModel(currentModel, parentContext.model),
-        },
+      await publishSyncTaskMetadata({
+        args,
+        ctx,
+        currentSessionID,
+        currentModel,
+        parentContext,
+        agentToUse,
+        spawnDepth,
       })
     }
 
@@ -207,11 +128,7 @@ export async function executeSyncTask(
     let activeSessionID = sessionID
 
     const cleanupRetrySession = (currentSessionID: string): void => {
-      subagentSessions.delete(currentSessionID)
-      syncSubagentSessions.delete(currentSessionID)
-      clearDelegatedChildSessionBootstrap(currentSessionID)
-      executorCtx.modelFallbackControllerAccessor?.clearSessionFallbackChain(currentSessionID)
-      SessionCategoryRegistry.remove(currentSessionID)
+      cleanupSyncSessionSideEffects(currentSessionID, executorCtx)
     }
 
     try {
@@ -258,25 +175,15 @@ export async function executeSyncTask(
               strictAbortRecovery: true,
             })
             if (recoveredResult.ok) {
-              const duration = formatDuration(startTime)
-
-              const actualModelStr = effectiveCategoryModel
-                ? `${effectiveCategoryModel.providerID}/${effectiveCategoryModel.modelID}`
-                : undefined
-              const parentModelStr = parentContext.model
-                ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
-                : undefined
-              let modelRoutingNote = ""
-              if (actualModelStr && parentModelStr && actualModelStr !== parentModelStr) {
-                modelRoutingNote = `\n⚠️  Model fallback used: requested ${parentModelStr}, executed ${actualModelStr}`
-              }
-
-              return `Task completed in ${duration}.\n\n---\n\n${recoveredResult.textContent || "(No text output)"}${modelRoutingNote}\n\n${buildTaskMetadataBlock({
-                sessionId: activeSessionID,
-                taskId: activeSessionID,
-                agent: agentToUse,
-                category: args.category,
-              })}`
+              return buildRecoveredSyncTaskCompletion({
+                activeSessionID,
+                agentToUse,
+                args,
+                effectiveCategoryModel,
+                parentContext,
+                startTime,
+                textContent: recoveredResult.textContent,
+              })
             }
           }
 
@@ -322,41 +229,21 @@ export async function executeSyncTask(
         }
 
         const result = await deps.fetchSyncResult(client, activeSessionID)
-      if (!result.ok) {
-        return result.error
-      }
+        if (!result.ok) {
+          return result.error
+        }
 
-      const duration = formatDuration(startTime)
+        await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnContext.childDepth)
 
-      const actualModelStr = effectiveCategoryModel
-        ? `${effectiveCategoryModel.providerID}/${effectiveCategoryModel.modelID}`
-        : undefined
-      const parentModelStr = parentContext.model
-        ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
-        : undefined
-      let modelRoutingNote = ""
-      if (actualModelStr && parentModelStr && actualModelStr !== parentModelStr) {
-        modelRoutingNote = `\n⚠️  Model routing: parent used ${parentModelStr}, this subagent used ${actualModelStr} (via category: ${args.category ?? "unknown"})`
-      } else if (actualModelStr) {
-        modelRoutingNote = `\nModel: ${actualModelStr}${args.category ? ` (category: ${args.category})` : ""}`
-      }
-
-      await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnContext.childDepth)
-
-      return `Task completed in ${duration}.
-
-Agent: ${agentToUse}${args.category ? ` (category: ${args.category})` : ""}${modelRoutingNote}
-
----
-
-${result.textContent || "(No text output)"}
-
-${buildTaskMetadataBlock({
-        sessionId: activeSessionID,
-        taskId: activeSessionID,
-        agent: agentToUse,
-        category: args.category,
-      })}`
+        return buildSyncTaskCompletion({
+          activeSessionID,
+          agentToUse,
+          args,
+          effectiveCategoryModel,
+          parentContext,
+          startTime,
+          textContent: result.textContent,
+        })
       }
     } finally {
       if (toastManager && taskId !== undefined) {
@@ -365,7 +252,8 @@ ${buildTaskMetadataBlock({
     }
   } catch (error) {
     spawnReservation?.rollback()
-    return formatDetailedError(error, {
+    const errorToFormat = error instanceof Error ? error : String(error)
+    return formatDetailedError(errorToFormat, {
       operation: "Execute task",
       args,
       sessionID: syncSessionID,
@@ -374,11 +262,7 @@ ${buildTaskMetadataBlock({
     })
   } finally {
     if (syncSessionID) {
-      subagentSessions.delete(syncSessionID)
-      syncSubagentSessions.delete(syncSessionID)
-      clearDelegatedChildSessionBootstrap(syncSessionID)
-      executorCtx.modelFallbackControllerAccessor?.clearSessionFallbackChain(syncSessionID)
-      SessionCategoryRegistry.remove(syncSessionID)
+      cleanupSyncSessionSideEffects(syncSessionID, executorCtx)
     }
   }
 }


### PR DESCRIPTION
## Summary
Split the oversized delegate-task sync executor into focused modules while preserving sync task behavior.

## Changes
- Extracted sync completion message formatting into `sync-completion-message.ts`
- Extracted poll abort recovery detection into `sync-poll-error-recovery.ts`
- Extracted sync session registration/cleanup side effects into `sync-session-lifecycle.ts`
- Extracted spawn reservation/depth handling into `sync-spawn-reservation.ts`
- Extracted sync metadata publishing into `sync-task-metadata.ts`
- Reduced `sync-task.ts` from 341 to 244 pure LOC

## Testing
- `bun test src/tools/delegate-task/sync-task.test.ts src/tools/delegate-task/metadata-task-id-consistency.test.ts src/tools/delegate-task/metadata-model-unification.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/delegate-task/sync-task.ts src/tools/delegate-task/sync-poll-error-recovery.ts src/tools/delegate-task/sync-completion-message.ts src/tools/delegate-task/sync-session-lifecycle.ts src/tools/delegate-task/sync-task-metadata.ts src/tools/delegate-task/sync-spawn-reservation.ts`
- LSP diagnostics on all changed files
- `bun run typecheck`
- `bun test`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the monolithic sync task executor into small, focused modules with no behavior changes. Improves readability, isolates side effects, and makes testing easier.

- **Refactors**
  - Moved completion message building to `sync-completion-message.ts` (standard + recovery).
  - Extracted poll abort recovery detection to `sync-poll-error-recovery.ts`.
  - Extracted session registration/cleanup to `sync-session-lifecycle.ts`.
  - Centralized spawn reservation/depth handling in `sync-spawn-reservation.ts`.
  - Centralized tool metadata publishing in `sync-task-metadata.ts`.
  - Further simplified `sync-task.ts` and added defensive error normalization.

<sup>Written for commit 7c12a191f53efcab20588d25d5f2598d01040818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

