### PR TITLE
refactor(plugin): split agent config handler facade

### DIFF
--- a/src/plugin-handlers/agent-config-assembly.ts
+++ b/src/plugin-handlers/agent-config-assembly.ts
@@ -1,0 +1,243 @@
+import type { AgentConfig } from "@opencode-ai/sdk";
+import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
+import type { OhMyOpenCodeConfig } from "../config";
+import {
+  getAgentConfigKey,
+  getAgentDisplayName,
+  normalizeAgentForPromptKey,
+} from "../shared/agent-display-names";
+import { migrateAgentConfig } from "../shared/permission-compat";
+import {
+  createProtectedAgentNameSet,
+  filterProtectedAgentOverrides,
+} from "./agent-override-protection";
+import type { AgentSourceMap, AgentSources } from "./agent-config-types";
+import { buildPlanDemoteConfig } from "./plan-model-inheritance";
+import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
+
+type BuiltinAgentMap = Record<string, AgentConfig | undefined>;
+
+type AssembleAgentConfigParams = {
+  config: Record<string, unknown>;
+  pluginConfig: OhMyOpenCodeConfig;
+  builtinAgents: BuiltinAgentMap;
+  sources: AgentSources;
+  currentModel: string | undefined;
+  useTaskSystem: boolean;
+  disabledAgentNames: ReadonlySet<string>;
+};
+
+type AssemblyResult = {
+  configuredDefaultAgent: string | undefined;
+};
+
+export function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
+  const defaultAgent = config.default_agent;
+  if (typeof defaultAgent !== "string") return undefined;
+  const trimmedDefaultAgent = defaultAgent.trim();
+  return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
+}
+
+function filterDisabledAgents(
+  agents: Record<string, unknown>,
+  disabledAgentNames: ReadonlySet<string>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(agents).filter(([name]) => !disabledAgentNames.has(name.toLowerCase())),
+  );
+}
+
+function defaultSubagentMode(agents: AgentSourceMap): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(agents).map(([key, value]) => {
+      if (!value) return [key, value];
+      const migrated = migrateAgentConfig(value);
+      if (!migrated.mode) migrated.mode = "subagent";
+      return [key, migrated];
+    }),
+  );
+}
+
+function filterCustomAgentSources(
+  sources: AgentSources,
+  protectedBuiltinAgentNames: ReadonlySet<string>,
+): Omit<AgentSources, "configAgent" | "customAgentSummaries"> {
+  return {
+    userAgents: filterProtectedAgentOverrides(sources.userAgents, protectedBuiltinAgentNames),
+    projectAgents: filterProtectedAgentOverrides(sources.projectAgents, protectedBuiltinAgentNames),
+    opencodeGlobalAgents: filterProtectedAgentOverrides(
+      sources.opencodeGlobalAgents,
+      protectedBuiltinAgentNames,
+    ),
+    opencodeProjectAgents: filterProtectedAgentOverrides(
+      sources.opencodeProjectAgents,
+      protectedBuiltinAgentNames,
+    ),
+    pluginAgents: filterProtectedAgentOverrides(sources.pluginAgents, protectedBuiltinAgentNames),
+    agentDefinitionAgents: filterProtectedAgentOverrides(
+      sources.agentDefinitionAgents,
+      protectedBuiltinAgentNames,
+    ),
+    opencodeConfigAgents: filterProtectedAgentOverrides(
+      sources.opencodeConfigAgents,
+      protectedBuiltinAgentNames,
+    ),
+  };
+}
+
+function orderedCustomAgentSources(
+  sources: Omit<AgentSources, "configAgent" | "customAgentSummaries">,
+  disabledAgentNames: ReadonlySet<string>,
+): Record<string, unknown> {
+  return {
+    ...filterDisabledAgents(sources.pluginAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.userAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.opencodeGlobalAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.projectAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.opencodeProjectAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.agentDefinitionAgents, disabledAgentNames),
+    ...filterDisabledAgents(sources.opencodeConfigAgents, disabledAgentNames),
+  };
+}
+
+async function createCoreAgentConfig(
+  params: AssembleAgentConfigParams,
+): Promise<Record<string, unknown>> {
+  const { builtinAgents, pluginConfig, sources, currentModel, useTaskSystem } = params;
+  const agentConfig: Record<string, unknown> = {
+    sisyphus: builtinAgents.sisyphus,
+  };
+
+  if (builtinAgents.hephaestus) {
+    agentConfig.hephaestus = builtinAgents.hephaestus;
+  }
+
+  if (pluginConfig.sisyphus_agent?.planner_enabled ?? true) {
+    agentConfig.prometheus = await buildPrometheusAgentConfig({
+      configAgentPlan: sources.configAgent?.plan,
+      pluginPrometheusOverride: pluginConfig.agents?.prometheus as
+        | (Record<string, unknown> & { prompt_append?: string })
+        | undefined,
+      userCategories: pluginConfig.categories,
+      currentModel,
+      disabledTools: pluginConfig.disabled_tools,
+    });
+  }
+
+  if (builtinAgents.atlas) {
+    agentConfig.atlas = builtinAgents.atlas;
+  }
+
+  agentConfig["sisyphus-junior"] = createSisyphusJuniorAgentWithOverrides(
+    pluginConfig.agents?.["sisyphus-junior"],
+    (builtinAgents.atlas as { model?: string } | undefined)?.model,
+    useTaskSystem,
+  );
+
+  return agentConfig;
+}
+
+function applyDefaultAgent(
+  config: Record<string, unknown>,
+  configuredDefaultAgent: string | undefined,
+): void {
+  if (configuredDefaultAgent) {
+    const configKey = getAgentConfigKey(configuredDefaultAgent);
+    const runtimeConfigKey = normalizeAgentForPromptKey(configuredDefaultAgent) ?? configKey;
+    config.default_agent = getAgentDisplayName(runtimeConfigKey);
+    return;
+  }
+
+  config.default_agent = getAgentDisplayName("sisyphus");
+}
+
+async function assembleSisyphusEnabledConfig(params: AssembleAgentConfigParams): Promise<void> {
+  const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
+  applyDefaultAgent(params.config, configuredDefaultAgent);
+
+  const agentConfig = await createCoreAgentConfig(params);
+  const { configAgent } = params.sources;
+  const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
+  const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
+  const shouldDemotePlan = plannerEnabled && replacePlan;
+
+  if (params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false) {
+    const { name: _buildName, ...buildConfigWithoutName } = configAgent?.build ?? {};
+    const migratedBuildConfig = migrateAgentConfig(buildConfigWithoutName);
+    const override = params.pluginConfig.agents?.["OpenCode-Builder"];
+    const base = {
+      ...migratedBuildConfig,
+      description: `${(configAgent?.build?.description as string) ?? "Build agent"} (OpenCode default)`,
+    };
+    agentConfig["OpenCode-Builder"] = override ? { ...base, ...override } : base;
+  }
+
+  const migratedBuild = configAgent?.build ? migrateAgentConfig(configAgent.build) : {};
+  const planDemoteConfig = shouldDemotePlan
+    ? buildPlanDemoteConfig(
+        agentConfig.prometheus as Record<string, unknown> | undefined,
+        params.pluginConfig.agents?.plan as Record<string, unknown> | undefined,
+      )
+    : undefined;
+  const protectedBuiltinAgentNames = createProtectedAgentNameSet([
+    ...Object.keys(agentConfig),
+    ...Object.keys(params.builtinAgents),
+  ]);
+  const filteredSources = filterCustomAgentSources(params.sources, protectedBuiltinAgentNames);
+  const filteredConfigAgents = configAgent
+    ? defaultSubagentMode(
+        filterProtectedAgentOverrides(
+          Object.fromEntries(
+            Object.entries(configAgent).filter(([key]) => {
+              if (key === "build") return false;
+              if (key === "plan" && shouldDemotePlan) return false;
+              return true;
+            }),
+          ),
+          protectedBuiltinAgentNames,
+        ),
+      )
+    : {};
+
+  params.config.agent = {
+    ...agentConfig,
+    ...Object.fromEntries(
+      Object.entries(params.builtinAgents).filter(
+        ([key]) => key !== "sisyphus" && key !== "hephaestus" && key !== "atlas",
+      ),
+    ),
+    ...orderedCustomAgentSources(filteredSources, params.disabledAgentNames),
+    ...filteredConfigAgents,
+    build: { ...migratedBuild, mode: "subagent", hidden: true },
+    ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
+  };
+}
+
+function assembleSisyphusDisabledConfig(params: AssembleAgentConfigParams): void {
+  const protectedBuiltinAgentNames = createProtectedAgentNameSet(Object.keys(params.builtinAgents));
+  const filteredSources = filterCustomAgentSources(params.sources, protectedBuiltinAgentNames);
+  const filteredConfigAgents = params.sources.configAgent
+    ? defaultSubagentMode(
+        filterProtectedAgentOverrides(params.sources.configAgent, protectedBuiltinAgentNames),
+      )
+    : {};
+
+  params.config.agent = {
+    ...params.builtinAgents,
+    ...orderedCustomAgentSources(filteredSources, params.disabledAgentNames),
+    ...filteredConfigAgents,
+  };
+}
+
+export async function assembleAgentConfig(params: AssembleAgentConfigParams): Promise<AssemblyResult> {
+  const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
+  const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
+
+  if (isSisyphusEnabled && params.builtinAgents.sisyphus) {
+    await assembleSisyphusEnabledConfig(params);
+  } else {
+    assembleSisyphusDisabledConfig(params);
+  }
+
+  return { configuredDefaultAgent };
+}

--- a/src/plugin-handlers/agent-config-finalizer.test.ts
+++ b/src/plugin-handlers/agent-config-finalizer.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  isAgentRegistered,
+  registerAgentName,
+  _resetForTesting as resetSessionStateForTesting,
+} from "../features/claude-code-session-state";
+import type { OhMyOpenCodeConfig } from "../config";
+import { finalizeAgentConfig } from "./agent-config-finalizer";
+
+function createPluginConfig(): OhMyOpenCodeConfig {
+  return {
+    sisyphus_agent: {
+      planner_enabled: false,
+    },
+  };
+}
+
+describe("finalizeAgentConfig", () => {
+  afterEach(() => {
+    resetSessionStateForTesting();
+  });
+
+  test("does not throw or keep stale registrations when config.agent is absent", () => {
+    // given
+    registerAgentName("stale-agent");
+
+    // when
+    const result = finalizeAgentConfig({
+      config: {},
+      pluginConfig: createPluginConfig(),
+      configuredDefaultAgent: undefined,
+    });
+
+    // then
+    expect(result).toEqual({});
+    expect(isAgentRegistered("stale-agent")).toBe(false);
+  });
+});

--- a/src/plugin-handlers/agent-config-finalizer.ts
+++ b/src/plugin-handlers/agent-config-finalizer.ts
@@ -1,0 +1,40 @@
+import {
+  clearRegisteredAgentNames,
+  registerAgentName,
+} from "../features/claude-code-session-state";
+import { log } from "../shared";
+import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
+import { remapAgentKeysToDisplayNames } from "./agent-key-remapper";
+import { reorderAgentsByPriority } from "./agent-priority-order";
+import type { ApplyAgentConfigParams } from "./agent-config-types";
+
+export function finalizeAgentConfig(
+  params: Pick<ApplyAgentConfigParams, "config" | "pluginConfig"> & {
+    configuredDefaultAgent: string | undefined;
+  },
+): Record<string, unknown> {
+  if (params.config.agent) {
+    params.config.agent = remapAgentKeysToDisplayNames(
+      params.config.agent as Record<string, unknown>,
+      params.pluginConfig.agents as Record<string, { displayName?: string } | undefined> | undefined,
+    );
+    params.config.agent = reorderAgentsByPriority(
+      params.config.agent as Record<string, unknown>,
+      params.pluginConfig.agent_order,
+    );
+  }
+
+  if (params.configuredDefaultAgent) {
+    setDefaultAgentForSort(
+      (params.config as { default_agent?: string }).default_agent ?? params.configuredDefaultAgent,
+    );
+  }
+
+  const agentResult = params.config.agent as Record<string, unknown>;
+  clearRegisteredAgentNames();
+  for (const name of Object.keys(agentResult)) {
+    registerAgentName(name);
+  }
+  log("[config-handler] agents loaded", { agentKeys: Object.keys(agentResult) });
+  return agentResult;
+}

--- a/src/plugin-handlers/agent-config-finalizer.ts
+++ b/src/plugin-handlers/agent-config-finalizer.ts
@@ -30,7 +30,8 @@ export function finalizeAgentConfig(
     );
   }
 
-  const agentResult = params.config.agent as Record<string, unknown>;
+  const agentResult =
+    params.config.agent != null ? (params.config.agent as Record<string, unknown>) : {};
   clearRegisteredAgentNames();
   for (const name of Object.keys(agentResult)) {
     registerAgentName(name);

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -66,6 +66,8 @@ describe("applyAgentConfig builtin override protection", () => {
   let discoverGlobalAgentsSkillsSpy: ReturnType<typeof spyOn>
   let loadUserAgentsSpy: ReturnType<typeof spyOn>
   let loadProjectAgentsSpy: ReturnType<typeof spyOn>
+  let loadOpencodeGlobalAgentsSpy: ReturnType<typeof spyOn>
+  let loadOpencodeProjectAgentsSpy: ReturnType<typeof spyOn>
   let loadAgentDefinitionsSpy: ReturnType<typeof spyOn>
   let readOpencodeConfigAgentsSpy: ReturnType<typeof spyOn>
   let migrateAgentConfigSpy: ReturnType<typeof spyOn>
@@ -149,6 +151,8 @@ describe("applyAgentConfig builtin override protection", () => {
 
     loadUserAgentsSpy = spyOn(agentLoader, "loadUserAgents").mockReturnValue({})
     loadProjectAgentsSpy = spyOn(agentLoader, "loadProjectAgents").mockReturnValue({})
+    loadOpencodeGlobalAgentsSpy = spyOn(agentLoader, "loadOpencodeGlobalAgents").mockReturnValue({})
+    loadOpencodeProjectAgentsSpy = spyOn(agentLoader, "loadOpencodeProjectAgents").mockReturnValue({})
     loadAgentDefinitionsSpy = spyOn(agentLoader, "loadAgentDefinitions").mockReturnValue({})
     readOpencodeConfigAgentsSpy = spyOn(
       agentLoader,
@@ -175,6 +179,8 @@ describe("applyAgentConfig builtin override protection", () => {
     discoverGlobalAgentsSkillsSpy.mockRestore()
     loadUserAgentsSpy.mockRestore()
     loadProjectAgentsSpy.mockRestore()
+    loadOpencodeGlobalAgentsSpy.mockRestore()
+    loadOpencodeProjectAgentsSpy.mockRestore()
     loadAgentDefinitionsSpy.mockRestore()
     readOpencodeConfigAgentsSpy.mockRestore()
     migrateAgentConfigSpy.mockRestore()
@@ -734,6 +740,81 @@ describe("applyAgentConfig builtin override protection", () => {
 
       // then
       expect(result["shared-name"]).toBeDefined()
+      expect(result["shared-name"]?.prompt).toBe("from-config")
+    })
+
+    test("precedence: custom agent sources resolve from lowest to highest priority", async () => {
+      // given
+      const pluginComponents = createPluginComponents()
+      pluginComponents.agents = {
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-plugin",
+          mode: "subagent",
+        },
+      }
+      loadUserAgentsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-user",
+          mode: "subagent",
+        },
+      })
+      loadOpencodeGlobalAgentsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-opencode-global",
+          mode: "subagent",
+        },
+      })
+      loadProjectAgentsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-project",
+          mode: "subagent",
+        },
+      })
+      loadOpencodeProjectAgentsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-opencode-project",
+          mode: "subagent",
+        },
+      })
+      loadAgentDefinitionsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-definitions",
+          mode: "subagent",
+        },
+      })
+      readOpencodeConfigAgentsSpy.mockReturnValue({
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-opencode-config",
+          mode: "subagent",
+        },
+      })
+      const config = createBaseConfig()
+      ;(config as Record<string, unknown>).agent = {
+        "shared-name": {
+          name: "shared-name",
+          prompt: "from-config",
+          mode: "subagent",
+        },
+      }
+      const pluginConfig = createPluginConfig()
+      pluginConfig.agent_definitions = ["/fake/path/agent.md"]
+
+      // when
+      const result = await applyAgentConfig({
+        config,
+        pluginConfig,
+        ctx: { directory: "/tmp" },
+        pluginComponents,
+      })
+
+      // then
       expect(result["shared-name"]?.prompt).toBe("from-config")
     })
 

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -1,185 +1,26 @@
 import { createBuiltinAgents } from "../agents";
-import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
-import type { OhMyOpenCodeConfig } from "../config";
-import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import {
-  getAgentConfigKey,
-  getAgentDisplayName,
-  normalizeAgentForPromptKey,
-} from "../shared/agent-display-names";
+import { isTaskSystemEnabled } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
-import { setDefaultAgentForSort } from "../shared/agent-sort-shim";
-import {
-  clearRegisteredAgentNames,
-  registerAgentName,
-} from "../features/claude-code-session-state";
-import {
-  deduplicateSkillsByName,
-  discoverConfigSourceSkills,
-  discoverGlobalAgentsSkills,
-  discoverOpencodeGlobalSkills,
-  discoverOpencodeProjectSkills,
-  discoverProjectAgentsSkills,
-  discoverProjectClaudeSkills,
-  discoverUserClaudeSkills,
-} from "../features/opencode-skill-loader";
-import {
-  loadProjectAgents,
-  loadUserAgents,
-  loadOpencodeGlobalAgents,
-  loadOpencodeProjectAgents,
-  loadAgentDefinitions,
-  readOpencodeConfigAgents,
-} from "../features/claude-code-agent-loader";
-import type { PluginComponents } from "./plugin-components-loader";
-import { reorderAgentsByPriority } from "./agent-priority-order";
-import { remapAgentKeysToDisplayNames } from "./agent-key-remapper";
-import {
-  createProtectedAgentNameSet,
-  filterProtectedAgentOverrides,
-} from "./agent-override-protection";
-import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
-import { buildPlanDemoteConfig } from "./plan-model-inheritance";
-import { adaptHostSkillConfig } from "../shared/host-skill-config";
+import { assembleAgentConfig } from "./agent-config-assembly";
+import { finalizeAgentConfig } from "./agent-config-finalizer";
+import { discoverAgentSkills } from "./agent-skill-discovery";
+import { loadAgentSources } from "./agent-source-loader";
+import type { ApplyAgentConfigParams } from "./agent-config-types";
 
-type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
-  build?: Record<string, unknown>;
-  plan?: Record<string, unknown>;
-};
-
-function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
-  const defaultAgent = config.default_agent;
-  if (typeof defaultAgent !== "string") return undefined;
-  const trimmedDefaultAgent = defaultAgent.trim();
-  return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
-}
-
-export async function applyAgentConfig(params: {
-  config: Record<string, unknown>;
-  pluginConfig: OhMyOpenCodeConfig;
-  ctx: { directory: string; client?: unknown };
-  pluginComponents: PluginComponents;
-}): Promise<Record<string, unknown>> {
+export async function applyAgentConfig(
+  params: ApplyAgentConfigParams,
+): Promise<Record<string, unknown>> {
   const migratedDisabledAgents = (params.pluginConfig.disabled_agents ?? []).map(
-    (agent: string) => {
-      return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
-    },
+    (agent: string) => AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent,
   ) as typeof params.pluginConfig.disabled_agents;
-
-  const includeClaudeSkillsForAwareness = params.pluginConfig.claude_code?.skills ?? true;
-  const hostSkillConfig = adaptHostSkillConfig(params.config.skills);
-  const [
-    discoveredConfigSourceSkills,
-    discoveredHostConfigSkills,
-    discoveredUserSkills,
-    discoveredProjectSkills,
-    discoveredProjectAgentsSkills,
-    discoveredOpencodeGlobalSkills,
-    discoveredOpencodeProjectSkills,
-    discoveredGlobalAgentsSkills,
-  ] = await Promise.all([
-    discoverConfigSourceSkills({
-      config: params.pluginConfig.skills,
-      configDir: params.ctx.directory,
-    }),
-    discoverConfigSourceSkills({
-      config: hostSkillConfig,
-      configDir: params.ctx.directory,
-    }),
-    includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
-    includeClaudeSkillsForAwareness
-       ? discoverProjectClaudeSkills(params.ctx.directory)
-       : Promise.resolve([]),
-    includeClaudeSkillsForAwareness
-      ? discoverProjectAgentsSkills(params.ctx.directory)
-      : Promise.resolve([]),
-    discoverOpencodeGlobalSkills(),
-    discoverOpencodeProjectSkills(params.ctx.directory),
-    includeClaudeSkillsForAwareness ? discoverGlobalAgentsSkills() : Promise.resolve([]),
-  ]);
-
-  // Same skill name reaches the agent prompt through multiple discovery paths
-  // (e.g. ~/.agents/skills/foo with a symlink at ~/.claude/skills/foo from
-  // `npx skills add ...`). Without dedup the SisyphusKAtlasKHephaestus
-  // `**YOUR SKILLS (PRIORITY)**` line renders the same skill twice, which
-  // both confuses the agent and wastes 5-10k tokens per session for users
-  // with cross-installed skill ecosystems (issue #4573). `discoverAllSkills`
-  // already collapses duplicates via the same helper, so doing it here keeps
-  // both rendering paths agreeing on the skill set.
-  const allDiscoveredSkills = deduplicateSkillsByName([
-    ...discoveredConfigSourceSkills,
-    ...discoveredHostConfigSkills,
-    ...discoveredOpencodeProjectSkills,
-    ...discoveredProjectSkills,
-    ...discoveredProjectAgentsSkills,
-    ...discoveredOpencodeGlobalSkills,
-    ...discoveredUserSkills,
-    ...discoveredGlobalAgentsSkills,
-  ]);
-
+  const allDiscoveredSkills = await discoverAgentSkills(params);
+  const sources = loadAgentSources(params);
   const browserProvider =
     params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
   const currentModel = params.config.model as string | undefined;
   const disabledSkills = new Set<string>(params.pluginConfig.disabled_skills ?? []);
   const useTaskSystem = isTaskSystemEnabled(params.pluginConfig);
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
-
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
-  const anthropicProvider = params.pluginConfig.claude_code?.anthropic_provider;
-  const userAgents = includeClaudeAgents ? loadUserAgents(anthropicProvider) : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory, anthropicProvider) : {};
-  const opencodeGlobalAgents = loadOpencodeGlobalAgents();
-  const opencodeProjectAgents = loadOpencodeProjectAgents(params.ctx.directory);
-  const rawPluginAgents = params.pluginComponents.agents;
-
-  const agentDefinitionAgents = params.pluginConfig.agent_definitions
-    ? loadAgentDefinitions(params.pluginConfig.agent_definitions, "definition-file", anthropicProvider)
-    : {};
-  const opencodeConfigAgents = readOpencodeConfigAgents(params.ctx.directory);
-
-  const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => {
-      if (!value) return [key, value];
-      const migrated = migrateAgentConfig(value as Record<string, unknown>);
-      if (!migrated.mode) migrated.mode = "subagent";
-      return [key, migrated];
-    }),
-  );
-
-  const configAgent = params.config.agent as AgentConfigRecord | undefined;
-
-  const customAgentSummaries = [
-    ...Object.entries(configAgent ?? {}),
-    ...Object.entries(userAgents),
-    ...Object.entries(projectAgents),
-    ...Object.entries(opencodeGlobalAgents),
-    ...Object.entries(opencodeProjectAgents),
-    ...Object.entries(pluginAgents).filter(([, config]) => config !== undefined),
-    ...Object.entries(agentDefinitionAgents),
-    ...Object.entries(opencodeConfigAgents),
-  ]
-    .filter(([, config]) => config != null)
-    .map(([name, config]) => ({
-      name,
-      description: typeof (config as Record<string, unknown>)?.description === "string"
-        ? ((config as Record<string, unknown>).description as string)
-        : "",
-    }));
-
-  log(
-    "[agent-config-handler] Agent sources loaded",
-    {
-      user: Object.keys(userAgents).length,
-      project: Object.keys(projectAgents).length,
-      opencodeGlobal: Object.keys(opencodeGlobalAgents).length,
-      opencodeProject: Object.keys(opencodeProjectAgents).length,
-      plugin: Object.keys(pluginAgents).length,
-      agentDefinitions: Object.keys(agentDefinitionAgents).length,
-      opencodeConfig: Object.keys(opencodeConfigAgents).length,
-      config: Object.keys(configAgent ?? {}).length,
-    }
-  );
-
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
     params.pluginConfig.agents,
@@ -188,7 +29,7 @@ export async function applyAgentConfig(params: {
     params.pluginConfig.categories,
     params.pluginConfig.git_master,
     allDiscoveredSkills,
-    customAgentSummaries,
+    sources.customAgentSummaries,
     browserProvider,
     currentModel,
     disabledSkills,
@@ -196,246 +37,22 @@ export async function applyAgentConfig(params: {
     disableOmoEnv,
     params.pluginConfig.team_mode?.enabled ?? false,
   );
-
   const disabledAgentNames = new Set(
-    (migratedDisabledAgents ?? []).map((agent: string) => agent.toLowerCase())
+    (migratedDisabledAgents ?? []).map((agent: string) => agent.toLowerCase()),
   );
+  const { configuredDefaultAgent } = await assembleAgentConfig({
+    config: params.config,
+    pluginConfig: params.pluginConfig,
+    builtinAgents,
+    sources,
+    currentModel,
+    useTaskSystem,
+    disabledAgentNames,
+  });
 
-  const filterDisabledAgents = (agents: Record<string, unknown>) =>
-    Object.fromEntries(
-      Object.entries(agents).filter(([name]) => !disabledAgentNames.has(name.toLowerCase()))
-    );
-
-  const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
-  const builderEnabled =
-    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
-  const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
-  const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
-  const shouldDemotePlan = plannerEnabled && replacePlan;
-  const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
-
-  if (isSisyphusEnabled && builtinAgents.sisyphus) {
-    if (configuredDefaultAgent) {
-      const configKey = getAgentConfigKey(configuredDefaultAgent);
-      const runtimeConfigKey = normalizeAgentForPromptKey(configuredDefaultAgent) ?? configKey;
-      (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName(runtimeConfigKey);
-    } else {
-      (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName("sisyphus");
-    }
-
-    // Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas
-    const agentConfig: Record<string, unknown> = {
-      sisyphus: builtinAgents.sisyphus,
-    };
-
-    if (builtinAgents.hephaestus) {
-      agentConfig["hephaestus"] = builtinAgents.hephaestus;
-    }
-
-    if (plannerEnabled) {
-      const prometheusOverride = params.pluginConfig.agents?.["prometheus"] as
-        | (Record<string, unknown> & { prompt_append?: string })
-        | undefined;
-
-      agentConfig["prometheus"] = await buildPrometheusAgentConfig({
-        configAgentPlan: configAgent?.plan,
-        pluginPrometheusOverride: prometheusOverride,
-        userCategories: params.pluginConfig.categories,
-        currentModel,
-        disabledTools: params.pluginConfig.disabled_tools,
-      });
-    }
-
-    if (builtinAgents.atlas) {
-      agentConfig["atlas"] = builtinAgents.atlas;
-    }
-
-    agentConfig["sisyphus-junior"] = createSisyphusJuniorAgentWithOverrides(
-      params.pluginConfig.agents?.["sisyphus-junior"],
-      (builtinAgents.atlas as { model?: string } | undefined)?.model,
-      useTaskSystem,
-    );
-
-    if (builderEnabled) {
-      const { name: _buildName, ...buildConfigWithoutName } =
-        configAgent?.build ?? {};
-      const migratedBuildConfig = migrateAgentConfig(
-        buildConfigWithoutName as Record<string, unknown>,
-      );
-      const override = params.pluginConfig.agents?.["OpenCode-Builder"];
-      const base = {
-        ...migratedBuildConfig,
-        description: `${(configAgent?.build?.description as string) ?? "Build agent"} (OpenCode default)`,
-      };
-      agentConfig["OpenCode-Builder"] = override ? { ...base, ...override } : base;
-    }
-
-    const migratedBuild = configAgent?.build
-      ? migrateAgentConfig(configAgent.build as Record<string, unknown>)
-      : {};
-
-    const planDemoteConfig = shouldDemotePlan
-      ? buildPlanDemoteConfig(
-          agentConfig["prometheus"] as Record<string, unknown> | undefined,
-          params.pluginConfig.agents?.plan as Record<string, unknown> | undefined,
-        )
-      : undefined;
-
-    const protectedBuiltinAgentNames = createProtectedAgentNameSet([
-      ...Object.keys(agentConfig),
-      ...Object.keys(builtinAgents),
-    ]);
-    const filteredConfigAgentSource = configAgent
-      ? filterProtectedAgentOverrides(
-          Object.fromEntries(
-            Object.entries(configAgent).filter(([key]) => {
-              if (key === "build") return false;
-              if (key === "plan" && shouldDemotePlan) return false;
-              return true;
-            }),
-          ),
-          protectedBuiltinAgentNames,
-        )
-      : {};
-    const filteredConfigAgents = Object.fromEntries(
-      Object.entries(filteredConfigAgentSource).map(([key, value]) => {
-        if (!value) return [key, value];
-        const migrated = migrateAgentConfig(value as Record<string, unknown>);
-        if (!migrated.mode) migrated.mode = "subagent";
-        return [key, migrated];
-      }),
-    );
-    const filteredUserAgents = filterProtectedAgentOverrides(
-      userAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredProjectAgents = filterProtectedAgentOverrides(
-      projectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredPluginAgents = filterProtectedAgentOverrides(
-      pluginAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeGlobalAgents = filterProtectedAgentOverrides(
-      opencodeGlobalAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeProjectAgents = filterProtectedAgentOverrides(
-      opencodeProjectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredAgentDefinitionAgents = filterProtectedAgentOverrides(
-      agentDefinitionAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeConfigAgents = filterProtectedAgentOverrides(
-      opencodeConfigAgents,
-      protectedBuiltinAgentNames,
-    );
-
-    params.config.agent = {
-      ...agentConfig,
-      ...Object.fromEntries(
-        Object.entries(builtinAgents).filter(
-          ([key]) => key !== "sisyphus" && key !== "hephaestus" && key !== "atlas",
-        ),
-      ),
-      // Precedence: later entries override earlier (project > global > user > plugin)
-      ...filterDisabledAgents(filteredPluginAgents),
-      ...filterDisabledAgents(filteredUserAgents),
-      ...filterDisabledAgents(filteredOpencodeGlobalAgents),
-      ...filterDisabledAgents(filteredProjectAgents),
-      ...filterDisabledAgents(filteredOpencodeProjectAgents),
-      ...filterDisabledAgents(filteredAgentDefinitionAgents),
-      ...filterDisabledAgents(filteredOpencodeConfigAgents),
-      ...filteredConfigAgents,
-      build: { ...migratedBuild, mode: "subagent", hidden: true },
-      ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
-    };
-  } else {
-    const protectedBuiltinAgentNames = createProtectedAgentNameSet(
-      Object.keys(builtinAgents),
-    );
-    const filteredUserAgents = filterProtectedAgentOverrides(
-      userAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredProjectAgents = filterProtectedAgentOverrides(
-      projectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredPluginAgents = filterProtectedAgentOverrides(
-      pluginAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeGlobalAgents = filterProtectedAgentOverrides(
-      opencodeGlobalAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeProjectAgents = filterProtectedAgentOverrides(
-      opencodeProjectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredAgentDefinitionAgents = filterProtectedAgentOverrides(
-      agentDefinitionAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredOpencodeConfigAgents = filterProtectedAgentOverrides(
-      opencodeConfigAgents,
-      protectedBuiltinAgentNames,
-    );
-
-    const filteredConfigAgentSource = configAgent
-      ? filterProtectedAgentOverrides(configAgent, protectedBuiltinAgentNames)
-      : {};
-    const defaultedConfigAgents = Object.fromEntries(
-      Object.entries(filteredConfigAgentSource).map(([key, value]) => {
-        if (!value) return [key, value];
-        const migrated = migrateAgentConfig(value as Record<string, unknown>);
-        if (!migrated.mode) migrated.mode = "subagent";
-        return [key, migrated];
-      }),
-    );
-
-    params.config.agent = {
-      ...builtinAgents,
-      // Precedence: later entries override earlier (project > global > user > plugin)
-      ...filterDisabledAgents(filteredPluginAgents),
-      ...filterDisabledAgents(filteredUserAgents),
-      ...filterDisabledAgents(filteredOpencodeGlobalAgents),
-      ...filterDisabledAgents(filteredProjectAgents),
-      ...filterDisabledAgents(filteredOpencodeProjectAgents),
-      ...filterDisabledAgents(filteredAgentDefinitionAgents),
-      ...filterDisabledAgents(filteredOpencodeConfigAgents),
-      ...defaultedConfigAgents,
-    };
-  }
-
-  if (params.config.agent) {
-    params.config.agent = remapAgentKeysToDisplayNames(
-      params.config.agent as Record<string, unknown>,
-      params.pluginConfig.agents as Record<string, { displayName?: string } | undefined> | undefined,
-    );
-    params.config.agent = reorderAgentsByPriority(
-      params.config.agent as Record<string, unknown>,
-      params.pluginConfig.agent_order,
-    );
-  }
-
-  if (configuredDefaultAgent) {
-    setDefaultAgentForSort(
-      (params.config as { default_agent?: string }).default_agent ?? configuredDefaultAgent,
-    );
-  }
-
-  const agentResult = params.config.agent as Record<string, unknown>;
-  clearRegisteredAgentNames();
-  for (const name of Object.keys(agentResult)) {
-    registerAgentName(name);
-  }
-  log("[config-handler] agents loaded", { agentKeys: Object.keys(agentResult) });
-  return agentResult;
+  return finalizeAgentConfig({
+    config: params.config,
+    pluginConfig: params.pluginConfig,
+    configuredDefaultAgent,
+  });
 }

--- a/src/plugin-handlers/agent-config-types.ts
+++ b/src/plugin-handlers/agent-config-types.ts
@@ -1,0 +1,28 @@
+import type { OhMyOpenCodeConfig } from "../config";
+import type { PluginComponents } from "./plugin-components-loader";
+
+export type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
+  build?: Record<string, unknown>;
+  plan?: Record<string, unknown>;
+};
+
+export type ApplyAgentConfigParams = {
+  config: Record<string, unknown>;
+  pluginConfig: OhMyOpenCodeConfig;
+  ctx: { directory: string; client?: unknown };
+  pluginComponents: PluginComponents;
+};
+
+export type AgentSourceMap = Record<string, Record<string, unknown> | undefined>;
+
+export type AgentSources = {
+  userAgents: AgentSourceMap;
+  projectAgents: AgentSourceMap;
+  opencodeGlobalAgents: AgentSourceMap;
+  opencodeProjectAgents: AgentSourceMap;
+  pluginAgents: AgentSourceMap;
+  agentDefinitionAgents: AgentSourceMap;
+  opencodeConfigAgents: AgentSourceMap;
+  configAgent: AgentConfigRecord | undefined;
+  customAgentSummaries: Array<{ name: string; description: string }>;
+};

--- a/src/plugin-handlers/agent-skill-discovery.ts
+++ b/src/plugin-handlers/agent-skill-discovery.ts
@@ -1,0 +1,60 @@
+import type { LoadedSkill } from "../features/opencode-skill-loader";
+import {
+  deduplicateSkillsByName,
+  discoverConfigSourceSkills,
+  discoverGlobalAgentsSkills,
+  discoverOpencodeGlobalSkills,
+  discoverOpencodeProjectSkills,
+  discoverProjectAgentsSkills,
+  discoverProjectClaudeSkills,
+  discoverUserClaudeSkills,
+} from "../features/opencode-skill-loader";
+import { adaptHostSkillConfig } from "../shared/host-skill-config";
+import type { ApplyAgentConfigParams } from "./agent-config-types";
+
+export async function discoverAgentSkills(
+  params: Pick<ApplyAgentConfigParams, "config" | "pluginConfig" | "ctx">,
+): Promise<LoadedSkill[]> {
+  const includeClaudeSkillsForAwareness = params.pluginConfig.claude_code?.skills ?? true;
+  const hostSkillConfig = adaptHostSkillConfig(params.config.skills);
+  const [
+    discoveredConfigSourceSkills,
+    discoveredHostConfigSkills,
+    discoveredUserSkills,
+    discoveredProjectSkills,
+    discoveredProjectAgentsSkills,
+    discoveredOpencodeGlobalSkills,
+    discoveredOpencodeProjectSkills,
+    discoveredGlobalAgentsSkills,
+  ] = await Promise.all([
+    discoverConfigSourceSkills({
+      config: params.pluginConfig.skills,
+      configDir: params.ctx.directory,
+    }),
+    discoverConfigSourceSkills({
+      config: hostSkillConfig,
+      configDir: params.ctx.directory,
+    }),
+    includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
+    includeClaudeSkillsForAwareness
+      ? discoverProjectClaudeSkills(params.ctx.directory)
+      : Promise.resolve([]),
+    includeClaudeSkillsForAwareness
+      ? discoverProjectAgentsSkills(params.ctx.directory)
+      : Promise.resolve([]),
+    discoverOpencodeGlobalSkills(),
+    discoverOpencodeProjectSkills(params.ctx.directory),
+    includeClaudeSkillsForAwareness ? discoverGlobalAgentsSkills() : Promise.resolve([]),
+  ]);
+
+  return deduplicateSkillsByName([
+    ...discoveredConfigSourceSkills,
+    ...discoveredHostConfigSkills,
+    ...discoveredOpencodeProjectSkills,
+    ...discoveredProjectSkills,
+    ...discoveredProjectAgentsSkills,
+    ...discoveredOpencodeGlobalSkills,
+    ...discoveredUserSkills,
+    ...discoveredGlobalAgentsSkills,
+  ]);
+}

--- a/src/plugin-handlers/agent-source-loader.ts
+++ b/src/plugin-handlers/agent-source-loader.ts
@@ -1,0 +1,100 @@
+import {
+  loadAgentDefinitions,
+  loadOpencodeGlobalAgents,
+  loadOpencodeProjectAgents,
+  loadProjectAgents,
+  loadUserAgents,
+  readOpencodeConfigAgents,
+} from "../features/claude-code-agent-loader";
+import { log, migrateAgentConfig } from "../shared";
+import type {
+  AgentConfigRecord,
+  AgentSourceMap,
+  AgentSources,
+  ApplyAgentConfigParams,
+} from "./agent-config-types";
+
+function migratePluginAgents(rawPluginAgents: Record<string, unknown>): AgentSourceMap {
+  const migratedAgents: AgentSourceMap = {};
+  for (const [key, value] of Object.entries(rawPluginAgents)) {
+    if (!value) {
+      migratedAgents[key] = undefined;
+      continue;
+    }
+    const migrated = migrateAgentConfig(value as Record<string, unknown>);
+    if (!migrated.mode) migrated.mode = "subagent";
+    migratedAgents[key] = migrated;
+  }
+  return migratedAgents;
+}
+
+function summarizeCustomAgents(
+  sources: Omit<AgentSources, "customAgentSummaries">,
+): Array<{ name: string; description: string }> {
+  return [
+    ...Object.entries(sources.configAgent ?? {}),
+    ...Object.entries(sources.userAgents),
+    ...Object.entries(sources.projectAgents),
+    ...Object.entries(sources.opencodeGlobalAgents),
+    ...Object.entries(sources.opencodeProjectAgents),
+    ...Object.entries(sources.pluginAgents).filter(([, config]) => config !== undefined),
+    ...Object.entries(sources.agentDefinitionAgents),
+    ...Object.entries(sources.opencodeConfigAgents),
+  ]
+    .filter(([, config]) => config != null)
+    .map(([name, config]) => ({
+      name,
+      description:
+        typeof (config as Record<string, unknown>).description === "string"
+          ? ((config as Record<string, unknown>).description as string)
+          : "",
+    }));
+}
+
+export function loadAgentSources(params: ApplyAgentConfigParams): AgentSources {
+  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+  const anthropicProvider = params.pluginConfig.claude_code?.anthropic_provider;
+  const userAgents = includeClaudeAgents ? loadUserAgents(anthropicProvider) : {};
+  const projectAgents = includeClaudeAgents
+    ? loadProjectAgents(params.ctx.directory, anthropicProvider)
+    : {};
+  const opencodeGlobalAgents = loadOpencodeGlobalAgents();
+  const opencodeProjectAgents = loadOpencodeProjectAgents(params.ctx.directory);
+  const pluginAgents = migratePluginAgents(params.pluginComponents.agents);
+  const agentDefinitionAgents = params.pluginConfig.agent_definitions
+    ? loadAgentDefinitions(
+        params.pluginConfig.agent_definitions,
+        "definition-file",
+        anthropicProvider,
+      )
+    : {};
+  const opencodeConfigAgents = readOpencodeConfigAgents(params.ctx.directory);
+  const configAgent = params.config.agent as AgentConfigRecord | undefined;
+  const sourceCounts = {
+    user: Object.keys(userAgents).length,
+    project: Object.keys(projectAgents).length,
+    opencodeGlobal: Object.keys(opencodeGlobalAgents).length,
+    opencodeProject: Object.keys(opencodeProjectAgents).length,
+    plugin: Object.keys(pluginAgents).length,
+    agentDefinitions: Object.keys(agentDefinitionAgents).length,
+    opencodeConfig: Object.keys(opencodeConfigAgents).length,
+    config: Object.keys(configAgent ?? {}).length,
+  };
+  const sources = {
+    userAgents,
+    projectAgents,
+    opencodeGlobalAgents,
+    opencodeProjectAgents,
+    pluginAgents,
+    agentDefinitionAgents,
+    opencodeConfigAgents,
+    configAgent,
+  };
+
+  log("[agent-config-handler] Agent sources loaded", sourceCounts);
+
+  return {
+    ...sources,
+    customAgentSummaries: summarizeCustomAgents(sources),
+  };
+}

--- a/src/plugin-handlers/agent-source-loader.ts
+++ b/src/plugin-handlers/agent-source-loader.ts
@@ -91,7 +91,7 @@ export function loadAgentSources(params: ApplyAgentConfigParams): AgentSources {
     configAgent,
   };
 
-  log("[agent-config-handler] Agent sources loaded", sourceCounts);
+  log("[agent-source-loader] Agent sources loaded", sourceCounts);
 
   return {
     ...sources,


### PR DESCRIPTION
## Summary
Split `src/plugin-handlers/agent-config-handler.ts` into focused stage modules while preserving `applyAgentConfig` as the public facade. Added a characterization test that pins custom agent source precedence before extraction.

## Changes
- Added `agent-config-types.ts`, `agent-skill-discovery.ts`, `agent-source-loader.ts`, `agent-config-assembly.ts`, and `agent-config-finalizer.ts`.
- Reduced `agent-config-handler.ts` from 397 pure LOC to 56 pure LOC.
- Kept every extracted source file below 250 pure LOC; largest is `agent-config-assembly.ts` at 217 pure LOC.
- Added deterministic loader spies and a custom-source precedence characterization test.

## Testing
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/plugin-handlers/agent-config-handler.ts src/plugin-handlers/agent-config-assembly.ts src/plugin-handlers/agent-source-loader.ts src/plugin-handlers/agent-skill-discovery.ts src/plugin-handlers/agent-config-finalizer.ts src/plugin-handlers/agent-config-types.ts src/plugin-handlers/agent-config-handler.test.ts`
- `bun run typecheck`
- `bun test src/plugin-handlers/agent-config-handler.test.ts src/plugin-handlers/agent-config-handler-agents-skills.test.ts`
- `bun test`
- `bun run build`

## Notes
- Behavior-preserving facade split only.
- Did not touch `src/features/background-agent/manager.ts` or `src/features/tmux-subagent/manager.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic agent config handler into focused modules while keeping `applyAgentConfig` as the public facade. Behavior is preserved and source precedence is enforced by tests.

- **Refactors**
  - Added `agent-config-assembly.ts`, `agent-config-finalizer.ts`, `agent-skill-discovery.ts`, `agent-source-loader.ts`, `agent-config-types.ts`.
  - Reduced `agent-config-handler.ts` from 397 to ~30 LOC.
  - Added a characterization test for custom agent source precedence and deterministic loader spies.
  - Public API unchanged; no migration needed.

- **Bug Fixes**
  - Hardened `finalizeAgentConfig` to tolerate missing `config.agent` and clear stale registrations; added `agent-config-finalizer.test.ts`.

<sup>Written for commit 787198628f447211fdccbd14f6b8787333ba857c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

