### PR TITLE
refactor(atlas): split post-tool after handler

### DIFF
--- a/src/hooks/atlas/tool-execute-after-direct-work.ts
+++ b/src/hooks/atlas/tool-execute-after-direct-work.ts
@@ -1,0 +1,67 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { resolve } from "node:path"
+import {
+  endTaskTimer,
+  getWorkForSession,
+  resolveBoulderPlanPathForWork,
+} from "../../features/boulder-state"
+import { log } from "../../shared/logger"
+import { HOOK_NAME } from "./hook-name"
+import { isOmoPath } from "./omo-path"
+import { DIRECT_WORK_REMINDER } from "./system-reminder-templates"
+import { parseCheckedTopLevelTaskKeys, readCheckedTaskKeysFromPlan } from "./tool-execute-after-plan-tasks"
+import type { ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
+import { isWriteOrEditToolName } from "./write-edit-tool-policy"
+
+export async function handleDirectWorkToolAfter(input: {
+  ctx: PluginInput
+  pendingFilePaths: Map<string, string>
+  pendingPlanSnapshots?: Map<string, string>
+  toolInput: ToolExecuteAfterInput
+  toolOutput: ToolExecuteAfterOutput
+}): Promise<boolean> {
+  const { ctx, pendingFilePaths, pendingPlanSnapshots, toolInput, toolOutput } = input
+  if (!isWriteOrEditToolName(toolInput.tool)) {
+    return false
+  }
+
+  let filePath = toolInput.callID ? pendingFilePaths.get(toolInput.callID) : undefined
+  const planSnapshot = toolInput.callID && pendingPlanSnapshots
+    ? pendingPlanSnapshots.get(toolInput.callID)
+    : undefined
+  if (toolInput.callID) {
+    pendingFilePaths.delete(toolInput.callID)
+    pendingPlanSnapshots?.delete(toolInput.callID)
+  }
+  const metadataFilePath = toolOutput.metadata?.filePath
+  if (!filePath && typeof metadataFilePath === "string") {
+    filePath = metadataFilePath
+  }
+
+  if (filePath && toolInput.sessionID) {
+    const sessionWork = getWorkForSession(ctx.directory, toolInput.sessionID)
+    if (sessionWork) {
+      const planPath = resolveBoulderPlanPathForWork(ctx.directory, sessionWork)
+      if (resolve(filePath) === resolve(planPath) && planSnapshot !== undefined) {
+        const beforeCheckedKeys = parseCheckedTopLevelTaskKeys(planSnapshot)
+        const afterCheckedKeys = readCheckedTaskKeysFromPlan(planPath)
+        for (const taskKey of afterCheckedKeys) {
+          if (!beforeCheckedKeys.has(taskKey)) {
+            endTaskTimer(ctx.directory, sessionWork.work_id, taskKey)
+          }
+        }
+      }
+    }
+  }
+
+  if (filePath && !isOmoPath(filePath)) {
+    toolOutput.output = (toolOutput.output || "") + DIRECT_WORK_REMINDER
+    log(`[${HOOK_NAME}] Direct work reminder appended`, {
+      sessionID: toolInput.sessionID,
+      tool: toolInput.tool,
+      filePath,
+    })
+  }
+
+  return true
+}

--- a/src/hooks/atlas/tool-execute-after-plan-tasks.test.ts
+++ b/src/hooks/atlas/tool-execute-after-plan-tasks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { parseCheckedTopLevelTaskKeys } from "./tool-execute-after-plan-tasks"
+
+describe("tool.execute.after plan task parsing", () => {
+  test("#given checked todo and final-wave top-level tasks #when parsed #then task keys preserve their sections", () => {
+    // given
+    const planContent = `# Plan
+
+## TODOs
+- [x] 1. Implement auth
+  - [x] 2. nested evidence ignored
+- [ ] 2. Add tests
+
+## Notes
+- [x] 99. ignored outside task sections
+
+## Final Verification Wave
+- [X] F1. Review behavior
+- [ ] F2. Run build
+  - [x] F3. nested final-wave evidence ignored
+`
+
+    // when
+    const keys = parseCheckedTopLevelTaskKeys(planContent)
+
+    // then
+    expect([...keys]).toEqual(["todo:1", "final-wave:f1"])
+  })
+})

--- a/src/hooks/atlas/tool-execute-after-plan-tasks.ts
+++ b/src/hooks/atlas/tool-execute-after-plan-tasks.ts
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync } from "node:fs"
+
+const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
+const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
+const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
+const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/
+const TODO_TASK_PATTERN = /^(\d+)\.\s+(.+)$/
+const FINAL_WAVE_TASK_PATTERN = /^(F\d+)\.\s+(.+)$/i
+
+export function isTrackedTaskChecked(planPath: string, taskKey: string): boolean {
+  if (!existsSync(planPath)) {
+    return false
+  }
+
+  const [section, label] = taskKey.split(":")
+  if (!section || !label) {
+    return false
+  }
+
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const matcher = section === "todo"
+    ? new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escapedLabel}\\.\\s+`, "m")
+    : section === "final-wave"
+      ? new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escapedLabel.toUpperCase()}\\.\\s+`, "m")
+      : null
+  if (!matcher) {
+    return false
+  }
+
+  try {
+    const content = readFileSync(planPath, "utf-8")
+    return matcher.test(content)
+  } catch {
+    return false
+  }
+}
+
+export function parseCheckedTopLevelTaskKeys(planContent: string): Set<string> {
+  const checkedKeys = new Set<string>()
+  const lines = planContent.split(/\r?\n/)
+  let section: "todo" | "final-wave" | "other" = "other"
+
+  for (const line of lines) {
+    if (SECOND_LEVEL_HEADING_PATTERN.test(line)) {
+      section = TODO_HEADING_PATTERN.test(line)
+        ? "todo"
+        : FINAL_VERIFICATION_HEADING_PATTERN.test(line)
+          ? "final-wave"
+          : "other"
+      continue
+    }
+
+    if (section !== "todo" && section !== "final-wave") {
+      continue
+    }
+
+    const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN)
+    if (!checkedMatch || checkedMatch[1].length > 0) {
+      continue
+    }
+
+    const taskBody = checkedMatch[2].trim()
+    if (section === "todo") {
+      const taskMatch = taskBody.match(TODO_TASK_PATTERN)
+      if (taskMatch?.[1]) {
+        checkedKeys.add(`todo:${taskMatch[1]}`)
+      }
+      continue
+    }
+
+    const taskMatch = taskBody.match(FINAL_WAVE_TASK_PATTERN)
+    if (taskMatch?.[1]) {
+      checkedKeys.add(`final-wave:${taskMatch[1].toLowerCase()}`)
+    }
+  }
+
+  return checkedKeys
+}
+
+export function readCheckedTaskKeysFromPlan(planPath: string): Set<string> {
+  if (!existsSync(planPath)) {
+    return new Set<string>()
+  }
+
+  try {
+    return parseCheckedTopLevelTaskKeys(readFileSync(planPath, "utf-8"))
+  } catch {
+    return new Set<string>()
+  }
+}

--- a/src/hooks/atlas/tool-execute-after-plan-tasks.ts
+++ b/src/hooks/atlas/tool-execute-after-plan-tasks.ts
@@ -30,7 +30,10 @@ export function isTrackedTaskChecked(planPath: string, taskKey: string): boolean
   try {
     const content = readFileSync(planPath, "utf-8")
     return matcher.test(content)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -84,7 +87,10 @@ export function readCheckedTaskKeysFromPlan(planPath: string): Set<string> {
 
   try {
     return parseCheckedTopLevelTaskKeys(readFileSync(planPath, "utf-8"))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return new Set<string>()
   }
 }

--- a/src/hooks/atlas/tool-execute-after-subagent-completion.ts
+++ b/src/hooks/atlas/tool-execute-after-subagent-completion.ts
@@ -1,0 +1,230 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import {
+  endTaskTimer,
+  getPlanProgress,
+  getTaskSessionState,
+  getWorkForSession,
+  readBoulderState,
+  resolveBoulderPlanPath,
+  resolveBoulderPlanPathForWork,
+  startTaskTimer,
+  upsertTaskSessionState,
+} from "../../features/boulder-state"
+import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktree"
+import { log } from "../../shared/logger"
+import { syncBackgroundLaunchSessionTracking } from "./background-launch-session-tracking"
+import { shouldPauseForFinalWaveApproval } from "./final-wave-approval-gate"
+import { HOOK_NAME } from "./hook-name"
+import { extractSessionIdFromOutput, validateSubagentSessionId } from "./subagent-session-id"
+import { resolvePreferredSessionId, resolveTaskContext } from "./task-context"
+import { isTrackedTaskChecked } from "./tool-execute-after-plan-tasks"
+import type { PendingTaskRef, SessionState, ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
+import {
+  buildCompletionGate,
+  buildFinalWaveApprovalReminder,
+  buildOrchestratorReminder,
+  buildStandaloneVerificationReminder,
+} from "./verification-reminders"
+
+function isBackgroundLaunchOutput(output: string): boolean {
+  return output.includes("Background task launched") || output.includes("Background task continued")
+    || output.includes("Background delegate launched")
+    || output.includes("Background agent task launched")
+}
+
+export async function handleSubagentCompletionAfter(input: {
+  ctx: PluginInput
+  pendingTaskRefs: Map<string, PendingTaskRef>
+  autoCommit: boolean
+  getState: (sessionID: string) => SessionState
+  collectGitDiffStats: typeof collectGitDiffStats
+  formatFileChanges: typeof formatFileChanges
+  toolInput: ToolExecuteAfterInput
+  toolOutput: ToolExecuteAfterOutput
+  metadataSessionId: string | undefined
+}): Promise<void> {
+  const {
+    ctx,
+    pendingTaskRefs,
+    autoCommit,
+    getState,
+    collectGitDiffStats: collectGitDiffStatsImpl,
+    formatFileChanges: formatFileChangesImpl,
+    toolInput,
+    toolOutput,
+    metadataSessionId,
+  } = input
+  const outputStr = typeof toolOutput.output === "string" ? toolOutput.output : ""
+  const pendingTaskRef = toolInput.callID ? pendingTaskRefs.get(toolInput.callID) : undefined
+  if (toolInput.callID) {
+    pendingTaskRefs.delete(toolInput.callID)
+  }
+
+  const boulderState = readBoulderState(ctx.directory)
+  if (isBackgroundLaunchOutput(outputStr)) {
+    await syncBackgroundLaunchSessionTracking({
+      ctx,
+      boulderState,
+      toolInput,
+      toolOutput,
+      pendingTaskRef,
+      metadataSessionId,
+    })
+    return
+  }
+
+  if (outputStr.length === 0) {
+    return
+  }
+
+  const worktreePath = boulderState?.worktree_path?.trim()
+  const verificationDirectory = worktreePath ? worktreePath : ctx.directory
+  const gitStats = collectGitDiffStatsImpl(verificationDirectory)
+  const fileChanges = formatFileChangesImpl(gitStats)
+  const extractedSessionId = metadataSessionId ?? extractSessionIdFromOutput(outputStr)
+
+  if (!boulderState) {
+    const lineageSessionIDs = toolInput.sessionID ? [toolInput.sessionID] : []
+    const subagentSessionId = await validateSubagentSessionId({
+      client: ctx.client,
+      sessionID: extractedSessionId,
+      lineageSessionIDs,
+    })
+    const preferredSessionId = pendingTaskRef?.kind === "skip"
+      ? undefined
+      : subagentSessionId
+    toolOutput.output += `\n<system-reminder>\n${buildStandaloneVerificationReminder(
+      resolvePreferredSessionId(preferredSessionId),
+    )}\n</system-reminder>`
+
+    log(`[${HOOK_NAME}] Verification reminder appended for orchestrator`, {
+      sessionID: toolInput.sessionID,
+      fileCount: gitStats.length,
+    })
+    return
+  }
+
+  const sessionWork = toolInput.sessionID
+    ? getWorkForSession(ctx.directory, toolInput.sessionID)
+    : null
+  const planPath = sessionWork
+    ? resolveBoulderPlanPathForWork(ctx.directory, sessionWork)
+    : resolveBoulderPlanPath(ctx.directory, boulderState)
+  const workScopedBoulderState = sessionWork
+    ? {
+        ...boulderState,
+        active_plan: sessionWork.active_plan,
+        plan_name: sessionWork.plan_name,
+        status: sessionWork.status,
+        started_at: sessionWork.started_at,
+        ended_at: sessionWork.ended_at,
+        elapsed_ms: sessionWork.elapsed_ms,
+        updated_at: sessionWork.updated_at,
+        session_ids: [...sessionWork.session_ids],
+        session_origins: sessionWork.session_origins ? { ...sessionWork.session_origins } : {},
+        agent: sessionWork.agent,
+        worktree_path: sessionWork.worktree_path,
+        task_sessions: sessionWork.task_sessions ? { ...sessionWork.task_sessions } : {},
+      }
+    : boulderState
+  const progress = getPlanProgress(planPath)
+  const {
+    currentTask,
+    shouldSkipTaskSessionUpdate,
+    shouldIgnoreCurrentSessionId,
+  } = resolveTaskContext(pendingTaskRef, planPath)
+  const trackedTaskSession = currentTask
+    ? getTaskSessionState(ctx.directory, currentTask.key)
+    : null
+  const sessionState = toolInput.sessionID ? getState(toolInput.sessionID) : undefined
+
+  const lineageSessionIDs = sessionWork?.session_ids ?? boulderState.session_ids
+  const subagentSessionId = await validateSubagentSessionId({
+    client: ctx.client,
+    sessionID: extractedSessionId,
+    lineageSessionIDs,
+  })
+
+  if (currentTask && subagentSessionId && !shouldSkipTaskSessionUpdate) {
+    if (sessionWork) {
+      startTaskTimer(ctx.directory, sessionWork.work_id, {
+        taskKey: currentTask.key,
+        taskLabel: currentTask.label,
+        taskTitle: currentTask.title,
+        sessionId: subagentSessionId,
+        agent: typeof toolOutput.metadata?.agent === "string" ? toolOutput.metadata.agent : undefined,
+        category: typeof toolOutput.metadata?.category === "string" ? toolOutput.metadata.category : undefined,
+      })
+      if (isTrackedTaskChecked(planPath, currentTask.key)) {
+        endTaskTimer(ctx.directory, sessionWork.work_id, currentTask.key)
+      }
+    } else {
+      upsertTaskSessionState(ctx.directory, {
+        taskKey: currentTask.key,
+        taskLabel: currentTask.label,
+        taskTitle: currentTask.title,
+        sessionId: subagentSessionId,
+        agent: typeof toolOutput.metadata?.agent === "string" ? toolOutput.metadata.agent : undefined,
+        category: typeof toolOutput.metadata?.category === "string" ? toolOutput.metadata.category : undefined,
+      })
+    }
+  }
+
+  const preferredSessionId = resolvePreferredSessionId(
+    shouldIgnoreCurrentSessionId ? undefined : subagentSessionId,
+    trackedTaskSession?.session_id,
+  )
+
+  const originalResponse = toolOutput.output
+  const shouldPauseForApproval = sessionState
+    ? shouldPauseForFinalWaveApproval({
+        planPath,
+        taskOutput: originalResponse,
+        sessionState,
+      })
+    : false
+
+  if (sessionState) {
+    sessionState.waitingForFinalWaveApproval = shouldPauseForApproval
+
+    if (shouldPauseForApproval && sessionState.pendingRetryTimer) {
+      clearTimeout(sessionState.pendingRetryTimer)
+      sessionState.pendingRetryTimer = undefined
+    }
+  }
+
+  const leadReminder = shouldPauseForApproval
+    ? buildFinalWaveApprovalReminder(workScopedBoulderState.plan_name, progress, preferredSessionId)
+    : buildCompletionGate(workScopedBoulderState.plan_name, preferredSessionId)
+  const followupReminder = shouldPauseForApproval
+    ? null
+    : buildOrchestratorReminder(workScopedBoulderState.plan_name, progress, preferredSessionId, autoCommit, false)
+
+  toolOutput.output = `
+<system-reminder>
+${leadReminder}
+</system-reminder>
+
+## SUBAGENT WORK COMPLETED
+
+${fileChanges}
+
+---
+
+**Subagent Response:**
+
+${originalResponse}
+
+${
+  followupReminder === null
+    ? ""
+    : `<system-reminder>\n${followupReminder}\n</system-reminder>`
+}`
+  log(`[${HOOK_NAME}] Output transformed for orchestrator mode (boulder)`, {
+    plan: workScopedBoulderState.plan_name,
+    progress: `${progress.completed}/${progress.total}`,
+    fileCount: gitStats.length,
+    preferredSessionId,
+    waitingForFinalWaveApproval: shouldPauseForApproval,
+  })
+}

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -1,126 +1,12 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import {
-  endTaskTimer,
-  getWorkForSession,
-  getPlanProgress,
-  getTaskSessionState,
-  readBoulderState,
-  resolveBoulderPlanPath,
-  resolveBoulderPlanPathForWork,
-  startTaskTimer,
-  upsertTaskSessionState,
-} from "../../features/boulder-state"
-import { existsSync, readFileSync } from "node:fs"
-import { resolve } from "node:path"
-import { log } from "../../shared/logger"
 import { isCallerOrchestrator } from "../../shared/session-utils"
-import { syncBackgroundLaunchSessionTracking } from "./background-launch-session-tracking"
 import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktree"
-import { shouldPauseForFinalWaveApproval } from "./final-wave-approval-gate"
-import { HOOK_NAME } from "./hook-name"
-import { DIRECT_WORK_REMINDER } from "./system-reminder-templates"
-import { isOmoPath } from "./omo-path"
-import { resolvePreferredSessionId, resolveTaskContext } from "./task-context"
-import { extractSessionIdFromMetadata, extractSessionIdFromOutput, validateSubagentSessionId } from "./subagent-session-id"
+import { extractSessionIdFromMetadata } from "./subagent-session-id"
+import { handleDirectWorkToolAfter } from "./tool-execute-after-direct-work"
+import { handleSubagentCompletionAfter } from "./tool-execute-after-subagent-completion"
 import { didToolMakeProgress, isTangibleProgressTool, recordToolProgress } from "./tool-progress"
-import {
-  buildCompletionGate,
-  buildFinalWaveApprovalReminder,
-  buildOrchestratorReminder,
-  buildStandaloneVerificationReminder,
-} from "./verification-reminders"
-import { isWriteOrEditToolName } from "./write-edit-tool-policy"
 import type { PendingTaskRef, SessionState } from "./types"
 import type { ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
-
-function isTrackedTaskChecked(planPath: string, taskKey: string): boolean {
-  if (!existsSync(planPath)) {
-    return false
-  }
-
-  const [section, label] = taskKey.split(":")
-  if (!section || !label) {
-    return false
-  }
-
-  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const matcher = section === "todo"
-    ? new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escapedLabel}\\.\\s+`, "m")
-    : section === "final-wave"
-      ? new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escapedLabel.toUpperCase()}\\.\\s+`, "m")
-      : null
-  if (!matcher) {
-    return false
-  }
-
-  try {
-    const content = readFileSync(planPath, "utf-8")
-    return matcher.test(content)
-  } catch {
-    return false
-  }
-}
-
-const TODO_HEADING_PATTERN = /^##\s+TODOs\b/i
-const FINAL_VERIFICATION_HEADING_PATTERN = /^##\s+Final Verification Wave\b/i
-const SECOND_LEVEL_HEADING_PATTERN = /^##\s+/
-const CHECKED_CHECKBOX_PATTERN = /^(\s*)[-*]\s*\[[xX]\]\s*(.+)$/
-const TODO_TASK_PATTERN = /^(\d+)\.\s+(.+)$/
-const FINAL_WAVE_TASK_PATTERN = /^(F\d+)\.\s+(.+)$/i
-
-function parseCheckedTopLevelTaskKeys(planContent: string): Set<string> {
-  const checkedKeys = new Set<string>()
-  const lines = planContent.split(/\r?\n/)
-  let section: "todo" | "final-wave" | "other" = "other"
-
-  for (const line of lines) {
-    if (SECOND_LEVEL_HEADING_PATTERN.test(line)) {
-      section = TODO_HEADING_PATTERN.test(line)
-        ? "todo"
-        : FINAL_VERIFICATION_HEADING_PATTERN.test(line)
-          ? "final-wave"
-          : "other"
-      continue
-    }
-
-    if (section !== "todo" && section !== "final-wave") {
-      continue
-    }
-
-    const checkedMatch = line.match(CHECKED_CHECKBOX_PATTERN)
-    if (!checkedMatch || checkedMatch[1].length > 0) {
-      continue
-    }
-
-    const taskBody = checkedMatch[2].trim()
-    if (section === "todo") {
-      const taskMatch = taskBody.match(TODO_TASK_PATTERN)
-      if (taskMatch?.[1]) {
-        checkedKeys.add(`todo:${taskMatch[1]}`)
-      }
-      continue
-    }
-
-    const taskMatch = taskBody.match(FINAL_WAVE_TASK_PATTERN)
-    if (taskMatch?.[1]) {
-      checkedKeys.add(`final-wave:${taskMatch[1].toLowerCase()}`)
-    }
-  }
-
-  return checkedKeys
-}
-
-function readCheckedTaskKeysFromPlan(planPath: string): Set<string> {
-  if (!existsSync(planPath)) {
-    return new Set<string>()
-  }
-
-  try {
-    return parseCheckedTopLevelTaskKeys(readFileSync(planPath, "utf-8"))
-  } catch {
-    return new Set<string>()
-  }
-}
 
 export function createToolExecuteAfterHandler(input: {
   ctx: PluginInput
@@ -151,43 +37,13 @@ export function createToolExecuteAfterHandler(input: {
       return
     }
 
-    if (isWriteOrEditToolName(toolInput.tool)) {
-      let filePath = toolInput.callID ? pendingFilePaths.get(toolInput.callID) : undefined
-      const planSnapshot = toolInput.callID && pendingPlanSnapshots
-        ? pendingPlanSnapshots.get(toolInput.callID)
-        : undefined
-      if (toolInput.callID) {
-        pendingFilePaths.delete(toolInput.callID)
-        pendingPlanSnapshots?.delete(toolInput.callID)
-      }
-      if (!filePath) {
-        filePath = toolOutput.metadata?.filePath as string | undefined
-      }
-
-      if (filePath && toolInput.sessionID) {
-        const sessionWork = getWorkForSession(ctx.directory, toolInput.sessionID)
-        if (sessionWork) {
-          const planPath = resolveBoulderPlanPathForWork(ctx.directory, sessionWork)
-          if (resolve(filePath) === resolve(planPath) && planSnapshot !== undefined) {
-            const beforeCheckedKeys = parseCheckedTopLevelTaskKeys(planSnapshot)
-            const afterCheckedKeys = readCheckedTaskKeysFromPlan(planPath)
-            for (const taskKey of afterCheckedKeys) {
-              if (!beforeCheckedKeys.has(taskKey)) {
-                endTaskTimer(ctx.directory, sessionWork.work_id, taskKey)
-              }
-            }
-          }
-        }
-      }
-
-      if (filePath && !isOmoPath(filePath)) {
-        toolOutput.output = (toolOutput.output || "") + DIRECT_WORK_REMINDER
-        log(`[${HOOK_NAME}] Direct work reminder appended`, {
-          sessionID: toolInput.sessionID,
-          tool: toolInput.tool,
-          filePath,
-        })
-      }
+    if (await handleDirectWorkToolAfter({
+      ctx,
+      pendingFilePaths,
+      pendingPlanSnapshots,
+      toolInput,
+      toolOutput,
+    })) {
       return
     }
 
@@ -197,178 +53,16 @@ export function createToolExecuteAfterHandler(input: {
       return
     }
 
-    const outputStr = toolOutput.output && typeof toolOutput.output === "string" ? toolOutput.output : ""
-    const pendingTaskRef = toolInput.callID ? pendingTaskRefs.get(toolInput.callID) : undefined
-    if (toolInput.callID) {
-      pendingTaskRefs.delete(toolInput.callID)
-    }
-    const boulderState = readBoulderState(ctx.directory)
-    const isBackgroundLaunch = outputStr.includes("Background task launched") || outputStr.includes("Background task continued")
-      || outputStr.includes("Background delegate launched")
-      || outputStr.includes("Background agent task launched")
-    if (isBackgroundLaunch) {
-      await syncBackgroundLaunchSessionTracking({
-        ctx,
-        boulderState,
-        toolInput,
-        toolOutput,
-        pendingTaskRef,
-        metadataSessionId,
-      })
-      return
-    }
-
-    if (toolOutput.output && typeof toolOutput.output === "string") {
-      const worktreePath = boulderState?.worktree_path?.trim()
-      const verificationDirectory = worktreePath ? worktreePath : ctx.directory
-      const gitStats = collectGitDiffStatsImpl(verificationDirectory)
-      const fileChanges = formatFileChangesImpl(gitStats)
-      const extractedSessionId = metadataSessionId ?? extractSessionIdFromOutput(toolOutput.output)
-
-      if (boulderState) {
-        const sessionWork = toolInput.sessionID
-          ? getWorkForSession(ctx.directory, toolInput.sessionID)
-          : null
-        const planPath = sessionWork
-          ? resolveBoulderPlanPathForWork(ctx.directory, sessionWork)
-          : resolveBoulderPlanPath(ctx.directory, boulderState)
-        const workScopedBoulderState = sessionWork
-          ? {
-              ...boulderState,
-              active_plan: sessionWork.active_plan,
-              plan_name: sessionWork.plan_name,
-              status: sessionWork.status,
-              started_at: sessionWork.started_at,
-              ended_at: sessionWork.ended_at,
-              elapsed_ms: sessionWork.elapsed_ms,
-              updated_at: sessionWork.updated_at,
-              session_ids: [...sessionWork.session_ids],
-              session_origins: sessionWork.session_origins ? { ...sessionWork.session_origins } : {},
-              agent: sessionWork.agent,
-              worktree_path: sessionWork.worktree_path,
-              task_sessions: sessionWork.task_sessions ? { ...sessionWork.task_sessions } : {},
-            }
-          : boulderState
-        const progress = getPlanProgress(planPath)
-        const {
-          currentTask,
-          shouldSkipTaskSessionUpdate,
-          shouldIgnoreCurrentSessionId,
-        } = resolveTaskContext(pendingTaskRef, planPath)
-        const trackedTaskSession = currentTask
-          ? getTaskSessionState(ctx.directory, currentTask.key)
-          : null
-        const sessionState = toolInput.sessionID ? getState(toolInput.sessionID) : undefined
-
-        const lineageSessionIDs = sessionWork?.session_ids ?? boulderState.session_ids
-        const subagentSessionId = await validateSubagentSessionId({
-          client: ctx.client,
-          sessionID: extractedSessionId,
-          lineageSessionIDs,
-        })
-
-        if (currentTask && subagentSessionId && !shouldSkipTaskSessionUpdate) {
-          if (sessionWork) {
-            startTaskTimer(ctx.directory, sessionWork.work_id, {
-              taskKey: currentTask.key,
-              taskLabel: currentTask.label,
-              taskTitle: currentTask.title,
-              sessionId: subagentSessionId,
-              agent: typeof toolOutput.metadata?.agent === "string" ? toolOutput.metadata.agent : undefined,
-              category: typeof toolOutput.metadata?.category === "string" ? toolOutput.metadata.category : undefined,
-            })
-            if (isTrackedTaskChecked(planPath, currentTask.key)) {
-              endTaskTimer(ctx.directory, sessionWork.work_id, currentTask.key)
-            }
-          } else {
-            upsertTaskSessionState(ctx.directory, {
-              taskKey: currentTask.key,
-              taskLabel: currentTask.label,
-              taskTitle: currentTask.title,
-              sessionId: subagentSessionId,
-              agent: typeof toolOutput.metadata?.agent === "string" ? toolOutput.metadata.agent : undefined,
-              category: typeof toolOutput.metadata?.category === "string" ? toolOutput.metadata.category : undefined,
-            })
-          }
-        }
-
-        const preferredSessionId = resolvePreferredSessionId(
-          shouldIgnoreCurrentSessionId ? undefined : subagentSessionId,
-          trackedTaskSession?.session_id,
-        )
-
-        // Preserve original subagent response - critical for debugging failed tasks
-        const originalResponse = toolOutput.output
-        const shouldPauseForApproval = sessionState
-          ? shouldPauseForFinalWaveApproval({
-              planPath,
-              taskOutput: originalResponse,
-              sessionState,
-            })
-          : false
-
-        if (sessionState) {
-          sessionState.waitingForFinalWaveApproval = shouldPauseForApproval
-
-          if (shouldPauseForApproval && sessionState.pendingRetryTimer) {
-            clearTimeout(sessionState.pendingRetryTimer)
-            sessionState.pendingRetryTimer = undefined
-          }
-        }
-
-        const leadReminder = shouldPauseForApproval
-          ? buildFinalWaveApprovalReminder(workScopedBoulderState.plan_name, progress, preferredSessionId)
-          : buildCompletionGate(workScopedBoulderState.plan_name, preferredSessionId)
-        const followupReminder = shouldPauseForApproval
-          ? null
-          : buildOrchestratorReminder(workScopedBoulderState.plan_name, progress, preferredSessionId, autoCommit, false)
-
-        toolOutput.output = `
-<system-reminder>
-${leadReminder}
-</system-reminder>
-
-## SUBAGENT WORK COMPLETED
-
-${fileChanges}
-
----
-
-**Subagent Response:**
-
-${originalResponse}
-
-${
-  followupReminder === null
-    ? ""
-    : `<system-reminder>\n${followupReminder}\n</system-reminder>`
-}`
-          log(`[${HOOK_NAME}] Output transformed for orchestrator mode (boulder)`, {
-          plan: workScopedBoulderState.plan_name,
-          progress: `${progress.completed}/${progress.total}`,
-          fileCount: gitStats.length,
-          preferredSessionId,
-          waitingForFinalWaveApproval: shouldPauseForApproval,
-        })
-      } else {
-        const lineageSessionIDs = toolInput.sessionID ? [toolInput.sessionID] : []
-        const subagentSessionId = await validateSubagentSessionId({
-          client: ctx.client,
-          sessionID: extractedSessionId,
-          lineageSessionIDs,
-        })
-        const preferredSessionId = pendingTaskRef?.kind === "skip"
-          ? undefined
-          : subagentSessionId
-        toolOutput.output += `\n<system-reminder>\n${buildStandaloneVerificationReminder(
-          resolvePreferredSessionId(preferredSessionId),
-        )}\n</system-reminder>`
-
-        log(`[${HOOK_NAME}] Verification reminder appended for orchestrator`, {
-          sessionID: toolInput.sessionID,
-          fileCount: gitStats.length,
-        })
-      }
-    }
+    await handleSubagentCompletionAfter({
+      ctx,
+      pendingTaskRefs,
+      autoCommit,
+      getState,
+      collectGitDiffStats: collectGitDiffStatsImpl,
+      formatFileChanges: formatFileChangesImpl,
+      toolInput,
+      toolOutput,
+      metadataSessionId,
+    })
   }
 }


### PR DESCRIPTION
## Summary
Refactors the oversized Atlas post-tool handler into focused modules while preserving the existing public facade import from `src/hooks/atlas/tool-execute-after.ts`.

## Changes
- Extracts plan task checkbox parsing and adds characterization coverage for TODO/final-wave top-level keys.
- Extracts direct Write/Edit post-processing, including plan timer completion and direct-work reminders.
- Extracts subagent completion/background-launch output handling from the facade.
- Reduces `tool-execute-after.ts` from 331 pure LOC to 61 pure LOC; all touched files are under 250 pure LOC.

## Testing
- `bun test src/hooks/atlas/tool-execute-after-plan-tasks.test.ts src/hooks/atlas/final-wave-approval-gate.test.ts src/hooks/atlas/final-wave-approval-gate-regression.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun -e 'const m = await import("./src/hooks/atlas/tool-execute-after.ts"); if (typeof m.createToolExecuteAfterHandler !== "function") throw new Error("missing handler"); console.log("handler import ok")'` ✅
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...changed files...` ✅
- `bun test src/hooks/atlas/tool-execute-after-task-timers.test.ts src/hooks/atlas/tool-execute-after-background-launch.test.ts` ⚠️ 10 pass / 3 fail, matching fresh origin/dev baseline failures where tests expect bare session IDs but storage now returns `opencode:`-prefixed session IDs.

## Notes
This is intended as a behavior-preserving modular split. No protected manager files were changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Atlas post-tool handler into three focused modules while keeping the `createToolExecuteAfterHandler` facade and import path intact. Typecheck and build pass; remaining test failures match the baseline due to `opencode:`-prefixed session IDs.

- **Refactors**
  - Moved plan task checkbox parsing to `tool-execute-after-plan-tasks.ts`; added unit test for TODO and Final Verification Wave tasks.
  - Moved direct write/edit handling to `tool-execute-after-direct-work.ts`; ends task timers on newly checked tasks and appends the direct-work reminder.
  - Moved subagent completion and background-launch handling to `tool-execute-after-subagent-completion.ts`; preserves verification reminders and session tracking.
  - Narrowed plan task read error handling to avoid swallowing non-Error exceptions during plan file reads.
  - Reduced `tool-execute-after.ts` from 331 LOC to 61; all touched files are under 250 LOC.

<sup>Written for commit c28664dbe09bdaf7832dcb6475581eabf3ec871d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

