### PR TITLE
fix(codex): move ultraresearch tool guidance before examples

### DIFF
--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -37,16 +37,53 @@ For work likely to exceed one wait cycle, require the child to send \`WORKING: <
 
 `;
 
-function insertCodexCompatibilityGuidance(content) {
-	if (!opencodeOnlyOrchestrationPattern.test(content)) return content;
-	if (content.includes("## Codex Harness Tool Compatibility")) return content;
+const codexCompatibilityEndMarkers = [
+	"For work likely to exceed one wait cycle, require the child to send `WORKING: <task> - <current phase>` before long passes and `BLOCKED: <reason>` only when progress stops. A `wait_agent` timeout only means no new mailbox update arrived. Treat a running child or latest `WORKING:` message as alive. Do not use `list_agents` as a polling loop. Fallback only when the child is completed without the deliverable, ack-only after followup, explicitly `BLOCKED:`, or no longer running.\n\n",
+	"Codex full-history forks inherit the parent agent type, model, and reasoning effort, so role-specific spawns with `agent_type` must use a non-full-history fork mode such as `fork_turns=\"none\"`. Include any required conversation context, files, diffs, constraints, and requested skill names directly in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
+	"When translating `load_skills=[...]`, include the requested skill names in the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
+	"When translating `load_skills=[...]`, name the skills inside the spawned agent's `message`. If a code block below conflicts with this section, this section wins.\n\n",
+];
 
-	const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n+/);
+function findCodexCompatibilitySectionEnd(content, searchStart) {
+	const structuralEndPattern = /\n(?:---|#{1,6}\s)/g;
+	structuralEndPattern.lastIndex = searchStart;
+	const structuralEnd = structuralEndPattern.exec(content);
+	if (structuralEnd) return structuralEnd.index + 1;
+
+	const knownEndMarker = codexCompatibilityEndMarkers.find((marker) => content.indexOf(marker, searchStart) !== -1);
+	if (knownEndMarker === undefined) return content.length;
+
+	return content.indexOf(knownEndMarker, searchStart) + knownEndMarker.length;
+}
+
+function removeCodexCompatibilityGuidance(content) {
+	const heading = "## Codex Harness Tool Compatibility";
+	let withoutGuidance = content;
+
+	while (true) {
+		const start = withoutGuidance.indexOf(heading);
+		if (start === -1) return withoutGuidance;
+
+		const end = findCodexCompatibilitySectionEnd(withoutGuidance, start + heading.length);
+
+		withoutGuidance = `${withoutGuidance.slice(0, start)}${withoutGuidance.slice(end)}`;
+	}
+}
+
+export function insertCodexCompatibilityGuidance(content) {
+	if (!opencodeOnlyOrchestrationPattern.test(content)) return content;
+	const firstExampleIndex = content.search(opencodeOnlyOrchestrationPattern);
+	const compatibilityIndex = content.indexOf("## Codex Harness Tool Compatibility");
+	if (compatibilityIndex !== -1 && compatibilityIndex < firstExampleIndex) return content;
+
+	const contentWithoutGuidance = removeCodexCompatibilityGuidance(content);
+
+	const frontmatterMatch = contentWithoutGuidance.match(/^---\n[\s\S]*?\n---\n+/);
 	if (!frontmatterMatch) {
-		return `${codexHarnessToolCompatibility}${content}`;
+		return `${codexHarnessToolCompatibility}${contentWithoutGuidance}`;
 	}
 
-	return `${frontmatterMatch[0]}${codexHarnessToolCompatibility}${content.slice(frontmatterMatch[0].length)}`;
+	return `${frontmatterMatch[0]}${codexHarnessToolCompatibility}${contentWithoutGuidance.slice(frontmatterMatch[0].length)}`;
 }
 
 async function adaptSkillForCodex(skillName) {
@@ -58,21 +95,27 @@ async function adaptSkillForCodex(skillName) {
 	}
 }
 
-await rm(skillsRoot, { recursive: true, force: true });
-await mkdir(skillsRoot, { recursive: true });
+async function syncSkills() {
+	await rm(skillsRoot, { recursive: true, force: true });
+	await mkdir(skillsRoot, { recursive: true });
 
-for (const [name, source] of skillSources) {
-	await cp(join(root, source), join(skillsRoot, name), { recursive: true });
-	await adaptSkillForCodex(name);
+	for (const [name, source] of skillSources) {
+		await cp(join(root, source), join(skillsRoot, name), { recursive: true });
+		await adaptSkillForCodex(name);
+	}
+
+	const sharedSkillEntries = await readdir(sharedSkillsRoot, { withFileTypes: true });
+	const sharedSkillNames = sharedSkillEntries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+
+	for (const skillName of sharedSkillNames) {
+		await cp(join(sharedSkillsRoot, skillName), join(skillsRoot, skillName), { recursive: true });
+		await adaptSkillForCodex(skillName);
+	}
 }
 
-const sharedSkillEntries = await readdir(sharedSkillsRoot, { withFileTypes: true });
-const sharedSkillNames = sharedSkillEntries
-	.filter((entry) => entry.isDirectory())
-	.map((entry) => entry.name)
-	.sort();
-
-for (const skillName of sharedSkillNames) {
-	await cp(join(sharedSkillsRoot, skillName), join(skillsRoot, skillName), { recursive: true });
-	await adaptSkillForCodex(skillName);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	await syncSkills();
 }

--- a/packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs
@@ -3,6 +3,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { insertCodexCompatibilityGuidance } from "../scripts/sync-skills.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -32,13 +33,74 @@ test("#given synced aggregate Codex skills #when they contain OpenCode orchestra
 		const content = await readSkill(skillName);
 		if (!opencodeOnlyToolPattern.test(content)) continue;
 
+		const compatibilityMatches = content.match(/## Codex Harness Tool Compatibility/g) ?? [];
 		const compatibilityIndex = content.indexOf("## Codex Harness Tool Compatibility");
 		assert.notEqual(compatibilityIndex, -1, `${skillName} is missing Codex compatibility guidance`);
+		assert.equal(compatibilityMatches.length, 1, `${skillName} must not duplicate Codex compatibility guidance`);
 		assert.ok(
 			compatibilityIndex < content.search(opencodeOnlyToolPattern),
 			`${skillName} must explain Codex tool translation before OpenCode-only examples`,
 		);
 	}
+});
+
+test("#given late variant Codex compatibility guidance #when adapting a skill #then it is moved without duplication", () => {
+	// given
+	const content = `---
+name: example
+---
+
+# Example Skill
+
+call_omo_agent(subagent_type="explore", prompt="inspect")
+
+## Codex Harness Tool Compatibility
+
+Older variant guidance.
+
+When translating \`load_skills=[...]\`, name the skills inside the spawned agent's \`message\`.
+
+---
+
+## Next Section
+
+task(category="quick", prompt="verify")
+`;
+
+	// when
+	const adapted = insertCodexCompatibilityGuidance(content);
+
+	// then
+	const compatibilityIndex = adapted.indexOf("## Codex Harness Tool Compatibility");
+	const firstToolIndex = adapted.search(/\b(?:call_omo_agent|task)\s*\(/);
+	assert.notEqual(compatibilityIndex, -1);
+	assert.ok(compatibilityIndex < firstToolIndex);
+	assert.equal(adapted.match(/## Codex Harness Tool Compatibility/g)?.length, 1);
+	assert.doesNotMatch(adapted, /Older variant guidance/);
+	assert.doesNotMatch(adapted, /When translating `load_skills=\[\.\.\.\]`/);
+	assert.match(adapted, /\n---\n\n## Next Section/);
+});
+
+test("#given early custom Codex compatibility guidance #when adapting a skill #then it is preserved exactly", () => {
+	// given
+	const content = `---
+name: example
+---
+
+## Codex Harness Tool Compatibility
+
+Custom guidance for this skill, including \`dispatchInternalPrompt(...)\`.
+
+# Example Skill
+
+call_omo_agent(subagent_type="explore", prompt="inspect")
+`;
+
+	// when
+	const adapted = insertCodexCompatibilityGuidance(content);
+
+	// then
+	assert.equal(adapted, content);
 });
 
 test("#given synced aggregate Codex skills #when they describe background orchestration #then liveness is framed as progress rather than timeout failure", async () => {


### PR DESCRIPTION
## Summary
Move Codex harness tool compatibility guidance ahead of OpenCode-only orchestration examples when syncing aggregate Codex skills.

## Changes
- Updates `sync-skills.mjs` to preserve already-correct early compatibility guidance, but remove and reinsert missing or late guidance after frontmatter.
- Regenerates the aggregate Codex `ultraresearch` skill so tool translation guidance appears before the first OpenCode-only example.
- Removes aggregate-only ultraresearch agent metadata that is not present in the shared skill source, keeping sync drift checks green.

## Testing
- `npm test -- --test-name-pattern "Codex tool compatibility guidance|shared skill package source|component skill sources|ultraresearch"` ✅
- `git diff --check` ✅
- `bun run test:codex` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Codex tool-compatibility guidance to the top of the `ultraresearch` skill and guarantees it appears exactly once. Refines the sync script to dedupe variants, preserve early custom guidance, and insert a single canonical block after frontmatter to keep sync checks green.

- **Bug Fixes**
  - `packages/omo-codex/plugin/scripts/sync-skills.mjs`: export `insertCodexCompatibilityGuidance`; remove duplicate/late guidance using structural end detection and known end markers; preserve early custom guidance; insert one block after frontmatter; wrap in `syncSkills()` with an entrypoint guard.
  - `packages/omo-codex/plugin/test/sync-skills-orchestration.test.mjs`: add unit tests to ensure late variants are replaced, early custom text is preserved, and guidance exists exactly once before OpenCode-only examples.

<sup>Written for commit af8c3f202b14bf6e30a327521fada631bdde228c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

