### PR TITLE
refactor: split team resume facade

### DIFF
--- a/src/features/team-mode/team-state-store/error-normalization.ts
+++ b/src/features/team-mode/team-state-store/error-normalization.ts
@@ -1,0 +1,22 @@
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function extractErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  if (typeof error !== "object" || error === null || !("message" in error)) return undefined
+  return typeof error.message === "string" ? error.message : undefined
+}
+
+function extractErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null || !("status" in error)) return undefined
+  return typeof error.status === "number" ? error.status : undefined
+}
+
+export function isSessionNotFoundError(error: unknown): boolean {
+  if (extractErrorStatus(error) === 404) return true
+  const message = extractErrorMessage(error)?.toLowerCase()
+  if (!message) return false
+  return message.includes("not found") || message.includes("missing")
+}

--- a/src/features/team-mode/team-state-store/reservation-reconciliation.ts
+++ b/src/features/team-mode/team-state-store/reservation-reconciliation.ts
@@ -1,0 +1,105 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { log } from "../../../shared/logger"
+import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
+import { ackMessages } from "../team-mailbox/ack"
+import { reclaimStaleReservations } from "../team-mailbox/reservation"
+import type { RuntimeStateMember } from "../types"
+import { transitionRuntimeState } from "./store"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function getMessagesData(response: unknown): unknown[] {
+  if (isRecord(response) && Array.isArray(response.data)) {
+    return response.data
+  }
+
+  return Array.isArray(response) ? response : []
+}
+
+function valueContainsMessageId(value: unknown, messageId: string): boolean {
+  if (typeof value === "string") {
+    return value.includes(messageId)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => valueContainsMessageId(entry, messageId))
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).some((entry) => valueContainsMessageId(entry, messageId))
+  }
+
+  return false
+}
+
+async function findAcceptedReclaimedMessageIds(
+  ctx: ExecutorContext,
+  member: RuntimeStateMember,
+  messageIds: readonly string[],
+): Promise<string[]> {
+  if (messageIds.length === 0 || member.sessionId === undefined) {
+    return []
+  }
+
+  try {
+    const response = await ctx.client.session.messages({ path: { id: member.sessionId } })
+    const messages = getMessagesData(response)
+    return messageIds.filter((messageId) => messages.some((message) => valueContainsMessageId(message, messageId)))
+  } catch (historyError) {
+    log("team mailbox reclaimed reservation history check failed", {
+      event: "team-mailbox-reclaim-history-check-failed",
+      member: member.name,
+      sessionID: member.sessionId,
+      error: historyError instanceof Error ? historyError.message : String(historyError),
+    })
+    return []
+  }
+}
+
+async function reconcileReclaimedReservations(
+  ctx: ExecutorContext,
+  teamRunId: string,
+  member: RuntimeStateMember,
+  reclaimedMessageIds: readonly string[],
+  config: TeamModeConfig,
+): Promise<void> {
+  if (reclaimedMessageIds.length === 0) {
+    return
+  }
+
+  const acceptedMessageIds = await findAcceptedReclaimedMessageIds(ctx, member, reclaimedMessageIds)
+  if (acceptedMessageIds.length > 0) {
+    await ackMessages(teamRunId, member.name, acceptedMessageIds, config)
+  }
+
+  const reclaimedMessageIdSet = new Set(reclaimedMessageIds)
+  await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
+    ...currentRuntimeState,
+    members: currentRuntimeState.members.map((currentMember) => (
+      currentMember.name === member.name
+        ? {
+          ...currentMember,
+          pendingInjectedMessageIds: currentMember.pendingInjectedMessageIds.filter((messageId) => !reclaimedMessageIdSet.has(messageId)),
+        }
+        : currentMember
+    )),
+  }), config)
+}
+
+export async function reconcileStaleReservationsForMember(
+  ctx: ExecutorContext,
+  teamRunId: string,
+  member: RuntimeStateMember,
+  config: TeamModeConfig,
+  staleReservationTtlMs: number,
+): Promise<void> {
+  const reclaimedMessageIds = await reclaimStaleReservations(
+    teamRunId,
+    member.name,
+    config,
+    staleReservationTtlMs,
+  )
+  await reconcileReclaimedReservations(ctx, teamRunId, member, reclaimedMessageIds, config)
+}

--- a/src/features/team-mode/team-state-store/resume-report.ts
+++ b/src/features/team-mode/team-state-store/resume-report.ts
@@ -1,0 +1,7 @@
+export interface ResumeReport {
+  resumed: number
+  marked_failed: number
+  marked_orphaned: number
+  cleaned: number
+  errors: Error[]
+}

--- a/src/features/team-mode/team-state-store/resume.ts
+++ b/src/features/team-mode/team-state-store/resume.ts
@@ -1,201 +1,21 @@
-import { rm, stat } from "node:fs/promises"
-
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import { log } from "../../../shared/logger"
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
-import { ackMessages } from "../team-mailbox/ack"
-import { reclaimStaleReservations } from "../team-mailbox/reservation"
-import { getRuntimeStateDir, resolveBaseDir } from "../team-registry/paths"
-import type { RuntimeState, RuntimeStateMember } from "../types"
+import type { RuntimeState } from "../types"
+import { toError } from "./error-normalization"
+import { reconcileStaleReservationsForMember } from "./reservation-reconciliation"
+import type { ResumeReport } from "./resume-report"
+import { cleanupMemberWorktrees, removeRuntimeDirectory } from "./runtime-cleanup"
+import { inspectWorkerMembers, sessionExists } from "./session-liveness"
 import { listActiveTeams, loadRuntimeState, transitionRuntimeState } from "./store"
+
+export type { ResumeReport } from "./resume-report"
 
 const CREATING_TIMEOUT_MS = 30 * 60 * 1000
 const STALE_RESERVATION_TTL_MS = 10 * 60 * 1000
 
-export interface ResumeReport {
-  resumed: number
-  marked_failed: number
-  marked_orphaned: number
-  cleaned: number
-  errors: Error[]
-}
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
-}
-
-function extractErrorMessage(error: unknown): string | undefined {
-  if (error instanceof Error) return error.message
-  if (typeof error === "string") return error
-  if (typeof error !== "object" || error === null || !("message" in error)) return undefined
-  return typeof error.message === "string" ? error.message : undefined
-}
-
-function extractErrorStatus(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null || !("status" in error)) return undefined
-  return typeof error.status === "number" ? error.status : undefined
-}
-
-function isSessionNotFoundError(error: unknown): boolean {
-  if (extractErrorStatus(error) === 404) return true
-  const message = extractErrorMessage(error)?.toLowerCase()
-  if (!message) return false
-  return message.includes("not found") || message.includes("missing")
-}
-
-async function runtimeDirectoryExists(teamRunId: string, config: TeamModeConfig): Promise<boolean> {
-  try {
-    await stat(getRuntimeStateDir(resolveBaseDir(config), teamRunId))
-    return true
-  } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException
-    if (nodeError.code === "ENOENT") return false
-    throw error
-  }
-}
-
-async function removeRuntimeDirectory(teamRunId: string, config: TeamModeConfig): Promise<boolean> {
-  if (!(await runtimeDirectoryExists(teamRunId, config))) return false
-  await rm(getRuntimeStateDir(resolveBaseDir(config), teamRunId), { recursive: true, force: true })
-  return true
-}
-
-async function cleanupMemberWorktrees(runtimeState: RuntimeState): Promise<void> {
-  await Promise.all(runtimeState.members.map(async (member) => {
-    if (!member.worktreePath) return
-    await rm(member.worktreePath, { recursive: true, force: true })
-  }))
-}
-
-async function sessionExists(
-  ctx: ExecutorContext,
-  sessionId: string,
-): Promise<boolean> {
-  try {
-    const response = await ctx.client.session.get({ path: { id: sessionId } })
-
-    if (response.error != null) {
-      if (isSessionNotFoundError(response.error)) return false
-      throw toError(response.error)
-    }
-
-    return response.data != null
-  } catch (error) {
-    if (isSessionNotFoundError(error)) return false
-    throw error
-  }
-}
-
 function isCreatingStateStuck(runtimeState: RuntimeState, now: number): boolean {
   return runtimeState.status === "creating" && now - runtimeState.createdAt > CREATING_TIMEOUT_MS
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
-
-function getMessagesData(response: unknown): unknown[] {
-  if (isRecord(response) && Array.isArray(response.data)) {
-    return response.data
-  }
-
-  return Array.isArray(response) ? response : []
-}
-
-function valueContainsMessageId(value: unknown, messageId: string): boolean {
-  if (typeof value === "string") {
-    return value.includes(messageId)
-  }
-
-  if (Array.isArray(value)) {
-    return value.some((entry) => valueContainsMessageId(entry, messageId))
-  }
-
-  if (isRecord(value)) {
-    return Object.values(value).some((entry) => valueContainsMessageId(entry, messageId))
-  }
-
-  return false
-}
-
-async function findAcceptedReclaimedMessageIds(
-  ctx: ExecutorContext,
-  member: RuntimeStateMember,
-  messageIds: readonly string[],
-): Promise<string[]> {
-  if (messageIds.length === 0 || member.sessionId === undefined) {
-    return []
-  }
-
-  try {
-    const response = await ctx.client.session.messages({ path: { id: member.sessionId } })
-    const messages = getMessagesData(response)
-    return messageIds.filter((messageId) => messages.some((message) => valueContainsMessageId(message, messageId)))
-  } catch (historyError) {
-    log("team mailbox reclaimed reservation history check failed", {
-      event: "team-mailbox-reclaim-history-check-failed",
-      member: member.name,
-      sessionID: member.sessionId,
-      error: historyError instanceof Error ? historyError.message : String(historyError),
-    })
-    return []
-  }
-}
-
-async function reconcileReclaimedReservations(
-  ctx: ExecutorContext,
-  teamRunId: string,
-  member: RuntimeStateMember,
-  reclaimedMessageIds: readonly string[],
-  config: TeamModeConfig,
-): Promise<void> {
-  if (reclaimedMessageIds.length === 0) {
-    return
-  }
-
-  const acceptedMessageIds = await findAcceptedReclaimedMessageIds(ctx, member, reclaimedMessageIds)
-  if (acceptedMessageIds.length > 0) {
-    await ackMessages(teamRunId, member.name, acceptedMessageIds, config)
-  }
-
-  const reclaimedMessageIdSet = new Set(reclaimedMessageIds)
-  await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
-    ...currentRuntimeState,
-    members: currentRuntimeState.members.map((currentMember) => (
-      currentMember.name === member.name
-        ? {
-          ...currentMember,
-          pendingInjectedMessageIds: currentMember.pendingInjectedMessageIds.filter((messageId) => !reclaimedMessageIdSet.has(messageId)),
-        }
-        : currentMember
-    )),
-  }), config)
-}
-
-interface WorkerLiveness {
-  readonly name: string
-  readonly wasSpawned: boolean
-  readonly stillAlive: boolean
-}
-
-async function inspectWorkerMembers(
-  ctx: ExecutorContext,
-  runtimeState: RuntimeState,
-): Promise<WorkerLiveness[]> {
-  const workerMembers = runtimeState.members.filter((member) => member.agentType !== "leader")
-
-  return await Promise.all(workerMembers.map(async (member) => {
-    if (member.status === "errored") {
-      return { name: member.name, wasSpawned: true, stillAlive: false }
-    }
-
-    if (member.sessionId === undefined) {
-      return { name: member.name, wasSpawned: false, stillAlive: true }
-    }
-
-    const stillAlive = await sessionExists(ctx, member.sessionId)
-    return { name: member.name, wasSpawned: true, stillAlive }
-  }))
 }
 
 export async function resumeAllTeams(
@@ -240,13 +60,13 @@ export async function resumeAllTeams(
 
           await Promise.all(runtimeState.members.map(async (member) => {
             try {
-              const reclaimedMessageIds = await reclaimStaleReservations(
+              await reconcileStaleReservationsForMember(
+                ctx,
                 runtimeState.teamRunId,
-                member.name,
+                member,
                 config,
                 STALE_RESERVATION_TTL_MS,
               )
-              await reconcileReclaimedReservations(ctx, runtimeState.teamRunId, member, reclaimedMessageIds, config)
             } catch (reclaimError) {
               log("team mailbox reservation reclaim failed", {
                 event: "team-mailbox-reclaim-failed",

--- a/src/features/team-mode/team-state-store/runtime-cleanup.ts
+++ b/src/features/team-mode/team-state-store/runtime-cleanup.ts
@@ -1,0 +1,35 @@
+import { rm, stat } from "node:fs/promises"
+
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { getRuntimeStateDir, resolveBaseDir } from "../team-registry/paths"
+import type { RuntimeState } from "../types"
+
+function isEnoentError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "ENOENT"
+}
+
+async function runtimeDirectoryExists(teamRunId: string, config: TeamModeConfig): Promise<boolean> {
+  try {
+    await stat(getRuntimeStateDir(resolveBaseDir(config), teamRunId))
+    return true
+  } catch (error) {
+    if (isEnoentError(error)) return false
+    throw error
+  }
+}
+
+export async function removeRuntimeDirectory(teamRunId: string, config: TeamModeConfig): Promise<boolean> {
+  if (!(await runtimeDirectoryExists(teamRunId, config))) return false
+  await rm(getRuntimeStateDir(resolveBaseDir(config), teamRunId), { recursive: true, force: true })
+  return true
+}
+
+export async function cleanupMemberWorktrees(runtimeState: RuntimeState): Promise<void> {
+  await Promise.all(runtimeState.members.map(async (member) => {
+    if (!member.worktreePath) return
+    await rm(member.worktreePath, { recursive: true, force: true })
+  }))
+}

--- a/src/features/team-mode/team-state-store/session-liveness.ts
+++ b/src/features/team-mode/team-state-store/session-liveness.ts
@@ -1,0 +1,48 @@
+import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
+import type { RuntimeState } from "../types"
+import { isSessionNotFoundError, toError } from "./error-normalization"
+
+interface WorkerLiveness {
+  readonly name: string
+  readonly wasSpawned: boolean
+  readonly stillAlive: boolean
+}
+
+export async function sessionExists(
+  ctx: ExecutorContext,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const response = await ctx.client.session.get({ path: { id: sessionId } })
+
+    if (response.error != null) {
+      if (isSessionNotFoundError(response.error)) return false
+      throw toError(response.error)
+    }
+
+    return response.data != null
+  } catch (error) {
+    if (isSessionNotFoundError(error)) return false
+    throw error
+  }
+}
+
+export async function inspectWorkerMembers(
+  ctx: ExecutorContext,
+  runtimeState: RuntimeState,
+): Promise<WorkerLiveness[]> {
+  const workerMembers = runtimeState.members.filter((member) => member.agentType !== "leader")
+
+  return await Promise.all(workerMembers.map(async (member) => {
+    if (member.status === "errored") {
+      return { name: member.name, wasSpawned: true, stillAlive: false }
+    }
+
+    if (member.sessionId === undefined) {
+      return { name: member.name, wasSpawned: false, stillAlive: true }
+    }
+
+    const stillAlive = await sessionExists(ctx, member.sessionId)
+    return { name: member.name, wasSpawned: true, stillAlive }
+  }))
+}


### PR DESCRIPTION
## Summary
Split team-mode runtime resume responsibilities out of `team-state-store/resume.ts` while keeping `resumeAllTeams` and `ResumeReport` exported from the same facade.

## Changes
- Extracted session error normalization and session liveness checks into focused sibling modules.
- Extracted runtime directory/worktree cleanup helpers.
- Extracted stale mailbox reservation reconciliation and kept resume orchestration in `resume.ts`.

## Testing
- `bun test src/features/team-mode/team-state-store/resume.test.ts`
- `bun test src/features/team-mode/team-state-store/resume.test.ts src/features/team-mode/integration.test.ts`
- `bun run typecheck`
- `bun run build`
- LSP diagnostics on changed files: no diagnostics

## Notes
- Behavior-preserving facade split only; no protected Sisyphus prompt files touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split team-mode resume logic into focused modules while keeping `resumeAllTeams` and `ResumeReport` in the same facade. Behavior unchanged; code is simpler and easier to test.

- **Refactors**
  - Extracted error normalization, session liveness, runtime cleanup, and reservation reconciliation into sibling modules.
  - Kept orchestration in `resume.ts` and re-exported `resumeAllTeams` and `ResumeReport`.
  - Reduced `resume.ts` size significantly without changing runtime behavior.

<sup>Written for commit 8dfff4132cf0c068568cd0a3fb020b947a973520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

