### PR TITLE
model-core: remove unused test type imports

### DIFF
--- a/packages/model-core/src/model-resolver.test.ts
+++ b/packages/model-core/src/model-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach, mock } from "bun:test"
 
-import { resolveModel, resolveModelWithFallback, type ModelResolutionInput, type ExtendedModelResolutionInput, type ModelResolutionResult, type ModelSource } from "./model-resolver"
+import { resolveModel, resolveModelWithFallback, type ModelResolutionInput, type ExtendedModelResolutionInput } from "./model-resolver"
 import { _setModelResolutionLogImplementationForTesting } from "./model-resolution-pipeline"
 import * as connectedProvidersCache from "./connected-providers-cache"
 


### PR DESCRIPTION
## Summary
Remove two unused type imports from `packages/model-core/src/model-resolver.test.ts`. This is a no-behavior-change test cleanup.

## Changes
- Removed unused `ModelResolutionResult` and `ModelSource` type imports.

## Testing
- `bun test packages/model-core/src/model-resolver.test.ts` ✅
- `bun run typecheck:packages` ✅

## Merge Policy
- Target branch: `dev`
- This repository requires merge commits for PRs into `dev`; do not squash or rebase merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two unused type imports in `packages/model-core/src/model-resolver.test.ts` to clean up tests and avoid unused import warnings. No behavior change.

<sup>Written for commit 736a70039de1c1ccd150d78c16a5516b2ea35d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

