### PR TITLE
test(hashline-core): prune duplicate dedupe smoke assertion

### DIFF
--- a/packages/hashline-core/src/smoke-untested-modules.test.ts
+++ b/packages/hashline-core/src/smoke-untested-modules.test.ts
@@ -6,7 +6,6 @@ import {
   NIBBLE_STR,
 } from "./constants"
 import { autocorrectReplacementLines } from "./autocorrect-replacement-lines"
-import { dedupeEdits } from "./edit-deduplication"
 import { collectLineRefs, detectOverlappingRanges } from "./edit-ordering"
 import { toNewLines } from "./edit-text-normalization"
 import { canonicalizeFileText, restoreFileText } from "./file-text-canonicalization"
@@ -27,12 +26,6 @@ describe("smoke coverage for moved modules without direct legacy tests", () => {
 
     const corrected = autocorrectReplacementLines(["  return 1"], ["return 2"])
     expect(corrected).toEqual(["  return 2"])
-
-    const deduped = dedupeEdits([
-      { op: "append", pos: "1#ZZ", lines: "x" },
-      { op: "append", pos: "1#ZZ", lines: "x" },
-    ])
-    expect(deduped.deduplicatedEdits).toBe(1)
 
     const refs = collectLineRefs([{ op: "replace", pos: "1#ZZ", lines: "x" }])
     expect(refs).toEqual(["1#ZZ"])


### PR DESCRIPTION
## Summary
Remove a redundant direct dedupe assertion from the legacy hashline-core smoke test. The same deduplication behavior remains covered through the public edit API in `edit-operations.test.ts`, so this trims the smoke file without changing production behavior.

## Changes
- Removed the unused `dedupeEdits` import from `smoke-untested-modules.test.ts`.
- Removed the duplicate append dedupe assertion from the representative helper smoke case.
- Net delta: 7 deleted lines, 6 pure LOC removed.

## Testing
- `bun run --cwd packages/hashline-core typecheck`
- `bun run --cwd packages/hashline-core test`

## Duplicate Check
- Checked open PRs targeting `dev`; avoided active `omo-codex` and `model-core` work.
- Checked recent merged package cleanup PRs including #4749, #4751, #4753, and #4810. This is a separate `hashline-core` smoke-test prune, not an import-only cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a redundant deduplication assertion from the `hashline-core` smoke test to reduce noise. No behavior change; dedupe is still covered through the public edit API tests.

- **Refactors**
  - Removed unused `dedupeEdits` import.
  - Deleted the duplicate append dedupe assertion in the smoke test.

<sup>Written for commit 2b2df7d48dcf7c295046bbdfb913e1feb4f1fe94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

