### PR TITLE
fix context window parser stringify fallback

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
@@ -65,6 +65,38 @@ describe("parseAnthropicTokenLimitError", () => {
     expect(result).not.toBeNull()
   })
 
+  it("#given token limit text only in fallback JSON #when parsing #then detects the token limit", () => {
+    //#given
+    const error = {
+      payload: {
+        reason: "prompt is too long: 250000 tokens > 200000 maximum",
+      },
+    }
+
+    //#when
+    const result = parseAnthropicTokenLimitError(error)
+
+    //#then
+    expect(result).not.toBeNull()
+    if (result === null) {
+      throw new Error("expected token limit parser result")
+    }
+    expect(result.currentTokens).toBe(250000)
+    expect(result.maxTokens).toBe(200000)
+  })
+
+  it("#given a circular reference error without string fields #when parsing #then returns null without crashing", () => {
+    //#given
+    const circular: Record<string, unknown> = { payload: { current: 1 } }
+    circular.self = circular
+
+    //#when
+    const result = parseAnthropicTokenLimitError(circular)
+
+    //#then
+    expect(result).toBeNull()
+  })
+
   it("#given an error where data.responseBody has invalid JSON #when parsing #then handles gracefully", () => {
     //#given
     const error = {

--- a/src/hooks/anthropic-context-window-limit-recovery/parser.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.ts
@@ -73,6 +73,17 @@ function isTokenLimitError(text: string): boolean {
   return TOKEN_LIMIT_KEYWORDS.some((kw) => lower.includes(kw))
 }
 
+function stringifyErrorObject(errObj: Record<string, unknown>): string | null {
+  try {
+    return JSON.stringify(errObj) ?? null
+  } catch (error) {
+    if (error instanceof Error) {
+      return null
+    }
+    return null
+  }
+}
+
 export function parseAnthropicTokenLimitError(err: unknown): ParsedTokenLimitError | null {
   try {
     return parseAnthropicTokenLimitErrorUnsafe(err)
@@ -126,12 +137,10 @@ function parseAnthropicTokenLimitErrorUnsafe(err: unknown): ParsedTokenLimitErro
   if (typeof dataObj?.error === "string") textSources.push(dataObj.error as string)
 
   if (textSources.length === 0) {
-    try {
-      const jsonStr = JSON.stringify(errObj)
-      if (isTokenLimitError(jsonStr)) {
-        textSources.push(jsonStr)
-      }
-    } catch {}
+    const jsonStr = stringifyErrorObject(errObj)
+    if (jsonStr !== null && isTokenLimitError(jsonStr)) {
+      textSources.push(jsonStr)
+    }
   }
 
   const combinedText = textSources.join(" ")

--- a/src/hooks/anthropic-context-window-limit-recovery/parser.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.ts
@@ -77,10 +77,21 @@ function stringifyErrorObject(errObj: Record<string, unknown>): string | null {
   try {
     return JSON.stringify(errObj) ?? null
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof TypeError) {
       return null
     }
-    return null
+    throw error
+  }
+}
+
+function parseJsonOrNull(text: string): unknown | null {
+  try {
+    return JSON.parse(text)
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return null
+    }
+    throw error
   }
 }
 
@@ -147,43 +158,39 @@ function parseAnthropicTokenLimitErrorUnsafe(err: unknown): ParsedTokenLimitErro
   if (!isTokenLimitError(combinedText)) return null
 
   if (typeof responseBody === "string") {
-    try {
-      const jsonPatterns = [
-        // Greedy match to last } for nested JSON
-        /data:\s*(\{[\s\S]*\})\s*$/m,
-        /(\{"type"\s*:\s*"error"[\s\S]*\})/,
-        /(\{[\s\S]*"error"[\s\S]*\})/,
-      ]
+    const jsonPatterns = [
+      // Greedy match to last } for nested JSON
+      /data:\s*(\{[\s\S]*\})\s*$/m,
+      /(\{"type"\s*:\s*"error"[\s\S]*\})/,
+      /(\{[\s\S]*"error"[\s\S]*\})/,
+    ]
 
-      for (const pattern of jsonPatterns) {
-        const dataMatch = responseBody.match(pattern)
-        if (dataMatch) {
-          try {
-            const jsonData: AnthropicErrorData = JSON.parse(dataMatch[1])
-            const message = jsonData.error?.message || ""
-            const tokens = extractTokensFromMessage(message)
+    for (const pattern of jsonPatterns) {
+      const dataMatch = responseBody.match(pattern)
+      if (dataMatch) {
+        const jsonData = parseJsonOrNull(dataMatch[1]) as AnthropicErrorData | null
+        const message = jsonData?.error?.message || ""
+        const tokens = extractTokensFromMessage(message)
 
-            if (tokens) {
-              return {
-                currentTokens: tokens.current,
-                maxTokens: tokens.max,
-                requestId: jsonData.request_id,
-                errorType: jsonData.error?.type || "token_limit_exceeded",
-              }
-            }
-          } catch {}
+        if (tokens) {
+          return {
+            currentTokens: tokens.current,
+            maxTokens: tokens.max,
+            requestId: jsonData?.request_id,
+            errorType: jsonData?.error?.type || "token_limit_exceeded",
+          }
         }
       }
+    }
 
-      const bedrockJson = JSON.parse(responseBody)
-      if (typeof bedrockJson.message === "string" && isTokenLimitError(bedrockJson.message)) {
-        return {
-          currentTokens: 0,
-          maxTokens: 0,
-          errorType: "bedrock_input_too_long",
-        }
+    const bedrockJson = parseJsonOrNull(responseBody) as Record<string, unknown> | null
+    if (typeof bedrockJson?.message === "string" && isTokenLimitError(bedrockJson.message)) {
+      return {
+        currentTokens: 0,
+        maxTokens: 0,
+        errorType: "bedrock_input_too_long",
       }
-    } catch {}
+    }
   }
 
   for (const text of textSources) {


### PR DESCRIPTION
## Summary
- replace the empty JSON.stringify fallback catch with an explicit helper that returns null on stringify failure
- keep token-limit detection from fallback JSON text when stringification succeeds
- add parser regressions for fallback JSON detection and circular objects without string fields

## Tests
- bun test src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
- bun run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Anthropic token limit parser to avoid crashes on stringify/JSON parse failures and correctly extract token limits from nested or fallback JSON, including Bedrock responses. Improves reliability of context window limit recovery.

- **Bug Fixes**
  - Added `stringifyErrorObject` to safely stringify error objects.
  - Added `parseJsonOrNull` to safely parse nested/invalid JSON in `responseBody` and handle Bedrock `message` parsing.
  - Added tests for fallback JSON detection and circular refs.

<sup>Written for commit 22e6037c8193b6618dfbde91a65bc659084f0467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

