### PR TITLE
Refactor delegate subagent resolver split

### DIFF
--- a/src/tools/delegate-task/subagent-agent-match.ts
+++ b/src/tools/delegate-task/subagent-agent-match.ts
@@ -1,0 +1,122 @@
+import type { ExecutorContext } from "./executor-types"
+import { isPlanAgent } from "./constants"
+import type { AgentInfo } from "./subagent-discovery"
+import {
+  findCallableAgentMatch,
+  findPrimaryAgentMatch,
+  isDemotedPlanAgent,
+  listCallableAgentNames,
+  mergeWithClaudeCodeAgents,
+} from "./subagent-discovery"
+import { getAgentConfigKey, stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import { normalizeSDKResponse } from "../../shared"
+import type { ResolveSubagentExecutionOptions, SubagentAgentMatch } from "./subagent-resolution-types"
+
+const DEFAULT_PLAN_FALLBACK_AGENT = "plan"
+const RESERVED_HIDDEN_NATIVE_AGENTS = new Set(["build"])
+
+function isReservedHiddenNativeAgent(agentName: string): boolean {
+  return RESERVED_HIDDEN_NATIVE_AGENTS.has(getAgentConfigKey(agentName))
+}
+
+function shouldUseHiddenPlanAgent(
+  requestedAgent: string,
+  serverPrimaryAgent: AgentInfo | undefined,
+  serverMatchedAgent: AgentInfo | undefined,
+  sisyphusAgentConfig: ExecutorContext["sisyphusAgentConfig"],
+  hasDemotedPlan: boolean,
+): boolean {
+  if (serverPrimaryAgent) {
+    return false
+  }
+
+  if (hasDemotedPlan) {
+    return false
+  }
+
+  if (serverMatchedAgent) {
+    return false
+  }
+
+  if (!isPlanAgent(requestedAgent)) {
+    return false
+  }
+
+  return sisyphusAgentConfig?.planner_enabled !== false
+    && sisyphusAgentConfig?.replace_plan !== false
+}
+
+export async function resolveSubagentAgentMatch(
+  requestedAgent: string,
+  executorCtx: ExecutorContext,
+  options: ResolveSubagentExecutionOptions,
+): Promise<SubagentAgentMatch> {
+  const agentsResult = await executorCtx.client.app.agents()
+  const agents = normalizeSDKResponse(agentsResult, [] as AgentInfo[], {
+    preferResponseOnMissingData: true,
+  })
+  const hasDemotedPlan = agents.some(isDemotedPlanAgent)
+  const serverPrimaryAgent = findPrimaryAgentMatch(agents, requestedAgent)
+  const serverMatchedAgent = findCallableAgentMatch(agents, requestedAgent)
+
+  const mergedAgents = mergeWithClaudeCodeAgents(agents, executorCtx.directory)
+  const matchedPrimaryAgent = findPrimaryAgentMatch(mergedAgents, requestedAgent)
+  const useHiddenPlanFallback = shouldUseHiddenPlanAgent(
+    requestedAgent,
+    serverPrimaryAgent,
+    serverMatchedAgent,
+    executorCtx.sisyphusAgentConfig,
+    hasDemotedPlan,
+  )
+
+  if (isReservedHiddenNativeAgent(requestedAgent) && !serverPrimaryAgent && !serverMatchedAgent) {
+    return {
+      kind: "error",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Unknown agent: "${requestedAgent}". Available agents: ${listCallableAgentNames(agents)}`,
+      },
+    }
+  }
+
+  if (matchedPrimaryAgent && !options.allowPrimaryAgentDelegation && !useHiddenPlanFallback) {
+    return {
+      kind: "error",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Cannot delegate to primary agent "${stripAgentListSortPrefix(matchedPrimaryAgent.name)}" via task. Select that agent directly instead.`,
+      },
+    }
+  }
+
+  const usePrimary = options.allowPrimaryAgentDelegation && matchedPrimaryAgent !== undefined
+  let matchedAgent = usePrimary
+    ? matchedPrimaryAgent
+    : findCallableAgentMatch(mergedAgents, requestedAgent)
+
+  if (useHiddenPlanFallback) {
+    matchedAgent = {
+      name: DEFAULT_PLAN_FALLBACK_AGENT,
+      mode: "subagent",
+    }
+  }
+
+  if (!matchedAgent) {
+    return {
+      kind: "error",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Unknown agent: "${requestedAgent}". Available agents: ${listCallableAgentNames(mergedAgents)}`,
+      },
+    }
+  }
+
+  return {
+    kind: "matched",
+    agentToUse: usePrimary ? matchedAgent.name : stripAgentListSortPrefix(matchedAgent.name),
+    matchedAgent,
+  }
+}

--- a/src/tools/delegate-task/subagent-model-resolution.ts
+++ b/src/tools/delegate-task/subagent-model-resolution.ts
@@ -1,0 +1,120 @@
+import type { AgentOverrides } from "../../config/schema"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { fuzzyMatchModel } from "../../shared/model-availability"
+import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
+import { normalizeModelFormat } from "../../shared/model-format-normalizer"
+import { flattenToFallbackModelStrings, normalizeFallbackModels } from "../../shared/model-resolver"
+import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
+import { log } from "../../shared/logger"
+import { getAvailableModelsForDelegateTask } from "./available-models"
+import { applyCategoryParams } from "./delegated-model-config"
+import type { ExecutorContext } from "./executor-types"
+import { applyFallbackEntrySettings } from "./fallback-entry-settings"
+import { resolveEffectiveFallbackEntry } from "./fallback-entry-resolution"
+import { resolveModelForDelegateTask } from "./model-selection"
+import type { AgentInfo } from "./subagent-discovery"
+import type { ResolvedSubagentModel } from "./subagent-resolution-types"
+
+function findAgentOverride(agentOverrides: AgentOverrides | undefined, agentConfigKey: string) {
+  return agentOverrides?.[agentConfigKey]
+    ?? Object.entries(agentOverrides ?? {}).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1]
+}
+
+export async function resolveSubagentModel(
+  agentToUse: string,
+  matchedAgent: AgentInfo,
+  executorCtx: ExecutorContext,
+): Promise<ResolvedSubagentModel> {
+  let categoryModel = undefined
+  let fallbackChain = undefined
+
+  const agentConfigKey = getAgentConfigKey(agentToUse)
+  const agentOverride = findAgentOverride(executorCtx.agentOverrides, agentConfigKey)
+  const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentConfigKey]
+  const agentCategoryConfig = agentOverride?.category
+    ? executorCtx.userCategories?.[agentOverride.category]
+    : undefined
+  const agentCategoryModel = agentCategoryConfig?.model
+  const normalizedAgentFallbackModels = normalizeFallbackModels(
+    agentOverride?.fallback_models
+    ?? agentCategoryConfig?.fallback_models
+  )
+
+  const availableModels = await getAvailableModelsForDelegateTask(executorCtx.client)
+  const normalizedMatchedModel = matchedAgent.model
+    ? normalizeModelFormat(matchedAgent.model)
+    : undefined
+  const matchedAgentModelStr = normalizedMatchedModel
+    ? `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
+    : undefined
+
+  if (agentOverride?.model || agentCategoryModel || agentRequirement || matchedAgent.model) {
+    const resolution = resolveModelForDelegateTask({
+      userModel: agentOverride?.model ?? agentCategoryModel,
+      userFallbackModels: flattenToFallbackModelStrings(normalizedAgentFallbackModels),
+      categoryDefaultModel: matchedAgentModelStr,
+      fallbackChain: agentRequirement?.fallbackChain,
+      availableModels,
+      systemDefaultModel: undefined,
+    })
+
+    const resolutionSkipped = resolution && "skipped" in resolution
+
+    if (resolution && !resolutionSkipped) {
+      const normalized = normalizeModelFormat(resolution.model)
+      if (normalized) {
+        const variantToUse = agentOverride?.variant ?? resolution.variant ?? agentCategoryConfig?.variant
+        const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
+        categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
+      }
+    } else if (resolutionSkipped && (agentOverride?.model ?? agentCategoryModel)) {
+      const explicitModel = agentOverride?.model ?? agentCategoryModel
+      const normalized = explicitModel ? normalizeModelFormat(explicitModel) : undefined
+      if (normalized) {
+        const variantToUse = agentOverride?.variant ?? agentCategoryConfig?.variant
+        const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
+        categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
+        log("[delegate-task] Cold cache: using explicit user override for subagent", {
+          agent: agentToUse,
+          model: agentOverride?.model ?? agentCategoryModel,
+        })
+      }
+    }
+
+    const defaultProviderID = categoryModel?.providerID
+      ?? normalizedMatchedModel?.providerID
+      ?? "opencode"
+    const configuredFallbackChain = buildFallbackChainFromModels(
+      normalizedAgentFallbackModels,
+      defaultProviderID,
+    )
+    fallbackChain = configuredFallbackChain ?? (resolutionSkipped ? undefined : agentRequirement?.fallbackChain)
+    const effectiveEntry = resolveEffectiveFallbackEntry({
+      categoryModel,
+      configuredFallbackChain,
+      resolution,
+    })
+
+    if (categoryModel && effectiveEntry) {
+      categoryModel = applyFallbackEntrySettings({
+        categoryModel,
+        effectiveEntry,
+        variantOverride: agentOverride?.variant,
+      })
+    }
+  }
+
+  if (!categoryModel && normalizedMatchedModel) {
+    const fullModel = `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
+    if (availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID])) {
+      categoryModel = normalizedMatchedModel
+    } else {
+      log("[delegate-task] Skipping unavailable agent default model", {
+        agent: agentToUse,
+        model: fullModel,
+      })
+    }
+  }
+
+  return { categoryModel, fallbackChain }
+}

--- a/src/tools/delegate-task/subagent-request-preflight.ts
+++ b/src/tools/delegate-task/subagent-request-preflight.ts
@@ -1,0 +1,68 @@
+import type { DelegateTaskArgs } from "./types"
+import { isCoordinatorAgent, COORDINATOR_AGENT_NAMES, isPlanFamily } from "./constants"
+import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
+import { sanitizeSubagentType } from "./subagent-discovery"
+import type { ResolveSubagentExecutionOptions, SubagentRequestPreflight } from "./subagent-resolution-types"
+
+function buildSisyphusJuniorError(categoryExamples: string): string {
+  const exampleHint = categoryExamples.trim() !== ""
+    ? `Use category parameter instead (e.g., ${categoryExamples}).`
+    : `Use the category parameter instead (pick one of: quick, deep, ultrabrain, visual-engineering, artistry, writing).`
+
+  return `Cannot use subagent_type="${SISYPHUS_JUNIOR_AGENT}" directly. ${exampleHint}
+
+Sisyphus-Junior is spawned automatically when you specify a category. Pick the appropriate category for your task domain.`
+}
+
+export function validateSubagentRequest(
+  args: DelegateTaskArgs,
+  parentAgent: string | undefined,
+  categoryExamples: string,
+  options: ResolveSubagentExecutionOptions,
+): SubagentRequestPreflight {
+  if (!args.subagent_type?.trim()) {
+    return {
+      kind: "invalid",
+      result: { agentToUse: "", categoryModel: undefined, error: `Agent name cannot be empty.` },
+    }
+  }
+
+  const agentName = sanitizeSubagentType(args.subagent_type)
+
+  if (!options.allowSisyphusJuniorDirect && agentName.toLowerCase() === SISYPHUS_JUNIOR_AGENT.toLowerCase()) {
+    return {
+      kind: "invalid",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: buildSisyphusJuniorError(categoryExamples),
+      },
+    }
+  }
+
+  if (isPlanFamily(agentName) && isPlanFamily(parentAgent)) {
+    return {
+      kind: "invalid",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `You are a plan-family agent (plan/prometheus). You cannot delegate to other plan-family agents via task.
+
+Create the work plan directly - that's your job as the planning agent.`,
+      },
+    }
+  }
+
+  if (isCoordinatorAgent(agentName)) {
+    return {
+      kind: "invalid",
+      result: {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Cannot delegate to coordinator agent "${agentName}" via task(). Coordinator agents (${COORDINATOR_AGENT_NAMES.join(", ")}) own the orchestration loop and must not be used as subagent targets — doing so creates duplicate coordinators and conflicting team state. Select a worker agent (e.g., sisyphus-junior via category, hephaestus, oracle) instead.`,
+      },
+    }
+  }
+
+  return { kind: "valid", agentName }
+}

--- a/src/tools/delegate-task/subagent-request-preflight.ts
+++ b/src/tools/delegate-task/subagent-request-preflight.ts
@@ -1,4 +1,5 @@
 import type { DelegateTaskArgs } from "./types"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { isCoordinatorAgent, COORDINATOR_AGENT_NAMES, isPlanFamily } from "./constants"
 import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
 import { sanitizeSubagentType } from "./subagent-discovery"
@@ -28,8 +29,9 @@ export function validateSubagentRequest(
   }
 
   const agentName = sanitizeSubagentType(args.subagent_type)
+  const agentConfigKey = getAgentConfigKey(agentName)
 
-  if (!options.allowSisyphusJuniorDirect && agentName.toLowerCase() === SISYPHUS_JUNIOR_AGENT.toLowerCase()) {
+  if (!options.allowSisyphusJuniorDirect && agentConfigKey === getAgentConfigKey(SISYPHUS_JUNIOR_AGENT)) {
     return {
       kind: "invalid",
       result: {

--- a/src/tools/delegate-task/subagent-resolution-types.ts
+++ b/src/tools/delegate-task/subagent-resolution-types.ts
@@ -1,0 +1,32 @@
+import type { FallbackEntry } from "../../shared/model-requirements"
+import type { AgentInfo } from "./subagent-discovery"
+import type { DelegatedModelConfig } from "./types"
+
+export interface ResolveSubagentExecutionOptions {
+  allowSisyphusJuniorDirect?: boolean
+  allowPrimaryAgentDelegation?: boolean
+}
+
+export interface ResolveSubagentExecutionResult {
+  agentToUse: string
+  categoryModel: DelegatedModelConfig | undefined
+  fallbackChain?: FallbackEntry[]
+  error?: string
+}
+
+export type SubagentRequestPreflight =
+  | { readonly kind: "valid"; readonly agentName: string }
+  | { readonly kind: "invalid"; readonly result: ResolveSubagentExecutionResult }
+
+export type SubagentAgentMatch =
+  | {
+      readonly kind: "matched"
+      readonly agentToUse: string
+      readonly matchedAgent: AgentInfo
+    }
+  | { readonly kind: "error"; readonly result: ResolveSubagentExecutionResult }
+
+export interface ResolvedSubagentModel {
+  readonly categoryModel: DelegatedModelConfig | undefined
+  readonly fallbackChain: FallbackEntry[] | undefined
+}

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -1,70 +1,12 @@
 import type { DelegateTaskArgs } from "./types"
 import type { ExecutorContext } from "./executor-types"
-import type { DelegatedModelConfig } from "./types"
-import { isPlanAgent, isPlanFamily, isCoordinatorAgent, COORDINATOR_AGENT_NAMES } from "./constants"
-import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
-import { applyCategoryParams } from "./delegated-model-config"
-import { getAvailableModelsForDelegateTask } from "./available-models"
-import { resolveEffectiveFallbackEntry } from "./fallback-entry-resolution"
-import { applyFallbackEntrySettings } from "./fallback-entry-settings"
-import type { AgentInfo } from "./subagent-discovery"
-import {
-  findPrimaryAgentMatch,
-  findCallableAgentMatch,
-  sanitizeSubagentType,
-  listCallableAgentNames,
-  mergeWithClaudeCodeAgents,
-  isDemotedPlanAgent,
-} from "./subagent-discovery"
-import type { FallbackEntry } from "../../shared/model-requirements"
-import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
-import { resolveModelForDelegateTask } from "./model-selection"
-import { fuzzyMatchModel } from "../../shared/model-availability"
-import { getAgentConfigKey, stripAgentListSortPrefix } from "../../shared/agent-display-names"
-import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
-import { normalizeSDKResponse } from "../../shared"
-import { normalizeModelFormat } from "../../shared/model-format-normalizer"
-import { flattenToFallbackModelStrings, normalizeFallbackModels } from "../../shared/model-resolver"
 import { log } from "../../shared/logger"
+import { resolveSubagentAgentMatch } from "./subagent-agent-match"
+import { resolveSubagentModel } from "./subagent-model-resolution"
+import { validateSubagentRequest } from "./subagent-request-preflight"
+import type { ResolveSubagentExecutionOptions, ResolveSubagentExecutionResult } from "./subagent-resolution-types"
 
-const DEFAULT_PLAN_FALLBACK_AGENT = "plan"
-const RESERVED_HIDDEN_NATIVE_AGENTS = new Set(["build"])
-
-function isReservedHiddenNativeAgent(agentName: string): boolean {
-  return RESERVED_HIDDEN_NATIVE_AGENTS.has(getAgentConfigKey(agentName))
-}
-
-function shouldUseHiddenPlanAgent(
-  requestedAgent: string,
-  serverPrimaryAgent: AgentInfo | undefined,
-  serverMatchedAgent: AgentInfo | undefined,
-  sisyphusAgentConfig: ExecutorContext["sisyphusAgentConfig"],
-  hasDemotedPlan: boolean,
-): boolean {
-  if (serverPrimaryAgent) {
-    return false
-  }
-
-  if (hasDemotedPlan) {
-    return false
-  }
-
-  if (serverMatchedAgent) {
-    return false
-  }
-
-  if (!isPlanAgent(requestedAgent)) {
-    return false
-  }
-
-  return sisyphusAgentConfig?.planner_enabled !== false
-    && sisyphusAgentConfig?.replace_plan !== false
-}
-
-export interface ResolveSubagentExecutionOptions {
-  allowSisyphusJuniorDirect?: boolean
-  allowPrimaryAgentDelegation?: boolean
-}
+export type { ResolveSubagentExecutionOptions, ResolveSubagentExecutionResult }
 
 export async function resolveSubagentExecution(
   args: DelegateTaskArgs,
@@ -72,205 +14,23 @@ export async function resolveSubagentExecution(
   parentAgent: string | undefined,
   categoryExamples: string,
   options: ResolveSubagentExecutionOptions = {},
-): Promise<{ agentToUse: string; categoryModel: DelegatedModelConfig | undefined; fallbackChain?: FallbackEntry[]; error?: string }> {
-  const { client, agentOverrides, userCategories } = executorCtx
-
-  if (!args.subagent_type?.trim()) {
-    return { agentToUse: "", categoryModel: undefined, error: `Agent name cannot be empty.` }
+): Promise<ResolveSubagentExecutionResult> {
+  const preflight = validateSubagentRequest(args, parentAgent, categoryExamples, options)
+  if (preflight.kind === "invalid") {
+    return preflight.result
   }
 
-  const agentName = sanitizeSubagentType(args.subagent_type)
-
-  if (
-    !options.allowSisyphusJuniorDirect &&
-    agentName.toLowerCase() === SISYPHUS_JUNIOR_AGENT.toLowerCase()
-  ) {
-    const exampleHint = categoryExamples.trim() !== ""
-      ? `Use category parameter instead (e.g., ${categoryExamples}).`
-      : `Use the category parameter instead (pick one of: quick, deep, ultrabrain, visual-engineering, artistry, writing).`
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      error: `Cannot use subagent_type="${SISYPHUS_JUNIOR_AGENT}" directly. ${exampleHint}
-
-Sisyphus-Junior is spawned automatically when you specify a category. Pick the appropriate category for your task domain.`,
-    }
-  }
-
-  if (isPlanFamily(agentName) && isPlanFamily(parentAgent)) {
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-    error: `You are a plan-family agent (plan/prometheus). You cannot delegate to other plan-family agents via task.
-
-Create the work plan directly - that's your job as the planning agent.`,
-    }
-  }
-
-  if (isCoordinatorAgent(agentName)) {
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      error: `Cannot delegate to coordinator agent "${agentName}" via task(). Coordinator agents (${COORDINATOR_AGENT_NAMES.join(", ")}) own the orchestration loop and must not be used as subagent targets — doing so creates duplicate coordinators and conflicting team state. Select a worker agent (e.g., sisyphus-junior via category, hephaestus, oracle) instead.`,
-    }
-  }
-
-  let agentToUse = agentName
-  let categoryModel: DelegatedModelConfig | undefined
-  let fallbackChain: FallbackEntry[] | undefined
+  let agentToUse = preflight.agentName
 
   try {
-    const agentsResult = await client.app.agents()
-    const agents = normalizeSDKResponse(agentsResult, [] as AgentInfo[], {
-      preferResponseOnMissingData: true,
-    })
-    const hasDemotedPlan = agents.some(isDemotedPlanAgent)
-    const serverPrimaryAgent = findPrimaryAgentMatch(agents, agentToUse)
-    const serverMatchedAgent = findCallableAgentMatch(agents, agentToUse)
-
-    const mergedAgents = mergeWithClaudeCodeAgents(agents, executorCtx.directory)
-    const matchedPrimaryAgent = findPrimaryAgentMatch(mergedAgents, agentToUse)
-    const useHiddenPlanFallback = shouldUseHiddenPlanAgent(
-      agentToUse,
-      serverPrimaryAgent,
-      serverMatchedAgent,
-      executorCtx.sisyphusAgentConfig,
-      hasDemotedPlan,
-    )
-
-    if (isReservedHiddenNativeAgent(agentToUse) && !serverPrimaryAgent && !serverMatchedAgent) {
-      return {
-        agentToUse: "",
-        categoryModel: undefined,
-        error: `Unknown agent: "${agentToUse}". Available agents: ${listCallableAgentNames(agents)}`,
-      }
+    const agentMatch = await resolveSubagentAgentMatch(agentToUse, executorCtx, options)
+    if (agentMatch.kind === "error") {
+      return agentMatch.result
     }
 
-    if (matchedPrimaryAgent && !options.allowPrimaryAgentDelegation && !useHiddenPlanFallback) {
-      return {
-        agentToUse: "",
-        categoryModel: undefined,
-        error: `Cannot delegate to primary agent "${stripAgentListSortPrefix(matchedPrimaryAgent.name)}" via task. Select that agent directly instead.`,
-      }
-    }
-
-    const usePrimary = options.allowPrimaryAgentDelegation && matchedPrimaryAgent !== undefined
-    let matchedAgent = usePrimary
-      ? matchedPrimaryAgent
-      : findCallableAgentMatch(mergedAgents, agentToUse)
-
-    if (useHiddenPlanFallback) {
-      matchedAgent = {
-        name: DEFAULT_PLAN_FALLBACK_AGENT,
-        mode: "subagent",
-      }
-    }
-
-    if (!matchedAgent) {
-      return {
-        agentToUse: "",
-        categoryModel: undefined,
-        error: `Unknown agent: "${agentToUse}". Available agents: ${listCallableAgentNames(mergedAgents)}`,
-      }
-    }
-
-    agentToUse = usePrimary
-      ? matchedAgent.name
-      : stripAgentListSortPrefix(matchedAgent.name)
-
-    const agentConfigKey = getAgentConfigKey(agentToUse)
-    const agentOverride = agentOverrides?.[agentConfigKey as keyof typeof agentOverrides]
-      ?? (agentOverrides ? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1] : undefined)
-    const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentConfigKey]
-    const agentCategoryConfig = agentOverride?.category
-      ? userCategories?.[agentOverride.category]
-      : undefined
-    const agentCategoryModel = agentCategoryConfig?.model
-    const normalizedAgentFallbackModels = normalizeFallbackModels(
-      agentOverride?.fallback_models
-      ?? agentCategoryConfig?.fallback_models
-    )
-
-    const availableModels = await getAvailableModelsForDelegateTask(client)
-
-    if (agentOverride?.model || agentCategoryModel || agentRequirement || matchedAgent.model) {
-
-      const normalizedMatchedModel = matchedAgent.model
-        ? normalizeModelFormat(matchedAgent.model)
-        : undefined
-      const matchedAgentModelStr = normalizedMatchedModel
-        ? `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
-        : undefined
-
-      const resolution = resolveModelForDelegateTask({
-        userModel: agentOverride?.model ?? agentCategoryModel,
-        userFallbackModels: flattenToFallbackModelStrings(normalizedAgentFallbackModels),
-        categoryDefaultModel: matchedAgentModelStr,
-        fallbackChain: agentRequirement?.fallbackChain,
-        availableModels,
-        systemDefaultModel: undefined,
-      })
-
-      const resolutionSkipped = resolution && 'skipped' in resolution
-
-      if (resolution && !resolutionSkipped) {
-        const normalized = normalizeModelFormat(resolution.model)
-        if (normalized) {
-          const variantToUse = agentOverride?.variant ?? resolution.variant ?? agentCategoryConfig?.variant
-          const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
-          categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
-        }
-      } else if (resolutionSkipped && (agentOverride?.model ?? agentCategoryModel)) {
-        const explicitModel = agentOverride?.model ?? agentCategoryModel
-        const normalized = explicitModel ? normalizeModelFormat(explicitModel) : undefined
-        if (normalized) {
-          const variantToUse = agentOverride?.variant ?? agentCategoryConfig?.variant
-          const resolvedModel = variantToUse ? { ...normalized, variant: variantToUse } : normalized
-          categoryModel = applyCategoryParams(resolvedModel, agentCategoryConfig)
-          log("[delegate-task] Cold cache: using explicit user override for subagent", {
-            agent: agentToUse,
-            model: agentOverride?.model ?? agentCategoryModel,
-          })
-        }
-      }
-
-      const defaultProviderID = categoryModel?.providerID
-        ?? normalizedMatchedModel?.providerID
-        ?? "opencode"
-      const configuredFallbackChain = buildFallbackChainFromModels(
-        normalizedAgentFallbackModels,
-        defaultProviderID,
-      )
-      fallbackChain = configuredFallbackChain ?? (resolutionSkipped ? undefined : agentRequirement?.fallbackChain)
-      const effectiveEntry = resolveEffectiveFallbackEntry({
-        categoryModel,
-        configuredFallbackChain,
-        resolution,
-      })
-
-      if (categoryModel && effectiveEntry) {
-        categoryModel = applyFallbackEntrySettings({
-          categoryModel,
-          effectiveEntry,
-          variantOverride: agentOverride?.variant,
-        })
-      }
-    }
-
-    if (!categoryModel && matchedAgent.model) {
-      const normalizedMatchedModel = normalizeModelFormat(matchedAgent.model)
-      if (normalizedMatchedModel) {
-        const fullModel = `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
-        if (availableModels.size === 0 || fuzzyMatchModel(fullModel, availableModels, [normalizedMatchedModel.providerID])) {
-          categoryModel = normalizedMatchedModel
-        } else {
-          log("[delegate-task] Skipping unavailable agent default model", {
-            agent: agentToUse,
-            model: fullModel,
-          })
-        }
-      }
-    }
+    agentToUse = agentMatch.agentToUse
+    const { categoryModel, fallbackChain } = await resolveSubagentModel(agentToUse, agentMatch.matchedAgent, executorCtx)
+    return { agentToUse, categoryModel, fallbackChain }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     log("[delegate-task] Failed to resolve subagent execution", {
@@ -285,6 +45,4 @@ Create the work plan directly - that's your job as the planning agent.`,
       error: `Failed to delegate to agent "${agentToUse}": ${errorMessage}`,
     }
   }
-
-  return { agentToUse, categoryModel, fallbackChain }
 }

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -663,6 +663,21 @@ describe("resolveSubagentExecution", () => {
     expect(result.categoryModel).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
   })
 
+  test("normalizes matched agent object model before returning categoryModel", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "oracle" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "oracle", mode: "subagent", model: { providerID: "openai", modelID: "gpt-5.5" } },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+  })
+
   test("matches agents even when zero-width characters are present in the requested name", async () => {
     //#given
     const args = createBaseArgs({ subagent_type: "\uFEFFSisyphus - Ultraworker" })

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -236,6 +236,22 @@ describe("resolveSubagentExecution", () => {
     expect(result.error).toContain("pick one of: quick, deep, ultrabrain")
   })
 
+  test("blocks zero-width-prefixed direct Sisyphus-Junior requests", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "\u200Bsisyphus-junior" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "Sisyphus-Junior", mode: "subagent" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('Cannot use subagent_type="Sisyphus-Junior" directly')
+  })
+
   test("requires explicit all or subagent mode for task-callable agents", async () => {
     //#given
     const args = createBaseArgs({ subagent_type: "custom-worker" })


### PR DESCRIPTION
## Summary
Splits the oversized delegate-task subagent resolver into focused request preflight, agent matching, and model resolution modules while keeping `resolveSubagentExecution` as the stable facade.

## Changes
- Added characterization coverage for object-style matched agent models.
- Extracted direct request guards into `subagent-request-preflight.ts`.
- Extracted runtime agent matching and hidden plan/build handling into `subagent-agent-match.ts`.
- Extracted subagent model and fallback-chain resolution into `subagent-model-resolution.ts`.
- Moved resolver result/option contracts into `subagent-resolution-types.ts`.

## Testing
- `bun test src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts src/tools/delegate-task/coordinator-subagent-guard.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/delegate-task/subagent-resolver.ts src/tools/delegate-task/subagent-request-preflight.ts src/tools/delegate-task/subagent-agent-match.ts src/tools/delegate-task/subagent-model-resolution.ts src/tools/delegate-task/subagent-resolution-types.ts`
- `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the delegate-task subagent resolver into focused modules for request validation, agent matching, and model resolution, keeping `resolveSubagentExecution` stable. Also hardens preflight to block direct Sisyphus‑Junior requests (including zero‑width/whitespace variants) and normalizes object-style agent models.

- **Refactors**
  - Moved request guards to `subagent-request-preflight.ts`.
  - Moved agent matching and hidden plan/build logic to `subagent-agent-match.ts`.
  - Moved model and fallback-chain resolution to `subagent-model-resolution.ts`.
  - Centralized result/options in `subagent-resolution-types.ts`.
  - Trimmed `subagent-resolver.ts` while preserving the facade.

- **Bug Fixes**
  - Sanitize `subagent_type` (zero-width chars, case) and block direct `Sisyphus-Junior` requests with clear guidance.
  - Normalize object-style matched agent `model` before returning `categoryModel` (with test coverage).

<sup>Written for commit d2ca8dd4bf0b862b9e16ee2e998054a9710d3e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

