### PR TITLE
fix: log skipped directory README injection failures

### DIFF
--- a/src/hooks/directory-readme-injector/injector.test.ts
+++ b/src/hooks/directory-readme-injector/injector.test.ts
@@ -7,12 +7,17 @@ import { join } from "node:path"
 import type { PluginInput } from "@opencode-ai/plugin"
 
 const storageMaps = new Map<string, Set<string>>()
+const logMock = mock(() => undefined)
 
 mock.module("./storage", () => ({
   loadInjectedPaths: (sessionID: string) => storageMaps.get(sessionID) ?? new Set<string>(),
   saveInjectedPaths: (sessionID: string, paths: Set<string>) => {
     storageMaps.set(sessionID, paths)
   },
+}))
+
+mock.module("../../shared/logger", () => ({
+  log: logMock,
 }))
 
 afterAll(() => {
@@ -45,6 +50,7 @@ describe("processFilePathForReadmeInjection", () => {
     testRoot = join(tmpdir(), `directory-readme-injector-${randomUUID()}`)
     mkdirSync(testRoot, { recursive: true })
     storageMaps.clear()
+    logMock.mockClear()
   })
 
   afterEach(() => {
@@ -238,5 +244,48 @@ describe("processFilePathForReadmeInjection", () => {
 
     // then
     expect(output.output).toBe("unchanged")
+  })
+
+  it("logs and skips a README when truncation fails", async () => {
+    // given
+    const sourceDirectory = join(testRoot, "src")
+    mkdirSync(sourceDirectory, { recursive: true })
+    const readmePath = join(sourceDirectory, "README.md")
+    writeFileSync(readmePath, "# Source README")
+
+    const { processFilePathForReadmeInjection } = await import("./injector")
+    const output = { title: "Result", output: "base", metadata: {} }
+    const sessionID = "session-truncation-failure"
+    const sessionCaches = new Map<string, Set<string>>()
+    const truncator = {
+      truncate: async (_sessionID: string, _content: string) => {
+        throw new Error("truncator unavailable")
+      },
+      getUsage: async (_sessionID: string) => null,
+      truncateSync: (value: string) => ({ result: value, truncated: false }),
+    }
+
+    // when
+    await processFilePathForReadmeInjection({
+      ctx: createPluginContext(testRoot),
+      truncator,
+      sessionCaches,
+      filePath: join(sourceDirectory, "file.ts"),
+      sessionID,
+      output,
+    })
+
+    // then
+    expect(output.output).toBe("base")
+    expect(storageMaps.has(sessionID)).toBe(false)
+    expect(sessionCaches.get(sessionID)?.has(sourceDirectory)).toBe(false)
+    expect(logMock).toHaveBeenCalledWith(
+      "[directory-readme-injector] Skipped README injection after read/truncate failure",
+      {
+        error: "truncator unavailable",
+        readmePath,
+        sessionID,
+      },
+    )
   })
 })

--- a/src/hooks/directory-readme-injector/injector.test.ts
+++ b/src/hooks/directory-readme-injector/injector.test.ts
@@ -278,7 +278,7 @@ describe("processFilePathForReadmeInjection", () => {
     // then
     expect(output.output).toBe("base")
     expect(storageMaps.has(sessionID)).toBe(false)
-    expect(sessionCaches.get(sessionID)?.has(sourceDirectory)).toBe(false)
+    expect(sessionCaches.get(sessionID)?.has(sourceDirectory) ?? false).toBe(false)
     expect(logMock).toHaveBeenCalledWith(
       "[directory-readme-injector] Skipped README injection after read/truncate failure",
       {

--- a/src/hooks/directory-readme-injector/injector.ts
+++ b/src/hooks/directory-readme-injector/injector.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { createDynamicTruncator } from "../../shared/dynamic-truncator";
+import { log } from "../../shared/logger";
 import { findReadmeMdUp, resolveFilePath } from "./finder";
 import { loadInjectedPaths, saveInjectedPaths } from "./storage";
 
@@ -18,6 +19,11 @@ function getSessionCache(
   return sessionCaches.get(sessionID)!;
 }
 
+function describeReadmeInjectionError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
 export async function processFilePathForReadmeInjection(input: {
   ctx: PluginInput;
   truncator: DynamicTruncator;
@@ -31,7 +37,7 @@ export async function processFilePathForReadmeInjection(input: {
 
   const dir = dirname(resolved);
   const cache = getSessionCache(input.sessionCaches, input.sessionID);
-   const readmePaths = await findReadmeMdUp({ startDir: dir, rootDir: input.ctx.directory });
+  const readmePaths = await findReadmeMdUp({ startDir: dir, rootDir: input.ctx.directory });
 
   let dirty = false;
   for (const readmePath of readmePaths) {
@@ -50,7 +56,13 @@ export async function processFilePathForReadmeInjection(input: {
       input.output.output += `\n\n[Project README: ${readmePath}]\n${result}${truncationNotice}`;
       cache.add(readmeDir);
       dirty = true;
-    } catch {}
+    } catch (error) {
+      log("[directory-readme-injector] Skipped README injection after read/truncate failure", {
+        error: describeReadmeInjectionError(error),
+        readmePath,
+        sessionID: input.sessionID,
+      });
+    }
   }
 
   if (dirty) {

--- a/src/hooks/directory-readme-injector/injector.ts
+++ b/src/hooks/directory-readme-injector/injector.ts
@@ -13,10 +13,14 @@ function getSessionCache(
   sessionCaches: Map<string, Set<string>>,
   sessionID: string,
 ): Set<string> {
-  if (!sessionCaches.has(sessionID)) {
-    sessionCaches.set(sessionID, loadInjectedPaths(sessionID));
+  const existing = sessionCaches.get(sessionID);
+  if (existing) {
+    return existing;
   }
-  return sessionCaches.get(sessionID)!;
+
+  const loaded = loadInjectedPaths(sessionID);
+  sessionCaches.set(sessionID, loaded);
+  return loaded;
 }
 
 function describeReadmeInjectionError(error: unknown): string {
@@ -57,8 +61,11 @@ export async function processFilePathForReadmeInjection(input: {
       cache.add(readmeDir);
       dirty = true;
     } catch (error) {
+      const errorMessage = error instanceof Error
+        ? error.message
+        : describeReadmeInjectionError(error);
       log("[directory-readme-injector] Skipped README injection after read/truncate failure", {
-        error: describeReadmeInjectionError(error),
+        error: errorMessage,
         readmePath,
         sessionID: input.sessionID,
       });


### PR DESCRIPTION
## Summary
- replace the empty per-README catch in the directory README injector with explicit logged skip handling
- preserve non-disruptive behavior: failed README read/truncate attempts do not mutate output, cache, or persisted injection state
- add a focused regression test for truncation failure handling

## Tests
- bun test src/hooks/directory-readme-injector/injector.test.ts
- bun run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log and skip README injection when read/truncate fails, without changing output or state. Adds a regression test for truncation failure that verifies logging and no state changes.

- **Bug Fixes**
  - Replace empty catch with a `log` call: message plus `error` (message string), `readmePath`, and `sessionID`.
  - Preserve behavior: no output mutation, no session cache updates, no persisted path changes on failure.
  - Add and correct a focused test that mocks truncator failure and asserts exact log args and unchanged state.

<sup>Written for commit 7b7ea1a373897cd43c9a2bab5f99b976c2a23c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

