### PR TITLE
Fix image converter cleanup error handling

### DIFF
--- a/src/tools/look-at/image-converter.test.ts
+++ b/src/tools/look-at/image-converter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import * as childProcess from "node:child_process"
-import { existsSync, mkdtempSync, writeFileSync, unlinkSync, rmSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, writeFileSync, unlinkSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
@@ -201,13 +201,54 @@ describe("image-converter command execution safety", () => {
       try {
         runConversion()
       } catch (error) {
-        const conversionError = error as Error & { temporaryOutputPath?: string }
-        expect(conversionError.temporaryOutputPath).toBeDefined()
-        expect(conversionError.temporaryOutputPath?.endsWith("converted.jpg")).toBe(true)
+        if (!(error instanceof Error)) {
+          throw error
+        }
+        const temporaryOutputPath = Reflect.get(error, "temporaryOutputPath")
+        expect(temporaryOutputPath).toBeDefined()
+        expect(
+          typeof temporaryOutputPath === "string" && temporaryOutputPath.endsWith("converted.jpg")
+        ).toBe(true)
       }
 
       if (existsSync(inputPath)) unlinkSync(inputPath)
       rmSync(testDir, { recursive: true, force: true })
+    })
+  })
+
+  test("preserves conversion error when temporary output cleanup fails", async () => {
+    await withMockPlatform("linux", async () => {
+      const testDir = mkdtempSync(join(tmpdir(), "img-converter-cleanup-failure-test-"))
+      const inputPath = join(testDir, "photo.heic")
+      let lockedConversionDirectory: string | null = null
+      writeFileSync(inputPath, "fake-heic-data")
+      const { convertImageToJpeg } = await loadImageConverter()
+
+      execFileSyncSpy.mockImplementation(
+        ((_command: string, args: string[]) => {
+          const outputPath = args[2]
+          if (typeof outputPath !== "string") {
+            throw new Error("expected ImageMagick output path")
+          }
+          writeFileSync(outputPath, "partial-jpeg")
+          lockedConversionDirectory = dirname(outputPath)
+          chmodSync(lockedConversionDirectory, 0o500)
+          throw new Error("conversion process failed")
+        }) as typeof childProcess.execFileSync,
+      )
+
+      const runConversion = () => convertImageToJpeg(inputPath, "image/heic")
+
+      try {
+        expect(runConversion).toThrow("No image conversion tool available")
+      } finally {
+        if (lockedConversionDirectory !== null) {
+          chmodSync(lockedConversionDirectory, 0o700)
+          rmSync(lockedConversionDirectory, { recursive: true, force: true })
+        }
+        if (existsSync(inputPath)) unlinkSync(inputPath)
+        rmSync(testDir, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/src/tools/look-at/image-converter.ts
+++ b/src/tools/look-at/image-converter.ts
@@ -34,6 +34,20 @@ const UNSUPPORTED_FORMATS = new Set([
 
 const CONVERSION_TIMEOUT_MS = 30_000
 
+function cleanupTemporaryFileAfterFailure(filePath: string): void {
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath)
+    }
+  } catch (cleanupError) {
+    const cleanupErrorDescription =
+      cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+    log(
+      `[image-converter] Ignored temporary cleanup failure for ${filePath}: ${cleanupErrorDescription}`
+    )
+  }
+}
+
 export function needsConversion(mimeType: string): boolean {
   if (SUPPORTED_FORMATS.has(mimeType)) {
     return false
@@ -70,7 +84,9 @@ export function convertImageToJpeg(inputPath: string, mimeType: string): string 
           return outputPath
         }
       } catch (sipsError) {
-        log(`[image-converter] sips failed: ${sipsError}`)
+        const sipsErrorDescription =
+          sipsError instanceof Error ? sipsError.message : String(sipsError)
+        log(`[image-converter] sips failed: ${sipsErrorDescription}`)
       }
     }
 
@@ -87,7 +103,9 @@ export function convertImageToJpeg(inputPath: string, mimeType: string): string 
         return outputPath
       }
     } catch (convertError) {
-      log(`[image-converter] ImageMagick convert failed: ${convertError}`)
+      const convertErrorDescription =
+        convertError instanceof Error ? convertError.message : String(convertError)
+      log(`[image-converter] ImageMagick convert failed: ${convertErrorDescription}`)
     }
 
     throw new Error(
@@ -97,11 +115,7 @@ export function convertImageToJpeg(inputPath: string, mimeType: string): string 
       `  RHEL/CentOS: sudo yum install ImageMagick`
     )
   } catch (error) {
-    try {
-      if (existsSync(outputPath)) {
-        unlinkSync(outputPath)
-      }
-    } catch {}
+    cleanupTemporaryFileAfterFailure(outputPath)
 
     if (error instanceof Error) {
       const conversionError = error as Error & { temporaryOutputPath?: string }
@@ -124,7 +138,8 @@ export function cleanupConvertedImage(filePath: string): void {
       log(`[image-converter] Cleaned up temporary directory: ${tempDirectory}`)
     }
   } catch (error) {
-    log(`[image-converter] Failed to cleanup ${filePath}: ${error}`)
+    const cleanupErrorDescription = error instanceof Error ? error.message : String(error)
+    log(`[image-converter] Failed to cleanup ${filePath}: ${cleanupErrorDescription}`)
   }
 }
 
@@ -154,11 +169,9 @@ export function convertBase64ImageToJpeg(
     
     return { base64: convertedBase64, tempFiles }
   } catch (error) {
-    tempFiles.forEach(file => {
-      try {
-        if (existsSync(file)) unlinkSync(file)
-      } catch {}
-    })
+    for (const file of tempFiles) {
+      cleanupTemporaryFileAfterFailure(file)
+    }
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- replace empty temporary-file cleanup catches in look_at image conversion with explicit ignored-cleanup logging
- keep conversion failures as the thrown error while preserving temporaryOutputPath for callers
- add a regression test for cleanup failure during conversion-error handling

## Tests
- bun test src/tools/look-at/image-converter.test.ts
- bun test src/tools/look-at/*.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/look-at/image-converter.ts src/tools/look-at/image-converter.test.ts
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves image conversion error handling by logging ignored cleanup failures and preserving the original conversion error while exposing the temporary output path. Adds a regression test to ensure cleanup failures don’t mask conversion errors.

- **Bug Fixes**
  - Replaced silent cleanup catches with logged, ignored failures via cleanupTemporaryFileAfterFailure().
  - Preserves the original conversion error and attaches temporaryOutputPath for callers.
  - Normalizes logging to use error.message for sips/convert/cleanup paths.
  - Adds a regression test for cleanup failure during a conversion error.

<sup>Written for commit 7824becbc809e1d28f55c151b11d33f8a6c2193a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

