### PR TITLE
refactor(background-agent): split spawner helper builders

### DIFF
--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -4,7 +4,7 @@ import {
   getSessionPromptParams,
 } from "../../shared/session-prompt-params-state"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
-import { createTask, startTask } from "./spawner"
+import { buildFallbackBody, createTask, isAgentNotFoundError, startTask } from "./spawner"
 import type { BackgroundTask } from "./types"
 
 /**
@@ -856,5 +856,43 @@ describe("background-agent spawner tmux callback ordering", () => {
       if (originalTmux === undefined) delete process.env.TMUX
       else process.env.TMUX = originalTmux
     }
+  })
+})
+
+describe("background-agent spawner fallback helper characterization", () => {
+  test("identifies agent-name failures across supported error shapes", () => {
+    const errorPayloads: readonly unknown[] = [
+      'Agent not found: "Sisyphus-Junior"',
+      new Error("agent.name must be one of the configured agents"),
+      { message: "agent.name validation failed" },
+    ]
+
+    const results = errorPayloads.map((payload) => isAgentNotFoundError(payload))
+
+    expect(results).toEqual([true, true, true])
+    expect(isAgentNotFoundError(new Error("Connection timeout"))).toBe(false)
+  })
+
+  test("rebuilds fallback tools while preserving prompt payload fields", () => {
+    const originalBody = {
+      agent: "Sisyphus-Junior",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      parts: [{ type: "text", text: "Do work" }],
+      tools: { task: true, read: true },
+    }
+
+    const fallbackBody = buildFallbackBody(originalBody, "general", {
+      includeTeamToolDenylist: false,
+    })
+
+    expect(fallbackBody).toEqual({
+      ...originalBody,
+      agent: "general",
+      tools: {
+        task: false,
+        call_omo_agent: true,
+        question: false,
+      },
+    })
   })
 })

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -1,4 +1,4 @@
-import { createInternalAgentTextPart, getAgentToolRestrictions, log, promptWithRetryInDirectory } from "../../shared"
+import { log, promptWithRetryInDirectory } from "../../shared"
 import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
@@ -8,40 +8,11 @@ import { getTaskToastManager } from "../task-toast-manager"
 import type { ConcurrencyManager } from "./concurrency"
 import type { OnSubagentSessionCreated, OpencodeClient, QueueItem } from "./constants"
 import type { BackgroundTask, LaunchInput, ResumeInput } from "./types"
+import { buildFallbackBody, FALLBACK_AGENT, isAgentNotFoundError } from "./spawner/fallback-agent"
+import { buildTaskRecord } from "./spawner/task-record"
+import { buildTaskPromptBody } from "./spawner/task-prompt-body"
 
-export const FALLBACK_AGENT = "general"
-
-export function isAgentNotFoundError(error: unknown): boolean {
-  const message =
-    typeof error === "string"
-      ? error
-      : error instanceof Error
-        ? error.message
-        : typeof error === "object" && error !== null && typeof (error as { message?: unknown }).message === "string"
-          ? (error as { message: string }).message
-          : String(error)
-  return (
-    message.includes("Agent not found") ||
-    message.includes("agent.name")
-  )
-}
-
-export function buildFallbackBody(
-  originalBody: Record<string, unknown>,
-  fallbackAgent: string,
-  options: { includeTeamToolDenylist?: boolean } = {},
-): Record<string, unknown> {
-  return {
-    ...originalBody,
-    agent: fallbackAgent,
-    tools: {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(fallbackAgent, options),
-    },
-  }
-}
+export { buildFallbackBody, FALLBACK_AGENT, isAgentNotFoundError }
 
 export interface SpawnerContext {
   client: OpencodeClient
@@ -53,27 +24,7 @@ export interface SpawnerContext {
 }
 
 export function createTask(input: LaunchInput): BackgroundTask {
-  return {
-    id: `bg_${crypto.randomUUID().slice(0, 8)}`,
-    status: "pending",
-    queuedAt: new Date(),
-    description: input.description,
-    prompt: input.prompt,
-    agent: input.agent,
-    parentSessionId: input.parentSessionId,
-    parentMessageId: input.parentMessageId,
-    teamRunId: input.teamRunId,
-    parentModel: input.parentModel,
-    parentAgent: input.parentAgent,
-    parentTools: input.parentTools,
-    model: input.model,
-    fallbackChain: input.fallbackChain,
-    skillContent: input.skillContent,
-    sessionPermission: input.sessionPermission,
-    category: input.category,
-    isUnstableAgent: input.isUnstableAgent,
-    onSessionCreated: input.onSessionCreated,
-  }
+  return buildTaskRecord(input, `bg_${crypto.randomUUID().slice(0, 8)}`, new Date())
 }
 
 export async function startTask(
@@ -96,7 +47,7 @@ export async function startTask(
   const parentSession = await client.session.get({
     path: { id: input.parentSessionId },
     query: { directory },
-  }).catch((err) => {
+  }).catch((err: unknown) => {
     log(`[background-agent] Failed to get parent session: ${err}`)
     return null
   })
@@ -111,7 +62,7 @@ export async function startTask(
     query: {
       directory: parentDirectory,
     },
-  }).catch((error) => {
+  }).catch((error: unknown) => {
     concurrencyManager.release(concurrencyKey)
     throw error
   })
@@ -152,31 +103,16 @@ export async function startTask(
     promptLength: input.prompt.length,
   })
 
-  const launchModel = input.model
-    ? {
-        providerID: input.model.providerID,
-        modelID: input.model.modelID,
-      }
-    : undefined
-  const launchVariant = input.model?.variant
-
   applySessionPromptParams(sessionID, input.model)
 
-  const promptBody = {
+  const promptBody = buildTaskPromptBody({
+    kind: "launch",
     agent: normalizedAgent,
-    ...(launchModel ? { model: launchModel } : {}),
-    ...(launchVariant ? { variant: launchVariant } : {}),
     system: input.skillContent,
-    tools: {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(normalizedAgent, {
-        includeTeamToolDenylist: input.teamRunId === undefined,
-      }),
-    },
-    parts: [createInternalAgentTextPart(input.prompt)],
-  }
+    model: input.model,
+    prompt: input.prompt,
+    includeTeamToolDenylist: input.teamRunId === undefined,
+  })
   setSessionTools(sessionID, promptBody.tools)
 
   // Must fire BEFORE tmux callback: attach client needs session activity to render TUI.
@@ -297,30 +233,15 @@ export async function resumeTask(
     promptLength: input.prompt.length,
   })
 
-  const resumeModel = task.model
-    ? {
-        providerID: task.model.providerID,
-        modelID: task.model.modelID,
-      }
-    : undefined
-  const resumeVariant = task.model?.variant
-
   applySessionPromptParams(sessionID, task.model)
 
-  const resumeBody = {
+  const resumeBody = buildTaskPromptBody({
+    kind: "resume",
     agent: task.agent,
-    ...(resumeModel ? { model: resumeModel } : {}),
-    ...(resumeVariant ? { variant: resumeVariant } : {}),
-    tools: {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(task.agent, {
-        includeTeamToolDenylist: task.teamRunId === undefined,
-      }),
-    },
-    parts: [createInternalAgentTextPart(input.prompt)],
-  }
+    model: task.model,
+    prompt: input.prompt,
+    includeTeamToolDenylist: task.teamRunId === undefined,
+  })
   setSessionTools(sessionID, resumeBody.tools)
 
   promptWithRetryInDirectory(client, {

--- a/src/features/background-agent/spawner/fallback-agent.ts
+++ b/src/features/background-agent/spawner/fallback-agent.ts
@@ -1,0 +1,41 @@
+import { getAgentToolRestrictions } from "../../../shared"
+
+export const FALLBACK_AGENT = "general"
+
+export function isAgentNotFoundError(error: unknown): boolean {
+  const message = getErrorMessage(error)
+  return (
+    message.includes("Agent not found") ||
+    message.includes("agent.name")
+  )
+}
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === "object" && error !== null && "message" in error && typeof error.message === "string") {
+    return error.message
+  }
+  return String(error)
+}
+
+export function buildFallbackBody(
+  originalBody: Record<string, unknown>,
+  fallbackAgent: string,
+  options: { includeTeamToolDenylist?: boolean } = {},
+): Record<string, unknown> {
+  return {
+    ...originalBody,
+    agent: fallbackAgent,
+    tools: {
+      task: false,
+      call_omo_agent: true,
+      question: false,
+      ...getAgentToolRestrictions(fallbackAgent, options),
+    },
+  }
+}

--- a/src/features/background-agent/spawner/task-prompt-body.ts
+++ b/src/features/background-agent/spawner/task-prompt-body.ts
@@ -1,0 +1,62 @@
+import { createInternalAgentTextPart, getAgentToolRestrictions } from "../../../shared"
+import type { LaunchInput } from "../types"
+
+type PromptModel = LaunchInput["model"]
+
+type TaskPromptBodyOptions =
+  | {
+      readonly kind: "launch"
+      readonly agent: string
+      readonly model: PromptModel
+      readonly system: LaunchInput["skillContent"]
+      readonly prompt: string
+      readonly includeTeamToolDenylist: boolean
+    }
+  | {
+      readonly kind: "resume"
+      readonly agent: string
+      readonly model: PromptModel
+      readonly prompt: string
+      readonly includeTeamToolDenylist: boolean
+    }
+
+export type TaskPromptBody = {
+  readonly agent: string
+  readonly model?: {
+    readonly providerID: string
+    readonly modelID: string
+  }
+  readonly variant?: string
+  readonly system?: string | undefined
+  readonly tools: Record<string, boolean>
+  readonly parts: readonly [{
+    readonly type: "text"
+    readonly text: string
+  }]
+}
+
+export function buildTaskPromptBody(options: TaskPromptBodyOptions): TaskPromptBody {
+  const promptModel = options.model
+    ? {
+        providerID: options.model.providerID,
+        modelID: options.model.modelID,
+      }
+    : undefined
+  const promptVariant = options.model?.variant
+
+  return {
+    agent: options.agent,
+    ...(promptModel ? { model: promptModel } : {}),
+    ...(promptVariant ? { variant: promptVariant } : {}),
+    ...(options.kind === "launch" ? { system: options.system } : {}),
+    tools: {
+      task: false,
+      call_omo_agent: true,
+      question: false,
+      ...getAgentToolRestrictions(options.agent, {
+        includeTeamToolDenylist: options.includeTeamToolDenylist,
+      }),
+    },
+    parts: [createInternalAgentTextPart(options.prompt)],
+  }
+}

--- a/src/features/background-agent/spawner/task-record.ts
+++ b/src/features/background-agent/spawner/task-record.ts
@@ -1,0 +1,25 @@
+import type { BackgroundTask, LaunchInput } from "../types"
+
+export function buildTaskRecord(input: LaunchInput, id: string, queuedAt: Date): BackgroundTask {
+  return {
+    id,
+    status: "pending",
+    queuedAt,
+    description: input.description,
+    prompt: input.prompt,
+    agent: input.agent,
+    parentSessionId: input.parentSessionId,
+    parentMessageId: input.parentMessageId,
+    teamRunId: input.teamRunId,
+    parentModel: input.parentModel,
+    parentAgent: input.parentAgent,
+    parentTools: input.parentTools,
+    model: input.model,
+    fallbackChain: input.fallbackChain,
+    skillContent: input.skillContent,
+    sessionPermission: input.sessionPermission,
+    category: input.category,
+    isUnstableAgent: input.isUnstableAgent,
+    onSessionCreated: input.onSessionCreated,
+  }
+}


### PR DESCRIPTION
## Summary
- Splits pure fallback detection/body construction, task record mapping, and prompt body construction out of `src/features/background-agent/spawner.ts`.
- Keeps `spawner.ts` as the public facade for existing imports, including `buildFallbackBody`, `FALLBACK_AGENT`, `isAgentNotFoundError`, `createTask`, `startTask`, and `resumeTask`.
- Leaves `src/features/background-agent/manager.ts` untouched.

## Audit Notes
- Checked open PRs against `dev`: no open PR touches `src/features/background-agent/spawner.ts`.
- Adjacent background-agent PRs do touch `manager.ts`, `task-poller.ts`, `parent-wake-notifier.ts`, and related tests, so this PR avoids those files.
- Preserved raw model/provider concurrency key construction, prompt gate route via `promptWithRetryInDirectory`, fallback retry behavior, session tool storage, tmux callback ordering, and `onTaskError` paths.
- `spawner.ts` pure LOC drops from 320 to 245.

## Testing
- `bun test src/features/background-agent/spawner.test.ts src/features/background-agent/spawner/parent-directory-resolver.test.ts`
- `bun test src/features/background-agent`
- `bun run typecheck`
- `bun run build`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split helper builders out of `spawner.ts` into focused modules for fallback handling, task prompt body creation, and task record mapping. This simplifies the background-agent spawner while keeping all behavior intact.

- **Refactors**
  - Moved `isAgentNotFoundError` and `buildFallbackBody` to `spawner/fallback-agent.ts`; added `FALLBACK_AGENT`.
  - Added `spawner/task-prompt-body.ts` and `spawner/task-record.ts`; `spawner.ts` now uses these builders.
  - `spawner.ts` remains the public facade, re-exporting `FALLBACK_AGENT`, `isAgentNotFoundError`, and `buildFallbackBody`, and still exposing `createTask`, `startTask`, `resumeTask`.
  - Preserves concurrency keys, prompt retry routing, fallback retries, session tools, tmux callback ordering, and error paths.
  - Left `manager.ts` unchanged.
  - Extended tests to characterize fallback helper behavior.

<sup>Written for commit 73524417704e376e45367f96ee4bbdc42f90f84b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

