### PR TITLE
refactor(tool-pair-validator): split message transform facade

### DIFF
--- a/src/hooks/tool-pair-validator/hook.test.ts
+++ b/src/hooks/tool-pair-validator/hook.test.ts
@@ -195,6 +195,50 @@ describe("createToolPairValidatorHook", () => {
     ])
   })
 
+  it("continues validating later assistant turns after inserting a synthetic repair message", async () => {
+    //#given
+    const messages = [
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_1" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "follow-up" }] },
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_2" }] },
+      { info: { role: "user" }, parts: [{ type: "text", text: "continue" }] },
+    ] satisfies TestMessage[]
+
+    //#when
+    await runTransform(messages)
+
+    //#then
+    expect(messages).toEqual([
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_1" }] },
+      {
+        info: { role: "user" },
+        parts: [{
+          type: "tool_result",
+          toolUseId: "toolu_1",
+          tool_use_id: "toolu_1",
+          isError: true,
+          content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+        }, {
+          type: "text",
+          text: TOOL_RESULT_RECOVERY_CONTINUATION,
+          synthetic: true,
+        }],
+      },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "follow-up" }] },
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_2" }] },
+      {
+        info: { role: "user" },
+        parts: [{
+          type: "tool_result",
+          toolUseId: "toolu_2",
+          tool_use_id: "toolu_2",
+          isError: true,
+          content: [{ type: "text", text: TOOL_RESULT_PLACEHOLDER }],
+        }, { type: "text", text: "continue" }],
+      },
+    ])
+  })
+
   it("injects only the missing tool_results for partial matches", async () => {
     //#given
     const messages = [

--- a/src/hooks/tool-pair-validator/hook.ts
+++ b/src/hooks/tool-pair-validator/hook.ts
@@ -1,29 +1,10 @@
-import { subagentSessions } from "../../features/claude-code-session-state"
-import {
-  getMessageSessionID,
-  repairMissingToolResults,
-  repairSubAgentMissingToolResults,
-} from "./tool-result-repair"
+import { validateToolPairsForMessages } from "./message-transform"
 import type { MessagesTransformHook } from "./types"
 
 export function createToolPairValidatorHook(): MessagesTransformHook {
   return {
     "experimental.chat.messages.transform": async (_input, output) => {
-      for (let i = 0; i < output.messages.length; i++) {
-        const messageInfo = output.messages[i].info
-
-        if (messageInfo.role !== "assistant") {
-          continue
-        }
-
-        const sessionID = getMessageSessionID(messageInfo)
-        if (sessionID && subagentSessions.has(sessionID)) {
-          repairSubAgentMissingToolResults(output.messages, i, sessionID)
-          continue
-        }
-
-        repairMissingToolResults(output.messages, i)
-      }
+      validateToolPairsForMessages(output.messages)
     },
   }
 }

--- a/src/hooks/tool-pair-validator/message-transform.ts
+++ b/src/hooks/tool-pair-validator/message-transform.ts
@@ -1,0 +1,25 @@
+import { subagentSessions } from "../../features/claude-code-session-state"
+import {
+  getMessageSessionID,
+  repairMissingToolResults,
+  repairSubAgentMissingToolResults,
+} from "./tool-result-repair"
+import type { MessageWithParts } from "./types"
+
+export function validateToolPairsForMessages(messages: MessageWithParts[]): void {
+  for (let i = 0; i < messages.length; i++) {
+    const messageInfo = messages[i].info
+
+    if (messageInfo.role !== "assistant") {
+      continue
+    }
+
+    const sessionID = getMessageSessionID(messageInfo)
+    if (sessionID && subagentSessions.has(sessionID)) {
+      repairSubAgentMissingToolResults(messages, i, sessionID)
+      continue
+    }
+
+    repairMissingToolResults(messages, i)
+  }
+}


### PR DESCRIPTION
## Summary
- Keeps `createToolPairValidatorHook` as the public hook facade while moving message traversal and subagent routing into `message-transform.ts`.
- Adds characterization coverage for continuing validation after synthetic repair insertion.

## Testing
- `bun test src/hooks/tool-pair-validator/hook.test.ts` ✅
- `git diff --check` ✅
- `bun run typecheck` ✅
- `bunx biome check src/hooks/tool-pair-validator/hook.ts src/hooks/tool-pair-validator/message-transform.ts src/hooks/tool-pair-validator/hook.test.ts` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split message traversal and subagent routing into `message-transform.ts` as `validateToolPairsForMessages`, keeping `createToolPairValidatorHook` as a thin facade. Added a characterization test to ensure validation continues on later assistant turns after inserting a synthetic repair message.

<sup>Written for commit 45e50a52569b8189b21bc422efbe79264199dec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

