### PR TITLE
refactor(session-notification): split sender facade

### DIFF
--- a/src/hooks/session-notification-desktop-sidecar.test.ts
+++ b/src/hooks/session-notification-desktop-sidecar.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="bun-types" />
+
+import type { PluginInput } from "@opencode-ai/plugin"
+import { afterEach, beforeEach, describe, expect, jest, spyOn, test } from "bun:test"
+import * as childProcess from "node:child_process"
+import { unsafeTestValue } from "../../test-support/unsafe-test-value"
+import * as sender from "./session-notification-sender"
+import * as utils from "./session-notification-utils"
+
+type ExecFileCall = {
+  readonly file: string
+  readonly args: readonly string[]
+  readonly options: {
+    readonly windowsHide?: boolean
+  }
+}
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
+type ExecFileResult = ReturnType<typeof childProcess.execFile>
+
+function mockExecFile(
+  calls: ExecFileCall[],
+  getError: (callIndex: number) => Error | null = () => null
+): ReturnType<typeof spyOn> {
+  return spyOn(childProcess, "execFile").mockImplementation(
+    unsafeTestValue<typeof childProcess.execFile>(
+      (
+        file: string,
+        args: readonly string[],
+        options: { readonly windowsHide?: boolean },
+        callback: ExecFileCallback
+      ) => {
+        const callIndex = calls.length
+        calls.push({ file, args: [...args], options })
+        callback(getError(callIndex), "", "")
+        return unsafeTestValue<ExecFileResult>({})
+      }
+    )
+  )
+}
+
+describe("session-notification Desktop sidecar fallback", () => {
+  const originalBundleId = process.env.__CFBundleIdentifier
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    process.env.__CFBundleIdentifier = "com.opencode.desktop"
+    spyOn(utils, "getCmuxPath").mockResolvedValue(null)
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
+    spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalBundleId === undefined) {
+      delete process.env.__CFBundleIdentifier
+      return
+    }
+
+    process.env.__CFBundleIdentifier = originalBundleId
+  })
+
+  describe("#given ctx.$ is unavailable in the Desktop sidecar", () => {
+    test("#then macOS notifications use execFile with the bundle activation args", async () => {
+      const execFileCalls: ExecFileCall[] = []
+      mockExecFile(execFileCalls)
+      const mockCtx = unsafeTestValue<PluginInput>({})
+
+      await sender.sendSessionNotification(mockCtx, "darwin", "Done", "Task completed")
+
+      expect(execFileCalls).toEqual([
+        {
+          file: "/usr/local/bin/terminal-notifier",
+          args: [
+            "-title",
+            "Done",
+            "-message",
+            "Task completed",
+            "-activate",
+            "com.opencode.desktop",
+          ],
+          options: { windowsHide: true },
+        },
+      ])
+    })
+
+    test("#then macOS falls back from terminal-notifier execFile failure to osascript execFile", async () => {
+      const execFileCalls: ExecFileCall[] = []
+      mockExecFile(execFileCalls, (callIndex) => callIndex === 0 ? new Error("terminal-notifier failed") : null)
+      const mockCtx = unsafeTestValue<PluginInput>({})
+
+      await sender.sendSessionNotification(mockCtx, "darwin", "Done", "Task completed")
+
+      expect(execFileCalls.length).toBe(2)
+      expect(execFileCalls[0]?.file).toBe("/usr/local/bin/terminal-notifier")
+      expect(execFileCalls[1]?.file).toBe("/usr/bin/osascript")
+      expect(execFileCalls[1]?.args[0]).toBe("-e")
+      expect(execFileCalls[1]?.args[1]).toContain('display notification "Task completed"')
+      expect(execFileCalls[1]?.args[1]).toContain('with title "Done"')
+      expect(execFileCalls[1]?.options.windowsHide).toBe(true)
+    })
+  })
+})

--- a/src/hooks/session-notification-send.ts
+++ b/src/hooks/session-notification-send.ts
@@ -1,0 +1,33 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { sendLinuxSessionNotification } from "./session-notification-linux"
+import { logOperationFailure } from "./session-notification-log"
+import { sendMacosSessionNotification } from "./session-notification-macos"
+import type { Platform } from "./session-notification-platform"
+import { sendWindowsSessionNotification } from "./session-notification-windows"
+
+export async function sendSessionNotification(
+  ctx: PluginInput,
+  platform: Platform,
+  title: string,
+  message: string
+): Promise<void> {
+  try {
+    switch (platform) {
+      case "darwin":
+        await sendMacosSessionNotification(ctx, title, message)
+        break
+      case "linux":
+        await sendLinuxSessionNotification(ctx, title, message)
+        break
+      case "win32":
+        await sendWindowsSessionNotification(ctx, title, message)
+        break
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      logOperationFailure("send", error)
+    } else {
+      logOperationFailure("send", String(error))
+    }
+  }
+}

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -1,74 +1,10 @@
-import type { PluginInput } from "@opencode-ai/plugin"
-import {
-  playLinuxSessionNotificationSound,
-  sendLinuxSessionNotification,
-} from "./session-notification-linux"
-import { logOperationFailure } from "./session-notification-log"
-import {
-  playMacosSessionNotificationSound,
-  sendMacosSessionNotification,
-} from "./session-notification-macos"
 import {
   type Platform,
   detectPlatform,
   getDefaultSoundPath,
 } from "./session-notification-platform"
-import {
-  playWindowsSessionNotificationSound,
-  sendWindowsSessionNotification,
-} from "./session-notification-windows"
+import { playSessionNotificationSound } from "./session-notification-sound"
+import { sendSessionNotification } from "./session-notification-send"
 
 export { type Platform, detectPlatform, getDefaultSoundPath }
-
-export async function sendSessionNotification(
-  ctx: PluginInput,
-  platform: Platform,
-  title: string,
-  message: string
-): Promise<void> {
-  try {
-    switch (platform) {
-      case "darwin":
-        await sendMacosSessionNotification(ctx, title, message)
-        break
-      case "linux":
-        await sendLinuxSessionNotification(ctx, title, message)
-        break
-      case "win32":
-        await sendWindowsSessionNotification(ctx, title, message)
-        break
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      logOperationFailure("send", error)
-    } else {
-      logOperationFailure("send", String(error))
-    }
-  }
-}
-
-export async function playSessionNotificationSound(
-  ctx: PluginInput,
-  platform: Platform,
-  soundPath: string
-): Promise<void> {
-  try {
-    switch (platform) {
-      case "darwin":
-        await playMacosSessionNotificationSound(ctx, soundPath)
-        break
-      case "linux":
-        await playLinuxSessionNotificationSound(ctx, soundPath)
-        break
-      case "win32":
-        await playWindowsSessionNotificationSound(ctx, soundPath)
-        break
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      logOperationFailure("sound", error)
-    } else {
-      logOperationFailure("sound", String(error))
-    }
-  }
-}
+export { sendSessionNotification, playSessionNotificationSound }

--- a/src/hooks/session-notification-sound.ts
+++ b/src/hooks/session-notification-sound.ts
@@ -1,0 +1,32 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { playLinuxSessionNotificationSound } from "./session-notification-linux"
+import { logOperationFailure } from "./session-notification-log"
+import { playMacosSessionNotificationSound } from "./session-notification-macos"
+import type { Platform } from "./session-notification-platform"
+import { playWindowsSessionNotificationSound } from "./session-notification-windows"
+
+export async function playSessionNotificationSound(
+  ctx: PluginInput,
+  platform: Platform,
+  soundPath: string
+): Promise<void> {
+  try {
+    switch (platform) {
+      case "darwin":
+        await playMacosSessionNotificationSound(ctx, soundPath)
+        break
+      case "linux":
+        await playLinuxSessionNotificationSound(ctx, soundPath)
+        break
+      case "win32":
+        await playWindowsSessionNotificationSound(ctx, soundPath)
+        break
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      logOperationFailure("sound", error)
+    } else {
+      logOperationFailure("sound", String(error))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Splits `src/hooks/session-notification-sender.ts` into a pure facade while preserving the public exports and notification behavior. The send and sound dispatchers now live in focused modules, and Desktop sidecar characterization tests pin the `ctx.$`-unavailable `execFile` fallback path.

Note: open PR #3873 also edits `src/hooks/session-notification-sender.ts` for Ghostty tab activation. This PR keeps behavior unchanged against current `dev`; that PR may need a small conflict resolution if both land.

## Changes
- Make `session-notification-sender.ts` re-export only platform helpers plus send/sound facade functions.
- Move send dispatcher/error logging into `session-notification-send.ts`.
- Move sound dispatcher/error logging into `session-notification-sound.ts`.
- Add Desktop sidecar characterization coverage for macOS `execFile` activation args and fallback from `terminal-notifier` failure to `osascript`.

## Testing
- `bun test src/hooks/session-notification-desktop-sidecar.test.ts src/hooks/session-notification-sender.test.ts src/hooks/session-notification.test.ts src/hooks/session-notification-input-needed.test.ts` ✅
- `bun run typecheck` ✅
- `git diff --check` ✅