### PR TITLE
refactor(team-mode): split team resume facade

### DIFF
--- a/src/features/team-mode/team-state-store/active-resume.ts
+++ b/src/features/team-mode/team-state-store/active-resume.ts
@@ -1,0 +1,78 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { log } from "../../../shared/logger"
+import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
+import type { RuntimeState } from "../types"
+import { reconcileStaleReservationsForMember } from "./reservation-reconciliation"
+import { inspectWorkerMembers, sessionExists } from "./session-liveness"
+import { markDeadWorkersErrored, summarizeWorkerLiveness } from "./worker-resume-status"
+import { transitionRuntimeState } from "./store"
+
+export type ActiveResumeOutcome = "resumed" | "marked_orphaned"
+
+async function reconcileMemberReservations(
+  ctx: ExecutorContext,
+  runtimeState: RuntimeState,
+  config: TeamModeConfig,
+  staleReservationTtlMs: number,
+): Promise<void> {
+  await Promise.all(runtimeState.members.map(async (member) => {
+    try {
+      await reconcileStaleReservationsForMember(
+        ctx,
+        runtimeState.teamRunId,
+        member,
+        config,
+        staleReservationTtlMs,
+      )
+    } catch (reclaimError) {
+      log("team mailbox reservation reclaim failed", {
+        event: "team-mailbox-reclaim-failed",
+        teamRunId: runtimeState.teamRunId,
+        member: member.name,
+        error: reclaimError instanceof Error ? reclaimError.message : String(reclaimError),
+      })
+    }
+  }))
+}
+
+async function markActiveTeamOrphaned(runtimeState: RuntimeState, config: TeamModeConfig): Promise<void> {
+  await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+    ...currentRuntimeState,
+    status: "orphaned",
+  }), config)
+}
+
+export async function resumeActiveTeam(
+  ctx: ExecutorContext,
+  runtimeState: RuntimeState,
+  config: TeamModeConfig,
+  staleReservationTtlMs: number,
+): Promise<ActiveResumeOutcome> {
+  if (!runtimeState.leadSessionId || !(await sessionExists(ctx, runtimeState.leadSessionId))) {
+    await markActiveTeamOrphaned(runtimeState, config)
+    return "marked_orphaned"
+  }
+
+  await reconcileMemberReservations(ctx, runtimeState, config, staleReservationTtlMs)
+
+  const workerCheckResults = await inspectWorkerMembers(ctx, runtimeState)
+  const workerResumeStatus = summarizeWorkerLiveness(workerCheckResults)
+
+  if (workerResumeStatus.hasAnyWorker && !workerResumeStatus.hasAliveWorker) {
+    await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+      ...markDeadWorkersErrored(currentRuntimeState, workerResumeStatus.deadWorkerNames),
+      status: "orphaned",
+    }), config)
+    return "marked_orphaned"
+  }
+
+  if (workerResumeStatus.deadWorkerNames.length > 0) {
+    await transitionRuntimeState(
+      runtimeState.teamRunId,
+      (currentRuntimeState) => markDeadWorkersErrored(currentRuntimeState, workerResumeStatus.deadWorkerNames),
+      config,
+    )
+  }
+
+  return "resumed"
+}

--- a/src/features/team-mode/team-state-store/creating-resume.ts
+++ b/src/features/team-mode/team-state-store/creating-resume.ts
@@ -1,0 +1,23 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import type { RuntimeState } from "../types"
+import { cleanupMemberWorktrees } from "./runtime-cleanup"
+import { transitionRuntimeState } from "./store"
+
+export function isCreatingStateStuck(
+  runtimeState: RuntimeState,
+  now: number,
+  creatingTimeoutMs: number,
+): boolean {
+  return runtimeState.status === "creating" && now - runtimeState.createdAt > creatingTimeoutMs
+}
+
+export async function markStuckCreatingTeamFailed(
+  runtimeState: RuntimeState,
+  config: TeamModeConfig,
+): Promise<void> {
+  await cleanupMemberWorktrees(runtimeState)
+  await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+    ...currentRuntimeState,
+    status: "failed",
+  }), config)
+}

--- a/src/features/team-mode/team-state-store/deleting-resume.ts
+++ b/src/features/team-mode/team-state-store/deleting-resume.ts
@@ -1,0 +1,23 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import type { RuntimeState } from "../types"
+import { cleanupMemberWorktrees, removeRuntimeDirectory } from "./runtime-cleanup"
+import { transitionRuntimeState } from "./store"
+
+export async function finishDeletingTeam(
+  runtimeState: RuntimeState,
+  config: TeamModeConfig,
+): Promise<boolean> {
+  await cleanupMemberWorktrees(runtimeState)
+  await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+    ...currentRuntimeState,
+    status: "deleted",
+  }), config)
+  return await removeRuntimeDirectory(runtimeState.teamRunId, config)
+}
+
+export async function cleanTerminalTeam(
+  runtimeState: RuntimeState,
+  config: TeamModeConfig,
+): Promise<boolean> {
+  return await removeRuntimeDirectory(runtimeState.teamRunId, config)
+}

--- a/src/features/team-mode/team-state-store/resume.test.ts
+++ b/src/features/team-mode/team-state-store/resume.test.ts
@@ -94,6 +94,14 @@ function createSpecWithTwoWorkers(name = `team-${randomUUID().slice(0, 8)}`): Te
   }
 }
 
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined
+  }
+
+  return typeof error.code === "string" ? error.code : undefined
+}
+
 type SessionGetMock = (input: { path: { id: string } }) => Promise<unknown>
 type SessionMessagesMock = (input: { path: { id: string } }) => Promise<unknown>
 
@@ -160,6 +168,28 @@ describe("resumeAllTeams", () => {
       statError = error as NodeJS.ErrnoException
     }
     expect(statError?.code).toBe("ENOENT")
+  })
+
+  test("leaves fresh creating teams pending during reload recovery", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const runtimeState = await createRuntimeState(createSpec(), "ses_lead", "user", config)
+
+    // when
+    const report = await resumeAllTeams(createExecutorContext(baseDir), config)
+    const persistedState = await loadRuntimeState(runtimeState.teamRunId, config)
+
+    // then
+    expect(persistedState.status).toBe("creating")
+    expect(report).toEqual({
+      resumed: 0,
+      marked_failed: 0,
+      marked_orphaned: 0,
+      cleaned: 0,
+      errors: [],
+    })
   })
 
   test("marks active teams orphaned when lead session no longer exists", async () => {
@@ -502,5 +532,56 @@ describe("resumeAllTeams", () => {
     expect(workerB?.sessionId).toBeUndefined()
     expect(report.resumed).toBe(0)
     expect(report.marked_orphaned).toBe(1)
+  })
+
+  test("finishes deleting teams and removes the runtime directory", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const runtimeState = await createRuntimeState(createSpec(), "ses_lead", "user", config)
+    await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+      ...currentRuntimeState,
+      status: "active",
+    }), config)
+    await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
+      ...currentRuntimeState,
+      status: "deleting",
+    }), config)
+    const worktreePath = path.join(baseDir, "worktrees", runtimeState.teamRunId, "worker")
+    await mkdir(worktreePath, { recursive: true })
+    await saveRuntimeState({
+      ...await loadRuntimeState(runtimeState.teamRunId, config),
+      members: runtimeState.members.map((member) => member.name === "worker"
+        ? { ...member, worktreePath }
+        : member),
+    }, config)
+
+    // when
+    const report = await resumeAllTeams(createExecutorContext(baseDir), config)
+
+    // then
+    expect(report).toEqual({
+      resumed: 0,
+      marked_failed: 0,
+      marked_orphaned: 0,
+      cleaned: 1,
+      errors: [],
+    })
+    let runtimeStatErrorCode: string | undefined
+    try {
+      await loadRuntimeState(runtimeState.teamRunId, config)
+    } catch (error) {
+      runtimeStatErrorCode = getErrorCode(error)
+    }
+    expect(runtimeStatErrorCode).toBe("ENOENT")
+
+    let worktreeStatErrorCode: string | undefined
+    try {
+      await stat(worktreePath)
+    } catch (error) {
+      worktreeStatErrorCode = getErrorCode(error)
+    }
+    expect(worktreeStatErrorCode).toBe("ENOENT")
   })
 })

--- a/src/features/team-mode/team-state-store/resume.ts
+++ b/src/features/team-mode/team-state-store/resume.ts
@@ -1,22 +1,17 @@
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import { log } from "../../../shared/logger"
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
-import type { RuntimeState } from "../types"
+import { resumeActiveTeam } from "./active-resume"
+import { isCreatingStateStuck, markStuckCreatingTeamFailed } from "./creating-resume"
+import { cleanTerminalTeam, finishDeletingTeam } from "./deleting-resume"
 import { toError } from "./error-normalization"
-import { reconcileStaleReservationsForMember } from "./reservation-reconciliation"
 import type { ResumeReport } from "./resume-report"
-import { cleanupMemberWorktrees, removeRuntimeDirectory } from "./runtime-cleanup"
-import { inspectWorkerMembers, sessionExists } from "./session-liveness"
-import { listActiveTeams, loadRuntimeState, transitionRuntimeState } from "./store"
+import { listActiveTeams, loadRuntimeState } from "./store"
 
 export type { ResumeReport } from "./resume-report"
 
 const CREATING_TIMEOUT_MS = 30 * 60 * 1000
 const STALE_RESERVATION_TTL_MS = 10 * 60 * 1000
-
-function isCreatingStateStuck(runtimeState: RuntimeState, now: number): boolean {
-  return runtimeState.status === "creating" && now - runtimeState.createdAt > CREATING_TIMEOUT_MS
-}
 
 export async function resumeAllTeams(
   ctx: ExecutorContext,
@@ -38,87 +33,24 @@ export async function resumeAllTeams(
 
       switch (runtimeState.status) {
         case "creating": {
-          if (!isCreatingStateStuck(runtimeState, now)) break
-          await cleanupMemberWorktrees(runtimeState)
-          await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
-            ...currentRuntimeState,
-            status: "failed",
-          }), config)
+          if (!isCreatingStateStuck(runtimeState, now, CREATING_TIMEOUT_MS)) break
+          await markStuckCreatingTeamFailed(runtimeState, config)
           report.marked_failed += 1
           break
         }
 
         case "active": {
-          if (!runtimeState.leadSessionId || !(await sessionExists(ctx, runtimeState.leadSessionId))) {
-            await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
-              ...currentRuntimeState,
-              status: "orphaned",
-            }), config)
+          const activeResumeOutcome = await resumeActiveTeam(ctx, runtimeState, config, STALE_RESERVATION_TTL_MS)
+          if (activeResumeOutcome === "marked_orphaned") {
             report.marked_orphaned += 1
             break
           }
-
-          await Promise.all(runtimeState.members.map(async (member) => {
-            try {
-              await reconcileStaleReservationsForMember(
-                ctx,
-                runtimeState.teamRunId,
-                member,
-                config,
-                STALE_RESERVATION_TTL_MS,
-              )
-            } catch (reclaimError) {
-              log("team mailbox reservation reclaim failed", {
-                event: "team-mailbox-reclaim-failed",
-                teamRunId: runtimeState.teamRunId,
-                member: member.name,
-                error: reclaimError instanceof Error ? reclaimError.message : String(reclaimError),
-              })
-            }
-          }))
-
-          const workerCheckResults = await inspectWorkerMembers(ctx, runtimeState)
-          const deadWorkerNames = new Set(
-            workerCheckResults
-              .filter((result) => result.wasSpawned && !result.stillAlive)
-              .map((result) => result.name),
-          )
-          const hasAliveWorker = workerCheckResults.some((result) => result.stillAlive)
-          const hasAnyWorker = workerCheckResults.length > 0
-
-          const markDeadWorkersErrored = (currentRuntimeState: RuntimeState): RuntimeState => ({
-            ...currentRuntimeState,
-            members: currentRuntimeState.members.map((member) => (
-              deadWorkerNames.has(member.name)
-                ? { ...member, status: "errored" as const, sessionId: undefined }
-                : member
-            )),
-          })
-
-          if (hasAnyWorker && !hasAliveWorker) {
-            await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
-              ...markDeadWorkersErrored(currentRuntimeState),
-              status: "orphaned",
-            }), config)
-            report.marked_orphaned += 1
-            break
-          }
-
-          if (deadWorkerNames.size > 0) {
-            await transitionRuntimeState(runtimeState.teamRunId, markDeadWorkersErrored, config)
-          }
-
           report.resumed += 1
           break
         }
 
         case "deleting": {
-          await cleanupMemberWorktrees(runtimeState)
-          await transitionRuntimeState(runtimeState.teamRunId, (currentRuntimeState) => ({
-            ...currentRuntimeState,
-            status: "deleted",
-          }), config)
-          if (await removeRuntimeDirectory(runtimeState.teamRunId, config)) {
+          if (await finishDeletingTeam(runtimeState, config)) {
             report.cleaned += 1
           }
           break
@@ -126,7 +58,7 @@ export async function resumeAllTeams(
 
         case "deleted":
         case "failed": {
-          if (await removeRuntimeDirectory(runtimeState.teamRunId, config)) {
+          if (await cleanTerminalTeam(runtimeState, config)) {
             report.cleaned += 1
           }
           break

--- a/src/features/team-mode/team-state-store/session-liveness.ts
+++ b/src/features/team-mode/team-state-store/session-liveness.ts
@@ -2,7 +2,7 @@ import type { ExecutorContext } from "../../../tools/delegate-task/executor-type
 import type { RuntimeState } from "../types"
 import { isSessionNotFoundError, toError } from "./error-normalization"
 
-interface WorkerLiveness {
+export interface WorkerLiveness {
   readonly name: string
   readonly wasSpawned: boolean
   readonly stillAlive: boolean

--- a/src/features/team-mode/team-state-store/worker-resume-status.ts
+++ b/src/features/team-mode/team-state-store/worker-resume-status.ts
@@ -1,0 +1,34 @@
+import type { RuntimeState } from "../types"
+import type { WorkerLiveness } from "./session-liveness"
+
+export interface WorkerResumeStatus {
+  readonly deadWorkerNames: readonly string[]
+  readonly hasAliveWorker: boolean
+  readonly hasAnyWorker: boolean
+}
+
+export function summarizeWorkerLiveness(workerCheckResults: readonly WorkerLiveness[]): WorkerResumeStatus {
+  return {
+    deadWorkerNames: workerCheckResults
+      .filter((result) => result.wasSpawned && !result.stillAlive)
+      .map((result) => result.name),
+    hasAliveWorker: workerCheckResults.some((result) => result.stillAlive),
+    hasAnyWorker: workerCheckResults.length > 0,
+  }
+}
+
+export function markDeadWorkersErrored(
+  runtimeState: RuntimeState,
+  deadWorkerNames: readonly string[],
+): RuntimeState {
+  const deadWorkerNameSet = new Set(deadWorkerNames)
+
+  return {
+    ...runtimeState,
+    members: runtimeState.members.map((member) => (
+      deadWorkerNameSet.has(member.name)
+        ? { ...member, status: "errored" as const, sessionId: undefined }
+        : member
+    )),
+  }
+}


### PR DESCRIPTION
## Summary
Split `team-state-store/resume.ts` into a thin resume facade plus focused recovery modules while preserving the existing exported `resumeAllTeams` surface.

## Changes
- Added characterization coverage for fresh `creating` runtime recovery and `deleting` cleanup.
- Extracted active-team resume logic, worker liveness summarization, creating recovery, and deleting/terminal cleanup into focused `team-state-store` modules.
- Kept the resume report shape and runtime status behavior unchanged.

## Testing
- `bun test src/features/team-mode/team-state-store/resume.test.ts src/features/team-mode/team-state-store/store.test.ts src/features/team-mode/team-state-store/locks.test.ts` ✅
- `bun run typecheck` ✅
- `git diff --check HEAD~4..HEAD` ✅
- LSP diagnostics clean on changed TypeScript files ✅

## Notes
- Checked open PR overlap before editing; no open PR touched `src/features/team-mode/team-state-store/resume.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the team resume logic into a thin facade with focused modules for active, creating, and deleting paths, keeping `resumeAllTeams` behavior and API unchanged. This makes the code easier to reason about and adds coverage for recovery edge cases.

- **Refactors**
  - Introduced active, creating, and deleting resume modules plus a worker resume status helper; moved liveness summary and dead-worker marking to dedicated utilities.
  - Simplified `resume.ts` to only orchestrate; the resume report shape and runtime status transitions are unchanged.
  - Added characterization tests for fresh creating recovery, deleting cleanup, and orphaning; exported `WorkerLiveness` for reuse.

<sup>Written for commit 040b882fd28a7a010c838fed4bfae7e1e7157608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

