### PR TITLE
test(rules-injector): pin injector facade exports

### DIFF
--- a/src/hooks/rules-injector/injection-processor.ts
+++ b/src/hooks/rules-injector/injection-processor.ts
@@ -16,14 +16,10 @@ import {
 	isDuplicateByRealPath,
 	shouldApplyRule,
 } from "./matcher";
-import {
-	createMatchDecisionCache,
-	getCachedMatchReason,
-	setCachedMatchReason,
-	type MatchDecisionCache,
-} from "./match-decision-cache";
+import { createMatchDecisionCache } from "./match-decision-cache";
 import { createParsedRuleReader } from "./parsed-rule-cache";
 import { resolveFilePath } from "./path-resolution";
+import { getRuleMatchReason } from "./rule-match-reason";
 import type { FindRuleFilesOptions } from "./rule-file-finder";
 import type { RuleScanCache } from "./rule-scan-cache";
 import { saveInjectedRules } from "./storage";
@@ -171,58 +167,4 @@ export function createRuleInjectionProcessor(
 	}
 
 	return { processFilePathForInjection };
-}
-
-function getRuleMatchReason(input: {
-	matchDecisionCache: MatchDecisionCache;
-	isSingleFile: boolean | undefined;
-	projectRoot: string | null;
-	resolved: string;
-	realPath: string;
-	statFingerprint: string | null;
-	metadata: Parameters<typeof shouldApplyRule>[0];
-	shouldApplyRuleImpl: typeof shouldApplyRule;
-}): string | null {
-	if (input.isSingleFile) {
-		return "copilot-instructions (always apply)";
-	}
-
-	const cachedMatchReason = getCachedMatchReason(
-		input.matchDecisionCache,
-		input.projectRoot,
-		input.resolved,
-		input.realPath,
-		input.statFingerprint,
-	);
-	if (cachedMatchReason !== undefined) {
-		return cachedMatchReason;
-	}
-
-	const matchResult = input.shouldApplyRuleImpl(
-		input.metadata,
-		input.resolved,
-		input.projectRoot,
-	);
-	if (!matchResult.applies) {
-		setCachedMatchReason(
-			input.matchDecisionCache,
-			input.projectRoot,
-			input.resolved,
-			input.realPath,
-			input.statFingerprint,
-			null,
-		);
-		return null;
-	}
-
-	const matchReason = matchResult.reason ?? "matched";
-	setCachedMatchReason(
-		input.matchDecisionCache,
-		input.projectRoot,
-		input.resolved,
-		input.realPath,
-		input.statFingerprint,
-		matchReason,
-	);
-	return matchReason;
 }

--- a/src/hooks/rules-injector/injector-facade.test.ts
+++ b/src/hooks/rules-injector/injector-facade.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createRuleInjectionProcessor as createRuleInjectionProcessorFromFacade } from "./injector";
+import type { RuleInjectionProcessorDeps as RuleInjectionProcessorDepsFromFacade } from "./injector";
+import { createRuleInjectionProcessor as createRuleInjectionProcessorFromProcessor } from "./injection-processor";
+import type { RuleInjectionProcessorDeps as RuleInjectionProcessorDepsFromTypes } from "./injection-types";
+import {
+	clearParsedRuleCache as clearParsedRuleCacheFromCache,
+	getParsedRuleCacheStats as getParsedRuleCacheStatsFromCache,
+} from "./parsed-rule-cache";
+import {
+	clearParsedRuleCache as clearParsedRuleCacheFromFacade,
+	getParsedRuleCacheStats as getParsedRuleCacheStatsFromFacade,
+} from "./injector";
+
+describe("rules injector facade", () => {
+	test("#given the injector facade #when runtime exports are imported #then it preserves the existing module boundary", () => {
+		const processorFactory = createRuleInjectionProcessorFromFacade;
+		const clearCache = clearParsedRuleCacheFromFacade;
+		const getCacheStats = getParsedRuleCacheStatsFromFacade;
+
+		expect(processorFactory).toBe(createRuleInjectionProcessorFromProcessor);
+		expect(clearCache).toBe(clearParsedRuleCacheFromCache);
+		expect(getCacheStats).toBe(getParsedRuleCacheStatsFromCache);
+	});
+
+	test("#given the injector facade #when dependency types are imported #then they match the processor contract", () => {
+		const dependencyContract: RuleInjectionProcessorDepsFromFacade = {
+			workspaceDirectory: "/tmp/project",
+			truncator: {
+				truncate: async (_sessionID: string, content: string) => ({
+					result: content,
+					truncated: false,
+				}),
+			},
+			getSessionCache: () => ({
+				contentHashes: new Set<string>(),
+				realPaths: new Set<string>(),
+			}),
+		};
+		const acceptProcessorDeps = (
+			deps: RuleInjectionProcessorDepsFromTypes,
+		): RuleInjectionProcessorDepsFromTypes => deps;
+
+		expect(acceptProcessorDeps(dependencyContract)).toBe(dependencyContract);
+	});
+});

--- a/src/hooks/rules-injector/injector.ts
+++ b/src/hooks/rules-injector/injector.ts
@@ -5,6 +5,7 @@ export {
 export type {
 	DynamicTruncator,
 	RuleFileReader,
+	RuleInjectionProcessorDeps,
 	RuleToInject,
 	ToolExecuteOutput,
 	TranscriptHydrationHook,

--- a/src/hooks/rules-injector/rule-match-reason.test.ts
+++ b/src/hooks/rules-injector/rule-match-reason.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { createMatchDecisionCache } from "./match-decision-cache";
+import { getRuleMatchReason } from "./rule-match-reason";
+import type { RuleMetadata } from "./types";
+
+const metadata: RuleMetadata = {};
+
+describe("getRuleMatchReason", () => {
+	test("#given a single-file rule #when resolving match reason #then it bypasses glob matching", () => {
+		let matchCalls = 0;
+
+		const matchReason = getRuleMatchReason({
+			matchDecisionCache: createMatchDecisionCache(),
+			isSingleFile: true,
+			projectRoot: "/repo",
+			resolved: "/repo/src/index.ts",
+			realPath: "/repo/.github/copilot-instructions.md",
+			statFingerprint: "100:20",
+			metadata,
+			shouldApplyRuleImpl: () => {
+				matchCalls += 1;
+				return { applies: true, reason: "matched" };
+			},
+		});
+
+		expect(matchReason).toBe("copilot-instructions (always apply)");
+		expect(matchCalls).toBe(0);
+	});
+
+	test("#given a cached rule decision #when resolving the same rule again #then it reuses the cached reason", () => {
+		let matchCalls = 0;
+		const matchDecisionCache = createMatchDecisionCache();
+		const input = {
+			matchDecisionCache,
+			isSingleFile: false,
+			projectRoot: "/repo",
+			resolved: "/repo/src/index.ts",
+			realPath: "/repo/.github/instructions/typescript.instructions.md",
+			statFingerprint: "100:20",
+			metadata,
+			shouldApplyRuleImpl: () => {
+				matchCalls += 1;
+				return { applies: true, reason: "typescript rule" };
+			},
+		};
+
+		const firstReason = getRuleMatchReason(input);
+		const secondReason = getRuleMatchReason(input);
+
+		expect(firstReason).toBe("typescript rule");
+		expect(secondReason).toBe("typescript rule");
+		expect(matchCalls).toBe(1);
+	});
+});

--- a/src/hooks/rules-injector/rule-match-reason.ts
+++ b/src/hooks/rules-injector/rule-match-reason.ts
@@ -1,0 +1,60 @@
+import { shouldApplyRule } from "./matcher";
+import {
+	getCachedMatchReason,
+	setCachedMatchReason,
+	type MatchDecisionCache,
+} from "./match-decision-cache";
+
+export function getRuleMatchReason(input: {
+	matchDecisionCache: MatchDecisionCache;
+	isSingleFile: boolean | undefined;
+	projectRoot: string | null;
+	resolved: string;
+	realPath: string;
+	statFingerprint: string | null;
+	metadata: Parameters<typeof shouldApplyRule>[0];
+	shouldApplyRuleImpl: typeof shouldApplyRule;
+}): string | null {
+	if (input.isSingleFile) {
+		return "copilot-instructions (always apply)";
+	}
+
+	const cachedMatchReason = getCachedMatchReason(
+		input.matchDecisionCache,
+		input.projectRoot,
+		input.resolved,
+		input.realPath,
+		input.statFingerprint,
+	);
+	if (cachedMatchReason !== undefined) {
+		return cachedMatchReason;
+	}
+
+	const matchResult = input.shouldApplyRuleImpl(
+		input.metadata,
+		input.resolved,
+		input.projectRoot,
+	);
+	if (!matchResult.applies) {
+		setCachedMatchReason(
+			input.matchDecisionCache,
+			input.projectRoot,
+			input.resolved,
+			input.realPath,
+			input.statFingerprint,
+			null,
+		);
+		return null;
+	}
+
+	const matchReason = matchResult.reason ?? "matched";
+	setCachedMatchReason(
+		input.matchDecisionCache,
+		input.projectRoot,
+		input.resolved,
+		input.realPath,
+		input.statFingerprint,
+		matchReason,
+	);
+	return matchReason;
+}


### PR DESCRIPTION
## Summary
Adds characterization coverage for the rules-injector `injector.ts` facade and keeps `injector.ts` as the compatibility facade. Also continues the behavior-preserving split by moving the processor match-reason/cache decision helper into a focused `rule-match-reason` module.

## Changes
- Added `injector-facade.test.ts` to pin runtime facade exports and the dependency type contract.
- Re-exported `RuleInjectionProcessorDeps` from `injector.ts` so consumers can stay on the facade boundary.
- Extracted `getRuleMatchReason` from `injection-processor.ts` into `rule-match-reason.ts`.
- Added `rule-match-reason.test.ts` characterization coverage for single-file rule bypass and cached match decisions.

## Testing
- `bun test src/hooks/rules-injector/injector-facade.test.ts`
- `bun test src/hooks/rules-injector/injector-facade.test.ts src/hooks/rules-injector/injector.test.ts`
- `bun test src/hooks/rules-injector/rule-match-reason.test.ts src/hooks/rules-injector/injector.test.ts src/hooks/rules-injector/injector-facade.test.ts`
- `bun test src/hooks/rules-injector`
- `bun run typecheck`
- `git diff --check`

## Notes
- Open PR overlap check found no open `dev` PR touching `src/hooks/rules-injector/injector.ts`.
- Latest `origin/dev` already has `injector.ts` as a small facade via `50b895cc1`; this PR avoids ROADMAP shims and preserves the `@oh-my-opencode/rules-engine` adapter boundary.