### PR TITLE
refactor(delegate-task): split sync task runner

### DIFF
--- a/src/tools/delegate-task/sync-task-runner.ts
+++ b/src/tools/delegate-task/sync-task-runner.ts
@@ -1,0 +1,216 @@
+import type { TaskToastManager } from "../../features/task-toast-manager/manager"
+import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
+import type { ModelFallbackState } from "../../hooks/model-fallback/hook"
+import type { FallbackEntry } from "../../shared/model-requirements"
+import { shouldRetryError } from "../../shared/model-error-classifier"
+import type { ExecutorContext, ParentContext } from "./executor-types"
+import { buildRecoveredSyncTaskCompletion, buildSyncTaskCompletion } from "./sync-completion-message"
+import { shouldAttemptPollErrorRecovery } from "./sync-poll-error-recovery"
+import type { SyncTaskDeps } from "./sync-task-deps"
+import { getNextSyncFallbackModel, retrySyncPromptWithFallbacks } from "./sync-task-fallback"
+import type { DelegatedModelConfig, DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+
+type SyncTaskRunnerInput = {
+  readonly args: DelegateTaskArgs
+  readonly ctx: ToolContextWithMetadata
+  readonly executorCtx: ExecutorContext
+  readonly parentContext: ParentContext
+  readonly agentToUse: string
+  readonly categoryModel: DelegatedModelConfig | undefined
+  readonly fallbackChain: FallbackEntry[] | undefined
+  readonly deps: SyncTaskDeps
+  readonly sessionID: string
+  readonly spawnDepth: number
+  readonly taskId: string
+  readonly startTime: Date
+  readonly syncPollTimeoutMs: number | undefined
+  readonly systemContent: string | undefined
+  readonly toastManager: TaskToastManager | undefined
+  readonly modelInfo: ModelFallbackInfo | undefined
+  readonly registerSyncSession: (newSessionID: string) => Promise<void>
+  readonly publishSyncMetadata: (
+    currentSessionID: string,
+    currentModel: DelegatedModelConfig | undefined,
+    spawnDepth: number,
+  ) => Promise<void>
+  readonly cleanupRetrySession: (currentSessionID: string) => void
+  readonly setSyncSessionID: (currentSessionID: string) => void
+}
+
+function addRetryTaskToast(input: {
+  readonly args: DelegateTaskArgs
+  readonly agentToUse: string
+  readonly sessionID: string
+  readonly taskId: string
+  readonly toastManager: TaskToastManager | undefined
+  readonly modelInfo: ModelFallbackInfo | undefined
+}): void {
+  if (!input.toastManager) return
+  input.toastManager.addTask({
+    id: input.taskId,
+    sessionID: input.sessionID,
+    description: input.args.description,
+    agent: input.agentToUse,
+    isBackground: false,
+    category: input.args.category,
+    skills: input.args.load_skills,
+    modelInfo: input.modelInfo,
+  })
+}
+
+export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<string> {
+  const {
+    args,
+    ctx,
+    executorCtx,
+    parentContext,
+    agentToUse,
+    fallbackChain,
+    deps,
+    spawnDepth,
+    taskId,
+    startTime,
+    syncPollTimeoutMs,
+    systemContent,
+    toastManager,
+    modelInfo,
+    registerSyncSession,
+    publishSyncMetadata,
+    cleanupRetrySession,
+    setSyncSessionID,
+  } = input
+  const { client, directory, sisyphusAgentConfig } = executorCtx
+  const hasActiveChildBackgroundTasks = executorCtx.manager?.hasActiveChildTasks?.bind(executorCtx.manager)
+  let effectiveCategoryModel = input.categoryModel
+  let fallbackState: ModelFallbackState | undefined = effectiveCategoryModel && fallbackChain?.length
+    ? {
+        providerID: effectiveCategoryModel.providerID,
+        modelID: effectiveCategoryModel.modelID,
+        fallbackChain,
+        attemptCount: 0,
+        pending: true,
+      }
+    : undefined
+  let activeSessionID = input.sessionID
+
+  while (true) {
+    let promptError = await deps.sendSyncPrompt(client, {
+      sessionID: activeSessionID,
+      agentToUse,
+      args,
+      systemContent,
+      directory,
+      toastManager,
+      taskId,
+      sisyphusAgentConfig,
+      categoryModel: effectiveCategoryModel,
+    })
+    if (promptError) {
+      const promptResult = await retrySyncPromptWithFallbacks({
+        sessionID: activeSessionID,
+        initialError: promptError,
+        categoryModel: effectiveCategoryModel,
+        fallbackChain,
+        sendPrompt: async (fallbackModel) => {
+          return deps.sendSyncPrompt(client, {
+            sessionID: activeSessionID,
+            agentToUse,
+            args,
+            systemContent,
+            directory,
+            toastManager,
+            taskId,
+            sisyphusAgentConfig,
+            categoryModel: fallbackModel,
+          })
+        },
+      })
+
+      promptError = promptResult.promptError
+      effectiveCategoryModel = promptResult.categoryModel
+      fallbackState = promptResult.fallbackState ?? fallbackState
+
+      if (promptError) {
+        return promptError
+      }
+    }
+
+    const pollError = await deps.pollSyncSession(ctx, client, {
+      sessionID: activeSessionID,
+      agentToUse,
+      toastManager,
+      taskId,
+      hasActiveChildBackgroundTasks,
+    }, syncPollTimeoutMs)
+    if (pollError) {
+      if (shouldAttemptPollErrorRecovery(pollError)) {
+        const recoveredResult = await deps.fetchSyncResult(client, activeSessionID, undefined, {
+          strictAbortRecovery: true,
+        })
+        if (recoveredResult.ok) {
+          return buildRecoveredSyncTaskCompletion({
+            activeSessionID,
+            agentToUse,
+            args,
+            effectiveCategoryModel,
+            parentContext,
+            startTime,
+            textContent: recoveredResult.textContent,
+          })
+        }
+      }
+
+      const nextFallbackModel = shouldRetryError({ message: pollError })
+        ? getNextSyncFallbackModel(activeSessionID, fallbackState)
+        : null
+      if (!nextFallbackModel) {
+        return pollError
+      }
+
+      cleanupRetrySession(activeSessionID)
+
+      const retrySessionResult = await deps.createSyncSession(client, {
+        parentSessionID: parentContext.sessionID,
+        agentToUse,
+        description: args.description,
+        defaultDirectory: directory,
+        categoryModel: nextFallbackModel,
+      })
+      if (!retrySessionResult.ok) {
+        return retrySessionResult.error
+      }
+
+      activeSessionID = retrySessionResult.sessionID
+      setSyncSessionID(activeSessionID)
+      effectiveCategoryModel = nextFallbackModel
+      await registerSyncSession(activeSessionID)
+      addRetryTaskToast({
+        args,
+        agentToUse,
+        sessionID: activeSessionID,
+        taskId,
+        toastManager,
+        modelInfo,
+      })
+      await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnDepth)
+      continue
+    }
+
+    const result = await deps.fetchSyncResult(client, activeSessionID)
+    if (!result.ok) {
+      return result.error
+    }
+
+    await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnDepth)
+
+    return buildSyncTaskCompletion({
+      activeSessionID,
+      agentToUse,
+      args,
+      effectiveCategoryModel,
+      parentContext,
+      startTime,
+      textContent: result.textContent,
+    })
+  }
+}

--- a/src/tools/delegate-task/sync-task.test.ts
+++ b/src/tools/delegate-task/sync-task.test.ts
@@ -696,6 +696,65 @@ describe("executeSyncTask - cleanup on error paths", () => {
     })
   })
 
+  test("#given no fallback chain #when poll returns retryable runtime error #then returns poll error without creating retry session", async () => {
+    //#given
+    const mockClient = {
+      session: {
+        create: async () => ({ data: { id: "ignored" } }),
+      },
+    }
+
+    const { executeSyncTask } = require("./sync-task")
+    const createdSessions: string[] = []
+    const polledSessions: string[] = []
+
+    const deps = {
+      createSyncSession: async () => {
+        const sessionID = createdSessions.length === 0 ? "ses_first" : "ses_second"
+        createdSessions.push(sessionID)
+        return { ok: true as const, sessionID }
+      },
+      sendSyncPrompt: async () => null,
+      pollSyncSession: async (_ctx: unknown, _client: unknown, input: { sessionID: string }) => {
+        polledSessions.push(input.sessionID)
+        return "Forbidden: Selected provider is forbidden"
+      },
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "unused" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+      directory: "/tmp",
+      onSyncSessionCreated: null,
+    }
+
+    const args = {
+      prompt: "test prompt",
+      description: "test task",
+      category: "quick",
+      load_skills: [],
+      run_in_background: false,
+      command: null,
+    }
+
+    //#when
+    const result = await executeSyncTask(args, mockCtx, mockExecutorCtx, {
+      sessionID: "parent-session",
+    }, "sisyphus-junior", undefined, undefined, undefined, undefined, deps)
+
+    //#then
+    expect(result).toBe("Forbidden: Selected provider is forbidden")
+    expect(createdSessions).toEqual(["ses_first"])
+    expect(polledSessions).toEqual(["ses_first"])
+    expect(deleteCalls).toContain("ses_first")
+  })
+
   test("registers child-session bootstrap before sync prompt and clears it after completion", async () => {
     const mockClient = {
       session: {

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -1,15 +1,12 @@
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
-import type { ModelFallbackState } from "../../hooks/model-fallback/hook"
-import { shouldRetryError } from "../../shared/model-error-classifier"
+import type { FallbackEntry } from "../../shared/model-requirements"
 import { formatDetailedError } from "./error-formatting"
 import type { ExecutorContext, ParentContext } from "./executor-types"
-import { buildRecoveredSyncTaskCompletion, buildSyncTaskCompletion } from "./sync-completion-message"
-import { shouldAttemptPollErrorRecovery } from "./sync-poll-error-recovery"
 import { reserveSyncSubagentSpawn } from "./sync-spawn-reservation"
 import { type SyncTaskDeps, syncTaskDeps } from "./sync-task-deps"
-import { getNextSyncFallbackModel, retrySyncPromptWithFallbacks } from "./sync-task-fallback"
 import { publishSyncTaskMetadata } from "./sync-task-metadata"
+import { runSyncTaskLoop } from "./sync-task-runner"
 import { cleanupSyncSessionSideEffects, registerSyncSessionSideEffects } from "./sync-session-lifecycle"
 import type { DelegatedModelConfig, DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 
@@ -22,11 +19,10 @@ export async function executeSyncTask(
   categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
   modelInfo?: ModelFallbackInfo,
-  fallbackChain?: import("../../shared/model-requirements").FallbackEntry[],
+  fallbackChain?: FallbackEntry[],
   deps: SyncTaskDeps = syncTaskDeps
 ): Promise<string> {
-  const { manager, client, directory, syncPollTimeoutMs } = executorCtx
-  const hasActiveChildBackgroundTasks = manager?.hasActiveChildTasks?.bind(manager)
+  const { client, directory, syncPollTimeoutMs } = executorCtx
   const toastManager = getTaskToastManager()
   let taskId: string | undefined
   let syncSessionID: string | undefined
@@ -104,147 +100,40 @@ export async function executeSyncTask(
     }
     await publishSyncMetadata(sessionID, categoryModel, spawnContext.childDepth)
 
-    const syncPromptInput = {
-      sessionID,
-      agentToUse,
-      args,
-      systemContent,
-      directory: createSessionResult.parentDirectory,
-      toastManager,
-      taskId,
-      sisyphusAgentConfig: executorCtx.sisyphusAgentConfig,
+    const setSyncSessionID = (currentSessionID: string): void => {
+      syncSessionID = currentSessionID
     }
-
-    let effectiveCategoryModel = categoryModel
-    let fallbackState: ModelFallbackState | undefined = effectiveCategoryModel && fallbackChain?.length
-      ? {
-          providerID: effectiveCategoryModel.providerID,
-          modelID: effectiveCategoryModel.modelID,
-          fallbackChain,
-          attemptCount: 0,
-          pending: true,
-        }
-      : undefined
-    let activeSessionID = sessionID
 
     const cleanupRetrySession = (currentSessionID: string): void => {
       cleanupSyncSessionSideEffects(currentSessionID, executorCtx)
     }
 
     try {
-      while (true) {
-        let promptError = await deps.sendSyncPrompt(client, {
-          ...syncPromptInput,
-          sessionID: activeSessionID,
-          categoryModel: effectiveCategoryModel,
-        })
-        if (promptError) {
-          const promptResult = await retrySyncPromptWithFallbacks({
-            sessionID: activeSessionID,
-            initialError: promptError,
-            categoryModel: effectiveCategoryModel,
-            fallbackChain,
-            sendPrompt: async (fallbackModel) => {
-              return deps.sendSyncPrompt(client, {
-                ...syncPromptInput,
-                sessionID: activeSessionID,
-                categoryModel: fallbackModel,
-              })
-            },
-          })
-
-          promptError = promptResult.promptError
-          effectiveCategoryModel = promptResult.categoryModel
-          fallbackState = promptResult.fallbackState ?? fallbackState
-
-          if (promptError) {
-            return promptError
-          }
-        }
-
-        const pollError = await deps.pollSyncSession(ctx, client, {
-          sessionID: activeSessionID,
-          agentToUse,
-          toastManager,
-          taskId,
-          hasActiveChildBackgroundTasks,
-        }, syncPollTimeoutMs)
-        if (pollError) {
-          if (shouldAttemptPollErrorRecovery(pollError)) {
-            const recoveredResult = await deps.fetchSyncResult(client, activeSessionID, undefined, {
-              strictAbortRecovery: true,
-            })
-            if (recoveredResult.ok) {
-              return buildRecoveredSyncTaskCompletion({
-                activeSessionID,
-                agentToUse,
-                args,
-                effectiveCategoryModel,
-                parentContext,
-                startTime,
-                textContent: recoveredResult.textContent,
-              })
-            }
-          }
-
-          const nextFallbackModel = shouldRetryError({ message: pollError })
-            ? getNextSyncFallbackModel(activeSessionID, fallbackState)
-            : null
-          if (!nextFallbackModel) {
-            return pollError
-          }
-
-          cleanupRetrySession(activeSessionID)
-
-          const retrySessionResult = await deps.createSyncSession(client, {
-            parentSessionID: parentContext.sessionID,
-            agentToUse,
-            description: args.description,
-            defaultDirectory: directory,
-            categoryModel: nextFallbackModel,
-          })
-          if (!retrySessionResult.ok) {
-            return retrySessionResult.error
-          }
-
-          activeSessionID = retrySessionResult.sessionID
-          effectiveCategoryModel = nextFallbackModel
-          await registerSyncSession(activeSessionID)
-          if (toastManager && taskId) {
-            toastManager.addTask({
-              id: taskId,
-              sessionID: activeSessionID,
-              description: args.description,
-              agent: agentToUse,
-              isBackground: false,
-              category: args.category,
-              skills: args.load_skills,
-              modelInfo,
-            })
-          }
-          if (taskId) {
-            await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnContext.childDepth)
-          }
-          continue
-        }
-
-        const result = await deps.fetchSyncResult(client, activeSessionID)
-        if (!result.ok) {
-          return result.error
-        }
-
-        await publishSyncMetadata(activeSessionID, effectiveCategoryModel, spawnContext.childDepth)
-
-        return buildSyncTaskCompletion({
-          activeSessionID,
-          agentToUse,
-          args,
-          effectiveCategoryModel,
-          parentContext,
-          startTime,
-          textContent: result.textContent,
-        })
-      }
+      return await runSyncTaskLoop({
+        args,
+        ctx,
+        executorCtx: {
+          ...executorCtx,
+          directory: createSessionResult.parentDirectory,
+        },
+        parentContext,
+        agentToUse,
+        categoryModel,
+        fallbackChain,
+        deps,
+        sessionID,
+        spawnDepth: spawnContext.childDepth,
+        taskId,
+        startTime,
+        syncPollTimeoutMs,
+        systemContent,
+        toastManager: toastManager ?? undefined,
+        modelInfo,
+        registerSyncSession,
+        publishSyncMetadata,
+        cleanupRetrySession,
+        setSyncSessionID,
+      })
     } finally {
       if (toastManager && taskId !== undefined) {
         toastManager.removeTask(taskId)


### PR DESCRIPTION
## Summary
- Split the long sync delegate execution loop out of `sync-task.ts` into `sync-task-runner.ts`.
- Kept `executeSyncTask` as the setup/error-cleanup facade for spawn reservation, session registration, metadata, and toast lifecycle.
- Added a characterization test for retryable poll errors without fallback chains, pinning the current no-retry behavior before extraction.

## Testing
- `bun test src/tools/delegate-task/sync-task.test.ts`
- `bun test src/tools/delegate-task/sync-*.test.ts`
- `bun run typecheck`
- `git diff --check`

## Scope Notes
- Avoided open-PR-owned `src/tools/delegate-task/category-resolver.ts` and `src/tools/delegate-task/constants.ts`.
- No behavior changes intended; this is a facade split around the existing sync execution flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the sync delegate execution loop into `sync-task-runner.ts` to isolate the long-running flow and simplify `executeSyncTask`. No behavior changes; added a characterization test to lock the current no-retry behavior when poll errors occur without fallbacks.

- **Refactors**
  - Extracted the prompt/poll/fallback loop to `runSyncTaskLoop` in `sync-task-runner.ts`.
  - Kept `executeSyncTask` as a thin setup/cleanup facade (reservation, session registration, metadata, toast).
  - Added a characterization test: retryable poll error without a fallback chain returns the poll error and does not create a retry session.

<sup>Written for commit 878785a7004b933b3e7bace5c57b54aa4fcc68e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

