### PR TITLE
refactor: split hook injector SDK context facade

### DIFF
--- a/src/features/hook-message-injector/context-resolver.ts
+++ b/src/features/hook-message-injector/context-resolver.ts
@@ -1,9 +1,7 @@
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import { findFirstMessageWithAgent, findNearestMessageWithFields } from "./json-message-lookup"
-import {
-  findMessageContextFromSDK,
-  type OpencodeClient,
-} from "./sdk-message-lookup"
+import { findMessageContextFromSDK } from "./sdk-message-context"
+import type { OpencodeClient } from "./sdk-message-lookup"
 import type { StoredMessage } from "./types"
 
 export async function resolveMessageContext(

--- a/src/features/hook-message-injector/index.ts
+++ b/src/features/hook-message-injector/index.ts
@@ -4,6 +4,7 @@ export {
   findFirstMessageWithAgent,
   findNearestMessageWithFieldsFromSDK,
   findFirstMessageWithAgentFromSDK,
+  findMessageContextFromSDK,
   resolveMessageContext,
 } from "./injector"
 export type { StoredMessage } from "./injector"

--- a/src/features/hook-message-injector/injection-boundaries.test.ts
+++ b/src/features/hook-message-injector/injection-boundaries.test.ts
@@ -177,6 +177,40 @@ describe("hook message injection boundaries", () => {
     expect(message.tools).toEqual({ write: "deny" })
   })
 
+  it("#given original context and older fallback data #when injecting through the facade #then writes the original context metadata", () => {
+    // given
+    const messageDir = join(TEST_MESSAGE_STORAGE, "ses_original_context")
+    mkdirSync(messageDir, { recursive: true })
+    writeFileSync(join(messageDir, "msg_previous.json"), JSON.stringify({
+      id: "msg_previous",
+      agent: "fallback-agent",
+      model: { providerID: "fallback-provider", modelID: "fallback-model" },
+      tools: { write: "deny" },
+      time: { created: 1 },
+    }))
+
+    // when
+    const result = injectHookMessage("ses_original_context", "test content", {
+      agent: "original-agent",
+      model: { providerID: "original-provider", modelID: "original-model" },
+      tools: { write: "allow" },
+    })
+
+    // then
+    expect(result).toBe(true)
+    const injectedFile = listJsonFiles(messageDir).find((fileName) => fileName !== "msg_previous.json")
+    expect(injectedFile).toBeDefined()
+    const message = readJsonFile<{
+      readonly agent: string
+      readonly model: { readonly providerID: string; readonly modelID: string }
+      readonly tools: Record<string, string>
+    }>(join(messageDir, injectedFile ?? ""))
+
+    expect(message.agent).toBe("original-agent")
+    expect(message.model).toEqual({ providerID: "original-provider", modelID: "original-model" })
+    expect(message.tools).toEqual({ write: "allow" })
+  })
+
   it("rejects session IDs that would escape message storage", () => {
     // given
     expect(injectHookMessage("../ses_escape", "test content", {

--- a/src/features/hook-message-injector/injector.test.ts
+++ b/src/features/hook-message-injector/injector.test.ts
@@ -6,6 +6,7 @@ import {
   findNearestMessageWithFields,
   findNearestMessageWithFieldsFromSDK,
   findFirstMessageWithAgentFromSDK,
+  findMessageContextFromSDK,
   generateMessageId,
   generatePartId,
   injectHookMessage,
@@ -314,6 +315,51 @@ describe("findFirstMessageWithAgentFromSDK", () => {
     const result = await findFirstMessageWithAgentFromSDK(unsafeTestValue(mockClient), "ses_123")
 
     expect(result).toBeNull()
+  })
+})
+
+describe("findMessageContextFromSDK", () => {
+  it("#given SDK messages with different chronology #when resolving context through the injector facade #then returns nearest metadata and first agent from one fetch", async () => {
+    // given
+    const messages = [
+      {
+        id: "msg_late",
+        info: {
+          agent: "latest-agent",
+          model: { providerID: "openai", modelID: "gpt-5" },
+          tools: { edit: true },
+          time: { created: 100 },
+        },
+      },
+      {
+        id: "msg_early",
+        info: {
+          agent: "first-agent",
+          model: { providerID: "anthropic", modelID: "claude-opus-4" },
+          time: { created: 10 },
+        },
+      },
+    ]
+    const messagesMock = vi.fn(async () => ({ data: messages }))
+    const mockClient = {
+      session: {
+        messages: messagesMock,
+      },
+    }
+
+    // when
+    const result = await findMessageContextFromSDK(unsafeTestValue(mockClient), "ses_123")
+
+    // then
+    expect(result).toEqual({
+      prevMessage: {
+        agent: "latest-agent",
+        model: { providerID: "openai", modelID: "gpt-5" },
+        tools: { edit: true },
+      },
+      firstMessageAgent: "first-agent",
+    })
+    expect(messagesMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -1,6 +1,7 @@
 export { resolveMessageContext } from "./context-resolver"
 export { generateMessageId, generatePartId } from "./id-generation"
 export { injectHookMessage } from "./message-injection"
+export { findMessageContextFromSDK } from "./sdk-message-context"
 export { findFirstMessageWithAgent, findNearestMessageWithFields } from "./json-message-lookup"
 export {
   findFirstMessageWithAgentFromSDK,

--- a/src/features/hook-message-injector/sdk-message-context.ts
+++ b/src/features/hook-message-injector/sdk-message-context.ts
@@ -1,0 +1,22 @@
+import {
+  fetchSDKMessages,
+  findFirstMessageWithAgentFromMessages,
+  findNearestMessageWithFieldsFromMessages,
+  type OpencodeClient,
+} from "./sdk-message-lookup"
+import type { StoredMessage } from "./types"
+
+export async function findMessageContextFromSDK(
+  client: OpencodeClient,
+  sessionID: string
+): Promise<{ prevMessage: StoredMessage | null; firstMessageAgent: string | null }> {
+  const messages = await fetchSDKMessages(client, sessionID)
+  if (!messages) {
+    return { prevMessage: null, firstMessageAgent: null }
+  }
+
+  return {
+    prevMessage: findNearestMessageWithFieldsFromMessages(messages),
+    firstMessageAgent: findFirstMessageWithAgentFromMessages(messages),
+  }
+}

--- a/src/features/hook-message-injector/sdk-message-lookup.ts
+++ b/src/features/hook-message-injector/sdk-message-lookup.ts
@@ -6,23 +6,23 @@ import type { StoredMessage, ToolPermission } from "./types"
 
 export type OpencodeClient = PluginInput["client"]
 
-interface SDKMessage {
-  id?: string
-  info?: {
-    agent?: string
-    model?: {
-      providerID?: string
-      modelID?: string
-      variant?: string
+export interface SDKMessage {
+  readonly id?: string
+  readonly info?: {
+    readonly agent?: string
+    readonly model?: {
+      readonly providerID?: string
+      readonly modelID?: string
+      readonly variant?: string
     }
-    providerID?: string
-    modelID?: string
-    tools?: Record<string, ToolPermission>
-    time?: {
-      created?: number
+    readonly providerID?: string
+    readonly modelID?: string
+    readonly tools?: Record<string, ToolPermission>
+    readonly time?: {
+      readonly created?: number
     }
   }
-  parts?: Array<{ type?: string }>
+  readonly parts?: readonly { readonly type?: string }[]
 }
 
 function convertSDKMessageToStoredMessage(msg: SDKMessage): StoredMessage | null {
@@ -50,7 +50,7 @@ function convertSDKMessageToStoredMessage(msg: SDKMessage): StoredMessage | null
   }
 }
 
-async function fetchSDKMessages(client: OpencodeClient, sessionID: string): Promise<SDKMessage[] | null> {
+export async function fetchSDKMessages(client: OpencodeClient, sessionID: string): Promise<SDKMessage[] | null> {
   try {
     const response = await client.session.messages({ path: { id: sessionID } })
     const emptyMessages: SDKMessage[] = []
@@ -65,7 +65,7 @@ async function fetchSDKMessages(client: OpencodeClient, sessionID: string): Prom
   return null
 }
 
-function findNearestMessageWithFieldsFromMessages(messages: readonly SDKMessage[]): StoredMessage | null {
+export function findNearestMessageWithFieldsFromMessages(messages: readonly SDKMessage[]): StoredMessage | null {
   const sortedMessages = messages
     .map((message) => ({
       stored: convertSDKMessageToStoredMessage(message),
@@ -91,7 +91,7 @@ function findNearestMessageWithFieldsFromMessages(messages: readonly SDKMessage[
   return null
 }
 
-function findFirstMessageWithAgentFromMessages(messages: readonly SDKMessage[]): string | null {
+export function findFirstMessageWithAgentFromMessages(messages: readonly SDKMessage[]): string | null {
   const sortedMessages = [...messages].sort((left, right) => {
     const leftTime = left.info?.time?.created ?? Number.POSITIVE_INFINITY
     const rightTime = right.info?.time?.created ?? Number.POSITIVE_INFINITY
@@ -125,19 +125,4 @@ export async function findFirstMessageWithAgentFromSDK(
 ): Promise<string | null> {
   const messages = await fetchSDKMessages(client, sessionID)
   return messages ? findFirstMessageWithAgentFromMessages(messages) : null
-}
-
-export async function findMessageContextFromSDK(
-  client: OpencodeClient,
-  sessionID: string
-): Promise<{ prevMessage: StoredMessage | null; firstMessageAgent: string | null }> {
-  const messages = await fetchSDKMessages(client, sessionID)
-  if (!messages) {
-    return { prevMessage: null, firstMessageAgent: null }
-  }
-
-  return {
-    prevMessage: findNearestMessageWithFieldsFromMessages(messages),
-    firstMessageAgent: findFirstMessageWithAgentFromMessages(messages),
-  }
 }


### PR DESCRIPTION
## Summary
- Splits the combined SDK message context lookup out of the hook-message-injector SDK lookup module.
- Keeps the public injector facade behavior intact and exposes the moved SDK context helper through the facade/barrel.
- Adds characterization coverage for SDK context resolution and injection metadata precedence.

## Testing
- `bun test src/features/hook-message-injector/injector.test.ts src/features/hook-message-injector/injection-boundaries.test.ts` ✅
- `bun test src/shared/prompt-async-route-audit.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `git diff --check` ✅

## Notes
- Checked open PR overlap before editing; no open PR touches `src/features/hook-message-injector/injector.ts`.
- No raw `session.prompt` / `session.promptAsync` route was added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the SDK message context resolver into its own module and re-exported `findMessageContextFromSDK` via the injector facade, preserving the public API. Added characterization tests for SDK context resolution and injection metadata precedence.

<sup>Written for commit 14bed007378e272f454733f09422067da86e9dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

