### PR TITLE
fix(docs): update uninstall jq command to handle version suffix

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -332,7 +332,7 @@ oh-my-openagent を削除するには:
 
    ```bash
    # jq を使用
-   jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+   jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -333,7 +333,7 @@ oh-my-openagent를 제거하려면:
 
    ```bash
    # jq 사용
-   jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+   jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ To remove oh-my-openagent:
 
    ```bash
    # Using jq
-   jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+   jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,7 +331,7 @@ project/
 
    ```bash
    # С помощью jq
-   jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+   jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -338,7 +338,7 @@ Agent 会自动顺藤摸瓜加载对应的 Context，免去了你所有的手动
 
    ```bash
    # 如果你有 jq 的话
-   jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+   jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -815,7 +815,7 @@ See [Privacy Policy](../legal/privacy-policy.md) and [Terms of Service](../legal
 
 ```bash
 # 1. Remove the plugin entry from opencode.json
-jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+jq '.plugin = [.plugin[] | select(split("@")[0] != "oh-my-openagent" and split("@")[0] != "oh-my-opencode")]' \
     ~/.config/opencode/opencode.json > /tmp/oc.json && \
     mv /tmp/oc.json ~/.config/opencode/opencode.json
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update uninstallation docs so the `jq` command uses `split("@")[0]` to ignore version suffixes when matching plugins. Removing `oh-my-openagent` and `oh-my-opencode` from `opencode.json` now works with or without pinned versions across all localized READMEs and the installation guide.

<sup>Written for commit 4d5bd4c4363a7bf33138a90c27bdcfe44807db5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

