### PR TITLE
test(openclaw): pin session registry facade

### DIFF
--- a/src/openclaw/__tests__/session-registry.test.ts
+++ b/src/openclaw/__tests__/session-registry.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import * as sessionRegistryModule from "../session-registry"
@@ -28,6 +36,12 @@ function createMapping(overrides: Partial<SessionMapping> = {}): SessionMapping 
 function resetRegistry(): void {
   rmSync(registryDir, { recursive: true, force: true })
   mkdirSync(registryDir, { recursive: true })
+}
+
+function writeStaleLock(content: string): void {
+  writeFileSync(lockPath, content, { mode: 0o600 })
+  const staleDate = new Date(Date.now() - 11_000)
+  utimesSync(lockPath, staleDate, staleDate)
 }
 
 beforeEach(() => {
@@ -60,6 +74,38 @@ describe("session-registry", () => {
 
     // then
     expect(sessionRegistryModule.loadAllMappings()).toEqual([firstMapping, secondMapping])
+    expect(existsSync(lockPath)).toBe(false)
+  })
+
+  test("skips malformed and non-mapping registry records during lookup", () => {
+    // given
+    const mapping = createMapping({ messageId: "valid-message" })
+    writeFileSync(
+      registryPath,
+      [
+        "not-json",
+        JSON.stringify({ sessionId: "missing-required-fields" }),
+        JSON.stringify(mapping),
+        "",
+      ].join("\n"),
+    )
+
+    // when/then
+    expect(sessionRegistryModule.loadAllMappings()).toEqual([mapping])
+    expect(sessionRegistryModule.lookupByMessageId("discord-bot", "valid-message")).toEqual(mapping)
+  })
+
+  test("recovers from a stale malformed lock before appending", () => {
+    // given
+    const mapping = createMapping()
+    writeStaleLock("not-json")
+
+    // when
+    const registered = sessionRegistryModule.registerMessage(mapping)
+
+    // then
+    expect(registered).toBe(true)
+    expect(sessionRegistryModule.loadAllMappings()).toEqual([mapping])
     expect(existsSync(lockPath)).toBe(false)
   })
 
@@ -124,6 +170,7 @@ describe("session-registry", () => {
 
     // then
     expect(sessionRegistryModule.loadAllMappings()).toEqual([keepMapping])
+    expect(readFileSync(registryPath, "utf-8")).toBe(`${JSON.stringify(keepMapping)}\n`)
   })
 
   test("prunes mappings older than the registry retention window", () => {

--- a/src/openclaw/session-registry.ts
+++ b/src/openclaw/session-registry.ts
@@ -45,7 +45,10 @@ export function loadAllMappings(): SessionMapping[] {
 
 export function lookupByMessageId(platform: string, messageId: string): SessionMapping | null {
   const mappings = loadAllMappings()
-  return mappings.find((mapping) => mapping.platform === platform && mapping.messageId === messageId) || null
+  return (
+    mappings.find((mapping) => mapping.platform === platform && mapping.messageId === messageId) ??
+    null
+  )
 }
 
 export function removeSession(sessionId: string): void {


### PR DESCRIPTION
## Summary
Adds characterization coverage around the OpenClaw session registry facade while keeping behavior unchanged. The current facade was already split into storage, lock, path, and type modules, so this PR pins the public contract and applies one small lookup cleanup in the facade.

## Changes
- Cover malformed/non-mapping JSONL rows during facade reads and lookups.
- Cover stale malformed lock recovery before append writes.
- Pin rewrite persistence after session/pane removals.
- Use nullish fallback for missing lookup results.

## Testing
- `bun test src/openclaw/__tests__/session-registry.test.ts`
- `bun test src/openclaw/__tests__/session-registry.test.ts src/openclaw/__tests__/runtime-dispatch.test.ts src/openclaw/__tests__/reply-listener-discord.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the OpenClaw session registry facade and adds tests to lock in behavior for malformed JSONL rows, stale lock recovery, and rewrite persistence after removals. Also cleans up message lookups to use a nullish fallback.

<sup>Written for commit be5a7b5ecbe3f0527276fcd949134bcc05009e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

