### PR TITLE
refactor(claude-code-plugin-loader): split discovery core

### DIFF
--- a/src/features/claude-code-plugin-loader/discovery-context.ts
+++ b/src/features/claude-code-plugin-loader/discovery-context.ts
@@ -1,0 +1,33 @@
+import { getPluginsBaseDir } from "./discovery-paths"
+import { loadInstalledPlugins } from "./installed-plugin-database"
+import { loadPluginManifest } from "./plugin-manifest"
+import { loadClaudeSettings } from "./plugin-settings"
+import type {
+  InstalledPluginsDatabase,
+  PluginLoaderOptions,
+  PluginManifest,
+} from "./types"
+
+export type PluginManifestLoader = (installPath: string) => PluginManifest | null
+
+export interface PluginDiscoveryContext {
+  readonly cwd: string
+  readonly db: InstalledPluginsDatabase | null
+  readonly manifestLoader: PluginManifestLoader
+  readonly overrideEnabledPlugins: Record<string, boolean> | undefined
+  readonly settingsEnabledPlugins: unknown
+}
+
+export function createPluginDiscoveryContext(
+  options?: PluginLoaderOptions,
+): PluginDiscoveryContext {
+  const pluginsBaseDir = options?.pluginsHomeOverride ?? getPluginsBaseDir()
+  const settings = loadClaudeSettings()
+  return {
+    cwd: process.cwd(),
+    db: loadInstalledPlugins(pluginsBaseDir),
+    manifestLoader: options?.loadPluginManifestOverride ?? loadPluginManifest,
+    overrideEnabledPlugins: options?.enabledPluginsOverride,
+    settingsEnabledPlugins: settings?.enabledPlugins,
+  }
+}

--- a/src/features/claude-code-plugin-loader/discovery-core.ts
+++ b/src/features/claude-code-plugin-loader/discovery-core.ts
@@ -1,11 +1,6 @@
-import { log } from "../../shared/logger"
-import { shouldLoadPluginForCwd } from "./scope-filter"
-import { getPluginsBaseDir } from "./discovery-paths"
-import { extractPluginEntries, loadInstalledPlugins } from "./installed-plugin-database"
-import { resolveActualInstallPath } from "./install-path-resolver"
-import { createLoadedPlugin } from "./loaded-plugin"
-import { loadPluginManifest } from "./plugin-manifest"
-import { isPluginEnabled, loadClaudeSettings } from "./plugin-settings"
+import { createPluginDiscoveryContext } from "./discovery-context"
+import { loadPluginEntry } from "./discovery-entry-loader"
+import { extractPluginEntries } from "./installed-plugin-database"
 import type {
   LoadedPlugin,
   PluginLoadError,
@@ -13,64 +8,35 @@ import type {
   PluginLoadResult,
 } from "./types"
 
+function unreachablePluginEntryResult(result: never): never {
+  throw new TypeError(`Unexpected plugin entry result: ${JSON.stringify(result)}`)
+}
+
 export function discoverInstalledPlugins(options?: PluginLoaderOptions): PluginLoadResult {
-  const pluginsBaseDir = options?.pluginsHomeOverride ?? getPluginsBaseDir()
-  const db = loadInstalledPlugins(pluginsBaseDir)
-  const settings = loadClaudeSettings()
+  const context = createPluginDiscoveryContext(options)
   const plugins: LoadedPlugin[] = []
   const errors: PluginLoadError[] = []
 
-  if (!db || (!Array.isArray(db) && !db.plugins)) {
+  if (!context.db || (!Array.isArray(context.db) && !context.db.plugins)) {
     return { plugins, errors }
   }
 
-  const settingsEnabledPlugins = settings?.enabledPlugins
-  const overrideEnabledPlugins = options?.enabledPluginsOverride
-  const pluginManifestLoader = options?.loadPluginManifestOverride ?? loadPluginManifest
-  const cwd = process.cwd()
-
-  for (const [pluginKey, installation] of extractPluginEntries(db)) {
+  for (const [pluginKey, installation] of extractPluginEntries(context.db)) {
     if (!installation) continue
 
-    if (!isPluginEnabled(pluginKey, settingsEnabledPlugins, overrideEnabledPlugins)) {
-      log(`Plugin disabled: ${pluginKey}`)
-      continue
+    const result = loadPluginEntry(pluginKey, installation, context)
+    switch (result.kind) {
+      case "loaded":
+        plugins.push(result.plugin)
+        break
+      case "error":
+        errors.push(result.error)
+        break
+      case "skipped":
+        break
+      default:
+        unreachablePluginEntryResult(result)
     }
-
-    if (!shouldLoadPluginForCwd(installation, cwd)) {
-      log(`Skipping ${installation.scope}-scoped plugin outside current cwd: ${pluginKey}`, {
-        projectPath: installation.projectPath,
-        cwd,
-      })
-      continue
-    }
-
-    const { installPath: configuredInstallPath } = installation
-    const installPath = resolveActualInstallPath(configuredInstallPath, pluginKey)
-    if (!installPath) {
-      errors.push({
-        pluginKey,
-        installPath: configuredInstallPath,
-        error: "Plugin installation path does not exist",
-      })
-      continue
-    }
-
-    if (installPath !== configuredInstallPath) {
-      log(`Recovered plugin install path for ${pluginKey}`, {
-        configured: configuredInstallPath,
-        resolved: installPath,
-      })
-    }
-
-    const manifest = pluginManifestLoader(installPath)
-    const loadedPlugin = createLoadedPlugin(pluginKey, installation, installPath, manifest)
-
-    plugins.push(loadedPlugin)
-    log(`Discovered plugin: ${loadedPlugin.name}@${installation.version} (${installation.scope})`, {
-      installPath,
-      hasManifest: !!manifest,
-    })
   }
 
   return { plugins, errors }

--- a/src/features/claude-code-plugin-loader/discovery-entry-loader.ts
+++ b/src/features/claude-code-plugin-loader/discovery-entry-loader.ts
@@ -1,0 +1,71 @@
+import { log } from "../../shared/logger"
+import { resolveActualInstallPath } from "./install-path-resolver"
+import { createLoadedPlugin } from "./loaded-plugin"
+import { isPluginEnabled } from "./plugin-settings"
+import { shouldLoadPluginForCwd } from "./scope-filter"
+import type { PluginDiscoveryContext } from "./discovery-context"
+import type {
+  LoadedPlugin,
+  PluginInstallation,
+  PluginLoadError,
+} from "./types"
+
+export type PluginEntryLoadResult =
+  | { readonly kind: "loaded"; readonly plugin: LoadedPlugin }
+  | { readonly kind: "error"; readonly error: PluginLoadError }
+  | { readonly kind: "skipped" }
+
+export function loadPluginEntry(
+  pluginKey: string,
+  installation: PluginInstallation,
+  context: PluginDiscoveryContext,
+): PluginEntryLoadResult {
+  if (
+    !isPluginEnabled(
+      pluginKey,
+      context.settingsEnabledPlugins,
+      context.overrideEnabledPlugins,
+    )
+  ) {
+    log(`Plugin disabled: ${pluginKey}`)
+    return { kind: "skipped" }
+  }
+
+  if (!shouldLoadPluginForCwd(installation, context.cwd)) {
+    log(`Skipping ${installation.scope}-scoped plugin outside current cwd: ${pluginKey}`, {
+      projectPath: installation.projectPath,
+      cwd: context.cwd,
+    })
+    return { kind: "skipped" }
+  }
+
+  const { installPath: configuredInstallPath } = installation
+  const installPath = resolveActualInstallPath(configuredInstallPath, pluginKey)
+  if (!installPath) {
+    return {
+      kind: "error",
+      error: {
+        pluginKey,
+        installPath: configuredInstallPath,
+        error: "Plugin installation path does not exist",
+      },
+    }
+  }
+
+  if (installPath !== configuredInstallPath) {
+    log(`Recovered plugin install path for ${pluginKey}`, {
+      configured: configuredInstallPath,
+      resolved: installPath,
+    })
+  }
+
+  const manifest = context.manifestLoader(installPath)
+  const loadedPlugin = createLoadedPlugin(pluginKey, installation, installPath, manifest)
+
+  log(`Discovered plugin: ${loadedPlugin.name}@${installation.version} (${installation.scope})`, {
+    installPath,
+    hasManifest: !!manifest,
+  })
+
+  return { kind: "loaded", plugin: loadedPlugin }
+}

--- a/src/features/claude-code-plugin-loader/discovery-facade.test.ts
+++ b/src/features/claude-code-plugin-loader/discovery-facade.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const originalClaudePluginsHome = process.env.CLAUDE_PLUGINS_HOME
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function writeDatabase(pluginsHome: string, installPath: string): void {
+  writeFileSync(
+    join(pluginsHome, "installed_plugins.json"),
+    JSON.stringify({
+      version: 2,
+      plugins: {
+        "facade-plugin@market": [
+          {
+            scope: "user",
+            installPath,
+            version: "1.2.3",
+            installedAt: "2026-03-26T00:00:00Z",
+            lastUpdated: "2026-03-26T00:00:00Z",
+          },
+        ],
+      },
+    }),
+    "utf-8",
+  )
+}
+
+function getClaudePluginsHomeForTest(): string {
+  const pluginsHome = process.env.CLAUDE_PLUGINS_HOME
+  if (pluginsHome === undefined) {
+    throw new TypeError("CLAUDE_PLUGINS_HOME must be set by test setup")
+  }
+  return pluginsHome
+}
+
+describe("discovery facade", () => {
+  beforeEach(() => {
+    mock.module("../../shared/logger", () => ({
+      log: () => {},
+    }))
+
+    process.env.CLAUDE_PLUGINS_HOME = createTemporaryDirectory("omo-facade-plugins-")
+  })
+
+  afterEach(() => {
+    mock.restore()
+
+    if (originalClaudePluginsHome === undefined) {
+      delete process.env.CLAUDE_PLUGINS_HOME
+    } else {
+      process.env.CLAUDE_PLUGINS_HOME = originalClaudePluginsHome
+    }
+
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("#given the public discovery module is imported #when plugin discovery runs #then it preserves legacy facade exports and behavior", async () => {
+    //#given
+    const pluginsHome = getClaudePluginsHomeForTest()
+    const installPath = createTemporaryDirectory("omo-facade-install-")
+    mkdirSync(join(installPath, ".claude-plugin"), { recursive: true })
+    writeFileSync(
+      join(installPath, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "facade-plugin", version: "1.2.3" }),
+      "utf-8",
+    )
+    writeDatabase(pluginsHome, installPath)
+
+    //#when
+    const discovery = await import(`./discovery?t=${Date.now()}-facade`)
+    const discovered = discovery.discoverInstalledPlugins({
+      pluginsHomeOverride: pluginsHome,
+    })
+
+    //#then
+    expect(discovery.resolveActualInstallPath(installPath, "facade-plugin@market")).toBe(
+      installPath,
+    )
+    expect(discovery.loadPluginManifest(installPath)?.name).toBe("facade-plugin")
+    expect(discovered.errors).toHaveLength(0)
+    expect(discovered.plugins.map((plugin) => plugin.pluginKey)).toEqual([
+      "facade-plugin@market",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
Split Claude Code plugin discovery orchestration into focused context and entry-loader modules while preserving the public discovery facade.

## Changes
- Add a facade characterization test that pins discovery exports and observable plugin loading behavior.
- Extract discovery context construction into `discovery-context.ts`.
- Extract per-plugin filtering/path recovery/loading into `discovery-entry-loader.ts`.

## Testing
- `bun test ./src/features/claude-code-plugin-loader/discovery-facade.test.ts ./src/features/claude-code-plugin-loader/discovery.test.ts ./src/features/claude-code-plugin-loader/discovery-components.test.ts ./src/features/claude-code-plugin-loader/discovery-settings.test.ts ./src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts ./src/features/claude-code-plugin-loader/scope-filter.test.ts` ✅
- `bun run typecheck` ✅
- `git diff --check origin/dev..HEAD` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Claude Code plugin discovery into two focused modules: a context builder and an entry loader. Keeps the public discovery facade and behavior the same.

- **Refactors**
  - Moved context construction to `discovery-context.ts` (cwd, DB, manifest loader, enabled-plugins overrides).
  - Moved per-plugin filtering, install-path recovery, and manifest load to `discovery-entry-loader.ts` with a typed result (loaded | error | skipped).
  - Simplified `discovery-core.ts` to iterate DB entries and delegate to the entry loader.
  - Added `discovery-facade.test.ts` to pin public exports and observed behavior.

<sup>Written for commit 84ae3955c6413488640b514aed0edb612c19f87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

