### PR TITLE
refactor(cli-run): group event handler facade

### DIFF
--- a/src/cli/run/event-handler-groups.ts
+++ b/src/cli/run/event-handler-groups.ts
@@ -1,0 +1,44 @@
+import type { EventState } from "./event-state"
+import {
+  handleMessagePartDelta,
+  handleMessagePartUpdated,
+  handleMessageUpdated,
+} from "./event-message-handlers"
+import { handleSessionError, handleSessionIdle, handleSessionStatus } from "./event-session-handlers"
+import { handleTuiToast } from "./event-toast-handlers"
+import { handleToolExecute, handleToolResult } from "./event-tool-handlers"
+import type { EventPayload, RunContext } from "./types"
+
+export type EventHandler = (
+  ctx: RunContext,
+  payload: EventPayload,
+  state: EventState,
+) => void
+
+export const sessionEventHandlers = [
+  handleSessionError,
+  handleSessionIdle,
+  handleSessionStatus,
+] as const satisfies readonly EventHandler[]
+
+export const messageEventHandlers = [
+  handleMessagePartUpdated,
+  handleMessagePartDelta,
+  handleMessageUpdated,
+] as const satisfies readonly EventHandler[]
+
+export const toolEventHandlers = [
+  handleToolExecute,
+  handleToolResult,
+] as const satisfies readonly EventHandler[]
+
+export const toastEventHandlers = [
+  handleTuiToast,
+] as const satisfies readonly EventHandler[]
+
+export const eventHandlers = [
+  ...sessionEventHandlers,
+  ...messageEventHandlers,
+  ...toolEventHandlers,
+  ...toastEventHandlers,
+] as const satisfies readonly EventHandler[]

--- a/src/cli/run/event-handlers.test.ts
+++ b/src/cli/run/event-handlers.test.ts
@@ -1,0 +1,91 @@
+/// <reference path="../../../bun-test.d.ts" />
+import { describe, expect, it, spyOn } from "bun:test"
+import { createEventState, processEvents } from "./events"
+import * as facadeHandlers from "./event-handlers"
+import * as messageHandlers from "./event-message-handlers"
+import * as sessionHandlers from "./event-session-handlers"
+import { createMockContext } from "./event-handler-test-support.test"
+import * as toastHandlers from "./event-toast-handlers"
+import * as toolHandlers from "./event-tool-handlers"
+
+async function* toAsyncIterable(items: readonly unknown[]): AsyncIterable<unknown> {
+  for (const item of items) {
+    yield item
+  }
+}
+
+describe("event-handlers facade", () => {
+  it("re-exports the concrete handler modules", () => {
+    //#given / #when / #then
+    expect(facadeHandlers.handleSessionError).toBe(sessionHandlers.handleSessionError)
+    expect(facadeHandlers.handleSessionIdle).toBe(sessionHandlers.handleSessionIdle)
+    expect(facadeHandlers.handleSessionStatus).toBe(sessionHandlers.handleSessionStatus)
+    expect(facadeHandlers.handleMessagePartDelta).toBe(messageHandlers.handleMessagePartDelta)
+    expect(facadeHandlers.handleMessagePartUpdated).toBe(messageHandlers.handleMessagePartUpdated)
+    expect(facadeHandlers.handleMessageUpdated).toBe(messageHandlers.handleMessageUpdated)
+    expect(facadeHandlers.handleToolExecute).toBe(toolHandlers.handleToolExecute)
+    expect(facadeHandlers.handleToolResult).toBe(toolHandlers.handleToolResult)
+    expect(facadeHandlers.handleTuiToast).toBe(toastHandlers.handleTuiToast)
+    expect(facadeHandlers.eventHandlers).toEqual([
+      sessionHandlers.handleSessionError,
+      sessionHandlers.handleSessionIdle,
+      sessionHandlers.handleSessionStatus,
+      messageHandlers.handleMessagePartUpdated,
+      messageHandlers.handleMessagePartDelta,
+      messageHandlers.handleMessageUpdated,
+      toolHandlers.handleToolExecute,
+      toolHandlers.handleToolResult,
+      toastHandlers.handleTuiToast,
+    ])
+  })
+
+  it("preserves routed event behavior through processEvents", async () => {
+    //#given
+    const ctx = createMockContext("ses_main")
+    const state = createEventState()
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {})
+    const events = toAsyncIterable([
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "ses_main",
+          status: { type: "busy" },
+        },
+      },
+      {
+        type: "session.idle",
+        properties: { sessionID: "other-session" },
+      },
+      {
+        type: "tui.toast.show",
+        properties: {
+          title: "Auth",
+          message: "Invalid API key",
+          variant: "error",
+        },
+      },
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "ses_main",
+          status: { type: "idle" },
+        },
+      },
+    ])
+
+    try {
+      //#when
+      await processEvents(ctx, events, state)
+
+      //#then
+      expect(state.mainSessionStarted).toBe(true)
+      expect(state.mainSessionIdle).toBe(true)
+      expect(state.mainSessionError).toBe(true)
+      expect(state.lastError).toBe("Auth: Invalid API key")
+      expect(state.hasReceivedMeaningfulWork).toBe(false)
+      expect(errorSpy).not.toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})

--- a/src/cli/run/event-handlers.ts
+++ b/src/cli/run/event-handlers.ts
@@ -2,3 +2,11 @@ export { handleSessionError, handleSessionIdle, handleSessionStatus } from "./ev
 export { handleMessagePartDelta, handleMessagePartUpdated, handleMessageUpdated } from "./event-message-handlers"
 export { handleToolExecute, handleToolResult } from "./event-tool-handlers"
 export { handleTuiToast } from "./event-toast-handlers"
+export {
+  eventHandlers,
+  messageEventHandlers,
+  sessionEventHandlers,
+  toastEventHandlers,
+  toolEventHandlers,
+} from "./event-handler-groups"
+export type { EventHandler } from "./event-handler-groups"

--- a/src/cli/run/event-stream-processor.ts
+++ b/src/cli/run/event-stream-processor.ts
@@ -2,17 +2,7 @@ import pc from "picocolors"
 import type { RunContext, EventPayload } from "./types"
 import type { EventState } from "./event-state"
 import { logEventVerbose } from "./event-formatting"
-import {
-  handleSessionError,
-  handleSessionIdle,
-  handleSessionStatus,
-  handleMessagePartUpdated,
-  handleMessagePartDelta,
-  handleMessageUpdated,
-  handleToolExecute,
-  handleToolResult,
-  handleTuiToast,
-} from "./event-handlers"
+import { eventHandlers } from "./event-handlers"
 
 export async function processEvents(
   ctx: RunContext,
@@ -38,15 +28,9 @@ export async function processEvents(
       // Update last event timestamp for watchdog detection
       state.lastEventTimestamp = Date.now()
 
-      handleSessionError(ctx, payload, state)
-      handleSessionIdle(ctx, payload, state)
-      handleSessionStatus(ctx, payload, state)
-      handleMessagePartUpdated(ctx, payload, state)
-      handleMessagePartDelta(ctx, payload, state)
-      handleMessageUpdated(ctx, payload, state)
-      handleToolExecute(ctx, payload, state)
-      handleToolResult(ctx, payload, state)
-      handleTuiToast(ctx, payload, state)
+      for (const handler of eventHandlers) {
+        handler(ctx, payload, state)
+      }
     } catch (err) {
       console.error(pc.red(`[event error] ${err}`))
     }


### PR DESCRIPTION
## Summary
Splits the CLI run event-handler facade into a typed handler-group surface while preserving the existing `./event-handlers` exports. `processEvents` now iterates the grouped facade instead of maintaining its own import list.

## Changes
- Add characterization coverage for the `event-handlers` facade exports and routed event behavior.
- Add typed session/message/tool/toast handler groups.
- Route `processEvents` through the grouped handler facade without changing handler order.

## Testing
- `bun test src/cli/run/event-handlers.test.ts`
- `bun test src/cli/run/event-handlers.test.ts src/cli/run/event-session-handlers.test.ts src/cli/run/event-message-handlers.test.ts src/cli/run/event-tool-handlers.test.ts src/cli/run/event-toast-handlers.test.ts src/cli/run/events.test.ts src/cli/run/message-part-delta.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test src/cli/run/*.test.ts`

## Notes
Open PR/title search did not find an obvious overlapping `cli-run event-handlers` facade split PR. Nearby open PRs mentioning cli-run or event handlers appear unrelated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the CLI run event-handler facade into typed handler groups and updated `processEvents` to iterate the grouped facade. Existing `./event-handlers` exports and handler order are preserved.

- **Refactors**
  - Added `EventHandler` and group exports: `sessionEventHandlers`, `messageEventHandlers`, `toolEventHandlers`, `toastEventHandlers`, and `eventHandlers`.
  - `processEvents` now loops over `eventHandlers` instead of calling each handler directly.
  - Kept all `./event-handlers` re-exports unchanged.
  - Added tests to pin the facade exports and verify routed event behavior.

<sup>Written for commit 47f04971a56f3b7828989e22d4aac843592bcbe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

