### PR TITLE
refactor(shared): split dynamic truncator facade

### DIFF
--- a/src/shared/dynamic-truncate.ts
+++ b/src/shared/dynamic-truncate.ts
@@ -1,0 +1,47 @@
+import type { PluginInput } from "@opencode-ai/plugin";
+import type { ContextLimitModelCacheState } from "./context-limit-resolver"
+import { getContextWindowUsage } from "./context-window-usage"
+import type {
+	TruncationOptions,
+	TruncationResult,
+} from "./dynamic-truncator-types"
+import { truncateToTokenLimit } from "./token-limit-truncator"
+
+const DEFAULT_TARGET_MAX_TOKENS = 50_000;
+
+export async function dynamicTruncate(
+	ctx: PluginInput,
+	sessionID: string,
+	output: string,
+	options: TruncationOptions = {},
+	modelCacheState?: ContextLimitModelCacheState,
+): Promise<TruncationResult> {
+	if (typeof output !== 'string') {
+		return { result: String(output ?? ''), truncated: false };
+	}
+
+	const {
+		targetMaxTokens = DEFAULT_TARGET_MAX_TOKENS,
+		preserveHeaderLines = 3,
+	} = options;
+
+	const usage = await getContextWindowUsage(ctx, sessionID, modelCacheState);
+
+	if (!usage) {
+		return truncateToTokenLimit(output, targetMaxTokens, preserveHeaderLines);
+	}
+
+	const maxOutputTokens = Math.min(
+		usage.remainingTokens * 0.5,
+		targetMaxTokens,
+	);
+
+	if (maxOutputTokens <= 0) {
+		return {
+			result: "[Output suppressed - context window exhausted]",
+			truncated: true,
+		};
+	}
+
+	return truncateToTokenLimit(output, maxOutputTokens, preserveHeaderLines);
+}

--- a/src/shared/dynamic-truncator-factory.ts
+++ b/src/shared/dynamic-truncator-factory.ts
@@ -1,0 +1,28 @@
+import type { PluginInput } from "@opencode-ai/plugin";
+import type { ContextLimitModelCacheState } from "./context-limit-resolver"
+import { getContextWindowUsage } from "./context-window-usage"
+import { dynamicTruncate } from "./dynamic-truncate"
+import type { TruncationOptions } from "./dynamic-truncator-types"
+import { truncateToTokenLimit } from "./token-limit-truncator"
+
+export function createDynamicTruncator(
+	ctx: PluginInput,
+	modelCacheState?: ContextLimitModelCacheState,
+) {
+	return {
+		truncate: (
+			sessionID: string,
+			output: string,
+			options?: TruncationOptions,
+		) => dynamicTruncate(ctx, sessionID, output, options, modelCacheState),
+
+		getUsage: (sessionID: string) =>
+			getContextWindowUsage(ctx, sessionID, modelCacheState),
+
+		truncateSync: (
+			output: string,
+			maxTokens: number,
+			preserveHeaderLines?: number,
+		) => truncateToTokenLimit(output, maxTokens, preserveHeaderLines),
+	};
+}

--- a/src/shared/dynamic-truncator-thresholds.test.ts
+++ b/src/shared/dynamic-truncator-thresholds.test.ts
@@ -1,0 +1,152 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+
+import {
+  createDynamicTruncator,
+  dynamicTruncate,
+} from "./dynamic-truncator"
+
+function createContextUsageMockContext(inputTokens: number) {
+  return {
+    client: {
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                providerID: "anthropic",
+                modelID: "claude-sonnet-4-5",
+                tokens: {
+                  input: inputTokens,
+                  output: 0,
+                  reasoning: 0,
+                  cache: { read: 0, write: 0 },
+                },
+              },
+            },
+          ],
+        }),
+      },
+    },
+  }
+}
+
+function createDynamicThresholdOutput(): string {
+  return [
+    "header",
+    "content one ".repeat(7),
+    "content two ".repeat(7),
+    "content three ".repeat(7),
+    "content four ".repeat(7),
+    "content five ".repeat(7),
+    "content six ".repeat(7),
+  ].join("\n")
+}
+
+describe("dynamicTruncate threshold behavior", () => {
+  it("#then limits output to half of the remaining context window when that is below the target", async () => {
+    // given
+    const ctx = createContextUsageMockContext(199800)
+
+    // when
+    const result = await dynamicTruncate(
+      ctx as never,
+      "ses_half_remaining_threshold",
+      createDynamicThresholdOutput(),
+      { targetMaxTokens: 1000, preserveHeaderLines: 1 },
+      { anthropicContext1MEnabled: false },
+    )
+
+    // then
+    expect(result).toEqual({
+      result: [
+        "header",
+        "content one ".repeat(7),
+        "content two ".repeat(7),
+        "",
+        "[4 more lines truncated due to context window limit]",
+      ].join("\n"),
+      truncated: true,
+      removedCount: 4,
+    })
+  })
+
+  it("#then caps output at the requested target when half of the remaining context is larger", async () => {
+    // given
+    const ctx = createContextUsageMockContext(198000)
+
+    // when
+    const result = await dynamicTruncate(
+      ctx as never,
+      "ses_target_threshold",
+      createDynamicThresholdOutput(),
+      { targetMaxTokens: 80, preserveHeaderLines: 1 },
+      { anthropicContext1MEnabled: false },
+    )
+
+    // then
+    expect(result).toEqual({
+      result: [
+        "header",
+        "content one ".repeat(7),
+        "",
+        "[5 more lines truncated due to context window limit]",
+      ].join("\n"),
+      truncated: true,
+      removedCount: 5,
+    })
+  })
+
+  it("#then leaves output unchanged when it is below the dynamic token budget", async () => {
+    // given
+    const ctx = createContextUsageMockContext(100000)
+    const output = "short output"
+
+    // when
+    const result = await dynamicTruncate(
+      ctx as never,
+      "ses_under_dynamic_budget",
+      output,
+      { targetMaxTokens: 100, preserveHeaderLines: 1 },
+      { anthropicContext1MEnabled: false },
+    )
+
+    // then
+    expect(result).toEqual({
+      result: output,
+      truncated: false,
+    })
+  })
+})
+
+describe("createDynamicTruncator threshold behavior", () => {
+  it("#then routes truncate through the dynamic context-aware threshold", async () => {
+    // given
+    const ctx = createContextUsageMockContext(199800)
+    const truncator = createDynamicTruncator(ctx as never, {
+      anthropicContext1MEnabled: false,
+    })
+
+    // when
+    const result = await truncator.truncate(
+      "ses_facade_truncate",
+      createDynamicThresholdOutput(),
+      { targetMaxTokens: 1000, preserveHeaderLines: 1 },
+    )
+
+    // then
+    expect(result).toEqual({
+      result: [
+        "header",
+        "content one ".repeat(7),
+        "content two ".repeat(7),
+        "",
+        "[4 more lines truncated due to context window limit]",
+      ].join("\n"),
+      truncated: true,
+      removedCount: 4,
+    })
+  })
+})

--- a/src/shared/dynamic-truncator.ts
+++ b/src/shared/dynamic-truncator.ts
@@ -1,18 +1,10 @@
-import type { PluginInput } from "@opencode-ai/plugin";
-import type { ContextLimitModelCacheState } from "./context-limit-resolver"
 import {
 	getContextWindowUsage,
 	invalidateContextWindowUsageCache,
 	_setContextWindowUsageFetchTimeoutMsForTesting,
 	DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS,
 } from "./context-window-usage"
-import type {
-	TruncationOptions,
-	TruncationResult,
-} from "./dynamic-truncator-types"
 import { truncateToTokenLimit } from "./token-limit-truncator"
-
-const DEFAULT_TARGET_MAX_TOKENS = 50_000;
 
 export {
 	DEFAULT_CONTEXT_WINDOW_USAGE_FETCH_TIMEOUT_MS,
@@ -20,65 +12,7 @@ export {
 	invalidateContextWindowUsageCache,
 	_setContextWindowUsageFetchTimeoutMsForTesting,
 }
+export { dynamicTruncate } from "./dynamic-truncate"
+export { createDynamicTruncator } from "./dynamic-truncator-factory"
 export { truncateToTokenLimit }
-export type { TruncationOptions, TruncationResult }
-
-export async function dynamicTruncate(
-	ctx: PluginInput,
-	sessionID: string,
-	output: string,
-	options: TruncationOptions = {},
-	modelCacheState?: ContextLimitModelCacheState,
-): Promise<TruncationResult> {
-	if (typeof output !== 'string') {
-		return { result: String(output ?? ''), truncated: false };
-	}
-
-	const {
-		targetMaxTokens = DEFAULT_TARGET_MAX_TOKENS,
-		preserveHeaderLines = 3,
-	} = options;
-
-	const usage = await getContextWindowUsage(ctx, sessionID, modelCacheState);
-
-	if (!usage) {
-		// Fallback: apply conservative truncation when context usage unavailable
-		return truncateToTokenLimit(output, targetMaxTokens, preserveHeaderLines);
-	}
-
-	const maxOutputTokens = Math.min(
-		usage.remainingTokens * 0.5,
-		targetMaxTokens,
-	);
-
-	if (maxOutputTokens <= 0) {
-		return {
-			result: "[Output suppressed - context window exhausted]",
-			truncated: true,
-		};
-	}
-
-	return truncateToTokenLimit(output, maxOutputTokens, preserveHeaderLines);
-}
-
-export function createDynamicTruncator(
-	ctx: PluginInput,
-	modelCacheState?: ContextLimitModelCacheState,
-) {
-	return {
-		truncate: (
-			sessionID: string,
-			output: string,
-			options?: TruncationOptions,
-		) => dynamicTruncate(ctx, sessionID, output, options, modelCacheState),
-
-		getUsage: (sessionID: string) =>
-			getContextWindowUsage(ctx, sessionID, modelCacheState),
-
-		truncateSync: (
-			output: string,
-			maxTokens: number,
-			preserveHeaderLines?: number,
-		) => truncateToTokenLimit(output, maxTokens, preserveHeaderLines),
-	};
-}
+export type { TruncationOptions, TruncationResult } from "./dynamic-truncator-types"


### PR DESCRIPTION
## Summary
Split `src/shared/dynamic-truncator.ts` into a behavior-preserving facade over focused implementation modules. Added characterization coverage for the dynamic threshold math before extraction.

## Changes
- Add threshold characterization tests for half-remaining context, target cap, no-op under budget, and factory delegation.
- Move `dynamicTruncate` into `dynamic-truncate.ts`.
- Move `createDynamicTruncator` into `dynamic-truncator-factory.ts`.
- Keep `dynamic-truncator.ts` public exports intact as the facade.

## Testing
- `bun test src/shared/dynamic-truncator-behavior.test.ts src/shared/dynamic-truncator-thresholds.test.ts src/shared/dynamic-truncator.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check HEAD~2..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the dynamic truncator into focused modules behind a stable facade and added tests to lock in the threshold math. Public API is unchanged and behavior is preserved.

- **Refactors**
  - Moved `dynamicTruncate` to `src/shared/dynamic-truncate.ts`.
  - Moved `createDynamicTruncator` to `src/shared/dynamic-truncator-factory.ts`.
  - Kept `src/shared/dynamic-truncator.ts` as the public facade re-exporting all APIs.
  - Added characterization tests for threshold behavior (half-remaining, target cap, under-budget, and factory delegation).

<sup>Written for commit 724ecb7f56e7ee5c62229f77e6137ad8b5e4c3f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

