### PR TITLE
refactor(team-mode): split live delivery facade

### DIFF
--- a/src/features/team-mode/tools/messaging-live-delivery-client.ts
+++ b/src/features/team-mode/tools/messaging-live-delivery-client.ts
@@ -1,0 +1,15 @@
+export type LiveDeliveryClient = {
+  session: {
+    promptAsync(input: {
+      path: { id: string }
+      body: {
+        parts: Array<{ type: "text"; text: string }>
+        agent?: string
+        model?: { providerID: string; modelID: string }
+        variant?: string
+      }
+      query?: { directory: string }
+    }): Promise<unknown>
+    status?: () => Promise<unknown>
+  }
+}

--- a/src/features/team-mode/tools/messaging-live-delivery-recipient.ts
+++ b/src/features/team-mode/tools/messaging-live-delivery-recipient.ts
@@ -1,0 +1,168 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../../hooks/shared/prompt-async-gate"
+import { log } from "../../../shared/logger"
+import { isAmbiguousPostDispatchPromptFailure } from "../../../shared/prompt-failure-classifier"
+import { applyMemberSessionRouting, buildMemberPromptBody } from "../member-session-routing"
+import { buildEnvelope } from "../team-mailbox/poll"
+import { commitDeliveryReservation } from "../team-mailbox/reservation"
+import type { Message, RuntimeState } from "../types"
+import type { LiveDeliveryClient } from "./messaging-live-delivery-client"
+import type { DeliveryReservation } from "./messaging-live-delivery-reservation"
+import { releaseReservationSafely } from "./messaging-live-delivery-reservation"
+import { markLiveDeliveryPending } from "./messaging-live-delivery-state"
+
+type RuntimeMember = RuntimeState["members"][number]
+type LiveDeliveryEnvelope = ReturnType<typeof buildEnvelope>
+
+export async function deliverLiveToRecipient(input: {
+  client: LiveDeliveryClient
+  message: Message
+  envelope: LiveDeliveryEnvelope
+  teamRunId: string
+  recipientName: string
+  recipientMember: RuntimeMember
+  reservation: DeliveryReservation
+  config: TeamModeConfig
+  directory: string
+}): Promise<void> {
+  const {
+    client,
+    message,
+    envelope,
+    teamRunId,
+    recipientName,
+    recipientMember,
+    reservation,
+    config,
+    directory,
+  } = input
+
+  if (recipientMember.pendingInjectedMessageIds.length > 0) {
+    await releaseReservationSafely(reservation, {
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+    return
+  }
+
+  if (recipientMember.status !== "idle") {
+    log("[team-mailbox] live delivery unavailable, recipient is not idle", {
+      reason: "recipient-not-idle",
+      teamRunId,
+      recipient: recipientName,
+      status: recipientMember.status,
+      messageId: message.messageId,
+    })
+    await releaseReservationSafely(reservation, {
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+    return
+  }
+
+  const recipientSessionId = recipientMember.sessionId
+  if (!recipientSessionId) {
+    log("[team-mailbox] live delivery unavailable, falling back to inbox injection", {
+      reason: "missing-session-id",
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+    await releaseReservationSafely(reservation, {
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+    return
+  }
+
+  applyMemberSessionRouting(recipientSessionId, recipientMember)
+
+  try {
+    const promptResult = await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: recipientSessionId,
+      source: "team-live-delivery",
+      queueBehavior: "defer",
+      input: {
+        path: { id: recipientSessionId },
+        body: buildMemberPromptBody(recipientMember, envelope),
+        query: { directory: recipientMember.worktreePath ?? directory },
+      },
+    })
+    if (promptResult.status === "failed" && isAmbiguousPostDispatchPromptFailure(promptResult)) {
+      await releaseReservationSafely(reservation, {
+        teamRunId,
+        recipient: recipientName,
+        messageId: message.messageId,
+      })
+      log("[team-mailbox] live delivery prompt failed ambiguously, released reservation to inbox", {
+        teamRunId,
+        recipient: recipientName,
+        recipientSessionId,
+        messageId: message.messageId,
+        error: promptResult.error instanceof Error ? promptResult.error.message : String(promptResult.error),
+      })
+      return
+    }
+    if (!isInternalPromptDispatchAccepted(promptResult)) {
+      log("[team-mailbox] live delivery skipped by promptAsync gate, falling back to inbox injection", {
+        status: promptResult.status,
+        teamRunId,
+        recipient: recipientName,
+        recipientSessionId,
+        messageId: message.messageId,
+      })
+      await releaseReservationSafely(reservation, {
+        teamRunId,
+        recipient: recipientName,
+        messageId: message.messageId,
+      })
+      return
+    }
+    try {
+      await markLiveDeliveryPending(teamRunId, recipientName, message.messageId, config)
+    } catch (markError) {
+      try {
+        await commitDeliveryReservation(reservation)
+      } catch (commitError) {
+        log("[team-mailbox] live delivery prompt dispatched but pending mark and reservation commit failed", {
+          teamRunId,
+          recipient: recipientName,
+          recipientSessionId,
+          messageId: message.messageId,
+          error: commitError instanceof Error ? commitError.message : String(commitError),
+        })
+      }
+      log("[team-mailbox] live delivery prompt dispatched but pending mark failed, committed reservation directly", {
+        teamRunId,
+        recipient: recipientName,
+        recipientSessionId,
+        messageId: message.messageId,
+        error: markError instanceof Error ? markError.message : String(markError),
+      })
+      return
+    }
+    log("[team-mailbox] live delivery reserved until recipient idle", {
+      teamRunId,
+      recipient: recipientName,
+      recipientSessionId,
+      messageId: message.messageId,
+    })
+  } catch (error) {
+    log("[team-mailbox] live delivery failed, falling back to inbox injection", {
+      error: error instanceof Error ? error.message : String(error),
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+    await releaseReservationSafely(reservation, {
+      teamRunId,
+      recipient: recipientName,
+      messageId: message.messageId,
+    })
+  }
+}

--- a/src/features/team-mode/tools/messaging-live-delivery-reservation.ts
+++ b/src/features/team-mode/tools/messaging-live-delivery-reservation.ts
@@ -1,0 +1,44 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { log } from "../../../shared/logger"
+import {
+  type DeliveryReservation as TeamMailboxDeliveryReservation,
+  releaseDeliveryReservation,
+  reserveMessageForDelivery,
+} from "../team-mailbox/reservation"
+
+export type DeliveryReservation = TeamMailboxDeliveryReservation
+export type NullableDeliveryReservation = DeliveryReservation | null
+
+export async function releaseReservationSafely(
+  reservation: NullableDeliveryReservation,
+  input: { teamRunId: string; recipient: string; messageId: string },
+): Promise<void> {
+  if (reservation === null) return
+
+  try {
+    await releaseDeliveryReservation(reservation)
+  } catch (releaseError) {
+    log("[team-mailbox] failed to release delivery reservation", {
+      error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+      teamRunId: input.teamRunId,
+      recipient: input.recipient,
+      messageId: input.messageId,
+    })
+  }
+}
+
+export async function releaseReservationsForRecipients(
+  teamRunId: string,
+  recipientNames: readonly string[],
+  messageId: string,
+  config: TeamModeConfig,
+): Promise<void> {
+  for (const recipientName of recipientNames) {
+    const reservation = await reserveMessageForDelivery(teamRunId, recipientName, messageId, config)
+    await releaseReservationSafely(reservation, {
+      teamRunId,
+      recipient: recipientName,
+      messageId,
+    })
+  }
+}

--- a/src/features/team-mode/tools/messaging-live-delivery-state.ts
+++ b/src/features/team-mode/tools/messaging-live-delivery-state.ts
@@ -1,0 +1,46 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { log } from "../../../shared/logger"
+import { transitionRuntimeState } from "../team-state-store/store"
+import type { RuntimeState } from "../types"
+import { releaseReservationsForRecipients } from "./messaging-live-delivery-reservation"
+import type { TeamSendMessageToolDeps } from "./messaging-runtime"
+
+export async function markLiveDeliveryPending(
+  teamRunId: string,
+  recipientName: string,
+  messageId: string,
+  config: TeamModeConfig,
+): Promise<void> {
+  await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
+    ...currentRuntimeState,
+    members: currentRuntimeState.members.map((member) => (
+      member.name === recipientName
+        ? {
+          ...member,
+          pendingInjectedMessageIds: Array.from(new Set([...member.pendingInjectedMessageIds, messageId])),
+        }
+        : member
+    )),
+  }), config)
+}
+
+export async function loadRuntimeStateForLiveDelivery(
+  teamRunId: string,
+  deliveredTo: readonly string[],
+  messageId: string,
+  config: TeamModeConfig,
+  deps: TeamSendMessageToolDeps,
+): Promise<RuntimeState | undefined> {
+  try {
+    return await deps.loadRuntimeState(teamRunId, config)
+  } catch (error) {
+    await releaseReservationsForRecipients(teamRunId, deliveredTo, messageId, config)
+    log("[team-mailbox] live delivery unavailable after pre-reserve, released recipients to inbox", {
+      teamRunId,
+      messageId,
+      deliveredTo,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}

--- a/src/features/team-mode/tools/messaging-live-delivery.ts
+++ b/src/features/team-mode/tools/messaging-live-delivery.ts
@@ -1,109 +1,14 @@
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
-import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../../hooks/shared/prompt-async-gate"
-import { log } from "../../../shared/logger"
-import { isAmbiguousPostDispatchPromptFailure } from "../../../shared/prompt-failure-classifier"
-import { applyMemberSessionRouting, buildMemberPromptBody } from "../member-session-routing"
 import { buildEnvelope } from "../team-mailbox/poll"
-import {
-  commitDeliveryReservation,
-  releaseDeliveryReservation,
-  reserveMessageForDelivery,
-} from "../team-mailbox/reservation"
-import { transitionRuntimeState } from "../team-state-store/store"
-import type { Message, RuntimeState } from "../types"
+import { reserveMessageForDelivery } from "../team-mailbox/reservation"
+import type { Message } from "../types"
+import type { LiveDeliveryClient } from "./messaging-live-delivery-client"
+import { releaseReservationSafely } from "./messaging-live-delivery-reservation"
+import { deliverLiveToRecipient } from "./messaging-live-delivery-recipient"
+import { loadRuntimeStateForLiveDelivery } from "./messaging-live-delivery-state"
 import type { TeamSendMessageToolDeps } from "./messaging-runtime"
 
-export type LiveDeliveryClient = {
-  session: {
-    promptAsync(input: {
-      path: { id: string }
-      body: {
-        parts: Array<{ type: "text"; text: string }>
-        agent?: string
-        model?: { providerID: string; modelID: string }
-        variant?: string
-      }
-      query?: { directory: string }
-    }): Promise<unknown>
-    status?: () => Promise<unknown>
-  }
-}
-
-type DeliveryReservation = Awaited<ReturnType<typeof reserveMessageForDelivery>>
-
-async function releaseReservationSafely(
-  reservation: DeliveryReservation,
-  input: { teamRunId: string; recipient: string; messageId: string },
-): Promise<void> {
-  if (reservation === null) return
-
-  try {
-    await releaseDeliveryReservation(reservation)
-  } catch (releaseError) {
-    log("[team-mailbox] failed to release delivery reservation", {
-      error: releaseError instanceof Error ? releaseError.message : String(releaseError),
-      teamRunId: input.teamRunId,
-      recipient: input.recipient,
-      messageId: input.messageId,
-    })
-  }
-}
-
-async function markLiveDeliveryPending(
-  teamRunId: string,
-  recipientName: string,
-  messageId: string,
-  config: TeamModeConfig,
-): Promise<void> {
-  await transitionRuntimeState(teamRunId, (currentRuntimeState) => ({
-    ...currentRuntimeState,
-    members: currentRuntimeState.members.map((member) => (
-      member.name === recipientName
-        ? {
-          ...member,
-          pendingInjectedMessageIds: Array.from(new Set([...member.pendingInjectedMessageIds, messageId])),
-        }
-        : member
-    )),
-  }), config)
-}
-
-async function releaseReservationsForRecipients(
-  teamRunId: string,
-  recipientNames: readonly string[],
-  messageId: string,
-  config: TeamModeConfig,
-): Promise<void> {
-  for (const recipientName of recipientNames) {
-    const reservation = await reserveMessageForDelivery(teamRunId, recipientName, messageId, config)
-    await releaseReservationSafely(reservation, {
-      teamRunId,
-      recipient: recipientName,
-      messageId,
-    })
-  }
-}
-
-async function loadRuntimeStateForLiveDelivery(
-  teamRunId: string,
-  deliveredTo: readonly string[],
-  messageId: string,
-  config: TeamModeConfig,
-  deps: TeamSendMessageToolDeps,
-): Promise<RuntimeState | undefined> {
-  try {
-    return await deps.loadRuntimeState(teamRunId, config)
-  } catch (error) {
-    await releaseReservationsForRecipients(teamRunId, deliveredTo, messageId, config)
-    log("[team-mailbox] live delivery unavailable after pre-reserve, released recipients to inbox", {
-      teamRunId,
-      messageId,
-      deliveredTo,
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return undefined
-  }
-}
+export type { LiveDeliveryClient } from "./messaging-live-delivery-client"
 
 export async function deliverLive(
   client: LiveDeliveryClient,
@@ -133,133 +38,16 @@ export async function deliverLive(
       continue
     }
 
-    if (recipientMember.pendingInjectedMessageIds.length > 0) {
-      await releaseReservationSafely(reservation, {
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-      continue
-    }
-
-    if (recipientMember.status !== "idle") {
-      log("[team-mailbox] live delivery unavailable, recipient is not idle", {
-        reason: "recipient-not-idle",
-        teamRunId,
-        recipient: recipientName,
-        status: recipientMember.status,
-        messageId: message.messageId,
-      })
-      await releaseReservationSafely(reservation, {
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-      continue
-    }
-
-    const recipientSessionId = recipientMember.sessionId
-    if (!recipientSessionId) {
-      log("[team-mailbox] live delivery unavailable, falling back to inbox injection", {
-        reason: "missing-session-id",
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-      await releaseReservationSafely(reservation, {
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-      continue
-    }
-
-    applyMemberSessionRouting(recipientSessionId, recipientMember)
-
-    try {
-      const promptResult = await dispatchInternalPrompt({
-        mode: "async",
-        client,
-        sessionID: recipientSessionId,
-        source: "team-live-delivery",
-        queueBehavior: "defer",
-        input: {
-          path: { id: recipientSessionId },
-          body: buildMemberPromptBody(recipientMember, envelope),
-          query: { directory: recipientMember.worktreePath ?? directory },
-        },
-      })
-      if (promptResult.status === "failed" && isAmbiguousPostDispatchPromptFailure(promptResult)) {
-        await releaseReservationSafely(reservation, {
-          teamRunId,
-          recipient: recipientName,
-          messageId: message.messageId,
-        })
-        log("[team-mailbox] live delivery prompt failed ambiguously, released reservation to inbox", {
-          teamRunId,
-          recipient: recipientName,
-          recipientSessionId,
-          messageId: message.messageId,
-          error: promptResult.error instanceof Error ? promptResult.error.message : String(promptResult.error),
-        })
-        continue
-      }
-      if (!isInternalPromptDispatchAccepted(promptResult)) {
-        log("[team-mailbox] live delivery skipped by promptAsync gate, falling back to inbox injection", {
-          status: promptResult.status,
-          teamRunId,
-          recipient: recipientName,
-          recipientSessionId,
-          messageId: message.messageId,
-        })
-        await releaseReservationSafely(reservation, {
-          teamRunId,
-          recipient: recipientName,
-          messageId: message.messageId,
-        })
-        continue
-      }
-      try {
-        await markLiveDeliveryPending(teamRunId, recipientName, message.messageId, config)
-      } catch (markError) {
-        try {
-          await commitDeliveryReservation(reservation)
-        } catch (commitError) {
-          log("[team-mailbox] live delivery prompt dispatched but pending mark and reservation commit failed", {
-            teamRunId,
-            recipient: recipientName,
-            recipientSessionId,
-            messageId: message.messageId,
-            error: commitError instanceof Error ? commitError.message : String(commitError),
-          })
-        }
-        log("[team-mailbox] live delivery prompt dispatched but pending mark failed, committed reservation directly", {
-          teamRunId,
-          recipient: recipientName,
-          recipientSessionId,
-          messageId: message.messageId,
-          error: markError instanceof Error ? markError.message : String(markError),
-        })
-        continue
-      }
-      log("[team-mailbox] live delivery reserved until recipient idle", {
-        teamRunId,
-        recipient: recipientName,
-        recipientSessionId,
-        messageId: message.messageId,
-      })
-    } catch (error) {
-      log("[team-mailbox] live delivery failed, falling back to inbox injection", {
-        error: error instanceof Error ? error.message : String(error),
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-      await releaseReservationSafely(reservation, {
-        teamRunId,
-        recipient: recipientName,
-        messageId: message.messageId,
-      })
-    }
+    await deliverLiveToRecipient({
+      client,
+      message,
+      envelope,
+      teamRunId,
+      recipientName,
+      recipientMember,
+      reservation,
+      config,
+      directory,
+    })
   }
 }


### PR DESCRIPTION
## Summary
Refactors team-mode live delivery into focused modules while preserving the existing prompt gate and mailbox reservation behavior.

## Changes
- Keeps `deliverLive` as a small facade over runtime load, envelope creation, and recipient iteration.
- Extracts live-delivery client typing, reservation release helpers, runtime pending-state handling, and per-recipient prompt dispatch handling.
- Leaves `team_send_message` behavior and prompt dispatch routed through `dispatchInternalPrompt` with `queueBehavior: "defer"`.

## Testing
- `bun test src/features/team-mode/tools/messaging.test.ts src/features/team-mode/tools/messaging-missing-session.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- `rg -n "dispatchInternalPrompt|\\.prompt(?:Async)?\\(" src/features/team-mode/tools/messaging-live-delivery*.ts src/features/team-mode/tools/messaging*.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split team-mode live delivery into small modules while preserving prompt gate, mailbox reservation, and defer-queue behavior. This simplifies `deliverLive` without changing runtime behavior.

- **Refactors**
  - Made `deliverLive` a thin facade for envelope build, runtime load, and per-recipient iteration.
  - Moved per-recipient delivery to `messaging-live-delivery-recipient` (session routing, `dispatchInternalPrompt` with `queueBehavior: "defer"`, fallbacks).
  - Added reservation helpers in `messaging-live-delivery-reservation` (safe release and batch release).
  - Added state helpers in `messaging-live-delivery-state` (mark pending; load runtime with pre-reserve cleanup on failure).
  - Defined `LiveDeliveryClient` in `messaging-live-delivery-client`.
  - Kept `team_send_message` and prompt gate behavior unchanged.

<sup>Written for commit 5aeb642008702005317a0d8eca6f24f3c97c348e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

