### PR TITLE
refactor(codex): split config TOML facade

### DIFF
--- a/src/cli/install-codex/codex-config-agents.ts
+++ b/src/cli/install-codex/codex-config-agents.ts
@@ -1,0 +1,38 @@
+import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
+import { parseAgentHeaderName, splitTomlSections } from "./codex-config-toml-sections"
+import type { CodexAgentConfig } from "./types"
+
+const MANAGED_CODEX_AGENT_NAMES = [
+  "codex-ultrawork-reviewer",
+  "explorer",
+  "librarian",
+  "metis",
+  "momus",
+  "plan",
+] as const
+
+export function removeStaleManagedAgentBlocks(config: string, keepAgentNames: Set<string>): string {
+  const managedAgentNames = new Set<string>(MANAGED_CODEX_AGENT_NAMES)
+  return splitTomlSections(config)
+    .filter((section) => {
+      if (section.header === null) return true
+      const agentName = parseAgentHeaderName(section.header)
+      if (agentName === null || !managedAgentNames.has(agentName) || keepAgentNames.has(agentName)) return true
+      return !section.text.includes(`config_file = ${JSON.stringify(`./agents/${agentName}.toml`)}`)
+    })
+    .map((section) => section.text)
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+}
+
+export function ensureAgentConfig(config: string, agentConfig: CodexAgentConfig): string {
+  const header = `agents.${tomlKeySegment(agentConfig.name)}`
+  const section = findTomlSection(config, header)
+  const configFile = JSON.stringify(agentConfig.configFile)
+  if (!section) return appendBlock(config, `[${header}]\nconfig_file = ${configFile}\n`)
+  return replaceOrInsertSetting(config, section, "config_file", configFile)
+}
+
+function tomlKeySegment(value: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(value) ? value : JSON.stringify(value)
+}

--- a/src/cli/install-codex/codex-config-features.ts
+++ b/src/cli/install-codex/codex-config-features.ts
@@ -1,0 +1,7 @@
+import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
+
+export function ensureFeatureEnabled(config: string, featureName: string): string {
+  const section = findTomlSection(config, "features")
+  if (!section) return appendBlock(config, `[features]\n${featureName} = true\n`)
+  return replaceOrInsertSetting(config, section, featureName, "true")
+}

--- a/src/cli/install-codex/codex-config-marketplaces.ts
+++ b/src/cli/install-codex/codex-config-marketplaces.ts
@@ -1,0 +1,64 @@
+import { appendBlock, findTomlSection } from "./toml-section-editor"
+import { parseJsonString, parsePluginHeaderKey, removeTomlSections } from "./codex-config-toml-sections"
+import type { CodexMarketplaceSource } from "./types"
+
+const SISYPHUS_LEGACY_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
+
+export function legacyMarketplaceNames(marketplaceName: string): readonly string[] {
+  return marketplaceName === "sisyphuslabs" ? SISYPHUS_LEGACY_MARKETPLACES : []
+}
+
+export function removeMarketplaceBlock(config: string, marketplaceName: string): string {
+  return removeTomlSections(config, (header) => header === `marketplaces.${marketplaceName}`)
+}
+
+export function removeStaleMarketplacePluginBlocks(
+  config: string,
+  marketplaceName: string,
+  keepPluginNames: Set<string>,
+): string {
+  return removeTomlSections(config, (header) => {
+    const pluginKey = parsePluginHeaderKey(header)
+    if (pluginKey === null) return false
+    const suffix = `@${marketplaceName}`
+    if (!pluginKey.endsWith(suffix)) return false
+    return !keepPluginNames.has(pluginKey.slice(0, -suffix.length))
+  })
+}
+
+export function removeStaleMarketplaceHookStateBlocks(
+  config: string,
+  marketplaceName: string,
+  keepPluginNames: Set<string>,
+): string {
+  return removeTomlSections(config, (header) => {
+    const prefix = "hooks.state."
+    if (!header.startsWith(prefix)) return false
+    const hookKey = parseJsonString(header.slice(prefix.length))
+    if (hookKey === null) return false
+    const separator = hookKey.indexOf(":")
+    if (separator === -1) return false
+    const pluginKey = hookKey.slice(0, separator)
+    const suffix = `@${marketplaceName}`
+    if (!pluginKey.endsWith(suffix)) return false
+    return !keepPluginNames.has(pluginKey.slice(0, -suffix.length))
+  })
+}
+
+export function ensureMarketplaceBlock(config: string, marketplaceName: string, source: CodexMarketplaceSource): string {
+  const header = `marketplaces.${marketplaceName}`
+  const lines = [
+    `[${header}]`,
+    `last_updated = "${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}"`,
+    `source_type = ${JSON.stringify(source.sourceType)}`,
+    `source = ${JSON.stringify(source.source)}`,
+  ]
+  if (source.sourceType === "git") {
+    lines.push(`ref = ${JSON.stringify(source.ref)}`)
+  }
+  lines.push("")
+  const block = lines.join("\n")
+  const section = findTomlSection(config, header)
+  if (section) return config.slice(0, section.start) + block + config.slice(section.end)
+  return appendBlock(config, block)
+}

--- a/src/cli/install-codex/codex-config-plugins.ts
+++ b/src/cli/install-codex/codex-config-plugins.ts
@@ -1,0 +1,36 @@
+import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
+import type { CodexInstallPlatform, TrustedHookState } from "./types"
+
+export function ensurePluginEnabled(config: string, pluginKey: string): string {
+  const header = `plugins.${JSON.stringify(pluginKey)}`
+  const section = findTomlSection(config, header)
+  if (!section) return appendBlock(config, `[${header}]\nenabled = true\n`)
+  return replaceOrInsertSetting(config, section, "enabled", "true")
+}
+
+export function ensureOmoBuiltinMcpPolicies(config: string, input: {
+  readonly marketplaceName: string
+  readonly pluginNames: readonly string[]
+  readonly platform?: CodexInstallPlatform
+}): string {
+  if (input.marketplaceName !== "sisyphuslabs" || !input.pluginNames.includes("omo")) return config
+  const gitBashEnabled = (input.platform ?? process.platform) === "win32"
+  let nextConfig = ensurePluginMcpEnabled(config, "omo@sisyphuslabs", "context7", true)
+  nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "git_bash", gitBashEnabled)
+  return nextConfig
+}
+
+export function ensureHookTrusted(config: string, state: TrustedHookState): string {
+  const header = `hooks.state.${JSON.stringify(state.key)}`
+  const section = findTomlSection(config, header)
+  if (!section) return appendBlock(config, `[${header}]\ntrusted_hash = ${JSON.stringify(state.trustedHash)}\n`)
+  return replaceOrInsertSetting(config, section, "trusted_hash", JSON.stringify(state.trustedHash))
+}
+
+function ensurePluginMcpEnabled(config: string, pluginKey: string, serverName: string, enabled: boolean): string {
+  const header = `plugins.${JSON.stringify(pluginKey)}.mcp_servers.${serverName}`
+  const section = findTomlSection(config, header)
+  const enabledValue = enabled ? "true" : "false"
+  if (!section) return appendBlock(config, `[${header}]\nenabled = ${enabledValue}\n`)
+  return replaceOrInsertSetting(config, section, "enabled", enabledValue)
+}

--- a/src/cli/install-codex/codex-config-toml-sections.ts
+++ b/src/cli/install-codex/codex-config-toml-sections.ts
@@ -1,0 +1,77 @@
+export interface TomlSection {
+  readonly header: string | null
+  readonly text: string
+}
+
+export function removeTomlSections(config: string, shouldRemove: (header: string) => boolean): string {
+  return splitTomlSections(config)
+    .filter((section) => section.header === null || !shouldRemove(section.header))
+    .map((section) => section.text)
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+}
+
+export function splitTomlSections(config: string): readonly TomlSection[] {
+  const lines = config.match(/[^\n]*\n?|$/g) ?? []
+  const sections: TomlSection[] = []
+  let current: TomlSection = { header: null, text: "" }
+  for (const line of lines) {
+    if (line.length === 0) break
+    const header = parseTomlHeader(line)
+    if (header !== null) {
+      if (current.text.length > 0) sections.push(current)
+      current = { header, text: line }
+    } else {
+      current = { ...current, text: current.text + line }
+    }
+  }
+  if (current.text.length > 0) sections.push(current)
+  return sections
+}
+
+export function parsePluginHeaderKey(header: string): string | null {
+  const prefix = "plugins."
+  if (!header.startsWith(prefix)) return null
+  return parseLeadingJsonString(header.slice(prefix.length))
+}
+
+export function parseAgentHeaderName(header: string): string | null {
+  const prefix = "agents."
+  if (!header.startsWith(prefix)) return null
+  const key = header.slice(prefix.length)
+  return key.startsWith('"') ? parseLeadingJsonString(key) : key
+}
+
+export function parseJsonString(value: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return typeof parsed === "string" ? parsed : null
+  } catch (error) {
+    if (error instanceof Error) return null
+    return null
+  }
+}
+
+function parseTomlHeader(line: string): string | null {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[[")) return null
+  return trimmed.slice(1, -1)
+}
+
+function parseLeadingJsonString(value: string): string | null {
+  if (!value.startsWith('"')) return parseJsonString(value)
+  let escaped = false
+  for (let index = 1; index < value.length; index += 1) {
+    const char = value[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === "\\") {
+      escaped = true
+      continue
+    }
+    if (char === '"') return parseJsonString(value.slice(0, index + 1))
+  }
+  return null
+}

--- a/src/cli/install-codex/codex-config-toml.test.ts
+++ b/src/cli/install-codex/codex-config-toml.test.ts
@@ -419,6 +419,54 @@ describe("codex-config-toml", () => {
     expect(content).not.toContain("ref = undefined")
   })
 
+  test("#given git marketplace source #when updating config #then writes second-precision timestamp and ref", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-marketplace-git-"))
+    const configPath = join(root, "config.toml")
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: {
+        sourceType: "git",
+        source: "https://github.com/code-yeongyu/lazycodex.git",
+        ref: "main",
+      },
+      pluginNames: ["omo"],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    const lastUpdatedLine = content.split("\n").find((line) => line.startsWith("last_updated = "))
+    expect(lastUpdatedLine ?? "").toMatch(/^last_updated = "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"$/)
+    expect(content).toContain('source_type = "git"')
+    expect(content).toContain('source = "https://github.com/code-yeongyu/lazycodex.git"')
+    expect(content).toContain('ref = "main"')
+  })
+
+  test("#given agent name needs quoting #when updating config #then writes quoted agent key", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-config-quoted-agent-"))
+    const configPath = join(root, "config.toml")
+
+    // when
+    await updateCodexConfig({
+      configPath,
+      repoRoot: "/repo/packages/omo-codex",
+      marketplaceName: "debug",
+      marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex" },
+      pluginNames: ["omo"],
+      agentConfigs: [{ name: "review.agent", configFile: "./agents/review.agent.toml" }],
+    })
+
+    // then
+    const content = await readFile(configPath, "utf8")
+    expect(content).toContain('[agents."review.agent"]')
+    expect(content).toContain('config_file = "./agents/review.agent.toml"')
+  })
+
   test("#given windows platform #when updating sisyphuslabs plugin config #then enables git_bash plugin mcp policy", async () => {
     // given
     const root = await mkdtemp(join(tmpdir(), "omo-codex-config-git-bash-win32-"))

--- a/src/cli/install-codex/codex-config-toml.ts
+++ b/src/cli/install-codex/codex-config-toml.ts
@@ -1,21 +1,20 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
+import { ensureAgentConfig, removeStaleManagedAgentBlocks } from "./codex-config-agents"
+import { ensureFeatureEnabled } from "./codex-config-features"
+import {
+  ensureMarketplaceBlock,
+  legacyMarketplaceNames,
+  removeMarketplaceBlock,
+  removeStaleMarketplaceHookStateBlocks,
+  removeStaleMarketplacePluginBlocks,
+} from "./codex-config-marketplaces"
 import { ensureAutonomousPermissions } from "./codex-config-permissions"
+import { ensureHookTrusted, ensureOmoBuiltinMcpPolicies, ensurePluginEnabled } from "./codex-config-plugins"
 import { ensureCodexReasoningConfig } from "./codex-config-reasoning"
 import { readCodexModelCatalog } from "./codex-model-catalog"
 import { ensureCodexMultiAgentV2Config } from "./codex-multi-agent-v2-config"
-import { appendBlock, findTomlSection, replaceOrInsertSetting } from "./toml-section-editor"
 import type { CodexAgentConfig, CodexInstallPlatform, CodexMarketplaceSource, TrustedHookState } from "./types"
-
-const SISYPHUS_LEGACY_MARKETPLACES = ["lazycodex", "code-yeongyu-codex-plugins"] as const
-const MANAGED_CODEX_AGENT_NAMES = [
-  "codex-ultrawork-reviewer",
-  "explorer",
-  "librarian",
-  "metis",
-  "momus",
-  "plan",
-] as const
 
 export async function updateCodexConfig(input: {
   readonly configPath: string
@@ -57,206 +56,13 @@ export async function updateCodexConfig(input: {
   }
   config = ensureOmoBuiltinMcpPolicies(config, input)
   for (const state of input.trustedHookStates ?? []) {
-    config = ensureHookTrusted(config, state.key, state.trustedHash)
+    config = ensureHookTrusted(config, state)
   }
   for (const agentConfig of input.agentConfigs ?? []) {
     config = ensureAgentConfig(config, agentConfig)
   }
 
   await writeFile(input.configPath, `${config.trimEnd()}\n`)
-}
-
-function legacyMarketplaceNames(marketplaceName: string): readonly string[] {
-  return marketplaceName === "sisyphuslabs" ? SISYPHUS_LEGACY_MARKETPLACES : []
-}
-
-function removeMarketplaceBlock(config: string, marketplaceName: string): string {
-  return removeTomlSections(config, (header) => header === `marketplaces.${marketplaceName}`)
-}
-
-function removeStaleMarketplacePluginBlocks(config: string, marketplaceName: string, keepPluginNames: Set<string>): string {
-  return removeTomlSections(config, (header) => {
-    const pluginKey = parsePluginHeaderKey(header)
-    if (pluginKey === null) return false
-    const suffix = `@${marketplaceName}`
-    if (!pluginKey.endsWith(suffix)) return false
-    return !keepPluginNames.has(pluginKey.slice(0, -suffix.length))
-  })
-}
-
-function removeStaleMarketplaceHookStateBlocks(config: string, marketplaceName: string, keepPluginNames: Set<string>): string {
-  return removeTomlSections(config, (header) => {
-    const prefix = "hooks.state."
-    if (!header.startsWith(prefix)) return false
-    const hookKey = parseJsonString(header.slice(prefix.length))
-    if (hookKey === null) return false
-    const separator = hookKey.indexOf(":")
-    if (separator === -1) return false
-    const pluginKey = hookKey.slice(0, separator)
-    const suffix = `@${marketplaceName}`
-    if (!pluginKey.endsWith(suffix)) return false
-    return !keepPluginNames.has(pluginKey.slice(0, -suffix.length))
-  })
-}
-
-function removeStaleManagedAgentBlocks(config: string, keepAgentNames: Set<string>): string {
-  const managedAgentNames = new Set<string>(MANAGED_CODEX_AGENT_NAMES)
-  return splitTomlSections(config)
-    .filter((section) => {
-      if (section.header === null) return true
-      const agentName = parseAgentHeaderName(section.header)
-      if (agentName === null || !managedAgentNames.has(agentName) || keepAgentNames.has(agentName)) return true
-      return !section.text.includes(`config_file = ${JSON.stringify(`./agents/${agentName}.toml`)}`)
-    })
-    .map((section) => section.text)
-    .join("")
-    .replace(/\n{3,}/g, "\n\n")
-}
-
-function ensureFeatureEnabled(config: string, featureName: string): string {
-  const section = findTomlSection(config, "features")
-  if (!section) return appendBlock(config, `[features]\n${featureName} = true\n`)
-  return replaceOrInsertSetting(config, section, featureName, "true")
-}
-
-function ensureMarketplaceBlock(config: string, marketplaceName: string, source: CodexMarketplaceSource): string {
-  const header = `marketplaces.${marketplaceName}`
-  const lines = [
-    `[${header}]`,
-    `last_updated = "${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}"`,
-    `source_type = ${JSON.stringify(source.sourceType)}`,
-    `source = ${JSON.stringify(source.source)}`,
-  ]
-  if (source.sourceType === "git") {
-    lines.push(`ref = ${JSON.stringify(source.ref)}`)
-  }
-  lines.push("")
-  const block = lines.join("\n")
-  const section = findTomlSection(config, header)
-  if (section) return config.slice(0, section.start) + block + config.slice(section.end)
-  return appendBlock(
-    config,
-    block,
-  )
-}
-
-function ensurePluginEnabled(config: string, pluginKey: string): string {
-  const header = `plugins.${JSON.stringify(pluginKey)}`
-  const section = findTomlSection(config, header)
-  if (!section) return appendBlock(config, `[${header}]\nenabled = true\n`)
-  return replaceOrInsertSetting(config, section, "enabled", "true")
-}
-
-function ensurePluginMcpEnabled(config: string, pluginKey: string, serverName: string, enabled: boolean): string {
-  const header = `plugins.${JSON.stringify(pluginKey)}.mcp_servers.${serverName}`
-  const section = findTomlSection(config, header)
-  const enabledValue = enabled ? "true" : "false"
-  if (!section) return appendBlock(config, `[${header}]\nenabled = ${enabledValue}\n`)
-  return replaceOrInsertSetting(config, section, "enabled", enabledValue)
-}
-
-function ensureOmoBuiltinMcpPolicies(config: string, input: {
-  readonly marketplaceName: string
-  readonly pluginNames: readonly string[]
-  readonly platform?: CodexInstallPlatform
-}): string {
-  if (input.marketplaceName !== "sisyphuslabs" || !input.pluginNames.includes("omo")) return config
-  const gitBashEnabled = (input.platform ?? process.platform) === "win32"
-  let nextConfig = ensurePluginMcpEnabled(config, "omo@sisyphuslabs", "context7", true)
-  nextConfig = ensurePluginMcpEnabled(nextConfig, "omo@sisyphuslabs", "git_bash", gitBashEnabled)
-  return nextConfig
-}
-
-function ensureHookTrusted(config: string, key: string, trustedHash: string): string {
-  const header = `hooks.state.${JSON.stringify(key)}`
-  const section = findTomlSection(config, header)
-  if (!section) return appendBlock(config, `[${header}]\ntrusted_hash = ${JSON.stringify(trustedHash)}\n`)
-  return replaceOrInsertSetting(config, section, "trusted_hash", JSON.stringify(trustedHash))
-}
-
-function ensureAgentConfig(config: string, agentConfig: CodexAgentConfig): string {
-  const header = `agents.${tomlKeySegment(agentConfig.name)}`
-  const section = findTomlSection(config, header)
-  const configFile = JSON.stringify(agentConfig.configFile)
-  if (!section) return appendBlock(config, `[${header}]\nconfig_file = ${configFile}\n`)
-  return replaceOrInsertSetting(config, section, "config_file", configFile)
-}
-
-function tomlKeySegment(value: string): string {
-  return /^[A-Za-z0-9_-]+$/.test(value) ? value : JSON.stringify(value)
-}
-
-function removeTomlSections(config: string, shouldRemove: (header: string) => boolean): string {
-  return splitTomlSections(config)
-    .filter((section) => section.header === null || !shouldRemove(section.header))
-    .map((section) => section.text)
-    .join("")
-    .replace(/\n{3,}/g, "\n\n")
-}
-
-function splitTomlSections(config: string): Array<{ header: string | null; text: string }> {
-  const lines = config.match(/[^\n]*\n?|$/g) ?? []
-  const sections: Array<{ header: string | null; text: string }> = []
-  let current: { header: string | null; text: string } = { header: null, text: "" }
-  for (const line of lines) {
-    if (line.length === 0) break
-    const header = parseTomlHeader(line)
-    if (header !== null) {
-      if (current.text.length > 0) sections.push(current)
-      current = { header, text: line }
-    } else {
-      current.text += line
-    }
-  }
-  if (current.text.length > 0) sections.push(current)
-  return sections
-}
-
-function parseTomlHeader(line: string): string | null {
-  const trimmed = line.trim()
-  if (!trimmed.startsWith("[") || !trimmed.endsWith("]") || trimmed.startsWith("[[")) return null
-  return trimmed.slice(1, -1)
-}
-
-function parsePluginHeaderKey(header: string): string | null {
-  const prefix = "plugins."
-  if (!header.startsWith(prefix)) return null
-  return parseLeadingJsonString(header.slice(prefix.length))
-}
-
-function parseAgentHeaderName(header: string): string | null {
-  const prefix = "agents."
-  if (!header.startsWith(prefix)) return null
-  const key = header.slice(prefix.length)
-  return key.startsWith('"') ? parseLeadingJsonString(key) : key
-}
-
-function parseLeadingJsonString(value: string): string | null {
-  if (!value.startsWith('"')) return parseJsonString(value)
-  let escaped = false
-  for (let index = 1; index < value.length; index += 1) {
-    const char = value[index]
-    if (escaped) {
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      escaped = true
-      continue
-    }
-    if (char === '"') return parseJsonString(value.slice(0, index + 1))
-  }
-  return null
-}
-
-function parseJsonString(value: string): string | null {
-  try {
-    const parsed: unknown = JSON.parse(value)
-    return typeof parsed === "string" ? parsed : null
-  } catch (error) {
-    if (error instanceof Error) return null
-    return null
-  }
 }
 
 async function exists(path: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
Split the Codex installer TOML updater into small purpose-specific modules while preserving the public `updateCodexConfig` facade and existing behavior.

## Changes
- Added characterization coverage for git marketplace timestamp/ref output and quoted agent TOML keys.
- Extracted TOML section parsing/removal, marketplace cleanup, plugin/MCP policy writes, agent config writes, and feature flag writes out of `codex-config-toml.ts`.
- Reduced `src/cli/install-codex/codex-config-toml.ts` from 270 lines to 76 lines.

## Testing
- `bun test src/cli/install-codex/codex-config-toml.test.ts src/cli/install-codex/codex-config-agent-cleanup.test.ts src/cli/install-codex/codex-config-reasoning.test.ts src/cli/install-codex/codex-config-autonomous-features.test.ts src/cli/install-codex/codex-config-shell-settings.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Codex installer’s TOML updater into small, focused modules while keeping the `updateCodexConfig` facade and behavior. Added tests to pin second-precision marketplace timestamps/refs and support quoted agent keys.

- **Refactors**
  - Split logic into `codex-config-agents.ts`, `codex-config-features.ts`, `codex-config-marketplaces.ts`, `codex-config-plugins.ts`, and `codex-config-toml-sections.ts`.
  - Reduced `src/cli/install-codex/codex-config-toml.ts` from 270 lines to 76 lines.

<sup>Written for commit 09109fb871079a8bc2d10506542a8fb78c2f07ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

