### PR TITLE
fix: make HTTP MCP cleanup ignores explicit

### DIFF
--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types"
+import { disconnectAll } from "./cleanup"
+import { createHttpClient, setHttpClientDependenciesForTesting } from "./http-client"
+import type { McpTransport, SkillMcpClientInfo, SkillMcpManagerState } from "./types"
+
+const trackedStates: SkillMcpManagerState[] = []
+const createdClients: MockHttpClient[] = []
+const createdTransports: MockHttpTransport[] = []
+let configureNextClient: ((client: MockHttpClient) => void) | undefined
+let configureNextTransport: ((transport: MockHttpTransport) => void) | undefined
+
+class MockHttpClient {
+  readonly close = mock(async () => {})
+  readonly listTools = mock(async () => ({ tools: [] }))
+  readonly listResources = mock(async () => ({ resources: [] }))
+  readonly listPrompts = mock(async () => ({ prompts: [] }))
+  readonly callTool = mock(async () => ({ content: [] }))
+  readonly readResource = mock(async () => ({ contents: [] }))
+  readonly getPrompt = mock(async () => ({ messages: [] }))
+  readonly connect = mock(async (_transport: McpTransport) => {})
+
+  constructor(
+    _clientInfo: { name: string; version: string },
+    _options: { capabilities: Record<string, never> },
+  ) {
+    createdClients.push(this)
+    configureNextClient?.(this)
+  }
+}
+
+class MockHttpTransport {
+  readonly close = mock(async () => {})
+  readonly send = mock(async () => {})
+
+  constructor(
+    readonly url: URL,
+    readonly options?: { requestInit?: RequestInit },
+  ) {
+    createdTransports.push(this)
+    configureNextTransport?.(this)
+  }
+
+  async start(): Promise<void> {}
+}
+
+afterAll(() => {
+  mock.restore()
+})
+
+function createState(): SkillMcpManagerState {
+  const state: SkillMcpManagerState = {
+    clients: new Map(),
+    pendingConnections: new Map(),
+    disconnectedSessions: new Map(),
+    authProviders: new Map(),
+    cleanupRegistered: false,
+    cleanupInterval: null,
+    cleanupHandlers: [],
+    idleTimeoutMs: 5 * 60 * 1000,
+    shutdownGeneration: 0,
+    inFlightConnections: new Map(),
+    disposed: false,
+    createOAuthProvider: () => ({
+      tokens: () => null,
+      login: async () => ({ accessToken: "test-token" }),
+      refresh: async () => ({ accessToken: "test-token" }),
+    }),
+  }
+
+  trackedStates.push(state)
+  return state
+}
+
+function createInfo(): SkillMcpClientInfo {
+  return {
+    serverName: "http-cleanup-server",
+    skillName: "http-cleanup-skill",
+    sessionID: "session-http-cleanup",
+    scope: "builtin",
+  }
+}
+
+function createClientKey(info: SkillMcpClientInfo): string {
+  return `${info.sessionID}:${info.skillName}:${info.serverName}`
+}
+
+function createConfig(): ClaudeCodeMcpServer {
+  return {
+    type: "http",
+    url: "https://example.com/mcp?api_key=secret-value",
+  }
+}
+
+beforeEach(() => {
+  createdClients.length = 0
+  createdTransports.length = 0
+  configureNextClient = undefined
+  configureNextTransport = undefined
+  setHttpClientDependenciesForTesting({
+    createClient: (clientInfo, options) => new MockHttpClient(clientInfo, options),
+    createTransport: (url, options) => new MockHttpTransport(url, options),
+  })
+})
+
+afterEach(async () => {
+  for (const state of trackedStates) {
+    await disconnectAll(state)
+  }
+
+  trackedStates.length = 0
+  createdClients.length = 0
+  createdTransports.length = 0
+  configureNextClient = undefined
+  configureNextTransport = undefined
+  setHttpClientDependenciesForTesting()
+})
+
+describe("createHttpClient cleanup failures", () => {
+  it("#given HTTP connect fails and transport close rejects #when creating the client #then the connection error is preserved", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error("connect boom")
+      })
+    }
+    configureNextTransport = (transport) => {
+      transport.close.mockImplementation(async () => {
+        throw new Error("cleanup boom")
+      })
+    }
+
+    await expect(createHttpClient({ state, clientKey, info, config })).rejects.toThrow(
+      /Failed to connect to MCP server "http-cleanup-server"[\s\S]*api_key=\*\*\*REDACTED\*\*\*[\s\S]*Reason: connect boom/,
+    )
+    expect(createdTransports[0]?.close).toHaveBeenCalledTimes(1)
+    expect(state.clients.has(clientKey)).toBe(false)
+  })
+
+  it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        state.shutdownGeneration += 1
+      })
+      client.close.mockImplementation(async () => {
+        throw new Error("client cleanup boom")
+      })
+    }
+    configureNextTransport = (transport) => {
+      transport.close.mockImplementation(async () => {
+        throw new Error("transport cleanup boom")
+      })
+    }
+
+    await expect(createHttpClient({ state, clientKey, info, config })).rejects.toThrow(
+      /MCP server "http-cleanup-server" connection completed after shutdown/,
+    )
+    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1)
+    expect(createdTransports[0]?.close).toHaveBeenCalledTimes(1)
+    expect(state.clients.has(clientKey)).toBe(false)
+  })
+})

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { log } from "../../shared/logger"
 import { registerProcessCleanup, startCleanupTimer } from "./cleanup"
 import { buildHttpRequestInit } from "./oauth-handler"
 import type { ManagedClient, McpClient, McpTransport, SkillMcpClientConnectionParams } from "./types"
@@ -55,6 +56,21 @@ function redactUrl(urlStr: string): string {
   }
 }
 
+async function closeHttpResourceIgnoringFailure(
+  close: () => Promise<void>,
+  context: { resource: "client" | "transport"; serverName: string; phase: "connect-failure" | "post-shutdown" },
+): Promise<void> {
+  try {
+    await close()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log("[skill-mcp-http-client] ignored cleanup failure", {
+      ...context,
+      error: message,
+    })
+  }
+}
+
 export async function createHttpClient(params: SkillMcpClientConnectionParams): Promise<McpClient> {
   const { state, clientKey, info, config } = params
   const shutdownGenAtStart = state.shutdownGeneration
@@ -88,11 +104,11 @@ export async function createHttpClient(params: SkillMcpClientConnectionParams): 
   try {
     await client.connect(transport)
   } catch (error) {
-    try {
-      await transport.close()
-    } catch {
-      // Transport may already be closed
-    }
+    await closeHttpResourceIgnoringFailure(() => transport.close(), {
+      resource: "transport",
+      serverName: info.serverName,
+      phase: "connect-failure",
+    })
 
     const errorMessage = error instanceof Error ? error.message : String(error)
     throw new Error(
@@ -107,8 +123,16 @@ export async function createHttpClient(params: SkillMcpClientConnectionParams): 
   }
 
   if (state.shutdownGeneration !== shutdownGenAtStart) {
-    try { await client.close() } catch {}
-    try { await transport.close() } catch {}
+    await closeHttpResourceIgnoringFailure(() => client.close(), {
+      resource: "client",
+      serverName: info.serverName,
+      phase: "post-shutdown",
+    })
+    await closeHttpResourceIgnoringFailure(() => transport.close(), {
+      resource: "transport",
+      serverName: info.serverName,
+      phase: "post-shutdown",
+    })
     throw new Error(`MCP server "${info.serverName}" connection completed after shutdown`)
   }
 


### PR DESCRIPTION
## Summary
- Replace empty cleanup catches in `src/features/skill-mcp-manager/http-client.ts` with an explicit ignored-cleanup helper.
- Log ignored HTTP MCP client/transport cleanup failures with resource and phase context while preserving existing thrown errors.
- Add characterization tests that pin connect-failure cleanup and post-shutdown cleanup behavior when close calls reject.

## Testing
- `bun test src/features/skill-mcp-manager/http-client.test.ts src/features/skill-mcp-manager/connection-race.test.ts src/features/skill-mcp-manager/manager.test.ts src/features/skill-mcp-manager/connection-env-vars.test.ts` ✅
- `bun run /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/skill-mcp-manager/http-client.ts src/features/skill-mcp-manager/http-client.test.ts` ✅
- `bun run typecheck` ✅
- `bun test src/features/skill-mcp-manager` ✅
- `bun run build` ✅

## Notes
- URL redaction, connect failure text, shutdown-generation behavior, and OAuth request-init handling are preserved.
- Static/security scan: N/A for this narrow cleanup change; no dedicated security scanner is configured for the touched files.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make HTTP MCP client cleanup explicit and logged. We preserve the original connect/shutdown errors, safely close resources, and redact secrets in error messages.

- **Bug Fixes**
  - Added `closeHttpResourceIgnoringFailure` to log cleanup failures for client/transport without masking the root error.
  - Always close client/transport on connect failure and after shutdown completion.
  - Redact sensitive query params (e.g., `api_key`) in URLs shown in error messages.
  - Added tests for connect failure and post-shutdown cleanup failures.

<sup>Written for commit a89ba37ee2ff1916057b5ec563bef4ffd5cbc704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

