### PR TITLE
refactor(plugin): sequence messages transform hooks

### DIFF
--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -46,11 +46,15 @@ function makeHook(handler: TransformHook): NonNullable<CreatedHooks["toolPairVal
 
 function makeHooks(overrides: {
   contextInjector?: TransformHook
+  teamModeStatus?: TransformHook
+  teamMailbox?: TransformHook
   thinkingBlock?: TransformHook
   toolPair?: TransformHook
 }): CreatedHooks {
   return {
     contextInjectorMessagesTransform: overrides.contextInjector ? makeHook(overrides.contextInjector) : undefined,
+    teamModeStatusInjector: overrides.teamModeStatus ? makeHook(overrides.teamModeStatus) : undefined,
+    teamMailboxInjector: overrides.teamMailbox ? makeHook(overrides.teamMailbox) : undefined,
     thinkingBlockValidator: overrides.thinkingBlock ? makeHook(overrides.thinkingBlock) : undefined,
     toolPairValidator: overrides.toolPair ? makeHook(overrides.toolPair) : undefined,
   } as CreatedHooks
@@ -72,6 +76,12 @@ describe("createMessagesTransformHandler", () => {
       contextInjector: async () => {
         callOrder.push("context-injector")
       },
+      teamModeStatus: async () => {
+        callOrder.push("team-mode-status-injector")
+      },
+      teamMailbox: async () => {
+        callOrder.push("team-mailbox-injector")
+      },
       thinkingBlock: async () => {
         callOrder.push("thinking-block-validator")
       },
@@ -86,6 +96,8 @@ describe("createMessagesTransformHandler", () => {
     //#then
     expect(callOrder).toEqual([
       "context-injector",
+      "team-mode-status-injector",
+      "team-mailbox-injector",
       "thinking-block-validator",
       "tool-pair-validator",
     ])
@@ -328,6 +340,131 @@ describe("createMessagesTransformHandler", () => {
       system: "system-prompt",
       tools: { bash: true },
     })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given multiple user turns and a rejecting assistant tail #when messages transform runs #then recovery copies the last user turn metadata", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_first_user",
+          role: "user",
+          sessionID: "ses_first_user",
+          agent: "atlas",
+          model: { providerID: "openai", modelID: "gpt-5.4" },
+          system: "old-system",
+          tools: { read: true },
+        },
+        parts: [{ type: "text", text: "first" }],
+      },
+      {
+        info: {
+          id: "msg_last_user",
+          role: "user",
+          sessionID: "ses_last_user",
+          agent: "sisyphus",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+          system: "new-system",
+          tools: { bash: true },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_tail_without_session",
+          role: "assistant",
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(4)
+    expect(messages.at(-1)?.info).toMatchObject({
+      id: "msg_tail_without_session_prefill_recovery",
+      role: "user",
+      sessionID: "ses_last_user",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      system: "new-system",
+      tools: { bash: true },
+    })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      sessionID: "ses_last_user",
+      messageID: "msg_tail_without_session_prefill_recovery",
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
+  })
+
+  it("#given an earlier compaction continuation but the last user turn is ordinary #when messages transform runs #then it does not recover the assistant tail", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      {
+        info: { role: "user" },
+        parts: [{
+          type: "text",
+          text: `[session recovered - continuing previous task]\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+          synthetic: true,
+          metadata: { compaction_continue: true },
+        }],
+      },
+      { info: { role: "user" }, parts: [{ type: "text", text: "ordinary follow-up" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "completed assistant answer" }] },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages).toHaveLength(3)
+    expect(messages.at(-1)?.info.role).toBe("assistant")
+  })
+
+  it("#given hooks leave an unsupported assistant tail #when messages transform runs #then recovery happens after hook validation", async () => {
+    //#given
+    const observedTailRoles: Array<TestMessage["info"]["role"] | undefined> = []
+    const messages: TestMessage[] = [
+      {
+        info: {
+          id: "msg_user_recovery_timing",
+          role: "user",
+          sessionID: "ses_recovery_timing",
+          agent: "sisyphus",
+          model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+        },
+        parts: [{ type: "text", text: "continue" }],
+      },
+      {
+        info: {
+          id: "msg_assistant_recovery_timing",
+          role: "assistant",
+          sessionID: "ses_recovery_timing",
+        },
+        parts: [{ type: "text", text: "done" }],
+      },
+    ]
+    const hooks = makeHooks({
+      toolPair: async (_input, output) => {
+        observedTailRoles.push(output.messages.at(-1)?.info.role)
+      },
+    })
+
+    //#when
+    await runHandler(hooks, messages)
+
+    //#then
+    expect(observedTailRoles).toEqual(["assistant"])
+    expect(messages.at(-1)?.info.role).toBe("user")
     expect(messages.at(-1)?.parts[0]).toMatchObject({
       type: "text",
       text: "[internal] Continue from the previous assistant state.",

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -35,11 +35,24 @@ type MessagesTransformHooks = {
   thinkingBlockValidator?: CreatedHooks["thinkingBlockValidator"]
   toolPairValidator?: CreatedHooks["toolPairValidator"]
 }
+type MessagesTransformHookKey = keyof MessagesTransformHooks
+type MessagesTransformHookEntry = {
+  readonly key: MessagesTransformHookKey
+  readonly name: string
+}
 type UserMessageInfo = Extract<Message, { role: "user" }>
 type ModelIdentifier = {
   providerID: string
   modelID: string
 }
+
+const MESSAGES_TRANSFORM_HOOKS = [
+  { key: "contextInjectorMessagesTransform", name: "contextInjectorMessagesTransform" },
+  { key: "teamModeStatusInjector", name: "teamModeStatusInjector" },
+  { key: "teamMailboxInjector", name: "teamMailboxInjector" },
+  { key: "thinkingBlockValidator", name: "thinkingBlockValidator" },
+  { key: "toolPairValidator", name: "toolPairValidator" },
+] satisfies readonly MessagesTransformHookEntry[]
 
 function getSessionID(message: MessageWithParts): string | undefined {
   return message.info.sessionID
@@ -226,50 +239,14 @@ export function createMessagesTransformHandler(args: {
   hooks: MessagesTransformHooks
 }): (input: Record<string, never>, output: MessagesTransformOutput) => Promise<void> {
   return async (input, output): Promise<void> => {
-    await runMessagesTransformHookSafely(
-      "contextInjectorMessagesTransform",
-      args.hooks.contextInjectorMessagesTransform?.[
-        "experimental.chat.messages.transform"
-      ],
-      input,
-      output,
-    )
-
-    await runMessagesTransformHookSafely(
-      "teamModeStatusInjector",
-      args.hooks.teamModeStatusInjector?.[
-        "experimental.chat.messages.transform"
-      ],
-      input,
-      output,
-    )
-
-    await runMessagesTransformHookSafely(
-      "teamMailboxInjector",
-      args.hooks.teamMailboxInjector?.[
-        "experimental.chat.messages.transform"
-      ],
-      input,
-      output,
-    )
-
-    await runMessagesTransformHookSafely(
-      "thinkingBlockValidator",
-      args.hooks.thinkingBlockValidator?.[
-        "experimental.chat.messages.transform"
-      ],
-      input,
-      output,
-    )
-
-    await runMessagesTransformHookSafely(
-      "toolPairValidator",
-      args.hooks.toolPairValidator?.[
-        "experimental.chat.messages.transform"
-      ],
-      input,
-      output,
-    )
+    for (const hook of MESSAGES_TRANSFORM_HOOKS) {
+      await runMessagesTransformHookSafely(
+        hook.name,
+        args.hooks[hook.key]?.["experimental.chat.messages.transform"],
+        input,
+        output,
+      )
+    }
 
     ensureUserTurnAfterAssistantTail(output)
   }


### PR DESCRIPTION
## Summary
Refactors `messages-transform` hook dispatch into a typed sequence loop while preserving assistant-prefill recovery behavior. Adds characterization coverage for hook ordering, recovery timing, and last-user/session metadata handling.

## Changes
- Pin full transform hook order including team-mode status and mailbox injectors.
- Pin assistant-prefill recovery metadata copied from the last user turn.
- Pin compaction continuation gating to the last user turn and recovery running after hook validation.
- Replace repeated hook-dispatch blocks with a single typed sequence.

## Testing
- `bun test src/plugin/messages-transform.test.ts src/plugin/messages-transform-prefill-alias.test.ts src/plugin/messages-transform-thinking-block.test.ts` ✅
- `git diff --check` ✅
- `bun run typecheck` ✅
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/plugin/messages-transform.ts src/plugin/messages-transform.test.ts` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the messages transform to run all hooks through a single typed sequence and locks the exact order. Preserves assistant-prefill recovery and adds tests for ordering, recovery timing, and last-user/session metadata.

- **Refactors**
  - Introduced `MESSAGES_TRANSFORM_HOOKS` to iterate and dispatch hooks once.
  - Pinned hook order: `contextInjectorMessagesTransform` → `teamModeStatusInjector` → `teamMailboxInjector` → `thinkingBlockValidator` → `toolPairValidator`.
  - Runs recovery after validators and copies model/session/system/tools from the last user turn; gates compaction continuation on the last user turn only.

<sup>Written for commit 388c65e5c01e1a3a2bf1d39d0533de67034e9e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

