### PR TITLE
fix: redact HTTP MCP cleanup log errors

### DIFF
--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -181,6 +181,34 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).not.toMatch(/secret-value|abcdefghijklmnopqrstuvwxyz/)
   })
 
+  it("#given HTTP connect failure includes compact JSON secrets #when creating the client #then URL and bearer values are both redacted", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error(
+          '{"url":"https://example.com/mcp?api_key=secret-value","headers":{"Authorization":"Bearer abcdefghijklmnopqrstuvwxyz"}}',
+        )
+      })
+    }
+
+    let thrown: unknown
+    try {
+      await createHttpClient({ state, clientKey, info, config })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    const message = thrown instanceof Error ? thrown.message : ""
+    expect(message).toContain('"url":"https://example.com/mcp?api_key=***REDACTED***"')
+    expect(message).toContain('"Authorization":"[REDACTED]"')
+    expect(message).not.toMatch(/secret-value|abcdefghijklmnopqrstuvwxyz/)
+  })
+
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
     const state = createState()
     const info = createInfo()

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -238,6 +238,31 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).not.toMatch(/secret-value|short-secret|Bearer short/)
   })
 
+  it("#given HTTP connect failure includes authorization equals secrets #when creating the client #then full values are redacted", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error("authorization=Basic short-secret; authorization=Bearer short")
+      })
+    }
+
+    let thrown: unknown
+    try {
+      await createHttpClient({ state, clientKey, info, config })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    const message = thrown instanceof Error ? thrown.message : ""
+    expect(message).toContain("authorization=[REDACTED]; authorization=[REDACTED]")
+    expect(message).not.toMatch(/short-secret|Bearer short/)
+  })
+
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
     const state = createState()
     const info = createInfo()

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -1,5 +1,9 @@
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types"
+import { _flushForTesting, _resetLoggerForTesting, _setLoggerForTesting } from "../../shared/logger"
 import { disconnectAll } from "./cleanup"
 import { createHttpClient, setHttpClientDependenciesForTesting } from "./http-client"
 import type { McpTransport, SkillMcpClientInfo, SkillMcpManagerState } from "./types"
@@ -9,6 +13,7 @@ const createdClients: MockHttpClient[] = []
 const createdTransports: MockHttpTransport[] = []
 let configureNextClient: ((client: MockHttpClient) => void) | undefined
 let configureNextTransport: ((transport: MockHttpTransport) => void) | undefined
+let testLogDir: string | undefined
 
 class MockHttpClient {
   readonly close = mock(async () => {})
@@ -97,6 +102,7 @@ beforeEach(() => {
   createdTransports.length = 0
   configureNextClient = undefined
   configureNextTransport = undefined
+  testLogDir = undefined
   setHttpClientDependenciesForTesting({
     createClient: (clientInfo, options) => new MockHttpClient(clientInfo, options),
     createTransport: (url, options) => new MockHttpTransport(url, options),
@@ -113,6 +119,11 @@ afterEach(async () => {
   createdTransports.length = 0
   configureNextClient = undefined
   configureNextTransport = undefined
+  _resetLoggerForTesting()
+  if (testLogDir) {
+    fs.rmSync(testLogDir, { recursive: true, force: true })
+    testLogDir = undefined
+  }
   setHttpClientDependenciesForTesting()
 })
 
@@ -167,5 +178,38 @@ describe("createHttpClient cleanup failures", () => {
     expect(createdClients[0]?.close).toHaveBeenCalledTimes(1)
     expect(createdTransports[0]?.close).toHaveBeenCalledTimes(1)
     expect(state.clients.has(clientKey)).toBe(false)
+  })
+
+  it("#given cleanup failure includes URL and bearer secrets #when the failure is logged #then secrets are redacted", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+    testLogDir = fs.mkdtempSync(path.join(os.tmpdir(), "omo-http-client-cleanup-"))
+    const logFilePath = path.join(testLogDir, "cleanup.log")
+
+    _setLoggerForTesting({ filePath: logFilePath, maxSizeBytes: 1024 * 1024, maxBackups: 2 })
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error("connect boom")
+      })
+    }
+    configureNextTransport = (transport) => {
+      transport.close.mockImplementation(async () => {
+        throw new Error(
+          "cleanup failed for https://example.com/mcp?api_key=secret-value with Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+        )
+      })
+    }
+
+    await expect(createHttpClient({ state, clientKey, info, config })).rejects.toThrow(/connect boom/)
+    _flushForTesting()
+
+    const logContent = fs.readFileSync(logFilePath, "utf8")
+    expect(logContent).toContain("ignored cleanup failure")
+    expect(logContent).toContain("api_key=***REDACTED***")
+    expect(logContent).toContain("Authorization: [REDACTED]")
+    expect(logContent).not.toContain("secret-value")
+    expect(logContent).not.toContain("abcdefghijklmnopqrstuvwxyz")
   })
 })

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -209,6 +209,35 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).not.toMatch(/secret-value|abcdefghijklmnopqrstuvwxyz/)
   })
 
+  it("#given HTTP connect failure includes non-bearer authorization secrets #when creating the client #then authorization values are redacted by key", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error(
+          '{"url":"https://example.com/mcp?api_key=secret-value","headers":{"Authorization":"Basic short-secret","authorization":"Bearer short"}}',
+        )
+      })
+    }
+
+    let thrown: unknown
+    try {
+      await createHttpClient({ state, clientKey, info, config })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    const message = thrown instanceof Error ? thrown.message : ""
+    expect(message).toContain('"url":"https://example.com/mcp?api_key=***REDACTED***"')
+    expect(message).toContain('"Authorization":"[REDACTED]"')
+    expect(message).toContain('"authorization":"[REDACTED]"')
+    expect(message).not.toMatch(/secret-value|short-secret|Bearer short/)
+  })
+
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
     const state = createState()
     const info = createInfo()

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -152,6 +152,35 @@ describe("createHttpClient cleanup failures", () => {
     expect(state.clients.has(clientKey)).toBe(false)
   })
 
+  it("#given HTTP connect failure includes URL and bearer secrets #when creating the client #then thrown reason redacts secrets", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error(
+          "connect failed for https://example.com/mcp?api_key=secret-value with Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+        )
+      })
+    }
+
+    let thrown: unknown
+    try {
+      await createHttpClient({ state, clientKey, info, config })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    const message = thrown instanceof Error ? thrown.message : ""
+    expect(message).toMatch(
+      /Reason: connect failed for https:\/\/example\.com\/mcp\?api_key=\*\*\*REDACTED\*\*\* with Authorization: \[REDACTED\]/,
+    )
+    expect(message).not.toMatch(/secret-value|abcdefghijklmnopqrstuvwxyz/)
+  })
+
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
     const state = createState()
     const info = createInfo()

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -58,8 +58,8 @@ function redactUrl(urlStr: string): string {
 }
 
 function redactCleanupErrorMessage(message: string): string {
-  const messageWithRedactedUrls = message.replace(/https?:\/\/[^\s]+/g, (url) => redactUrl(url))
-  return redactSensitiveData(messageWithRedactedUrls)
+  const messageWithRedactedSecrets = redactSensitiveData(message)
+  return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }
 
 async function closeHttpResourceIgnoringFailure(

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -116,7 +116,7 @@ export async function createHttpClient(params: SkillMcpClientConnectionParams): 
       phase: "connect-failure",
     })
 
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = redactCleanupErrorMessage(error instanceof Error ? error.message : String(error))
     throw new Error(
       `Failed to connect to MCP server "${info.serverName}".\n\n` +
       `URL: ${redactUrl(config.url)}\n` +

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { log } from "../../shared/logger"
 import { registerProcessCleanup, startCleanupTimer } from "./cleanup"
+import { redactSensitiveData } from "./error-redaction"
 import { buildHttpRequestInit } from "./oauth-handler"
 import type { ManagedClient, McpClient, McpTransport, SkillMcpClientConnectionParams } from "./types"
 
@@ -56,6 +57,11 @@ function redactUrl(urlStr: string): string {
   }
 }
 
+function redactCleanupErrorMessage(message: string): string {
+  const messageWithRedactedUrls = message.replace(/https?:\/\/[^\s]+/g, (url) => redactUrl(url))
+  return redactSensitiveData(messageWithRedactedUrls)
+}
+
 async function closeHttpResourceIgnoringFailure(
   close: () => Promise<void>,
   context: { resource: "client" | "transport"; serverName: string; phase: "connect-failure" | "post-shutdown" },
@@ -66,7 +72,7 @@ async function closeHttpResourceIgnoringFailure(
     const message = error instanceof Error ? error.message : String(error)
     log("[skill-mcp-http-client] ignored cleanup failure", {
       ...context,
-      error: message,
+      error: redactCleanupErrorMessage(message),
     })
   }
 }

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -58,7 +58,11 @@ function redactUrl(urlStr: string): string {
 }
 
 function redactCleanupErrorMessage(message: string): string {
-  const messageWithRedactedSecrets = redactSensitiveData(message)
+  const messageWithRedactedAuthorization = message
+    .replace(/("authorization"\s*:\s*")([^"]*)(")/gi, "$1[REDACTED]$3")
+    .replace(/(\bauthorization\s*:\s*)([^\n,;}]*)/gi, "$1[REDACTED]")
+    .replace(/(\bauthorization\s*=\s*)([^\s,;}]*)/gi, "$1[REDACTED]")
+  const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }
 

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -61,7 +61,7 @@ function redactCleanupErrorMessage(message: string): string {
   const messageWithRedactedAuthorization = message
     .replace(/("authorization"\s*:\s*")([^"]*)(")/gi, "$1[REDACTED]$3")
     .replace(/(\bauthorization\s*:\s*)([^\n,;}]*)/gi, "$1[REDACTED]")
-    .replace(/(\bauthorization\s*=\s*)([^\s,;}]*)/gi, "$1[REDACTED]")
+    .replace(/(\bauthorization\s*=\s*)([^\n,;}]*)/gi, "$1[REDACTED]")
   const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }


### PR DESCRIPTION
## Summary
- Follow-up to #4846 after the initial cleanup PR was merged externally.
- Redacts URL query secrets and bearer/token-like strings before logging ignored HTTP MCP cleanup failures.
- Adds a logger-backed regression test proving cleanup error logs do not include URL query or bearer secrets.

## Testing
- `bun test src/features/skill-mcp-manager/http-client.test.ts src/features/skill-mcp-manager` ✅
- `bun run /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/skill-mcp-manager/http-client.ts src/features/skill-mcp-manager/http-client.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅

## Review Notes
- Security re-review passed after this fix.
- Original PR #4846 was merged by code-yeongyu before this follow-up commit landed; this PR carries only the redaction fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts secrets in HTTP MCP connect errors and cleanup logs to prevent leaking URL query params and any authorization values. Thrown reasons and cleanup logs now only include masked values.

- **Bug Fixes**
  - Expand `redactCleanupErrorMessage` to redact `authorization` values by key (case-insensitive) in JSON, header-style `authorization: ...`, and `authorization=...`; bound URL masking via `redactUrl` + `redactSensitiveData`; applied in `closeHttpResourceIgnoringFailure` and `createHttpClient`.
  - Add tests for plain text and compact JSON errors, non-bearer and equals-form authorization, and a file-backed logger to ensure secrets are not present.

<sup>Written for commit 9685c4ce040c4f1416581a1c2488cbbe5404f0bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

