### PR TITLE
fix(parser): preserve nested anthropic error payloads

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
@@ -119,6 +119,30 @@ describe("parseAnthropicTokenLimitError", () => {
     expect(result.maxTokens).toBe(200000)
   })
 
+  it("#given responseBody JSON with nested error but no top-level type #when parsing #then preserves nested type and request id", () => {
+    //#given
+    const error = {
+      data: {
+        responseBody:
+          '{"error":{"type":"context_length_exceeded","message":"prompt is too long: 250000 tokens > 200000 maximum"},"request_id":"req_123"}',
+      },
+      message: "prompt is too long",
+    }
+
+    //#when
+    const result = parseAnthropicTokenLimitError(error)
+
+    //#then
+    expect(result).not.toBeNull()
+    if (result === null) {
+      throw new Error("expected token limit parser result")
+    }
+    expect(result.currentTokens).toBe(250000)
+    expect(result.maxTokens).toBe(200000)
+    expect(result.errorType).toBe("context_length_exceeded")
+    expect(result.requestId).toBe("req_123")
+  })
+
   it("#given an error with data as a string (not object) #when parsing #then does not crash", () => {
     //#given
     const error = {

--- a/src/hooks/anthropic-context-window-limit-recovery/parser.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.ts
@@ -1,9 +1,9 @@
 import type { ParsedTokenLimitError } from "./types"
 
 interface AnthropicErrorData {
-  type: "error"
+  type?: "error"
   error: {
-    type: string
+    type?: string
     message: string
   }
   request_id?: string
@@ -66,7 +66,7 @@ function readStringProperty(source: Record<string, unknown>, key: string): strin
 }
 
 function isAnthropicErrorData(value: unknown): value is AnthropicErrorData {
-  if (!isRecord(value) || readProperty(value, "type") !== "error") {
+  if (!isRecord(value)) {
     return false
   }
 
@@ -75,7 +75,8 @@ function isAnthropicErrorData(value: unknown): value is AnthropicErrorData {
     return false
   }
 
-  return typeof readProperty(error, "type") === "string" && typeof readProperty(error, "message") === "string"
+  const requestId = readProperty(value, "request_id")
+  return typeof readProperty(error, "message") === "string" && (requestId === undefined || typeof requestId === "string")
 }
 
 function extractTokensFromMessage(message: string): { current: number; max: number } | null {


### PR DESCRIPTION
## Summary
Follow-up to #4845. Preserve the legacy responseBody parsing behavior for Anthropic-style JSON payloads that contain a nested `error` object but omit top-level `type: "error"`.

## Changes
- Accept parsed responseBody JSON when it has `error.message`, with optional `error.type` and optional string `request_id`.
- Add a regression test proving nested error type and request ID are preserved.

## Testing
- `bun test src/hooks/anthropic-context-window-limit-recovery/parser.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/parser.ts src/hooks/anthropic-context-window-limit-recovery/parser.test.ts`
- `bun run typecheck`
- `bun run build`

## Notes
#4845 was merged before this review-found semantics fix could be pushed. This PR restores the behavior without rewriting merged history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix token limit error parsing for Anthropic responses that include a nested `error` object without a top-level `type: "error"`. We now preserve `error.type` and `request_id` for accurate context-window recovery.

- **Bug Fixes**
  - Accept `responseBody` JSON with `error.message` (optional `error.type`, optional string `request_id`) even when top-level `type` is missing.
  - Add a regression test to verify nested error type and request ID are preserved.

<sup>Written for commit 8ddeff23d2dbae1a4abacb013aa772502fc53f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

