### PR TITLE
fix(tmux): close subagent pane when background task completes (#4773)

### DIFF
--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -140,6 +140,20 @@ export function createManagers(args: {
 
         log("[create-managers] onSubagentSessionCreated callback completed")
     },
+    onSubagentSessionDeleted: async (event: { sessionID: string }) => {
+      log("[create-managers] onSubagentSessionDeleted callback received", {
+        sessionID: event.sessionID,
+      })
+
+      await tmuxSessionManager.onSessionDeleted(event).catch((error) => {
+        log("[create-managers] onSubagentSessionDeleted callback error:", {
+          sessionID: event.sessionID,
+          error: String(error),
+        })
+      })
+
+      log("[create-managers] onSubagentSessionDeleted callback completed")
+    },
     onShutdown: async () => {
       await cleanupTeamModeRuns().catch((error) => {
         log("[create-managers] team-mode cleanup error during shutdown:", error)

--- a/packages/omo-opencode/src/features/background-agent/index.ts
+++ b/packages/omo-opencode/src/features/background-agent/index.ts
@@ -1,4 +1,4 @@
 export * from "./types"
-export { BackgroundManager, type SubagentSessionCreatedEvent, type OnSubagentSessionCreated } from "./manager"
+export { BackgroundManager, type SubagentSessionCreatedEvent, type OnSubagentSessionCreated, type SubagentSessionDeletedEvent, type OnSubagentSessionDeleted } from "./manager"
 export { waitForTaskSessionID } from "./wait-for-task-session"
 export type { WaitForTaskSessionIDOptions } from "./wait-for-task-session"

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -2374,6 +2374,45 @@ describe("BackgroundManager.tryCompleteTask", () => {
     expect(abortedSessionIDs).toEqual(["session-1"])
   })
 
+  test("should fire onSubagentSessionDeleted callback on completion", async () => {
+    // #given
+    const deletedSessionIDs: string[] = []
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    manager.shutdown()
+    manager = new BackgroundManager({
+      pluginContext: createPluginInput(client),
+      onSubagentSessionDeleted: async (event) => {
+        deletedSessionIDs.push(event.sessionID)
+      },
+    })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-deleted-callback",
+      sessionId: "session-deleted-cb",
+      parentSessionId: "session-parent",
+      parentMessageId: "msg-1",
+      description: "test task for deleted callback",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+
+    // #when
+    await tryCompleteTaskForTest(manager, task)
+
+    // #then
+    expect(deletedSessionIDs).toEqual(["session-deleted-cb"])
+  })
+
   test("should clean pendingByParent even when promptAsync notification fails", async () => {
     // given
     const client = {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -216,6 +216,12 @@ export interface SubagentSessionCreatedEvent {
 
 export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>
 
+export interface SubagentSessionDeletedEvent {
+  sessionID: string
+}
+
+export type OnSubagentSessionDeleted = (event: SubagentSessionDeletedEvent) => Promise<void>
+
 const MAX_TASK_REMOVAL_RESCHEDULES = 6
 const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 100
 const PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS = 5_000
@@ -225,6 +231,7 @@ export interface BackgroundManagerConfig {
   config?: BackgroundTaskConfig
   tmuxConfig?: TmuxConfig
   onSubagentSessionCreated?: OnSubagentSessionCreated
+  onSubagentSessionDeleted?: OnSubagentSessionDeleted
   onShutdown?: () => void | Promise<void>
   enableParentSessionNotifications?: boolean
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
@@ -248,6 +255,7 @@ export class BackgroundManager {
   private config?: BackgroundTaskConfig
   private tmuxEnabled: boolean
   private onSubagentSessionCreated?: OnSubagentSessionCreated
+  private onSubagentSessionDeleted?: OnSubagentSessionDeleted
   private onShutdown?: () => void | Promise<void>
 
   private queuesByKey: Map<string, QueueItem[]> = new Map()
@@ -283,6 +291,7 @@ export class BackgroundManager {
     this.config = options.config
     this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false
     this.onSubagentSessionCreated = options?.onSubagentSessionCreated
+    this.onSubagentSessionDeleted = options?.onSubagentSessionDeleted
     this.onShutdown = options?.onShutdown
     this.rootDescendantCounts = new Map()
     this.preStartDescendantReservations = new Set()
@@ -2479,6 +2488,13 @@ The task was re-queued on a fallback model after a retryable failure.
     if (task.sessionId) {
       // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT)
       await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
+
+      // @allow Notify tmux to close the pane immediately. client.session.abort() does not
+      // reliably emit session.deleted, so the polling fallback (60-min SESSION_TIMEOUT_MS)
+      // leaves panes orphaned for too long. See #4773.
+      await this.onSubagentSessionDeleted?.({ sessionID: task.sessionId }).catch((error) => {
+        log("[background-agent] onSubagentSessionDeleted callback failed:", { taskId: task.id, sessionID: task.sessionId, error: String(error) })
+      })
 
       clearDelegatedChildSessionBootstrap(task.sessionId)
       SessionCategoryRegistry.remove(task.sessionId)


### PR DESCRIPTION
## Bug

Tmux subagent panes stay open for ~60 minutes after background task completion instead of closing within seconds.

## Root Cause

`BackgroundManager.tryCompleteTask()` aborts the subagent session via `client.session.abort()`, but OpenCode does not reliably emit a `session.deleted` event for aborted sessions. The `TmuxPollingManager` only triggers pane cleanup for sessions with `status === "idle"` — not for "stopped"/"cancelled" terminal states. Result: orphaned panes accumulate until `SESSION_TIMEOUT_MS` (60 min) elapses.

## Fix

Added an explicit `onSubagentSessionDeleted` callback from `BackgroundManager` → `TmuxSessionManager`, mirroring the existing `onSubagentSessionCreated` pattern. When `tryCompleteTask()` completes a task, after aborting the session, it now directly notifies `TmuxSessionManager.onSessionDeleted()` to close the pane immediately.

**No double-close risk**: if OpenCode's `session.deleted` eventually arrives, `onSessionDeleted` checks `this.sessions.get(sessionID)` and returns early since our callback already removed the tracked session.

**3 files changed, +31/-1:**

| File | Change |
|------|--------|
| `src/features/background-agent/manager.ts` | +14: Types (`SubagentSessionDeletedEvent`, `OnSubagentSessionDeleted`), config field, private field, callback call in `tryCompleteTask()` |
| `src/features/background-agent/index.ts` | +1: Export new types |
| `src/create-managers.ts` | +13: Wire callback → `tmuxSessionManager.onSessionDeleted()` |

Fixes #4773

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close tmux subagent panes immediately when a background task completes by directly notifying tmux on session abort. Prevents panes lingering ~60 minutes when OpenCode misses the `session.deleted` event. Fixes #4773.

- **Bug Fixes**
  - Added `onSubagentSessionDeleted` in `BackgroundManager` and fire it right after `abortSessionWithLogging()` in `tryCompleteTask()`.
  - Wired the callback in `create-managers` to `tmuxSessionManager.onSessionDeleted()`; exported new types from `features/background-agent/index.ts`.
  - Idempotent cleanup: if a later `session.deleted` arrives, `onSessionDeleted` no-ops if already removed.
  - Added a unit test to verify the deleted callback fires on task completion.

<sup>Written for commit 35089e0de8a1d37c4706b653539a6c22fe6fff23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

