### PR TITLE
fix(skill-mcp): harden cleanup error header redaction

### DIFF
--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -272,7 +272,7 @@ describe("createHttpClient cleanup failures", () => {
     configureNextClient = (client) => {
       client.connect.mockImplementation(async () => {
         throw new Error(
-          '{"headers":{"X-API-Key":"tiny","x-auth-token":"mini"},"detail":"api-key=short"} X-API-Key: "small"; api-key="brief"',
+          '{"headers":{"X-API-Key":"tiny","x-auth-token":"mini"},"detail":"api-key=short"} X-API-Key: "small"; api-key="brief"; {\'X-API-Key\':\'little\', \'x-auth-token\':\'tokenlet\'}',
         )
       })
     }
@@ -290,7 +290,9 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).toContain('"x-auth-token":"[REDACTED]"')
     expect(message).toContain('"detail":"api-key=[REDACTED]"')
     expect(message).toContain('X-API-Key: "[REDACTED]"; api-key="[REDACTED]"')
-    expect(message).not.toMatch(/tiny|mini|api-key=short|small|brief/)
+    expect(message).toContain("'X-API-Key':'[REDACTED]'")
+    expect(message).toContain("'x-auth-token':'[REDACTED]'")
+    expect(message).not.toMatch(/tiny|mini|api-key=short|small|brief|little|tokenlet/)
   })
 
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -263,6 +263,35 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).not.toMatch(/short-secret|Bearer short/)
   })
 
+  it("#given HTTP connect failure includes short sensitive header secrets #when creating the client #then header values are redacted by key", async () => {
+    const state = createState()
+    const info = createInfo()
+    const clientKey = createClientKey(info)
+    const config = createConfig()
+
+    configureNextClient = (client) => {
+      client.connect.mockImplementation(async () => {
+        throw new Error(
+          '{"headers":{"X-API-Key":"tiny","x-auth-token":"mini"},"detail":"api-key=short"}',
+        )
+      })
+    }
+
+    let thrown: unknown
+    try {
+      await createHttpClient({ state, clientKey, info, config })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    const message = thrown instanceof Error ? thrown.message : ""
+    expect(message).toContain('"X-API-Key":"[REDACTED]"')
+    expect(message).toContain('"x-auth-token":"[REDACTED]"')
+    expect(message).toContain("api-key=[REDACTED]")
+    expect(message).not.toMatch(/tiny|mini|api-key=short/)
+  })
+
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {
     const state = createState()
     const info = createInfo()

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -272,7 +272,7 @@ describe("createHttpClient cleanup failures", () => {
     configureNextClient = (client) => {
       client.connect.mockImplementation(async () => {
         throw new Error(
-          '{"headers":{"X-API-Key":"tiny","x-auth-token":"mini"},"detail":"api-key=short"}',
+          '{"headers":{"X-API-Key":"tiny","x-auth-token":"mini"},"detail":"api-key=short"} X-API-Key: "small"; api-key="brief"',
         )
       })
     }
@@ -289,7 +289,8 @@ describe("createHttpClient cleanup failures", () => {
     expect(message).toContain('"X-API-Key":"[REDACTED]"')
     expect(message).toContain('"x-auth-token":"[REDACTED]"')
     expect(message).toContain('"detail":"api-key=[REDACTED]"')
-    expect(message).not.toMatch(/tiny|mini|api-key=short/)
+    expect(message).toContain('X-API-Key: "[REDACTED]"; api-key="[REDACTED]"')
+    expect(message).not.toMatch(/tiny|mini|api-key=short|small|brief/)
   })
 
   it("#given shutdown completes during HTTP connect and cleanup rejects #when creating the client #then the shutdown error is preserved", async () => {

--- a/src/features/skill-mcp-manager/http-client.test.ts
+++ b/src/features/skill-mcp-manager/http-client.test.ts
@@ -288,7 +288,7 @@ describe("createHttpClient cleanup failures", () => {
     const message = thrown instanceof Error ? thrown.message : ""
     expect(message).toContain('"X-API-Key":"[REDACTED]"')
     expect(message).toContain('"x-auth-token":"[REDACTED]"')
-    expect(message).toContain("api-key=[REDACTED]")
+    expect(message).toContain('"detail":"api-key=[REDACTED]"')
     expect(message).not.toMatch(/tiny|mini|api-key=short/)
   })
 

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -58,10 +58,11 @@ function redactUrl(urlStr: string): string {
 }
 
 function redactCleanupErrorMessage(message: string): string {
+  const sensitiveHeaderKey = "(?:authorization|x-api-key|api-key|x-auth-token|auth-token|x-access-token|access-token)"
   const messageWithRedactedAuthorization = message
-    .replace(/("authorization"\s*:\s*")([^"]*)(")/gi, "$1[REDACTED]$3")
-    .replace(/(\bauthorization\s*:\s*)([^\n,;}]*)/gi, "$1[REDACTED]")
-    .replace(/(\bauthorization\s*=\s*)([^\n,;}]*)/gi, "$1[REDACTED]")
+    .replace(new RegExp(`("${sensitiveHeaderKey}"\\s*:\\s*")([^"]*)(")`, "gi"), "$1[REDACTED]$3")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\n,;}]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\n,;}]*)`, "gi"), "$1[REDACTED]")
   const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -61,12 +61,14 @@ function redactCleanupErrorMessage(message: string): string {
   const sensitiveHeaderKey = "(?:authorization|x-api-key|api-key|x-auth-token|auth-token|x-access-token|access-token)"
   const messageWithRedactedAuthorization = message
     .replace(new RegExp(`("${sensitiveHeaderKey}"\\s*:\\s*")([^"]*)(")`, "gi"), "$1[REDACTED]$3")
+    .replace(new RegExp(`('${sensitiveHeaderKey}'\\s*:\\s*')([^']*)(')`, "gi"), "$1[REDACTED]$3")
     .replace(
       new RegExp(`(\\b${sensitiveHeaderKey}\\s*[:=]\\s*\\\\?")((?:\\\\.|[^"\\\\])*)(\\\\?")`, "gi"),
       "$1[REDACTED]$3",
     )
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\s"\\n,;}][^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\s"\\n,;}][^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*[:=]\\s*')([^']*)(')`, "gi"), "$1[REDACTED]$3")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\s'"\\n,;}][^\\n,;}'"]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\s'"\\n,;}][^\\n,;}'"]*)`, "gi"), "$1[REDACTED]")
   const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -61,8 +61,8 @@ function redactCleanupErrorMessage(message: string): string {
   const sensitiveHeaderKey = "(?:authorization|x-api-key|api-key|x-auth-token|auth-token|x-access-token|access-token)"
   const messageWithRedactedAuthorization = message
     .replace(new RegExp(`("${sensitiveHeaderKey}"\\s*:\\s*")([^"]*)(")`, "gi"), "$1[REDACTED]$3")
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\n,;}]*)`, "gi"), "$1[REDACTED]")
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\n,;}]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
   const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }

--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -61,8 +61,12 @@ function redactCleanupErrorMessage(message: string): string {
   const sensitiveHeaderKey = "(?:authorization|x-api-key|api-key|x-auth-token|auth-token|x-access-token|access-token)"
   const messageWithRedactedAuthorization = message
     .replace(new RegExp(`("${sensitiveHeaderKey}"\\s*:\\s*")([^"]*)(")`, "gi"), "$1[REDACTED]$3")
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
-    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
+    .replace(
+      new RegExp(`(\\b${sensitiveHeaderKey}\\s*[:=]\\s*\\\\?")((?:\\\\.|[^"\\\\])*)(\\\\?")`, "gi"),
+      "$1[REDACTED]$3",
+    )
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*:\\s*)([^\\s"\\n,;}][^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
+    .replace(new RegExp(`(\\b${sensitiveHeaderKey}\\s*=\\s*)([^\\s"\\n,;}][^\\n,;}"]*)`, "gi"), "$1[REDACTED]")
   const messageWithRedactedSecrets = redactSensitiveData(messageWithRedactedAuthorization)
   return messageWithRedactedSecrets.replace(/https?:\/\/[^\s"'<>)}\]]+/g, (url) => redactUrl(url))
 }


### PR DESCRIPTION
## Summary
Follow-up to #4848. Extends cleanup error redaction to cover additional sensitive header patterns beyond `Authorization`.

### Changes
- Extend `redactCleanupErrorMessage()` to redact `X-API-Key`, `api-key`, `x-auth-token`, `auth-token`, `x-access-token`, `access-token` header values
- Handle JSON double-quoted, single-quoted, unquoted colon-style, and equals-style header value formats
- Add regression tests for all new patterns

### Testing
- `bun test src/features/skill-mcp-manager/http-client.test.ts` - 11 tests pass
- `bun run typecheck` - pass
- `bun run build` - pass
- Runtime smoke test - pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded cleanup error redaction in the Skill MCP HTTP client to cover more sensitive headers and formats. Prevents secrets from appearing in cleanup failure messages.

- **Bug Fixes**
  - Redacts values for `authorization`, `X-API-Key`/`api-key`, `x-auth-token`/`auth-token`, and `x-access-token`/`access-token`.
  - Supports JSON double-quoted, single-quoted, and unquoted colon/equals styles (including escaped quotes).
  - Adds regression tests for all new patterns.

<sup>Written for commit 0e144a07594012f9b73f0d103730120761935f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

