### PR TITLE
fix(openclaw): make reply listener fallbacks explicit

### DIFF
--- a/src/openclaw/__tests__/reply-listener.test.ts
+++ b/src/openclaw/__tests__/reply-listener.test.ts
@@ -8,6 +8,9 @@ import {
   createPendingReplyListenerState,
   markReplyListenerStopped,
   recordReplyListenerPoll,
+  readReplyListenerDaemonConfig,
+  readReplyListenerDaemonState,
+  readReplyListenerPid,
 } from "../reply-listener-state"
 import type { OpenClawConfig } from "../types"
 
@@ -560,6 +563,25 @@ describe("isDaemonRunning", () => {
     // then
     expect(result).toBe(false)
     expect(existsSync(pidFilePath)).toBe(false)
+  })
+})
+
+describe("reply-listener persisted state readers", () => {
+  test("#given malformed persisted daemon files #when reading state config and pid #then null fallbacks are returned", () => {
+    // given
+    writeFileSync(stateFilePath, "{")
+    writeFileSync(configFilePath, "{")
+    writeFileSync(pidFilePath, "not-a-pid")
+
+    // when
+    const state = readReplyListenerDaemonState()
+    const config = readReplyListenerDaemonConfig()
+    const pid = readReplyListenerPid()
+
+    // then
+    expect(state).toBeNull()
+    expect(config).toBeNull()
+    expect(pid).toBeNull()
   })
 })
 

--- a/src/openclaw/reply-listener-log.ts
+++ b/src/openclaw/reply-listener-log.ts
@@ -15,13 +15,19 @@ import {
 
 const MAX_REPLY_LISTENER_LOG_SIZE_BYTES = 1024 * 1024
 
+function ignoreReplyListenerLogError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export function writeSecureReplyListenerFile(filePath: string, content: string): void {
   ensureReplyListenerStateDir()
   writeFileSync(filePath, content, { mode: REPLY_LISTENER_SECURE_FILE_MODE })
 
   try {
     chmodSync(filePath, REPLY_LISTENER_SECURE_FILE_MODE)
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerLogError(error)
   }
 }
 
@@ -37,7 +43,8 @@ function rotateReplyListenerLogIfNeeded(logPath: string): void {
       unlinkSync(backupPath)
     }
     renameSync(logPath, backupPath)
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerLogError(error)
   }
 }
 
@@ -50,6 +57,7 @@ export function logReplyListenerMessage(message: string): void {
     appendFileSync(logFilePath, `[${timestamp}] ${message}\n`, {
       mode: REPLY_LISTENER_SECURE_FILE_MODE,
     })
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerLogError(error)
   }
 }

--- a/src/openclaw/reply-listener-process.ts
+++ b/src/openclaw/reply-listener-process.ts
@@ -36,6 +36,11 @@ const REPLY_LISTENER_DAEMON_ENV_ALLOWLIST = [
   "COMSPEC",
 ] as const
 
+function ignoreReplyListenerProcessProbeError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export function createReplyListenerDaemonEnv(extraEnv: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = {}
 
@@ -53,7 +58,8 @@ export function isReplyListenerProcessRunning(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerProcessProbeError(error)
     return false
   }
 }
@@ -72,7 +78,8 @@ export async function isReplyListenerDaemonProcess(pid: number): Promise<boolean
     const stdout = await new Response(processInfo.stdout).text()
     if (processInfo.exitCode !== 0) return false
     return stdout.includes(REPLY_LISTENER_DAEMON_IDENTITY_MARKER)
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerProcessProbeError(error)
     return false
   }
 }

--- a/src/openclaw/reply-listener-state.ts
+++ b/src/openclaw/reply-listener-state.ts
@@ -25,6 +25,11 @@ export interface ReplyListenerDaemonState {
   lastError?: string
 }
 
+function ignoreReplyListenerStateReadError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 function createDefaultReplyListenerState(): ReplyListenerDaemonState {
   return {
     isRunning: false,
@@ -96,7 +101,8 @@ export function readReplyListenerDaemonState(): ReplyListenerDaemonState | null 
     const stateFilePath = getReplyListenerStateFilePath()
     if (!existsSync(stateFilePath)) return null
     return normalizeReplyListenerState(JSON.parse(readFileSync(stateFilePath, "utf-8")))
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerStateReadError(error)
     return null
   }
 }
@@ -121,7 +127,8 @@ export function readReplyListenerDaemonConfig(): OpenClawConfig | null {
     const configFilePath = getReplyListenerConfigFilePath()
     if (!existsSync(configFilePath)) return null
     return JSON.parse(readFileSync(configFilePath, "utf-8")) as OpenClawConfig
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerStateReadError(error)
     return null
   }
 }
@@ -136,7 +143,8 @@ export function readReplyListenerPid(): number | null {
     if (!existsSync(pidFilePath)) return null
     const pid = Number.parseInt(readFileSync(pidFilePath, "utf-8").trim(), 10)
     return Number.isNaN(pid) ? null : pid
-  } catch {
+  } catch (error) {
+    ignoreReplyListenerStateReadError(error)
     return null
   }
 }

--- a/src/openclaw/reply-listener-telegram.ts
+++ b/src/openclaw/reply-listener-telegram.ts
@@ -22,6 +22,11 @@ function parseTelegramUpdatesResponse(body: unknown): TelegramUpdate[] {
   return Array.isArray(result) ? result : []
 }
 
+function ignoreTelegramAcknowledgementError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export async function pollTelegramReplies(
   config: OpenClawConfig,
   state: ReplyListenerDaemonState,
@@ -76,7 +81,8 @@ export async function pollTelegramReplies(
               reply_to_message_id: message.message_id,
             }),
           })
-        } catch {
+        } catch (error) {
+          ignoreTelegramAcknowledgementError(error)
         }
       } else {
         state.errors += 1


### PR DESCRIPTION
## Summary
- Replaces 9 empty catch blocks across `reply-listener-log`, `reply-listener-process`, `reply-listener-state`, and `reply-listener-telegram`.
- Preserves existing best-effort behavior for log writes/rotation, process probes, persisted state reads, and Telegram acknowledgement sends.
- Adds characterization coverage for malformed persisted reply-listener state/config/pid files.

## Manual QA
- `bun test src/openclaw/__tests__/reply-listener.test.ts src/openclaw/__tests__/reply-listener-discord.test.ts src/openclaw/__tests__/session-registry.test.ts src/openclaw/__tests__/dispatcher.test.ts src/openclaw/__tests__/tmux.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun` smoke for malformed reply-listener state/config/pid readers
- `git diff --check origin/dev`
- `rg -n "catch\s*\{" src/openclaw/reply-listener-*.ts` returned no matches

## Review
- Single GPT 5.5 xhigh review pass: no P0/P1 blocking correctness regressions found.
- P2/P3 note recorded, not fixed per owner directive: helpers rethrow non-Error thrown values, while platform FS/process/fetch/JSON failures normally throw Error-like values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make reply-listener error handling explicit and safer. Replace empty catch blocks with small helpers, return null on malformed persisted files, and keep best-effort behavior for logs, process probes, state reads, and Telegram acks.

- **Bug Fixes**
  - Replaced 9 empty catch blocks with ignore helpers that only swallow `Error` instances.
  - `readReplyListenerDaemonState`, `readReplyListenerDaemonConfig`, and `readReplyListenerPid` now return null on malformed files; tests added.
  - Log writes/rotation and Telegram acknowledgements fail soft; process checks return false on errors.

<sup>Written for commit b24027b84522d5327d4433d1739a8113a9d000f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

