### PR TITLE
fix(interactive-bash): make fallback catches explicit

### DIFF
--- a/src/tools/interactive-bash/tmux-path-resolver.ts
+++ b/src/tools/interactive-bash/tmux-path-resolver.ts
@@ -5,6 +5,11 @@ let tmuxPath: string | null = null
 let initPromise: Promise<string | null> | null = null
 let tmuxPathEnvironmentKey: "cmux" | "tmux" | null = null
 
+function ignoreTmuxPathResolutionError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 function getEnvironmentKey(): "cmux" | "tmux" {
   return isCmuxCompatEnvironment() ? "cmux" : "tmux"
 }
@@ -33,7 +38,8 @@ async function findCommandPath(command: string): Promise<string | null> {
     }
 
     return path
-  } catch {
+  } catch (error) {
+    ignoreTmuxPathResolutionError(error)
     return null
   }
 }
@@ -57,7 +63,8 @@ async function findVerifiedTmuxPath(): Promise<string | null> {
     }
 
     return path
-  } catch {
+  } catch (error) {
+    ignoreTmuxPathResolutionError(error)
     return null
   }
 }
@@ -109,6 +116,8 @@ export function resetTmuxPathCacheForTesting(): void {
 export function startBackgroundCheck(): void {
   if (!initPromise) {
     initPromise = getTmuxPath()
-    initPromise.catch(() => {})
+    initPromise.catch((error) => {
+      ignoreTmuxPathResolutionError(error)
+    })
   }
 }

--- a/src/tools/interactive-bash/tools.ts
+++ b/src/tools/interactive-bash/tools.ts
@@ -11,6 +11,11 @@ import { getCachedTmuxPath } from "./tmux-path-resolver"
 
 const GLOBAL_TMUX_OPTIONS_WITH_ARGS = new Set(["-L", "-S", "-f", "-c", "-T"])
 
+function ignoreInteractiveBashKillError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 function resolveTmuxExecutable(tmuxPath: string): string[] {
   if (!isCmuxCompatEnvironment()) {
     return [tmuxPath]
@@ -181,8 +186,11 @@ export async function executeInteractiveBash(args: InteractiveBashArgs): Promise
         try {
           proc.kill()
           // Fire-and-forget: wait for process exit in background to avoid zombies
-          void proc.exited.catch(() => {})
-        } catch {
+          void proc.exited.catch((error) => {
+            ignoreInteractiveBashKillError(error)
+          })
+        } catch (error) {
+          ignoreInteractiveBashKillError(error)
           // Ignore kill errors; we'll still reject with timeoutError below
         }
         reject(timeoutError)


### PR DESCRIPTION
## Summary
- replace interactive-bash empty catch paths with explicit ignore helpers
- preserve fallback behavior for normal Error values while rethrowing non-Error thrown values

## Manual QA
- `bun test src/tools/interactive-bash/tmux-path-resolver.test.ts src/tools/interactive-bash/tools.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- `rg -n "catch\\s*\\{|catch\\(\\(\\)\\s*=>\\s*\\{\\s*\\}\\)" src/tools/interactive-bash || true`
- `bun --print "import('./src/tools/interactive-bash/tools.ts').then(async ({ executeInteractiveBash }) => { const result = await executeInteractiveBash({ tmux_command: 'kill-server' }); console.log(result.includes(\"Error: 'kill-server' is prohibited\") ? 'surface-ok' : result); })"`

## Review
- GPT 5.5 xhigh review PASS (P0/P1 blockers only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make interactive-bash fallback catches explicit to avoid silently swallowing non-Error throws. Keeps existing fallback behavior while surfacing unexpected thrown values.

- **Bug Fixes**
  - Added `ignoreTmuxPathResolutionError` and `ignoreInteractiveBashKillError` helpers that ignore `Error` and rethrow non-Error values.
  - Updated `tmux-path-resolver` to use helpers in command/path checks and background init; returns null on expected failures.
  - Updated `executeInteractiveBash` to use helpers around `proc.kill()` and `proc.exited`, preserving timeout rejection behavior.

<sup>Written for commit f4c08d0c75ca156f0d6499cef1f80d5d14dc9def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

