### PR TITLE
fix(skill): make native skill fallback catches explicit

### DIFF
--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -25,6 +25,11 @@ import {
   mergeNativeSkills,
 } from "./native-skills"
 
+function ignoreNativeSkillsError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
   let cachedDescription: string | null = null
 
@@ -45,7 +50,8 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
       try {
         const nativeAll = await options.nativeSkills.all()
         mergeNativeSkills(allSkills, nativeAll)
-      } catch {
+      } catch (error) {
+        ignoreNativeSkillsError(error)
       }
     }
 
@@ -90,7 +96,8 @@ export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
         } else {
           mergeNativeSkillInfos(skillInfos, nativeAll)
         }
-      } catch {
+      } catch (error) {
+        ignoreNativeSkillsError(error)
       }
     }
 


### PR DESCRIPTION
## Summary
- replace skill tool nativeSkills empty catch blocks with an explicit fallback handler
- preserve existing behavior: normal native skill failures skip native skill enrichment
- rethrow non-Error thrown values instead of silently swallowing them

## Manual QA
- `bun install` (fresh worktree dependency links)
- `bun test src/tools/skill/tools.factory.test.ts src/tools/skill/async-description-refresh.test.ts src/tools/skill/zauc-mocks-skill-tools/tools.test.ts` (43 pass)
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- `rg -n "catch\\s*\\{|catch\\(\\(\\)\\s*=>\\s*\\{\\s*\\}\\)" src/tools/skill/tools.ts || true`
- direct smoke: throwing `nativeSkills.all()` still returns a usable skill description

## Review
- GPT review skipped per owner direction for trivial empty-catch cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace silent empty catches in native skill loading with an explicit fallback that skips enrichment on normal Errors and rethrows non-Error values. This keeps existing behavior while making failure handling explicit and safer.

<sup>Written for commit 6a751522e1006145780aca5793017cf31e225dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

