### PR TITLE
fix(atlas): make last-agent fallbacks explicit

### DIFF
--- a/src/hooks/atlas/session-last-agent.ts
+++ b/src/hooks/atlas/session-last-agent.ts
@@ -20,6 +20,11 @@ const defaultSessionLastAgentDeps: SessionLastAgentDeps = {
   isCompactionMessage,
 }
 
+function ignoreSessionLastAgentError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 type SessionMessagesClient = {
   session: {
     messages: (input: { path: { id: string } }) => Promise<unknown>
@@ -40,7 +45,8 @@ function getLastAgentFromMessageDir(messageDir: string): string | null {
             agent: parsed.agent,
             createdAt: typeof parsed.time?.created === "number" ? parsed.time.created : Number.NEGATIVE_INFINITY,
           }
-        } catch {
+        } catch (error) {
+          ignoreSessionLastAgentError(error)
           return null
         }
       })
@@ -57,7 +63,8 @@ function getLastAgentFromMessageDir(messageDir: string): string | null {
         return message.agent.toLowerCase()
       }
     }
-  } catch {
+  } catch (error) {
+    ignoreSessionLastAgentError(error)
     return null
   }
 
@@ -99,7 +106,8 @@ async function getLastAgentFromSessionMessages(
         return agent.toLowerCase()
       }
     }
-  } catch {
+  } catch (error) {
+    ignoreSessionLastAgentError(error)
     return null
   }
 
@@ -139,7 +147,8 @@ export async function getLastAgentFromSession(
             agent: parsed.agent,
             createdAt: typeof parsed.time?.created === "number" ? parsed.time.created : Number.NEGATIVE_INFINITY,
           }
-        } catch {
+        } catch (error) {
+          ignoreSessionLastAgentError(error)
           return null
         }
       })
@@ -156,7 +165,8 @@ export async function getLastAgentFromSession(
         return message.agent.toLowerCase()
       }
     }
-  } catch {
+  } catch (error) {
+    ignoreSessionLastAgentError(error)
     return null
   }
 


### PR DESCRIPTION
## Summary
- replace atlas session-last-agent empty catch blocks with explicit fallback handling
- preserve normal Error fallback behavior for unreadable/malformed message storage and session message lookup failures
- rethrow non-Error thrown values instead of silently swallowing them

## Manual QA
- `bun install` (fresh worktree dependency links)
- `bun test src/hooks/atlas/session-last-agent.json.test.ts src/hooks/atlas/session-last-agent.sqlite.test.ts` (6 pass)
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- `rg -n "catch\\s*\\{|catch\\(\\(\\)\\s*=>\\s*\\{\\s*\\}\\)" src/hooks/atlas/session-last-agent.ts || true`
- direct smoke: malformed JSON message is skipped while newest valid agent still resolves

## Review
- GPT review loop skipped per Batch 3 direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make last-agent resolution in Atlas fail-safe by adding explicit fallbacks and rethrowing non-Error exceptions. Prevents silent failures and keeps returning the newest valid agent when messages are malformed or unreadable.

- **Bug Fixes**
  - Replaced empty catch blocks in `session-last-agent` with explicit handling via `ignoreSessionLastAgentError`.
  - Preserve null fallback for standard Errors during parsing and lookups; rethrow non-Error thrown values to avoid swallowing unexpected issues.

<sup>Written for commit 73ccb154573e97f48943cbddb93667fad34c527c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

