### PR TITLE
fix(skill-mcp): make oauth fallbacks explicit

### DIFF
--- a/src/features/skill-mcp-manager/oauth-handler.ts
+++ b/src/features/skill-mcp-manager/oauth-handler.ts
@@ -5,6 +5,11 @@ import type { OAuthTokenData } from "../mcp-oauth/storage"
 import { isStepUpRequired, mergeScopes } from "../mcp-oauth/step-up"
 import type { OAuthProviderFactory, OAuthProviderLike } from "./types"
 
+function ignoreOAuthFallbackError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export function getOrCreateAuthProvider(
   authProviders: Map<string, OAuthProviderLike>,
   serverUrl: string,
@@ -48,21 +53,24 @@ export async function buildHttpRequestInit(
     if (!tokenData) {
       try {
         tokenData = await provider.login()
-      } catch {
+      } catch (error) {
+        ignoreOAuthFallbackError(error)
         tokenData = null
       }
     }
 
-      if (tokenData && isTokenExpired(tokenData)) {
+    if (tokenData && isTokenExpired(tokenData)) {
+      try {
+        const refreshToken = tokenData.refreshToken
+        tokenData = refreshToken
+          ? await withRefreshMutex(config.url, () => provider.refresh(refreshToken))
+          : await provider.login()
+      } catch (error) {
+        ignoreOAuthFallbackError(error)
         try {
-          const refreshToken = tokenData.refreshToken
-          tokenData = refreshToken
-            ? await withRefreshMutex(config.url, () => provider.refresh(refreshToken))
-            : await provider.login()
-        } catch {
-          try {
-            tokenData = await provider.login()
-        } catch {
+          tokenData = await provider.login()
+        } catch (error) {
+          ignoreOAuthFallbackError(error)
           tokenData = null
         }
       }
@@ -114,7 +122,8 @@ export async function handleStepUpIfNeeded(params: {
   try {
     await provider.login()
     return true
-  } catch {
+  } catch (error) {
+    ignoreOAuthFallbackError(error)
     return false
   }
 }
@@ -154,7 +163,8 @@ export async function handlePostRequestAuthError(params: {
     const refreshToken = tokenData.refreshToken
     await withRefreshMutex(config.url, () => provider.refresh(refreshToken))
     return true
-  } catch {
+  } catch (error) {
+    ignoreOAuthFallbackError(error)
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace skill MCP OAuth empty catch blocks with explicit fallback handling
- preserve normal Error fallback behavior for login, refresh, step-up, and post-request refresh failures
- keep OAuth errors unlogged while rethrowing non-Error thrown values

## Manual QA
- `bun install` (fresh worktree dependency links)
- `bun test src/features/skill-mcp-manager/oauth-handler.test.ts src/features/skill-mcp-manager/manager-oauth-retry.test.ts src/features/skill-mcp-manager/manager.test.ts` (44 pass)
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- `rg -n "catch\\s*\\{|catch\\(\\(\\)\\s*=>\\s*\\{\\s*\\}\\)" src/features/skill-mcp-manager/oauth-handler.ts || true`
- direct smoke: OAuth login failure still returns no request init instead of throwing

## Review
- GPT review loop skipped per Batch 3 direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth fallbacks explicit in the Skill MCP auth flow by replacing empty catch blocks and rethrowing non-Error values. Keeps the existing behavior of returning unauthenticated requests on OAuth failure without logging.

- **Bug Fixes**
  - Introduced `ignoreOAuthFallbackError` to rethrow non-Error thrown values while allowing `Error` fallbacks.
  - Replaced empty catches in login, refresh, step-up, and post-request refresh with explicit null/false fallbacks.
  - Preserves silent handling for OAuth errors; prevents swallowing unexpected non-Error exceptions.

<sup>Written for commit bfbb2b73e2fa36e1cd501ad74bfe1a3791426e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

