### PR TITLE
fix(claude-tasks): make storage fallbacks explicit

### DIFF
--- a/src/features/claude-tasks/storage.ts
+++ b/src/features/claude-tasks/storage.ts
@@ -5,6 +5,11 @@ import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { z } from "zod"
 import type { OhMyOpenCodeConfig } from "../../config/schema"
 
+function ignoreClaudeTaskStorageError(error: unknown): void {
+  if (error instanceof Error) return
+  throw error
+}
+
 export function getTaskDir(config: Partial<OhMyOpenCodeConfig> = {}): string {
   const tasksConfig = config.sisyphus?.tasks
   const storagePath = tasksConfig?.storage_path
@@ -56,7 +61,8 @@ export function readJsonSafe<T>(filePath: string, schema: z.ZodType<T>): T | nul
     }
 
     return result.data
-  } catch {
+  } catch (error) {
+    ignoreClaudeTaskStorageError(error)
     return null
   }
 }
@@ -75,7 +81,8 @@ export function writeJsonAtomic(filePath: string, data: unknown): void {
       if (existsSync(tempPath)) {
         unlinkSync(tempPath)
       }
-    } catch {
+    } catch (cleanupError) {
+      ignoreClaudeTaskStorageError(cleanupError)
       // Ignore cleanup errors
     }
     throw error
@@ -113,7 +120,8 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
       const lockData = JSON.parse(lockContent)
       const lockAge = Date.now() - lockData.timestamp
       return lockAge > STALE_LOCK_THRESHOLD_MS
-    } catch {
+    } catch (error) {
+      ignoreClaudeTaskStorageError(error)
       return true
     }
   }
@@ -137,7 +145,8 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
   if (!acquired && isStale()) {
     try {
       unlinkSync(lockPath)
-    } catch {
+    } catch (error) {
+      ignoreClaudeTaskStorageError(error)
       // Ignore cleanup errors
     }
     acquired = tryAcquire()
@@ -161,7 +170,8 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
         const lockData = JSON.parse(lockContent)
         if (lockData.id !== lockId) return
         unlinkSync(lockPath)
-      } catch {
+      } catch (error) {
+        ignoreClaudeTaskStorageError(error)
         // Ignore cleanup errors
       }
     },


### PR DESCRIPTION
## Summary
- replace claude task storage empty catch blocks with explicit fallback handling
- preserve normal Error fallback behavior for invalid JSON, stale lock parsing, temp cleanup, lock cleanup, and release cleanup
- rethrow non-Error thrown values instead of silently swallowing them

## Manual QA
- `bun install` (fresh worktree dependency links)
- `bun test src/features/claude-tasks/storage.test.ts` (29 pass)
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- `rg -n "catch\\s*\\{|catch\\(\\(\\)\\s*=>\\s*\\{\\s*\\}\\)" src/features/claude-tasks/storage.ts || true`
- direct smoke: malformed task JSON still returns `null` from `readJsonSafe`

## Review
- GPT review loop skipped per Batch 3 direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Claude tasks storage fallbacks explicit and prevents silently swallowing non-Error throws. Improves reliability for JSON parsing, lock handling, and cleanup paths.

- **Bug Fixes**
  - Replaced empty catch blocks with explicit fallbacks using a shared helper that ignores normal Errors and rethrows non-Error values.
  - `readJsonSafe` still returns null for malformed JSON.
  - Lock and cleanup operations remain resilient: expected Errors are ignored; unexpected throw types are surfaced.

<sup>Written for commit 1b86cef30ea6e8442fcdbe4deae51a4392665423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

