### PR TITLE
fix(openclaw): make tmux fallbacks explicit

### DIFF
--- a/src/openclaw/__tests__/tmux.test.ts
+++ b/src/openclaw/__tests__/tmux.test.ts
@@ -107,6 +107,19 @@ describe("openclaw tmux helpers", () => {
     expect(runTmuxCommandMock).toHaveBeenCalledWith("/mock/tmux", ["display-message", "-p", "#S"])
   })
 
+  test("getTmuxSessionName returns null when tmux command lookup throws Error", async () => {
+    // given
+    runTmuxCommandMock.mockImplementation(async () => {
+      throw new Error("tmux unavailable")
+    })
+
+    // when
+    const result = await tmuxModule.getTmuxSessionName()
+
+    // then
+    expect(result).toBeNull()
+  })
+
   test("captureTmuxPane delegates pane capture through runTmuxCommand", async () => {
     // given
     runTmuxCommandMock.mockResolvedValue({
@@ -123,6 +136,27 @@ describe("openclaw tmux helpers", () => {
     // then
     expect(result).toBe("pane output")
     expect(runTmuxCommandMock).toHaveBeenCalledWith("/mock/tmux", ["capture-pane", "-p", "-t", "%42", "-S", "-30"])
+  })
+
+  test("captureTmuxPane rethrows non-Error command failures", async () => {
+    // given
+    const thrownValue = { reason: "unexpected throw shape" }
+    runTmuxCommandMock.mockImplementation(async () => {
+      throw thrownValue
+    })
+
+    // when
+    const result = tmuxModule.captureTmuxPane("%42", 30)
+
+    // then
+    await result.then(
+      () => {
+        throw new Error("Expected captureTmuxPane to reject")
+      },
+      (error: unknown) => {
+        expect(error).toBe(thrownValue)
+      },
+    )
   })
 
   test("sendToPane delegates literal text and Enter through runTmuxCommand", async () => {

--- a/src/openclaw/tmux.ts
+++ b/src/openclaw/tmux.ts
@@ -22,7 +22,8 @@ export async function getTmuxSessionName(): Promise<string | null> {
     const result = await runOpenClawTmuxCommand(["display-message", "-p", "#S"])
     if (!result?.success) return null
     return result.output.trim() || null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return null
   }
 }
@@ -32,7 +33,8 @@ export async function captureTmuxPane(paneId: string, lines = 15): Promise<strin
     const result = await runOpenClawTmuxCommand(["capture-pane", "-p", "-t", paneId, "-S", `-${lines}`])
     if (!result?.success) return null
     return result.output.trim() || null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return null
   }
 }
@@ -46,7 +48,8 @@ export async function sendToPane(paneId: string, text: string, confirm = true): 
 
     const enterResult = await runOpenClawTmuxCommand(["send-keys", "-t", paneId, "Enter"])
     return enterResult?.success ?? false
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return false
   }
 }
@@ -55,7 +58,8 @@ export async function isTmuxAvailable(): Promise<boolean> {
   try {
     const result = await runOpenClawTmuxCommand(["-V"])
     return result?.success ?? false
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace 4 empty catches in `src/openclaw/tmux.ts` with explicit `Error` fallback handling
- rethrow non-`Error` command failures instead of silently swallowing unexpected throw shapes
- add focused characterization tests for the preserved `Error` fallback and non-`Error` propagation contract

## Manual QA
- `bun test src/openclaw/__tests__/tmux.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/openclaw/tmux.ts src/openclaw/__tests__/tmux.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- empty-catch scan on changed files
- direct smoke: imported `src/openclaw/tmux.ts`, checked pane confidence, and verified invalid pane capture returns `null`

## Notes
- #3036 also touches `src/openclaw/tmux.ts` for terminal probe stripping, but this PR only changes catch handling and currently has no merge conflict with `origin/dev`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tmux helpers fail safely by replacing empty catch blocks with explicit fallbacks and rethrowing non-Error failures. This prevents silent failures and keeps existing null/false behavior on real tmux errors.

- **Bug Fixes**
  - Replaced four empty catches in `src/openclaw/tmux.ts` with explicit Error fallbacks (return null/false).
  - Rethrow non-Error exceptions from tmux commands to avoid masking unexpected issues.
  - Added focused tests to confirm Error fallbacks and non-Error propagation.

<sup>Written for commit 7cb29870c37e5b360efb6a25e9ad8d330ef6a94b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

