### PR TITLE
fix(session-recovery): make error detection fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/detect-error-type.test.ts
+++ b/src/hooks/session-recovery/detect-error-type.test.ts
@@ -3,6 +3,22 @@ import { describe, expect, it } from "bun:test"
 import { detectErrorType, extractMessageIndex, extractUnavailableToolName } from "./detect-error-type"
 
 describe("detectErrorType", () => {
+  it("#given an error object throws a non-Error while reading data #when detecting #then rethrows", () => {
+    //#given
+    const thrownValue = { reason: "unexpected throw shape" }
+    class MalformedError {
+      get data(): string {
+        throw thrownValue
+      }
+    }
+
+    //#when
+    const run = () => detectErrorType(new MalformedError())
+
+    //#then
+    expect(run).toThrow()
+  })
+
   it("#given a tool_use/tool_result error #when detecting #then returns tool_result_missing", () => {
     //#given
     const error = { message: "tool_use block must be followed by tool_result" }

--- a/src/hooks/session-recovery/detect-error-type.ts
+++ b/src/hooks/session-recovery/detect-error-type.ts
@@ -30,7 +30,8 @@ function getErrorMessage(error: unknown): string {
 
   try {
     return JSON.stringify(error).toLowerCase()
-  } catch {
+  } catch (stringifyError) {
+    if (!(stringifyError instanceof Error)) throw stringifyError
     return ""
   }
 }
@@ -40,7 +41,8 @@ export function extractMessageIndex(error: unknown): number | null {
     const message = getErrorMessage(error)
     const match = message.match(/messages\.(\d+)/)
     return match ? parseInt(match[1], 10) : null
-  } catch {
+  } catch (extractionError) {
+    if (!(extractionError instanceof Error)) throw extractionError
     return null
   }
 }
@@ -50,7 +52,8 @@ export function extractUnavailableToolName(error: unknown): string | null {
     const message = getErrorMessage(error)
     const match = message.match(/(?:unavailable tool|no such tool)[:\s'"]+([^'".\s]+)/)
     return match ? match[1] : null
-  } catch {
+  } catch (extractionError) {
+    if (!(extractionError instanceof Error)) throw extractionError
     return null
   }
 }
@@ -101,7 +104,8 @@ export function detectErrorType(error: unknown): RecoveryErrorType {
     }
 
     return null
-  } catch {
+  } catch (detectionError) {
+    if (!(detectionError instanceof Error)) throw detectionError
     return null
   }
 }


### PR DESCRIPTION
## Summary
- replace 4 bare fallback catches in `detect-error-type.ts` with explicit `Error` narrowing
- preserve existing `Error` fallback behavior for circular/malformed errors
- add a focused characterization that non-`Error` throws from malformed error objects propagate instead of being silently swallowed

## Manual QA
- `bun test src/hooks/session-recovery/detect-error-type.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/detect-error-type.ts src/hooks/session-recovery/detect-error-type.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- direct smoke: imported `detect-error-type.ts`, checked tool-result detection, message-index extraction, unavailable-tool extraction, and circular fallback

## Notes
- Checked related PR overlap before editing. Open runtime-fallback PR #1777 does not patch this file. Older session-recovery PRs touching this file are already merged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error detection in session recovery safer by using explicit Error checks. Non-Error throws now rethrow instead of being swallowed, while existing Error fallbacks remain.

- **Bug Fixes**
  - Replaced 4 bare catches in `detect-error-type.ts` with explicit `Error` narrowing so non-Error exceptions propagate.
  - Added a focused test that verifies rethrowing when a malformed error object throws during read.

<sup>Written for commit d9d5abada31f0e874ca3603645ead017ec0a4537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

