### PR TITLE
fix(mcp-oauth): make storage fallbacks explicit

### DIFF
--- a/src/features/mcp-oauth/storage.ts
+++ b/src/features/mcp-oauth/storage.ts
@@ -27,7 +27,8 @@ function normalizeHost(serverHost: string): string {
   if (host.includes("://")) {
     try {
       host = new URL(host).hostname
-    } catch {
+    } catch (urlError) {
+      if (!(urlError instanceof Error)) throw urlError
       host = host.split("/")[0]
     }
   } else {
@@ -68,7 +69,8 @@ function readStore(): TokenStore | null {
   try {
     const content = readFileSync(filePath, "utf-8")
     return JSON.parse(content) as TokenStore
-  } catch {
+  } catch (readError) {
+    if (!(readError instanceof Error)) throw readError
     return null
   }
 }
@@ -87,7 +89,8 @@ function writeStore(store: TokenStore): boolean {
     chmodSync(tempPath, 0o600)
     renameSync(tempPath, filePath)
     return true
-  } catch {
+  } catch (writeError) {
+    if (!(writeError instanceof Error)) throw writeError
     return false
   }
 }
@@ -125,7 +128,8 @@ export function deleteToken(serverHost: string, resource: string): boolean {
         unlinkSync(filePath)
       }
       return true
-    } catch {
+    } catch (deleteError) {
+      if (!(deleteError instanceof Error)) throw deleteError
       return false
     }
   }


### PR DESCRIPTION
## Summary
- replace 4 bare catches in `src/features/mcp-oauth/storage.ts` with explicit `Error` fallback handling
- preserve existing URL/storage fallback behavior for normal Error failures
- keep non-Error throws from being silently swallowed

## Manual QA
- `bun test src/features/mcp-oauth/storage.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/mcp-oauth/storage.ts src/features/mcp-oauth/storage.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`
- direct smoke: temp `OPENCODE_CONFIG_DIR`, save/load/list/delete token via `storage.ts`

## Notes
- Existing storage tests already cover missing-file and invalid-JSON fallback behavior, so this is a production-only diff.
- Duplicate/overlap search found no open PR touching this file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes error handling in `src/features/mcp-oauth/storage.ts` explicit to avoid swallowing unexpected exceptions. Preserves existing URL and storage fallbacks while rethrowing non-Error throws for better debuggability.

- **Bug Fixes**
  - Replaced 4 bare catches with `instanceof Error` checks.
  - Kept existing fallbacks on expected errors; rethrow non-Error values.

<sup>Written for commit 3c49e694afdeb61c1a9f112b9794d73498b44323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

