### PR TITLE
fix(hooks): redirect to registered agent name, not bare config key (fixes "Agent not found: sisyphus")

### DIFF
--- a/src/hooks/no-hephaestus-non-gpt/hook.ts
+++ b/src/hooks/no-hephaestus-non-gpt/hook.ts
@@ -6,7 +6,7 @@ import {
   updateSessionAgent,
 } from "../../features/claude-code-session-state"
 import { log } from "../../shared"
-import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { getAgentConfigKey, normalizeAgentForPrompt } from "../../shared/agent-display-names"
 
 const TOAST_TITLE = "NEVER Use Hephaestus with Non-GPT"
 const TOAST_MESSAGE = [
@@ -56,11 +56,20 @@ export function createNoHephaestusNonGptHook(
         if (allowNonGptModel) {
           return
         }
-        input.agent = resolveRegisteredAgentName("sisyphus") ?? "sisyphus"
+        // Prefer the live registered name; fall back to the static display name.
+        // resolveRegisteredAgentName returns the bare config key when the registry
+        // has not resolved it yet, which would later fail with "Agent not found"
+        // once stored on the session (#4140).
+        const registeredSisyphus = resolveRegisteredAgentName("sisyphus")
+        const sisyphusAgent = registeredSisyphus !== undefined
+          && registeredSisyphus !== getAgentConfigKey("sisyphus")
+          ? registeredSisyphus
+          : normalizeAgentForPrompt("sisyphus") ?? "sisyphus"
+        input.agent = sisyphusAgent
         if (output?.message) {
-          output.message.agent = resolveRegisteredAgentName("sisyphus") ?? "sisyphus"
+          output.message.agent = sisyphusAgent
         }
-        updateSessionAgent(input.sessionID, "sisyphus")
+        updateSessionAgent(input.sessionID, sisyphusAgent)
       }
     },
   }

--- a/src/hooks/no-hephaestus-non-gpt/index.test.ts
+++ b/src/hooks/no-hephaestus-non-gpt/index.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, spyOn, test } from "bun:test"
-import { _resetForTesting, updateSessionAgent } from "../../features/claude-code-session-state"
+import { _resetForTesting, getSessionAgent, updateSessionAgent } from "../../features/claude-code-session-state"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { createNoHephaestusNonGptHook } from "./index"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
@@ -41,8 +41,8 @@ describe("no-hephaestus-non-gpt hook", () => {
 
     // then - toast is shown and agent is switched to sisyphus
     expect(showToast).toHaveBeenCalledTimes(2)
-    expect(output1.message.agent).toBe("sisyphus")
-    expect(output2.message.agent).toBe("sisyphus")
+    expect(output1.message.agent).toBe(SISYPHUS_DISPLAY)
+    expect(output2.message.agent).toBe(SISYPHUS_DISPLAY)
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({
       body: {
         title: "NEVER Use Hephaestus with Non-GPT",
@@ -142,6 +142,27 @@ describe("no-hephaestus-non-gpt hook", () => {
 
     // then - toast shown via session-agent fallback, switched to sisyphus
     expect(showToast).toHaveBeenCalledTimes(1)
-    expect(output.message.agent).toBe("sisyphus")
+    expect(output.message.agent).toBe(SISYPHUS_DISPLAY)
   })
+
+  test("stores the registered display name on the session, not the config key (regression #4140)", async () => {
+    // given - a fresh session using Hephaestus on a non-GPT model
+    _resetForTesting()
+    const showToast = spyOn({ fn: async (_input: unknown) => ({}) }, "fn")
+    const hook = createNoHephaestusNonGptHook(unsafeTestValue({
+      client: { tui: { showToast } },
+    }))
+
+    // when - the hook redirects to Sisyphus
+    await hook["chat.message"]?.({
+      sessionID: "ses_regression",
+      agent: HEPHAESTUS_DISPLAY,
+      model: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+    }, createOutput())
+
+    // then - session stores the REGISTERED name so later prompts resolve
+    // (raw "sisyphus" would later fail with "Agent not found")
+    expect(getSessionAgent("ses_regression")).toBe(SISYPHUS_DISPLAY)
+  })
+
 })

--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -6,7 +6,7 @@ import {
   updateSessionAgent,
 } from "../../features/claude-code-session-state"
 import { AGENT_MODEL_REQUIREMENTS, log } from "../../shared"
-import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { getAgentConfigKey, normalizeAgentForPrompt } from "../../shared/agent-display-names"
 
 const TOAST_TITLE = "NEVER Use Sisyphus with GPT"
 const TOAST_MESSAGE = [
@@ -71,11 +71,20 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
 
       if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
         showToast(ctx, input.sessionID)
-        input.agent = resolveRegisteredAgentName("hephaestus") ?? "hephaestus"
+        // Prefer the live registered name; fall back to the static display name.
+        // resolveRegisteredAgentName returns the bare config key when the registry
+        // has not resolved it yet, which would later fail with "Agent not found"
+        // once stored on the session (#4140).
+        const registeredHephaestus = resolveRegisteredAgentName("hephaestus")
+        const hephaestusAgent = registeredHephaestus !== undefined
+          && registeredHephaestus !== getAgentConfigKey("hephaestus")
+          ? registeredHephaestus
+          : normalizeAgentForPrompt("hephaestus") ?? "hephaestus"
+        input.agent = hephaestusAgent
         if (output?.message) {
-          output.message.agent = resolveRegisteredAgentName("hephaestus") ?? "hephaestus"
+          output.message.agent = hephaestusAgent
         }
-        updateSessionAgent(input.sessionID, "hephaestus")
+        updateSessionAgent(input.sessionID, hephaestusAgent)
       }
     },
   }

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, spyOn, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
-import { _resetForTesting, updateSessionAgent } from "../../features/claude-code-session-state"
+import { _resetForTesting, getSessionAgent, updateSessionAgent } from "../../features/claude-code-session-state"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { createNoSisyphusGptHook } from "./index"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
@@ -30,7 +30,7 @@ function createHookContext(showToast: (input: unknown) => Promise<unknown>): Plu
 
 describe("no-sisyphus-gpt hook", () => {
   test("shows toast on every chat.message when sisyphus uses gpt model", async () => {
-    // given - sisyphus (display name) with gpt model
+    // given - sisyphus (display name) with a non-native gpt model
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
     const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
@@ -41,18 +41,18 @@ describe("no-sisyphus-gpt hook", () => {
     await hook["chat.message"]?.({
       sessionID: "ses_1",
       agent: SISYPHUS_DISPLAY,
-      model: { providerID: "openai", modelID: "gpt-5.5" },
+      model: { providerID: "openai", modelID: "gpt-4o" },
     }, output1)
     await hook["chat.message"]?.({
       sessionID: "ses_1",
       agent: SISYPHUS_DISPLAY,
-      model: { providerID: "openai", modelID: "gpt-5.5" },
+      model: { providerID: "openai", modelID: "gpt-4o" },
     }, output2)
 
     // then - toast is shown for every message
     expect(showToast).toHaveBeenCalledTimes(2)
-    expect(output1.message.agent).toBe("hephaestus")
-    expect(output2.message.agent).toBe("hephaestus")
+    expect(output1.message.agent).toBe(HEPHAESTUS_DISPLAY)
+    expect(output2.message.agent).toBe(HEPHAESTUS_DISPLAY)
     const firstToastCall = (showToast.mock.calls as Array<Array<unknown>>)[0]?.[0]
     expect(firstToastCall).toMatchObject({
       body: {
@@ -196,6 +196,25 @@ describe("no-sisyphus-gpt hook", () => {
 
     // then - toast shown via session-agent fallback
     expect(showToast).toHaveBeenCalledTimes(1)
-    expect(output.message.agent).toBe("hephaestus")
+    expect(output.message.agent).toBe(HEPHAESTUS_DISPLAY)
   })
+
+  test("stores the registered display name on the session, not the config key (regression #4140)", async () => {
+    // given - a fresh session using Sisyphus on a non-native GPT model
+    _resetForTesting()
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    // when - the hook redirects to Hephaestus
+    await hook["chat.message"]?.({
+      sessionID: "ses_regression",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-4o" },
+    }, createOutput())
+
+    // then - session stores the REGISTERED name so later prompts resolve
+    // (raw "hephaestus" would later fail with "Agent not found")
+    expect(getSessionAgent("ses_regression")).toBe(HEPHAESTUS_DISPLAY)
+  })
+
 })


### PR DESCRIPTION
## Problem

`createNoSisyphusGptHook` and `createNoHephaestusNonGptHook` redirect to a fallback agent by writing the **bare config key** (`"hephaestus"` / `"sisyphus"`) to `input.agent`, `output.message.agent`, and the session via `updateSessionAgent()`:

```ts
input.agent = resolveRegisteredAgentName("sisyphus") ?? "sisyphus"
...
updateSessionAgent(input.sessionID, "sisyphus")
```

`resolveRegisteredAgentName()` returns the **bare config key** (not `undefined`) when the live agent registry hasn't resolved the agent yet, so the `?? "<key>"` fallback never engages. The raw key then gets stamped onto the session, and **every subsequent prompt fails**:

```
ERROR ... Agent not found: "sisyphus". Available agents: Sisyphus - ultraworker, ...
prompt_async failed
```

This hangs the session and any loop continuation (`/ulw-loop`, `/ralph-loop`, todo-continuation). It's especially easy to hit when Sisyphus is routed to a GPT model, or when an agent falls back to a non-GPT model (e.g. an Atlas → Claude fallback triggers the Hephaestus-non-GPT path). Refs #4140, #2882, #2858.

## Fix

Resolve the redirect target the same way `todo-continuation-enforcer` already does — prefer the live registered name, but fall back to the **static display name** (`normalizeAgentForPrompt`) when the registry returns the bare config key:

```ts
const registeredSisyphus = resolveRegisteredAgentName("sisyphus")
const sisyphusAgent = registeredSisyphus !== undefined
  && registeredSisyphus !== getAgentConfigKey("sisyphus")
  ? registeredSisyphus
  : normalizeAgentForPrompt("sisyphus") ?? "sisyphus"
```

This stores e.g. `"Sisyphus - ultraworker"`, which later prompts can resolve.

## Tests

- Updated the redirect assertions to expect the **registered display name** (they previously encoded the buggy raw-key behaviour).
- Added regression tests asserting the **persisted session agent** is the registered display name, not the config key — this is the value that actually broke prompting.
- Repaired a stale redirect test that used `gpt-5.5` (now a *native* Sisyphus model, so the redirect no longer fires) to use a non-native GPT model so it exercises the redirect path again.

```
bun test src/hooks/no-sisyphus-gpt/ src/hooks/no-hephaestus-non-gpt/
 15 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect hooks now write the registered agent display name instead of bare config keys, preventing “Agent not found: sisyphus” errors and stuck sessions. This stabilizes redirects when Sisyphus/Hephaestus are used with non-native models.

- Bug Fixes
  - In no-sisyphus-gpt and no-hephaestus-non-gpt, prefer the live registered name; fall back to `normalizeAgentForPrompt` when the registry returns the config key.
  - Store the resolved display name in `input.agent`, `output.message.agent`, and via `updateSessionAgent(...)` to keep later prompts resolvable.
  - Updated tests to expect the registered display name, added regression coverage for session persistence, and switched the stale GPT test to a non-native model.

<sup>Written for commit 8e46121776a1bcdb5a4441e62cff0bc8966add08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

