### PR TITLE
fix(doctor): make dependency fallbacks explicit

### DIFF
--- a/src/cli/doctor/checks/dependencies.ts
+++ b/src/cli/doctor/checks/dependencies.ts
@@ -16,8 +16,8 @@ async function checkBinaryExists(binary: string): Promise<BinaryCheck> {
     if (path) {
       return { exists: true, path }
     }
-  } catch {
-    // intentionally empty - binary not found
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
   }
   return { exists: false, path: null }
 }
@@ -27,7 +27,8 @@ async function getBinaryVersion(binary: string): Promise<string | null> {
     const result = await spawnWithTimeout([binary, "--version"], { stdout: "pipe", stderr: "pipe" })
     if (result.timedOut || result.exitCode !== 0) return null
     return result.stdout.trim().split("\n")[0] ?? null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return null
   }
 }
@@ -70,7 +71,8 @@ export async function checkAstGrepNapi(): Promise<DependencyInfo> {
       version: null,
       path: null,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     // Fallback: check common installation paths
     const { existsSync } = await import("fs")
     const { join } = await import("path")
@@ -118,8 +120,8 @@ export function findCommentCheckerPackageBinary(baseDirOverride?: string): strin
     if (existsSync(vendorPath)) return vendorPath
     const binPath = join(packageDir, "bin", binaryName)
     if (existsSync(binPath)) return binPath
-  } catch {
-    // intentionally empty - package not installed
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
   }
   return null
 }


### PR DESCRIPTION
## Summary
- replace four empty dependency-probing catches with explicit Error-only fallback handling
- preserve doctor behavior for missing binaries, version command failures, missing AST-Grep NAPI, and missing comment-checker package installs
- rethrow non-Error throws instead of silently swallowing unexpected control flow

## Manual QA
- bun test src/cli/doctor/checks/dependencies.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/doctor/checks/dependencies.ts src/cli/doctor/checks/dependencies.test.ts
- git diff --check origin/dev
- bun run typecheck
- bun run build
- bun src/cli/index.ts doctor --json

Doctor smoke note: command exited 0; Tools passed. Local environment still reports pre-existing warnings for outdated loaded plugin and unresolvable TUI plugin entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make doctor dependency checks explicit by replacing empty catch blocks with Error-only handling and rethrowing non-Error throws. Fallbacks stay the same for missing binaries, version failures, missing AST-Grep NAPI, and missing `comment-checker` installs.

- **Bug Fixes**
  - Stop swallowing unexpected non-Error throws.
  - Keep existing fallbacks for binary lookup, version parsing, AST-Grep NAPI, and `comment-checker` bin resolution.
  - No user-facing change for expected missing tools; clearer failures for real errors.

<sup>Written for commit e581d71488a46a40211ed754f66f1ab06928d106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

