### PR TITLE
test(codex): match escaped local wrapper paths

### DIFF
--- a/packages/omo-codex/scripts/install-local.test.mjs
+++ b/packages/omo-codex/scripts/install-local.test.mjs
@@ -10,6 +10,14 @@ import { makeTempDir, writeJson, writePluginAt } from "./install-test-fixtures.m
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
+function escapePosixDoubleQuoted(value) {
+	return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("$", "\\$").replaceAll("`", "\\`");
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 test("#given default CODEX_HOME #when resolving local installer bin dir without override #then preserves user local bin precedence", () => {
 	const homeDir = join(tmpdir(), "omo-codex-home-default");
 	const codexHome = join(homeDir, ".codex");
@@ -52,7 +60,7 @@ test("#given custom CODEX_HOME and PATH without omo #when installing locally wit
 	assert.equal(result.installed.length, 1);
 	const wrapper = await readFile(join(codexHome, "bin", "omo"), "utf8");
 	assert.match(wrapper, /OMO_GENERATED_RUNTIME_WRAPPER/);
-	assert.match(wrapper, new RegExp(join(repoRoot, "dist", "cli", "index.js").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.match(wrapper, new RegExp(escapeRegExp(escapePosixDoubleQuoted(join(repoRoot, "dist", "cli", "index.js")))));
 	assert.match(wrapper, /CODEX_HOME/);
 	assert.match(wrapper, /OMO_SPARKSHELL_APP_SERVER_SOCKET/);
 	assert.match(wrapper, /omo-ulw-loop/);


### PR DESCRIPTION
## Summary
- fix a pre-existing Windows codex-compatibility failure on current dev
- make the local installer wrapper test match the POSIX shell escaped CLI path that the generated wrapper actually writes
- keep this as a test-only unblocker separate from #4868

## Evidence
- Current dev run 27023010638 is red at cab8ea476 on codex-compatibility (windows-latest)
- #4868 failed the same Windows test twice while touching only src/cli/doctor/checks/dependencies.ts

## Manual QA
- node --test packages/omo-codex/scripts/install-local.test.mjs
- bun run test:codex (after git submodule update --init --recursive packages/lsp-tools-mcp)
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows codex-compatibility by updating the local installer wrapper test to expect the POSIX double-quoted escaped CLI path written by the generated wrapper.

- **Bug Fixes**
  - In `packages/omo-codex/scripts/install-local.test.mjs`, escape the expected `dist/cli/index.js` path using POSIX double-quoted and RegExp escaping before matching, aligning the test with the wrapper output.

<sup>Written for commit a56511d88967a3487c59bc2cf28d298f7eedd413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

