### PR TITLE
fix(session-recovery): make thinking prepend fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/storage/thinking-prepend.ts
+++ b/src/hooks/session-recovery/storage/thinking-prepend.ts
@@ -66,7 +66,12 @@ async function readTargetPartIDsFromSDK(
     return targetMessage.parts
       .map((part) => part.id)
       .filter((id): id is string => typeof id === "string")
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
+    log("[session-recovery] readTargetPartIDsFromSDK failed", { error: error.message })
     return []
   }
 }
@@ -170,7 +175,12 @@ export function prependThinkingPart(
       JSON.stringify(previousThinkingPart, null, 2)
     )
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
+    deps.log("[session-recovery] prependThinkingPart failed", { error: error.message })
     return false
   }
 }
@@ -198,7 +208,12 @@ async function findLastThinkingPartFromSDK(
         }
       }
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
+    log("[session-recovery] findLastThinkingPartFromSDK failed", { error: error.message })
     return null
   }
   return null
@@ -240,7 +255,11 @@ export async function prependThinkingPartAsync(
       toPatchBody(previousThinkingPart)
     )
   } catch (error) {
-    deps.log("[session-recovery] prependThinkingPartAsync failed", { error: String(error) })
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
+    deps.log("[session-recovery] prependThinkingPartAsync failed", { error: error.message })
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace four silent thinking-prepend catch paths with explicit Error narrowing
- preserve existing fallback outcomes for real Error failures: [] / false / null
- rethrow non-Error throws instead of silently hiding unexpected values

## Manual QA
- bun test src/hooks/session-recovery/index.test.ts src/hooks/session-recovery/thinking-prepend-latest.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/storage/thinking-prepend.ts
- bun run typecheck
- bun run build
- bun -e module smoke for prependThinkingPart/prependThinkingPartAsync latest-message guards
- git diff --check origin/dev
- rg confirmed no working-tree catch { remains in src/hooks/session-recovery/storage/thinking-prepend.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make thinking-prepend error handling explicit in session recovery to prevent silent failures.

- **Bug Fixes**
  - Convert bare catch blocks to Error-checked catches; rethrow non-Error values.
  - Preserve existing fallbacks on Error paths: [] / false / null.
  - Log error.message for clearer debugging across thinking-prepend reads, finds, and prepends.

<sup>Written for commit db4d4792aabd32c6472bdc881b21109f8efd9a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

