### PR TITLE
fix(context-recovery): make tool result storage fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/tool-result-storage.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/tool-result-storage.ts
@@ -33,8 +33,11 @@ export function findToolResultsBySize(sessionID: string): ToolResultInfo[] {
 						outputSize: part.state.output.length,
 					})
 				}
-			} catch {
-				continue
+			} catch (error) {
+				if (error instanceof Error) {
+					continue
+				}
+				throw error
 			}
 		}
 	}
@@ -83,7 +86,11 @@ export function truncateToolResult(partPath: string): {
 		writeFileSync(partPath, JSON.stringify(part, null, 2))
 
 		return { success: true, toolName, originalSize }
-	} catch {
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error
+		}
+
 		return { success: false }
 	}
 }
@@ -109,8 +116,11 @@ export function countTruncatedResults(sessionID: string): number {
 				if (part.truncated === true) {
 					count++
 				}
-			} catch {
-				continue
+			} catch (error) {
+				if (error instanceof Error) {
+					continue
+				}
+				throw error
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- replace three silent file-backed tool-result storage catch paths with explicit Error narrowing
- preserve existing corrupt/missing-storage fallback behavior for normal Error failures
- rethrow non-Error throws instead of silently hiding unexpected values

## Manual QA
- bun test src/hooks/anthropic-context-window-limit-recovery/*.test.ts
- XDG_DATA_HOME="/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/tmp.iI9kvIcjvk" bun -e smoke for findToolResultsBySize/truncateToolResult/countTruncatedResults with corrupt JSON skip
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/tool-result-storage.ts
- bun run typecheck
- bun run build
- git diff --check origin/dev
- rg confirmed no working-tree catch { remains in src/hooks/anthropic-context-window-limit-recovery/tool-result-storage.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tool-result storage error handling explicit in Anthropic context recovery. We keep existing fallbacks for normal `Error`s and rethrow non-Error values instead of silently swallowing them.

- **Bug Fixes**
  - Replaced bare catches in `findToolResultsBySize`, `truncateToolResult`, and `countTruncatedResults` with `Error` narrowing.
  - Preserved corrupt/missing storage fallbacks on `Error`; rethrow unexpected non-Error throws.

<sup>Written for commit 65d328bcb87d3dbda843ab4c740393bc690eb56d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

