### PR TITLE
fix(skill-mcp): make stdio cleanup fallbacks explicit

### DIFF
--- a/src/features/skill-mcp-manager/stdio-client.ts
+++ b/src/features/skill-mcp-manager/stdio-client.ts
@@ -5,6 +5,7 @@ import { createCleanMcpEnvironment } from "./env-cleaner"
 import { registerProcessCleanup, startCleanupTimer } from "./cleanup"
 import { redactSensitiveData } from "./error-redaction"
 import type { ManagedClient, McpClient, McpTransport, SkillMcpClientConnectionParams } from "./types"
+import { log } from "../../shared/logger"
 
 type StdioClientFactory = (
   clientInfo: { name: string; version: string },
@@ -45,6 +46,21 @@ function getStdioCommand(config: ClaudeCodeMcpServer, serverName: string): strin
   return config.command
 }
 
+async function closeStdioResourceIgnoringFailure(
+  close: () => Promise<void>,
+  context: { resource: "client" | "transport"; serverName: string; phase: "connect-failure" | "post-shutdown" }
+): Promise<void> {
+  try {
+    await close()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log("[skill-mcp-stdio-client] ignored cleanup failure", {
+      ...context,
+      error: redactSensitiveData(message),
+    })
+  }
+}
+
 export async function createStdioClient(params: SkillMcpClientConnectionParams): Promise<McpClient> {
   const { state, clientKey, info, config } = params
   const shutdownGenAtStart = state.shutdownGeneration
@@ -71,12 +87,11 @@ export async function createStdioClient(params: SkillMcpClientConnectionParams):
   try {
     await client.connect(transport)
   } catch (error) {
-    // Close transport to prevent orphaned MCP process on connection failure
-    try {
-      await transport.close()
-    } catch {
-      // Process may already be terminated
-    }
+    await closeStdioResourceIgnoringFailure(() => transport.close(), {
+      resource: "transport",
+      serverName: info.serverName,
+      phase: "connect-failure",
+    })
 
     const errorMessage = error instanceof Error ? error.message : String(error)
     const fullCommand = `${command} ${args.join(" ")}`
@@ -94,8 +109,16 @@ export async function createStdioClient(params: SkillMcpClientConnectionParams):
   }
 
   if (state.shutdownGeneration !== shutdownGenAtStart) {
-    try { await client.close() } catch {}
-    try { await transport.close() } catch {}
+    await closeStdioResourceIgnoringFailure(() => client.close(), {
+      resource: "client",
+      serverName: info.serverName,
+      phase: "post-shutdown",
+    })
+    await closeStdioResourceIgnoringFailure(() => transport.close(), {
+      resource: "transport",
+      serverName: info.serverName,
+      phase: "post-shutdown",
+    })
     throw new Error(`MCP server "${info.serverName}" connection completed after shutdown`)
   }
 


### PR DESCRIPTION
## Summary
- replace silent stdio cleanup catches with an explicit cleanup helper
- preserve original connect/shutdown failures while logging redacted cleanup failures
- remove stale inline comments around swallowed close failures

## Manual QA
- bun test src/features/skill-mcp-manager/*.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/skill-mcp-manager/stdio-client.ts
- bun -e smoke for createStdioClient connect failure with rejecting transport.close; verified original connect error is preserved and cleanup/connect secrets are not present in thrown error
- bun run typecheck
- bun run build
- git diff --check origin/dev
- rg confirmed no working-tree catch { remains in src/features/skill-mcp-manager/stdio-client.ts

## Note
- While smoke-testing, I observed a pre-existing stdio command-string redaction gap for positional secrets like `--token secret-value`. This PR keeps scope to cleanup fallback handling and does not change command redaction behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make stdio cleanup explicit and logged in the skill MCP client. Replaces silent catches with a helper that closes resources, logs redacted failures, and preserves the original connect/shutdown error.

- **Bug Fixes**
  - Replaced silent cleanup catches with `closeStdioResourceIgnoringFailure`, which logs redacted errors and context.
  - Ensured transport is closed on connect failure and both client/transport are closed after shutdown races without masking the original error.
  - Removed stale comments about swallowed close errors.

<sup>Written for commit b53bd48865b16c4325a91dd0e7e0881895a9a4ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

