### PR TITLE
fix(doctor): make team mode fallbacks explicit

### DIFF
--- a/src/cli/doctor/checks/team-mode.ts
+++ b/src/cli/doctor/checks/team-mode.ts
@@ -46,8 +46,12 @@ function loadTeamModeConfig() {
   if (!configPath) return { team_mode: undefined }
   try {
     return parseJsonc<{ team_mode?: { enabled?: boolean } }>(readFileSync(configPath, "utf-8"))
-  } catch {
-    return { team_mode: undefined }
+  } catch (error) {
+    if (error instanceof Error) {
+      return { team_mode: undefined }
+    }
+
+    throw error
   }
 }
 
@@ -55,8 +59,12 @@ async function safeCount(dir: string): Promise<number> {
   try {
     const entries = await fs.readdir(dir, { withFileTypes: true })
     return entries.filter((entry) => entry.isDirectory()).length
-  } catch {
-    return 0
+  } catch (error) {
+    if (error instanceof Error) {
+      return 0
+    }
+
+    throw error
   }
 }
 
@@ -64,7 +72,11 @@ async function pathExists(dir: string): Promise<boolean> {
   try {
     const stats = await fs.stat(dir)
     return stats.isDirectory()
-  } catch {
-    return false
+  } catch (error) {
+    if (error instanceof Error) {
+      return false
+    }
+
+    throw error
   }
 }


### PR DESCRIPTION
## Summary
- replace three silent Team Mode doctor catch paths with explicit Error narrowing
- preserve existing fallback behavior: invalid config disables the check, unreadable dirs count as missing/zero
- rethrow non-Error throws instead of hiding unexpected values

## Manual QA
- bun test src/cli/doctor/**/*.test.ts src/cli/doctor/*.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/doctor/checks/team-mode.ts
- bun src/cli/index.ts doctor --json in a temp project with malformed .opencode/oh-my-openagent.jsonc, then parsed JSON and verified Team Mode status is skip
- bun run typecheck
- bun run build
- git diff --check origin/dev
- rg confirmed no working-tree catch { remains in src/cli/doctor/checks/team-mode.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Team Mode doctor fallbacks explicit and handle only real Errors, rethrowing unexpected values. Preserves current behavior while improving error clarity.

- **Bug Fixes**
  - Replaced silent catches with explicit Error checks in loadTeamModeConfig, safeCount, and pathExists.
  - Preserved fallbacks: invalid config skips the check; unreadable dirs act as missing/zero.
  - Rethrow non-Error values instead of swallowing them.

<sup>Written for commit 0145ad656c4c3ed7a2ac07131f9f211ac5680a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

