### PR TITLE
fix(shared): make project discovery fallbacks explicit

### DIFF
--- a/src/shared/project-discovery-dirs.ts
+++ b/src/shared/project-discovery-dirs.ts
@@ -15,7 +15,10 @@ function normalizePath(path: string): string {
 
   try {
     return realpathSync(resolvedPath)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return resolvedPath
   }
 }
@@ -74,7 +77,10 @@ export function detectWorktreePath(directory: string): string | undefined {
 
     worktreePathCache.set(resolvedDirectory, worktreePath)
     return worktreePath
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     worktreePathCache.set(resolvedDirectory, undefined)
     return undefined
   }


### PR DESCRIPTION
## Summary
- Replace two empty project-discovery catch blocks with explicit Error narrowing.
- Preserve the existing fallback behavior for filesystem/git command Errors while rethrowing non-Error throws.

## Testing
- `bun test src/shared/project-discovery-dirs.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/project-discovery-dirs.ts`
- manual `bun -e` smoke for skill-dir discovery and non-git worktree fallback
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make project discovery fallbacks explicit and safer. We now only handle real Error objects in normalizePath and detectWorktreePath—preserving existing fallbacks for filesystem/git failures—while rethrowing non-Error values.

<sup>Written for commit c4ff9c76b2663eafa05c3826a454353807ca0034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

