### PR TITLE
fix(telemetry): make posthog fallbacks explicit

### DIFF
--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -89,7 +89,10 @@ function safeCpus(): { length: number; model: string | undefined } {
   try {
     const cpus = resolveOsProvider().cpus()
     return { length: cpus.length, model: cpus[0]?.model }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return { length: 0, model: undefined }
   }
 }
@@ -137,7 +140,10 @@ function createPostHogClient(
       host: getPostHogHost(),
       disableGeoip: false,
     })
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return NO_OP_POSTHOG
   }
   const sharedProperties = getSharedProperties(source)


### PR DESCRIPTION
## Summary
- Replace two empty telemetry catch blocks with explicit Error narrowing.
- Preserve existing fallback behavior for normal Error failures in CPU metadata lookup and PostHog client construction.
- Rethrow non-Error throws instead of silently swallowing them.

## Testing
- `bun test src/shared/posthog.test.ts src/shared/posthog-activity-state.test.ts src/cli/run/runner.telemetry.test.ts src/cli/cli-installer.telemetry.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/posthog.ts`
- manual disabled-telemetry `bun -e` smoke
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make telemetry fallbacks explicit by catching only real Errors in CPU metadata and PostHog client setup. Keeps existing fallbacks for normal failures and prevents swallowing unexpected throws.

- **Bug Fixes**
  - `safeCpus()`: fallback to `{ length: 0, model: undefined }` only for `Error`; rethrow non-Error.
  - `createPostHogClient()`: fallback to `NO_OP_POSTHOG` only for `Error`; rethrow non-Error.

<sup>Written for commit 21c13f938fc5713c639ca98c48ba90e3ef778f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

