### PR TITLE
fix(migration): make config migration catches explicit

### DIFF
--- a/src/shared/migration/config-migration.ts
+++ b/src/shared/migration/config-migration.ts
@@ -179,7 +179,10 @@ export function migrateConfigFile(
     let existingContent: string | undefined
     try {
       existingContent = fs.readFileSync(configPath, "utf-8")
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       // File may not exist yet
     }
     const contentChanged = existingContent !== newContent
@@ -191,7 +194,10 @@ export function migrateConfigFile(
       try {
         fs.copyFileSync(configPath, backupPath)
         backupSucceeded = true
-      } catch {
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
         backupSucceeded = false
       }
     }
@@ -200,8 +206,11 @@ export function migrateConfigFile(
     try {
       writeFileAtomically(configPath, newContent)
       writeSucceeded = true
-    } catch (err) {
-      log(`Failed to write migrated config to ${configPath}:`, err)
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+      log(`Failed to write migrated config to ${configPath}:`, error)
     }
 
     if (writeSucceeded && shouldWriteSidecar) {
@@ -212,8 +221,11 @@ export function migrateConfigFile(
         try {
           writeFileAtomically(configPath, JSON.stringify(configWithoutLegacyMigrations, null, 2) + "\n")
           finalConfig = configWithoutLegacyMigrations
-        } catch (err) {
-          log(`Failed to remove legacy _migrations fallback from ${configPath}:`, err)
+        } catch (error) {
+          if (!(error instanceof Error)) {
+            throw error
+          }
+          log(`Failed to remove legacy _migrations fallback from ${configPath}:`, error)
         }
       }
     }


### PR DESCRIPTION
## Summary
- Replace two empty config-migration catch blocks with explicit Error narrowing.
- Clean the two existing catch-without-narrowing sites in the same touched file so the file passes no-excuse rules.
- Preserve current fallback behavior for normal filesystem/write Errors while rethrowing non-Error throws.

## Testing
- `bun test src/shared/migration.test.ts src/shared/migration/config-migration.test.ts src/shared/migration/migrations-sidecar.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/migration/config-migration.ts`
- manual missing-file migration `bun -e` smoke
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes config migration error handling explicit to avoid swallowing non-Error throws while preserving existing fallbacks for normal filesystem errors. Updates read/backup/write paths to narrow `error`, rethrow non-Errors, and log real Error instances.

- **Bug Fixes**
  - Replaced empty catch blocks with explicit `error` narrowing; rethrow non-Error values.
  - Kept existing behavior for missing files and write failures; log and continue as before.
  - Cleaned remaining catches in the file to satisfy no-excuse rules.

<sup>Written for commit 39dbc7b1f254194592a9d774644c8af512beaaca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

