### PR TITLE
fix(background-agent): preserve final parent wake liveness

### DIFF
--- a/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { BackgroundManager } from "./manager"
 import type { BackgroundTask } from "./types"
-import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import { releaseAllPromptAsyncReservationsForTesting, releasePromptAsyncReservation } from "../../hooks/shared/prompt-async-gate"
 
 type PromptAsyncCall = {
   path: { id: string }
@@ -97,6 +97,13 @@ function getPendingParentWakes(manager: BackgroundManager): Map<string, PendingP
   return parentWakeNotifier.getPendingParentWakes()
 }
 
+function getPendingParentWakeTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
+  const parentWakeNotifier = Reflect.get(manager, "parentWakeNotifier") as {
+    getPendingParentWakeTimers: () => Map<string, ReturnType<typeof setTimeout>>
+  }
+  return parentWakeNotifier.getPendingParentWakeTimers()
+}
+
 async function notifyParentSessionForTest(manager: BackgroundManager, task: BackgroundTask): Promise<void> {
   const notifyParentSession = Reflect.get(manager, "notifyParentSession") as (task: BackgroundTask) => Promise<void>
   return notifyParentSession.call(manager, task)
@@ -108,7 +115,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake active turn events", () => {
-  test("#when background task completes during active parent turn #then parent wake is recorded without forking a reply", async () => {
+  test("#when background task completes during active parent turn #then noReply admission is followed by idle resume", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -132,10 +139,27 @@ describe("BackgroundManager parent wake active turn events", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+    expect(getPendingParentWakeTimers(manager).has("parent-1")).toBe(true)
+
+    // when
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(1)
+    releasePromptAsyncReservation("parent-1", "background-agent-parent-wake")
+
+    // when
+    sessionStatuses["parent-1"] = { type: "idle" }
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(2)
+    expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when duplicate background completions overlap an active parent turn #then one coalesced admit-only wake is recorded", async () => {
+  test("#when duplicate background completions overlap an active parent turn #then coalesced noReply admission is followed by idle resume", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -171,11 +195,21 @@ describe("BackgroundManager parent wake active turn events", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-    expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
+    releasePromptAsyncReservation("parent-1", "background-agent-parent-wake")
+
+    // when
+    sessionStatuses["parent-1"] = { type: "idle" }
+    await flushPendingParentWakeForTest(manager, "parent-1")
+
+    // then
+    expect(promptAsyncCalls).toHaveLength(2)
+    expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+    expect(JSON.stringify(promptAsyncCalls[1]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
     expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
   })
 
-  test("#when background task fails during active parent turn #then parent wake is recorded without forking a reply", async () => {
+  test("#when background task fails during active parent turn #then reply wake stays pending", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "busy" },
@@ -198,12 +232,11 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
+    expect(promptAsyncCalls).toHaveLength(0)
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 
-  test("#when parent reasoning delta is newer than stale idle state #then background completion records an admit-only wake", async () => {
+  test("#when parent reasoning delta is newer than stale idle state #then completion wake is admitted as noReply and retained", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -235,10 +268,10 @@ describe("BackgroundManager parent wake active turn events", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 
-  test("#when parent idle event follows fresh reasoning delta #then background completion still records an admit-only wake", async () => {
+  test("#when parent idle event follows fresh reasoning delta #then completion wake is admitted as noReply and retained", async () => {
     // given
     const sessionStatuses: Record<string, { type: string }> = {
       "parent-1": { type: "idle" },
@@ -271,6 +304,6 @@ describe("BackgroundManager parent wake active turn events", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-    expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
+    expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 })

--- a/src/features/background-agent/parent-wake-activity-window.test.ts
+++ b/src/features/background-agent/parent-wake-activity-window.test.ts
@@ -8,7 +8,11 @@ import type { BackgroundTask } from "./types"
 
 type PromptAsyncCall = {
   readonly path: { readonly id: string }
-  readonly body: { readonly parts?: readonly unknown[] }
+  readonly body: { readonly noReply?: boolean; readonly parts?: readonly unknown[] }
+}
+
+type PendingParentWakeForTest = {
+  readonly shouldReply: boolean
 }
 
 let managerUnderTest: BackgroundManager | undefined
@@ -73,9 +77,9 @@ function getPendingByParent(manager: BackgroundManager): Map<string, Set<string>
   return unsafeTestValue<Map<string, Set<string>>>(Reflect.get(manager, "pendingByParent"))
 }
 
-function getPendingParentWakes(manager: BackgroundManager): Map<string, unknown> {
+function getPendingParentWakes(manager: BackgroundManager): Map<string, PendingParentWakeForTest> {
   const notifier = unsafeTestValue<{
-    readonly getPendingParentWakes: () => Map<string, unknown>
+    readonly getPendingParentWakes: () => Map<string, PendingParentWakeForTest>
   }>(Reflect.get(manager, "parentWakeNotifier"))
   return notifier.getPendingParentWakes()
 }
@@ -91,7 +95,7 @@ async function flushPendingParentWakeForTest(manager: BackgroundManager, session
 }
 
 describe("BackgroundManager parent wake activity window", () => {
-  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake is recorded without forking a reply", async () => {
+  test("#given parent tool activity is within the tool deferral window #when stale idle flushes a wake #then wake is admitted without consuming reply liveness", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -122,7 +126,7 @@ describe("BackgroundManager parent wake activity window", () => {
       // then
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(getPendingParentWakes(manager).has("parent-1")).toBe(false)
+      expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
     } finally {
       Date.now = originalDateNow
     }

--- a/src/features/background-agent/parent-wake-dedupe.ts
+++ b/src/features/background-agent/parent-wake-dedupe.ts
@@ -12,6 +12,7 @@ export type PendingParentWake = {
   notifications: string[]
   shouldReply: boolean
   dispatchedAt?: number
+  noReplyAdmittedAt?: number
   toolCallDeferralStartedAt?: number
   allowEmptyAssistantTurnRetry?: boolean
 }
@@ -33,6 +34,7 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     notifications: [...wake.notifications],
     shouldReply: wake.shouldReply,
     ...(wake.dispatchedAt !== undefined ? { dispatchedAt: wake.dispatchedAt } : {}),
+    ...(wake.noReplyAdmittedAt !== undefined ? { noReplyAdmittedAt: wake.noReplyAdmittedAt } : {}),
     ...(wake.toolCallDeferralStartedAt !== undefined
       ? { toolCallDeferralStartedAt: wake.toolCallDeferralStartedAt }
       : {}),

--- a/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/src/features/background-agent/parent-wake-flush-runner.ts
@@ -32,10 +32,17 @@ export class ParentWakeFlushRunner {
       if (await this.isSessionActive(sessionID)) {
         const latestWake = this.deps.pendingQueue.getWake(sessionID)
         if (latestWake) {
+          if (this.deferUnsafeReplyWake(sessionID, latestWake)) {
+            return
+          }
+          if (this.deferRetainedNoReplyWake(sessionID, latestWake)) {
+            return
+          }
           await this.sendParentWakePrompt(sessionID, latestWake, {
             emptyAssistantTurnRetry: false,
             toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
             forceNoReply: true,
+            retainPendingWake: isReplyRequiredFinalWake(latestWake),
           })
         }
         return
@@ -47,19 +54,33 @@ export class ParentWakeFlushRunner {
       return
     }
     if (sessionActive) {
+      if (this.deferUnsafeReplyWake(sessionID, latestWake)) {
+        return
+      }
+      if (this.deferRetainedNoReplyWake(sessionID, latestWake)) {
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry: false,
         toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
         forceNoReply: true,
+        retainPendingWake: isReplyRequiredFinalWake(latestWake),
       })
       return
     }
 
     if (this.hasRecentParentSessionActivity(sessionID)) {
+      if (this.deferUnsafeReplyWake(sessionID, latestWake)) {
+        return
+      }
+      if (this.deferRetainedNoReplyWake(sessionID, latestWake)) {
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry: false,
         toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
         forceNoReply: true,
+        retainPendingWake: isReplyRequiredFinalWake(latestWake),
       })
       log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
         sessionID,
@@ -70,10 +91,17 @@ export class ParentWakeFlushRunner {
     const emptyAssistantTurnRetry = latestWake.allowEmptyAssistantTurnRetry === true
     const toolWaitDecision = await this.shouldDeferParentWakeForSessionHistory(sessionID, latestWake)
     if (toolWaitDecision.defer) {
+      if (this.deferUnsafeReplyWake(sessionID, latestWake)) {
+        return
+      }
+      if (this.deferRetainedNoReplyWake(sessionID, latestWake)) {
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry,
         toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
         forceNoReply: true,
+        retainPendingWake: isReplyRequiredFinalWake(latestWake),
       })
       return
     }
@@ -85,10 +113,17 @@ export class ParentWakeFlushRunner {
       // @parcel/watcher TSFN callbacks firing into a torn-down JS env.
       // Store the wake as noReply so the user's own turn can consume it without
       // forking another assistant turn. See issue #4120.
+      if (this.deferUnsafeReplyWake(sessionID, latestWake)) {
+        return
+      }
+      if (this.deferRetainedNoReplyWake(sessionID, latestWake)) {
+        return
+      }
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry,
         toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
         forceNoReply: true,
+        retainPendingWake: isReplyRequiredFinalWake(latestWake),
       })
       log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
         sessionID,
@@ -109,6 +144,24 @@ export class ParentWakeFlushRunner {
     })
   }
 
+  private deferUnsafeReplyWake(sessionID: string, latestWake: PendingParentWake): boolean {
+    if (!isFailureParentWake(latestWake)) {
+      return false
+    }
+    this.schedulePendingParentWakeFlush(sessionID)
+    log("[background-agent] Deferred failure parent wake until parent session is safe:", { sessionID })
+    return true
+  }
+
+  private deferRetainedNoReplyWake(sessionID: string, latestWake: PendingParentWake): boolean {
+    if (!isReplyRequiredFinalWake(latestWake) || latestWake.noReplyAdmittedAt === undefined) {
+      return false
+    }
+    this.schedulePendingParentWakeFlush(sessionID)
+    log("[background-agent] Deferred retained final parent wake until parent session is safe:", { sessionID })
+    return true
+  }
+
   schedulePendingParentWakeFlush(sessionID: string, delayMs?: number): void {
     this.deps.pendingQueue.scheduleFlush(sessionID, () => this.flushPendingParentWake(sessionID), delayMs)
   }
@@ -124,9 +177,12 @@ export class ParentWakeFlushRunner {
       readonly emptyAssistantTurnRetry: boolean
       readonly toolWaitDecision: ToolWaitDeferralDecision
       readonly forceNoReply?: boolean
+      readonly retainPendingWake?: boolean
     },
   ): Promise<void> {
-    this.deps.pendingQueue.deleteWake(sessionID)
+    if (options.retainPendingWake !== true) {
+      this.deps.pendingQueue.deleteWake(sessionID)
+    }
 
     await sendParentWakePrompt({
       client: this.deps.notifierDeps.client,
@@ -134,6 +190,7 @@ export class ParentWakeFlushRunner {
       sessionID,
       latestWake,
       ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
+      ...(options.retainPendingWake !== undefined ? { retainPendingWake: options.retainPendingWake } : {}),
       emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
       toolWaitDecision: options.toolWaitDecision,
       getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
@@ -167,4 +224,19 @@ export class ParentWakeFlushRunner {
   private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
     this.deps.pendingQueue.requeueWake(sessionID, latestWake)
   }
+}
+
+function isReplyRequiredFinalWake(wake: PendingParentWake): boolean {
+  return wake.shouldReply && wake.notifications.some((notification) =>
+    notification.includes("[ALL BACKGROUND TASKS COMPLETE]")
+  )
+}
+
+function isFailureParentWake(wake: PendingParentWake): boolean {
+  return wake.shouldReply && wake.notifications.some((notification) =>
+    notification.includes("[BACKGROUND TASK ERROR]")
+    || notification.includes("[BACKGROUND TASK CANCELLED]")
+    || notification.includes("[BACKGROUND TASK INTERRUPTED]")
+    || notification.includes("[ALL BACKGROUND TASKS FINISHED")
+  )
 }

--- a/src/features/background-agent/parent-wake-non-error-retry.test.ts
+++ b/src/features/background-agent/parent-wake-non-error-retry.test.ts
@@ -133,7 +133,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
     }
   })
 
-  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake is recorded without a reply", async () => {
+  test("#given session.messages rejects with a string after the retry timer is cleared #when the wake flush runs #then the final wake is admitted without consuming reply liveness", async () => {
     // given
     const { notifier, promptAsyncCalls } = createNotifier({
       sessionMessagesImpl: async (attempt) => {
@@ -163,7 +163,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
       // then
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().has(sessionID)).toBe(false)
+      expect(notifier.getPendingParentWakes().get(sessionID)?.shouldReply).toBe(true)
     } finally {
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()

--- a/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/src/features/background-agent/parent-wake-pending-queue.ts
@@ -73,6 +73,7 @@ export class ParentWakePendingQueue {
       )
       pendingWake.shouldReply = pendingWake.shouldReply || latestWake.shouldReply
       pendingWake.promptContext = latestWake.promptContext
+      pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
       return

--- a/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -16,6 +16,7 @@ type ParentWakePromptDispatchInput = {
   readonly sessionID: string
   readonly latestWake: PendingParentWake
   readonly forceNoReply?: boolean
+  readonly retainPendingWake?: boolean
   readonly emptyAssistantTurnRetry: boolean
   readonly toolWaitDecision: ToolWaitDeferralDecision
   readonly getDispatchedWake: () => PendingParentWake | undefined
@@ -57,7 +58,8 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         const dispatchedWake = cloneParentWake(input.latestWake)
         dispatchedWake.dispatchedAt = dispatchStartedAt
         if (await input.hasRecordedPromptAfterDispatch(dispatchedWake)) {
-          input.trackDispatchedWake(input.latestWake, dispatchStartedAt)
+          markRetainedNoReplyAdmission(input, dispatchStartedAt)
+          input.trackDispatchedWake(createTrackedDispatchedWake(input.latestWake, input.forceNoReply), dispatchStartedAt)
           log("[background-agent] Treated failed parent wake prompt as accepted after observing session history:", {
             sessionID: input.sessionID,
             error: promptResult.error,
@@ -93,11 +95,31 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
     }
     log("[background-agent] Sent deferred parent wake:", { sessionID: input.sessionID })
     delete input.latestWake.allowEmptyAssistantTurnRetry
-    input.trackDispatchedWake(input.latestWake, dispatchStartedAt)
+    markRetainedNoReplyAdmission(input, dispatchStartedAt)
+    input.trackDispatchedWake(createTrackedDispatchedWake(input.latestWake, input.forceNoReply), dispatchStartedAt)
   } catch (error) {
     const errorText = error instanceof Error ? `${error.name}: ${error.message}` : getErrorText(error) || String(error)
     input.requeueWake(input.latestWake)
     input.scheduleFlush()
     log("[background-agent] Failed to send deferred parent wake:", { sessionID: input.sessionID, error: errorText })
+  }
+}
+
+function markRetainedNoReplyAdmission(input: ParentWakePromptDispatchInput, dispatchStartedAt: number): void {
+  if (input.retainPendingWake !== true || input.forceNoReply !== true || !input.latestWake.shouldReply) {
+    return
+  }
+  input.latestWake.noReplyAdmittedAt = dispatchStartedAt
+  input.scheduleFlush()
+}
+
+function createTrackedDispatchedWake(wake: PendingParentWake, forceNoReply: boolean | undefined): PendingParentWake {
+  if (forceNoReply !== true || !wake.shouldReply) {
+    return wake
+  }
+
+  return {
+    ...cloneParentWake(wake),
+    shouldReply: false,
   }
 }

--- a/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -221,7 +221,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given all-complete wake arrives while prior assistant turn is still streaming #when the parent status is stale-idle #then the wake is recorded without forking a reply", async () => {
+  test("#given all-complete wake arrives while prior assistant turn is still streaming #when the parent status is stale-idle #then noReply admission is retained for later resume", async () => {
     // given
     const sessionMessages: SessionMessageStub[] = [
       {
@@ -263,7 +263,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     // then
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-    expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(false)
+    expect(notifier.getPendingParentWakes().get("parent-stale-idle")?.shouldReply).toBe(true)
 
     notifier.shutdown()
     releaseAllPromptAsyncReservationsForTesting()
@@ -447,7 +447,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     releaseAllPromptAsyncReservationsForTesting()
   })
 
-  test("#given stale all-complete wake and gate sees a repaired user tail #when latest assistant is still waiting on tools #then wake is recorded without forking a reply", async () => {
+  test("#given stale all-complete wake and gate sees a repaired user tail #when latest assistant is still waiting on tools #then noReply admission is retained for later resume", async () => {
     // given
     const originalDateNow = Date.now
     Date.now = () => 100_000
@@ -526,7 +526,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       // then
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(false)
+      expect(notifier.getPendingParentWakes().get("parent-repaired-tail")?.shouldReply).toBe(true)
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()


### PR DESCRIPTION
## Summary

- Preserve final all-complete parent wake liveness after active-turn `noReply` admission.
- Keep #4164 active-turn completion visibility while avoiding duplicate `noReply` admissions.
- Keep failure/cancel/interrupted wakes deferred while the parent is unsafe.

## Changes

- Retain successful final `[ALL BACKGROUND TASKS COMPLETE]` wakes after informational `noReply` delivery.
- Track force-`noReply` admissions as non-reply-covering so later reply-required flushes are not deduped away.
- Schedule retry flushes for retained final wakes and suppress duplicate active-turn `noReply` prompts while still unsafe.
- Add regression coverage for TDD red/green behavior: active `noReply` admission, retained `shouldReply`, retry timer, duplicate active flush suppression, and later idle `noReply: false` resume.

## Testing

```bash
bun test src/features/background-agent/parent-wake-active-turn-event.test.ts
bun test src/features/background-agent/parent-wake-active-turn-event.test.ts src/features/background-agent/parent-wake-user-message-race.test.ts
bun test src/features/background-agent/parent-wake-*.test.ts
bun run typecheck
bun run build
git diff --check
```

TDD note: before the scheduling fix, `bun test src/features/background-agent/parent-wake-active-turn-event.test.ts` failed because the retained final wake had no retry timer after `noReply` admission. The test passed after adding retained-admission scheduling.

Foreground review:

- Goal/constraint review: PASS
- Code quality review: PASS
- Context/missed-requirements review: PASS
- QA execution: PASS
- Security review: PASS

## Related Issues

Closes #4874

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves liveness for final “[ALL BACKGROUND TASKS COMPLETE]” wakes after an active-turn `noReply`, so the session resumes with a real reply once idle, while avoiding duplicate prompts and deferring unsafe failure wakes.

- **Bug Fixes**
  - Retain final wakes after `noReply`, track `noReplyAdmittedAt`, and schedule a retry flush; resume with a reply when the parent goes idle.
  - Defer failure/cancel/interrupted wakes and retained finals while the parent is active or otherwise unsafe; schedule a later flush instead of prompting.
  - Treat forced `noReply` admissions as non-reply-covering so later reply-required flushes aren’t deduped; track dispatched wakes without consuming reply liveness.
  - Coalesce duplicates to prevent repeated `noReply` during active turns; add timer tracking and update tests for idle resume, tool deferral window, retries, and user-message races.

<sup>Written for commit 3d0eac3992ae1a42505ab7021e0c24f3d3150844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

