### PR TITLE
fix(git-worktree): make diff stat fallbacks explicit

### DIFF
--- a/src/shared/git-worktree/collect-git-diff-stats.ts
+++ b/src/shared/git-worktree/collect-git-diff-stats.ts
@@ -37,7 +37,10 @@ export function collectGitDiffStats(directory: string): GitFileStat[] {
               const content = fs.readFileSync(join(directory, filePath), "utf-8")
               const lineCount = content.split("\n").length - (content.endsWith("\n") ? 1 : 0)
               return `${lineCount}\t0\t${filePath}`
-            } catch {
+            } catch (error) {
+              if (!(error instanceof Error)) {
+                throw error
+              }
               return `0\t0\t${filePath}`
             }
           })
@@ -50,7 +53,10 @@ export function collectGitDiffStats(directory: string): GitFileStat[] {
 
     const statusMap = parseGitStatusPorcelain(statusOutput)
     return parseGitDiffNumstat(combinedNumstat, statusMap)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }


### PR DESCRIPTION
## Summary
- Replace two empty git diff stat catch blocks with explicit Error narrowing.
- Preserve current fallback behavior for unreadable untracked files and git command failures.
- Rethrow non-Error throws instead of silently swallowing them.

## Testing
- `bun test src/shared/git-worktree/*.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/git-worktree/collect-git-diff-stats.ts`
- manual real-git repository `bun -e` smoke
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

Note: I also tried the broader Atlas hook tests and saw existing session-id-prefix expectation failures unrelated to this one-file helper change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make diff stat fallbacks explicit in `collectGitDiffStats` by replacing empty catch blocks with Error checks. Non-Error throws are rethrown; existing fallbacks stay the same (0/0 for unreadable untracked files, [] on git failures).

<sup>Written for commit 09d71c92f9532ff3434e5467f7eb53d92e59f53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

