### PR TITLE
fix(start-work): make worktree detector fallbacks explicit

### DIFF
--- a/src/hooks/start-work/worktree-detector.ts
+++ b/src/hooks/start-work/worktree-detector.ts
@@ -58,7 +58,10 @@ export function listWorktrees(directory: string): WorktreeEntry[] {
       stdio: ["pipe", "pipe", "pipe"],
     })
     return parseWorktreeListPorcelain(output)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -71,7 +74,10 @@ export function detectWorktreePath(directory: string): string | null {
       timeout: 5000,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim()
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- Replace two empty start-work worktree detector catch blocks with explicit Error narrowing.
- Preserve existing fallback behavior for git command Errors: listWorktrees returns [] and detectWorktreePath returns null.
- Rethrow non-Error throws instead of silently swallowing them.

## Testing
- `bun test src/hooks/start-work/worktree-detector.test.ts src/hooks/start-work/index.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/start-work/worktree-detector.ts`
- manual canonical real-git worktree detector `bun -e` smoke
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error handling explicit in the start-work worktree detector to avoid swallowing non-Error throws. Replaces empty catches in `listWorktrees` and `detectWorktreePath` with Error checks, rethrows non-Error values, and preserves fallbacks: `[]` and `null` on git command errors.

<sup>Written for commit e0b6751fb7a94dda5719a34501dada4174d0195f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

