### PR TITLE
fix(session-recovery): make parts reader fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/storage/parts-reader.ts
+++ b/src/hooks/session-recovery/storage/parts-reader.ts
@@ -20,7 +20,10 @@ export function readParts(messageID: string): StoredPart[] {
     try {
       const content = readFileSync(join(partDir, file), "utf-8")
       parts.push(JSON.parse(content))
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }
@@ -50,7 +53,10 @@ export async function readPartsFromSDK(
         return { ...part, sessionID, messageID } as StoredPart
       })
       .filter((part): part is StoredPart => part !== null)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }


### PR DESCRIPTION
## Summary
- Replace two empty session recovery parts-reader catch blocks with explicit Error narrowing.
- Preserve existing fallback behavior for corrupt part files and SDK fetch Errors.
- Rethrow non-Error throws instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-recovery/storage/readers-from-sdk.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/session-recovery/recover-unavailable-tool.test.ts src/hooks/session-recovery/hook.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/storage/parts-reader.ts`
- manual SDK reader `bun -e` smoke
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

Note: local runtime reports SQLite backend, where filesystem readParts intentionally returns [] before reading legacy part files, so manual smoke covered the SDK reader surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session recovery parts readers handle errors explicitly. Preserve fallbacks for corrupt part files and SDK fetch errors, and rethrow non-Error throws to avoid silent failures.

- **Bug Fixes**
  - Replace empty catch blocks with explicit `Error` narrowing in `readParts` and `readPartsFromSDK`.
  - Keep existing fallback: skip bad JSON and return `[]` on SDK read failures.
  - Rethrow non-`Error` exceptions instead of swallowing them.

<sup>Written for commit c1f8352f0a2ce3855eb1661b56610da976d4a3b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

