### PR TITLE
fix(session-recovery): make message reader fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/storage/messages-reader.ts
+++ b/src/hooks/session-recovery/storage/messages-reader.ts
@@ -43,7 +43,10 @@ export function readMessages(sessionID: string): StoredMessageMeta[] {
     try {
       const content = readFileSync(join(messageDir, file), "utf-8")
       messages.push(JSON.parse(content))
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }
@@ -77,7 +80,10 @@ export async function readMessagesFromSDK(
       if (aTime !== bTime) return aTime - bTime
       return a.id.localeCompare(b.id)
     })
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }


### PR DESCRIPTION
## Summary
Replaces the remaining empty catches in the session-recovery message reader with explicit Error narrowing while preserving the existing fallback behavior.

## Changes
- Keep corrupt message JSON/file read failures as skipped files after narrowing to Error.
- Keep SDK message-list failures as an empty fallback after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-recovery/storage/readers-from-sdk.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/session-recovery/recover-unavailable-tool.test.ts src/hooks/session-recovery/hook.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/storage/messages-reader.ts`
- Manual SDK smoke: sorted message read path
- Manual SDK smoke: Error fallback returns []
- Manual filesystem smoke: missing session returns []
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session-recovery message readers handle errors explicitly while keeping existing fallbacks. Non-Error throwables now propagate instead of being silently swallowed.

- **Bug Fixes**
  - Skip corrupt files on read/JSON parse errors after narrowing to Error.
  - Return [] on SDK message-list failures after narrowing to Error.
  - Rethrow non-Error values instead of catching them.

<sup>Written for commit 6b8da0fb24bea55227d9ae1343d5a62f788e368a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

