### PR TITLE
fix(session-recovery): make empty text fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/storage/empty-text.ts
+++ b/src/hooks/session-recovery/storage/empty-text.ts
@@ -36,7 +36,10 @@ export function replaceEmptyTextParts(messageID: string, replacementText: string
           anyReplaced = true
         }
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }
@@ -71,6 +74,9 @@ export async function replaceEmptyTextPartsAsync(
 
     return anyReplaced
   } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     log("[session-recovery] replaceEmptyTextPartsAsync failed", { error: String(error) })
     return false
   }
@@ -112,7 +118,10 @@ export async function findMessagesWithEmptyTextPartsFromSDK(
     }
 
     return result
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }


### PR DESCRIPTION
## Summary
Replaces the empty catches in the session-recovery empty-text storage helper with explicit Error narrowing, while preserving existing fallback behavior. Also narrows the existing same-file async catch so the no-excuse gate passes for this target.

## Changes
- Keep corrupt stored part reads skipped after narrowing to Error.
- Keep SDK empty-text lookup failures as an empty fallback after narrowing to Error.
- Keep async replacement failures as false fallback after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-recovery/storage/readers-from-sdk.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/session-recovery/recover-unavailable-tool.test.ts src/hooks/session-recovery/hook.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/storage/empty-text.ts`
- Manual SDK smoke: finds empty text message
- Manual SDK smoke: Error fallback returns []
- Manual filesystem smoke: missing message replacement returns false
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error handling explicit in `session-recovery` empty-text helpers. Catch only `Error`, rethrow non-Error, and keep current fallback behavior.

- **Bug Fixes**
  - Narrowed catches to `Error` in `replaceEmptyTextParts`, `replaceEmptyTextPartsAsync`, and `findMessagesWithEmptyTextPartsFromSDK`.
  - Preserved fallbacks: skip corrupt reads, return `[]` for SDK failures, and return `false` for async replacement failures.

<sup>Written for commit 992c855cec8073928179bc4c0defcbaa385a5622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

