### PR TITLE
fix(session-recovery): make unavailable tool fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/recover-unavailable-tool.ts
+++ b/src/hooks/session-recovery/recover-unavailable-tool.ts
@@ -67,7 +67,10 @@ async function readPartsFromSDKFallback(
       id: "callID" in part ? (part as { callID?: string }).callID : part.id,
       name: "name" in part && typeof part.name === "string" ? part.name : ("tool" in part && typeof (part as { tool?: unknown }).tool === "string" ? (part as { tool: string }).tool : undefined),
     }))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -134,7 +137,10 @@ export async function recoverUnavailableTool(
       return true
     }
     return isInternalPromptDispatchAccepted(promptResult)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
Replaces the empty catches in unavailable-tool session recovery with explicit Error narrowing while preserving the existing fallback behavior.

## Changes
- Keep SDK part fallback failures as an empty parts result after narrowing to Error.
- Keep recovery dispatch failures as false after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-recovery/recover-unavailable-tool.test.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/session-recovery/hook.test.ts src/hooks/session-recovery/storage/readers-from-sdk.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/recover-unavailable-tool.ts`
- Manual smoke: direct unavailable-tool recovery dispatches a synthetic result
- Manual smoke: SDK fallback Error returns false
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make unavailable-tool session recovery fallbacks explicit by narrowing to real Errors and rethrowing non-Error values. Keeps current behavior for legitimate Error cases while preventing silent failures.

- **Bug Fixes**
  - SDK parts fallback: return [] only on Error; rethrow non-Error values.
  - Recovery dispatch: return false only on Error; rethrow non-Error values.
  - Improves debuggability by not swallowing non-Error throwables.

<sup>Written for commit 42c0a3f8cb13f9e442279f6110ecbaac6455076c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

