### PR TITLE
fix(session-recovery): make thinking order fallbacks explicit

### DIFF
--- a/src/hooks/session-recovery/recover-thinking-block-order.ts
+++ b/src/hooks/session-recovery/recover-thinking-block-order.ts
@@ -79,7 +79,10 @@ async function findMessagesWithOrphanThinkingFromSDK(
   try {
     const response = await client.session.messages({ path: { id: sessionID } })
     messages = normalizeSDKResponse(response, [] as MessageData[], { preferResponseOnMissingData: true })
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 
@@ -113,7 +116,10 @@ async function findMessageByIndexNeedingThinkingFromSDK(
   try {
     const response = await client.session.messages({ path: { id: sessionID } })
     messages = normalizeSDKResponse(response, [] as MessageData[], { preferResponseOnMissingData: true })
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 


### PR DESCRIPTION
## Summary
Replaces the empty catches in thinking-block-order recovery SDK fallback helpers with explicit Error narrowing while preserving existing fallback behavior.

## Changes
- Keep SDK orphan-thinking lookup failures as an empty result after narrowing to Error.
- Keep SDK indexed-message lookup failures as null after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-recovery/hook.test.ts src/hooks/session-recovery/index.test.ts src/hooks/session-recovery/thinking-block-modified-recovery.test.ts src/hooks/session-recovery/thinking-prepend-latest.test.ts src/hooks/session-recovery/detect-error-type.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/recover-thinking-block-order.ts`
- Manual smoke: non-SQLite thinking-order recovery returns false for missing stored context
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes thinking-order recovery safer by replacing empty catch blocks with explicit Error checks and rethrowing non-Error exceptions. Keeps the previous fallback behavior for SDK lookup failures.

- **Bug Fixes**
  - Orphan-thinking lookup: return [] on SDK Error; rethrow non-Error.
  - Indexed-message lookup: return null on SDK Error; rethrow non-Error.
  - Removes silent catch-alls that hid unexpected failures.

<sup>Written for commit 1187bc6e1b7a297359f06c4d7b468833250e1f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

