### PR TITLE
fix(hooks): make session notification fallbacks explicit

### DIFF
--- a/src/hooks/session-notification-content.ts
+++ b/src/hooks/session-notification-content.ts
@@ -87,7 +87,10 @@ async function readSessionTitle(
     if (sessionInfo?.title && sessionInfo.title.trim().length > 0) {
       return sessionInfo.title.trim()
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
   }
 
   return sessionID
@@ -112,7 +115,10 @@ async function readSessionMessages(
     })
 
     return Array.isArray(messages) ? messages : []
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }


### PR DESCRIPTION
## Summary
Replaces the empty catches in session notification content loading with explicit Error narrowing while preserving existing fallback behavior.

## Changes
- Keep title read failures falling back to the session id after narrowing to Error.
- Keep message read failures falling back to an empty message list after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/hooks/session-notification-content.test.ts src/hooks/session-notification.test.ts src/plugin/event.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-notification-content.ts`
- Manual smoke: rich notification content includes title/user/assistant line
- Manual smoke: SDK read Errors fall back to session id and base message
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

Note: an initial inline smoke command had malformed shell quoting and failed before importing the module; the corrected smoke command passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session notification content error handling explicit by narrowing caught values to Error. Keep existing fallbacks and rethrow non-Error throwables instead of swallowing them.

- **Bug Fixes**
  - Title read errors now fall back to the session ID.
  - Message read errors now fall back to an empty list.

<sup>Written for commit 55476b9d1f3c2e7c1840a6887753aa7759bc2872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

