### PR TITLE
fix(hashline): make diff enhancer fallbacks explicit

### DIFF
--- a/src/hooks/hashline-edit-diff-enhancer/hook.ts
+++ b/src/hooks/hashline-edit-diff-enhancer/hook.ts
@@ -43,7 +43,10 @@ async function captureOldContent(filePath: string): Promise<string> {
 		if (await file.exists()) {
 			return await file.text()
 		}
-	} catch {
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error
+		}
 		log("[hashline-edit-diff-enhancer] failed to read old content", { filePath })
 	}
 	return ""
@@ -81,7 +84,10 @@ export function createHashlineEditDiffEnhancerHook(config: HashlineEditDiffEnhan
 			let newContent: string
 			try {
 				newContent = await bunFile(filePath).text()
-			} catch {
+			} catch (error) {
+				if (!(error instanceof Error)) {
+					throw error
+				}
 				log("[hashline-edit-diff-enhancer] failed to read new content", { filePath })
 				return
 			}


### PR DESCRIPTION
## Summary
Replaces the empty catches in the hashline edit diff enhancer with explicit Error narrowing while preserving existing fallback behavior.

## Changes
- Keep old-content read failures falling back to an empty before-content snapshot after narrowing to Error.
- Keep new-content read failures logging and skipping diff metadata after narrowing to Error.
- Rethrow non-Error throwables instead of silently swallowing them.

## Testing
- `bun test src/tools/hashline-edit/diff-utils.test.ts src/tools/hashline-edit/tools.test.ts src/hooks/hashline-read-enhancer/index.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/hashline-edit-diff-enhancer/hook.ts`
- Manual smoke: diff enhancer captures old content, reads new content, and writes metadata.diff/filediff
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error handling in the hashline edit diff enhancer explicit to keep safe fallbacks and avoid swallowing unexpected errors. This preserves existing behavior for failed reads and improves logging.

- **Bug Fixes**
  - Old-content read failures: narrow to Error, log, return empty string.
  - New-content read failures: narrow to Error, log, skip diff metadata.
  - Non-Error throwables: rethrow instead of silently catching.

<sup>Written for commit 96aaf2b10c96a89f7c1740847be71b80cfae8004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

