### PR TITLE
fix(claude-hooks): make post tool fallbacks explicit

### DIFF
--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -154,7 +154,10 @@ export async function executePostToolUseHooks(
                 systemMessage: normalizeHookText(output.systemMessage),
               }
             }
-          } catch {
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              throw error
+            }
             const stdout = normalizeHookText(result.stdout)
             if (stdout !== undefined) {
               messages.push(stdout)
@@ -180,7 +183,10 @@ export async function executePostToolUseHooks(
                 systemMessage: normalizeHookText(output.systemMessage),
               }
             }
-          } catch {
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              throw error
+            }
             const stdout = normalizeHookText(result.stdout)
             if (stdout !== undefined) {
               messages.push(stdout)


### PR DESCRIPTION
## Summary
- Replace two empty PostToolUse JSON parse fallback catches with explicit Error narrowing
- Preserve existing non-JSON stdout normalization behavior for command hook output

## Manual QA
- bun test src/hooks/claude-code-hooks/post-tool-use.test.ts src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.test.ts src/hooks/claude-code-hooks/transcript.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/claude-code-hooks/post-tool-use.ts
- bun -e smoke test for executePostToolUseHooks with a real command hook returning non-JSON CRLF stdout
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make post-tool-use JSON parse fallbacks explicit by only handling Error instances in catch blocks. This keeps the existing non-JSON stdout normalization and prevents non-Error throws from being swallowed.

<sup>Written for commit 714b096ab350a96b1627136cb6bc6922a7be8b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

