### PR TITLE
fix(background-agent): bypass session-active gate for child-session prompt dispatch

### DIFF
--- a/packages/omo-opencode/src/shared/session-route.test.ts
+++ b/packages/omo-opencode/src/shared/session-route.test.ts
@@ -90,6 +90,32 @@ describe("promptAsyncInDirectory", () => {
     expect(result).toBeUndefined()
     expect(promptAsync).toHaveBeenCalledTimes(1)
   })
+
+  test("#given the session reports an active status #when routing a gated promptAsync request #then the active status defers the prompt", async () => {
+    // given
+    const promptAsync = mock(async () => ({ data: "sent" }))
+    const status = mock(async () => ({ data: { ses_route_active: { type: "running" } } }))
+    const client = {
+      session: {
+        promptAsync,
+        status,
+      },
+    }
+    const args = {
+      path: { id: "ses_route_active" },
+      body: { parts: [{ type: "text", text: "continue" }] },
+    }
+
+    // when, then
+    await expect(
+      promptAsyncInDirectory(
+        unsafeTestValue(client),
+        unsafeTestValue(args),
+        "/workspace/project",
+      ),
+    ).rejects.toThrow("promptAsync skipped by gate: active")
+    expect(promptAsync).toHaveBeenCalledTimes(0)
+  })
 })
 
 describe("promptWithRetryInDirectory", () => {
@@ -126,5 +152,32 @@ describe("promptWithRetryInDirectory", () => {
     await expect(second).rejects.toThrow("promptAsync skipped by gate: reserved")
     expect(promptAsync).toHaveBeenCalledTimes(1)
     expect(promptAsync.mock.calls[0]?.[0].query).toEqual({ directory: "/workspace/project" })
+  })
+
+  test("#given the session reports an active status #when routing a retry prompt for a background-agent dispatch #then the wrapper bypasses the status gate and still dispatches", async () => {
+    // given
+    const promptAsync = mock(async () => undefined)
+    const status = mock(async () => ({ data: { ses_retry_route_active: { type: "running" } } }))
+    const client = {
+      session: {
+        promptAsync,
+        status,
+      },
+    }
+    const args = {
+      path: { id: "ses_retry_route_active" },
+      body: { parts: [{ type: "text", text: "continue" }] },
+    }
+
+    // when
+    await promptWithRetryInDirectory(
+      unsafeTestValue(client),
+      unsafeTestValue(args),
+      "/workspace/project",
+    )
+
+    // then
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+    expect(status).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/omo-opencode/src/shared/session-route.ts
+++ b/packages/omo-opencode/src/shared/session-route.ts
@@ -87,7 +87,13 @@ export function promptWithRetryInDirectory(
   args: PromptRetryArgs,
   directory: string,
 ): Promise<void> {
-  return promptWithModelSuggestionRetry(client, routePromptRetry(args, directory), { queueBehavior: "defer" })
+  // Gate bypass mirrors sendSyncPrompt: background dispatch targets a manager-owned child
+  // session that can momentarily read as "active", which would otherwise interrupt the launch.
+  return promptWithModelSuggestionRetry(client, routePromptRetry(args, directory), {
+    queueBehavior: "defer",
+    checkStatus: false,
+    checkToolState: false,
+  })
 }
 
 export function promptSyncWithRetryInDirectory(


### PR DESCRIPTION
## Summary

Background task launches (`task(run_in_background=true)`) can fail to start with:

```
Task failed to start (status: interrupt)
... promptAsync skipped by gate: active
```

When this happens, sync delegation keeps working but every background subagent is rejected before it runs.

## Root cause

`BackgroundManager.launch()` and its resume/fallback paths dispatch the child-session prompt through `promptWithRetryInDirectory` (`src/shared/session-route.ts`). That wrapper forwarded only `{ queueBehavior: "defer" }` to the prompt-async gate, leaving the session-active check (`checkStatus`) enabled.

The dispatch target is a freshly created, manager-owned child session, which can momentarily report an active status (`busy`/`running`). When it does, `dispatchAfterSessionIdle` returns `{ status: "active" }`, the launch promise rejects with `promptAsync skipped by gate: active`, and `interruptTaskFromAsyncPromptFailure` marks the task `interrupt`.

The synchronous delegate path (`sendSyncPrompt`) already avoids this by passing `checkStatus: false` / `checkToolState: false`, precisely because it targets a manager-owned child session where the anti-duplicate gate does not apply.

## Fix

Pass `checkStatus: false` and `checkToolState: false` from `promptWithRetryInDirectory`, mirroring `sendSyncPrompt`. All six call sites of this wrapper are background-agent launch/resume dispatches into manager-owned child sessions, so none of them want the session-active gate.

## Tests

Added two self-validating cases in `src/shared/session-route.test.ts`:

- the gated `promptAsync` route still defers when the session reports an active status (proves the active status is detected);
- the retry wrapper dispatches without consulting session status (proves the bypass).

```
bun test src/shared/session-route.test.ts
6 pass / 0 fail
```

## Checklist

- [x] Code follows project conventions
- [x] `bun run build` succeeds (ESM bundle regenerated)
- [x] Tested locally with OpenCode via the `file://` plugin method — background subagents now launch instead of interrupting
- [x] No version changes in `package.json`
- [x] `bun run typecheck` is clean for the changed files (the change adds no type errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background agent launch failures by bypassing the session-active gate for child-session prompts in `promptWithRetryInDirectory`. Background tasks now start reliably instead of being interrupted with "promptAsync skipped by gate: active".

- Bug Fixes
  - In `promptWithRetryInDirectory`, bypass session-active/tool-state checks with `{ queueBehavior: "defer", checkStatus: false, checkToolState: false }` (mirrors `sendSyncPrompt`) for manager-owned child sessions during background-agent launch/resume.
  - Tests in `src/shared/session-route.test.ts` confirm the gated route still defers on active, and the retry wrapper dispatches without consulting `status`.

<sup>Written for commit fa6227671b3b5dcb7f028b7cc5085f1dd820313b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

