### PR TITLE
fix(ralph-loop): make completion detector fallbacks explicit

### DIFF
--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -88,12 +88,18 @@ export function detectCompletionInTranscript(
 				if (!entryText) continue
 				if (!shouldInspectTranscriptEntry(entry, promise, entryText)) continue
 				if (pattern.test(entryText)) return true
-			} catch {
+			} catch (error) {
+				if (!(error instanceof Error)) {
+					throw error
+				}
 				continue
 			}
 		}
 		return false
-	} catch {
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error
+		}
 		return false
 	}
 }
@@ -153,11 +159,12 @@ export async function detectCompletionInSessionMessages(
 		}
 
 		return false
-	} catch (err) {
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error)
 		setTimeout(() => {
 			log(`[${HOOK_NAME}] Session messages check failed`, {
 				sessionID: options.sessionID,
-				error: String(err),
+				error: errorMessage,
 			})
 		}, 0)
 		return false


### PR DESCRIPTION
## Summary
- Replace Ralph-loop completion transcript empty catches with explicit Error handling
- Keep malformed JSONL lines skipped and transcript read failures returning false
- Make the same-file session-message error logging catch pass the no-excuse rule while preserving string fallback behavior

## Manual QA
- bun test src/hooks/ralph-loop/completion-promise-transcript-detector.test.ts src/hooks/ralph-loop/completion-promise-detector.test.ts src/hooks/ralph-loop/completion-promise-session-negative.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/ralph-loop/completion-promise-detector.ts
- bun -e smoke test for malformed JSONL transcript skip plus missing transcript false fallback
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make completion detection fallbacks explicit in `ralph-loop` to avoid silently swallowing non-Error throws and to keep predictable false returns on failures. Also improves error logging to satisfy the no-excuse rule while preserving existing behavior for malformed JSONL lines.

- **Bug Fixes**
  - In transcript detection, rethrow non-Error throws; continue on parse/inspection errors; keep false fallback for missing/failed transcript reads.
  - In session message detection, log a safe error message (message or stringified) and return false; logging now complies with the no-excuse rule.

<sup>Written for commit 7f36ab68f771bbeab11d9acbb38da7417fc73759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

