### PR TITLE
fix(auto-update): make local dev fallbacks explicit

### DIFF
--- a/src/hooks/auto-update-checker/checker/local-dev-path.ts
+++ b/src/hooks/auto-update-checker/checker/local-dev-path.ts
@@ -22,11 +22,17 @@ export function getLocalDevPath(directory: string): string | null {
         if (!ACCEPTED_PACKAGE_NAMES.some(name => entry.includes(name))) continue
         try {
           return fileURLToPath(entry)
-        } catch {
+        } catch (error) {
+          if (!(error instanceof Error)) {
+            throw error
+          }
           return entry.replace("file://", "")
         }
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }


### PR DESCRIPTION
## Summary
- Replace two empty local-dev path catches with explicit Error handling
- Preserve fallback behavior for invalid file URLs and malformed/unreadable config files

## Manual QA
- bun test src/hooks/auto-update-checker/hook.test.ts src/hooks/auto-update-checker/checker/cached-version.test.ts src/hooks/auto-update-checker/checker/package-json-locator.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/auto-update-checker/checker/local-dev-path.ts
- bun -e smoke test for invalid file:// URL fallback
- HOME=<tmp> bun -e smoke test for malformed project config skipped in favor of valid user JSONC config
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make local dev path resolution safer by replacing empty catch blocks with explicit Error handling. Non-Error throws are rethrown, and existing fallbacks for invalid file:// URLs and unreadable entries are preserved so local dev behavior stays the same.

<sup>Written for commit 5318aca17bf23f99b9d35c72bc46b76babdb54ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

