### PR TITLE
fix(context-recovery): make tool result sdk fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/tool-result-storage-sdk.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/tool-result-storage-sdk.ts
@@ -53,7 +53,10 @@ export async function findToolResultsBySizeFromSDK(
     }
 
     return results.sort((a, b) => b.outputSize - a.outputSize)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -87,7 +90,8 @@ export async function truncateToolResultAsync(
     if (!patched) return { success: false }
     return { success: true, toolName, originalSize }
   } catch (error) {
-    log("[context-window-recovery] truncateToolResultAsync failed", { error: String(error) })
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    log("[context-window-recovery] truncateToolResultAsync failed", { error: errorMessage })
     return { success: false }
   }
 }
@@ -109,7 +113,10 @@ export async function countTruncatedResultsFromSDK(
     }
 
     return count
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return 0
   }
 }


### PR DESCRIPTION
## Summary
- Replace two empty SDK fallback catches with explicit Error handling
- Make the same-file truncate failure log path pass no-excuse narrowing
- Preserve [] / 0 / success:false fallback behavior for SDK failures

## Manual QA
- bun test src/hooks/anthropic-context-window-limit-recovery/storage.test.ts src/shared/normalize-sdk-response.test.ts src/shared/opencode-http-api.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/tool-result-storage-sdk.ts
- bun -e smoke test with fake SDK client for sorted tool results, compacted count, and SDK failure fallbacks
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tool result SDK fallbacks explicit in context-window recovery to avoid swallowing unexpected throws. We rethrow non-Error values, preserve [], 0, and success:false fallbacks for Error-based SDK failures, and log a normalized message for truncate failures.

<sup>Written for commit f7aedb1d912927fd72db1f98da0427d7249e1462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

