### PR TITLE
fix(context-recovery): make tool output pruning fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/pruning-tool-output-truncation.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/pruning-tool-output-truncation.ts
@@ -86,7 +86,10 @@ export async function truncateToolOutputsByCallId(
         if (result.success) {
           truncatedCount++
         }
-      } catch {
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
         continue
       }
     }
@@ -136,7 +139,10 @@ async function truncateToolOutputsByCallIdFromSDK(
     }
 
     return { truncatedCount }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return { truncatedCount: 0 }
   }
 }


### PR DESCRIPTION
## Summary
- Replace two empty tool-output pruning catches with explicit Error handling
- Preserve malformed stored part skip and SDK failure truncatedCount=0 fallback behavior

## Manual QA
- bun test src/hooks/anthropic-context-window-limit-recovery/recovery-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/storage.test.ts src/shared/normalize-sdk-response.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/pruning-tool-output-truncation.ts
- bun -e smoke test for empty call set and missing local message storage fallback
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tool-output pruning error handling explicit to avoid swallowing non-Error throws while preserving existing fallbacks. This improves reliability of context recovery without behavior changes.

- **Bug Fixes**
  - Replace empty catches with `Error`-aware handling in `truncateToolOutputsByCallId` and `truncateToolOutputsByCallIdFromSDK`.
  - Rethrow non-`Error` exceptions; continue on `Error` to keep malformed stored-part skip behavior.
  - Preserve SDK failure fallback: return `{ truncatedCount: 0 }`.

<sup>Written for commit 6027a1383eda3c3819edb73f72cc3048417412d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

