### PR TITLE
fix(context-recovery): make pruning dedup fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/pruning-deduplication.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/pruning-deduplication.ts
@@ -63,7 +63,10 @@ function readMessages(sessionID: string): MessagePart[] {
         messages.push(data)
       }
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 
@@ -75,7 +78,10 @@ async function readMessagesFromSDK(client: OpencodeClient, sessionID: string): P
     const response = await client.session.messages({ path: { id: sessionID } })
     const rawMessages = normalizeSDKResponse(response, [] as Array<{ parts?: ToolPart[] }>, { preferResponseOnMissingData: true })
     return rawMessages.filter((m) => m.parts) as MessagePart[]
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -116,21 +122,25 @@ export async function executeDeduplication(
       
       const signature = createToolSignature(part.tool, part.state?.input)
       
-      if (!signatures.has(signature)) {
-        signatures.set(signature, [])
+      let calls = signatures.get(signature)
+      if (!calls) {
+        calls = []
+        signatures.set(signature, calls)
       }
-      
-      signatures.get(signature)!.push({
+
+      calls.push({
         toolName: part.tool,
         signature,
         callID: part.callID,
         turn: currentTurn,
       })
-      
-      if (!state.toolSignatures.has(signature)) {
-        state.toolSignatures.set(signature, [])
+
+      let stateCalls = state.toolSignatures.get(signature)
+      if (!stateCalls) {
+        stateCalls = []
+        state.toolSignatures.set(signature, stateCalls)
       }
-      state.toolSignatures.get(signature)!.push({
+      stateCalls.push({
         toolName: part.tool,
         signature,
         callID: part.callID,


### PR DESCRIPTION
## Summary
- replace two empty fallback catches in pruning deduplication with Error-narrowed fallbacks
- remove same-file non-null assertions flagged by the no-excuse checker
- preserve missing storage / SDK failure behavior as an empty message list fallback

## Manual QA
- bun test src/hooks/anthropic-context-window-limit-recovery/pruning-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/recovery-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/storage.test.ts src/shared/normalize-sdk-response.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/pruning-deduplication.ts
- bun -e smoke for stable signatures and missing-session fallback
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes error handling in context-recovery pruning dedup explicit and safer. Replaces silent catches with Error-checked fallbacks and removes non-null assertions without changing behavior.

- **Bug Fixes**
  - Replace empty catch blocks with Error-narrowed fallbacks returning [] in `readMessages` and `readMessagesFromSDK`.
  - Remove non-null assertions by initializing map entries before pushes.
  - Preserve fallback behavior: return empty messages on missing storage or SDK failures.

<sup>Written for commit 261d36ccbbe13e931ce2d90963b5a960f33ce2fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

