### PR TITLE
fix(context-recovery): make empty content sdk fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
@@ -66,7 +66,10 @@ async function findEmptyMessagesFromSDK(client: Client, sessionID: string): Prom
     }
 
     return emptyIds
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -104,7 +107,10 @@ async function findEmptyMessageByIndexFromSDK(
     }
 
     return null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- replace two empty SDK lookup catches with Error-narrowed fallbacks
- preserve current fallback behavior for SDK failures: no empty message ids / no indexed target
- rethrow non-Error throws instead of silently swallowing them

## Manual QA
- bun test src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts src/hooks/anthropic-context-window-limit-recovery/recovery-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/executor.test.ts src/hooks/session-recovery/recover-empty-content-message-sdk.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
- bun -e smoke for SDK failure fallback result
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SDK error fallbacks explicit in empty-content recovery. We now return []/null only for Error instances and rethrow non-Error throws, preserving existing fallback behavior for SDK failures (no empty message ids / no indexed target).

<sup>Written for commit edd987759a1033484fbb62261d703dc2675ef64b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

