### PR TITLE
fix(team-mode): make worktree cleanup fallbacks explicit

### DIFF
--- a/src/features/team-mode/team-worktree/cleanup.ts
+++ b/src/features/team-mode/team-worktree/cleanup.ts
@@ -49,7 +49,10 @@ export async function findOrphanWorktrees(baseDir: string, _config: TeamModeConf
   let teamRunDirectories: string[]
   try {
     teamRunDirectories = await fs.readdir(worktreesDir)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return orphanWorktrees
   }
 
@@ -68,7 +71,10 @@ export async function findOrphanWorktrees(baseDir: string, _config: TeamModeConf
         if (state.status !== "active" && state.status !== "shutdown_requested") {
           orphanWorktrees.push(worktreePath)
         }
-      } catch {
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
         orphanWorktrees.push(worktreePath)
       }
     }


### PR DESCRIPTION
## Summary
- replace two empty fallback catches in team worktree cleanup with Error-narrowed fallbacks
- preserve current behavior for missing worktree dirs and unreadable/inactive runtime state
- rethrow non-Error throws instead of silently swallowing them

## Manual QA
- bun test src/features/team-mode/team-worktree/cleanup.test.ts src/features/team-mode/team-worktree/manager.test.ts src/features/team-mode/team-runtime/cleanup-team-run-resources.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/team-mode/team-worktree/cleanup.ts
- bun -e smoke for missing worktrees dir and missing runtime state orphan detection
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make team worktree cleanup error handling explicit to prevent silent failures. Replaces empty catch blocks in `findOrphanWorktrees` with Error-checked fallbacks, preserves behavior for missing worktree directories and unreadable/inactive runtime state, and rethrows non-Error exceptions.

<sup>Written for commit b03cbaabbada7686f639daaf781bc8d87fb9d138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

