### PR TITLE
fix(team-mode): make state lock fallbacks explicit

### DIFF
--- a/src/features/team-mode/team-state-store/locks.ts
+++ b/src/features/team-mode/team-state-store/locks.ts
@@ -43,7 +43,10 @@ function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -104,7 +107,10 @@ export async function detectStaleLock(lockPath: string, staleAfterMs: number): P
     if (isPidAlive(parsed.ownerPid)) return false
 
     return Date.now() - parsed.acquiredAtEpochMs > staleAfterMs
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace two empty fallback catches in team state lock handling with Error-narrowed fallbacks
- preserve current stale-lock behavior for missing/unreadable lock files and dead PIDs
- rethrow non-Error throws instead of silently swallowing them

## Manual QA
- bun test src/features/team-mode/team-state-store/locks.test.ts src/features/team-mode/team-runtime/status.test.ts src/features/team-mode/team-tasklist/claim.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/team-mode/team-state-store/locks.ts
- bun -e smoke for missing lock, stale lock detection, and reap
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened team-mode state lock handling by replacing empty catches with explicit Error fallbacks and rethrowing non-Error throws. Preserves current behavior for missing/unreadable lock files and dead PIDs while preventing silent failures.

- **Bug Fixes**
  - Replaced empty catch blocks in `isPidAlive` and `detectStaleLock` with Error checks; non-Error throws are rethrown.
  - Kept existing fallback of returning false for unreadable/missing locks or dead PIDs to maintain stale-lock semantics.

<sup>Written for commit 18d2d4e93bc210954626fa6db3f71a141e1598fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

