### PR TITLE
fix(skill-mcp): make http url fallbacks explicit

### DIFF
--- a/src/features/skill-mcp-manager/http-client.ts
+++ b/src/features/skill-mcp-manager/http-client.ts
@@ -52,7 +52,10 @@ function redactUrl(urlStr: string): string {
       }
     }
     return u.toString()
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return urlStr
   }
 }
@@ -99,7 +102,10 @@ export async function createHttpClient(params: SkillMcpClientConnectionParams): 
   let url: URL
   try {
     url = new URL(config.url)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     throw new Error(
       `MCP server "${info.serverName}" has invalid URL: ${redactUrl(config.url)}\n\n` +
       `Expected a valid URL like: https://mcp.example.com/mcp`


### PR DESCRIPTION
## Summary
- replace two empty URL parsing catches in the skill MCP HTTP client with explicit Error narrowing
- preserve the existing invalid URL fallback and user-facing error behavior

## Manual QA
- bun test src/features/skill-mcp-manager/manager.test.ts src/features/skill-mcp-manager/connection-env-vars.test.ts src/features/skill-mcp-manager/manager-oauth-retry.test.ts src/features/skill-mcp-manager/oauth-handler.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/skill-mcp-manager/http-client.ts
- bun -e invalid URL smoke import for createHttpClient
- bun run typecheck
- bun run build
- git diff --check origin/dev

## Notes
- Invalid URL strings are still reported verbatim, matching existing behavior. Redaction semantics for invalid URL parse failures are intentionally not changed in this cleanup PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make URL parsing fallbacks explicit in the Skill MCP HTTP client. Improves error safety while keeping existing invalid-URL messages and redaction.

- **Bug Fixes**
  - Narrow caught values to `Error` in `redactUrl` and `createHttpClient`; rethrow non-Error exceptions.
  - Preserve invalid URL fallback and user-facing error text (no change to redaction).

<sup>Written for commit 9001e066e970d5ed18a9139a12e680316e815217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

