### PR TITLE
fix(skill-mcp): make connection cleanup fallbacks explicit

### DIFF
--- a/src/features/skill-mcp-manager/connection.ts
+++ b/src/features/skill-mcp-manager/connection.ts
@@ -52,13 +52,25 @@ export async function getOrCreateClient(params: {
     const isStale = state.pendingConnections.has(clientKey) && state.pendingConnections.get(clientKey) !== currentConnectionPromise
     if (isStale) {
       removeClientIfCurrent(state, clientKey, client)
-      try { await client.close() } catch {}
+      try {
+        await client.close()
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
+      }
       throw new Error(`Connection for "${info.sessionID}" was superseded by a newer connection attempt.`)
     }
 
     if (state.shutdownGeneration !== shutdownGenAtStart) {
       removeClientIfCurrent(state, clientKey, client)
-      try { await client.close() } catch {}
+      try {
+        await client.close()
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
+      }
       throw new Error(`Shutdown occurred during MCP connection for "${info.sessionID}"`)
     }
 


### PR DESCRIPTION
## Summary
- replace two cleanup-only empty catches in skill MCP connection race handling with explicit Error narrowing
- preserve existing behavior for ordinary Error cleanup failures while propagating non-Error throws

## Manual QA
- bun test src/features/skill-mcp-manager/manager.test.ts src/features/skill-mcp-manager/connection-env-vars.test.ts src/features/skill-mcp-manager/manager-oauth-retry.test.ts src/features/skill-mcp-manager/oauth-handler.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/skill-mcp-manager/connection.ts
- bun -e superseded connection cleanup smoke for getOrCreateClient
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP connection cleanup explicit in `getOrCreateClient`. We still ignore normal Error failures when closing clients, but we now rethrow non-Error throws so unexpected exceptions aren’t silently swallowed during superseded or shutdown cleanup.

<sup>Written for commit 80c0280899002e904a3b7c1744b4b8d7967d0d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

