### PR TITLE
fix(skills): make mcp config fallbacks explicit

### DIFF
--- a/src/features/opencode-skill-loader/skill-mcp-config.ts
+++ b/src/features/opencode-skill-loader/skill-mcp-config.ts
@@ -12,7 +12,10 @@ export function parseSkillMcpConfigFromFrontmatter(content: string): SkillMcpCon
     if (parsed && typeof parsed === "object" && "mcp" in parsed && parsed.mcp) {
       return parsed.mcp as SkillMcpConfig
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return undefined
   }
   return undefined
@@ -37,7 +40,10 @@ export async function loadMcpJsonFromDir(skillDir: string): Promise<SkillMcpConf
         return parsed as SkillMcpConfig
       }
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return undefined
   }
 


### PR DESCRIPTION
## Summary
- replace two parser-boundary empty catches in skill MCP config loading with explicit Error narrowing
- preserve existing behavior where invalid frontmatter, missing/invalid mcp.json, or parse errors return undefined

## Manual QA
- bun test src/plugin-handlers/config-handler.test.ts src/plugin-handlers/agent-config-handler.test.ts src/plugin-handlers/command-config-handler.test.ts src/tools/skill-mcp/tools.test.ts src/plugin/skill-context.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/opencode-skill-loader/skill-mcp-config.ts
- bun -e frontmatter + mcp.json parser smoke
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP config parsing fallbacks explicit to avoid swallowing non-Error throws. We now narrow caught values to Error and rethrow non-Error, while preserving existing behavior: invalid frontmatter, missing/invalid `mcp.json`, or parse errors return undefined.

<sup>Written for commit bfe7976ac45aad37fae371e005fffd0acf22c388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

