### PR TITLE
fix(agents): make file uri fallbacks explicit

### DIFF
--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -31,7 +31,10 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
     filePath = isAbsolute(expanded)
       ? expanded
       : resolve(configDir ?? process.cwd(), expanded)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return `[WARNING: Malformed file URI (invalid percent-encoding): ${promptAppend}]`
   }
 
@@ -52,7 +55,10 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
 
   try {
     return readFileSync(filePath, "utf8")
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return `[WARNING: Could not read file: ${promptAppend}]`
   }
 }


### PR DESCRIPTION
## Summary
- replace two empty fallback catches in agent file URI prompt resolution with explicit Error narrowing
- preserve existing warning behavior for malformed percent-encoding and unreadable files

## Manual QA
- bun test src/agents/builtin-agents/resolve-file-uri.test.ts src/agents/builtin-agents/sisyphus-agent.test.ts src/plugin-handlers/agent-config-handler.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/agents/builtin-agents/resolve-file-uri.ts
- bun -e resolvePromptAppend file URI smoke
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make file URI resolution safer by replacing empty catch blocks with explicit Error checks in `resolvePromptAppend`. Non-Error exceptions now bubble up, while malformed percent-encoding and unreadable files still return the same warning messages.

<sup>Written for commit aa2b188b2b91a365f37809b1b3d716981184fdb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

