### PR TITLE
fix(doctor): make gh check fallbacks explicit

### DIFF
--- a/src/cli/doctor/checks/tools-gh.ts
+++ b/src/cli/doctor/checks/tools-gh.ts
@@ -14,7 +14,10 @@ async function checkBinaryExists(binary: string): Promise<{ exists: boolean; pat
   try {
     const binaryPath = Bun.which(binary)
     return { exists: Boolean(binaryPath), path: binaryPath ?? null }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return { exists: false, path: null }
   }
 }
@@ -26,7 +29,10 @@ async function getGhVersion(): Promise<string | null> {
 
     const matchedVersion = result.stdout.match(/gh version (\S+)/)
     return matchedVersion?.[1] ?? result.stdout.trim().split("\n")[0] ?? null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- replace two empty fallback catches in the GitHub CLI doctor check with explicit Error narrowing
- preserve existing doctor behavior for missing Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories
  skill:         Install and manage agent skills (preview)

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands
  telemetry:     Information about telemetry in gh

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` and failed gh version 2.92.0 (2026-04-28)
https://github.com/cli/cli/releases/tag/v2.92.0 checks

## Manual QA
- bun test src/cli/doctor/checks/tools-gh.test.ts src/cli/doctor/formatter.test.ts src/cli/doctor/format-default.test.ts src/cli/doctor/runner.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/doctor/checks/tools-gh.ts
- bun -e getGhCliInfo doctor helper smoke
- bun run typecheck
- bun run build
- git diff --check origin/dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the GitHub CLI doctor check by replacing silent catch blocks with explicit Error handling. Keeps current behavior when `gh` is missing or version parsing fails, and surfaces unexpected non-Error throws.

- **Bug Fixes**
  - Updated `checkBinaryExists` and `getGhVersion` to narrow caught values to `Error`, returning safe fallbacks only for real Errors and rethrowing non-Error values.
  - No user-visible changes in normal scenarios; improves diagnostics for unexpected runtime issues.

<sup>Written for commit 5a2c5dd3557eea54e6d5a45cf0c71529ddbef076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

