### PR TITLE
fix(cli-run): make event formatting fallbacks explicit

### DIFF
--- a/src/cli/run/event-formatting.ts
+++ b/src/cli/run/event-formatting.ts
@@ -47,8 +47,10 @@ export function serializeError(error: unknown): string {
       if (json !== "{}") {
         return json
       }
-    } catch (_) {
-      void _
+    } catch (stringifyError) {
+      if (!(stringifyError instanceof Error)) {
+        throw stringifyError
+      }
     }
   }
 
@@ -120,10 +122,16 @@ export function logEventVerbose(ctx: RunContext, payload: EventPayload): void {
       let inputStr: string
       try {
         inputStr = JSON.stringify(input)
-      } catch {
+      } catch (jsonError) {
+        if (!(jsonError instanceof Error)) {
+          throw jsonError
+        }
         try {
           inputStr = String(input)
-        } catch {
+        } catch (stringError) {
+          if (!(stringError instanceof Error)) {
+            throw stringError
+          }
           inputStr = "[unserializable]"
         }
       }


### PR DESCRIPTION
## Summary
- replace empty `catch` fallbacks in CLI run event formatting with explicit `Error` narrowing
- preserve existing fallback behavior for `Error` serialization failures and rethrow non-`Error` throws instead of silently swallowing them

## Manual QA
- `bun test src/cli/run/events.test.ts src/cli/run/event-tool-handlers.test.ts src/cli/run/event-session-handlers.test.ts` -> 26 pass
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/run/event-formatting.ts` -> no violations
- `bun run typecheck` -> pass
- `bun run build` -> pass
- `git diff --check` -> pass
- `bun -e 'import { serializeError } from "./src/cli/run/events"; console.log(serializeError({ code: "ERR_SMOKE", status: 500 }))'` -> printed serialized object\n\n## Empty-catch count\n- `src/cli/run/event-formatting.ts`: 2 -> 0\n- non-test `src/**/*.ts` branch count: 151 -> 149

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CLI event formatting by removing empty catch blocks in `serializeError` and `logEventVerbose`. Non-Error throws now rethrow; existing serialization fallbacks are unchanged.

- **Bug Fixes**
  - Replaced empty catches with explicit `instanceof Error` checks.
  - Preserved JSON/string fallbacks; still returns "[unserializable]" when both fail.
  - Rethrow non-Error values to avoid silent failures.

<sup>Written for commit 2bf1b9b5c161c94d626ac64d32c9e5553aeb22a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

