### PR TITLE
fix(anthropic-recovery): make message fallbacks explicit

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
@@ -10,7 +10,6 @@ import {
 } from "../session-recovery/storage"
 import { findMessagesWithEmptyTextPartsFromSDK, replaceEmptyTextPartsAsync } from "../session-recovery/storage/empty-text"
 import { injectTextPartAsync } from "../session-recovery/storage/text-part-injector"
-import type { Client } from "./client"
 
 export const PLACEHOLDER_TEXT = "[user interrupted]"
 
@@ -75,7 +74,10 @@ async function findEmptyMessageIdsFromSDK(
     }
 
     return emptyIds
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -155,12 +157,11 @@ export function formatBytes(bytes: number): string {
 
 export async function getLastAssistant(
   sessionID: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  client: any,
+  client: OpencodeClient,
   directory: string,
 ): Promise<{ info: Record<string, unknown>; hasContent: boolean } | null> {
   try {
-    const resp = await (client as Client).session.messages({
+    const resp = await client.session.messages({
       path: { id: sessionID },
       query: { directory },
     })
@@ -184,7 +185,10 @@ export async function getLastAssistant(
       info,
       hasContent: messageHasContentFromSDK(message),
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- replace empty SDK recovery catches in `message-builder.ts` with explicit `Error` narrowing
- keep normal `Error` fallback behavior (`[]` / `null`) while rethrowing non-`Error` throws
- remove the local `client: any` escape hatch by using the existing `PluginInput["client"]` alias

## Manual QA
- `bun test src/hooks/anthropic-context-window-limit-recovery/message-builder.test.ts src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts src/hooks/anthropic-context-window-limit-recovery/recovery-hook-regression.test.ts src/hooks/anthropic-context-window-limit-recovery/executor.test.ts` -> 20 pass
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/anthropic-context-window-limit-recovery/message-builder.ts` -> no violations
- `bun run typecheck` -> pass
- `bun run build` -> pass
- `git diff --check` -> pass
- `bun -e 'import { formatBytes } from "./src/hooks/anthropic-context-window-limit-recovery/message-builder"; console.log(formatBytes(1536))'` -> `1.5KB`\n\n## Empty-catch count\n- `src/hooks/anthropic-context-window-limit-recovery/message-builder.ts`: 2 -> 0\n- non-test `src/**/*.ts` branch count: 149 -> 147

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Anthropic context‑window recovery fallbacks explicit and safer. We now return []/null on real errors, rethrow non-Error throws, and use a typed client instead of any.

- **Bug Fixes**
  - Replace empty catches in `message-builder.ts` with `Error` narrowing in `findEmptyMessageIdsFromSDK` and `getLastAssistant` (fallbacks preserved).
  - Remove `client: any`; use the typed `PluginInput["client"]` alias.

<sup>Written for commit f1aac6fca357135c65db62039ec52672f6ac3a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

