### PR TITLE
fix(slashcommand): make command discovery fallback explicit

### DIFF
--- a/src/tools/slashcommand/command-discovery.ts
+++ b/src/tools/slashcommand/command-discovery.ts
@@ -78,7 +78,10 @@ function discoverCommandsFromDir(
         content: body,
         scope,
       })
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }


### PR DESCRIPTION
## Summary
- replace the empty catch in slashcommand markdown discovery with explicit `Error` narrowing
- preserve normal unreadable/malformed markdown skip behavior for `Error` failures
- rethrow non-`Error` throws instead of silently swallowing them

## Manual QA
- `bun test src/tools/slashcommand/command-discovery.test.ts src/tools/slashcommand/opencode-project-command-discovery.test.ts src/tools/slashcommand/execution-compatibility.test.ts src/tools/slashcommand/index.test.ts` -> 16 pass
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/slashcommand/command-discovery.ts` -> no violations
- `bun run typecheck` -> pass
- `bun run build` -> pass
- `git diff --check` -> pass
- `bun -e 'import { discoverCommandsSync } from "./src/tools/slashcommand/command-discovery"; const commands = discoverCommandsSync(process.cwd(), { pluginsEnabled: false }); console.log(commands.length >= 0 ? "discovery-ok" : "bad")'` -> `discovery-ok`\n\n## Empty-catch count\n- `src/tools/slashcommand/command-discovery.ts`: 1 -> 0\n- non-test `src/**/*.ts` branch count: 147 -> 146

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make slashcommand command discovery fallback explicit by replacing the empty catch with explicit `Error` handling. We still skip unreadable/malformed markdown, but now rethrow non-`Error` throws instead of silently swallowing them.

<sup>Written for commit faa6f32879d142e17c0b221102984d37131bf03e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

