### PR TITLE
fix(look-at): make mime fallback explicit

### DIFF
--- a/src/tools/look-at/mime-type-inference.ts
+++ b/src/tools/look-at/mime-type-inference.ts
@@ -21,8 +21,10 @@ export function inferMimeTypeFromBase64(base64Data: string): string {
       return "image/heif"
     }
     if (header.startsWith("%PDF")) return "application/pdf"
-  } catch {
-    // invalid base64 - fall through
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
   }
 
   return "image/png"


### PR DESCRIPTION
## Summary
- replace the empty catch in Base64 MIME inference with explicit `Error` narrowing
- preserve the existing invalid/unknown Base64 fallback to `image/png` for normal `Error` failures
- rethrow non-`Error` throws instead of silently swallowing them

## Manual QA
- `bun test src/tools/look-at/mime-type-inference.test.ts src/tools/look-at/look-at-arguments.test.ts src/tools/look-at/tools.test.ts` -> 36 pass
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/look-at/mime-type-inference.ts` -> no violations
- `bun run typecheck` -> pass
- `bun run build` -> pass
- `git diff --check` -> pass
- `bun -e 'import { inferMimeTypeFromBase64, inferMimeTypeFromFilePath } from "./src/tools/look-at/mime-type-inference"; console.log(inferMimeTypeFromBase64("dW5rbm93biBiaW5hcnk="), inferMimeTypeFromFilePath("/tmp/photo.HEIC"))'` -> `image/png image/heic`\n\n## Empty-catch count\n- `src/tools/look-at/mime-type-inference.ts`: 1 -> 0\n- non-test `src/**/*.ts` branch count: 146 -> 145

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Base64 MIME inference safer by removing the empty catch and handling errors explicitly. Invalid or unknown Base64 still falls back to image/png; non-Error throws are rethrown.

- **Bug Fixes**
  - Replace empty catch with explicit `Error` check in `inferMimeTypeFromBase64`.
  - Keep fallback to "image/png" for normal `Error` cases.
  - Re-throw non-`Error` exceptions instead of swallowing them.

<sup>Written for commit 825cc8f803cb84fb54945990d98a2aff8e806cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

