### PR TITLE
fix(glob): make mtime fallback explicit

### DIFF
--- a/src/tools/glob/cli.ts
+++ b/src/tools/glob/cli.ts
@@ -89,7 +89,10 @@ async function getFileMtime(filePath: string): Promise<number> {
   try {
     const stats = await stat(filePath)
     return stats.mtime.getTime()
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return 0
   }
 }


### PR DESCRIPTION
## Summary
- replace the empty catch in `getFileMtime` with explicit `Error` narrowing
- preserve the existing `mtime=0` fallback for normal filesystem `Error` failures
- rethrow non-`Error` throws instead of silently swallowing them

## Manual QA
- `bun test src/tools/glob/cli.test.ts` -> 21 pass
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/glob/cli.ts` -> no violations
- `bun run typecheck` -> pass
- `bun run build` -> pass
- `git diff --check` -> pass
- `bun -e 'import { runRgFiles } from "./src/tools/glob/cli"; const result = await runRgFiles({ pattern: "package.json", paths: [process.cwd()], limit: 2 }); console.log(result.files.length >= 1 ? "glob-ok" : JSON.stringify(result))'` -> `glob-ok`\n\n## Empty-catch count\n- `src/tools/glob/cli.ts`: 1 -> 0\n- non-test `src/**/*.ts` branch count: 145 -> 144

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `getFileMtime` error handling explicit in glob. Keep `mtime=0` fallback for filesystem `Error`s and rethrow non-`Error` throws to avoid silent failures.

<sup>Written for commit 7f9ee494d1cedf407671c686c5f2660d34588d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

