### PR TITLE
fix(shared): make legacy plugin warning fallback explicit

### DIFF
--- a/src/shared/legacy-plugin-warning.ts
+++ b/src/shared/legacy-plugin-warning.ts
@@ -62,7 +62,11 @@ export function checkForLegacyPluginEntry(overrideConfigDir?: string): LegacyPlu
       legacyEntries,
       configPath,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return { hasLegacyEntry: false, hasCanonicalEntry: false, legacyEntries: [], configPath: null }
   }
 }


### PR DESCRIPTION
## Summary
- replace an empty catch in legacy plugin warning detection with an explicit Error fallback
- preserve the best-effort no-warning result for normal config read/parse failures
- rethrow non-Error throws instead of silently swallowing unknown control flow

## Manual QA
- bun test src/shared/legacy-plugin-warning.test.ts src/shared/log-legacy-plugin-startup-warning.test.ts src/hooks/legacy-plugin-toast/hook.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/legacy-plugin-warning.ts
- git diff --check
- bun run typecheck
- bun run build
- bun --print import smoke for checkForLegacyPluginEntry() with a missing config directory

Cubic is intentionally not required for this batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made legacy plugin warning detection safer by replacing the empty catch with explicit Error handling. Non-Error throws are rethrown, and normal config read/parse failures still return the safe no‑warning fallback to avoid false positives.

<sup>Written for commit ce9d38123302c8576ec67acf6a490a3e2de3d7e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

