### PR TITLE
fix(shared): make data path fallback explicit

### DIFF
--- a/src/shared/data-path.ts
+++ b/src/shared/data-path.ts
@@ -9,7 +9,11 @@ function resolveWritableDirectory(preferredDir: string, fallbackSuffix: string):
     mkdirSync(preferredDir, { recursive: true })
     accessSync(preferredDir, constants.W_OK)
     return preferredDir
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     const fallbackDir = path.join(os.tmpdir(), fallbackSuffix)
     mkdirSync(fallbackDir, { recursive: true })
     return fallbackDir


### PR DESCRIPTION
## Summary
- replace the empty catch in shared data/cache directory resolution with explicit Error narrowing
- preserve tmpdir fallback for normal filesystem failures
- rethrow non-Error throws instead of silently swallowing unknown control flow

## Manual QA
- bun test src/shared/opencode-provider-auth.test.ts src/shared/opencode-storage-detection.test.ts src/shared/connected-providers-cache.test.ts src/shared/model-capabilities-cache.test.ts src/shared/ripgrep-cli.test.ts src/shared/model-availability.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/data-path.ts
- git diff --check
- forced fallback smoke: set XDG_CACHE_HOME to a file path and verified getCacheDir() returns tmpdir/opencode-cache
- bun run typecheck
- bun run build

Cubic is intentionally not required for this batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make shared data path fallback explicit by only handling real `Error` instances. Keeps tmpdir fallback for filesystem failures, and rethrows non-Error throws to prevent silent control flow swallowing.

<sup>Written for commit 6cbeb11818faf4cb89a067c2309b915dd2ef9516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

