### PR TITLE
fix(shared): make bun which fallback explicit

### DIFF
--- a/src/shared/bun-which-shim.ts
+++ b/src/shared/bun-which-shim.ts
@@ -18,7 +18,11 @@ function isExecutable(filePath: string): boolean {
   try {
     accessSync(filePath, constants.X_OK)
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error) && Object.prototype.toString.call(error) !== "[object Error]") {
+      throw error
+    }
+
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace the empty catch in the executable probe with explicit Error narrowing
- preserve Node fallback behavior, including VM cross-realm Error objects used by the shim tests
- rethrow non-Error throws instead of silently swallowing unknown control flow

## Manual QA
- bun test src/shared/bun-which-shim.test.ts src/mcp/runtime-executable.test.ts src/cli/install-codex/codex-installation-detection.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/bun-which-shim.ts
- git diff --check
- direct smoke: bunWhich() returns null for a definitely missing command
- bun run typecheck
- bun run build

Cubic is intentionally not required for this batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `bunWhich` executable check handle errors explicitly and rethrow non-Error throws. This preserves Node-like fallback behavior (including cross-realm `Error`s) and prevents silently swallowing unexpected control flow.

<sup>Written for commit 6e1f40ec1df3ac6e72146b321738744240f9f314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

