### PR TITLE
fix(plugin): make event error stringify fallback explicit

### DIFF
--- a/src/plugin/event-error-utils.ts
+++ b/src/plugin/event-error-utils.ts
@@ -42,7 +42,11 @@ export function extractErrorMessage(error: unknown): string {
 
   try {
     return JSON.stringify(error);
-  } catch {
+  } catch (stringifyError) {
+    if (!(stringifyError instanceof Error)) {
+      throw stringifyError;
+    }
+
     return String(error);
   }
 }


### PR DESCRIPTION
## Summary
- replace the empty catch in event error message extraction with explicit Error narrowing
- preserve the existing String(error) fallback for circular or otherwise unserializable payloads
- rethrow non-Error stringify throws instead of silently swallowing unknown control flow

## Manual QA
- bun test src/plugin/event-error-utils.test.ts src/plugin/event.test.ts src/plugin/event.model-fallback.test.ts src/plugin/event.model-fallback-pin-agent.test.ts src/plugin/event.model-fallback-2941.test.ts src/plugin/event-abort-interrupted-recovery.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/plugin/event-error-utils.ts
- git diff --check
- circular-object smoke for extractErrorMessage() fallback
- bun run typecheck
- bun run build

Cubic is intentionally not required for this batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make error handling in event error utils explicit: only fall back to String(error) when JSON.stringify throws an Error, and rethrow non-Error throws. This prevents silently swallowing unknown control flow and keeps the fallback for circular or unserializable objects.

<sup>Written for commit 1e6f5702e85699d8d55110dd941b73248050ce87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

