### PR TITLE
fix(plugin): make chat header lookup fallback explicit

### DIFF
--- a/src/plugin/chat-headers.ts
+++ b/src/plugin/chat-headers.ts
@@ -93,7 +93,11 @@ async function hasInternalMarker(
     }
 
     return hasMarker
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     internalMarkerCache.set(cacheKey, false)
     if (internalMarkerCache.size > INTERNAL_MARKER_CACHE_LIMIT) {
       internalMarkerCache.clear()


### PR DESCRIPTION
## Summary
- replace the empty catch in Copilot internal-marker lookup with explicit Error narrowing
- preserve the existing cache-false fallback when marker lookup fails
- rethrow non-Error throws instead of silently swallowing unknown control flow

## Manual QA
- bun test src/plugin/chat-headers.test.ts src/plugin/chat-message.test.ts src/plugin/messages-transform.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/plugin/chat-headers.ts
- git diff --check
- failed marker lookup smoke: handler leaves x-initiator unset when client.session.message throws
- bun run typecheck
- bun run build

Cubic is intentionally not required for this batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat header internal marker lookup errors explicit. Non-Error throws are rethrown, while real errors set the cache to false as before, preventing silent failures and preserving existing header behavior.

<sup>Written for commit cd8e82cc27f5248b756d004b12b1c721f8a74d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

