### PR TITLE
fix(plugin-config): make git master override fallback explicit

### DIFF
--- a/src/plugin-config/single-config-loader.ts
+++ b/src/plugin-config/single-config-loader.ts
@@ -25,7 +25,10 @@ export function loadExplicitGitMasterOverrides(configPath: string): Record<strin
     if (isRecord(gitMaster)) {
       return gitMaster;
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- Replaces the empty catch in `loadExplicitGitMasterOverrides` with an explicit `Error` fallback.
- Keeps malformed or unreadable git_master override configs best-effort by returning `undefined` for ordinary `Error` failures.
- Rethrows non-Error values instead of silently swallowing impossible internal failures.

## Manual QA
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/plugin-config/single-config-loader.ts`
- `bun test src/plugin-config.test.ts`
- `bun --eval "import { mkdtempSync, writeFileSync } from 'fs'; import { join } from 'path'; import { tmpdir } from 'os'; import { loadExplicitGitMasterOverrides } from './src/plugin-config/single-config-loader.ts'; const dir = mkdtempSync(join(tmpdir(), 'omo-single-config-smoke-')); const file = join(dir, 'oh-my-openagent.jsonc'); writeFileSync(file, '{ git_master: '); const result = loadExplicitGitMasterOverrides(file); if (result !== undefined) throw new Error('expected malformed config to return undefined'); console.log('smoke: malformed git_master override returns undefined');"`
- `git diff --check`
- `bun run typecheck`
- `bun run build`

## Notes
- Cubic is not required for this cleanup batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `git_master` override fallback explicit in the single-config loader. Replaces the empty catch in loadExplicitGitMasterOverrides to return undefined for normal errors (malformed or unreadable configs) and rethrow non-Error values to avoid hiding internal failures.

<sup>Written for commit f0b9c4d89db134be22a1c9592094b6b4c2852846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

