### PR TITLE
fix(openclaw): make gateway url fallback explicit

### DIFF
--- a/src/openclaw/gateway-url-validation.ts
+++ b/src/openclaw/gateway-url-validation.ts
@@ -12,7 +12,10 @@ export function validateGatewayUrl(url: string): boolean {
       return true
     }
     return false
-  } catch {
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the empty catch in `validateGatewayUrl` with explicit `TypeError` handling for invalid URL input.
- Keeps existing allow/reject behavior for HTTPS, localhost HTTP, remote HTTP, and invalid URL strings.
- Rethrows unexpected non-URL-constructor failures instead of silently swallowing them.

## Manual QA
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/openclaw/gateway-url-validation.ts`
- `bun test src/openclaw/gateway-url-validation.test.ts src/openclaw/__tests__/config.test.ts`
- `bun --eval "import { validateGatewayUrl } from './src/openclaw/gateway-url-validation.ts'; const cases = [['https://example.com', true], ['http://localhost:3000', true], ['http://example.com', false], ['not-a-url', false]] as const; for (const [url, expected] of cases) { const actual = validateGatewayUrl(url); if (actual !== expected) throw new Error(url + ' expected ' + expected + ' got ' + actual); } console.log('smoke: gateway url validation preserves allow/reject behavior');"`
- `git diff --check`
- `bun run typecheck`
- `bun run build`

## Notes
- Cubic is not required for this cleanup batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make gateway URL validation stricter and safer by catching only TypeError from the URL constructor and rethrowing any other errors. Keeps the current allow/reject rules (HTTPS allowed, localhost HTTP allowed, remote HTTP and invalid strings rejected).

<sup>Written for commit 0877409b2faa1d11ce5a957641d403cc3ba70654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

