### PR TITLE
fix(hooks): make tool truncation fallback explicit

### DIFF
--- a/src/hooks/tool-output-truncator.test.ts
+++ b/src/hooks/tool-output-truncator.test.ts
@@ -129,6 +129,32 @@ describe("createToolOutputTruncatorHook", () => {
       })
     })
 
+    describe("#given truncation fails", () => {
+      describe("#when output is processed", () => {
+        it("#then should leave the tool output unchanged", async () => {
+          // given
+          const truncateMock = mock(async () => {
+            throw new Error("truncation failed")
+          })
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never)
+
+          const input = createInput("grep")
+          const output = createOutput("grep output")
+
+          // when
+          await hook["tool.execute.after"](input, output)
+
+          // then
+          expect(output.output).toBe("grep output")
+        })
+      })
+    })
+
     describe("#given non-truncatable tool", () => {
       describe("#when tool is not in TRUNCATABLE_TOOLS list", () => {
         it("#then should not call truncator", async () => {

--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -55,8 +55,10 @@ export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOu
       if (truncated) {
         output.output = result
       }
-    } catch {
-      // Graceful degradation - don't break tool execution
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Replaces the empty catch in `createToolOutputTruncatorHook` with explicit `Error` failure isolation.
- Adds a characterization test proving truncator failures leave the original tool output unchanged.
- Rethrows unexpected non-Error throws instead of silently swallowing them.

## Manual QA
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/tool-output-truncator.ts src/hooks/tool-output-truncator.test.ts`
- `bun test src/hooks/tool-output-truncator.test.ts`
- `bun --eval "import { mock, spyOn } from 'bun:test'; import { createToolOutputTruncatorHook } from './src/hooks/tool-output-truncator.ts'; import * as dynamicTruncator from './src/shared/dynamic-truncator.ts'; const spy = spyOn(dynamicTruncator, 'createDynamicTruncator').mockReturnValue({ truncate: mock(async () => { throw new Error('boom'); }), getUsage: mock(async () => null), truncateSync: mock(() => ({ result: '', truncated: false })) }); const hook = createToolOutputTruncatorHook({} as never); const output = { title: 'Result', output: 'keep me', metadata: {} }; await hook['tool.execute.after']({ tool: 'grep', sessionID: 's', callID: 'c' }, output); spy.mockRestore(); if (output.output !== 'keep me') throw new Error('expected output to remain unchanged'); console.log('smoke: truncator failure leaves tool output unchanged');"`
- `git diff --check`
- `bun run typecheck`
- `bun run build`

## Notes
- Cubic is not required for this cleanup batch per owner directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tool output truncation safer and clearer. We now keep the original tool output on `Error` and rethrow non-Error throws.

- **Bug Fixes**
  - Updated `createToolOutputTruncatorHook` to swallow only `Error` instances and rethrow non-Error values.
  - Added a test ensuring truncation failures leave the tool output unchanged.

<sup>Written for commit 9c5cd6c89b9bd7368943c1ae3f038c3fd43818bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

