### PR TITLE
fix(session-recovery): narrow text part injection catches

### DIFF
--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { randomUUID } from "node:crypto"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -27,6 +27,7 @@ mock.module("../../shared", () => ({
 }))
 
 const { prependThinkingPart, prependThinkingPartAsync } = await import("./storage/thinking-prepend")
+const { injectTextPart } = await import("./storage/text-part-injector")
 
 describe("detectErrorType", () => {
   describe("thinking_block_order errors", () => {
@@ -549,5 +550,22 @@ describe("thinking-prepend", () => {
 
     expect(result).toBe(false)
     expect(patchPartMock).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe("text-part-injector", () => {
+  it("returns false when part storage cannot accept a new injected part", () => {
+    // given
+    const messageID = "msg_text_injector_blocked"
+    mkdirSync(TEST_PART_STORAGE, { recursive: true })
+    writeFileSync(join(TEST_PART_STORAGE, messageID), "not a directory")
+
+    // when
+    const result = injectTextPart("ses_text_injector", messageID, "visible answer")
+
+    // then
+    expect(result).toBe(false)
+
+    rmSync(join(TEST_PART_STORAGE, messageID), { force: true })
   })
 })

--- a/src/hooks/session-recovery/storage/text-part-injector.ts
+++ b/src/hooks/session-recovery/storage/text-part-injector.ts
@@ -33,7 +33,10 @@ export function injectTextPart(sessionID: string, messageID: string, text: strin
   try {
     writeFileSync(join(partDir, `${partId}.json`), JSON.stringify(part, null, 2))
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -57,6 +60,9 @@ export async function injectTextPartAsync(
   try {
     return await patchPart(client, sessionID, messageID, partId, part)
   } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     log("[session-recovery] injectTextPartAsync failed", { error: String(error) })
     return false
   }


### PR DESCRIPTION
## Summary
- replace the sync text-part injection empty catch with explicit Error narrowing
- make the async injection fallback catch follow the same narrowing rule
- add a characterization test for the existing storage-write failure fallback

## Manual QA
- bun test src/hooks/session-recovery/index.test.ts src/hooks/session-recovery/storage/readers-from-sdk.test.ts src/hooks/session-recovery/storage/thinking-strip.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/storage/text-part-injector.ts src/hooks/session-recovery/index.test.ts
- git diff --check
- bun --eval 'const mod = await import(./src/hooks/session-recovery/storage/text-part-injector.ts); console.log(typeof mod.injectTextPart, typeof mod.injectTextPartAsync)'
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened error handling in session recovery text-part injection so only real Errors are handled; unexpected non-Error throws now bubble up. Added a test to confirm we return false when part storage can’t accept a new part.

- **Bug Fixes**
  - `injectTextPart`: replaced empty catch with Error narrowing; rethrow non-Error, return false on write failures.
  - `injectTextPartAsync`: applied the same narrowing; keep logging and false fallback.
  - Added a test to characterize storage-write failure behavior in `index.test.ts`.

<sup>Written for commit b01b500d4e15152f2d7a0e909eee25b6a4952d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

