### PR TITLE
fix(session-recovery): log recovery fallback catches

### DIFF
--- a/src/hooks/session-recovery/error-recovery.ts
+++ b/src/hooks/session-recovery/error-recovery.ts
@@ -57,8 +57,11 @@ export function createSessionErrorRecoveryHandler(
         const msgs = normalizeSDKResponse(messagesResp, [] as MessageData[])
         const lastAssistant = msgs?.findLast((m) => m.info?.role === "assistant" && m.info?.error)
         assistantMsgID = lastAssistant?.info?.id
-      } catch {
-        log("[session-recovery] Failed to fetch messages for messageID fallback", { sessionID })
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
+        log("[session-recovery] Failed to fetch messages for messageID fallback", { sessionID, error })
       }
     }
 
@@ -96,7 +99,12 @@ export function createSessionErrorRecoveryHandler(
         callbacks.onAbortCallback(sessionID)
       }
 
-      await ctx.client.session.abort({ path: { id: sessionID } }).catch(() => {})
+      await ctx.client.session.abort({ path: { id: sessionID } }).catch((error: unknown) => {
+        if (!(error instanceof Error)) {
+          throw error
+        }
+        log("[session-recovery] Failed to abort session before recovery", { sessionID, error })
+      })
 
       const messagesResp = await ctx.client.session.messages({
         path: { id: sessionID },
@@ -118,7 +126,12 @@ export function createSessionErrorRecoveryHandler(
             duration: 3000,
           },
         })
-        .catch(() => {})
+        .catch((error: unknown) => {
+          if (!(error instanceof Error)) {
+            throw error
+          }
+          log("[session-recovery] Failed to show recovery toast", { sessionID, error })
+        })
 
       let success = false
 
@@ -152,6 +165,9 @@ export function createSessionErrorRecoveryHandler(
       }
       return success
     } catch (err) {
+      if (!(err instanceof Error)) {
+        throw err
+      }
       log("[session-recovery] Recovery failed:", err)
       return false
     } finally {

--- a/src/hooks/session-recovery/hook.test.ts
+++ b/src/hooks/session-recovery/hook.test.ts
@@ -234,6 +234,88 @@ describe("session-recovery hook persistent dedupe", () => {
     expect(promptAsyncCalls).toHaveLength(1)
     expect(promptAsyncCalls[0]?.body.parts[0]?.toolUseId).toBe("toolu_array_response")
   })
+
+  test("#given fallback message lookup fails #when recovering without an assistant message id #then recovery returns false", async () => {
+    // given
+    let messagesCalls = 0
+    const ctx = {
+      client: {
+        session: {
+          abort: async () => ({}),
+          messages: async () => {
+            messagesCalls += 1
+            throw new Error("messages unavailable")
+          },
+          promptAsync: async () => ({}),
+        },
+        tui: {
+          showToast: async () => ({}),
+        },
+      },
+      directory: "/tmp/session-recovery-message-fallback-test",
+    }
+    const hook = createSessionRecoveryHook(ctx as never)
+
+    // when
+    const result = await hook.handleSessionRecovery({
+      role: "assistant",
+      sessionID: "ses_recovery_message_fallback",
+      error: { message: "messages.3 has tool_use without a matching tool_result" },
+    })
+
+    // then
+    expect(result).toBe(false)
+    expect(messagesCalls).toBe(1)
+  })
+
+  test("#given abort and toast fail #when handling unsupported prefill recovery #then recovery still completes", async () => {
+    // given
+    const calls = { abort: 0, messages: 0, toast: 0, complete: 0 }
+    const info = createPrefillErrorInfo()
+    const ctx = {
+      client: {
+        session: {
+          abort: async () => {
+            calls.abort += 1
+            throw new Error("abort unavailable")
+          },
+          messages: async () => {
+            calls.messages += 1
+            return {
+              data: [
+                {
+                  info: {
+                    id: info.id,
+                    role: "assistant",
+                    error: info.error,
+                  },
+                },
+              ],
+            }
+          },
+          promptAsync: async () => ({}),
+        },
+        tui: {
+          showToast: async () => {
+            calls.toast += 1
+            throw new Error("toast unavailable")
+          },
+        },
+      },
+      directory: "/tmp/session-recovery-swallow-test",
+    }
+    const hook = createSessionRecoveryHook(ctx as never)
+    hook.setOnRecoveryCompleteCallback(() => {
+      calls.complete += 1
+    })
+
+    // when
+    const result = await hook.handleSessionRecovery(info)
+
+    // then
+    expect(result).toBe(false)
+    expect(calls).toEqual({ abort: 1, messages: 1, toast: 1, complete: 1 })
+  })
 })
 
 describe("session-recovery hook interrupted idle recovery", () => {


### PR DESCRIPTION
## Summary
- replace the message-id fallback empty catch with explicit Error narrowing and logging
- make abort/toast recovery fallback catches log expected Error failures instead of silently swallowing them
- narrow the outer recovery catch and rethrow non-Error values
- add characterization coverage for fallback message lookup failure and abort/toast failures

## Manual QA
- bun test src/hooks/session-recovery/hook.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/error-recovery.ts src/hooks/session-recovery/hook.test.ts
- git diff --check
- bun --eval 'const mod = await import(./src/hooks/session-recovery/error-recovery.ts); console.log(typeof mod.createSessionErrorRecoveryHandler)'
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session recovery error handling explicit and observable by replacing silent catches with `Error` narrowing and logging. Also add tests to cover message lookup and abort/toast failure paths.

- **Bug Fixes**
  - Log errors when fetching messages for the message-id fallback; rethrow non-`Error` values.
  - Log failures when calling session `abort` and when showing recovery toast; rethrow non-`Error` values.
  - Narrow the outer recovery `catch` to `Error` and bubble up non-`Error` throws.

<sup>Written for commit 0ab6f18c4e95e5755b5e9f32648bbc22f228a754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

