### PR TITLE
fix(rules-injector): narrow storage fallback catch

### DIFF
--- a/src/hooks/rules-injector/storage.test.ts
+++ b/src/hooks/rules-injector/storage.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { RULES_INJECTOR_STORAGE } from "./constants";
 import {
@@ -53,5 +53,19 @@ describe("storage", () => {
     expect([...firstLoaded.realPaths]).toEqual(["/tmp/first-rule.md"]);
     expect([...secondLoaded.contentHashes]).toEqual(["hash:second"]);
     expect([...secondLoaded.realPaths]).toEqual(["/tmp/second-rule.md"]);
+  });
+
+  it("#given malformed persisted data #when loading injected rules #then returns empty sets", () => {
+    // given
+    const sessionID = createSessionID("storage-malformed");
+    mkdirSync(RULES_INJECTOR_STORAGE, { recursive: true });
+    writeFileSync(getStoragePath(sessionID), "{");
+
+    // when
+    const loaded = loadInjectedRules(sessionID);
+
+    // then
+    expect([...loaded.contentHashes]).toEqual([]);
+    expect([...loaded.realPaths]).toEqual([]);
   });
 });

--- a/src/hooks/rules-injector/storage.ts
+++ b/src/hooks/rules-injector/storage.ts
@@ -28,7 +28,10 @@ export function loadInjectedRules(sessionID: string): {
       contentHashes: new Set(data.injectedHashes),
       realPaths: new Set(data.injectedRealPaths ?? []),
     };
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
     return { contentHashes: new Set(), realPaths: new Set() };
   }
 }


### PR DESCRIPTION
## Summary
- replace the rules-injector storage empty catch with explicit Error narrowing
- preserve the malformed persisted JSON fallback behavior with characterization coverage

## Manual QA
- bun test src/hooks/rules-injector/storage.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/rules-injector/storage.ts src/hooks/rules-injector/storage.test.ts
- git diff --check
- bun --eval 'const mod = await import(./src/hooks/rules-injector/storage.ts); console.log(typeof mod.loadInjectedRules, typeof mod.saveInjectedRules, typeof mod.clearInjectedRules)'
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed error handling in the rules-injector storage loader to only catch Error instances, preventing silent failures when non-Error values are thrown. Preserves the empty-set fallback for malformed persisted JSON and adds a test to lock this behavior.

<sup>Written for commit 311178a867c5f25f6abd1aad3416f5e396d27f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

