### PR TITLE
fix(rules-injector): narrow parsed cache catch

### DIFF
--- a/src/hooks/rules-injector/parsed-rule-cache.test.ts
+++ b/src/hooks/rules-injector/parsed-rule-cache.test.ts
@@ -37,4 +37,41 @@ describe("parsed rule cache", () => {
 		expect(readCounts.get("/rules/0.md")).toBe(1);
 		expect(readCounts.get("/rules/100.md")).toBe(2);
 	});
+
+	it("#given stat throws an error #when reading a rule #then falls back to uncached content", () => {
+		// given
+		const readRule = createParsedRuleReader({
+			readFileSync: () => "---\ndescription: fallback\n---\nbody\n",
+			statSync: () => {
+				throw new Error("stat unavailable");
+			},
+		});
+
+		// when
+		const result = readRule("/rules/fallback.md", "/rules/fallback.md");
+
+		// then
+		expect(result.statFingerprint).toBeNull();
+		expect(result.metadata.description).toBe("fallback");
+		expect(result.body).toBe("body\n");
+	});
+
+	it("#given stat throws a non-error value #when reading a rule #then rethrows it", () => {
+		// given
+		const thrown = "stat unavailable";
+		const readRule = createParsedRuleReader({
+			readFileSync: () => "---\ndescription: fallback\n---\nbody\n",
+			statSync: () => {
+				throw thrown;
+			},
+		});
+
+		// when
+		const read = (): void => {
+			readRule("/rules/fallback.md", "/rules/fallback.md");
+		};
+
+		// then
+		expect(read).toThrow(thrown);
+	});
 });

--- a/src/hooks/rules-injector/parsed-rule-cache.ts
+++ b/src/hooks/rules-injector/parsed-rule-cache.ts
@@ -62,7 +62,10 @@ export function createParsedRuleReader(options?: {
 				body,
 			});
 			return { metadata, body, statFingerprint };
-		} catch {
+		} catch (error) {
+			if (!(error instanceof Error)) {
+				throw error;
+			}
 			const rawContent = readRuleFileSync(filePath, "utf-8");
 			const { metadata, body } = parseRuleFrontmatter(rawContent);
 			return { metadata, body, statFingerprint: null };


### PR DESCRIPTION
## Summary
- replace the parsed rule cache empty catch with narrowed Error fallback handling
- preserve legacy uncached read fallback for normal Error failures
- rethrow non-Error throws instead of silently swallowing them

## Manual QA
- bun test src/hooks/rules-injector/parsed-rule-cache.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/rules-injector/parsed-rule-cache.ts src/hooks/rules-injector/parsed-rule-cache.test.ts
- git diff --check
- bun --eval import smoke for createParsedRuleReader fallback path
- bun run typecheck
- bun run build

## Empty catch impact
- origin/dev baseline before PR: 109 empty catches in non-test src/**/*.ts
- expected after merge: 108


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened error handling in the parsed rule cache to only fall back on uncached reads for real `Error` cases and rethrow non-Error throws. This prevents silent failures while preserving the legacy fallback when `statSync` fails.

- **Bug Fixes**
  - Narrowed catch in `createParsedRuleReader`: rethrow non-Error values; use uncached fallback for `Error` failures.
  - Added tests for both fallback and rethrow paths.
  - Reduced empty catch count in src by 1.

<sup>Written for commit 11f9cb10f77820a64aa8fa10d7865060a72071fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

