### PR TITLE
fix(rules-injector): narrow injection processor catch

### DIFF
--- a/src/hooks/rules-injector/injection-processor.ts
+++ b/src/hooks/rules-injector/injection-processor.ts
@@ -147,7 +147,10 @@ export function createRuleInjectionProcessor(
 				cache.realPaths.add(candidate.realPath);
 				cache.contentHashes.add(contentHash);
 				dirty = true;
-			} catch {
+			} catch (error) {
+				if (!(error instanceof Error)) {
+					throw error;
+				}
 				continue;
 			}
 		}

--- a/src/hooks/rules-injector/injector.test.ts
+++ b/src/hooks/rules-injector/injector.test.ts
@@ -449,6 +449,43 @@ describe("createRuleInjectionProcessor", () => {
 		expect(trackedShouldApplyRuleCount).toBe(2);
 	});
 
+	it("#given rule processing throws a non-error value #when injecting #then rethrows it", async () => {
+		// given
+		const thrown = "stat failed";
+		const processor = createRuleInjectionProcessor({
+			workspaceDirectory: projectRoot,
+			truncator: {
+				truncate: async (_sessionID: string, content: string) => ({
+					result: content,
+					truncated: false,
+				}),
+			},
+			getSessionCache: () => ({
+				contentHashes: new Set<string>(),
+				realPaths: new Set<string>(),
+			}),
+			readFileSync: originalReadFileSync,
+			statSync: (filePath: string) => {
+				if (filePath === ruleFile) {
+					throw thrown;
+				}
+				return originalStatSync(filePath);
+			},
+			homedir: () => homeRoot,
+			shouldApplyRule: () => ({ applies: true, reason: "matched" }),
+		});
+
+		// when
+		const process = processor.processFilePathForInjection(
+			targetFile,
+			"session-1",
+			createOutput(),
+		);
+
+		// then
+		await expect(process).rejects.toBe(thrown);
+	});
+
 	it("#given transcript hydration reports prior rule banner #when same rule matches #then rule is skipped and cache absorbs the realPath", async () => {
 		// given
 		const hydratedRelativePath =


### PR DESCRIPTION
## Summary
- replace the rule injection processor empty catch with narrowed Error handling
- preserve per-rule skip behavior for normal Error failures
- rethrow non-Error throws instead of silently swallowing them

## Manual QA
- bun test src/hooks/rules-injector/injector.test.ts src/hooks/rules-injector/injector-facade.test.ts src/hooks/rules-injector/parsed-rule-cache.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/rules-injector/injection-processor.ts src/hooks/rules-injector/injector.test.ts
- git diff --check
- bun --eval import smoke for createRuleInjectionProcessor no-candidate path
- bun run typecheck
- bun run build

## Empty catch impact
- origin/dev baseline before PR: 108 empty catches in non-test src/**/*.ts
- expected after merge: 107


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed error handling in the rules injection processor to stop swallowing non-Error throws. Keeps existing rule skip behavior for standard Errors and adds a test to enforce this.

- **Bug Fixes**
  - Replaced empty catch in `createRuleInjectionProcessor` with `catch (error) { if (!(error instanceof Error)) throw error; }`.
  - Added a test to ensure non-Error throws are rethrown.
  - Preserves per-rule skip behavior and cache updates for normal `Error` failures.

<sup>Written for commit 0368b8cc7449b1feab4292843d46fbd5110ad7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

