### PR TITLE
fix(rules-injector): narrow transcript hydration catch

### DIFF
--- a/src/hooks/rules-injector/transcript-hydration.test.ts
+++ b/src/hooks/rules-injector/transcript-hydration.test.ts
@@ -1,18 +1,15 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { PluginInput } from "@opencode-ai/plugin";
 import { createTranscriptHydrationStore } from "./transcript-hydration";
-
-type SessionClient = PluginInput["client"]["session"];
 
 function makeClient(
 	messages: (sessionID: string) => Promise<{ data: unknown }>,
-): PluginInput["client"] {
+): Parameters<typeof createTranscriptHydrationStore>[0]["client"] {
 	const session = {
 		messages: mock(async (args: { path: { id: string } }) =>
 			messages(args.path.id),
 		),
-	} as unknown as SessionClient;
-	return { session } as unknown as PluginInput["client"];
+	};
+	return { session };
 }
 
 function ruleMarker(relativePath: string, body = "Rule body."): string {
@@ -131,6 +128,22 @@ describe("createTranscriptHydrationStore", () => {
 
 		// then
 		expect(result.size).toBe(0);
+	});
+
+	it("#given fetch throws a non-error value #when hydrateSession runs #then rethrows it", async () => {
+		// given
+		const thrown = "network down";
+		const store = createTranscriptHydrationStore({
+			client: makeClient(async () => {
+				throw thrown;
+			}),
+		});
+
+		// when
+		const hydrate = store.hydrateSession("session-1");
+
+		// then
+		await expect(hydrate).rejects.toBe(thrown);
 	});
 
 	it("#given hydrated session #when clearSession then re-hydrate #then transcript is rescanned", async () => {

--- a/src/hooks/rules-injector/transcript-hydration.ts
+++ b/src/hooks/rules-injector/transcript-hydration.ts
@@ -1,5 +1,3 @@
-import type { PluginInput } from "@opencode-ai/plugin";
-
 /**
  * Pattern that matches the injector's own rule banner emitted into tool
  * outputs. The capture group is the rule's path relative to project root.
@@ -18,7 +16,7 @@ const HYDRATION_MAX_MESSAGES = 200;
 const HYDRATION_MAX_CHARS = 1_000_000;
 
 export interface TranscriptHydrationDeps {
-	readonly client: PluginInput["client"];
+	readonly client: TranscriptHydrationClient;
 }
 
 export interface TranscriptHydrationStore {
@@ -31,6 +29,14 @@ interface SessionHydrationState {
 	relativePaths: Set<string>;
 	hydrated: boolean;
 	inflight?: Promise<void>;
+}
+
+interface TranscriptHydrationClient {
+	readonly session: {
+		readonly messages: (args: {
+			readonly path: { readonly id: string };
+		}) => Promise<{ readonly data?: unknown }>;
+	};
 }
 
 /**
@@ -76,7 +82,10 @@ export function createTranscriptHydrationStore(
 					for (const relativePath of fetched) {
 						state.relativePaths.add(relativePath);
 					}
-				} catch {
+				} catch (error) {
+					if (!(error instanceof Error)) {
+						throw error;
+					}
 					// best-effort: a hydration failure must never block injection.
 				} finally {
 					state.hydrated = true;
@@ -102,13 +111,13 @@ export function createTranscriptHydrationStore(
 const EMPTY_SET: ReadonlySet<string> = new Set();
 
 async function fetchTranscriptRelativePaths(
-	client: PluginInput["client"],
+	client: TranscriptHydrationClient,
 	sessionID: string,
 ): Promise<Set<string>> {
 	const relativePaths = new Set<string>();
-	const response = (await client.session.messages({
+	const response = await client.session.messages({
 		path: { id: sessionID },
-	})) as { data?: unknown };
+	});
 	const data = Array.isArray(response.data) ? response.data : [];
 	const start = Math.max(0, data.length - HYDRATION_MAX_MESSAGES);
 	let scannedChars = 0;


### PR DESCRIPTION
## Summary
- replace the transcript hydration empty catch with narrowed Error handling
- preserve best-effort fallback for normal Error failures
- rethrow non-Error throws instead of silently swallowing them
- remove pre-existing test helper `as unknown` assertions by narrowing the client dependency contract

## Manual QA
- bun test src/hooks/rules-injector/transcript-hydration.test.ts src/hooks/rules-injector/injector.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/rules-injector/transcript-hydration.ts src/hooks/rules-injector/transcript-hydration.test.ts
- git diff --check
- bun --eval transcript hydration import smoke
- bun run typecheck
- bun run build

## Empty catch impact
- origin/dev baseline before PR: 107 empty catches in non-test src/**/*.ts
- expected after merge: 106


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transcript hydration so non-Error throws are rethrown. Keeps best-effort fallback on normal Errors.

- **Bug Fixes**
  - Narrowed the client to a small local interface, removing `as unknown` casts and decoupling from `@opencode-ai/plugin`.
  - Added a test that ensures non-Error throws propagate.

<sup>Written for commit 6285a323d729d831760aded90da111c6ad69a7d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

