### PR TITLE
fix(session-recovery): narrow resume catch

### DIFF
--- a/src/hooks/session-recovery/resume.test.ts
+++ b/src/hooks/session-recovery/resume.test.ts
@@ -1,5 +1,4 @@
-declare const require: (name: string) => any
-const { afterEach, describe, expect, test } = require("bun:test")
+import { afterEach, describe, expect, test } from "bun:test"
 
 import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
 import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
@@ -150,5 +149,52 @@ describe("session-recovery resume", () => {
     // then
     expect(ok).toBe(true)
     expect(promptCalls).toBe(1)
+  })
+
+  test("#given resume setup throws an error #when resuming #then returns false", async () => {
+    // given
+    const client = {
+      session: {
+        promptAsync: async () => ({}),
+      },
+    }
+    const tools: Record<string, boolean> = new Proxy({}, {
+      ownKeys: () => {
+        throw new Error("tools unavailable")
+      },
+    })
+
+    // when
+    const ok = await resumeSession(client as never, {
+      sessionID: "ses_resume_error",
+      tools,
+    })
+
+    // then
+    expect(ok).toBe(false)
+  })
+
+  test("#given resume setup throws a non-error value #when resuming #then rethrows it", async () => {
+    // given
+    const thrown = "tools unavailable"
+    const client = {
+      session: {
+        promptAsync: async () => ({}),
+      },
+    }
+    const tools: Record<string, boolean> = new Proxy({}, {
+      ownKeys: () => {
+        throw thrown
+      },
+    })
+
+    // when
+    const resume = resumeSession(client as never, {
+      sessionID: "ses_resume_non_error",
+      tools,
+    })
+
+    // then
+    await expect(resume).rejects.toBe(thrown)
   })
 })

--- a/src/hooks/session-recovery/resume.ts
+++ b/src/hooks/session-recovery/resume.ts
@@ -60,7 +60,10 @@ export async function resumeSession(client: Client, config: ResumeConfig): Promi
       return true
     }
     return isInternalPromptDispatchAccepted(promptResult)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace the session recovery resume empty catch with narrowed Error handling
- preserve `false` fallback for ordinary Error setup failures
- rethrow non-Error throws instead of silently swallowing them
- remove the old `require`/`any` bun:test shim from the touched resume test

## Manual QA
- bun test src/hooks/session-recovery/resume.test.ts src/hooks/session-recovery/hook.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/resume.ts src/hooks/session-recovery/resume.test.ts
- git diff --check
- bun --eval import smoke for resume helpers
- bun run typecheck
- bun run build

## Empty catch impact
- origin/dev baseline before PR: 106 empty catches in non-test src/**/*.ts
- expected after merge: 105


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed session recovery resume error handling to return false only for real Error cases and rethrow non-Error throws. Updated tests to use `bun:test` imports and cover both behaviors.

- **Bug Fixes**
  - `resumeSession`: replace empty catch with `catch (error)`; rethrow non-Error values; keep `false` for `Error` setup failures.
  - Tests: remove old `require` shim; add tests for Error vs non-Error throws.

<sup>Written for commit 7c00a7fc211564a9354a394843a8dbe3dc3a20e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

