### PR TITLE
fix(read-image-resizer): narrow image dimension parser catch

### DIFF
--- a/src/hooks/read-image-resizer/image-dimensions.test.ts
+++ b/src/hooks/read-image-resizer/image-dimensions.test.ts
@@ -35,6 +35,15 @@ function createLargePngDataUrl(width: number, height: number, extraBase64Chars: 
   return `data:image/png;base64,${paddedBase64}`
 }
 
+function createTruncatedVp8WebpDataUrl(): string {
+  const buf = Buffer.alloc(26)
+  buf.write("RIFF", 0, "ascii")
+  buf.write("WEBP", 8, "ascii")
+  buf.write("VP8 ", 12, "ascii")
+  buf.set([0x9d, 0x01, 0x2a], 23)
+  return `data:image/webp;base64,${buf.toString("base64")}`
+}
+
 describe("parseImageDimensions", () => {
   it("parses PNG 1x1 dimensions", () => {
     //#given
@@ -119,6 +128,17 @@ describe("parseImageDimensions", () => {
 
     //#when
     const result = parseImageDimensions(dataUrl, "image/heic")
+
+    //#then
+    expect(result).toBeNull()
+  })
+
+  it("returns null when truncated WEBP headers cannot be read", () => {
+    //#given
+    const dataUrl = createTruncatedVp8WebpDataUrl()
+
+    //#when
+    const result = parseImageDimensions(dataUrl, "image/webp")
 
     //#then
     expect(result).toBeNull()

--- a/src/hooks/read-image-resizer/image-dimensions.ts
+++ b/src/hooks/read-image-resizer/image-dimensions.ts
@@ -185,7 +185,10 @@ export function parseImageDimensions(base64DataUrl: string, mimeType: string): I
     }
 
     return null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }


### PR DESCRIPTION
## Summary
- replace the parser-level bare catch with an Error-narrowed catch
- preserve the existing null fallback for malformed image headers
- add a WEBP truncation characterization for Buffer read failures

## Manual QA
- bun test src/hooks/read-image-resizer/image-dimensions.test.ts src/hooks/read-image-resizer/hook.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/read-image-resizer/image-dimensions.ts src/hooks/read-image-resizer/image-dimensions.test.ts
- git diff --check
- bun --eval import smoke for parseImageDimensions truncated WEBP fallback
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts error handling in `parseImageDimensions` to only catch `Error` objects, keeping the null fallback for malformed headers. Adds handling and tests for truncated WEBP (VP8) headers so Buffer read failures return null.

<sup>Written for commit 602112df9d4c0885f132d664ff767fe60a3fdfd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

