### PR TITLE
fix(legacy-plugin-toast): narrow auto migrate catch

### DIFF
--- a/src/hooks/legacy-plugin-toast/auto-migrate.test.ts
+++ b/src/hooks/legacy-plugin-toast/auto-migrate.test.ts
@@ -152,6 +152,30 @@ describe("autoMigrateLegacyPluginEntry", () => {
     })
   })
 
+  describe("#given the migrator throws while rewriting a legacy entry", () => {
+    it("#then returns migrated false", async () => {
+      // given
+      writeFileSync(
+        join(testConfigDir, "opencode.json"),
+        JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n",
+      )
+      mockMigrateLegacyPluginEntry.mockImplementation(() => {
+        throw new Error("rewrite failed")
+      })
+
+      const { autoMigrateLegacyPluginEntry } = await autoMigrateModulePromise
+
+      // when
+      const result = autoMigrateLegacyPluginEntry(testConfigDir)
+
+      // then
+      expect(result.migrated).toBe(false)
+      expect(result.from).toBeNull()
+      expect(result.to).toBeNull()
+      expect(result.configPath).toBe(join(testConfigDir, "opencode.json"))
+    })
+  })
+
   describe("#given only canonical entry exists", () => {
     it("#then returns migrated false and leaves file untouched", async () => {
       // given

--- a/src/hooks/legacy-plugin-toast/auto-migrate.ts
+++ b/src/hooks/legacy-plugin-toast/auto-migrate.ts
@@ -58,7 +58,10 @@ export function autoMigrateLegacyPluginEntry(overrideConfigDir?: string): Migrat
       to: hasCanonical ? PLUGIN_NAME : to,
       configPath,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return { migrated: false, from: null, to: null, configPath }
   }
 }


### PR DESCRIPTION
## Summary
- replace the auto-migration bare catch with an Error-narrowed catch
- preserve the existing false migration result for ordinary config read/parse/rewrite failures
- add characterization for a migrator rewrite Error

## Manual QA
- bun test src/hooks/legacy-plugin-toast/auto-migrate.test.ts src/hooks/legacy-plugin-toast/hook.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/legacy-plugin-toast/auto-migrate.ts src/hooks/legacy-plugin-toast/auto-migrate.test.ts
- git diff --check
- bun --eval import smoke for autoMigrateLegacyPluginEntry missing config fallback
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed the catch in the legacy plugin auto-migration to only handle Error objects, preventing silent failures when non-Error values are thrown. Keeps the existing "migrated: false" behavior for read/parse/rewrite issues and adds a test for a migrator rewrite error.

<sup>Written for commit 1d8069cb18280dcdd49fdec6dac22f483929a828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

