### PR TITLE
fix(interactive-bash): narrow tracker cleanup catch

### DIFF
--- a/src/hooks/interactive-bash-session/interactive-bash-session-tracker.test.ts
+++ b/src/hooks/interactive-bash-session/interactive-bash-session-tracker.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockLoadInteractiveBashSessionState = mock(() => null);
+const mockSaveInteractiveBashSessionState = mock(() => {});
+const mockClearInteractiveBashSessionState = mock(() => {});
+const mockSpawnWithWindowsHide = mock(() => {
+  throw new Error("tmux unavailable");
+});
+
+mock.module("./storage", () => ({
+  loadInteractiveBashSessionState: mockLoadInteractiveBashSessionState,
+  saveInteractiveBashSessionState: mockSaveInteractiveBashSessionState,
+  clearInteractiveBashSessionState: mockClearInteractiveBashSessionState,
+}));
+
+mock.module("../../shared/spawn-with-windows-hide", () => ({
+  spawnWithWindowsHide: mockSpawnWithWindowsHide,
+}));
+
+const trackerModulePromise = import("./interactive-bash-session-tracker");
+
+describe("createInteractiveBashSessionTracker", () => {
+  beforeEach(() => {
+    mockLoadInteractiveBashSessionState.mockReset();
+    mockSaveInteractiveBashSessionState.mockReset();
+    mockClearInteractiveBashSessionState.mockReset();
+    mockSpawnWithWindowsHide.mockReset();
+    mockLoadInteractiveBashSessionState.mockReturnValue(null);
+    mockSpawnWithWindowsHide.mockImplementation(() => {
+      throw new Error("tmux unavailable");
+    });
+  });
+
+  it("#given tracked tmux session kill throws #when session is deleted #then cleanup still completes", async () => {
+    // given
+    const abortSession = mock(async () => undefined);
+    const { createInteractiveBashSessionTracker } = await trackerModulePromise;
+    const tracker = createInteractiveBashSessionTracker({ abortSession });
+    tracker.handleTmuxCommand({
+      sessionID: "session-1",
+      subCommand: "new-session",
+      sessionName: "omo-shell",
+      toolOutput: "",
+    });
+
+    // when
+    await tracker.handleSessionDeleted("session-1");
+
+    // then
+    expect(mockSpawnWithWindowsHide).toHaveBeenCalledWith(["tmux", "kill-session", "-t", "omo-shell"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    expect(mockClearInteractiveBashSessionState).toHaveBeenCalledWith("session-1");
+  });
+});

--- a/src/hooks/interactive-bash-session/interactive-bash-session-tracker.ts
+++ b/src/hooks/interactive-bash-session/interactive-bash-session-tracker.ts
@@ -25,8 +25,10 @@ async function killAllTrackedSessions(
         stderr: "ignore",
       })
       await proc.exited
-    } catch {
-      // best-effort cleanup
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the interactive bash tracker tmux cleanup bare catch with an Error-narrowed catch
- preserve best-effort cleanup for ordinary tmux kill failures
- add characterization coverage for session deletion cleanup when tmux kill throws

## Manual QA
- bun test src/hooks/interactive-bash-session/interactive-bash-session-tracker.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/interactive-bash-session/interactive-bash-session-tracker.ts src/hooks/interactive-bash-session/interactive-bash-session-tracker.test.ts
- git diff --check
- bun --eval import smoke for createInteractiveBashSessionTracker reminder path
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened error handling in the interactive bash session tracker to only catch real Errors, avoiding silent failures while keeping best-effort tmux cleanup. Added a test to verify state cleanup when tmux kill-session throws.

- **Bug Fixes**
  - Replaced bare catch with Error-narrowed catch; non-Error values rethrow.
  - Ensures session state is cleared even if tmux kill-session fails.

<sup>Written for commit e2278d3b28c729f6a6699ed8faba402d56736c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

