### PR TITLE
fix(interactive-bash): narrow storage load catch

### DIFF
--- a/src/hooks/interactive-bash-session/storage.test.ts
+++ b/src/hooks/interactive-bash-session/storage.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let testStorageDir = "";
+
+mock.module("./constants", () => ({
+  INTERACTIVE_BASH_SESSION_STORAGE: testStorageDir,
+}));
+
+const storageModulePromise = import("./storage");
+
+describe("interactive bash session storage", () => {
+  beforeEach(() => {
+    testStorageDir = mkdtempSync(join(tmpdir(), "omo-interactive-bash-storage-"));
+  });
+
+  afterEach(() => {
+    rmSync(testStorageDir, { recursive: true, force: true });
+  });
+
+  it("#given corrupted persisted state #when loading session state #then returns null", async () => {
+    // given
+    writeFileSync(join(testStorageDir, "session-1.json"), "{not json");
+    const { loadInteractiveBashSessionState } = await storageModulePromise;
+
+    // when
+    const result = loadInteractiveBashSessionState("session-1");
+
+    // then
+    expect(result).toBeNull();
+  });
+});

--- a/src/hooks/interactive-bash-session/storage.ts
+++ b/src/hooks/interactive-bash-session/storage.ts
@@ -30,7 +30,10 @@ export function loadInteractiveBashSessionState(
       tmuxSessions: new Set(serialized.tmuxSessions),
       updatedAt: serialized.updatedAt,
     };
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- replace the empty catch in interactive-bash session storage loading with an Error-narrowed catch
- preserve existing corrupted/unreadable state behavior by returning null for Error failures
- add a characterization test for corrupted persisted JSON

## Manual QA
- bun test src/hooks/interactive-bash-session/storage.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/interactive-bash-session/storage.ts src/hooks/interactive-bash-session/storage.test.ts
- git diff --check
- bun --eval import smoke for loadInteractiveBashSessionState
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened error handling in interactive-bash session storage: only catch real Errors when loading session state, preserving null for corrupted files and rethrowing non-Error failures.

- **Bug Fixes**
  - Narrowed catch in `loadInteractiveBashSessionState` to `Error`; rethrow non-Error values, return null on parse/read failures.
  - Added a test to validate corrupted persisted JSON returns null (`src/hooks/interactive-bash-session/storage.test.ts`).

<sup>Written for commit 312a73dbb6abcbf1b63923836f75e35c08c6b65d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

