### PR TITLE
fix(shared): narrow opencode version fallbacks

### DIFF
--- a/src/shared/opencode-version.test.ts
+++ b/src/shared/opencode-version.test.ts
@@ -180,6 +180,58 @@ describe("opencode-version", () => {
       expect(result).toBe("1.14.42")
       expect(calls).toEqual(["exec"])
     })
+
+    test("falls back to opencode binary when adjacent package JSON is invalid", () => {
+      // given adjacent package JSON cannot be parsed
+
+      // when getting version
+      const result = getOpenCodeVersion({
+        getBinaryPath: () => "/tmp/opencode-ai/bin/opencode",
+        realpath: (filePath) => filePath,
+        exists: (filePath) => filePath === "/tmp/opencode-ai/package.json",
+        readText: () => "{not json",
+        execCommand: () => "opencode 1.14.43",
+      })
+
+      // then the CLI fallback remains intact
+      expect(result).toBe("1.14.43")
+    })
+
+    test("falls back to opencode binary when resolving the adjacent package fails", () => {
+      // given the binary realpath lookup fails
+
+      // when getting version
+      const result = getOpenCodeVersion({
+        getBinaryPath: () => "/tmp/opencode-ai/bin/opencode",
+        realpath: () => {
+          throw new Error("realpath failed")
+        },
+        exists: () => true,
+        readText: () => JSON.stringify({ name: "opencode-ai", version: "1.14.44" }),
+        execCommand: () => "opencode 1.14.44",
+      })
+
+      // then the CLI fallback remains intact
+      expect(result).toBe("1.14.44")
+    })
+
+    test("returns null when opencode binary execution fails", () => {
+      // given package lookup is unavailable and the binary command fails
+
+      // when getting version
+      const result = getOpenCodeVersion({
+        getBinaryPath: () => null,
+        realpath: (filePath) => filePath,
+        exists: () => false,
+        readText: () => "",
+        execCommand: () => {
+          throw new Error("opencode missing")
+        },
+      })
+
+      // then version detection remains fail-safe
+      expect(result).toBeNull()
+    })
   })
 
   describe("isOpenCodeVersionAtLeast", () => {

--- a/src/shared/opencode-version.ts
+++ b/src/shared/opencode-version.ts
@@ -92,7 +92,10 @@ function parsePackageVersion(content: string): string | null {
     if (typeof version !== "string" || version.length === 0) return null
 
     return version
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }
@@ -103,7 +106,10 @@ function getPackageVersionFromBinary(binaryPath: string, deps: OpenCodeVersionDe
     const packagePath = join(dirname(dirname(realBinaryPath)), "package.json")
     if (!deps.exists(packagePath)) return null
     return parsePackageVersion(deps.readText(packagePath))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }
@@ -133,7 +139,10 @@ export function getOpenCodeVersion(deps: Partial<OpenCodeVersionDeps> = {}): str
     const versionMatch = result.match(/(\d+\.\d+\.\d+(?:-[\w.]+)?)/)
     cachedVersion = versionMatch?.[1] ?? null
     return cachedVersion
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     cachedVersion = null
     return null
   }


### PR DESCRIPTION
## Summary
- replace three empty catches in opencode-version fallback paths with Error-narrowed catches
- preserve fail-safe behavior for invalid package JSON, package lookup errors, and opencode --version execution errors
- add focused characterization coverage for each fallback path

## Manual QA
- bun test src/shared/opencode-version.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/opencode-version.ts src/shared/opencode-version.test.ts
- git diff --check
- bun --eval import/manual smoke for getOpenCodeVersion execution failure fallback
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed error handling in OpenCode version detection to only catch `Error` instances, preventing silent failures while keeping all fail-safe fallbacks intact. Added focused tests for invalid package.json, package resolution errors, and CLI execution failure.

- **Bug Fixes**
  - Replaced bare catches with Error-narrowed catches in `parsePackageVersion`, `getPackageVersionFromBinary`, and `getOpenCodeVersion` (re-throw non-Error values).
  - Confirmed fallbacks: use CLI when package JSON is invalid or package resolution fails; return null if CLI execution fails (tests added).

<sup>Written for commit 26c2232fafbd17f2858109d3dec87a8eba6c61a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

