### PR TITLE
fix(ralph-loop): narrow storage fallbacks

### DIFF
--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -167,6 +167,36 @@ describe("ralph-loop", () => {
       expect(result).toBeNull()
     })
 
+    test("#given state path is a directory #when reading state #then returns null", () => {
+      // given
+      mkdirSync(join(TEST_DIR, ".ralph-loop-state.md"), { recursive: true })
+
+      // when
+      const result = readState(TEST_DIR)
+
+      // then
+      expect(result).toBeNull()
+    })
+
+    test("#given state parent path is a file #when writing state #then returns false", () => {
+      // given
+      writeFileSync(join(TEST_DIR, "blocked"), "")
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 50,
+        completion_promise: "DONE",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt: "Test prompt",
+      }
+
+      // when
+      const result = writeState(TEST_DIR, state, "blocked/state.md")
+
+      // then
+      expect(result).toBe(false)
+    })
+
     test("should clear state correctly", () => {
       // given - existing state
       const state: RalphLoopState = {

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -85,7 +85,10 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
           : undefined,
       strategy: data.strategy === "reset" || data.strategy === "continue" ? data.strategy : undefined,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }
@@ -148,7 +151,10 @@ ${state.prompt}
 
     writeFileSync(filePath, content, "utf-8")
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -161,7 +167,10 @@ export function clearState(directory: string, customPath?: string): boolean {
       unlinkSync(filePath)
     }
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace three empty catches in ralph-loop storage with Error-narrowed catches
- preserve read failure fallback as null and write failure fallback as false
- add storage characterization coverage for read/write filesystem failure paths

## Manual QA
- bun test src/hooks/ralph-loop/index.test.ts -t storage
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/ralph-loop/storage.ts src/hooks/ralph-loop/index.test.ts
- git diff --check
- bun --eval import/manual smoke for readState missing-state fallback
- bun run typecheck
- bun run build

## Note
- `bun test src/hooks/ralph-loop/index.test.ts -t "API timeout protection"` fails locally on clean `origin/dev` with Bun 1.3.11, so it is pre-existing local behavior and not introduced by this storage fallback change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened `ralph-loop` storage error handling by only catching real `Error` objects and keeping clear fallbacks (read → null, write/clear → false). Adds tests for filesystem edge cases to ensure correct behavior.

- **Bug Fixes**
  - Replaced three empty catch blocks in `readState`, `writeState`, and `clearState` with Error-narrowed catches; non-Error throws now surface.
  - Added tests for directory-as-state-path (read returns null) and file-as-parent-path (write returns false).

<sup>Written for commit 49430521ffe9883e76fb2f4e8e6c461f0561ee44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

