### PR TITLE
fix(doctor): narrow loaded version fallbacks

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -169,6 +169,26 @@ describe("system loaded version", () => {
       expect(loadedVersion.loadedVersion).toBe("7.7.7")
     })
 
+    it("returns null versions when selected package JSON files are invalid", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+
+      writeFileSync(join(configDir, "package.json"), "{not json", "utf-8")
+      const installedPackagePath = join(configDir, "node_modules", PACKAGE_NAME, "package.json")
+      mkdirSync(dirname(installedPackagePath), { recursive: true })
+      writeFileSync(installedPackagePath, "{not json", "utf-8")
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.installedPackagePath).toBe(installedPackagePath)
+      expect(loadedVersion.expectedVersion).toBeNull()
+      expect(loadedVersion.loadedVersion).toBeNull()
+    })
+
     it("resolves symlinked config directories before selecting install path", () => {
       //#given
       const realConfigDir = createTemporaryDirectory("omo-real-config-")

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -59,7 +59,10 @@ function readPackageJson(filePath: string): PackageJsonShape | null {
   try {
     const content = readFileSync(filePath, "utf-8")
     return parseJsonc<PackageJsonShape>(content)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }
@@ -96,11 +99,17 @@ function resolveInstalledPackageJsonPath(): { packageName: string; packageJsonPa
         if (existsSync(packageJsonPath)) {
           return { packageName, packageJsonPath }
         }
-      } catch {
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
         continue
       }
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
   return null


### PR DESCRIPTION
## Summary
- replace three empty catches in the doctor loaded-version check with Error-narrowed catches
- preserve invalid package JSON fallback behavior by returning null versions
- add focused characterization coverage for invalid cache and installed package JSON files

## Manual QA
- bun test src/cli/doctor/checks/system-loaded-version.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/doctor/checks/system-loaded-version.ts src/cli/doctor/checks/system-loaded-version.test.ts
- git diff --check
- bun --eval import/manual smoke for getLoadedPluginVersion
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens error handling in the doctor loaded-version check to avoid swallowing unexpected failures. Keeps the null-version fallback when package.json files are invalid and adds focused test coverage.

- **Bug Fixes**
  - Narrowed try/catch to only handle `Error` instances; rethrow non-Error throws.
  - Preserve behavior: return null expected/loaded versions when package.json is invalid.
  - Added test to verify null-version fallback with invalid config and installed package JSON files.

<sup>Written for commit 2bc98a54b70ed87820c8a14040e29866fcd75172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

