### PR TITLE
fix(command-executor): narrow hook kill fallbacks

### DIFF
--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -151,7 +151,10 @@ export async function executeHookCommand(
         if (!isWin32 && proc.pid) {
           try {
             process.kill(-proc.pid, signal);
-          } catch {
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              throw error;
+            }
             proc.kill(signal);
           }
         } else {
@@ -160,7 +163,11 @@ export async function executeHookCommand(
             killWindowsProcessTree();
           }
         }
-      } catch {}
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error;
+        }
+      }
     };
 
     const appendTimeoutNotice = () => {


### PR DESCRIPTION
## Summary
- replace two empty catches in hook command timeout kill handling with Error-narrowed catches
- preserve process-group kill fallback to child kill
- preserve timeout resolution when kill cleanup fails with ordinary Error failures

## Manual QA
- bun test src/shared/command-executor/execute-hook-command.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/shared/command-executor/execute-hook-command.ts src/shared/command-executor/execute-hook-command.test.ts
- git diff --check
- bun --eval import/manual smoke for executeHookCommand
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened hook command timeout kill cleanup in `executeHookCommand` by replacing empty catches with Error-narrowed handling. Non-Error exceptions now surface; process-group kills still fall back to child kills, and timeouts resolve when normal kill errors occur.

- **Bug Fixes**
  - Preserve `process.kill(-pid, signal)` fallback to `proc.kill(signal)` on Unix; use Windows process tree kill when needed.
  - Ignore ordinary `Error` failures during kill cleanup so the timeout still resolves.

<sup>Written for commit 21974217645d2c6a26b85fad45b7563eb58f6dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

