### PR TITLE
fix(hooks): narrow recovery and cache fallbacks

### DIFF
--- a/src/hooks/auto-update-checker/cache.test.ts
+++ b/src/hooks/auto-update-checker/cache.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { invalidatePackage } from "./cache"
+
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe("auto-update cache invalidation", () => {
+  it("#given invalid text lockfile only #when invalidating package #then returns false without deleting cache root", () => {
+    // given
+    const cacheDir = createTemporaryDirectory("omo-auto-update-cache-")
+    const userConfigDir = createTemporaryDirectory("omo-auto-update-config-")
+    writeFileSync(join(cacheDir, "bun.lock"), "{not json", "utf-8")
+
+    // when
+    const result = invalidatePackage("oh-my-openagent", {
+      acceptedPackageNames: ["oh-my-openagent"],
+      cacheDir,
+      defaultPackageName: "oh-my-openagent",
+      userConfigDir,
+    })
+
+    // then
+    expect(result).toBe(false)
+    expect(existsSync(cacheDir)).toBe(true)
+  })
+
+  it("#given binary lockfile only #when invalidating package #then deletes lockfile", () => {
+    // given
+    const cacheDir = createTemporaryDirectory("omo-auto-update-cache-")
+    const userConfigDir = createTemporaryDirectory("omo-auto-update-config-")
+    const lockPath = join(cacheDir, "bun.lockb")
+    writeFileSync(lockPath, "binary", "utf-8")
+
+    // when
+    const result = invalidatePackage("oh-my-openagent", {
+      acceptedPackageNames: ["oh-my-openagent"],
+      cacheDir,
+      defaultPackageName: "oh-my-openagent",
+      userConfigDir,
+    })
+
+    // then
+    expect(result).toBe(true)
+    expect(existsSync(lockPath)).toBe(false)
+  })
+})

--- a/src/hooks/auto-update-checker/cache.ts
+++ b/src/hooks/auto-update-checker/cache.ts
@@ -42,7 +42,10 @@ function removeFromTextBunLock(lockPath: string, packageNames: readonly string[]
     }
 
     return removed
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -52,7 +55,10 @@ function deleteBinaryBunLock(lockPath: string): boolean {
     fs.unlinkSync(lockPath)
     log(`[auto-update-checker] Removed bun.lockb to force re-resolution`)
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }
@@ -146,8 +152,11 @@ export function invalidatePackage(
     }
 
     return true
-  } catch (err) {
-    log("[auto-update-checker] Failed to invalidate package:", err)
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+    log("[auto-update-checker] Failed to invalidate package:", error)
     return false
   }
 }

--- a/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -36,6 +36,36 @@ describe("ralph-loop continuation prompt injector", () => {
     }
   })
 
+  test("#given promptAsync resolves circular SDK error #when injecting continuation prompt #then it returns rejection without throwing", async () => {
+    // given
+    const circularError: Record<string, unknown> = {}
+    circularError.self = circularError
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({ data: [] }),
+          promptAsync: async () => ({
+            error: circularError,
+          }),
+        },
+      },
+    }
+
+    // when
+    const result = await injectContinuationPrompt(ctx as never, {
+      sessionID: "ses_rejected_circular_response",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(result.status).toBe("rejected")
+    if (result.status === "rejected") {
+      expect(String(result.error)).toContain("[object Object]")
+    }
+  })
+
   test("#given promptAsync rejects #when injecting continuation prompt #then it returns rejection without throwing", async () => {
     // given
     const ctx = {

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -53,7 +53,10 @@ function describePromptAsyncError(error: unknown): string {
 
 	try {
 		return JSON.stringify(error)
-	} catch {
+	} catch (jsonError) {
+		if (!(jsonError instanceof Error)) {
+			throw jsonError
+		}
 		return String(error)
 	}
 }
@@ -106,7 +109,10 @@ export async function injectContinuationPrompt(
 				break
 			}
 		}
-	} catch {
+	} catch (error) {
+		if (!(error instanceof Error)) {
+			throw error
+		}
 		const messageDir = getMessageDir(sourceSessionID)
 		const currentMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
 		agent = currentMessage?.agent

--- a/src/hooks/session-recovery/recover-tool-result-missing.test.ts
+++ b/src/hooks/session-recovery/recover-tool-result-missing.test.ts
@@ -38,6 +38,7 @@ interface PromptAsyncInput {
 function createMockClient(
   messages: MessageData[] = [],
   promptAsyncImpl?: (input: PromptAsyncInput) => Promise<unknown>,
+  messagesImpl?: () => Promise<unknown>,
 ) {
   const promptAsyncCalls: PromptAsyncInput[] = []
   const promptAsync = mock((input: PromptAsyncInput) => {
@@ -48,7 +49,7 @@ function createMockClient(
   return {
     client: {
       session: {
-        messages: mock(() => Promise.resolve({ data: messages })),
+        messages: mock(() => messagesImpl ? messagesImpl() : Promise.resolve({ data: messages })),
         promptAsync,
       },
     } as never,
@@ -85,6 +86,21 @@ describe("recoverToolResultMissing", () => {
         parts: [{ type: "tool", id: "prt_missing_call", name: "bash", input: {} }],
       },
     ])
+
+    //#when
+    const result = await recoverToolResultMissing(client, "ses_1", failedAssistantMsg)
+
+    //#then
+    expect(result).toBe(false)
+    expect(promptAsync).not.toHaveBeenCalled()
+  })
+
+  it("#given sqlite fallback message fetch fails #when recovering missing tool result #then returns false", async () => {
+    //#given
+    sqliteBackend = true
+    const { client, promptAsync } = createMockClient([], undefined, async () => {
+      throw new Error("messages unavailable")
+    })
 
     //#when
     const result = await recoverToolResultMissing(client, "ses_1", failedAssistantMsg)
@@ -310,6 +326,27 @@ describe("recoverToolResultMissing", () => {
 
     // then
     expect(result).toBe(true)
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given prompt dispatch fails non-ambiguously #when recovering missing tool result #then returns false", async () => {
+    // given
+    storedParts = [{
+      type: "tool",
+      id: "prt_stored_rejected_call",
+      callID: "toolu_rejected",
+      tool: "bash",
+      state: { input: {} },
+    }]
+    const { client, promptAsync } = createMockClient([], async () => {
+      throw new Error("permission denied")
+    })
+
+    // when
+    const result = await recoverToolResultMissing(client, "ses_rejected_recovery", failedAssistantMsg)
+
+    // then
+    expect(result).toBe(false)
     expect(promptAsync).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/hooks/session-recovery/recover-tool-result-missing.ts
+++ b/src/hooks/session-recovery/recover-tool-result-missing.ts
@@ -110,7 +110,10 @@ async function readPartsFromSDKFallback(
     if (!target?.parts) return []
 
     return target.parts.map((part) => normalizeMessagePart(part)).filter((part): part is MessagePart => part !== null)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }
@@ -183,7 +186,10 @@ export async function recoverToolResultMissing(
       return true
     }
     return isInternalPromptDispatchAccepted(promptResult)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return false
   }
 }


### PR DESCRIPTION
## Summary
- replace 7 empty/broad catch fallbacks across related hook recovery/cache paths with Error-narrowed handling
- add characterization coverage for auto-update cache invalidation, ralph-loop circular SDK errors, and session-recovery failure paths
- keep existing Error fallback behavior while allowing non-Error throws to propagate instead of being silently swallowed

## Manual QA
- bun test src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/ralph-loop/continuation-prompt-injector.test.ts src/hooks/auto-update-checker/cache.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/session-recovery/recover-tool-result-missing.ts src/hooks/session-recovery/recover-tool-result-missing.test.ts src/hooks/ralph-loop/continuation-prompt-injector.ts src/hooks/ralph-loop/continuation-prompt-injector.test.ts src/hooks/auto-update-checker/cache.ts src/hooks/auto-update-checker/cache.test.ts
- git diff --check
- git grep -n -F '} catch {' -- src/hooks/session-recovery/recover-tool-result-missing.ts src/hooks/ralph-loop/continuation-prompt-injector.ts src/hooks/auto-update-checker/cache.ts
- bun run typecheck
- bun run build
- bun --eval import-smoke for recoverToolResultMissing, injectContinuationPrompt, invalidatePackage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens error handling across session recovery, ralph-loop, and auto-update cache hooks to only catch real Errors. Prevents silent failures and fixes edge cases around cache invalidation and prompt dispatch.

- **Bug Fixes**
  - Auto-update cache: return false on invalid text lockfile, delete `bun.lockb` when present, and let non-Error throws propagate; improved logging.
  - Ralph-loop continuation prompt: safely stringify circular SDK errors and return a rejected result instead of throwing; non-Error throws propagate.
  - Session recovery: return false when SDK message fetch fails or prompt dispatch clearly fails; non-Error throws propagate.

<sup>Written for commit eccec5d817476273e0f3e9a090cd209af3c04f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

