### PR TITLE
fix(hashline-edit): handle direct formatter config responses

### DIFF
--- a/src/tools/hashline-edit/formatter-trigger.test.ts
+++ b/src/tools/hashline-edit/formatter-trigger.test.ts
@@ -76,6 +76,28 @@ describe("resolveFormatters", () => {
     expect(result.get(".tsx")).toEqual([{ command: ["prettier", "--write", "$FILE"], environment: {} }])
   })
 
+  it("resolves formatters from direct SDK config responses", async () => {
+    //#given
+    const client = {
+      config: {
+        get: mock(() => Promise.resolve({
+          formatter: {
+            prettier: {
+              command: ["prettier", "--write", "$FILE"],
+              extensions: [".json"],
+            },
+          },
+        })),
+      },
+    }
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".json")).toEqual([{ command: ["prettier", "--write", "$FILE"], environment: {} }])
+  })
+
   it("resolves formatters from experimental.hook.file_edited section", async () => {
     //#given
     const client = createMockClient({

--- a/src/tools/hashline-edit/formatter-trigger.ts
+++ b/src/tools/hashline-edit/formatter-trigger.ts
@@ -22,7 +22,7 @@ interface OpencodeConfig {
 
 export interface FormatterClient {
   config: {
-    get: (options?: { query?: { directory?: string } }) => Promise<{ data?: OpencodeConfig }>
+    get: (options?: { query?: { directory?: string } }) => Promise<OpencodeConfig | { data: OpencodeConfig | undefined }>
   }
 }
 
@@ -33,6 +33,11 @@ const cachedFormattersByDirectory = new Map<string, FormatterMap>()
 
 function getFormatterCacheKey(directory: string): string {
   return path.resolve(directory)
+}
+
+function unwrapConfigResponse(response: OpencodeConfig | { data: OpencodeConfig | undefined }): OpencodeConfig | undefined {
+  if ("data" in response) return response.data
+  return response
 }
 
 export async function resolveFormatters(
@@ -47,7 +52,7 @@ export async function resolveFormatters(
 
   try {
     const response = await client.config.get({ query: { directory } })
-    const config = response.data
+    const config = unwrapConfigResponse(response)
     if (!config) return result
 
     if (config.formatter && typeof config.formatter === "object") {


### PR DESCRIPTION
## Summary

Fixes #4853. Formatter resolution now supports the real OpenCode SDK `config.get()` response shape, where the config object is returned directly instead of wrapped in `{ data }`.

## Changes

- Add a regression test for direct SDK config responses in `resolveFormatters()`.
- Keep support for the existing wrapped `{ data }` config shape used by current tests/mocks.
- Normalize config responses before resolving `formatter` and `experimental.hook.file_edited` entries.

## Screenshots

N/A

## Testing

```bash
bun test src/tools/hashline-edit/formatter-trigger.test.ts
bun test src/tools/hashline-edit/formatter-trigger-cache.test.ts src/tools/hashline-edit/formatter-trigger.test.ts
bun run typecheck
bun test
bun run build
```

## Related Issues

Closes #4853

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support direct OpenCode SDK `config.get()` responses in hashline-edit formatter resolution to prevent formatter lookup failures (fixes #4853). Keeps support for the legacy `{ data }` shape.

- **Bug Fixes**
  - Unwrap SDK config responses (direct or `{ data }`) before reading `formatter` and `experimental.hook.file_edited` via `unwrapConfigResponse()` and an updated `FormatterClient` type.
  - Add a regression test for the direct response shape in `resolveFormatters()`.

<sup>Written for commit ced8f48c5fcd35aa97f8786aed7bbf116eea0942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

