### PR TITLE
fix: narrow MCP OAuth catch fallbacks

### DIFF
--- a/src/features/mcp-oauth/dcr.test.ts
+++ b/src/features/mcp-oauth/dcr.test.ts
@@ -161,4 +161,29 @@ describe("getOrRegisterClient", () => {
     expect(result).toEqual({ clientId: "fallback-client" })
     expect(storage.getLastSet()).toBeNull()
   })
+
+  it("propagates non-Error registration failures", async () => {
+    // given
+    const storage = createStorage(null)
+    const nonErrorFailure = Object.freeze({ reason: "non-error network failure" })
+    const fetchMock: DcrFetch = async () => {
+      throw nonErrorFailure
+    }
+
+    // when
+    const result = getOrRegisterClient({
+      registrationEndpoint: "https://server.example.com/register",
+      serverIdentifier: "server-5",
+      clientName: "Test Client",
+      redirectUris: ["https://app.example.com/callback"],
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientId: "fallback-client",
+      storage,
+      fetch: fetchMock,
+    })
+
+    // then
+    await expect(result).rejects.toBe(nonErrorFailure)
+    expect(storage.getLastSet()).toBeNull()
+  })
 })

--- a/src/features/mcp-oauth/dcr.ts
+++ b/src/features/mcp-oauth/dcr.ts
@@ -75,7 +75,8 @@ export async function getOrRegisterClient(
 
     options.storage.setClientRegistration(serverIdentifier, parsed)
     return parsed
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return options.clientId ? { clientId: options.clientId } : null
   }
 }

--- a/src/features/mcp-oauth/oauth-authorization-flow.ts
+++ b/src/features/mcp-oauth/oauth-authorization-flow.ts
@@ -112,8 +112,8 @@ function openBrowser(url: string): void {
     const child = spawn(command, args, { stdio: "ignore", detached: true })
     child.on("error", () => {})
     child.unref()
-  } catch {
-    // Browser open failed - user must navigate manually
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
   }
 }
 

--- a/src/features/mcp-oauth/provider.test.ts
+++ b/src/features/mcp-oauth/provider.test.ts
@@ -285,10 +285,8 @@ describe("McpOAuthProvider", () => {
           { status: 200, headers: { "content-type": "application/json" } },
         )
       })
-      const fetchMock = Object.assign(
-        async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => fetchStub(...args),
-        { preconnect: originalFetch?.preconnect?.bind(originalFetch) ?? (() => {}) },
-      ) satisfies typeof fetch
+      const fetchMock = (async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        fetchStub(...args)) satisfies typeof fetch
       globalThis.fetch = fetchMock
 
       // given
@@ -310,6 +308,58 @@ describe("McpOAuthProvider", () => {
       // then
       expect(result.accessToken).toBe("refreshed-access-token")
       expect(result.refreshToken).toBe("refresh-token-456") // preserved from input when absent in response
+    })
+
+    it("propagates non-Error token error-body parse failures", async () => {
+      // given
+      const nonErrorFailure = Object.freeze({ reason: "non-error json failure" })
+      const fetchStub = mock(async (input: RequestInfo | URL) => {
+        const url = input.toString()
+        if (url.includes("oauth-protected-resource")) {
+          return new Response(
+            JSON.stringify({ authorization_servers: ["https://auth.example.com"] }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.includes(".well-known")) {
+          return new Response(
+            JSON.stringify({
+              issuer: "https://auth.example.com",
+              authorization_endpoint: "https://auth.example.com/authorize",
+              token_endpoint: "https://auth.example.com/token",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+
+        const tokenResponse = new Response("", { status: 400 })
+        Object.defineProperty(tokenResponse, "json", {
+          value: async () => {
+            throw nonErrorFailure
+          },
+        })
+        return tokenResponse
+      })
+      const fetchMock = (async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        fetchStub(...args)) satisfies typeof fetch
+      globalThis.fetch = fetchMock
+      const providerModule = await importFreshProviderModule()
+      const provider = new providerModule.McpOAuthProvider({
+        serverUrl: "https://mcp.example.com",
+        clientId: "my-client",
+      })
+      provider.saveTokens({
+        accessToken: "old-access-token",
+        refreshToken: "refresh-token-456",
+        expiresAt: Math.floor(Date.now() / 1000) - 60,
+        clientInfo: { clientId: "my-client" },
+      })
+
+      // when
+      const result = provider.refresh("refresh-token-456")
+
+      // then
+      await expect(result).rejects.toBe(nonErrorFailure)
     })
   })
 

--- a/src/features/mcp-oauth/provider.ts
+++ b/src/features/mcp-oauth/provider.ts
@@ -31,8 +31,8 @@ async function parseTokenResponse(tokenResponse: Response): Promise<Record<strin
           errorDetail += `: ${body.error_description}`
         }
       }
-    } catch {
-      // Response body not JSON
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
     }
     throw new Error(`Token exchange failed: ${errorDetail}`)
   }

--- a/src/mcp/ast-grep.ts
+++ b/src/mcp/ast-grep.ts
@@ -78,7 +78,8 @@ function addAncestorCommandCandidates(
 function getModuleDirectory(moduleUrl: string): string | null {
   try {
     return dirname(fileURLToPath(moduleUrl));
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
     return null;
   }
 }

--- a/src/mcp/lsp.ts
+++ b/src/mcp/lsp.ts
@@ -99,7 +99,8 @@ function addAncestorCommandCandidates(
 function getModuleDirectory(moduleUrl: string): string | null {
   try {
     return dirname(fileURLToPath(moduleUrl))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return null
   }
 }

--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -90,7 +90,8 @@ export function applyGrepFilter(output: string, pattern: string | undefined): st
     const lines = output.split("\n")
     const filtered = lines.filter((line) => regex.test(line))
     return filtered.length > 0 ? filtered.join("\n") : `[grep] No lines matched pattern: ${pattern}`
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return output
   }
 }


### PR DESCRIPTION
## Summary
- Replace scoped no-binding `catch {` blocks across built-in MCP, skill MCP, and MCP OAuth surfaces with narrowed `catch (error)` handling.
- Preserve existing `Error` fallback behavior while allowing non-`Error` throws to propagate.
- Add characterization coverage for DCR and token error-body parse non-`Error` propagation.

## Testing
- `bun test src/mcp/ast-grep.test.ts src/mcp/lsp.test.ts src/tools/skill-mcp/tools.test.ts src/features/mcp-oauth/dcr.test.ts src/features/mcp-oauth/provider.test.ts`
- `bun run /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/mcp/ast-grep.ts src/mcp/lsp.ts src/tools/skill-mcp/tools.ts src/features/mcp-oauth/dcr.ts src/features/mcp-oauth/oauth-authorization-flow.ts src/features/mcp-oauth/provider.ts src/features/mcp-oauth/dcr.test.ts src/features/mcp-oauth/provider.test.ts`
- `git diff --check origin/dev..HEAD`
- `rg -n "catch \{" src/mcp/ast-grep.ts src/mcp/lsp.ts src/tools/skill-mcp/tools.ts src/features/mcp-oauth/dcr.ts src/features/mcp-oauth/oauth-authorization-flow.ts src/features/mcp-oauth/provider.ts` (no matches)
- `bun run typecheck`
- `bun run build`
- `bash scripts/lib/common.sh --self-check` from `.agents/skills/opencode-qa`
- `bash scripts/server-smoke.sh` from `.agents/skills/opencode-qa`
- `bun test` before rebasing onto latest `origin/dev`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed generic catch blocks across MCP and OAuth to only swallow real Errors and rethrow non-Error exceptions. Keeps existing fallbacks for Error cases and adds tests for DCR and token error-body parsing.

- **Bug Fixes**
  - MCP OAuth: `getOrRegisterClient` and token parsing now propagate non-Error failures; `openBrowser` swallows only `Error`.
  - MCP/skills: module directory resolution and `grep` filter now return fallbacks only for `Error`; non-Error rethrown.
  - Tests: new cases assert non-Error propagation in DCR and token JSON parse paths.

<sup>Written for commit 1156d50276aced4f838ec8de70520a8b0a32e859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

