### PR TITLE
Fix recovery hook catch fallbacks

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/message-storage-directory.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/message-storage-directory.ts
@@ -20,7 +20,10 @@ export async function getMessageIdsFromSDK(
     const response = await client.session.messages({ path: { id: sessionID } })
     const messages = normalizeSDKResponse(response, [] as SDKMessage[], { preferResponseOnMissingData: true })
     return messages.map(msg => msg.info.id)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return []
   }
 }

--- a/src/hooks/anthropic-context-window-limit-recovery/target-token-truncation.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/target-token-truncation.ts
@@ -78,7 +78,10 @@ export async function truncateUntilTargetTokens(
 					toolPartsByKey.set(`${messageID}:${part.id}`, part)
 				}
 			}
-		} catch {
+		} catch (error) {
+			if (!(error instanceof Error)) {
+				throw error
+			}
 			toolPartsByKey = new Map<string, SDKToolPart>()
 		}
 

--- a/src/hooks/atlas/background-launch-session-tracking.ts
+++ b/src/hooks/atlas/background-launch-session-tracking.ts
@@ -108,7 +108,10 @@ async function resolveFallbackTrackedSessionId(input: {
       return input.extractedSessionId
     }
     return undefined
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return undefined
   }
 }

--- a/src/hooks/atlas/catch-fallbacks.test.ts
+++ b/src/hooks/atlas/catch-fallbacks.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { resolveRecentPromptContextForSession } from "./recent-model-resolver"
+
+describe("atlas catch fallbacks", () => {
+  test("resolveRecentPromptContextForSession falls back to storage when SDK messages throw an Error", async () => {
+    // given
+    const ctx = unsafeTestValue<Parameters<typeof resolveRecentPromptContextForSession>[0]>({
+      client: {
+        session: {
+          messages: async () => {
+            throw new Error("sdk unavailable")
+          },
+        },
+      },
+    })
+
+    // when
+    const result = await resolveRecentPromptContextForSession(ctx, "ses_error", {
+      isSqliteBackend: () => false,
+      getMessageDir: () => null,
+      findNearestMessageWithFields: () => null,
+      findNearestMessageWithFieldsFromSDK: async () => null,
+    })
+
+    // then
+    expect(result).toEqual({ tools: undefined })
+  })
+
+  test("resolveRecentPromptContextForSession rethrows non-Error SDK message failures", async () => {
+    // given
+    const thrown = "non-error sdk failure"
+    const ctx = unsafeTestValue<Parameters<typeof resolveRecentPromptContextForSession>[0]>({
+      client: {
+        session: {
+          messages: async () => {
+            throw thrown
+          },
+        },
+      },
+    })
+
+    // when
+    const result = resolveRecentPromptContextForSession(ctx, "ses_non_error", {
+      isSqliteBackend: () => false,
+      getMessageDir: () => null,
+      findNearestMessageWithFields: () => null,
+      findNearestMessageWithFieldsFromSDK: async () => null,
+    })
+
+    // then
+    await expect(result).rejects.toBe(thrown)
+  })
+})

--- a/src/hooks/atlas/final-wave-plan-state.ts
+++ b/src/hooks/atlas/final-wave-plan-state.ts
@@ -54,7 +54,10 @@ export function readFinalWavePlanState(planPath: string): FinalWavePlanState | n
       pendingImplementationTaskCount,
       pendingFinalWaveTaskCount,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }

--- a/src/hooks/atlas/recent-model-resolver.ts
+++ b/src/hooks/atlas/recent-model-resolver.ts
@@ -69,7 +69,10 @@ export async function resolveRecentPromptContextForSession(
         return { model: { providerID: info.providerID, modelID: info.modelID }, tools }
       }
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     // ignore - fallback to message storage
   }
 

--- a/src/hooks/atlas/tool-execute-before.ts
+++ b/src/hooks/atlas/tool-execute-before.ts
@@ -104,7 +104,10 @@ export function createToolExecuteBeforeHandler(input: {
           if (existsSync(planPath)) {
             pendingPlanSnapshots.set(toolInput.callID, readFileSync(planPath, "utf-8"))
           }
-        } catch {
+        } catch (error) {
+          if (!(error instanceof Error)) {
+            throw error
+          }
           pendingPlanSnapshots.delete(toolInput.callID)
         }
       }

--- a/src/hooks/runtime-fallback/catch-fallbacks.test.ts
+++ b/src/hooks/runtime-fallback/catch-fallbacks.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { getErrorMessage } from "./error-classifier"
+import type { RuntimeFallbackPluginInput } from "./types"
+import { hasVisibleAssistantResponse } from "./visible-assistant-response"
+
+describe("runtime fallback catch fallbacks", () => {
+  test("getErrorMessage returns an empty fallback when JSON serialization throws an Error", () => {
+    // given
+    const error = {
+      toJSON: () => {
+        throw new Error("cannot serialize")
+      },
+    }
+
+    // when
+    const message = getErrorMessage(error)
+
+    // then
+    expect(message).toBe("")
+  })
+
+  test("getErrorMessage rethrows non-Error JSON serialization failures", () => {
+    // given
+    const thrown = "non-error serialization failure"
+    const error = {
+      toJSON: () => {
+        throw thrown
+      },
+    }
+
+    // when
+    const readMessage = () => getErrorMessage(error)
+
+    // then
+    expect(readMessage).toThrow(thrown)
+  })
+
+  test("hasVisibleAssistantResponse returns false when message loading throws an Error", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const ctx = unsafeTestValue<RuntimeFallbackPluginInput>({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          messages: async () => {
+            throw new Error("messages unavailable")
+          },
+        },
+      },
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "ses_error", undefined)
+
+    // then
+    expect(result).toBe(false)
+  })
+
+  test("hasVisibleAssistantResponse rethrows non-Error message loading failures", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(() => undefined)
+    const thrown = "non-error message loading failure"
+    const ctx = unsafeTestValue<RuntimeFallbackPluginInput>({
+      directory: "/tmp/project",
+      client: {
+        session: {
+          messages: async () => {
+            throw thrown
+          },
+        },
+      },
+    })
+
+    // when
+    const result = checkVisibleResponse(ctx, "ses_non_error", undefined)
+
+    // then
+    await expect(result).rejects.toBe(thrown)
+  })
+})

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -33,7 +33,10 @@ export function getErrorMessage(error: unknown): string {
 
   try {
     return JSON.stringify(error).toLowerCase()
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return ""
   }
 }

--- a/src/hooks/runtime-fallback/visible-assistant-response.ts
+++ b/src/hooks/runtime-fallback/visible-assistant-response.ts
@@ -73,7 +73,10 @@ export function hasVisibleAssistantResponse(extractAutoRetrySignalFn: typeof ext
       }
 
       return false
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       return false
     }
   }


### PR DESCRIPTION
## Summary
Narrow no-binding catch fallbacks in recovery and agent-flow hooks so normal Error failures keep the existing fallback behavior while unexpected non-Error throws propagate.

## Changes
- Replaced the eight targeted `catch {` blocks in Atlas, Anthropic context-window recovery, and runtime fallback hooks.
- Added focused characterization coverage for runtime fallback and Atlas SDK fallback behavior.

## Testing
- `bun test ./src/hooks/runtime-fallback/error-classifier.test.ts ./src/hooks/runtime-fallback/message-update-handler.test.ts ./src/hooks/runtime-fallback/catch-fallbacks.test.ts`
- `bun test ./src/hooks/atlas/recent-model-resolver.test.ts ./src/hooks/atlas/recent-model-resolver-fallback.test.ts ./src/hooks/atlas/catch-fallbacks.test.ts`
- `bun test ./src/hooks/anthropic-context-window-limit-recovery/storage.test.ts ./src/hooks/anthropic-context-window-limit-recovery/aggressive-truncation-strategy.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...touched files...`
- `git diff --check`
- `rg -n "catch \\{" ...target files...` (no matches)
- `bun run typecheck`
- `bun run build`
- `bash /Users/yeongyu/local-workspaces/omo/.agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
- `bash /Users/yeongyu/local-workspaces/omo/.agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened catch fallbacks in recovery and agent-flow hooks so normal Error failures still use safe fallbacks, while non-Error throws now bubble up. This prevents silent failures from SDK or serialization issues without changing expected behavior.

- **Bug Fixes**
  - Replaced bare `catch {}` with `catch (error)` and rethrow for non-Error across Atlas, runtime-fallback, and Anthropic context-window recovery.
  - Kept intended fallbacks on Error: e.g., empty message IDs, null plan state, and false for visible response checks.
  - Added targeted tests for Atlas and runtime-fallback to verify Error fallback vs non-Error propagation.

<sup>Written for commit dec66fad130ce4614f3cd31a71eb95c05548d760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

