### PR TITLE
fix(doctor): narrow cli fallback catches

### DIFF
--- a/src/cli/config-manager/npm-dist-tags.test.ts
+++ b/src/cli/config-manager/npm-dist-tags.test.ts
@@ -39,6 +39,17 @@ describe("fetchNpmDistTags", () => {
     expect(result).toBeNull()
   })
 
+  test("rethrows non-Error fetch failures", async () => {
+    //#given
+    globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() => Promise.reject("Network error")))
+
+    //#when
+    const promise = fetchNpmDistTags("oh-my-openagent")
+
+    //#then
+    await expect(promise).rejects.toBe("Network error")
+  })
+
   test("returns null on non-ok response", async () => {
     //#given
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() =>

--- a/src/cli/config-manager/npm-dist-tags.test.ts
+++ b/src/cli/config-manager/npm-dist-tags.test.ts
@@ -44,10 +44,13 @@ describe("fetchNpmDistTags", () => {
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() => Promise.reject("Network error")))
 
     //#when
-    const promise = fetchNpmDistTags("oh-my-openagent")
+    const result = await fetchNpmDistTags("oh-my-openagent").then(
+      () => "resolved",
+      (error: unknown) => error,
+    )
 
     //#then
-    await expect(promise).rejects.toBe("Network error")
+    expect(result).toBe("Network error")
   })
 
   test("returns null on non-ok response", async () => {

--- a/src/cli/config-manager/npm-dist-tags.ts
+++ b/src/cli/config-manager/npm-dist-tags.ts
@@ -15,7 +15,11 @@ export async function fetchNpmDistTags(packageName: string): Promise<NpmDistTags
     if (!res.ok) return null
     const data = (await res.json()) as NpmDistTags
     return data
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return null
   }
 }

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -167,4 +167,17 @@ describe("getOpenCodeVersion (installer)", () => {
       expect(result).toBe(null)
     })
   })
+
+  describe("#given spawn throws a non-Error value #when getOpenCodeVersion #then the value is rethrown", () => {
+    it("does not swallow unknown throw values", async () => {
+      const unknownFailure = { reason: "ENOENT" } as const
+      spawnSpy.mockImplementation(() => {
+        throw unknownFailure
+      })
+
+      const promise = getOpenCodeVersion()
+
+      await expect(promise).rejects.toBe(unknownFailure)
+    })
+  })
 })

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -175,9 +175,12 @@ describe("getOpenCodeVersion (installer)", () => {
         throw unknownFailure
       })
 
-      const promise = getOpenCodeVersion()
+      const result = await getOpenCodeVersion().then(
+        () => "resolved",
+        (error: unknown) => error,
+      )
 
-      await expect(promise).rejects.toBe(unknownFailure)
+      expect(result).toBe(unknownFailure)
     })
   })
 })

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -78,7 +78,11 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
         initConfigContext(binary, version)
         return { binary, version }
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+
       continue
     }
   }

--- a/src/cli/config-manager/version-compatibility.test.ts
+++ b/src/cli/config-manager/version-compatibility.test.ts
@@ -57,6 +57,17 @@ describe("checkVersionCompatibility", () => {
     const result = checkVersionCompatibility("3.15.0", "v3.16.0")
     expect(result.canUpgrade).toBe(true)
   })
+
+  it("falls back cautiously when version comparison cannot parse a version", () => {
+    const result = checkVersionCompatibility("not-a-version", "3.16.0")
+
+    expect(result.canUpgrade).toBe(true)
+    expect(result.isDowngrade).toBe(false)
+    expect(result.requiresMigration).toBe(false)
+    expect(result.reason).toBe(
+      "Unable to compare versions not-a-version and 3.16.0 - proceeding with caution",
+    )
+  })
 })
 
 describe("extractVersionFromPluginEntry", () => {

--- a/src/cli/config-manager/version-compatibility.ts
+++ b/src/cli/config-manager/version-compatibility.ts
@@ -8,7 +8,12 @@ export interface VersionCompatibility {
 
 function parseVersion(version: string): number[] {
   const clean = version.replace(/^v/, "").split("-")[0]
-  return clean.split(".").map(Number)
+  const parts = clean.split(".").map(Number)
+  if (parts.some((part) => !Number.isFinite(part))) {
+    throw new RangeError(`Invalid semver: ${version}`)
+  }
+
+  return parts
 }
 
 function compareVersions(a: string, b: string): number {
@@ -86,7 +91,11 @@ export function checkVersionCompatibility(
       isMajorBump: false,
       requiresMigration: false,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return {
       canUpgrade: true,
       reason: `Unable to compare versions ${currentVersion} and ${newVersion} - proceeding with caution`,

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -89,7 +89,11 @@ export function getPluginInfo(): PluginInfo {
       pinnedVersion,
       isLocalDev: pluginEntry.isLocalDev,
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return {
       registered: false,
       configPath,

--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -1,10 +1,13 @@
 /// <reference types="bun-types" />
 
-import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { PLUGIN_NAME } from "../../../shared"
 import type { PluginInfo } from "./system-plugin"
 import type { OpenCodeBinaryInfo } from "./system-binary"
-import { checkSystem } from "./system"
+import { checkSystem, gatherSystemInfo } from "./system"
 
 const mockFindOpenCodeBinary = mock<() => Promise<OpenCodeBinaryInfo | null>>(async () => ({
   binary: "opencode",
@@ -30,6 +33,7 @@ const mockGetLoadedPluginVersion = mock(() => ({
 const mockGetLatestPluginVersion = mock(async (_currentVersion: string | null) => null as string | null)
 const mockGetSuggestedInstallTag = mock(() => "latest")
 
+const temporaryDirectories: string[] = []
 
 function createSystemDeps() {
   return {
@@ -76,6 +80,36 @@ describe("system check", () => {
     })
     mockGetLatestPluginVersion.mockResolvedValue(null)
     mockGetSuggestedInstallTag.mockReturnValue("latest")
+  })
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  describe("#given malformed config JSONC", () => {
+    it("marks the config invalid without throwing", async () => {
+      //#given
+      const directory = mkdtempSync(join(tmpdir(), "omo-system-config-"))
+      temporaryDirectories.push(directory)
+      const configPath = join(directory, "opencode.json")
+      writeFileSync(configPath, "{", "utf-8")
+      mockGetPluginInfo.mockReturnValue({
+        registered: false,
+        entry: null,
+        isPinned: false,
+        pinnedVersion: null,
+        configPath,
+        isLocalDev: false,
+      })
+
+      //#when
+      const result = await gatherSystemInfo(createSystemDeps())
+
+      //#then
+      expect(result.configValid).toBe(false)
+    })
   })
 
   describe("#given cache directory contains spaces", () => {

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -35,7 +35,11 @@ function isConfigValid(configPath: string | null): boolean {
   try {
     parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return false
   }
 }

--- a/src/cli/doctor/checks/tools-lsp.test.ts
+++ b/src/cli/doctor/checks/tools-lsp.test.ts
@@ -83,4 +83,20 @@ describe("getInstalledLspServers", () => {
     expect(servers).toEqual([{ id: "lsp-tools-mcp", extensions: ["*"] }])
   })
 
+  it("ignores malformed OMO config files when detecting disabled MCPs", async () => {
+    // given
+    const userConfigDirectory = createTemporaryDirectory("omo-tools-lsp-user-")
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-lsp-malformed-")
+    mkdirSync(userConfigDirectory, { recursive: true })
+    writeFileSync(join(userConfigDirectory, "oh-my-openagent.json"), "{", "utf-8")
+    clearPluginConfigFileDetectionCache()
+
+    const { getInstalledLspServers } = await import(`./tools-lsp?t=${Date.now()}-malformed`)
+
+    // when
+    const servers = getInstalledLspServers({ configDirectory: userConfigDirectory, cwd: workspaceDirectory })
+
+    // then
+    expect(servers).toEqual([{ id: "lsp-tools-mcp", extensions: ["*"] }])
+  })
 })

--- a/src/cli/doctor/checks/tools-lsp.ts
+++ b/src/cli/doctor/checks/tools-lsp.ts
@@ -25,7 +25,11 @@ function readOmoConfig(configDirectory: string): OmoConfigForDoctor | null {
   try {
     const content = readFileSync(detected.path, "utf-8")
     return parseJsonc<OmoConfigForDoctor>(content)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return null
   }
 }

--- a/src/cli/doctor/checks/tools-mcp.test.ts
+++ b/src/cli/doctor/checks/tools-mcp.test.ts
@@ -1,0 +1,95 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const temporaryDirectories: string[] = []
+const originalCwd = process.cwd()
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  process.chdir(originalCwd)
+
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe("getUserMcpInfo", () => {
+  it("loads valid project MCP servers", async () => {
+    // given
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-mcp-valid-")
+    process.chdir(workspaceDirectory)
+    writeFileSync(
+      join(workspaceDirectory, ".mcp.json"),
+      JSON.stringify({ mcpServers: { example: { command: "node" } } }),
+      "utf-8",
+    )
+
+    const { getUserMcpInfo } = await import(`./tools-mcp?t=${Date.now()}-valid`)
+
+    // when
+    const servers = getUserMcpInfo()
+
+    // then
+    expect(servers).toEqual([
+      {
+        id: "example",
+        type: "user",
+        enabled: true,
+        valid: true,
+        error: undefined,
+      },
+    ])
+  })
+
+  it("skips malformed MCP config files", async () => {
+    // given
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-mcp-malformed-")
+    process.chdir(workspaceDirectory)
+    writeFileSync(join(workspaceDirectory, ".mcp.json"), "{", "utf-8")
+
+    const { getUserMcpInfo } = await import(`./tools-mcp?t=${Date.now()}-malformed`)
+
+    // when
+    const servers = getUserMcpInfo()
+
+    // then
+    expect(servers).toEqual([])
+  })
+
+  it("marks non-object MCP server entries invalid", async () => {
+    // given
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-mcp-invalid-")
+    mkdirSync(join(workspaceDirectory, ".claude"), { recursive: true })
+    process.chdir(workspaceDirectory)
+    writeFileSync(
+      join(workspaceDirectory, ".claude", ".mcp.json"),
+      JSON.stringify({ mcpServers: { broken: "node" } }),
+      "utf-8",
+    )
+
+    const { getUserMcpInfo } = await import(`./tools-mcp?t=${Date.now()}-invalid`)
+
+    // when
+    const servers = getUserMcpInfo()
+
+    // then
+    expect(servers).toEqual([
+      {
+        id: "broken",
+        type: "user",
+        enabled: true,
+        valid: false,
+        error: "Invalid configuration format",
+      },
+    ])
+  })
+})

--- a/src/cli/doctor/checks/tools-mcp.ts
+++ b/src/cli/doctor/checks/tools-mcp.ts
@@ -31,7 +31,11 @@ function loadUserMcpConfig(): Record<string, unknown> {
       if (config.mcpServers) {
         Object.assign(servers, config.mcpServers)
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
+
       continue
     }
   }

--- a/src/cli/doctor/spawn-with-timeout.test.ts
+++ b/src/cli/doctor/spawn-with-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { afterEach, describe, expect, it, mock } from "bun:test"
 import { spawnWithTimeout } from "./spawn-with-timeout"
 
 describe("spawnWithTimeout", () => {
@@ -68,6 +68,31 @@ describe("spawnWithTimeout", () => {
       // then
       expect(result.timedOut).toBe(false)
       expect(result.exitCode).toBe(1)
+    })
+  })
+
+  describe("#given spawn throws a non-Error value", () => {
+    afterEach(() => {
+      mock.restore()
+    })
+
+    it("rethrows the unknown value", async () => {
+      // given
+      const unknownFailure = { reason: "spawn failed" } as const
+      mock.module("../../shared/spawn-with-windows-hide", () => ({
+        spawnWithWindowsHide: () => {
+          throw unknownFailure
+        },
+      }))
+      const { spawnWithTimeout: spawnWithMockedSpawn } = await import(
+        `./spawn-with-timeout?non-error=${Date.now()}`
+      )
+
+      // when
+      const promise = spawnWithMockedSpawn(["test-command"], { stdout: "pipe", stderr: "pipe" })
+
+      // then
+      await expect(promise).rejects.toBe(unknownFailure)
     })
   })
 })

--- a/src/cli/doctor/spawn-with-timeout.test.ts
+++ b/src/cli/doctor/spawn-with-timeout.test.ts
@@ -89,10 +89,13 @@ describe("spawnWithTimeout", () => {
       )
 
       // when
-      const promise = spawnWithMockedSpawn(["test-command"], { stdout: "pipe", stderr: "pipe" })
+      const result = await spawnWithMockedSpawn(["test-command"], { stdout: "pipe", stderr: "pipe" }).then(
+        () => "resolved",
+        (error: unknown) => error,
+      )
 
       // then
-      await expect(promise).rejects.toBe(unknownFailure)
+      expect(result).toBe(unknownFailure)
     })
   })
 })

--- a/src/cli/doctor/spawn-with-timeout.ts
+++ b/src/cli/doctor/spawn-with-timeout.ts
@@ -18,7 +18,11 @@ export async function spawnWithTimeout(
   let proc: ReturnType<typeof spawnWithWindowsHide>
   try {
     proc = spawnWithWindowsHide(command, options)
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+
     return { stdout: "", stderr: "", exitCode: 1, timedOut: false }
   }
 


### PR DESCRIPTION
## Summary
- replace CLI doctor/config no-binding catch fallbacks with Error-narrowed handling
- rethrow non-Error values instead of swallowing them
- add focused tests for npm dist-tags, OpenCode binary detection, version comparison, system config validity, LSP/MCP config parsing, and spawn fallback behavior

## Test plan
- bun test src/cli/config-manager/npm-dist-tags.test.ts src/cli/config-manager/opencode-binary.test.ts src/cli/config-manager/version-compatibility.test.ts src/cli/doctor/checks/system.test.ts src/cli/doctor/checks/tools-lsp.test.ts src/cli/doctor/checks/tools-mcp.test.ts src/cli/doctor/spawn-with-timeout.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts <touched files>
- git diff --check
- rg -n "catch \{" <target production files> || true
- bun run typecheck
- bun run build
- opencode QA common.sh --self-check
- isolated CLI smoke: bun ./src/cli/index.ts get-local-version
- isolated doctor smoke: bun ./src/cli/index.ts doctor --status (runs; exits 1 because isolated env reports AST-Grep and gh missing)
- isolated opencode smoke: opencode --version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens CLI doctor/config error handling by rethrowing non-Error values and only falling back on real Errors. Adds semver validation and safe handling of malformed configs to prevent silent failures.

- **Bug Fixes**
  - Rethrow non-Error failures in `fetchNpmDistTags`, OpenCode binary lookup, system plugin info, LSP/MCP checks, and `spawnWithTimeout`.
  - Validate semver before comparing; on parse failure, return a cautious “can upgrade” result with a clear reason.
  - Treat malformed JSON/JSONC as invalid without throwing (system config, LSP config, `.mcp.json`), and ignore bad MCP/LSP entries.

- **Refactors**
  - Replace broad `catch {}` with `catch (error) { if (!(error instanceof Error)) throw error }` across CLI doctor/config paths.
  - Update tests to use explicit then/catch to avoid async rejection matcher hints.

<sup>Written for commit 6e89f638a6281c9b203959bc8e34091cddfb943b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

