### PR TITLE
fix(mcp-oauth): narrow fallback catches

### DIFF
--- a/src/features/mcp-oauth/dcr.test.ts
+++ b/src/features/mcp-oauth/dcr.test.ts
@@ -161,4 +161,27 @@ describe("getOrRegisterClient", () => {
     expect(result).toEqual({ clientId: "fallback-client" })
     expect(storage.getLastSet()).toBeNull()
   })
+
+  it("propagates non-Error registration failures", async () => {
+    // given
+    const storage = createStorage(null)
+    const rejection = { kind: "non-error-rejection" }
+    const fetchMock: DcrFetch = async () => Promise.reject(rejection)
+
+    // when
+    const result = getOrRegisterClient({
+      registrationEndpoint: "https://server.example.com/register",
+      serverIdentifier: "server-5",
+      clientName: "Test Client",
+      redirectUris: ["https://app.example.com/callback"],
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientId: "fallback-client",
+      storage,
+      fetch: fetchMock,
+    })
+
+    // then
+    await expect(result).rejects.toBe(rejection)
+    expect(storage.getLastSet()).toBeNull()
+  })
 })

--- a/src/features/mcp-oauth/dcr.ts
+++ b/src/features/mcp-oauth/dcr.ts
@@ -75,7 +75,8 @@ export async function getOrRegisterClient(
 
     options.storage.setClientRegistration(serverIdentifier, parsed)
     return parsed
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return options.clientId ? { clientId: options.clientId } : null
   }
 }

--- a/src/features/mcp-oauth/oauth-authorization-flow.ts
+++ b/src/features/mcp-oauth/oauth-authorization-flow.ts
@@ -112,7 +112,8 @@ function openBrowser(url: string): void {
     const child = spawn(command, args, { stdio: "ignore", detached: true })
     child.on("error", () => {})
     child.unref()
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     // Browser open failed - user must navigate manually
   }
 }

--- a/src/features/mcp-oauth/provider.test.ts
+++ b/src/features/mcp-oauth/provider.test.ts
@@ -311,6 +311,56 @@ describe("McpOAuthProvider", () => {
       expect(result.accessToken).toBe("refreshed-access-token")
       expect(result.refreshToken).toBe("refresh-token-456") // preserved from input when absent in response
     })
+
+    it("propagates non-Error token error body failures", async () => {
+      // given
+      const rejection = { kind: "non-error-token-body" }
+      const fetchStub = mock(async (input: RequestInfo | URL) => {
+        const url = input.toString()
+        if (url.includes("oauth-protected-resource")) {
+          return new Response(
+            JSON.stringify({ authorization_servers: ["https://auth.example.com"] }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.includes(".well-known")) {
+          return new Response(
+            JSON.stringify({
+              issuer: "https://auth.example.com",
+              authorization_endpoint: "https://auth.example.com/authorize",
+              token_endpoint: "https://auth.example.com/token",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        const tokenResponse = new Response("", { status: 400 })
+        tokenResponse.json = async () => Promise.reject(rejection)
+        return tokenResponse
+      })
+      const fetchMock = Object.assign(
+        async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => fetchStub(...args),
+        { preconnect: originalFetch?.preconnect?.bind(originalFetch) ?? (() => {}) },
+      ) satisfies typeof fetch
+      globalThis.fetch = fetchMock
+
+      const providerModule = await importFreshProviderModule()
+      const provider = new providerModule.McpOAuthProvider({
+        serverUrl: "https://mcp.example.com",
+        clientId: "my-client",
+      })
+      provider.saveTokens({
+        accessToken: "old-access-token",
+        refreshToken: "refresh-token-456",
+        expiresAt: Math.floor(Date.now() / 1000) - 60,
+        clientInfo: { clientId: "my-client" },
+      })
+
+      // when
+      const result = provider.refresh("refresh-token-456")
+
+      // then
+      await expect(result).rejects.toBe(rejection)
+    })
   })
 
   describe("redirectUrl", () => {

--- a/src/features/mcp-oauth/provider.ts
+++ b/src/features/mcp-oauth/provider.ts
@@ -31,7 +31,8 @@ async function parseTokenResponse(tokenResponse: Response): Promise<Record<strin
           errorDetail += `: ${body.error_description}`
         }
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
       // Response body not JSON
     }
     throw new Error(`Token exchange failed: ${errorDetail}`)

--- a/src/mcp/ast-grep.ts
+++ b/src/mcp/ast-grep.ts
@@ -78,7 +78,8 @@ function addAncestorCommandCandidates(
 function getModuleDirectory(moduleUrl: string): string | null {
   try {
     return dirname(fileURLToPath(moduleUrl));
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
     return null;
   }
 }

--- a/src/mcp/lsp.ts
+++ b/src/mcp/lsp.ts
@@ -99,7 +99,8 @@ function addAncestorCommandCandidates(
 function getModuleDirectory(moduleUrl: string): string | null {
   try {
     return dirname(fileURLToPath(moduleUrl))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return null
   }
 }

--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -90,7 +90,8 @@ export function applyGrepFilter(output: string, pattern: string | undefined): st
     const lines = output.split("\n")
     const filtered = lines.filter((line) => regex.test(line))
     return filtered.length > 0 ? filtered.join("\n") : `[grep] No lines matched pattern: ${pattern}`
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return output
   }
 }


### PR DESCRIPTION
## Summary
Clean up the six no-binding catch fallbacks across MCP/OAuth surfaces by preserving existing Error fallback behavior while letting non-Error throws propagate.

## Changes
- Bind and narrow fallback catches in builtin MCP path resolution, skill MCP grep filtering, and MCP OAuth flows.
- Add OAuth characterization coverage for non-Error DCR and token-body failures.
- Leave storage.ts untouched.

## Testing
- `bun test src/mcp/ast-grep.test.ts src/mcp/lsp.test.ts src/tools/skill-mcp/tools.test.ts src/features/mcp-oauth/dcr.test.ts src/features/mcp-oauth/provider.test.ts` ✅
- `bun /Users/yeongyu/.agents/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...` ✅
- `git diff --check` ✅
- target catch grep ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` ✅
- opencode-qa `common.sh --self-check` ✅
- opencode-qa `server-smoke.sh` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed catch-all fallbacks across MCP OAuth, path resolution, and grep. Errors still follow safe fallbacks; non-Error throws now bubble up, with new tests for DCR and token error bodies.

- **Bug Fixes**
  - MCP OAuth: `dcr.ts`, `provider.ts`, and `oauth-authorization-flow.ts` rethrow non-Error throws; preserve existing Error fallbacks.
  - Path resolution: `mcp/ast-grep.ts` and `mcp/lsp.ts` return null only on real Errors.
  - Skill MCP grep: `tools.ts` falls back only on Error.
  - Added tests for non-Error DCR registration failures and token body parse failures.

<sup>Written for commit 8953bb6f322e10ef3581e33a9d4b823ddd7d1859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

