### PR TITLE
fix(cli): log doctor fallback catch errors

### DIFF
--- a/src/cli/config-manager/npm-dist-tags.test.ts
+++ b/src/cli/config-manager/npm-dist-tags.test.ts
@@ -1,8 +1,9 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 
 import { fetchNpmDistTags } from "../config-manager"
+import * as logger from "../../shared/logger"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
 describe("fetchNpmDistTags", () => {
@@ -31,12 +32,21 @@ describe("fetchNpmDistTags", () => {
   test("returns null on network failure", async () => {
     //#given
     globalThis.fetch = unsafeTestValue<typeof fetch>(mock(() => Promise.reject(new Error("Network error"))))
+    const logSpy = spyOn(logger, "log").mockImplementation(() => {})
 
-    //#when
-    const result = await fetchNpmDistTags("oh-my-openagent")
+    try {
+      //#when
+      const result = await fetchNpmDistTags("oh-my-openagent")
 
-    //#then
-    expect(result).toBeNull()
+      //#then
+      expect(result).toBeNull()
+      expect(logSpy).toHaveBeenCalledWith("npm dist-tags fetch failed", {
+        packageName: "oh-my-openagent",
+        error: "Network error",
+      })
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
   test("returns null on non-ok response", async () => {

--- a/src/cli/config-manager/npm-dist-tags.ts
+++ b/src/cli/config-manager/npm-dist-tags.ts
@@ -1,3 +1,5 @@
+import { log } from "../../shared/logger"
+
 export interface NpmDistTags {
   latest?: string
   beta?: string
@@ -15,7 +17,12 @@ export async function fetchNpmDistTags(packageName: string): Promise<NpmDistTags
     if (!res.ok) return null
     const data = (await res.json()) as NpmDistTags
     return data
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      log("npm dist-tags fetch failed", { packageName, error: error.message })
+    } else {
+      log("npm dist-tags fetch failed", { packageName, error: String(error) })
+    }
     return null
   }
 }

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 
 import * as configContext from "./config-context"
+import * as logger from "../../shared/logger"
 import * as spawnHelpers from "../../shared/spawn-with-windows-hide"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
@@ -158,13 +159,22 @@ describe("getOpenCodeVersion (installer)", () => {
 
   describe("#given no opencode binary on PATH #when getOpenCodeVersion #then returns null", () => {
     it("all candidate spawns throw", async () => {
+      const logSpy = spyOn(logger, "log").mockImplementation(() => {})
       spawnSpy.mockImplementation(() => {
         throw new Error("ENOENT")
       })
 
-      const result = await getOpenCodeVersion()
+      try {
+        const result = await getOpenCodeVersion()
 
-      expect(result).toBe(null)
+        expect(result).toBe(null)
+        expect(logSpy).toHaveBeenCalledWith("opencode binary version check failed", {
+          binary: "opencode",
+          error: "ENOENT",
+        })
+      } finally {
+        logSpy.mockRestore()
+      }
     })
   })
 })

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -1,4 +1,5 @@
 import { extractSemverFromOutput } from "../../shared/extract-semver"
+import { log } from "../../shared/logger"
 import type { OpenCodeBinaryType } from "../../shared/opencode-config-dir-types"
 import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
 import { initConfigContext } from "./config-context"
@@ -78,7 +79,12 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
         initConfigContext(binary, version)
         return { binary, version }
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof Error) {
+        log("opencode binary version check failed", { binary, error: error.message })
+      } else {
+        log("opencode binary version check failed", { binary, error: String(error) })
+      }
       continue
     }
   }

--- a/src/cli/config-manager/version-compatibility.ts
+++ b/src/cli/config-manager/version-compatibility.ts
@@ -1,3 +1,5 @@
+import { log } from "../../shared/logger"
+
 export interface VersionCompatibility {
   canUpgrade: boolean
   reason?: string
@@ -86,7 +88,12 @@ export function checkVersionCompatibility(
       isMajorBump: false,
       requiresMigration: false,
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      log("version compatibility comparison failed", { currentVersion, newVersion, error: error.message })
+    } else {
+      log("version compatibility comparison failed", { currentVersion, newVersion, error: String(error) })
+    }
     return {
       canUpgrade: true,
       reason: `Unable to compare versions ${currentVersion} and ${newVersion} - proceeding with caution`,

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 
 import { LEGACY_PLUGIN_NAME, PLUGIN_NAME, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
+import { log } from "../../../shared/logger"
 
 export interface PluginInfo {
   registered: boolean
@@ -89,7 +90,12 @@ export function getPluginInfo(): PluginInfo {
       pinnedVersion,
       isLocalDev: pluginEntry.isLocalDev,
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      log("doctor plugin config parse failed", { configPath, error: error.message })
+    } else {
+      log("doctor plugin config parse failed", { configPath, error: String(error) })
+    }
     return {
       registered: false,
       configPath,

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -6,6 +6,7 @@ import { findOpenCodeBinary, getOpenCodeVersion, compareVersions } from "./syste
 import { getPluginInfo } from "./system-plugin"
 import { getLatestPluginVersion, getLoadedPluginVersion, getSuggestedInstallTag } from "./system-loaded-version"
 import { parseJsonc } from "../../../shared"
+import { log } from "../../../shared/logger"
 import { PUBLISHED_PACKAGE_NAME, PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../../shared/plugin-identity"
 
 interface SystemCheckDeps {
@@ -35,7 +36,12 @@ function isConfigValid(configPath: string | null): boolean {
   try {
     parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
     return true
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      log("doctor system config parse failed", { configPath, error: error.message })
+    } else {
+      log("doctor system config parse failed", { configPath, error: String(error) })
+    }
     return false
   }
 }

--- a/src/cli/doctor/checks/tools-lsp.test.ts
+++ b/src/cli/doctor/checks/tools-lsp.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { clearPluginConfigFileDetectionCache } from "../../../shared/jsonc-parser"
+import * as logger from "../../../shared/logger"
 
 const temporaryDirectories: string[] = []
 
@@ -83,4 +84,27 @@ describe("getInstalledLspServers", () => {
     expect(servers).toEqual([{ id: "lsp-tools-mcp", extensions: ["*"] }])
   })
 
+  it("falls back to enabled when project config cannot be parsed", async () => {
+    // given
+    const userConfigDirectory = createTemporaryDirectory("omo-tools-lsp-user-")
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-lsp-malformed-")
+    const projectConfigDirectory = join(workspaceDirectory, ".opencode")
+    mkdirSync(projectConfigDirectory, { recursive: true })
+    writeFileSync(join(projectConfigDirectory, "oh-my-openagent.json"), "{", "utf-8")
+    clearPluginConfigFileDetectionCache()
+    const logSpy = spyOn(logger, "log").mockImplementation(() => {})
+
+    const { getInstalledLspServers } = await import(`./tools-lsp?t=${Date.now()}-malformed`)
+
+    try {
+      // when
+      const servers = getInstalledLspServers({ configDirectory: userConfigDirectory, cwd: workspaceDirectory })
+
+      // then
+      expect(servers).toEqual([{ id: "lsp-tools-mcp", extensions: ["*"] }])
+      expect(logSpy).toHaveBeenCalled()
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
 })

--- a/src/cli/doctor/checks/tools-lsp.ts
+++ b/src/cli/doctor/checks/tools-lsp.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { createLspMcpConfig } from "../../../mcp/lsp"
 import { detectPluginConfigFile, getOpenCodeConfigDir, parseJsonc } from "../../../shared"
+import { log } from "../../../shared/logger"
 import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "../../../shared/plugin-identity"
 
 type OmoConfigForDoctor = {
@@ -25,7 +26,12 @@ function readOmoConfig(configDirectory: string): OmoConfigForDoctor | null {
   try {
     const content = readFileSync(detected.path, "utf-8")
     return parseJsonc<OmoConfigForDoctor>(content)
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      log("doctor lsp config parse failed", { configPath: detected.path, error: error.message })
+    } else {
+      log("doctor lsp config parse failed", { configPath: detected.path, error: String(error) })
+    }
     return null
   }
 }

--- a/src/cli/doctor/checks/tools-mcp.test.ts
+++ b/src/cli/doctor/checks/tools-mcp.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import * as logger from "../../../shared/logger"
+
+const temporaryDirectories: string[] = []
+const originalCwd = process.cwd()
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  process.chdir(originalCwd)
+
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe("getUserMcpInfo", () => {
+  it("skips malformed MCP config files and logs the parse failure", async () => {
+    // given
+    const workspaceDirectory = createTemporaryDirectory("omo-tools-mcp-")
+    const claudeDirectory = join(workspaceDirectory, ".claude")
+    mkdirSync(claudeDirectory, { recursive: true })
+    writeFileSync(join(workspaceDirectory, ".mcp.json"), "{", "utf-8")
+    writeFileSync(
+      join(claudeDirectory, ".mcp.json"),
+      JSON.stringify({ mcpServers: { good: { command: "echo" } } }),
+      "utf-8",
+    )
+    process.chdir(workspaceDirectory)
+    const logSpy = spyOn(logger, "log").mockImplementation(() => {})
+
+    const { getUserMcpInfo } = await import(`./tools-mcp?t=${Date.now()}-malformed`)
+
+    try {
+      // when
+      const servers = getUserMcpInfo()
+
+      // then
+      expect(servers).toEqual([
+        {
+          id: "good",
+          type: "user",
+          enabled: true,
+          valid: true,
+          error: undefined,
+        },
+      ])
+      expect(logSpy).toHaveBeenCalled()
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})

--- a/src/cli/doctor/checks/tools-mcp.ts
+++ b/src/cli/doctor/checks/tools-mcp.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 
 import type { McpServerInfo } from "../types"
 import { parseJsonc } from "../../../shared"
+import { log } from "../../../shared/logger"
 
 const BUILTIN_MCP_SERVERS = ["websearch", "context7", "grep_app", "lsp", "ast_grep"]
 
@@ -31,7 +32,12 @@ function loadUserMcpConfig(): Record<string, unknown> {
       if (config.mcpServers) {
         Object.assign(servers, config.mcpServers)
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof Error) {
+        log("doctor mcp config parse failed", { configPath, error: error.message })
+      } else {
+        log("doctor mcp config parse failed", { configPath, error: String(error) })
+      }
       continue
     }
   }

--- a/src/cli/doctor/spawn-with-timeout.test.ts
+++ b/src/cli/doctor/spawn-with-timeout.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn } from "bun:test"
 import { spawnWithTimeout } from "./spawn-with-timeout"
+import * as logger from "../../shared/logger"
+import * as spawnHelpers from "../../shared/spawn-with-windows-hide"
 
 describe("spawnWithTimeout", () => {
   describe("#given a command that completes quickly", () => {
@@ -56,18 +58,33 @@ describe("spawnWithTimeout", () => {
     })
   })
 
-  describe("#given a nonexistent command", () => {
-    it("handles gracefully without hanging", async () => {
-      // when
-      const result = await spawnWithTimeout(
-        ["nonexistent-binary-that-does-not-exist-12345"],
-        { stdout: "pipe", stderr: "pipe" },
-        2000
-      )
+  describe("#given process start throws", () => {
+    it("returns stderr and logs the failure", async () => {
+      // given
+      const logSpy = spyOn(logger, "log").mockImplementation(() => {})
+      const spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockImplementation(() => {
+        throw new Error("spawn failed")
+      })
 
-      // then
-      expect(result.timedOut).toBe(false)
-      expect(result.exitCode).toBe(1)
+      try {
+        // when
+        const result = await spawnWithTimeout(["not-started"], { stdout: "pipe", stderr: "pipe" }, 2000)
+
+        // then
+        expect(result).toEqual({
+          stdout: "",
+          stderr: "spawn failed",
+          exitCode: 1,
+          timedOut: false,
+        })
+        expect(logSpy).toHaveBeenCalledWith("doctor spawn failed before process start", {
+          command: ["not-started"],
+          error: "spawn failed",
+        })
+      } finally {
+        spawnSpy.mockRestore()
+        logSpy.mockRestore()
+      }
     })
   })
 })

--- a/src/cli/doctor/spawn-with-timeout.ts
+++ b/src/cli/doctor/spawn-with-timeout.ts
@@ -1,4 +1,5 @@
 import type { SpawnOptions } from "../../shared/spawn-with-windows-hide"
+import { log } from "../../shared/logger"
 import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
 
 const DEFAULT_SPAWN_TIMEOUT_MS = 10_000
@@ -18,8 +19,10 @@ export async function spawnWithTimeout(
   let proc: ReturnType<typeof spawnWithWindowsHide>
   try {
     proc = spawnWithWindowsHide(command, options)
-  } catch {
-    return { stdout: "", stderr: "", exitCode: 1, timedOut: false }
+  } catch (error) {
+    const stderr = error instanceof Error ? error.message : String(error)
+    log("doctor spawn failed before process start", { command, error: stderr })
+    return { stdout: "", stderr, exitCode: 1, timedOut: false }
   }
 
   let timer: ReturnType<typeof setTimeout> | undefined


### PR DESCRIPTION
## Summary
- bind and narrow CLI doctor/config fallback catch errors instead of silent `catch {}` blocks
- log npm registry, OpenCode binary, version comparison, doctor config, LSP/MCP config, and spawn-start fallback failures to the shared file logger
- add focused tests for registry, binary, spawn, LSP config, and MCP config fallback paths

## Verification
- bun test src/cli/config-manager/npm-dist-tags.test.ts src/cli/config-manager/opencode-binary.test.ts src/cli/config-manager/version-compatibility.test.ts src/cli/doctor/spawn-with-timeout.test.ts src/cli/doctor/checks/tools-lsp.test.ts src/cli/doctor/checks/tools-mcp.test.ts
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts <changed files>
- rg -n "catch \{" <target files>
- git diff --check
- bun run typecheck
- bun run build
- isolated HOME/XDG_CONFIG_HOME doctor --json smoke with minimal opencode.json plugin entry (exit 0)

## Notes
- Worktree branch uses `-2` because an existing dirty worktree already occupied the suggested branch name locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CLI doctor/config fallbacks log caught errors instead of swallowing them, improving diagnostics while keeping safe behavior. Also surfaces spawn start failures and adds focused tests for these paths.

- **Bug Fixes**
  - Log fallback errors via the shared file logger for: npm dist-tags fetch, OpenCode binary/version checks, version compatibility, doctor system/plugin config, LSP config, MCP config, and spawn start failures.
  - spawnWithTimeout: when spawn throws before start, return the error message in stderr and log it.
  - Added focused tests for registry, binary detection, spawn fallback, and LSP/MCP config parsing.

<sup>Written for commit 5040b6f57329f5aba834fc51bf37bc2d5a3ba50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

