### PR TITLE
fix: clean shared misc catch fallbacks

### DIFF
--- a/src/hooks/session-todo-status.test.ts
+++ b/src/hooks/session-todo-status.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+
+import { unsafeTestValue } from "../../test-support/unsafe-test-value"
+import { hasIncompleteTodos } from "./session-todo-status"
+
+describe("hasIncompleteTodos", () => {
+  test("#given todo fetch fails with an Error #when checking incomplete todos #then it returns the no-todo fallback", async () => {
+    // given
+    const ctx = {
+      client: {
+        session: {
+          todo: async () => {
+            throw new Error("todo fetch failed")
+          },
+        },
+      },
+    }
+
+    // when
+    const result = await hasIncompleteTodos(unsafeTestValue(ctx), "ses_error")
+
+    // then
+    expect(result).toBe(false)
+  })
+
+  test("#given todo fetch fails with a non-Error #when checking incomplete todos #then it rethrows the thrown value", async () => {
+    // given
+    const thrown = { kind: "todo-thrown-value" } as const
+    const ctx = {
+      client: {
+        session: {
+          todo: async () => {
+            throw thrown
+          },
+        },
+      },
+    }
+
+    // when / then
+    await expect(hasIncompleteTodos(unsafeTestValue(ctx), "ses_non_error")).rejects.toThrow(Object)
+  })
+})

--- a/src/hooks/session-todo-status.ts
+++ b/src/hooks/session-todo-status.ts
@@ -15,7 +15,8 @@ export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): P
     const todos = normalizeSDKResponse(response, [] as Todo[], { preferResponseOnMissingData: true })
     if (!todos || todos.length === 0) return false
     return todos.some((todo) => todo.status !== "completed" && todo.status !== "cancelled")
-  } catch {
+  } catch (todoError) {
+    if (!(todoError instanceof Error)) throw todoError
     return false
   }
 }

--- a/src/hooks/write-existing-file-guard/hook.ts
+++ b/src/hooks/write-existing-file-guard/hook.ts
@@ -50,7 +50,8 @@ export function toCanonicalPath(absolutePath: string): string {
   if (existsSync(absolutePath)) {
     try {
       canonicalPath = realpathSync.native(absolutePath)
-    } catch {
+    } catch (canonicalPathError) {
+      if (!(canonicalPathError instanceof Error)) throw canonicalPathError
       canonicalPath = absolutePath
     }
   } else {

--- a/src/hooks/write-existing-file-guard/lazy-canonical-path-init.test.ts
+++ b/src/hooks/write-existing-file-guard/lazy-canonical-path-init.test.ts
@@ -60,4 +60,25 @@ describe("createWriteExistingFileGuardHook", () => {
     expect(existsSyncMock).toHaveBeenCalledTimes(3)
     expect(realpathNativeMock).toHaveBeenCalledTimes(2)
   })
+
+  test("#given realpath throws a non-Error #when canonicalizing an existing path #then it rethrows the thrown value", async () => {
+    // given
+    const thrown = { kind: "realpath-thrown-value" } as const
+    existsSyncMock = mock(() => true)
+    realpathNativeMock = mock(() => {
+      throw thrown
+    })
+    mock.module("fs", () => ({
+      ...realFs,
+      existsSync: existsSyncMock,
+      realpathSync: {
+        ...realFs.realpathSync,
+        native: realpathNativeMock,
+      },
+    }))
+    const { toCanonicalPath } = await import(`./hook?test=${crypto.randomUUID()}`)
+
+    // when / then
+    expect(() => toCanonicalPath(join(tempDir, "existing.txt"))).toThrow(Object)
+  })
 })

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -88,6 +88,35 @@ describe("OpenClaw Dispatcher", () => {
     }
   })
 
+  test("#given gateway metadata JSON parsing fails with a non-Error #when wakeGateway parses metadata #then it reports the dispatch failure", async () => {
+    // given
+    const fetchSpy = spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    const parseSpy = spyOn(JSON, "parse").mockImplementation(() => {
+      throw { kind: "json-parse-thrown-value" } as const
+    })
+
+    try {
+      // when
+      const result = await wakeGateway(
+        "test",
+        { url: "https://example.com", method: "POST", timeout: 1000, type: "http" },
+        { foo: "bar" },
+      )
+
+      // then
+      expect(result).toEqual({
+        gateway: "test",
+        success: false,
+        error: "Unknown error",
+      })
+    } finally {
+      fetchSpy.mockRestore()
+      parseSpy.mockRestore()
+    }
+  })
+
   test("wakeGateway prefers nested message metadata over wrapper ids", async () => {
     const fetchSpy = spyOn(global, "fetch").mockResolvedValue(
       new Response(

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -94,7 +94,8 @@ function parseWakeMetadata(raw: string): Pick<WakeResult, "messageId" | "platfor
   if (!trimmed) return {}
   try {
     return extractWakeMetadata(JSON.parse(trimmed))
-  } catch {
+  } catch (parseError) {
+    if (!(parseError instanceof Error)) throw parseError
     const messageId = trimmed.match(/message\s+id:\s*([^\s]+)/i)?.[1]
     const platform = trimmed.match(/sent\s+via\s+([a-z0-9_-]+)/i)?.[1]?.toLowerCase()
     return {

--- a/src/shared/model-suggestion-retry.ts
+++ b/src/shared/model-suggestion-retry.ts
@@ -26,7 +26,8 @@ function extractMessage(error: unknown): string {
     if (typeof obj.message === "string") return obj.message
     try {
       return JSON.stringify(error)
-    } catch {
+    } catch (stringifyError) {
+      if (!(stringifyError instanceof Error)) throw stringifyError
       return ""
     }
   }

--- a/src/shared/prompt-failure-classifier.test.ts
+++ b/src/shared/prompt-failure-classifier.test.ts
@@ -28,6 +28,34 @@ describe("prompt failure classifier", () => {
     expect(ambiguous).toBe(true)
   })
 
+  test("#given error serialization fails with an Error #when classifying ambiguity #then it uses the empty-message fallback", () => {
+    // given
+    const error = {
+      toJSON() {
+        throw new Error("cannot serialize")
+      },
+    }
+
+    // when
+    const ambiguous = isAmbiguousPromptDispatchFailure(error)
+
+    // then
+    expect(ambiguous).toBe(false)
+  })
+
+  test("#given error serialization fails with a non-Error #when classifying ambiguity #then it rethrows the thrown value", () => {
+    // given
+    const thrown = { kind: "serializer-thrown-value" } as const
+    const error = {
+      toJSON() {
+        throw thrown
+      },
+    }
+
+    // when / then
+    expect(() => isAmbiguousPromptDispatchFailure(error)).toThrow(Object)
+  })
+
   test("#given ambiguous failure before dispatch #when classifying post-dispatch acceptance #then it is not treated as accepted", () => {
     // given
     const result = {

--- a/src/shared/prompt-failure-classifier.ts
+++ b/src/shared/prompt-failure-classifier.ts
@@ -6,7 +6,8 @@ export function extractPromptFailureMessage(error: unknown): string {
     if (typeof record.message === "string") return record.message
     try {
       return JSON.stringify(error)
-    } catch {
+    } catch (stringifyError) {
+      if (!(stringifyError instanceof Error)) throw stringifyError
       return ""
     }
   }


### PR DESCRIPTION
## Summary
- Replace no-binding catch fallbacks in selected shared/OpenClaw/hooks runtime utilities with explicit Error-only fallback handling.
- Preserve existing Error fallback behavior while allowing non-Error thrown values to propagate through the fallback path.
- Skipped exact-file overlaps: `src/plugin-handlers/tool-config-handler.ts` (#4242), `src/plugin/ultrawork-db-model-override.ts` and `src/shared/spawn-with-windows-hide.ts` (#3820).

## Changes
- Shared prompt failure/model retry message extraction now rethrows non-Error stringify failures.
- OpenClaw metadata parsing keeps text fallback for JSON parse Errors and surfaces unusual non-Error parser failures.
- Hook fallback paths for canonical paths and todo status now only swallow real Errors.

## Testing
- `bun test src/shared/prompt-failure-classifier.test.ts src/openclaw/__tests__/dispatcher.test.ts src/hooks/write-existing-file-guard/lazy-canonical-path-init.test.ts src/hooks/session-todo-status.test.ts` ✅
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...changed files...` ✅
- `git diff --check` ✅
- `rg -n "catch \{" <target files>` ✅ (no matches)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash scripts/lib/common.sh --self-check` ✅
- `bash scripts/server-smoke.sh` ✅
- `bash scripts/sse-hook-probe.sh --self-test` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened catch fallbacks across shared utils, OpenClaw, and hooks to only swallow real Errors. Non-Error thrown values now propagate, avoiding hidden failures while preserving existing Error fallbacks.

- **Bug Fixes**
  - `extractPromptFailureMessage` and model retry: rethrow non-Error serialization failures; keep empty-message fallback on Error.
  - OpenClaw `parseWakeMetadata`: keep text fallback on JSON parse Error; propagate non-Error parse throws; added test.
  - `toCanonicalPath`: fall back to the input path only on Error; rethrow non-Error; added test.
  - `hasIncompleteTodos`: return false only on Error when fetching todos; rethrow non-Error; added test.

<sup>Written for commit a1c7f04b20d6d1acf5c512bc26fa21038d6fe7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

