### PR TITLE
fix(team-mode): rethrow non-error catch fallbacks

### DIFF
--- a/src/features/team-mode/deps.test.ts
+++ b/src/features/team-mode/deps.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import { checkTeamModeDependencies } from "./deps"
+
+test("checkTeamModeDependencies preserves Error fallback for unavailable binaries", async () => {
+  // given
+  const config = TeamModeConfigSchema.parse({})
+
+  // when
+  const report = await checkTeamModeDependencies(config, {
+    spawn: () => {
+      throw new Error("spawn failed")
+    },
+    tmuxEnv: "",
+  })
+
+  // then
+  expect(report).toEqual({ tmuxAvailable: false, gitAvailable: false })
+})
+
+test("checkTeamModeDependencies rethrows non-Error probe failures", async () => {
+  // given
+  const config = TeamModeConfigSchema.parse({})
+  const thrownValue = "spawn failed"
+
+  // when
+  let caught: unknown
+  try {
+    await checkTeamModeDependencies(config, {
+      spawn: () => {
+        throw thrownValue
+      },
+      tmuxEnv: "",
+    })
+  } catch (error) {
+    if (error instanceof Error) throw error
+    caught = error
+  }
+
+  // then
+  expect(caught).toBe(thrownValue)
+})

--- a/src/features/team-mode/deps.ts
+++ b/src/features/team-mode/deps.ts
@@ -6,11 +6,21 @@ export interface TeamModeDependencyReport {
   gitAvailable: boolean
 }
 
+type Spawn = typeof spawn
+
+type TeamModeDependencyDeps = {
+  readonly spawn?: Spawn
+  readonly tmuxEnv?: string
+}
+
 export async function checkTeamModeDependencies(
   config: TeamModeConfig,
+  deps: TeamModeDependencyDeps = {},
 ): Promise<TeamModeDependencyReport> {
-  const tmuxAvailable = Boolean(process.env["TMUX"]) || (await probeBinary("tmux", ["-V"]))
-  const gitAvailable = await probeBinary("git", ["--version"])
+  const spawnImpl = deps.spawn ?? spawn
+  const tmuxEnv = deps.tmuxEnv ?? process.env["TMUX"]
+  const tmuxAvailable = Boolean(tmuxEnv) || (await probeBinary("tmux", ["-V"], spawnImpl))
+  const gitAvailable = await probeBinary("git", ["--version"], spawnImpl)
   if (config.tmux_visualization && !tmuxAvailable) {
     console.warn(
       "[team-mode] tmux_visualization=true but tmux not available; layout will be skipped at runtime",
@@ -19,12 +29,13 @@ export async function checkTeamModeDependencies(
   return { tmuxAvailable, gitAvailable }
 }
 
-async function probeBinary(cmd: string, args: string[]): Promise<boolean> {
+async function probeBinary(cmd: string, args: string[], spawnImpl: Spawn): Promise<boolean> {
   try {
-    const proc = spawn({ cmd: [cmd, ...args], stdout: "pipe", stderr: "pipe" })
+    const proc = spawnImpl({ cmd: [cmd, ...args], stdout: "pipe", stderr: "pipe" })
     const code = await proc.exited
     return code === 0
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return false
   }
 }

--- a/src/features/team-mode/team-mailbox/reservation.ts
+++ b/src/features/team-mode/team-mailbox/reservation.ts
@@ -95,7 +95,8 @@ export async function reclaimStaleReservations(
     try {
       await rename(filePath, restoredPath)
       reclaimedIds.push(messageId)
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
       continue
     }
   }

--- a/src/features/team-mode/team-registry/paths.ts
+++ b/src/features/team-mode/team-registry/paths.ts
@@ -59,7 +59,8 @@ async function readTeamSpecDirectories(directoryPath: string, scope: "project" |
         scope,
         path: path.resolve(directoryPath, entry.name, "config.json"),
       }))
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return []
   }
 }

--- a/src/features/team-mode/team-tasklist/claim.ts
+++ b/src/features/team-mode/team-tasklist/claim.ts
@@ -16,7 +16,8 @@ async function lockExists(lockPath: string): Promise<boolean> {
   try {
     await access(lockPath)
     return true
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return false
   }
 }

--- a/src/features/team-mode/team-tasklist/list.ts
+++ b/src/features/team-mode/team-tasklist/list.ts
@@ -23,7 +23,8 @@ export async function listTasks(
   let entries: Dirent[]
   try {
     entries = await readdir(tasksDirectory, { withFileTypes: true })
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return []
   }
 

--- a/src/features/team-mode/team-tasklist/store.ts
+++ b/src/features/team-mode/team-tasklist/store.ts
@@ -14,7 +14,8 @@ async function readHighWatermark(watermarkPath: string): Promise<number> {
     const watermarkContent = (await readFile(watermarkPath, "utf8")).trim()
     const parsedWatermark = Number.parseInt(watermarkContent, 10)
     return Number.isInteger(parsedWatermark) && parsedWatermark >= 0 ? parsedWatermark : 0
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     await atomicWrite(watermarkPath, "0")
     return 0
   }

--- a/src/features/team-mode/tools/messaging-runtime.ts
+++ b/src/features/team-mode/tools/messaging-runtime.ts
@@ -65,7 +65,8 @@ export async function resolveTeamRuntimeDetails(
         .map((entry) => entry.name)
         .filter((name) => name !== senderName),
     }
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) throw error
     return {
       teamRunId,
       isLead: false,

--- a/src/features/team-mode/tools/messaging.test.ts
+++ b/src/features/team-mode/tools/messaging.test.ts
@@ -25,6 +25,7 @@ import type { Message } from "../types"
 import { MessageSchema } from "../types"
 import { createTeamIdleWakeHint } from "../../../hooks/team-session-events/team-idle-wake-hint"
 import { createTeamSendMessageTool } from "./messaging"
+import { resolveTeamRuntimeDetails } from "./messaging-runtime"
 
 type PromptAsyncCall = {
   sessionId: string
@@ -159,6 +160,48 @@ async function createTeamFixture() {
 }
 
 describe("createTeamSendMessageTool", () => {
+  test("resolveTeamRuntimeDetails preserves Error fallback for missing runtime state", async () => {
+    // given
+    const config = createConfig(await createFixtureBaseDir())
+
+    // when
+    const runtimeDetails = await resolveTeamRuntimeDetails("team-run-missing", "session-missing", config, {
+      loadRuntimeState: async () => {
+        throw new Error("missing runtime state")
+      },
+    })
+
+    // then
+    expect(runtimeDetails).toEqual({
+      teamRunId: "team-run-missing",
+      isLead: false,
+      senderName: "unknown",
+      activeMembers: [],
+    })
+  })
+
+  test("resolveTeamRuntimeDetails rethrows non-Error runtime load failures", async () => {
+    // given
+    const config = createConfig(await createFixtureBaseDir())
+    const thrownValue = "missing runtime state"
+
+    // when
+    let caught: unknown
+    try {
+      await resolveTeamRuntimeDetails("team-run-missing", "session-missing", config, {
+        loadRuntimeState: async () => {
+          throw thrownValue
+        },
+      })
+    } catch (error) {
+      if (error instanceof Error) throw error
+      caught = error
+    }
+
+    // then
+    expect(caught).toBe(thrownValue)
+  })
+
   test("routes a member message to one recipient", async () => {
     // given
     const fixture = await createTeamFixture()


### PR DESCRIPTION
## Summary
- replace team-mode bare catch fallbacks with Error-only fallback handling
- rethrow non-Error values in tasklist, mailbox reservation, registry discovery, messaging runtime, and dependency probing paths
- add characterization coverage for dependency probing and runtime detail fallback semantics

## Validation
- bun test src/features/team-mode/deps.test.ts src/features/team-mode/tools/messaging.test.ts src/features/team-mode/team-tasklist/store.test.ts src/features/team-mode/team-tasklist/list.test.ts src/features/team-mode/team-tasklist/claim.test.ts src/features/team-mode/team-registry/paths.test.ts src/features/team-mode/team-mailbox/poll.test.ts
- bun test src/features/team-mode
- bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/team-mode/team-tasklist/store.ts src/features/team-mode/team-tasklist/list.ts src/features/team-mode/team-tasklist/claim.ts src/features/team-mode/tools/messaging-runtime.ts src/features/team-mode/team-registry/paths.ts src/features/team-mode/team-mailbox/reservation.ts src/features/team-mode/deps.ts src/features/team-mode/deps.test.ts src/features/team-mode/tools/messaging.test.ts
- git diff --check
- rg -n "catch \{" <target files>
- bun run typecheck
- bun run build
- opencode QA common self-check
- opencode server-smoke
- opencode --version && opencode --help

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rethrow non-Error exceptions in team-mode so we only fall back on expected Error cases. This prevents silent failures during dependency checks and runtime discovery.

- **Bug Fixes**
  - Replace bare `catch {}` with Error-only fallbacks across tasklist, mailbox reservation, registry discovery, messaging runtime, and dependency probing.
  - `checkTeamModeDependencies` and `resolveTeamRuntimeDetails` now rethrow non-Error values; keep Error-based fallbacks for missing binaries/runtime state.

- **Refactors**
  - Add DI to `checkTeamModeDependencies` (inject `spawn` and `tmuxEnv`); update `probeBinary` to accept injected `spawn`.
  - Add tests to characterize dependency probing and runtime detail fallback behavior.

<sup>Written for commit 98de391ac402d0b6d7be5005521e8e9d7c522c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

