### PR TITLE
fix(hooks): narrow utility catch fallbacks

### DIFF
--- a/src/hooks/agent-usage-reminder/storage.test.ts
+++ b/src/hooks/agent-usage-reminder/storage.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { AGENT_USAGE_REMINDER_STORAGE } from "./constants"
+import { loadAgentUsageState } from "./storage"
+
+describe("agent usage reminder storage catch fallbacks", () => {
+  const sessionID = `catch-fallback-${crypto.randomUUID()}`
+  const statePath = join(AGENT_USAGE_REMINDER_STORAGE, `${sessionID}.json`)
+
+  afterEach(() => {
+    rmSync(statePath, { force: true })
+  })
+
+  it("returns null when persisted state JSON is malformed", () => {
+    // given
+    mkdirSync(AGENT_USAGE_REMINDER_STORAGE, { recursive: true })
+    writeFileSync(statePath, "{not-valid-json")
+
+    // when
+    const state = loadAgentUsageState(sessionID)
+
+    // then
+    expect(state).toBeNull()
+  })
+})

--- a/src/hooks/agent-usage-reminder/storage.ts
+++ b/src/hooks/agent-usage-reminder/storage.ts
@@ -20,7 +20,10 @@ export function loadAgentUsageState(sessionID: string): AgentUsageState | null {
   try {
     const content = readFileSync(filePath, "utf-8");
     return JSON.parse(content) as AgentUsageState;
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
     return null;
   }
 }

--- a/src/hooks/auto-update-checker/checker/catch-fallbacks.test.ts
+++ b/src/hooks/auto-update-checker/checker/catch-fallbacks.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import * as fs from "node:fs"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { PACKAGE_NAME } from "../constants"
+import { getLatestVersion } from "./latest-version"
+import { getLocalDevVersion } from "./local-dev-version"
+
+describe("auto-update checker catch fallbacks", () => {
+  const originalFetch = globalThis.fetch
+  let temporaryDirectory: string | null = null
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+
+    if (temporaryDirectory !== null) {
+      rmSync(temporaryDirectory, { recursive: true, force: true })
+      temporaryDirectory = null
+    }
+  })
+
+  it("returns null when latest version fetch throws an Error", async () => {
+    // given
+    globalThis.fetch = mock(async () => {
+      throw new Error("network unavailable")
+    }) as typeof fetch
+
+    // when
+    const version = await getLatestVersion()
+
+    // then
+    expect(version).toBeNull()
+  })
+
+  it("rethrows non-Error latest version fetch failures", async () => {
+    // given
+    const nonError = Symbol("network unavailable")
+    globalThis.fetch = mock(async () => {
+      throw nonError
+    }) as typeof fetch
+
+    await expect(getLatestVersion()).rejects.toBe(nonError)
+  })
+
+  it("returns null when local dev package JSON is malformed", () => {
+    // given
+    const directory = mkdtempSync(join(tmpdir(), "omo-local-dev-version-"))
+    temporaryDirectory = directory
+    const packageDirectory = join(directory, "packages", "plugin")
+    const configDirectory = join(directory, ".opencode")
+    mkdirSync(packageDirectory, { recursive: true })
+    mkdirSync(configDirectory, { recursive: true })
+    writeFileSync(join(packageDirectory, "package.json"), "{not-valid-json")
+    writeFileSync(
+      join(configDirectory, "opencode.json"),
+      JSON.stringify({ plugin: [`file://${packageDirectory}`] }),
+    )
+
+    // when
+    const version = getLocalDevVersion(directory)
+
+    // then
+    expect(version).toBeNull()
+  })
+
+  it("rethrows non-Error local dev version read failures", () => {
+    // given
+    const directory = mkdtempSync(join(tmpdir(), "omo-local-dev-version-"))
+    temporaryDirectory = directory
+    const packageDirectory = join(directory, "packages", "plugin")
+    const configDirectory = join(directory, ".opencode")
+    mkdirSync(packageDirectory, { recursive: true })
+    mkdirSync(configDirectory, { recursive: true })
+    writeFileSync(join(packageDirectory, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "4.7.5" }))
+    writeFileSync(
+      join(configDirectory, "opencode.json"),
+      JSON.stringify({ plugin: [`file://${packageDirectory}`] }),
+    )
+
+    const nonError = Symbol("read failure")
+    const readFileSyncSpy = spyOn(fs, "readFileSync").mockImplementation(
+      () => {
+        throw nonError
+      },
+    )
+
+    try {
+      let thrown: unknown = null
+      try {
+        getLocalDevVersion(directory)
+      } catch (error) {
+        if (error instanceof Error) {
+          throw error
+        }
+        thrown = error
+      }
+      expect(thrown).toBe(nonError)
+    } finally {
+      readFileSyncSpy.mockRestore()
+    }
+  })
+})

--- a/src/hooks/auto-update-checker/checker/latest-version.ts
+++ b/src/hooks/auto-update-checker/checker/latest-version.ts
@@ -15,7 +15,10 @@ export async function getLatestVersion(channel: string = "latest"): Promise<stri
 
     const data = (await response.json()) as NpmDistTags
     return data[channel] ?? data.latest ?? null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   } finally {
     clearTimeout(timeoutId)

--- a/src/hooks/auto-update-checker/checker/local-dev-version.ts
+++ b/src/hooks/auto-update-checker/checker/local-dev-version.ts
@@ -13,7 +13,10 @@ export function getLocalDevVersion(directory: string): string | null {
     const content = fs.readFileSync(pkgPath, "utf-8")
     const pkg = JSON.parse(content) as PackageJson
     return pkg.version ?? null
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     return null
   }
 }

--- a/src/hooks/auto-update-checker/checker/plugin-entry.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.ts
@@ -35,7 +35,10 @@ export function findPluginEntry(directory: string): PluginEntryInfo | null {
           }
         }
       }
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error
+      }
       continue
     }
   }

--- a/src/hooks/comment-checker/downloader.ts
+++ b/src/hooks/comment-checker/downloader.ts
@@ -79,7 +79,10 @@ function getPackageVersion(): string {
     const require = createRequire(import.meta.url)
     const pkg = require("@code-yeongyu/comment-checker/package.json")
     return pkg.version
-  } catch {
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
     // Fallback to hardcoded version if package not found
     return "0.4.1"
   }

--- a/src/hooks/directory-readme-injector/finder.catch-fallbacks.test.ts
+++ b/src/hooks/directory-readme-injector/finder.catch-fallbacks.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, it, mock } from "bun:test"
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("directory README finder catch fallbacks", () => {
+  it("skips missing README files when access rejects with an Error", async () => {
+    // given
+    mock.module("node:fs/promises", () => ({
+      access: mock(async () => {
+        throw new Error("missing")
+      }),
+    }))
+    const { findReadmeMdUp } = await import(`./finder?error=${crypto.randomUUID()}`)
+
+    // when
+    const found = await findReadmeMdUp({ startDir: "/workspace/src", rootDir: "/workspace" })
+
+    // then
+    expect(found).toEqual([])
+  })
+
+  it("rethrows non-Error access rejections", async () => {
+    // given
+    const nonError = Symbol("missing")
+    mock.module("node:fs/promises", () => ({
+      access: mock(async () => {
+        throw nonError
+      }),
+    }))
+    const { findReadmeMdUp } = await import(`./finder?non-error=${crypto.randomUUID()}`)
+
+    // when
+    let thrown: unknown = null
+    try {
+      await findReadmeMdUp({ startDir: "/workspace/src", rootDir: "/workspace" })
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error
+      }
+      thrown = error
+    }
+
+    // then
+    expect(thrown).toBe(nonError)
+  })
+})

--- a/src/hooks/directory-readme-injector/finder.ts
+++ b/src/hooks/directory-readme-injector/finder.ts
@@ -21,7 +21,10 @@ export async function findReadmeMdUp(input: {
     try {
       await access(readmePath);
       found.push(readmePath);
-    } catch {
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
     }
 
     if (current === input.rootDir) break;


### PR DESCRIPTION
## Summary
- Replace bare catch fallbacks in auto-update checker utilities, agent usage reminder storage, comment-checker downloader, and README finder with Error-only fallback guards.
- Preserve existing Error fallback behavior while rethrowing non-Error values.
- Add focused characterization coverage for registry/local-dev version fallback behavior, agent usage storage malformed JSON fallback, and README finder Error/non-Error access behavior.

## Open PR overlap
- Skipped `src/hooks/auto-update-checker/checker/cached-version.ts` because open PRs #4329 and #4328 touch it.
- Skipped `src/hooks/auto-update-checker/hook/background-update-check.ts` because open PRs #4720, #4513, #4442, #4349, and #3933 touch it.

## Validation
- `bun test src/hooks/auto-update-checker/checker/catch-fallbacks.test.ts src/hooks/agent-usage-reminder/storage.test.ts src/hooks/directory-readme-injector/finder.catch-fallbacks.test.ts src/hooks/agent-usage-reminder/index.test.ts src/hooks/directory-readme-injector/injector.test.ts src/hooks/comment-checker/cli.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...`
- `rg -n "catch \{" <target files>` (no matches)
- `git diff --check`
- `bun run typecheck`
- `bun run build`
- `bash scripts/lib/common.sh --self-check && bash scripts/server-smoke.sh && bash scripts/sse-hook-probe.sh --self-test` from `.agents/skills/opencode-qa`

## Local note
- `src/hooks/auto-update-checker/checker/plugin-entry.test.ts` has an existing local-environment failure on this machine because it reads `/Users/yeongyu/.config/opencode/opencode.json` for the unrelated-plugin case; this PR does not modify that behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened error handling in multiple hooks so we only swallow thrown Errors and rethrow non-Error values, preventing silent failures. Existing fallbacks (returning null or defaults) are preserved, with focused tests added.

- **Bug Fixes**
  - Auto-update checker: `getLatestVersion` and `getLocalDevVersion` now return null on Error and rethrow non-Error; `findPluginEntry` continues search on Error.
  - Agent usage reminder: `loadAgentUsageState` returns null for malformed JSON; rethrows non-Error.
  - Comment checker downloader: version lookup falls back to "0.4.1" only on Error; rethrows non-Error when loading `@code-yeongyu/comment-checker`.
  - Directory README finder: skips missing files on Error; rethrows non-Error.
  - Added targeted tests covering all fallback paths.

<sup>Written for commit c888008a92205e8abdfe6675aaf34e0a9f23f2b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

