### PR TITLE
test(utils): table-drive parser utility coverage

### DIFF
--- a/packages/utils/src/frontmatter.test.ts
+++ b/packages/utils/src/frontmatter.test.ts
@@ -1,40 +1,48 @@
 import { describe, test, expect } from "bun:test"
 import { parseFrontmatter } from "./frontmatter"
 
+type FrontmatterCase = readonly [
+  label: string,
+  content: string,
+  expectedData: Record<string, unknown>,
+  expectedBody: string,
+]
+
 describe("parseFrontmatter", () => {
   // #region backward compatibility
-  test("parses simple key-value frontmatter", () => {
-    // given
-    const content = `---
+  const compatibilityCases = [
+    [
+      "parses simple key-value frontmatter",
+      `---
 description: Test command
 agent: build
 ---
-Body content`
-
-    // when
-    const result = parseFrontmatter(content)
-
-    // then
-    expect(result.data.description).toBe("Test command")
-    expect(result.data.agent).toBe("build")
-    expect(result.body).toBe("Body content")
-  })
-
-  test("parses boolean values", () => {
-    // given
-    const content = `---
+Body content`,
+      { description: "Test command", agent: "build" },
+      "Body content",
+    ],
+    [
+      "parses boolean values",
+      `---
 subtask: true
 enabled: false
 ---
-Body`
+Body`,
+      { subtask: true, enabled: false },
+      "Body",
+    ],
+  ] as const satisfies readonly FrontmatterCase[]
 
-    // when
-    const result = parseFrontmatter<{ subtask: boolean; enabled: boolean }>(content)
+  for (const [label, content, expectedData, expectedBody] of compatibilityCases) {
+    test(label, () => {
+      // when
+      const result = parseFrontmatter(content)
 
-    // then
-    expect(result.data.subtask).toBe(true)
-    expect(result.data.enabled).toBe(false)
-  })
+      // then
+      expect(result.data).toEqual(expectedData)
+      expect(result.body).toBe(expectedBody)
+    })
+  }
   // #endregion
 
   // #region complex YAML (handoffs support)
@@ -104,94 +112,76 @@ Content`
   // #endregion
 
   // #region edge cases
-  test("handles content without frontmatter", () => {
-    // given
-    const content = "Just body content"
-
-    // when
-    const result = parseFrontmatter(content)
-
-    // then
-    expect(result.data).toEqual({})
-    expect(result.body).toBe("Just body content")
-  })
-
-  test("handles empty frontmatter", () => {
-    // given
-    const content = `---
+  const edgeCases = [
+    ["handles content without frontmatter", "Just body content", {}, "Just body content"],
+    [
+      "handles empty frontmatter",
+      `---
 ---
-Body`
-
-    // when
-    const result = parseFrontmatter(content)
-
-    // then
-    expect(result.data).toEqual({})
-    expect(result.body).toBe("Body")
-  })
-
-  test("handles invalid YAML gracefully", () => {
-    // given
-    const content = `---
+Body`,
+      {},
+      "Body",
+    ],
+    [
+      "handles invalid YAML gracefully",
+      `---
 invalid: yaml: syntax: here
   bad indentation
 ---
-Body`
-
-    // when
-    const result = parseFrontmatter(content)
-
-    // then - should not throw, return empty data
-    expect(result.data).toEqual({})
-    expect(result.body).toBe("Body")
-  })
-
-  test("handles frontmatter with only whitespace", () => {
-    // given
-    const content = `---
+Body`,
+      {},
+      "Body",
+    ],
+    [
+      "handles frontmatter with only whitespace",
+      `---
    
 ---
-Body with whitespace-only frontmatter`
+Body with whitespace-only frontmatter`,
+      {},
+      "Body with whitespace-only frontmatter",
+    ],
+  ] as const satisfies readonly FrontmatterCase[]
 
-    // when
-    const result = parseFrontmatter(content)
+  for (const [label, content, expectedData, expectedBody] of edgeCases) {
+    test(label, () => {
+      // when
+      const result = parseFrontmatter(content)
 
-    // then
-    expect(result.data).toEqual({})
-    expect(result.body).toBe("Body with whitespace-only frontmatter")
-  })
+      // then
+      expect(result.data).toEqual(expectedData)
+      expect(result.body).toBe(expectedBody)
+    })
+  }
   // #endregion
 
   // #region mixed content
-  test("preserves multiline body content", () => {
-    // given
-    const content = `---
+  const mixedContentCases = [
+    [
+      "preserves multiline body content",
+      `---
 title: Test
 ---
 Line 1
 Line 2
 
-Line 4 after blank`
+Line 4 after blank`,
+      { title: "Test" },
+      "Line 1\nLine 2\n\nLine 4 after blank",
+    ],
+    ["handles CRLF line endings", "---\r\ndescription: Test\r\n---\r\nBody", { description: "Test" }, "Body"],
+  ] as const satisfies readonly FrontmatterCase[]
 
-    // when
-    const result = parseFrontmatter<{ title: string }>(content)
+  for (const [label, content, expectedData, expectedBody] of mixedContentCases) {
+    test(label, () => {
+      // when
+      const result = parseFrontmatter(content)
 
-    // then
-    expect(result.data.title).toBe("Test")
-    expect(result.body).toBe("Line 1\nLine 2\n\nLine 4 after blank")
-  })
-
-  test("handles CRLF line endings", () => {
-    // given
-    const content = "---\r\ndescription: Test\r\n---\r\nBody"
-
-    // when
-    const result = parseFrontmatter<{ description: string }>(content)
-
-    // then
-    expect(result.data.description).toBe("Test")
-    expect(result.body).toBe("Body")
-  })
+      // then
+      expect(result.data).toEqual(expectedData)
+      expect(result.body).toBe(expectedBody)
+    })
+  }
   // #endregion
 
   // #region extra fields tolerance

--- a/packages/utils/src/jsonc-parser.test.ts
+++ b/packages/utils/src/jsonc-parser.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { clearPluginConfigFileDetectionCache, detectConfigFile, detectPluginConfigFile, parseJsonc, parseJsoncSafe, readJsoncFile } from "./jsonc-parser"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 
 const pluginConfigDetectionOptions = {
   basenames: ["oh-my-openagent"],
   legacyBasenames: ["oh-my-opencode"],
 } as const
+
+type ConfigDetectionCase = readonly [label: string, extensions: readonly string[], expectedFormat: "json" | "jsonc"]
 
 describe("parseJsonc", () => {
   test("parses plain JSON", () => {
@@ -217,9 +219,17 @@ describe("readJsoncFile", () => {
   const testDir = join(__dirname, ".test-jsonc")
   const testFile = join(testDir, "config.jsonc")
 
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
   test("reads and parses valid JSONC file", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
     const content = `{
       // Comment
       "test": "value"
@@ -232,8 +242,6 @@ describe("readJsoncFile", () => {
     // then
     expect(result).not.toBeNull()
     expect(result?.test).toBe("value")
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("returns null for non-existent file", () => {
@@ -249,7 +257,6 @@ describe("readJsoncFile", () => {
 
   test("returns null for malformed JSON", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
     writeFileSync(testFile, "{ invalid }")
 
     // when
@@ -257,13 +264,10 @@ describe("readJsoncFile", () => {
 
     // then
     expect(result).toBeNull()
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("reads JSONC file written with UTF-8 BOM (Windows scenario)", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
     const bomBytes = Buffer.from([0xef, 0xbb, 0xbf])
     const jsonBytes = Buffer.from(`{
       // Created on Windows with BOM
@@ -279,46 +283,42 @@ describe("readJsoncFile", () => {
     expect(result).not.toBeNull()
     expect(result?.$schema).toBe("https://opencode.ai/config.json")
     expect(result?.plugin).toEqual(["oh-my-openagent@3.15.3"])
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 })
 
 describe("detectConfigFile", () => {
   const testDir = join(__dirname, ".test-detect")
 
-  test("prefers .jsonc over .json", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    const basePath = join(testDir, "config")
-    writeFileSync(`${basePath}.json`, "{}")
-    writeFileSync(`${basePath}.jsonc`, "{}")
-
-    // when
-    const result = detectConfigFile(basePath)
-
-    // then
-    expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(`${basePath}.jsonc`)
-
+  beforeEach(() => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  test("detects .json when .jsonc doesn't exist", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    const basePath = join(testDir, "config")
-    writeFileSync(`${basePath}.json`, "{}")
-
-    // when
-    const result = detectConfigFile(basePath)
-
-    // then
-    expect(result.format).toBe("json")
-    expect(result.path).toBe(`${basePath}.json`)
-
+  afterEach(() => {
     rmSync(testDir, { recursive: true, force: true })
   })
+
+  const cases = [
+    ["prefers .jsonc over .json", ["json", "jsonc"], "jsonc"],
+    ["detects .json when .jsonc doesn't exist", ["json"], "json"],
+  ] as const satisfies readonly ConfigDetectionCase[]
+
+  for (const [label, extensions, expectedFormat] of cases) {
+    test(label, () => {
+      // given
+      mkdirSync(testDir, { recursive: true })
+      const basePath = join(testDir, "config")
+      for (const extension of extensions) {
+        writeFileSync(`${basePath}.${extension}`, "{}")
+      }
+
+      // when
+      const result = detectConfigFile(basePath)
+
+      // then
+      expect(result.format).toBe(expectedFormat)
+      expect(result.path).toBe(`${basePath}.${expectedFormat}`)
+    })
+  }
 
   test("returns none when neither exists", () => {
     // given
@@ -336,16 +336,18 @@ describe("detectPluginConfigFile", () => {
   const testDir = join(__dirname, ".test-detect-plugin")
 
   beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
     clearPluginConfigFileDetectionCache()
   })
 
   afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
     clearPluginConfigFileDetectionCache()
   })
 
   test("prefers oh-my-openagent over oh-my-opencode when both jsonc files exist", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+    mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
     writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}")
 
@@ -356,13 +358,11 @@ describe("detectPluginConfigFile", () => {
     expect(result.format).toBe("jsonc")
     expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"))
     expect(result.legacyPath).toBe(join(testDir, "oh-my-opencode.jsonc"))
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("falls back to oh-my-opencode when oh-my-openagent doesn't exist", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+    mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}")
 
     // when
@@ -372,13 +372,11 @@ describe("detectPluginConfigFile", () => {
     expect(result.format).toBe("jsonc")
     expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"))
     expect(result.legacyPath).toBeUndefined()
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("loads oh-my-openagent.json before oh-my-opencode.json when no jsonc exists", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+    mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-openagent.json"), "{}")
     writeFileSync(join(testDir, "oh-my-opencode.json"), "{}")
 
@@ -389,14 +387,12 @@ describe("detectPluginConfigFile", () => {
     expect(result.format).toBe("json")
     expect(result.path).toBe(join(testDir, "oh-my-openagent.json"))
     expect(result.legacyPath).toBe(join(testDir, "oh-my-opencode.json"))
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("returns none when no config files exist", () => {
     // given
     const emptyDir = join(testDir, "empty")
-    if (!existsSync(emptyDir)) mkdirSync(emptyDir, { recursive: true })
+    mkdirSync(emptyDir, { recursive: true })
 
     // when
     const result = detectPluginConfigFile(emptyDir, pluginConfigDetectionOptions)
@@ -404,13 +400,11 @@ describe("detectPluginConfigFile", () => {
     // then
     expect(result.format).toBe("none")
     expect(result.path).toBe(join(emptyDir, "oh-my-openagent.json"))
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("prefers canonical jsonc over legacy json when both exist", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+    mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-opencode.json"), "{}")
     writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
 
@@ -421,13 +415,11 @@ describe("detectPluginConfigFile", () => {
     expect(result.format).toBe("jsonc")
     expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"))
     expect(result.legacyPath).toBe(join(testDir, "oh-my-opencode.json"))
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 
   test("loads oh-my-openagent when only canonical jsonc exists", () => {
     // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+    mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
 
     // when
@@ -437,7 +429,5 @@ describe("detectPluginConfigFile", () => {
     expect(result.format).toBe("jsonc")
     expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"))
     expect(result.legacyPath).toBeUndefined()
-
-    rmSync(testDir, { recursive: true, force: true })
   })
 })

--- a/packages/utils/src/tool-name.test.ts
+++ b/packages/utils/src/tool-name.test.ts
@@ -1,155 +1,79 @@
-import { describe, it, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { transformToolName } from "./tool-name"
+
+type ToolNameCase = readonly [label: string, toolName: string, expected: string]
 
 describe("transformToolName", () => {
   describe("whitespace trimming", () => {
-    it("trims leading whitespace from tool name", () => {
-      // given
-      const toolName = " delegate_task"
+    const cases = [
+      ["trims leading whitespace from tool name", " delegate_task", "DelegateTask"],
+      ["trims trailing whitespace from tool name", "delegate_task ", "DelegateTask"],
+      ["trims both leading and trailing whitespace", " delegate_task ", "DelegateTask"],
+      ["applies special mapping after trimming whitespace", " webfetch", "WebFetch"],
+      ["handles simple case with leading and trailing spaces", " read ", "Read"],
+    ] as const satisfies readonly ToolNameCase[]
 
-      // when
-      const result = transformToolName(toolName)
+    for (const [label, toolName, expected] of cases) {
+      test(label, () => {
+        // when
+        const result = transformToolName(toolName)
 
-      // then
-      expect(result).toBe("DelegateTask")
-    })
-
-    it("trims trailing whitespace from tool name", () => {
-      // given
-      const toolName = "delegate_task "
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("DelegateTask")
-    })
-
-    it("trims both leading and trailing whitespace", () => {
-      // given
-      const toolName = " delegate_task "
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("DelegateTask")
-    })
-
-    it("applies special mapping after trimming whitespace", () => {
-      // given
-      const toolName = " webfetch"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("WebFetch")
-    })
-
-    it("handles simple case with leading and trailing spaces", () => {
-      // given
-      const toolName = " read "
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("Read")
-    })
+        // then
+        expect(result).toBe(expected)
+      })
+    }
   })
 
   describe("special tool mappings", () => {
-    it("maps webfetch to WebFetch", () => {
-      // given
-      const toolName = "webfetch"
+    const cases = [
+      ["maps webfetch to WebFetch", "webfetch", "WebFetch"],
+      ["maps websearch to WebSearch", "websearch", "WebSearch"],
+      ["maps todoread to TodoRead", "todoread", "TodoRead"],
+      ["maps todowrite to TodoWrite", "todowrite", "TodoWrite"],
+    ] as const satisfies readonly ToolNameCase[]
 
-      // when
-      const result = transformToolName(toolName)
+    for (const [label, toolName, expected] of cases) {
+      test(label, () => {
+        // when
+        const result = transformToolName(toolName)
 
-      // then
-      expect(result).toBe("WebFetch")
-    })
-
-    it("maps websearch to WebSearch", () => {
-      // given
-      const toolName = "websearch"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("WebSearch")
-    })
-
-    it("maps todoread to TodoRead", () => {
-      // given
-      const toolName = "todoread"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("TodoRead")
-    })
-
-    it("maps todowrite to TodoWrite", () => {
-      // given
-      const toolName = "todowrite"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("TodoWrite")
-    })
+        // then
+        expect(result).toBe(expected)
+      })
+    }
   })
 
   describe("kebab-case and snake_case conversion", () => {
-    it("converts snake_case to PascalCase", () => {
-      // given
-      const toolName = "delegate_task"
+    const cases = [
+      ["converts snake_case to PascalCase", "delegate_task", "DelegateTask"],
+      ["converts kebab-case to PascalCase", "call-omo-agent", "CallOmoAgent"],
+    ] as const satisfies readonly ToolNameCase[]
 
-      // when
-      const result = transformToolName(toolName)
+    for (const [label, toolName, expected] of cases) {
+      test(label, () => {
+        // when
+        const result = transformToolName(toolName)
 
-      // then
-      expect(result).toBe("DelegateTask")
-    })
-
-    it("converts kebab-case to PascalCase", () => {
-      // given
-      const toolName = "call-omo-agent"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("CallOmoAgent")
-    })
+        // then
+        expect(result).toBe(expected)
+      })
+    }
   })
 
   describe("simple capitalization", () => {
-    it("capitalizes simple single-word tool names", () => {
-      // given
-      const toolName = "read"
+    const cases = [
+      ["capitalizes simple single-word tool names", "read", "Read"],
+      ["preserves capitalization of already capitalized names", "Write", "Write"],
+    ] as const satisfies readonly ToolNameCase[]
 
-      // when
-      const result = transformToolName(toolName)
+    for (const [label, toolName, expected] of cases) {
+      test(label, () => {
+        // when
+        const result = transformToolName(toolName)
 
-      // then
-      expect(result).toBe("Read")
-    })
-
-    it("preserves capitalization of already capitalized names", () => {
-      // given
-      const toolName = "Write"
-
-      // when
-      const result = transformToolName(toolName)
-
-      // then
-      expect(result).toBe("Write")
-    })
+        // then
+        expect(result).toBe(expected)
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary
Table-drives repeated parser/frontmatter/tool-name utility tests while preserving the same expected behavior.

## Changes
- Consolidates repeated `transformToolName` input/output cases with typed test case arrays.
- Moves repeated JSONC temp-directory setup/cleanup into per-describe hooks.
- Consolidates selected frontmatter cases where full-object equality preserves the original assertions.

## Testing
- `bun test packages/utils/src/tool-name.test.ts packages/utils/src/jsonc-parser.test.ts packages/utils/src/frontmatter.test.ts packages/utils/src/deep-merge.test.ts packages/utils/src/file-utils.test.ts packages/utils/src/port-utils.test.ts` ✅ 102 pass, 0 fail
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/utils/src/tool-name.test.ts packages/utils/src/jsonc-parser.test.ts packages/utils/src/frontmatter.test.ts` ✅
- `git diff --check` ✅
- `bun run typecheck:packages` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` ✅
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` ✅
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh` ✅

## LOC
- `packages/utils/src/frontmatter.test.ts`: 90 insertions, 100 deletions
- `packages/utils/src/jsonc-parser.test.ts`: 45 insertions, 55 deletions
- `packages/utils/src/tool-name.test.ts`: 64 insertions, 140 deletions
- Total: 199 insertions, 295 deletions (net -96)

Behavior change: none intended; test structure only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `packages/utils` tests to use typed, table‑driven cases and shared setup to reduce duplication while preserving all expectations. No behavior changes; tests only.

- **Refactors**
  - Consolidated `transformToolName` scenarios into typed case arrays with looped `test` calls.
  - Moved JSONC temp directory setup/cleanup into per‑suite `beforeEach`/`afterEach`.
  - Grouped frontmatter compatibility, edge, and mixed content cases into typed arrays with full object equality.
  - Net change: −96 LOC across `frontmatter.test.ts`, `jsonc-parser.test.ts`, and `tool-name.test.ts`.

<sup>Written for commit 89e244ddb3a83d9c1ff7b0395c0426374b600d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

