### PR TITLE
test(utils): reduce parser utility pure loc

### DIFF
--- a/packages/utils/src/frontmatter.test.ts
+++ b/packages/utils/src/frontmatter.test.ts
@@ -1,16 +1,9 @@
 import { describe, test, expect } from "bun:test"
 import { parseFrontmatter } from "./frontmatter"
 
-type FrontmatterCase = readonly [
-  label: string,
-  content: string,
-  expectedData: Record<string, unknown>,
-  expectedBody: string,
-]
-
 describe("parseFrontmatter", () => {
   // #region backward compatibility
-  const compatibilityCases = [
+  test.each([
     [
       "parses simple key-value frontmatter",
       `---
@@ -31,18 +24,14 @@ Body`,
       { subtask: true, enabled: false },
       "Body",
     ],
-  ] as const satisfies readonly FrontmatterCase[]
+  ] as const)("%s", (_label, content, expectedData, expectedBody) => {
+    // when
+    const result = parseFrontmatter(content)
 
-  for (const [label, content, expectedData, expectedBody] of compatibilityCases) {
-    test(label, () => {
-      // when
-      const result = parseFrontmatter(content)
-
-      // then
-      expect(result.data).toEqual(expectedData)
-      expect(result.body).toBe(expectedBody)
-    })
-  }
+    // then
+    expect(result.data).toEqual(expectedData)
+    expect(result.body).toBe(expectedBody)
+  })
   // #endregion
 
   // #region complex YAML (handoffs support)
@@ -112,7 +101,7 @@ Content`
   // #endregion
 
   // #region edge cases
-  const edgeCases = [
+  test.each([
     ["handles content without frontmatter", "Just body content", {}, "Just body content"],
     [
       "handles empty frontmatter",
@@ -141,22 +130,18 @@ Body with whitespace-only frontmatter`,
       {},
       "Body with whitespace-only frontmatter",
     ],
-  ] as const satisfies readonly FrontmatterCase[]
+  ] as const)("%s", (_label, content, expectedData, expectedBody) => {
+    // when
+    const result = parseFrontmatter(content)
 
-  for (const [label, content, expectedData, expectedBody] of edgeCases) {
-    test(label, () => {
-      // when
-      const result = parseFrontmatter(content)
-
-      // then
-      expect(result.data).toEqual(expectedData)
-      expect(result.body).toBe(expectedBody)
-    })
-  }
+    // then
+    expect(result.data).toEqual(expectedData)
+    expect(result.body).toBe(expectedBody)
+  })
   // #endregion
 
   // #region mixed content
-  const mixedContentCases = [
+  test.each([
     [
       "preserves multiline body content",
       `---
@@ -170,18 +155,14 @@ Line 4 after blank`,
       "Line 1\nLine 2\n\nLine 4 after blank",
     ],
     ["handles CRLF line endings", "---\r\ndescription: Test\r\n---\r\nBody", { description: "Test" }, "Body"],
-  ] as const satisfies readonly FrontmatterCase[]
+  ] as const)("%s", (_label, content, expectedData, expectedBody) => {
+    // when
+    const result = parseFrontmatter(content)
 
-  for (const [label, content, expectedData, expectedBody] of mixedContentCases) {
-    test(label, () => {
-      // when
-      const result = parseFrontmatter(content)
-
-      // then
-      expect(result.data).toEqual(expectedData)
-      expect(result.body).toBe(expectedBody)
-    })
-  }
+    // then
+    expect(result.data).toEqual(expectedData)
+    expect(result.body).toBe(expectedBody)
+  })
   // #endregion
 
   // #region extra fields tolerance

--- a/packages/utils/src/jsonc-parser.test.ts
+++ b/packages/utils/src/jsonc-parser.test.ts
@@ -8,8 +8,6 @@ const pluginConfigDetectionOptions = {
   legacyBasenames: ["oh-my-opencode"],
 } as const
 
-type ConfigDetectionCase = readonly [label: string, extensions: readonly string[], expectedFormat: "json" | "jsonc"]
-
 describe("parseJsonc", () => {
   test("parses plain JSON", () => {
     // given
@@ -297,28 +295,24 @@ describe("detectConfigFile", () => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  const cases = [
+  test.each([
     ["prefers .jsonc over .json", ["json", "jsonc"], "jsonc"],
     ["detects .json when .jsonc doesn't exist", ["json"], "json"],
-  ] as const satisfies readonly ConfigDetectionCase[]
+  ] as const)("%s", (_label, extensions, expectedFormat) => {
+    // given
+    mkdirSync(testDir, { recursive: true })
+    const basePath = join(testDir, "config")
+    for (const extension of extensions) {
+      writeFileSync(`${basePath}.${extension}`, "{}")
+    }
 
-  for (const [label, extensions, expectedFormat] of cases) {
-    test(label, () => {
-      // given
-      mkdirSync(testDir, { recursive: true })
-      const basePath = join(testDir, "config")
-      for (const extension of extensions) {
-        writeFileSync(`${basePath}.${extension}`, "{}")
-      }
+    // when
+    const result = detectConfigFile(basePath)
 
-      // when
-      const result = detectConfigFile(basePath)
-
-      // then
-      expect(result.format).toBe(expectedFormat)
-      expect(result.path).toBe(`${basePath}.${expectedFormat}`)
-    })
-  }
+    // then
+    expect(result.format).toBe(expectedFormat)
+    expect(result.path).toBe(`${basePath}.${expectedFormat}`)
+  })
 
   test("returns none when neither exists", () => {
     // given

--- a/packages/utils/src/tool-name.test.ts
+++ b/packages/utils/src/tool-name.test.ts
@@ -1,79 +1,61 @@
 import { describe, expect, test } from "bun:test"
 import { transformToolName } from "./tool-name"
 
-type ToolNameCase = readonly [label: string, toolName: string, expected: string]
-
 describe("transformToolName", () => {
   describe("whitespace trimming", () => {
-    const cases = [
+    test.each([
       ["trims leading whitespace from tool name", " delegate_task", "DelegateTask"],
       ["trims trailing whitespace from tool name", "delegate_task ", "DelegateTask"],
       ["trims both leading and trailing whitespace", " delegate_task ", "DelegateTask"],
       ["applies special mapping after trimming whitespace", " webfetch", "WebFetch"],
       ["handles simple case with leading and trailing spaces", " read ", "Read"],
-    ] as const satisfies readonly ToolNameCase[]
+    ] as const)("%s", (_label, toolName, expected) => {
+      // when
+      const result = transformToolName(toolName)
 
-    for (const [label, toolName, expected] of cases) {
-      test(label, () => {
-        // when
-        const result = transformToolName(toolName)
-
-        // then
-        expect(result).toBe(expected)
-      })
-    }
+      // then
+      expect(result).toBe(expected)
+    })
   })
 
   describe("special tool mappings", () => {
-    const cases = [
+    test.each([
       ["maps webfetch to WebFetch", "webfetch", "WebFetch"],
       ["maps websearch to WebSearch", "websearch", "WebSearch"],
       ["maps todoread to TodoRead", "todoread", "TodoRead"],
       ["maps todowrite to TodoWrite", "todowrite", "TodoWrite"],
-    ] as const satisfies readonly ToolNameCase[]
+    ] as const)("%s", (_label, toolName, expected) => {
+      // when
+      const result = transformToolName(toolName)
 
-    for (const [label, toolName, expected] of cases) {
-      test(label, () => {
-        // when
-        const result = transformToolName(toolName)
-
-        // then
-        expect(result).toBe(expected)
-      })
-    }
+      // then
+      expect(result).toBe(expected)
+    })
   })
 
   describe("kebab-case and snake_case conversion", () => {
-    const cases = [
+    test.each([
       ["converts snake_case to PascalCase", "delegate_task", "DelegateTask"],
       ["converts kebab-case to PascalCase", "call-omo-agent", "CallOmoAgent"],
-    ] as const satisfies readonly ToolNameCase[]
+    ] as const)("%s", (_label, toolName, expected) => {
+      // when
+      const result = transformToolName(toolName)
 
-    for (const [label, toolName, expected] of cases) {
-      test(label, () => {
-        // when
-        const result = transformToolName(toolName)
-
-        // then
-        expect(result).toBe(expected)
-      })
-    }
+      // then
+      expect(result).toBe(expected)
+    })
   })
 
   describe("simple capitalization", () => {
-    const cases = [
+    test.each([
       ["capitalizes simple single-word tool names", "read", "Read"],
       ["preserves capitalization of already capitalized names", "Write", "Write"],
-    ] as const satisfies readonly ToolNameCase[]
+    ] as const)("%s", (_label, toolName, expected) => {
+      // when
+      const result = transformToolName(toolName)
 
-    for (const [label, toolName, expected] of cases) {
-      test(label, () => {
-        // when
-        const result = transformToolName(toolName)
-
-        // then
-        expect(result).toBe(expected)
-      })
-    }
+      // then
+      expect(result).toBe(expected)
+    })
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #4974: keeps the same parser utility test behavior while making the cleanup reduce pure LOC, not just raw lines.

## Changes
- Uses `test.each` for existing parser/frontmatter/tool-name test case tables.
- Removes tuple helper types and loop boilerplate introduced by #4974.
- Keeps the same test names, inputs, and expected assertions.

## Testing
- `bun test packages/utils/src/tool-name.test.ts packages/utils/src/jsonc-parser.test.ts packages/utils/src/frontmatter.test.ts packages/utils/src/deep-merge.test.ts packages/utils/src/file-utils.test.ts packages/utils/src/port-utils.test.ts` ✅ 102 pass, 0 fail
- `bun run typecheck:packages` ✅
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/utils/src/tool-name.test.ts packages/utils/src/jsonc-parser.test.ts packages/utils/src/frontmatter.test.ts` ✅
- `git diff --check` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` ✅
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` ✅
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh` ✅

## LOC
- Raw diff: 71 insertions, 114 deletions (net -43)
- Pure LOC in touched files on current dev: 509 -> 477 (net -32)

Behavior change: none intended; test structure only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors utils tests to use `test.each`, removing boilerplate and reducing pure LOC with no behavior changes.

- **Refactors**
  - Switched to `test.each` and removed tuple helper types/loops in `packages/utils/src/frontmatter.test.ts`, `packages/utils/src/jsonc-parser.test.ts`, and `packages/utils/src/tool-name.test.ts`.
  - Preserved test names, inputs, and assertions.
  - Reduced pure LOC by 32 (509 → 477); raw diff -43 lines.

<sup>Written for commit 582f8af17e541268817f49b7dcf02766bc68050d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

