### PR TITLE
test(ulw-loop): table-drive steering parser cases

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/test/cli-steering.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/cli-steering.test.ts
@@ -15,6 +15,15 @@ import type { SteerUlwLoopResult, UlwLoopPlan } from "../src/types.js";
 import { UlwLoopError } from "../src/types.js";
 
 const NOW = "2026-05-23T00:00:00.000Z";
+const REVISE_CRITERION_BASE_ARGS = [
+	"--kind",
+	"revise_criterion",
+	"--goal-id",
+	"G001",
+	"--criterion-id",
+	"C002",
+] as const;
+const REQUIRED_AUDIT_ARGS = ["--evidence", "x", "--rationale", "y"] as const;
 
 function plan(): UlwLoopPlan {
 	return {
@@ -64,21 +73,23 @@ function captureStdout(action: () => void): string {
 }
 
 describe("parseSteeringKind", () => {
-	it("returns valid kind from --kind", () => {
-		expect(parseSteeringKind(["--kind", "add_subgoal"])).toBe("add_subgoal");
-	});
+	for (const testCase of [
+		{ name: "returns valid kind from --kind", args: ["--kind", "add_subgoal"], expected: "add_subgoal" },
+		{ name: "accepts revise_criterion", args: ["--kind", "revise_criterion"], expected: "revise_criterion" },
+	] as const) {
+		it(testCase.name, () => {
+			expect(parseSteeringKind(testCase.args)).toBe(testCase.expected);
+		});
+	}
 
-	it("accepts revise_criterion", () => {
-		expect(parseSteeringKind(["--kind", "revise_criterion"])).toBe("revise_criterion");
-	});
-
-	it("throws when --kind missing", () => {
-		expect(() => parseSteeringKind([])).toThrow(UlwLoopError);
-	});
-
-	it("throws when kind unknown", () => {
-		expect(() => parseSteeringKind(["--kind", "bogus"])).toThrow(UlwLoopError);
-	});
+	for (const testCase of [
+		{ name: "throws when --kind missing", args: [] },
+		{ name: "throws when kind unknown", args: ["--kind", "bogus"] },
+	] as const) {
+		it(testCase.name, () => {
+			expect(() => parseSteeringKind(testCase.args)).toThrow(UlwLoopError);
+		});
+	}
 });
 
 describe("parseSteeringSource", () => {
@@ -141,18 +152,10 @@ describe("parseSteeringProposal add_subgoal", () => {
 describe("parseSteeringProposal revise_criterion", () => {
 	it("builds proposal with goal, criterion, scenario, evidence, and rationale", async () => {
 		const p = await parseSteeringProposal([
-			"--kind",
-			"revise_criterion",
-			"--goal-id",
-			"G001",
-			"--criterion-id",
-			"C002",
+			...REVISE_CRITERION_BASE_ARGS,
 			"--scenario",
 			"new scenario",
-			"--evidence",
-			"x",
-			"--rationale",
-			"y",
+			...REQUIRED_AUDIT_ARGS,
 		]);
 
 		expect(p.kind).toBe("revise_criterion");
@@ -162,94 +165,47 @@ describe("parseSteeringProposal revise_criterion", () => {
 		expect(p.scenario).toBe("new scenario");
 	});
 
-	it("accepts --expected-evidence as an update field", async () => {
-		const p = await parseSteeringProposal([
-			"--kind",
-			"revise_criterion",
-			"--goal-id",
-			"G001",
-			"--criterion-id",
-			"C002",
-			"--expected-evidence",
-			"new evidence",
-			"--evidence",
-			"x",
-			"--rationale",
-			"y",
-		]);
+	for (const testCase of [
+		{
+			name: "accepts --expected-evidence as an update field",
+			updateArgs: ["--expected-evidence", "new evidence"],
+			expected: { expectedEvidence: "new evidence" },
+		},
+		{
+			name: "accepts --user-model as an update field",
+			updateArgs: ["--user-model", "edge"],
+			expected: { userModel: "edge" },
+		},
+	] as const) {
+		it(testCase.name, async () => {
+			const p = await parseSteeringProposal([
+				...REVISE_CRITERION_BASE_ARGS,
+				...testCase.updateArgs,
+				...REQUIRED_AUDIT_ARGS,
+			]);
 
-		expect(p.expectedEvidence).toBe("new evidence");
-	});
+			expect(p).toMatchObject(testCase.expected);
+		});
+	}
 
-	it("accepts --user-model as an update field", async () => {
-		const p = await parseSteeringProposal([
-			"--kind",
-			"revise_criterion",
-			"--goal-id",
-			"G001",
-			"--criterion-id",
-			"C002",
-			"--user-model",
-			"edge",
-			"--evidence",
-			"x",
-			"--rationale",
-			"y",
-		]);
-
-		expect(p.userModel).toBe("edge");
-	});
-
-	it("throws when none of scenario/expected-evidence/user-model provided", async () => {
-		await expect(
-			parseSteeringProposal([
-				"--kind",
-				"revise_criterion",
-				"--goal-id",
-				"G001",
-				"--criterion-id",
-				"C002",
-				"--evidence",
-				"x",
-				"--rationale",
-				"y",
-			]),
-		).rejects.toThrow(UlwLoopError);
-	});
-
-	it("throws when goal-id missing", async () => {
-		await expect(
-			parseSteeringProposal([
-				"--kind",
-				"revise_criterion",
-				"--criterion-id",
-				"C002",
-				"--scenario",
-				"s",
-				"--evidence",
-				"x",
-				"--rationale",
-				"y",
-			]),
-		).rejects.toThrow(UlwLoopError);
-	});
-
-	it("throws when criterion-id missing", async () => {
-		await expect(
-			parseSteeringProposal([
-				"--kind",
-				"revise_criterion",
-				"--goal-id",
-				"G001",
-				"--scenario",
-				"s",
-				"--evidence",
-				"x",
-				"--rationale",
-				"y",
-			]),
-		).rejects.toThrow(UlwLoopError);
-	});
+	for (const testCase of [
+		{
+			name: "throws when none of scenario/expected-evidence/user-model provided",
+			args: [...REVISE_CRITERION_BASE_ARGS, ...REQUIRED_AUDIT_ARGS],
+		},
+		{
+			name: "throws when goal-id missing",
+			args: ["--kind", "revise_criterion", "--criterion-id", "C002", "--scenario", "s", ...REQUIRED_AUDIT_ARGS],
+		},
+		{
+			name: "throws when criterion-id missing",
+			args: ["--kind", "revise_criterion", "--goal-id", "G001", "--scenario", "s", ...REQUIRED_AUDIT_ARGS],
+		},
+	] as const) {
+		it(testCase.name, async () => {
+			await expect(parseSteeringProposal(testCase.args)).rejects.toThrow(UlwLoopError);
+		});
+	}
 });
 
 describe("parseSteeringProposal split_subgoal", () => {


### PR DESCRIPTION
## Summary
- table-drive repeated `parseSteeringKind` valid/error cases
- reuse shared revise-criterion required args in CLI steering parser tests
- table-drive revise-criterion update-field and required-field error assertions without changing covered behavior

## LOC
- `packages/omo-codex/plugin/components/ulw-loop/test/cli-steering.test.ts`: 362 -> 324 pure LOC (-38)
- package pure LOC: 43,750 -> 43,712 (-38)

## Manual QA
- `npm test -- test/cli-steering.test.ts` (25 pass)
- `npm exec -- biome check test/cli-steering.test.ts`
- `npm run typecheck` in `packages/omo-codex/plugin/components/ulw-loop`
- `npm run build` in `packages/omo-codex/plugin/components/ulw-loop`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-codex/plugin/components/ulw-loop/test/cli-steering.test.ts`
- `bun run typecheck:packages`
- `bun run typecheck`
- `bun run build`
- `bun run test:codex`
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh`

## Notes
- Full `npm run lint` in the ulw-loop component still reports a pre-existing unrelated formatter issue in `src/codex-goal-instruction.ts`; the touched file passes Biome directly.
- No behavior change intended; test names and observable assertions remain covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Table-drove CLI steering parser tests to reduce duplication while keeping behavior unchanged. Cuts 38 LOC in cli-steering.test.ts and maintains full coverage.

- **Refactors**
  - Converted `parseSteeringKind` valid/error cases to table-driven tests.
  - Table-drove `revise_criterion` update-field and required-field error assertions.
  - Extracted shared arg lists (`REVISE_CRITERION_BASE_ARGS`, `REQUIRED_AUDIT_ARGS`) for reuse.

<sup>Written for commit 86202f362cae57937c36cdfe4597a44aaccf932f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

