### PR TITLE
test(rules): table-drive context pressure recovery cases

### DIFF
--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-context-pressure.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-context-pressure.test.ts
@@ -9,6 +9,35 @@ const tempDirectories: string[] = [];
 const PROJECT_ONLY_ENV = {
 	CODEX_RULES_ENABLED_SOURCES: "AGENTS.md,.omo/rules",
 };
+const PROMPT_CONTEXT_PRESSURE_CASES = [
+	[
+		"#given context-pressure recovery prompt and empty static cache #when UserPromptSubmit runs #then it emits no static context",
+		[
+			"Context compacted",
+			"error context_too_large: Your input exceeds the context window of this model.",
+			"Please adjust your input and try again.",
+		].join("\n"),
+	],
+	[
+		"#given Codex canonical context-window prompt and empty static cache #when UserPromptSubmit runs #then it emits no static context",
+		[
+			"error context_length_exceeded",
+			"Codex ran out of room in the model's context window. Start a new thread before retrying.",
+		].join("\n"),
+	],
+] as const;
+const TRANSCRIPT_CONTEXT_PRESSURE_CASES = [
+	[
+		"#given context-pressure transcript and empty static cache #when UserPromptSubmit runs #then it emits no static context",
+		"#given context-pressure transcript and empty dynamic cache #when PostToolUse runs #then it emits no dynamic context",
+		writeContextPressureTranscript,
+	],
+	[
+		"#given Codex canonical context-window transcript and empty static cache #when UserPromptSubmit runs #then it emits no static context",
+		"#given Codex canonical context-window transcript and empty dynamic cache #when PostToolUse runs #then it emits no dynamic context",
+		writeCodexContextWindowTranscript,
+	],
+] as const;
 
 afterEach(() => {
 	for (const directory of tempDirectories.splice(0)) {
@@ -17,144 +46,54 @@ afterEach(() => {
 });
 
 describe("codex rules context-pressure recovery", () => {
-	it("#given context-pressure recovery prompt and empty static cache #when UserPromptSubmit runs #then it emits no static context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
+	for (const [name, prompt] of PROMPT_CONTEXT_PRESSURE_CASES) {
+		it(name, async () => {
+			// given
+			const { root, pluginData } = makeTempProject();
 
-		// when
-		const output = await runUserPromptSubmitHook(
-			{
-				...userPromptSubmitInput(root),
-				prompt: [
-					"Context compacted",
-					"error context_too_large: Your input exceeds the context window of this model.",
-					"Please adjust your input and try again.",
-				].join("\n"),
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
+			// when
+			const output = await runUserPromptSubmitHook(
+				{ ...userPromptSubmitInput(root), prompt },
+				{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
+			);
 
-		// then
-		expect(output).toBe("");
-	});
+			// then
+			expect(output).toBe("");
+		});
+	}
 
-	it("#given Codex canonical context-window prompt and empty static cache #when UserPromptSubmit runs #then it emits no static context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
+	for (const [userPromptName, postToolName, writeTranscript] of TRANSCRIPT_CONTEXT_PRESSURE_CASES) {
+		it(userPromptName, async () => {
+			// given
+			const { root, pluginData } = makeTempProject();
+			const transcriptPath = writeTranscript(root);
 
-		// when
-		const output = await runUserPromptSubmitHook(
-			{
-				...userPromptSubmitInput(root),
-				prompt: [
-					"error context_length_exceeded",
-					"Codex ran out of room in the model's context window. Start a new thread before retrying.",
-				].join("\n"),
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
+			// when
+			const output = await runUserPromptSubmitHook(
+				{ ...userPromptSubmitInput(root), transcript_path: transcriptPath, prompt: "continue" },
+				{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
+			);
 
-		// then
-		expect(output).toBe("");
-	});
+			// then
+			expect(output).toBe("");
+		});
 
-	it("#given context-pressure transcript and empty static cache #when UserPromptSubmit runs #then it emits no static context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
-		const transcriptPath = writeContextPressureTranscript(root);
+		it(postToolName, async () => {
+			// given
+			const { root, pluginData } = makeTempProject();
+			const transcriptPath = writeTranscript(root);
+			const filePath = writeAppFile(root);
 
-		// when
-		const output = await runUserPromptSubmitHook(
-			{
-				...userPromptSubmitInput(root),
-				transcript_path: transcriptPath,
-				prompt: "continue",
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
+			// when
+			const output = await runPostToolUseHook(postToolUseInput(root, transcriptPath, filePath), {
+				pluginDataRoot: pluginData,
+				env: PROJECT_ONLY_ENV,
+			});
 
-		// then
-		expect(output).toBe("");
-	});
-
-	it("#given Codex canonical context-window transcript and empty static cache #when UserPromptSubmit runs #then it emits no static context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
-		const transcriptPath = writeCodexContextWindowTranscript(root);
-
-		// when
-		const output = await runUserPromptSubmitHook(
-			{
-				...userPromptSubmitInput(root),
-				transcript_path: transcriptPath,
-				prompt: "continue",
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
-
-		// then
-		expect(output).toBe("");
-	});
-
-	it("#given context-pressure transcript and empty dynamic cache #when PostToolUse runs #then it emits no dynamic context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
-		const transcriptPath = writeContextPressureTranscript(root);
-		const filePath = path.join(root, "src", "app.ts");
-		mkdirSync(path.dirname(filePath), { recursive: true });
-		writeFileSync(filePath, "export const answer = 42;\n");
-
-		// when
-		const output = await runPostToolUseHook(
-			{
-				session_id: "session-context-pressure",
-				turn_id: "turn-1",
-				transcript_path: transcriptPath,
-				cwd: root,
-				hook_event_name: "PostToolUse",
-				model: "gpt-5.5",
-				permission_mode: "default",
-				tool_name: "mcp__filesystem__read_file",
-				tool_input: { path: filePath },
-				tool_response: { text: "export const answer = 42;" },
-				tool_use_id: "call-1",
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
-
-		// then
-		expect(output).toBe("");
-	});
-
-	it("#given Codex canonical context-window transcript and empty dynamic cache #when PostToolUse runs #then it emits no dynamic context", async () => {
-		// given
-		const { root, pluginData } = makeTempProject();
-		const transcriptPath = writeCodexContextWindowTranscript(root);
-		const filePath = path.join(root, "src", "app.ts");
-		mkdirSync(path.dirname(filePath), { recursive: true });
-		writeFileSync(filePath, "export const answer = 42;\n");
-
-		// when
-		const output = await runPostToolUseHook(
-			{
-				session_id: "session-context-pressure",
-				turn_id: "turn-1",
-				transcript_path: transcriptPath,
-				cwd: root,
-				hook_event_name: "PostToolUse",
-				model: "gpt-5.5",
-				permission_mode: "default",
-				tool_name: "mcp__filesystem__read_file",
-				tool_input: { path: filePath },
-				tool_response: { text: "export const answer = 42;" },
-				tool_use_id: "call-1",
-			},
-			{ pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV },
-		);
-
-		// then
-		expect(output).toBe("");
-	});
+			// then
+			expect(output).toBe("");
+		});
+	}
 });
 
 function makeTempProject(): { readonly root: string; readonly pluginData: string } {
@@ -189,6 +128,33 @@ function userPromptSubmitInput(root: string): Parameters<typeof runUserPromptSub
 		permission_mode: "default",
 		prompt: "read src/app.ts",
 	};
+}
+
+function postToolUseInput(
+	root: string,
+	transcriptPath: string,
+	filePath: string,
+): Parameters<typeof runPostToolUseHook>[0] {
+	return {
+		session_id: "session-context-pressure",
+		turn_id: "turn-1",
+		transcript_path: transcriptPath,
+		cwd: root,
+		hook_event_name: "PostToolUse",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		tool_name: "mcp__filesystem__read_file",
+		tool_input: { path: filePath },
+		tool_response: { text: "export const answer = 42;" },
+		tool_use_id: "call-1",
+	};
+}
+
+function writeAppFile(root: string): string {
+	const filePath = path.join(root, "src", "app.ts");
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, "export const answer = 42;\n");
+	return filePath;
 }
 
 function writeContextPressureTranscript(root: string): string {


### PR DESCRIPTION
## Summary
- table-drive context-pressure prompt and transcript recovery cases
- preserve all six scenario names and the empty-output assertions for static/dynamic hook surfaces
- keep the change scoped to the rules component test; no production behavior changes

## LOC
- `packages/omo-codex/plugin/components/rules/test/codex-hook-context-pressure.test.ts`: 200 -> 182 pure LOC (-18)
- cumulative package LOC after #4976 + this PR: expected 43,750 -> 43,694 (-56)

## Manual QA
- `npm test -- test/codex-hook-context-pressure.test.ts` in `packages/omo-codex/plugin/components/rules`
- `npm run typecheck` in `packages/omo-codex/plugin/components/rules`
- `npm run build` in `packages/omo-codex/plugin/components/rules`
- `npm exec -- biome check test/codex-hook-context-pressure.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-codex/plugin/components/rules/test/codex-hook-context-pressure.test.ts`
- `bun run typecheck:packages`
- `bun run typecheck`
- `bun run build`
- `bun run test:codex`
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh`

## Notes
- Branch is behind the just-merged #4976, but `git merge-tree` shows no conflicts; per policy I did not rebase a conflict-free, mergeable branch.
- I tried the adjacent `post-compact-budget.test.ts` scout target but dropped it because formatting made pure LOC increase rather than decrease.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Table-drove the context-pressure recovery tests in `rules` to reduce duplication and keep all six scenarios intact. Test-only change with no production impact.

- **Refactors**
  - Converted repeated cases into parameterized tests for prompts and transcripts.
  - Added small helpers to DRY setup: `postToolUseInput` and `writeAppFile`.
  - Kept scenario names and empty-output assertions for `UserPromptSubmit` and `PostToolUse`.
  - Reduced LOC in `packages/omo-codex/plugin/components/rules/test/codex-hook-context-pressure.test.ts` by 18.

<sup>Written for commit 2c3e692a2f71a198b842418eeac27f72550a847d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

