### PR TITLE
test(rules): table-drive single path extraction cases

### DIFF
--- a/packages/omo-codex/plugin/components/rules/test/tool-paths.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/tool-paths.test.ts
@@ -30,22 +30,34 @@ function postToolUse(input: { toolName: string; toolInput?: unknown; toolRespons
 }
 
 describe("extractCodexToolPaths", () => {
-	it("#given filesystem read payload #when extracting #then returns resolved path", () => {
-		// given
-		const root = makeProject();
+	for (const [name, toolName, toolInput] of [
+		[
+			"#given filesystem read payload #when extracting #then returns resolved path",
+			"mcp__filesystem__read_file",
+			{ path: "src/app.ts" },
+		],
+		[
+			"#given mcp write-file payload #when extracting #then returns resolved path",
+			"mcp__filesystem__write_file",
+			{ path: "src/app.ts", content: "export const app = true;\n" },
+		],
+		[
+			"#given mcp edit-file payload #when extracting #then returns resolved path",
+			"mcp__filesystem__edit_file",
+			{ path: "src/app.ts", edits: [] },
+		],
+	] as const) {
+		it(name, () => {
+			// given
+			const root = makeProject();
 
-		// when
-		const paths = extractCodexToolPaths(
-			postToolUse({
-				toolName: "mcp__filesystem__read_file",
-				toolInput: { path: "src/app.ts" },
-			}),
-			root,
-		);
+			// when
+			const paths = extractCodexToolPaths(postToolUse({ toolName, toolInput }), root);
 
-		// then
-		expect(paths).toEqual([path.join(root, "src", "app.ts")]);
-	});
+			// then
+			expect(paths).toEqual([path.join(root, "src", "app.ts")]);
+		});
+	}
 
 	it("#given apply_patch payload #when extracting #then returns patched file paths", () => {
 		// given
@@ -107,40 +119,6 @@ describe("extractCodexToolPaths", () => {
 			path.join(root, "src", "app.ts"),
 			path.join(root, "src", "moved.ts"),
 		]);
-	});
-
-	it("#given mcp write-file payload #when extracting #then returns resolved path", () => {
-		// given
-		const root = makeProject();
-
-		// when
-		const paths = extractCodexToolPaths(
-			postToolUse({
-				toolName: "mcp__filesystem__write_file",
-				toolInput: { path: "src/app.ts", content: "export const app = true;\n" },
-			}),
-			root,
-		);
-
-		// then
-		expect(paths).toEqual([path.join(root, "src", "app.ts")]);
-	});
-
-	it("#given mcp edit-file payload #when extracting #then returns resolved path", () => {
-		// given
-		const root = makeProject();
-
-		// when
-		const paths = extractCodexToolPaths(
-			postToolUse({
-				toolName: "mcp__filesystem__edit_file",
-				toolInput: { path: "src/app.ts", edits: [] },
-			}),
-			root,
-		);
-
-		// then
-		expect(paths).toEqual([path.join(root, "src", "app.ts")]);
 	});
 
 	it("#given mcp read-multiple-files payload #when extracting #then returns all resolved paths", () => {


### PR DESCRIPTION
## Summary
- table-drive the repeated single-path filesystem extraction cases in `tool-paths.test.ts`
- preserve each generated test name and the same resolved-path assertion
- keep multi-path, apply_patch, shell token, and failed-tool cases separate because they pin different behavior

## LOC
- `packages/omo-codex/plugin/components/rules/test/tool-paths.test.ts`: 145 -> 131 pure LOC (-14 by file measurement)

## Manual QA
- `npm test -- test/tool-paths.test.ts` in `packages/omo-codex/plugin/components/rules`
- `npm run typecheck` in `packages/omo-codex/plugin/components/rules`
- `npm run build` in `packages/omo-codex/plugin/components/rules`
- `npm exec -- biome check test/tool-paths.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-codex/plugin/components/rules/test/tool-paths.test.ts`
- `bun run typecheck:packages`
- `bun run typecheck`
- `bun run build`
- `bun run test:codex`
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh`

## Notes
- `git merge-tree` against latest `origin/dev` is conflict-free; no rebase was needed.
- No production code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Table-drove the single-path extraction tests in `packages/omo-codex/plugin/components/rules/test/tool-paths.test.ts` to remove repetition while keeping coverage the same. Reduced the test file by 14 LOC.

- **Refactors**
  - Consolidated read/write/edit cases into a data-driven loop and preserved each test name.
  - Left multi-path, `apply_patch`, shell token, and failed-tool tests separate to pin distinct behavior.
  - No production code changes.

<sup>Written for commit a08da32c0776d5171b2ae7ed748129c394979d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

