### PR TITLE
test(ulw-loop): table-drive steering-created goal cases

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts
@@ -159,46 +159,37 @@ describe("steerUlwLoop", () => {
 			});
 		}
 
-		it("add_subgoal: uses next numeric id + default success criteria", async () => {
-			const repoRoot = await repoWithPlan(sluggedPlan());
-			const result = await steerUlwLoop(repoRoot, steering({ idempotencyKey: "slug-add" }));
-			expect(result.plan.goals.at(-1)).toMatchObject({
-				id: "G003",
-				successCriteria: [{ id: "C001" }, { id: "C002" }, { id: "C003" }],
-			});
-		});
-
-		it("split_subgoal: replacement goals use default success criteria", async () => {
-			const repoRoot = await repoWithPlan(sluggedPlan());
-			const result = await steerUlwLoop(
-				repoRoot,
+		for (const [name, proposal, goalIndex] of [
+			["add_subgoal: uses next numeric id + default success criteria", steering({ idempotencyKey: "slug-add" }), -1],
+			[
+				"split_subgoal: replacement goals use default success criteria",
 				steering({
 					kind: "split_subgoal",
 					targetGoalId: "G001-goal-a",
 					childGoals: [{ title: "Child A", objective: "Do child A" }],
 				}),
-			);
-			expect(result.plan.goals[1]).toMatchObject({
-				id: "G003",
-				successCriteria: [{ id: "C001" }, { id: "C002" }, { id: "C003" }],
-			});
-		});
-
-		it("mark_blocked_superseded: replacement goals use default success criteria", async () => {
-			const repoRoot = await repoWithPlan(sluggedPlan());
-			const result = await steerUlwLoop(
-				repoRoot,
+				1,
+			],
+			[
+				"mark_blocked_superseded: replacement goals use default success criteria",
 				steering({
 					kind: "mark_blocked_superseded",
 					targetGoalId: "G001-goal-a",
 					childGoals: [{ title: "Replacement", objective: "Replace blocked path" }],
 				}),
-			);
-			expect(result.plan.goals[1]).toMatchObject({
-				id: "G003",
-				successCriteria: [{ id: "C001" }, { id: "C002" }, { id: "C003" }],
+				1,
+			],
+		] as const) {
+			it(name, async () => {
+				const repoRoot = await repoWithPlan(sluggedPlan());
+				const result = await steerUlwLoop(repoRoot, proposal);
+				const createdGoal = goalIndex === -1 ? result.plan.goals.at(-1) : result.plan.goals[goalIndex];
+				expect(createdGoal).toMatchObject({
+					id: "G003",
+					successCriteria: [{ id: "C001" }, { id: "C002" }, { id: "C003" }],
+				});
 			});
-		});
+		}
 	});
 
 	it("add_subgoal: appends goal + ledger entry", async () => {


### PR DESCRIPTION
## Summary
- table-drive the three steering-created goal default-success-criteria cases
- preserve each generated scenario name and the same `G003`/default criteria assertion
- keep the broader mutation behavior tests separate

## LOC
- `packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts`: 321 -> 314 pure LOC (-7)
- package pure LOC from latest dev: 43,684 -> 43,677 (-7)

## Manual QA
- `npm test -- test/steering.test.ts` in `packages/omo-codex/plugin/components/ulw-loop`
- `npm run typecheck` in `packages/omo-codex/plugin/components/ulw-loop`
- `npm run build` in `packages/omo-codex/plugin/components/ulw-loop`
- `npm exec -- biome check test/steering.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts`
- `bun run typecheck:packages`
- `bun run typecheck`
- `bun run build`
- `bun run test:codex`
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check`
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test`
- `bash .agents/skills/opencode-qa/scripts/server-smoke.sh`

## Notes
- `git merge-tree` against latest `origin/dev` is conflict-free; no rebase needed.
- No production code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Table-drove the three steering-created goal cases in `packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts` to remove repetition while keeping behavior the same. No production code changes.

- **Refactors**
  - Consolidated `add_subgoal`, `split_subgoal`, and `mark_blocked_superseded` into a single table-driven loop with preserved scenario names.
  - Selects the correct created goal per proposal (last or index 1).
  - Asserts the new goal is `G003` with default criteria `C001`–`C003`; net −7 LOC in the test file.

<sup>Written for commit 42715c4af9a19998e9d33d6f643b56df4bd6004c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

