### PR TITLE
test(keyword-detector): narrow hyperplan text assertions

### DIFF
--- a/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
+++ b/src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
@@ -34,6 +34,15 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     })
   }
 
+  function textOf(output: { readonly parts: readonly { readonly type: string; readonly text?: string }[] }): string {
+    const textPart = output.parts.find((part) => part.type === "text")
+    expect(textPart).toBeDefined()
+    if (!textPart || typeof textPart.text !== "string") {
+      throw new Error("expected text part")
+    }
+    return textPart.text
+  }
+
   test("should inject combo message when user types 'hpp ulw' (forward order)", async () => {
     // given - main session with adjacent forward-order combo keywords
     const sessionID = "combo-forward-session"
@@ -48,11 +57,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - combo banner and embedded ultrawork content both present
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<ultrawork-mode>")
-    expect(textPart!.text).toContain("refactor the auth module")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<ultrawork-mode>")
+    expect(text).toContain("refactor the auth module")
   })
 
   test("should inject combo message when user types 'ulw hpp' (reverse order)", async () => {
@@ -69,11 +77,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - combo fires identically regardless of word order
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<ultrawork-mode>")
-    expect(textPart!.text).toContain("ship this feature")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<ultrawork-mode>")
+    expect(text).toContain("ship this feature")
   })
 
   test("should NOT trigger combo on non-adjacent 'hpp do ulw' but fire both standalones instead", async () => {
@@ -90,11 +97,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - combo absent, both standalone banners injected separately
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<hyperplan-mode>")
-    expect(textPart!.text).toContain("<ultrawork-mode>")
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<hyperplan-mode>")
+    expect(text).toContain("<ultrawork-mode>")
   })
 
   test("should suppress standalone messages when combo fires (only ONE banner injected)", async () => {
@@ -111,11 +117,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - only combo banner present, standalone hyperplan suppressed, ultrawork content appears once via embed
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
-    const ultraworkMatches = textPart!.text!.match(/<ultrawork-mode>/g) ?? []
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-ultrawork-mode>")
+    expect(text).not.toContain("<hyperplan-mode>")
+    const ultraworkMatches = text.match(/<ultrawork-mode>/g) ?? []
     expect(ultraworkMatches).toHaveLength(1)
   })
 
@@ -158,11 +163,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - combo absent, both individual standalones still match and inject
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<hyperplan-mode>")
-    expect(textPart!.text).toContain("<ultrawork-mode>")
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<hyperplan-mode>")
+    expect(text).toContain("<ultrawork-mode>")
   })
 
   test("should block combo via intersection rule when disabled_keywords includes 'ultrawork'", async () => {
@@ -185,11 +189,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - no combo, no ultrawork content leaks; standalone hyperplan still fires
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).not.toContain("<ultrawork-mode>")
-    expect(textPart!.text).toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-ultrawork-mode>")
+    expect(text).not.toContain("<ultrawork-mode>")
+    expect(text).toContain("<hyperplan-mode>")
     expect(toastCalls).not.toContain("Hyperplan Ultrawork Mode Activated")
     expect(toastCalls).not.toContain("Ultrawork Mode Activated")
   })
@@ -209,11 +212,10 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID: subagentSessionID }, output)
 
     // then - combo banner reaches non-main session (whitelisted alongside standalone ultrawork)
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<ultrawork-mode>")
-    expect(textPart!.text).toContain("run this")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<ultrawork-mode>")
+    expect(text).toContain("run this")
   })
 
   test("should filter combo when agent is prometheus (planner)", async () => {
@@ -229,12 +231,11 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     await hook["chat.message"]({ sessionID, agent: "prometheus" }, output)
 
     // then - text untouched: combo, ultrawork, and hyperplan all filtered for planner
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("hpp ulw plan stuff")
-    expect(textPart!.text).not.toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).not.toContain("<ultrawork-mode>")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("hpp ulw plan stuff")
+    expect(text).not.toContain("<hyperplan-ultrawork-mode>")
+    expect(text).not.toContain("<ultrawork-mode>")
+    expect(text).not.toContain("<hyperplan-mode>")
   })
 
   test("should reuse ultrawork variant: combo with GPT model embeds GPT ultrawork content", async () => {
@@ -254,9 +255,8 @@ describe("keyword-detector hyperplan-ultrawork combo", () => {
     )
 
     // then - combo banner present and GPT-variant ultrawork content embedded (output_verbosity_spec is GPT-only)
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-ultrawork-mode>")
-    expect(textPart!.text).toContain("<output_verbosity_spec>")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-ultrawork-mode>")
+    expect(text).toContain("<output_verbosity_spec>")
   })
 })

--- a/src/hooks/keyword-detector/hyperplan.test.ts
+++ b/src/hooks/keyword-detector/hyperplan.test.ts
@@ -4,6 +4,7 @@ import { createKeywordDetectorHook } from "./index"
 import { setMainSession, _resetForTesting } from "../../features/claude-code-session-state"
 import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
 
 describe("keyword-detector hyperplan keyword", () => {
   let logSpy: ReturnType<typeof spyOn>
@@ -22,7 +23,7 @@ describe("keyword-detector hyperplan keyword", () => {
 
   function createMockPluginInput(options: { toastCalls?: string[] } = {}) {
     const toastCalls = options.toastCalls ?? []
-    return {
+    return unsafeTestValue<PluginInput>({
       client: {
         tui: {
           showToast: async (opts: { body: { title: string } }) => {
@@ -30,7 +31,16 @@ describe("keyword-detector hyperplan keyword", () => {
           },
         },
       },
-    } as PluginInput
+    })
+  }
+
+  function textOf(output: { readonly parts: readonly { readonly type: string; readonly text?: string }[] }): string {
+    const textPart = output.parts.find((part) => part.type === "text")
+    expect(textPart).toBeDefined()
+    if (!textPart || typeof textPart.text !== "string") {
+      throw new Error("expected text part")
+    }
+    return textPart.text
   }
 
   test("should inject hyperplan message when user types 'hyperplan'", async () => {
@@ -47,20 +57,19 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan-mode wrapper and skill-loading instruction should be present
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-mode>")
-    expect(textPart!.text).toContain('skill(name="hyperplan")')
-    expect(textPart!.text).toContain("HYPERPLAN MODE ENABLED")
-    expect(textPart!.text).toContain("unspecified-low")
-    expect(textPart!.text).toContain("unspecified-high")
-    expect(textPart!.text).toContain("artistry")
-    expect(textPart!.text).toContain("ultrabrain")
-    expect(textPart!.text).toContain("deep")
-    expect(textPart!.text).toContain("only if")
-    expect(textPart!.text).toContain("enabled")
-    expect(textPart!.text).toContain("refactor the auth module")
-    expect(textPart!.text).toContain("---")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-mode>")
+    expect(text).toContain('skill(name="hyperplan")')
+    expect(text).toContain("HYPERPLAN MODE ENABLED")
+    expect(text).toContain("unspecified-low")
+    expect(text).toContain("unspecified-high")
+    expect(text).toContain("artistry")
+    expect(text).toContain("ultrabrain")
+    expect(text).toContain("deep")
+    expect(text).toContain("only if")
+    expect(text).toContain("enabled")
+    expect(text).toContain("refactor the auth module")
+    expect(text).toContain("---")
   })
 
   test("should inject hyperplan message when user types 'hpp' shorthand", async () => {
@@ -77,10 +86,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan injection should fire
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-mode>")
-    expect(textPart!.text).toContain('skill(name="hyperplan")')
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-mode>")
+    expect(text).toContain('skill(name="hyperplan")')
   })
 
   test("should inject hyperplan message case-insensitively", async () => {
@@ -97,9 +105,8 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan should still fire
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-mode>")
   })
 
   test("should NOT trigger hyperplan when 'hpp' is a substring of another word", async () => {
@@ -116,10 +123,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan should NOT trigger because 'hpp' lacks word boundaries
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("myhppvar = 1")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("myhppvar = 1")
+    expect(text).not.toContain("<hyperplan-mode>")
   })
 
   test("should NOT trigger hyperplan when 'hpp' is the extension of a C++ header path", async () => {
@@ -136,10 +142,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan must NOT fire just because '.hpp' appears as a file extension
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("please help to check interface.hpp")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("please help to check interface.hpp")
+    expect(text).not.toContain("<hyperplan-mode>")
   })
 
   test("should NOT trigger hyperplan when path-like '.hpp' appears in a deeper file path", async () => {
@@ -156,10 +161,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan must not fire (the trailing '.hpp' is a header extension, not the trigger)
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
-    expect(textPart!.text).not.toContain('skill(name="hyperplan")')
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-mode>")
+    expect(text).not.toContain('skill(name="hyperplan")')
   })
 
   test("should fire 'Hyperplan Mode Activated' toast when keyword detected", async () => {
@@ -200,10 +204,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - neither injection nor toast should occur
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("hyperplan refactor this")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("hyperplan refactor this")
+    expect(text).not.toContain("<hyperplan-mode>")
     expect(toastCalls).not.toContain("Hyperplan Mode Activated")
   })
 
@@ -222,10 +225,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID: subagentSessionID }, output)
 
     // then - hyperplan injection should be skipped in non-main session
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("hyperplan please")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("hyperplan please")
+    expect(text).not.toContain("<hyperplan-mode>")
   })
 
   test("should skip hyperplan injection when agent is prometheus (planner)", async () => {
@@ -241,11 +243,10 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID, agent: "prometheus" }, output)
 
     // then - hyperplan should be filtered out for planner agents
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
-    expect(textPart!.text).not.toContain('skill(name="hyperplan")')
-    expect(textPart!.text).toContain("hyperplan refactor stuff")
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-mode>")
+    expect(text).not.toContain('skill(name="hyperplan")')
+    expect(text).toContain("hyperplan refactor stuff")
   })
 
   test("should NOT inject hyperplan when user invokes /hyperplan slash command", async () => {
@@ -263,10 +264,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - the slash command path owns the message; keyword detector must not double-inject
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("/hyperplan refactor the auth module")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("/hyperplan refactor the auth module")
+    expect(text).not.toContain("<hyperplan-mode>")
     expect(toastCalls).not.toContain("Hyperplan Mode Activated")
   })
 
@@ -284,10 +284,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - keyword detector should yield to the slash command system
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toBe("/hpp investigate the build pipeline")
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toBe("/hpp investigate the build pipeline")
+    expect(text).not.toContain("<hyperplan-mode>")
   })
 
   test("should still inject hyperplan when slash appears mid-message (not a slash command)", async () => {
@@ -304,9 +303,8 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID }, output)
 
     // then - hyperplan should still fire (this is a real keyword invocation, not a slash command)
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).toContain("<hyperplan-mode>")
+    const text = textOf(output)
+    expect(text).toContain("<hyperplan-mode>")
   })
 
   test("should skip hyperplan injection when agent name contains 'planner' token", async () => {
@@ -322,10 +320,9 @@ describe("keyword-detector hyperplan keyword", () => {
     await hook["chat.message"]({ sessionID, agent: "Plan Agent" }, output)
 
     // then - hyperplan should be filtered out
-    const textPart = output.parts.find(p => p.type === "text")
-    expect(textPart).toBeDefined()
-    expect(textPart!.text).not.toContain("<hyperplan-mode>")
-    expect(textPart!.text).not.toContain('skill(name="hyperplan")')
-    expect(textPart!.text).toContain("hpp build the feature")
+    const text = textOf(output)
+    expect(text).not.toContain("<hyperplan-mode>")
+    expect(text).not.toContain('skill(name="hyperplan")')
+    expect(text).toContain("hpp build the feature")
   })
 })


### PR DESCRIPTION
## Summary
- replace hyperplan text-part non-null assertions with typed text extraction
- preserve the existing text-part existence assertion count inside the helper
- align hyperplan mock setup with the existing unsafeTestValue test helper

## Manual QA
- bun test src/hooks/keyword-detector/hyperplan.test.ts src/hooks/keyword-detector/hyperplan-ultrawork.test.ts (24 pass, 93 expect calls)
- bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/keyword-detector/hyperplan.test.ts src/hooks/keyword-detector/hyperplan-ultrawork.test.ts
- git diff --check
- bun run typecheck
- bun test
- bun run build

## LOC
- hyperplan.test.ts pure LOC: 243 -> 239
- hyperplan-ultrawork.test.ts pure LOC: 198 -> 197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened hyperplan keyword-detector tests by replacing non-null text-part access with a typed `textOf` helper and aligning mock setup with `unsafeTestValue` for safer, clearer assertions without changing behavior.

- **Refactors**
  - Introduced `textOf` to validate and extract the text part while preserving the assertion count.
  - Replaced direct `textPart!` checks with `textOf` in `hyperplan.test.ts` and `hyperplan-ultrawork.test.ts`.
  - Updated mock `PluginInput` creation to use `unsafeTestValue` to match existing test helpers.
  - Small LOC reduction; no functional changes.

<sup>Written for commit af752004ad75c6a9c1978ff3bbc65981d4a683b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

