### PR TITLE
test(keyword-detector): remove ralph loop non-null assertions

### DIFF
--- a/src/hooks/keyword-detector/hook-ralph-loop.test.ts
+++ b/src/hooks/keyword-detector/hook-ralph-loop.test.ts
@@ -190,9 +190,9 @@ describe("keyword-detector ultrawork routing", () => {
     await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
 
     // then
-    const textPart = output.parts.find((p) => p.type === "text")
-    expect(textPart!.text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
-    expect(textPart!.text).toContain("do this")
+    const text = output.parts.find((p) => p.type === "text")?.text
+    expect(text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
+    expect(text).toContain("do this")
   })
 
   test("#given partial 'ulw' substring in StatefulWidget #when chat.message fires #then ralph-loop startLoop is not invoked", async () => {
@@ -251,9 +251,9 @@ The system mentions ulw mode in passing.
     await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
 
     // then
-    const textPart = output.parts.find((p) => p.type === "text")
-    expect(textPart!.text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
-    expect(textPart!.text).toContain("refactor the codebase")
+    const text = output.parts.find((p) => p.type === "text")?.text
+    expect(text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
+    expect(text).toContain("refactor the codebase")
     expect(startLoopCalls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
Removes no-excuse non-null assertion patterns from `src/hooks/keyword-detector/hook-ralph-loop.test.ts` only.

The cleanup preserves Ralph-loop keyword routing behavior and keeps the focused test assertion count unchanged at 20 `expect()` calls.

## Changes
- Replaces two `textPart!.text` lookup uses with optional-chained text lookup.
- Leaves all existing `toContain` behavior assertions intact.
- Does not touch any other keyword-detector tests.

## Manual QA
- `bun test src/hooks/keyword-detector/hook-ralph-loop.test.ts` passed: 11 tests, 20 expect calls.
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/keyword-detector/hook-ralph-loop.test.ts` passed.
- `git diff --check` passed.
- `bun run typecheck` passed.
- `bun test` passed.
- `bun run build` passed.

## Duplicate PR Check
- `gh pr list --state all --search "hook-ralph-loop.test.ts"` showed no dedicated open cleanup PR for this file.