### PR TITLE
test(keyword-detector): remove ralph-loop non-null assertions

### DIFF
--- a/src/hooks/keyword-detector/hook-ralph-loop.test.ts
+++ b/src/hooks/keyword-detector/hook-ralph-loop.test.ts
@@ -190,9 +190,9 @@ describe("keyword-detector ultrawork routing", () => {
     await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
 
     // then
-    const textPart = output.parts.find((p) => p.type === "text")
-    expect(textPart!.text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
-    expect(textPart!.text).toContain("do this")
+    const textPartText = output.parts.find((p) => p.type === "text")?.text ?? ""
+    expect(textPartText).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
+    expect(textPartText).toContain("do this")
   })
 
   test("#given partial 'ulw' substring in StatefulWidget #when chat.message fires #then ralph-loop startLoop is not invoked", async () => {
@@ -251,9 +251,9 @@ The system mentions ulw mode in passing.
     await hook["chat.message"]({ sessionID: "main-session", agent: "sisyphus" }, output)
 
     // then
-    const textPart = output.parts.find((p) => p.type === "text")
-    expect(textPart!.text).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
-    expect(textPart!.text).toContain("refactor the codebase")
+    const textPartText = output.parts.find((p) => p.type === "text")?.text ?? ""
+    expect(textPartText).toContain("YOU MUST LEVERAGE ALL AVAILABLE AGENTS")
+    expect(textPartText).toContain("refactor the codebase")
     expect(startLoopCalls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- Replaced two `textPart!.text` test assertions with optional text extraction in `hook-ralph-loop.test.ts`.
- Preserved the focused test assertion count at 20 while removing the four postfix non-null assertions.

## Verification
- `bun test src/hooks/keyword-detector/hook-ralph-loop.test.ts`
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/keyword-detector/hook-ralph-loop.test.ts`
- `git diff --check`
- LSP diagnostics on changed file: no diagnostics
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed non-null assertions in `hook-ralph-loop.test.ts` by safely reading the text part with `?.text ?? ""`. This avoids undefined access while keeping test behavior and the 20 focused assertions unchanged.

<sup>Written for commit 8c927a1e2ada635a5e20fbc81faecbfead84af21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

