### PR TITLE
test(ralph-loop): remove unsafe state assertions

### DIFF
--- a/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
+++ b/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
@@ -17,6 +17,14 @@ describe("ralph-loop dispatch failure invariants", () => {
 	let messagesCalls: Array<{ sessionID: string }>
 	let createSessionCalls: Array<{ parentID: string }>
 
+	function requireState(state: RalphLoopState | null): RalphLoopState {
+		expect(state).not.toBeNull()
+		if (state === null) {
+			throw new Error("Expected ralph loop state")
+		}
+		return state
+	}
+
 	beforeEach(() => {
 		promptCalls = []
 		toastCalls = []
@@ -220,7 +228,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
 		writeState(testDirectory, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			iteration: 2,
 			verification_pending: true,
 			verification_session_id: "ses-oracle",
@@ -228,7 +236,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 			initial_completion_promise: "DONE",
 		})
 		writeState(testDirectory, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -292,7 +300,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 
 		hook.startLoop("session-123", "Build API", { ultrawork: true })
 		writeState(testDirectory, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			iteration: 2,
 			verification_pending: true,
 			verification_session_id: "ses-oracle",
@@ -411,7 +419,7 @@ describe("ralph-loop dispatch failure invariants", () => {
 			event: { type: "session.idle", properties: { sessionID: "session-A" } },
 		})
 		await new Promise((resolve) => setTimeout(resolve, 10))
-		writeState(testDirectory, { ...hook.getState()!, session_id: "session-B" })
+		writeState(testDirectory, { ...requireState(hook.getState()), session_id: "session-B" })
 		await eventPromise
 
 		// then

--- a/src/hooks/ralph-loop/ulw-loop-verification.test.ts
+++ b/src/hooks/ralph-loop/ulw-loop-verification.test.ts
@@ -6,6 +6,7 @@ import { createRalphLoopHook } from "./index"
 import { ULTRAWORK_VERIFICATION_PROMISE } from "./constants"
 import { clearState, writeState } from "./storage"
 import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import type { RalphLoopState } from "./types"
 
 describe("ulw-loop verification", () => {
 	const testDir = join(tmpdir(), `ulw-loop-verification-${Date.now()}`)
@@ -41,6 +42,14 @@ describe("ulw-loop verification", () => {
 			},
 			directory: testDir,
 		})
+	}
+
+	function requireState(state: RalphLoopState | null): RalphLoopState {
+		expect(state).not.toBeNull()
+		if (state === null) {
+			throw new Error("Expected ralph loop state")
+		}
+		return state
 	}
 
 	beforeEach(() => {
@@ -96,7 +105,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -122,7 +131,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -148,7 +157,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -203,7 +212,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -251,7 +260,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -352,7 +361,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle-old",
 		})
 		hook.startLoop("session-456", "Ship CLI", { ultrawork: true })
@@ -381,7 +390,7 @@ describe("ulw-loop verification", () => {
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle-old",
 		})
 		hook.startLoop("session-123", "Restarted task", { ultrawork: true })
@@ -542,7 +551,7 @@ session_id: ses-oracle
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -582,7 +591,7 @@ session_id: ses-oracle
 
 		await hook.event({ event: { type: "session.idle", properties: { sessionID: "session-123" } } })
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle",
 		})
 		writeFileSync(
@@ -598,7 +607,7 @@ session_id: ses-oracle
 			`${JSON.stringify({ type: "assistant", timestamp: new Date().toISOString(), content: "fixed it <promise>DONE</promise>" })}\n`,
 		)
 		writeState(testDir, {
-			...hook.getState()!,
+			...requireState(hook.getState()),
 			verification_session_id: "ses-oracle-old",
 		})
 


### PR DESCRIPTION
## Summary
- replace Ralph-loop test non-null assertions with typed state narrowing helpers
- keep the same state writes and behavior assertions while satisfying no-excuse rules

## Manual QA
- bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/ralph-loop/ulw-loop-verification.test.ts src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
- bun test src/hooks/ralph-loop/ulw-loop-verification.test.ts src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
- git diff --check
- bun run typecheck
- bun run build
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe `getState()!` assertions in Ralph-loop tests with a `requireState` helper that narrows to `RalphLoopState`. This removes unsafe assertions and keeps test behavior unchanged while satisfying no-excuse rules.

- **Refactors**
  - Added `requireState(state: RalphLoopState | null): RalphLoopState` in tests to replace non-null assertions.
  - Updated `dispatch-failure-invariant.test.ts` and `ulw-loop-verification.test.ts` to use `...requireState(hook.getState())` in `writeState` calls.

<sup>Written for commit 74e804130d9451f862c7fa51bc1634538096e473. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

