### PR TITLE
test: remove unsafe no-excuse patterns

### DIFF
--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -168,40 +168,26 @@ describe("run environment setup", () => {
 describe("run with invalid model", () => {
   it("given invalid --model value, when run, then returns exit code 1 with error message", async () => {
     // given
-    const originalExit = process.exit
     const originalError = console.error
     const errorMessages: string[] = []
-    const exitCodes: number[] = []
 
     console.error = (...args: unknown[]) => {
       errorMessages.push(args.map(String).join(" "))
     }
-    process.exit = ((code?: number) => {
-      exitCodes.push(code ?? 0)
-      throw new Error("exit")
-    }) as typeof process.exit
 
     try {
       // when
-      // Note: This will actually try to run - but the issue is that resolveRunModel
-      // is called BEFORE the try block, so it throws an unhandled exception
-      // We're testing the runner's error handling
       const { run } = await import("./runner")
+      const exitCode = await run({
+        message: "test",
+        model: "invalid",
+      })
 
-      // This will throw because model "invalid" is invalid format
-      try {
-        await run({
-          message: "test",
-          model: "invalid",
-        })
-      } catch {
-        // Expected to potentially throw due to unhandled model resolution error
-      }
+      // then
+      expect(exitCode).toBe(1)
+      expect(errorMessages.join("\n")).toContain("Model string must be in 'provider/model' format")
     } finally {
-      // then - verify error handling
-      // Currently this will fail because the error is not caught properly
       console.error = originalError
-      process.exit = originalExit
     }
   })
 })

--- a/src/hooks/atlas/system-reminder-templates.test.ts
+++ b/src/hooks/atlas/system-reminder-templates.test.ts
@@ -7,11 +7,37 @@ import {
   VERIFICATION_REMINDER_GEMINI,
 } from "./system-reminder-templates"
 
+function requireContinuationRulesSection(): string {
+  const rulesSection = BOULDER_CONTINUATION_PROMPT.split("RULES:")[1]
+  expect(rulesSection).toBeDefined()
+  if (rulesSection === undefined) {
+    throw new Error("Expected boulder continuation rules section")
+  }
+  return rulesSection
+}
+
+function requireFirstRule(rulesSection: string): string {
+  const firstRule = rulesSection.split("\n")[1]
+  expect(firstRule).toBeDefined()
+  if (firstRule === undefined) {
+    throw new Error("Expected first boulder continuation rule")
+  }
+  return firstRule.trim()
+}
+
+function requireMatchIndex(match: RegExpMatchArray | null, label: string): number {
+  expect(match).not.toBeNull()
+  if (match === null || match.index === undefined) {
+    throw new Error(`Expected ${label} match index`)
+  }
+  return match.index
+}
+
 describe("BOULDER_CONTINUATION_PROMPT", () => {
   describe("checkbox-first priority rules", () => {
     it("first rule after RULES: mentions both reading the plan AND marking a still-unchecked completed task", () => {
-      const rulesSection = BOULDER_CONTINUATION_PROMPT.split("RULES:")[1]!
-      const firstRule = rulesSection.split("\n")[1]!.trim()
+      const rulesSection = requireContinuationRulesSection()
+      const firstRule = requireFirstRule(rulesSection)
 
       expect(firstRule).toContain("Read the plan")
       expect(firstRule).toContain("mark")
@@ -19,23 +45,20 @@ describe("BOULDER_CONTINUATION_PROMPT", () => {
     })
 
     it("first rule includes IMMEDIATELY keyword", () => {
-      const rulesSection = BOULDER_CONTINUATION_PROMPT.split("RULES:")[1]!
-      const firstRule = rulesSection.split("\n")[1]!.trim()
+      const rulesSection = requireContinuationRulesSection()
+      const firstRule = requireFirstRule(rulesSection)
 
       expect(firstRule).toContain("IMMEDIATELY")
     })
 
     it("checkbox-marking guidance appears BEFORE Proceed without asking for permission", () => {
-      const rulesSection = BOULDER_CONTINUATION_PROMPT.split("RULES:")[1]!
+      const rulesSection = requireContinuationRulesSection()
 
       const checkboxMarkingMatch = rulesSection.match(/- \[x\]/i)
       const proceedMatch = rulesSection.match(/Proceed without asking for permission/)
 
-      expect(checkboxMarkingMatch).not.toBeNull()
-      expect(proceedMatch).not.toBeNull()
-
-      const checkboxPosition = checkboxMarkingMatch!.index ?? -1
-      const proceedPosition = proceedMatch!.index ?? -1
+      const checkboxPosition = requireMatchIndex(checkboxMarkingMatch, "checkbox marking")
+      const proceedPosition = requireMatchIndex(proceedMatch, "proceed guidance")
 
       expect(checkboxPosition).toBeLessThan(proceedPosition)
     })

--- a/src/hooks/read-image-resizer/png-fallback-resizer.test.ts
+++ b/src/hooks/read-image-resizer/png-fallback-resizer.test.ts
@@ -173,10 +173,13 @@ describe("resizeImageFallback", () => {
 
       //#then
       expect(result).not.toBeNull()
-      expect(result?.original).toEqual({ width: 2000, height: 1500 })
-      expect(result?.resized).toEqual({ width: 1568, height: 1176 })
+      if (result === null) {
+        throw new Error("Expected resized image result")
+      }
+      expect(result.original).toEqual({ width: 2000, height: 1500 })
+      expect(result.resized).toEqual({ width: 1568, height: 1176 })
 
-      const parsed = parseImageDimensions(result!.resizedDataUrl, "image/png")
+      const parsed = parseImageDimensions(result.resizedDataUrl, "image/png")
       expect(parsed).toEqual({ width: 1568, height: 1176 })
     })
 
@@ -189,7 +192,10 @@ describe("resizeImageFallback", () => {
 
       //#then
       expect(result).not.toBeNull()
-      const parsed = parseImageDimensions(result!.resizedDataUrl, "image/png")
+      if (result === null) {
+        throw new Error("Expected resized image result")
+      }
+      const parsed = parseImageDimensions(result.resizedDataUrl, "image/png")
       expect(parsed).toEqual({ width: 100, height: 100 })
     })
 

--- a/src/tools/grep/downloader.test.ts
+++ b/src/tools/grep/downloader.test.ts
@@ -86,7 +86,10 @@ describe("findFileRecursive", () => {
 
     // then
     expect(result).not.toBeNull()
-    expect(result!.endsWith("rg")).toBe(true)
+    if (result === null) {
+      throw new Error("Expected recursive file lookup result")
+    }
+    expect(result.endsWith("rg")).toBe(true)
   })
 
   test("should match exact filename, not partial", () => {


### PR DESCRIPTION
## Summary
- Replace unsafe non-null assertions in Atlas prompt and PNG fallback tests with explicit narrowing helpers.
- Replace the CLI runner invalid-model swallow test with observable exit-code and stderr assertions.
- Narrow the grep downloader recursive lookup assertion without postfix non-null assertion.

## Manual QA
- bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/run/runner.test.ts src/hooks/atlas/system-reminder-templates.test.ts src/hooks/read-image-resizer/png-fallback-resizer.test.ts src/tools/grep/downloader.test.ts
- bun test src/cli/run/runner.test.ts src/hooks/atlas/system-reminder-templates.test.ts src/hooks/read-image-resizer/png-fallback-resizer.test.ts src/tools/grep/downloader.test.ts
- git diff --check
- bun run typecheck
- bun run build
- bun test

## Notes
- Exact open-PR file overlap was checked before push.
- Dropped plugin-config.test.ts, plugin/event.test.ts, and src/tools/skill/zauc-mocks-skill-tools/tools.test.ts from this branch because active PRs already touch them.
- src/hooks/prometheus-md-only/index.test.ts has a pre-existing failing boulder-state priority test, so I left that file untouched for a separate fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe non-null assertions in tests and replaced them with explicit guards, plus updated the CLI invalid model test to assert exit code 1 and error output for more reliable coverage.

- **Refactors**
  - Atlas reminder prompt tests: add helpers to narrow the rules section, first rule, and match indices.
  - PNG fallback resizer tests: guard nulls before accessing resized results; parse dimensions from safe values.
  - CLI runner invalid-model test: assert returned exit code and stderr content instead of stubbing `process.exit`.
  - Grep downloader test: validate recursive lookup with explicit null checks.

<sup>Written for commit 419fc85d1c759f751048474f36c18124787890a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

