### PR TITLE
test(cli): remove unsafe run output assertions

### DIFF
--- a/src/cli/run/integration.test.ts
+++ b/src/cli/run/integration.test.ts
@@ -53,6 +53,15 @@ function createMockWriteStream(): MockWriteStream {
   }
 }
 
+function requireWrite(stream: MockWriteStream, index: number): string {
+  const value = stream.writes[index]
+  expect(value).toBeDefined()
+  if (value === undefined) {
+    throw new Error(`Expected write at index ${index}`)
+  }
+  return value
+}
+
 const createMockClient = (
   getResult?: { error?: unknown; data?: { id: string } }
 ): OpencodeClient => (unsafeTestValue<OpencodeClient>({
@@ -86,7 +95,7 @@ describe("integration: --json mode", () => {
 
     // then
     expect(mockStdout.writes).toHaveLength(1)
-    const emitted = mockStdout.writes[0]!
+    const emitted = requireWrite(mockStdout, 0)
     expect(() => JSON.parse(emitted)).not.toThrow()
     const parsed = JSON.parse(emitted) as RunResult
     expect(parsed.sessionId).toBe("test-session")
@@ -289,7 +298,7 @@ describe("integration: option combinations", () => {
 
     // then - json emits result AND on-complete hook runs
     expect(mockStdout.writes).toHaveLength(1)
-    const emitted = mockStdout.writes[0]!
+    const emitted = requireWrite(mockStdout, 0)
     expect(() => JSON.parse(emitted)).not.toThrow()
     expect(spawnSpy).toHaveBeenCalledTimes(1)
     const [args] = spawnSpy.mock.calls[0] as Parameters<typeof spawnWithWindowsHideModule.spawnWithWindowsHide>

--- a/src/cli/run/json-output.test.ts
+++ b/src/cli/run/json-output.test.ts
@@ -19,6 +19,15 @@ function createMockWriteStream(): MockWriteStream {
   return stream
 }
 
+function requireWrite(stream: MockWriteStream, index: number): string {
+  const value = stream.writes[index]
+  expect(value).toBeDefined()
+  if (value === undefined) {
+    throw new Error(`Expected write at index ${index}`)
+  }
+  return value
+}
+
 describe("createJsonOutputManager", () => {
   let mockStdout: MockWriteStream
   let mockStderr: MockWriteStream
@@ -85,7 +94,7 @@ describe("createJsonOutputManager", () => {
 
       // then
       expect(mockStdout.writes).toHaveLength(1)
-      const emitted = mockStdout.writes[0]!
+      const emitted = requireWrite(mockStdout, 0)
       expect(() => JSON.parse(emitted)).not.toThrow()
     })
 
@@ -107,7 +116,7 @@ describe("createJsonOutputManager", () => {
       manager.emitResult(result)
 
       // then
-      const emitted = mockStdout.writes[0]!
+      const emitted = requireWrite(mockStdout, 0)
       const parsed = JSON.parse(emitted) as RunResult
       expect(parsed).toEqual(result)
       expect(parsed.sessionId).toBe("test-session")
@@ -137,7 +146,7 @@ describe("createJsonOutputManager", () => {
 
       // then
       expect(mockStdout.writes).toHaveLength(1)
-      expect(mockStdout.writes[0]!).toBe(JSON.stringify(result) + "\n")
+      expect(requireWrite(mockStdout, 0)).toBe(JSON.stringify(result) + "\n")
 
       mockStdout.write("after emit")
       expect(mockStdout.writes).toHaveLength(2)


### PR DESCRIPTION
## Summary
- replace postfix non-null assertions in cli run JSON/integration tests with explicit write guards
- keep behavior assertions unchanged while making missing writes fail with a targeted error
- exclude `timestamp-output.test.ts` from this PR because open PR #2907 already edits the same lines

## Manual QA
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/run/integration.test.ts src/cli/run/json-output.test.ts`
- `bun test src/cli/run/integration.test.ts src/cli/run/json-output.test.ts` (14 pass, 0 fail)
- `git diff --check`
- `bun run typecheck`
- `bun run build`
- `bun test` (full suite exit 0)

## Overlap Check
- checked open PRs matching cli run test filenames
- #2907 overlaps `src/cli/run/timestamp-output.test.ts`, so this PR does not modify that file


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe non-null assertions in CLI run JSON/integration tests with an explicit write guard to make missing stream writes fail clearly. No behavior changes; timestamp-output test is intentionally untouched to avoid overlap with concurrent changes.

- **Refactors**
  - Added `requireWrite` helper to assert and read stream writes by index.
  - Updated `integration.test.ts` and `json-output.test.ts` to use it instead of postfix `!`.

<sup>Written for commit 6d39b2a1e5cb4819d5564665bc677ea26be2476e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/4999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

