### PR TITLE
test: remove schema catch probes

### DIFF
--- a/src/config/schema/background-task-circuit-breaker.test.ts
+++ b/src/config/schema/background-task-circuit-breaker.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test"
-import { ZodError } from "zod"
 import { BackgroundTaskConfigSchema } from "./background-task"
 
 describe("BackgroundTaskConfigSchema.circuitBreaker", () => {
@@ -19,38 +18,26 @@ describe("BackgroundTaskConfigSchema.circuitBreaker", () => {
   })
 
   describe("#given consecutiveThreshold below minimum", () => {
-    test("#when parsed #then throws ZodError", () => {
-      let thrownError: unknown
+    test("#when parsed #then reports schema failure", () => {
+      const result = BackgroundTaskConfigSchema.safeParse({
+        circuitBreaker: {
+          consecutiveThreshold: 4,
+        },
+      })
 
-      try {
-        BackgroundTaskConfigSchema.parse({
-          circuitBreaker: {
-            consecutiveThreshold: 4,
-          },
-        })
-      } catch (error) {
-        thrownError = error
-      }
-
-      expect(thrownError).toBeInstanceOf(ZodError)
+      expect(result.success).toBe(false)
     })
   })
 
   describe("#given consecutiveThreshold is zero", () => {
-    test("#when parsed #then throws ZodError", () => {
-      let thrownError: unknown
+    test("#when parsed #then reports schema failure", () => {
+      const result = BackgroundTaskConfigSchema.safeParse({
+        circuitBreaker: {
+          consecutiveThreshold: 0,
+        },
+      })
 
-      try {
-        BackgroundTaskConfigSchema.parse({
-          circuitBreaker: {
-            consecutiveThreshold: 0,
-          },
-        })
-      } catch (error) {
-        thrownError = error
-      }
-
-      expect(thrownError).toBeInstanceOf(ZodError)
+      expect(result.success).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary
- replace broad try/catch probes in `background-task-circuit-breaker.test.ts` with `safeParse` schema-failure assertions
- remove the now-unused `ZodError` import
- narrowed this PR to avoid overlap with open PR #4218, which also edits `background-task.test.ts`

## Manual QA
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/config/schema/background-task-circuit-breaker.test.ts`
- `bun test src/config/schema/background-task-circuit-breaker.test.ts` (3 pass, 0 fail)
- `git diff --check origin/dev...HEAD`
- `bun run typecheck`
- `bun run build`
- `bun test`

## Overlap Check
- `#4218` touches `src/config/schema/background-task.test.ts`; this PR no longer modifies that file
- no remaining open PR exact-file overlap found for `src/config/schema/background-task-circuit-breaker.test.ts`
