### PR TITLE
test(team-mode): remove catch-based rejection assertions

### DIFF
--- a/src/features/team-mode/team-mailbox/send.test.ts
+++ b/src/features/team-mode/team-mailbox/send.test.ts
@@ -76,12 +76,7 @@ describe("sendMessage", () => {
     const result = sendMessage(message, randomUUID(), config, { isLead: false, activeMembers: ["m1"] })
 
     // then
-    try {
-      await result
-      throw new Error("expected sendMessage to reject")
-    } catch (error) {
-      expect(error).toBeInstanceOf(PayloadTooLargeError)
-    }
+    await expect(result).rejects.toBeInstanceOf(PayloadTooLargeError)
   })
 
   test("rejects sends when recipient unread bytes exceed the backpressure limit", async () => {
@@ -97,12 +92,7 @@ describe("sendMessage", () => {
     const result = sendMessage(createMessage(), teamRunId, config, { isLead: false, activeMembers: ["m1"] })
 
     // then
-    try {
-      await result
-      throw new Error("expected sendMessage to reject")
-    } catch (error) {
-      expect(error).toBeInstanceOf(RecipientBackpressureError)
-    }
+    await expect(result).rejects.toBeInstanceOf(RecipientBackpressureError)
   })
 
   test("counts in-flight .delivering-* reservations toward recipient backpressure", async () => {
@@ -123,12 +113,7 @@ describe("sendMessage", () => {
     const result = sendMessage(createMessage(), teamRunId, config, { isLead: false, activeMembers: ["m1"] })
 
     // then
-    try {
-      await result
-      throw new Error("expected sendMessage to reject")
-    } catch (error) {
-      expect(error).toBeInstanceOf(RecipientBackpressureError)
-    }
+    await expect(result).rejects.toBeInstanceOf(RecipientBackpressureError)
   })
 
   test("rejects duplicate message ids for the same recipient", async () => {
@@ -143,12 +128,7 @@ describe("sendMessage", () => {
     const result = sendMessage(message, teamRunId, config, { isLead: false, activeMembers: ["m1"] })
 
     // then
-    try {
-      await result
-      throw new Error("expected sendMessage to reject")
-    } catch (error) {
-      expect(error).toBeInstanceOf(DuplicateMessageIdError)
-    }
+    await expect(result).rejects.toBeInstanceOf(DuplicateMessageIdError)
   })
 
   test("gates broadcasts to leads and fans out to each active member", async () => {
@@ -169,12 +149,7 @@ describe("sendMessage", () => {
     })
 
     // then
-    try {
-      await rejectedSend
-      throw new Error("expected sendMessage to reject")
-    } catch (error) {
-      expect(error).toBeInstanceOf(BroadcastNotPermittedError)
-    }
+    await expect(rejectedSend).rejects.toBeInstanceOf(BroadcastNotPermittedError)
 
     expect(await deliveredSend).toEqual({
       messageId: broadcastMessage.messageId,

--- a/src/features/team-mode/team-registry/paths.test.ts
+++ b/src/features/team-mode/team-registry/paths.test.ts
@@ -148,22 +148,21 @@ describe("paths", () => {
     logCalls.splice(0)
 
     // when
-    let thrown: unknown = null
-    try {
-      await ensureBaseDirsWithMockedChmod(baseDir)
-    } catch (error) {
-      thrown = error
-    }
+    const ensuredBaseDirectories = ensureBaseDirsWithMockedChmod(baseDir)
 
     // then: function does not throw, EPERM was reached, and one warning was logged.
-    expect(thrown).toBeNull()
+    await expect(ensuredBaseDirectories).resolves.toBeUndefined()
     expect(chmodCalls).toBeGreaterThan(0)
     const warnings = logCalls.filter(([message]) =>
       message === "team-mode: chmod refused on base directory; continuing with existing permissions"
     )
     expect(warnings.length).toBeGreaterThan(0)
-    const firstWarning = warnings[0]?.[1] as { code?: string; path?: string } | undefined
-    expect(firstWarning?.code).toBe("EPERM")
-    expect(firstWarning?.path).toContain(baseDir)
+    const firstWarning = warnings[0]?.[1]
+    expect(firstWarning).toBeObject()
+    if (typeof firstWarning !== "object" || firstWarning === null) {
+      throw new Error("expected warning metadata")
+    }
+    expect("code" in firstWarning ? firstWarning.code : undefined).toBe("EPERM")
+    expect("path" in firstWarning ? firstWarning.path : undefined).toContain(baseDir)
   })
 })

--- a/src/features/team-mode/team-tasklist/claim.test.ts
+++ b/src/features/team-mode/team-tasklist/claim.test.ts
@@ -51,15 +51,10 @@ test("claimTask rejects blocked tasks until blockers complete", async () => {
     )
 
     // when
-    let blockedError: unknown = null
-    try {
-      await claimTask(fixture.teamRunId, blockedTask.id, "member-a", fixture.config)
-    } catch (error) {
-      blockedError = error
-    }
+    const blockedClaim = claimTask(fixture.teamRunId, blockedTask.id, "member-a", fixture.config)
 
     // then
-    expect(blockedError).toBeInstanceOf(BlockedByError)
+    await expect(blockedClaim).rejects.toBeInstanceOf(BlockedByError)
 
     // given
     await claimTask(fixture.teamRunId, blockerTask.id, "member-b", fixture.config)
@@ -81,11 +76,11 @@ test("claimTask reaps a stale claim lock before claiming", async () => {
   // given
   const fixture = await createTasklistFixture()
 
-    try {
-      const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
-      const tasksDirectory = getTasksDir(resolveBaseDir(fixture.config), fixture.teamRunId)
-      const staleLockPath = path.join(tasksDirectory, "claims", `${task.id}.lock`)
-      await writeFile(staleLockPath, `member-z\n999999\n${Date.now() - 600_000}\n`)
+  try {
+    const task = await createTask(fixture.teamRunId, createTaskInput(), fixture.config)
+    const tasksDirectory = getTasksDir(resolveBaseDir(fixture.config), fixture.teamRunId)
+    const staleLockPath = path.join(tasksDirectory, "claims", `${task.id}.lock`)
+    await writeFile(staleLockPath, `member-z\n999999\n${Date.now() - 600_000}\n`)
 
     // when
     const claimedTask = await claimTask(fixture.teamRunId, task.id, "member-a", fixture.config)

--- a/src/features/team-mode/team-tasklist/get.test.ts
+++ b/src/features/team-mode/team-tasklist/get.test.ts
@@ -29,16 +29,10 @@ test("getTask throws when the task file is missing", async () => {
 
   try {
     // when
-    let thrownError: unknown = null
-
-    try {
-      await getTask(fixture.teamRunId, "999", fixture.config)
-    } catch (error) {
-      thrownError = error
-    }
+    const loadedTask = getTask(fixture.teamRunId, "999", fixture.config)
 
     // then
-    expect(thrownError).toBeInstanceOf(Error)
+    await expect(loadedTask).rejects.toBeInstanceOf(Error)
   } finally {
     await fixture.cleanup()
   }

--- a/src/features/team-mode/team-tasklist/update.test.ts
+++ b/src/features/team-mode/team-tasklist/update.test.ts
@@ -64,16 +64,14 @@ test("updateTaskStatus rejects reverse transitions", async () => {
     )
 
     // when
-    let thrownError: unknown = null
-    try {
-      await updateTaskStatus(fixture.teamRunId, task.id, "claimed", "member-a", fixture.config)
-    } catch (error) {
-      thrownError = error
-    }
+    const reversedTransition = updateTaskStatus(fixture.teamRunId, task.id, "claimed", "member-a", fixture.config)
 
     // then
-    expect(thrownError).toBeInstanceOf(InvalidTaskTransitionError)
-    expect(thrownError).toHaveProperty("message", "no reverse transitions from completed to claimed")
+    await expect(reversedTransition).rejects.toBeInstanceOf(InvalidTaskTransitionError)
+    await expect(reversedTransition).rejects.toHaveProperty(
+      "message",
+      "no reverse transitions from completed to claimed",
+    )
   } finally {
     await fixture.cleanup()
   }
@@ -91,15 +89,10 @@ test("updateTaskStatus rejects non-owner updates except deletion", async () => {
     )
 
     // when
-    let crossOwnerError: unknown = null
-    try {
-      await updateTaskStatus(fixture.teamRunId, task.id, "in_progress", "member-b", fixture.config)
-    } catch (error) {
-      crossOwnerError = error
-    }
+    const crossOwnerUpdate = updateTaskStatus(fixture.teamRunId, task.id, "in_progress", "member-b", fixture.config)
 
     // then
-    expect(crossOwnerError).toBeInstanceOf(CrossOwnerUpdateError)
+    await expect(crossOwnerUpdate).rejects.toBeInstanceOf(CrossOwnerUpdateError)
 
     // when
     const deletedTask = await updateTaskStatus(fixture.teamRunId, task.id, "deleted", "lead-member", fixture.config)


### PR DESCRIPTION
## Summary
Removes catch-without-narrowing patterns from scoped team-mode tests by using Bun's rejected/resolved promise assertions instead.

## Changes
- Converted team mailbox rejection checks to `await expect(...).rejects` assertions.
- Converted team tasklist rejection checks to rejected promise assertions while preserving cleanup behavior.
- Converted the team registry chmod no-throw check to a resolved promise assertion and narrowed warning metadata before inspecting it.

## Overlap Check
- Open PR exact-file scan: no overlap for the five scoped files.
- Recently merged PR exact-file scan: no overlap for the five scoped files.

## Testing
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/team-mode/team-mailbox/send.test.ts src/features/team-mode/team-tasklist/claim.test.ts src/features/team-mode/team-tasklist/get.test.ts src/features/team-mode/team-tasklist/update.test.ts src/features/team-mode/team-registry/paths.test.ts` passed.
- `bun test src/features/team-mode/team-mailbox/send.test.ts src/features/team-mode/team-tasklist/claim.test.ts src/features/team-mode/team-tasklist/get.test.ts src/features/team-mode/team-tasklist/update.test.ts src/features/team-mode/team-registry/paths.test.ts` passed: 20 tests.
- `git diff --check` passed.
- `bun run typecheck` passed.
- `bun run build` passed.
- `bun test` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces try/catch rejection checks in team‑mode tests with Bun’s promise `rejects/resolves` assertions for clearer, safer tests without behavior changes.

- **Refactors**
  - Mailbox: switched rejection checks to `await expect(...).rejects`.
  - Tasklist (claim/get/update): replaced try/catch with `rejects`; preserved cleanup; added specific message/property assertions where relevant.
  - Registry paths: asserted non-throw with `await expect(...).resolves`; narrowed warning metadata before checking `code` and `path`.

<sup>Written for commit e72f767e269f363a5e6541b59ff8fcd6fe2522bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

