### PR TITLE
fix(rules-injector): remove no-excuse cache slop

### DIFF
--- a/src/hooks/rules-injector/cache.ts
+++ b/src/hooks/rules-injector/cache.ts
@@ -14,10 +14,14 @@ export function createSessionCacheStore(): {
   const sessionCaches = new Map<string, SessionInjectedRulesCache>();
 
   function getSessionCache(sessionID: string): SessionInjectedRulesCache {
-    if (!sessionCaches.has(sessionID)) {
-      sessionCaches.set(sessionID, loadInjectedRules(sessionID));
+    const existingCache = sessionCaches.get(sessionID);
+    if (existingCache !== undefined) {
+      return existingCache;
     }
-    return sessionCaches.get(sessionID)!;
+
+    const cache = loadInjectedRules(sessionID);
+    sessionCaches.set(sessionID, cache);
+    return cache;
   }
 
   function clearSessionCache(sessionID: string): void {

--- a/src/hooks/rules-injector/transcript-hydration.ts
+++ b/src/hooks/rules-injector/transcript-hydration.ts
@@ -83,10 +83,10 @@ export function createTranscriptHydrationStore(
 						state.relativePaths.add(relativePath);
 					}
 				} catch (error) {
-					if (!(error instanceof Error)) {
-						throw error;
+					if (error instanceof Error) {
+						return;
 					}
-					// best-effort: a hydration failure must never block injection.
+					throw error;
 				} finally {
 					state.hydrated = true;
 					state.inflight = undefined;


### PR DESCRIPTION
## Summary
- Removes the postfix non-null assertion from `createSessionCacheStore()` by using explicit cache get-or-initialize narrowing.
- Makes transcript hydration's handled `Error` branch explicit while preserving best-effort hydration behavior.
- Behavior is unchanged: hydration failures still do not block injection, non-`Error` throws still propagate, and injector rule processing behavior remains covered by focused tests.

## Changes
- `src/hooks/rules-injector/cache.ts`: replace `sessionCaches.get(sessionID)!` with explicit initialization and return.
- `src/hooks/rules-injector/transcript-hydration.ts`: replace comment-only handled catch path with explicit `return` for `Error` values and rethrow non-`Error` values.

## Overlap Audit
- Checked open PRs targeting `dev` for exact overlap on:
  - `src/hooks/rules-injector/transcript-hydration.ts`
  - `src/hooks/rules-injector/injector.ts`
  - `src/hooks/rules-injector/cache.ts`
  - `src/hooks/rules-injector/injection-processor.ts` (current implementation behind the `injector.ts` facade)
- Result: no exact file overlap found; no files skipped.

## QA
- Baseline after `bun install`: `bun test src/hooks/rules-injector/transcript-hydration.test.ts src/hooks/rules-injector/cache.test.ts src/hooks/rules-injector/injector.test.ts src/hooks/rules-injector/injector-facade.test.ts` ✅ 26 pass, 0 fail
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/hooks/rules-injector/transcript-hydration.ts src/hooks/rules-injector/injector.ts src/hooks/rules-injector/cache.ts` ✅ No violations in 3 file(s)
- `bun test src/hooks/rules-injector/transcript-hydration.test.ts src/hooks/rules-injector/cache.test.ts src/hooks/rules-injector/injector.test.ts src/hooks/rules-injector/injector-facade.test.ts` ✅ 26 pass, 0 fail
- `git diff --check` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` ✅ exited 0


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unsafe non-null assertion in `createSessionCacheStore` and make transcript hydration error handling explicit. Improves type safety and readability without changing injector behavior: hydration errors don’t block injection; non-Error throws still propagate.

- **Refactors**
  - Replace `sessionCaches.get(sessionID)!` with explicit get-or-initialize and early return.
  - In transcript hydration, return on `Error` and rethrow non-`Error` values.

<sup>Written for commit 1fac37052d777aa98b59d33f565080c989ba292f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

