### PR TITLE
model-core: tighten model suggestion parsing

### DIFF
--- a/packages/model-core/src/parse-model-suggestion.test.ts
+++ b/packages/model-core/src/parse-model-suggestion.test.ts
@@ -65,4 +65,11 @@ describe("parseModelSuggestion", () => {
     expect(parseModelSuggestion(new Error("Connection timeout"))).toBeNull()
     expect(parseModelSuggestion(null)).toBeNull()
   })
+
+  it("returns null for circular object payloads without messages", () => {
+    const error: { self?: unknown } = {}
+    error.self = error
+
+    expect(parseModelSuggestion(error)).toBeNull()
+  })
 })

--- a/packages/model-core/src/parse-model-suggestion.ts
+++ b/packages/model-core/src/parse-model-suggestion.ts
@@ -4,14 +4,10 @@ export interface ModelSuggestionInfo {
   suggestion: string
 }
 
-function hasProperty(value: object, key: PropertyKey): value is object & Record<PropertyKey, unknown> {
-  return key in value
-}
-
 function readProperty(value: unknown, key: PropertyKey): unknown {
   if (typeof value !== "object" || value === null) return undefined
-  if (!hasProperty(value, key)) return undefined
-  return value[key]
+  if (!(key in value)) return undefined
+  return Reflect.get(value, key)
 }
 
 function extractMessage(error: unknown): string {
@@ -22,9 +18,8 @@ function extractMessage(error: unknown): string {
     if (typeof message === "string") return message
     try {
       return JSON.stringify(error)
-    } catch (jsonError) {
-      if (jsonError instanceof TypeError) return ""
-      throw jsonError
+    } catch {
+      return ""
     }
   }
   return String(error)

--- a/packages/model-core/src/parse-model-suggestion.ts
+++ b/packages/model-core/src/parse-model-suggestion.ts
@@ -4,16 +4,27 @@ export interface ModelSuggestionInfo {
   suggestion: string
 }
 
+function hasProperty(value: object, key: PropertyKey): value is object & Record<PropertyKey, unknown> {
+  return key in value
+}
+
+function readProperty(value: unknown, key: PropertyKey): unknown {
+  if (typeof value !== "object" || value === null) return undefined
+  if (!hasProperty(value, key)) return undefined
+  return value[key]
+}
+
 function extractMessage(error: unknown): string {
   if (typeof error === "string") return error
   if (error instanceof Error) return error.message
   if (typeof error === "object" && error !== null) {
-    const obj = error as Record<string, unknown>
-    if (typeof obj.message === "string") return obj.message
+    const message = readProperty(error, "message")
+    if (typeof message === "string") return message
     try {
       return JSON.stringify(error)
-    } catch {
-      return ""
+    } catch (jsonError) {
+      if (jsonError instanceof TypeError) return ""
+      throw jsonError
     }
   }
   return String(error)
@@ -23,15 +34,13 @@ export function parseModelSuggestion(error: unknown): ModelSuggestionInfo | null
   if (!error) return null
 
   if (typeof error === "object") {
-    const errObj = error as Record<string, unknown>
-
-    if (errObj.name === "ProviderModelNotFoundError" && typeof errObj.data === "object" && errObj.data !== null) {
-      const data = errObj.data as Record<string, unknown>
-      const suggestions = data.suggestions
-      if (Array.isArray(suggestions) && suggestions.length > 0 && typeof suggestions[0] === "string") {
+    if (readProperty(error, "name") === "ProviderModelNotFoundError") {
+      const data = readProperty(error, "data")
+      const suggestions = readProperty(data, "suggestions")
+      if (typeof data === "object" && data !== null && Array.isArray(suggestions) && typeof suggestions[0] === "string") {
         return {
-          providerID: String(data.providerID ?? ""),
-          modelID: String(data.modelID ?? ""),
+          providerID: String(readProperty(data, "providerID") ?? ""),
+          modelID: String(readProperty(data, "modelID") ?? ""),
           suggestion: suggestions[0],
         }
       }
@@ -39,7 +48,7 @@ export function parseModelSuggestion(error: unknown): ModelSuggestionInfo | null
     }
 
     for (const key of ["data", "error", "cause"] as const) {
-      const nested = errObj[key]
+      const nested = readProperty(error, key)
       if (nested && typeof nested === "object") {
         const result = parseModelSuggestion(nested)
         if (result) return result
@@ -53,13 +62,14 @@ export function parseModelSuggestion(error: unknown): ModelSuggestionInfo | null
   const modelMatch = message.match(/model not found:\s*([^/\s]+)\s*\/\s*([^.\s]+)/i)
   const suggestionMatch = message.match(/did you mean:\s*([^,?]+)/i)
 
-  if (modelMatch && suggestionMatch) {
-    return {
-      providerID: modelMatch[1].trim(),
-      modelID: modelMatch[2].trim(),
-      suggestion: suggestionMatch[1].trim(),
-    }
-  }
+  const providerID = modelMatch?.[1]
+  const modelID = modelMatch?.[2]
+  const suggestion = suggestionMatch?.[1]
+  if (!providerID || !modelID || !suggestion) return null
 
-  return null
+  return {
+    providerID: providerID.trim(),
+    modelID: modelID.trim(),
+    suggestion: suggestion.trim(),
+  }
 }


### PR DESCRIPTION
## Summary
Tightens `parseModelSuggestion` so unknown object payloads are read through explicit property narrowing instead of broad record assertions. The JSON stringification fallback now only swallows the known circular-object `TypeError` case and rethrows unexpected failures.

## Changes
- Adds a circular object characterization test for message extraction fallback behavior.
- Replaces broad `Record<string, unknown>` assertions with a typed property reader.
- Narrows the JSON stringify catch path while preserving current `null` behavior for circular payloads.

## Testing
- `bun test packages/model-core/src/parse-model-suggestion.test.ts` ✅
- `bun packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/model-core/src/parse-model-suggestion.ts packages/model-core/src/parse-model-suggestion.test.ts` ✅
- `bun test packages/model-core/src` ✅
- `git diff --check` ✅
- `bun run typecheck:packages` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened `parseModelSuggestion` in `model-core` with explicit property reads and safer message extraction. Preserves JSON.stringify fallback semantics and returns null for circular payloads without messages.

- **Bug Fixes**
  - Read properties via a typed helper instead of broad `Record<string, unknown>` assertions.
  - Preserve JSON.stringify fallback by swallowing stringify errors to avoid unexpected throws.
  - Return null for circular object payloads without messages; added a test.
  - Keep recursive checks over `data`, `error`, and `cause` with safer guards.

<sup>Written for commit 9f71b01e61ee4ede37dfb864f674ea165fc41270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

