### PR TITLE
test(doctor): remove model resolution non-null assertions

### DIFF
--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "bun:test"
 
+function expectDefined<T>(value: T | null | undefined, label: string): T {
+  expect(value, label).toBeDefined()
+  if (value === null || value === undefined) {
+    throw new Error(`${label} must be defined`)
+  }
+  return value
+}
+
 describe("model-resolution check", () => {
   describe("parseProviderModel", () => {
     it("splits chutes model IDs at the provider separator", async () => {
@@ -53,10 +61,12 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfo()
 
       // then: Should have agent entries
-      const sisyphus = info.agents.find((a) => a.name === "sisyphus")
-      expect(sisyphus).toBeDefined()
-      expect(sisyphus!.requirement.fallbackChain[0]?.model).toBe("claude-opus-4-7")
-      expect(sisyphus!.requirement.fallbackChain[0]?.providers).toContain("anthropic")
+      const sisyphus = expectDefined(
+        info.agents.find((a) => a.name === "sisyphus"),
+        "sisyphus agent resolution",
+      )
+      expect(sisyphus.requirement.fallbackChain[0]?.model).toBe("claude-opus-4-7")
+      expect(sisyphus.requirement.fallbackChain[0]?.providers).toContain("anthropic")
     })
 
     it("returns category requirements with provider chains", async () => {
@@ -65,10 +75,12 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfo()
 
       // then: Should have category entries
-      const visual = info.categories.find((c) => c.name === "visual-engineering")
-      expect(visual).toBeDefined()
-      expect(visual!.requirement.fallbackChain[0]?.model).toBe("gemini-3.1-pro")
-      expect(visual!.requirement.fallbackChain[0]?.providers).toContain("google")
+      const visual = expectDefined(
+        info.categories.find((c) => c.name === "visual-engineering"),
+        "visual-engineering category resolution",
+      )
+      expect(visual.requirement.fallbackChain[0]?.model).toBe("gemini-3.1-pro")
+      expect(visual.requirement.fallbackChain[0]?.providers).toContain("google")
     })
   })
 
@@ -90,10 +102,9 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides(mockConfig)
 
       // then: Oracle should show the override
-      const oracle = info.agents.find((a) => a.name === "oracle")
-      expect(oracle).toBeDefined()
-      expect(oracle!.userOverride).toBe("anthropic/claude-opus-4-7")
-      expect(oracle!.effectiveResolution).toBe("User override: anthropic/claude-opus-4-7")
+      const oracle = expectDefined(info.agents.find((a) => a.name === "oracle"), "oracle agent resolution")
+      expect(oracle.userOverride).toBe("anthropic/claude-opus-4-7")
+      expect(oracle.effectiveResolution).toBe("User override: anthropic/claude-opus-4-7")
     })
 
     it("shows user override for category when configured", async () => {
@@ -109,10 +120,12 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides(mockConfig)
 
       // then: visual-engineering should show the override
-      const visual = info.categories.find((c) => c.name === "visual-engineering")
-      expect(visual).toBeDefined()
-      expect(visual!.userOverride).toBe("openai/gpt-5.4")
-      expect(visual!.effectiveResolution).toBe("User override: openai/gpt-5.4")
+      const visual = expectDefined(
+        info.categories.find((c) => c.name === "visual-engineering"),
+        "visual-engineering category resolution",
+      )
+      expect(visual.userOverride).toBe("openai/gpt-5.4")
+      expect(visual.effectiveResolution).toBe("User override: openai/gpt-5.4")
     })
 
     it("shows provider fallback when no override exists", async () => {
@@ -124,11 +137,13 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides(mockConfig)
 
       // then: Should show provider fallback chain
-      const sisyphus = info.agents.find((a) => a.name === "sisyphus")
-      expect(sisyphus).toBeDefined()
-      expect(sisyphus!.userOverride).toBeUndefined()
-      expect(sisyphus!.effectiveResolution).toContain("Provider fallback:")
-      expect(sisyphus!.effectiveResolution).toContain("anthropic")
+      const sisyphus = expectDefined(
+        info.agents.find((a) => a.name === "sisyphus"),
+        "sisyphus agent resolution",
+      )
+      expect(sisyphus.userOverride).toBeUndefined()
+      expect(sisyphus.effectiveResolution).toContain("Provider fallback:")
+      expect(sisyphus.effectiveResolution).toContain("anthropic")
     })
 
     it("captures user variant for agent when configured", async () => {
@@ -145,10 +160,9 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides(mockConfig)
 
       //#then Oracle should have userVariant set
-      const oracle = info.agents.find((a) => a.name === "oracle")
-      expect(oracle).toBeDefined()
-      expect(oracle!.userOverride).toBe("openai/gpt-5.4")
-      expect(oracle!.userVariant).toBe("xhigh")
+      const oracle = expectDefined(info.agents.find((a) => a.name === "oracle"), "oracle agent resolution")
+      expect(oracle.userOverride).toBe("openai/gpt-5.4")
+      expect(oracle.userVariant).toBe("xhigh")
     })
 
     it("captures user variant for category when configured", async () => {
@@ -165,20 +179,24 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides(mockConfig)
 
       //#then visual-engineering should have userVariant set
-      const visual = info.categories.find((c) => c.name === "visual-engineering")
-      expect(visual).toBeDefined()
-      expect(visual!.userOverride).toBe("google/gemini-3-flash-preview")
-      expect(visual!.userVariant).toBe("high")
+      const visual = expectDefined(
+        info.categories.find((c) => c.name === "visual-engineering"),
+        "visual-engineering category resolution",
+      )
+      expect(visual.userOverride).toBe("google/gemini-3-flash-preview")
+      expect(visual.userVariant).toBe("high")
     })
 
     it("attaches snapshot-backed capability diagnostics for built-in models", async () => {
       const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
 
       const info = getModelResolutionInfoWithOverrides({})
-      const sisyphus = info.agents.find((a) => a.name === "sisyphus")
+      const sisyphus = expectDefined(
+        info.agents.find((a) => a.name === "sisyphus"),
+        "sisyphus agent resolution",
+      )
 
-      expect(sisyphus).toBeDefined()
-      expect(sisyphus!.capabilityDiagnostics).toMatchObject({
+      expect(sisyphus.capabilityDiagnostics).toMatchObject({
         resolutionMode: "snapshot-backed",
         snapshot: { source: "bundled-snapshot" },
       })
@@ -193,10 +211,12 @@ describe("model-resolution check", () => {
         },
       })
 
-      const visual = info.categories.find((category) => category.name === "visual-engineering")
-      expect(visual).toBeDefined()
-      expect(visual!.effectiveModel).toBe("google/gemini-3.1-pro-high")
-      expect(visual!.capabilityDiagnostics).toMatchObject({
+      const visual = expectDefined(
+        info.categories.find((category) => category.name === "visual-engineering"),
+        "visual-engineering category resolution",
+      )
+      expect(visual.effectiveModel).toBe("google/gemini-3.1-pro-high")
+      expect(visual.capabilityDiagnostics).toMatchObject({
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
@@ -214,10 +234,9 @@ describe("model-resolution check", () => {
         },
       })
 
-      const oracle = info.agents.find((agent) => agent.name === "oracle")
-      expect(oracle).toBeDefined()
-      expect(oracle!.effectiveModel).toBe("anthropic/claude-opus-4-7-thinking")
-      expect(oracle!.capabilityDiagnostics).toMatchObject({
+      const oracle = expectDefined(info.agents.find((agent) => agent.name === "oracle"), "oracle agent resolution")
+      expect(oracle.effectiveModel).toBe("anthropic/claude-opus-4-7-thinking")
+      expect(oracle.capabilityDiagnostics).toMatchObject({
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
@@ -249,16 +268,16 @@ describe("model-resolution check", () => {
       const result = await checkModelResolution()
 
       // then: Details should contain agent/category resolution info
-      expect(result.details).toBeDefined()
-      expect(result.details!.length).toBeGreaterThan(0)
+      const details = expectDefined(result.details, "model resolution details")
+      expect(details.length).toBeGreaterThan(0)
       // Should have Available Models and Configured Models headers
-      expect(result.details!.some((d) => d.includes("Available Models"))).toBe(true)
-      expect(result.details!.some((d) => d.includes("Configured Models"))).toBe(true)
-      expect(result.details!.some((d) => d.includes("Agents:"))).toBe(true)
-      expect(result.details!.some((d) => d.includes("Categories:"))).toBe(true)
+      expect(details.some((d) => d.includes("Available Models"))).toBe(true)
+      expect(details.some((d) => d.includes("Configured Models"))).toBe(true)
+      expect(details.some((d) => d.includes("Agents:"))).toBe(true)
+      expect(details.some((d) => d.includes("Categories:"))).toBe(true)
       // Should have legend
-      expect(result.details!.some((d) => d.includes("user override"))).toBe(true)
-      expect(result.details!.some((d) => d.includes("capabilities: snapshot-backed"))).toBe(true)
+      expect(details.some((d) => d.includes("user override"))).toBe(true)
+      expect(details.some((d) => d.includes("capabilities: snapshot-backed"))).toBe(true)
     })
 
     it("collects warnings when configured models rely on compatibility fallback", async () => {


### PR DESCRIPTION
## Summary
Removes postfix non-null assertions from `src/cli/doctor/checks/model-resolution.test.ts` while preserving the existing doctor/model-resolution behavior.

## Changes
- Added a small `expectDefined` test helper that asserts and narrows nullable lookup results.
- Replaced `sisyphus!`, `visual!`, `oracle!`, and `result.details!` test patterns with narrowed values.
- No production files changed.

## Overlap Checks
- `gh pr list --state open --base dev --json number,title,headRefName,files --jq '.[] | select(any(.files[]?; .path == "src/cli/doctor/checks/model-resolution.test.ts")) | {number,title,headRefName,files:[.files[].path]}'` -> no output
- `gh pr list --state merged --base dev --limit 50 --json number,title,headRefName,files,mergedAt --jq '.[] | select(any(.files[]?; .path == "src/cli/doctor/checks/model-resolution.test.ts")) | {number,title,headRefName,mergedAt,files:[.files[].path]}'` -> no output

## Testing
- Baseline before edits:
  - `bun test src/cli/doctor/checks/model-resolution.test.ts` -> initially failed because the fresh worktree had not installed workspace deps: `Cannot find module '@oh-my-opencode/rules-engine'`
  - `bun install` -> passed, installed dependencies and ran postinstall build
  - `bun test src/cli/doctor/checks/model-resolution.test.ts` -> 17 pass, 0 fail, 47 expect() calls
- After edits:
  - `rg -n "[A-Za-z0-9_)\\]]!" src/cli/doctor/checks/model-resolution.test.ts || true` -> no output
  - `bun test src/cli/doctor/checks/model-resolution.test.ts src/cli/doctor/formatter.test.ts` -> 29 pass, 0 fail, 81 expect() calls
  - `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/cli/doctor/checks/model-resolution.test.ts` -> No violations in 1 file(s).
  - `git diff --check` -> no output
  - `bun run typecheck` -> passed (`tsgo --noEmit`, script typecheck, package typechecks)
  - `bun run build` -> passed, generated plugin bundle, CLI bundle, and schema

## Manual QA
- `bun run src/cli/index.ts doctor --help` -> exit 0, printed `Usage: oh-my-opencode doctor [options]` with `--status`, `--verbose`, `--json`, and help examples.
- `bun run src/cli/index.ts doctor --verbose` -> exit 0, rendered the doctor output including `Models`, `Available Models (from cache)`, `Configured Models`, agent/category model resolution rows, and summary `4 passed, 0 failed, 2 warnings`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe non‑null assertions from model‑resolution tests by introducing a small expectDefined helper to assert and narrow values. No production code changed; behavior and test expectations stay the same.

- **Refactors**
  - Added expectDefined<T>(value, label) to assert and narrow nullable lookups.
  - Replaced all postfix non‑null usages in model and details checks with narrowed values.
  - Kept test coverage and outcomes unchanged.

<sup>Written for commit de24e17decfe0450a893a91dfdee0c40bb2f1931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

