### PR TITLE
test: clean mock module lifecycle allowlist

### DIFF
--- a/src/cli/doctor/checks/dependencies.test.ts
+++ b/src/cli/doctor/checks/dependencies.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"

--- a/src/cli/doctor/checks/dependencies.test.ts
+++ b/src/cli/doctor/checks/dependencies.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import * as deps from "./dependencies"
 
+afterEach(() => mock.restore())
+
 describe("dependencies check", () => {
   describe("checkAstGrepCli", () => {
     it("returns valid dependency info", async () => {

--- a/src/features/team-mode/team-mailbox/inbox.test.ts
+++ b/src/features/team-mode/team-mailbox/inbox.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock, test } from "bun:test"
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { tmpdir } from "node:os"
@@ -13,6 +13,8 @@ mock.module("../../../shared/logger", () => ({
     logCalls.push([message, data])
   },
 }))
+
+afterEach(() => mock.restore())
 
 const { listUnreadMessages } = await import("./inbox")
 const { TeamModeConfigSchema } = await import("../../../config/schema/team-mode")

--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -425,7 +425,7 @@ describe("thinking-prepend", () => {
     )
     const sessionID = "ses_thinking_prepend_async"
     const targetMessageID = "msg_target_async"
-    const patchPartMock = mock(async () => true)
+    const patchPartMock = mock(async (..._args: readonly unknown[]) => true)
     const originalPart = {
       id: "prt_prev_async",
       type: "thinking",

--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { randomUUID } from "node:crypto"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it, mock } from "bun:test"
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test"
 import { detectErrorType } from "./index"
 
 const TEST_STORAGE_ROOT = join(tmpdir(), `session-recovery-thinking-prepend-${randomUUID()}`)
@@ -25,6 +25,10 @@ mock.module("../../shared", () => ({
     return fallback
   },
 }))
+
+afterEach(() => mock.restore())
+
+afterAll(() => rmSync(TEST_STORAGE_ROOT, { recursive: true, force: true }))
 
 const { prependThinkingPart, prependThinkingPartAsync } = await import("./storage/thinking-prepend")
 const { injectTextPart } = await import("./storage/text-part-injector")

--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { randomUUID } from "node:crypto"
 import { tmpdir } from "node:os"

--- a/src/shared/mock-module-lifecycle-audit.test.ts
+++ b/src/shared/mock-module-lifecycle-audit.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import { readdir, readFile, stat } from "node:fs/promises"
 import path from "node:path"

--- a/src/shared/mock-module-lifecycle-audit.test.ts
+++ b/src/shared/mock-module-lifecycle-audit.test.ts
@@ -7,21 +7,6 @@ const SOURCE_ROOT = path.resolve(import.meta.dir, "..")
 const WORKSPACE_ROOT = path.resolve(SOURCE_ROOT, "..")
 const MOCK_MODULE_TOKEN = "mock.module"
 const MOCK_MODULE_LIFECYCLE_ALLOWLIST = new Map<string, string>([
-  // TODO(MOCK-MODULE-AUDIT): add cleanup for team mailbox inbox module mocks.
-  [
-    path.join(SOURCE_ROOT, "features", "team-mode", "team-mailbox", "inbox.test.ts"),
-    "justification: legacy mock.module call predates audit; TODO(MOCK-MODULE-AUDIT): add cleanup",
-  ],
-  // TODO(MOCK-MODULE-AUDIT): add cleanup for doctor dependency module mocks.
-  [
-    path.join(SOURCE_ROOT, "cli", "doctor", "checks", "dependencies.test.ts"),
-    "justification: legacy mock.module call predates audit; TODO(MOCK-MODULE-AUDIT): add cleanup",
-  ],
-  // TODO(MOCK-MODULE-AUDIT): add cleanup for session recovery module mocks.
-  [
-    path.join(SOURCE_ROOT, "hooks", "session-recovery", "index.test.ts"),
-    "justification: legacy mock.module call predates audit; TODO(MOCK-MODULE-AUDIT): add cleanup",
-  ],
   // TODO(MOCK-MODULE-AUDIT): add cleanup for auto-update checker hook module mocks.
   [
     path.join(SOURCE_ROOT, "hooks", "auto-update-checker", "hook.test.ts"),


### PR DESCRIPTION
## Summary
- Added `mock.restore()` lifecycle cleanup to the team mailbox inbox, doctor dependencies, and session recovery tests.
- Removed those three mock-module lifecycle audit allowlist TODO entries.
- Added Bun test type references where needed so changed Bun test files are clean in LSP, and typed the session recovery `patchPart` mock call arguments.
- Left auto-update checker and tmux mock test allowlist entries untouched per scope.

## Overlap checks
- Open PR file overlap check: no matches for the four scoped files.
- Local worktree overlap check: one non-PR local branch, `feat/team-mode`, also changes `src/features/team-mode/team-mailbox/inbox.test.ts`; this PR stayed to the mock lifecycle cleanup surface only.

## Verification
- `bun test src/features/team-mode/team-mailbox/inbox.test.ts src/cli/doctor/checks/dependencies.test.ts src/hooks/session-recovery/index.test.ts`: passed, 34 pass / 0 fail.
- `bun test src/shared/mock-module-lifecycle-audit.test.ts`: expected pre-existing failure. After this PR, the audit reports only unrelated offenders: `hooks/interactive-bash-session/interactive-bash-session-tracker.test.ts` and `hooks/session-recovery/storage/thinking-strip.test.ts`; the three scoped files are no longer reported.
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/features/team-mode/team-mailbox/inbox.test.ts src/cli/doctor/checks/dependencies.test.ts src/hooks/session-recovery/index.test.ts src/shared/mock-module-lifecycle-audit.test.ts`: passed, No violations in 4 file(s).
- LSP diagnostics: clean on all four changed files.
- `git diff --check`: passed.
- `bun run typecheck`: passed.
- `bun run build`: passed.

## Actual-use doctor QA
- `bun run src/cli/index.ts doctor --help`: passed and rendered the doctor usage, flags (`--status`, `--verbose`, `--json`, `--help`), and examples.
- `bun run src/cli/index.ts doctor --json`: passed with `exitCode: 0`, summary `total: 6`, `passed: 4`, `failed: 0`, `warnings: 2`. The warnings were local environment warnings: loaded plugin 4.6.0 is behind latest 4.7.5, and local `tui.json` has an unresolvable TUI plugin entry.

## Notes
- No Cubic run requested. Do not merge.