### PR TITLE
fix(rules-engine): remove defensive distance fallback

### DIFF
--- a/packages/rules-engine/src/distance.test.ts
+++ b/packages/rules-engine/src/distance.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+
+import { GLOBAL_DISTANCE } from "./constants";
+import { calculateDistance } from "./distance";
+
+describe("calculateDistance", () => {
+  it("#given no project root #when calculating rule distance #then returns the global distance", () => {
+    // given
+    const rulePath = "/repo/.omo/rules/rule.md";
+    const currentFile = "/repo/src/index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, null);
+
+    // then
+    expect(distance).toBe(GLOBAL_DISTANCE);
+  });
+
+  it("#given rule and current file share a directory #when calculating rule distance #then returns zero", () => {
+    // given
+    const projectRoot = "/repo";
+    const rulePath = "/repo/src/rule.md";
+    const currentFile = "/repo/src/index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, projectRoot);
+
+    // then
+    expect(distance).toBe(0);
+  });
+
+  it("#given the current file is nested below the rule directory #when calculating rule distance #then counts unmatched current path segments", () => {
+    // given
+    const projectRoot = "/repo";
+    const rulePath = "/repo/src/rule.md";
+    const currentFile = "/repo/src/features/search/index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, projectRoot);
+
+    // then
+    expect(distance).toBe(2);
+  });
+
+  it("#given rule and current file are in sibling project directories #when calculating rule distance #then counts from the current file directory", () => {
+    // given
+    const projectRoot = "/repo";
+    const rulePath = "/repo/packages/rules/.omo/rules/rule.md";
+    const currentFile = "/repo/packages/app/src/index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, projectRoot);
+
+    // then
+    expect(distance).toBe(2);
+  });
+
+  it("#given the current file is outside the project #when calculating rule distance #then returns the global distance", () => {
+    // given
+    const projectRoot = "/repo";
+    const rulePath = "/repo/.omo/rules/rule.md";
+    const currentFile = "/external/src/index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, projectRoot);
+
+    // then
+    expect(distance).toBe(GLOBAL_DISTANCE);
+  });
+
+  it("#given Windows-style paths on a POSIX runtime #when calculating rule distance #then preserves the existing global fallback behavior", () => {
+    // given
+    const projectRoot = "C:\\repo";
+    const rulePath = "C:\\repo\\.omo\\rules\\rule.md";
+    const currentFile = "C:\\repo\\src\\index.ts";
+
+    // when
+    const distance = calculateDistance(rulePath, currentFile, projectRoot);
+
+    // then
+    expect(distance).toBe(GLOBAL_DISTANCE);
+  });
+});

--- a/packages/rules-engine/src/distance.ts
+++ b/packages/rules-engine/src/distance.ts
@@ -3,21 +3,17 @@ import { GLOBAL_DISTANCE } from "./constants";
 
 export function calculateDistance(rulePath: string, currentFile: string, projectRoot: string | null): number {
   if (!projectRoot) return GLOBAL_DISTANCE;
-  try {
-    const ruleRelative = relative(projectRoot, dirname(rulePath));
-    const currentRelative = relative(projectRoot, dirname(currentFile));
-    if (ruleRelative.startsWith("..") || currentRelative.startsWith("..")) return GLOBAL_DISTANCE;
-    const ruleParts = toParts(ruleRelative);
-    const currentParts = toParts(currentRelative);
-    let shared = 0;
-    for (let index = 0; index < Math.min(ruleParts.length, currentParts.length); index += 1) {
-      if (ruleParts[index] !== currentParts[index]) break;
-      shared += 1;
-    }
-    return currentParts.length - shared;
-  } catch {
-    return GLOBAL_DISTANCE;
+  const ruleRelative = relative(projectRoot, dirname(rulePath));
+  const currentRelative = relative(projectRoot, dirname(currentFile));
+  if (ruleRelative.startsWith("..") || currentRelative.startsWith("..")) return GLOBAL_DISTANCE;
+  const ruleParts = toParts(ruleRelative);
+  const currentParts = toParts(currentRelative);
+  let shared = 0;
+  for (let index = 0; index < Math.min(ruleParts.length, currentParts.length); index += 1) {
+    if (ruleParts[index] !== currentParts[index]) break;
+    shared += 1;
   }
+  return currentParts.length - shared;
 }
 
 function toParts(path: string): string[] {


### PR DESCRIPTION
## Summary
- Removes the over-defensive catch fallback around pure `node:path` distance calculations.
- Adds focused characterization coverage for `calculateDistance` so current behavior stays pinned across null roots, same/nested directories, sibling packages, outside-project paths, and POSIX handling of Windows-style strings.

## Changes
- `packages/rules-engine/src/distance.ts`: unwraps the pure path-string calculation from `try/catch` while preserving all existing branch behavior.
- `packages/rules-engine/src/distance.test.ts`: adds focused Given/When/Then characterization tests.

## QA
- `bun test src/distance.test.ts` from `packages/rules-engine`: 6 pass, 0 fail.
- `bun run test` from `packages/rules-engine`: 16 pass, 0 fail.
- `bun run typecheck` from `packages/rules-engine`: passed (`tsgo --noEmit -p tsconfig.json`).
- `bun run build` from repo root: passed, including ast-grep MCP, git-bash MCP, plugin bundle, declarations, CLI bundle, and schema generation.
- `git diff --check`: passed.
- LSP diagnostics for `packages/rules-engine/src/distance.ts`: no diagnostics.
- LSP diagnostics for `packages/rules-engine/src/distance.test.ts`: no diagnostics.
- Actual-use manual QA evidence: `.omo/ulw-loop/evidence/rules-distance-actual-use.txt` in the worktree. Output covered null-root, same-dir, nested-current, sibling-package, outside-project, ending with `actual-use: passed`.

## Notes
- `packages/rules-engine` has no package-level `build` script, so root `bun run build` was used as the feasible build gate.
- Optional skill-local TypeScript no-excuse audit was attempted, but the plugin-cache script could not resolve its `typescript` dependency; no code changes were made for that tool issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the defensive try/catch fallback in `packages/rules-engine` distance logic and added tests to lock in `calculateDistance` behavior. This simplifies path math and keeps results stable across edge cases.

- **Refactors**
  - Unwrapped `node:path` distance calculation in `calculateDistance` and preserved existing behavior, including `GLOBAL_DISTANCE` for out-of-root paths.
  - Added focused tests covering null root, same/nested dirs, sibling packages, outside-project paths, and POSIX handling of Windows-style paths.

<sup>Written for commit c8483829732c95ade8d7005526d38e9e32aaf631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

