### PR TITLE
test: tighten package test helpers

### DIFF
--- a/packages/git-bash-mcp/src/mcp.test.ts
+++ b/packages/git-bash-mcp/src/mcp.test.ts
@@ -3,6 +3,24 @@ import { handleGitBashMcpRequest } from "./mcp";
 import type { JsonRpcResponse } from "./mcp";
 import type { RunGitBashCommand } from "./runner";
 
+type WhichBashPayload = {
+  readonly source: string;
+  readonly path: string;
+};
+
+type DiagnosePayload = {
+  readonly enabled: boolean;
+  readonly status: string;
+};
+
+type RunPayload = {
+  readonly stdout: string;
+};
+
+class MalformedMcpPayloadError extends Error {
+  readonly name = "MalformedMcpPayloadError";
+}
+
 describe("git_bash MCP", () => {
   it("#given simulated Windows with env override #when which_bash is called #then returns path and source", async () => {
     const response = await handleGitBashMcpRequest(
@@ -20,7 +38,7 @@ describe("git_bash MCP", () => {
       },
     );
 
-    const payload = JSON.parse(textFromResponse(response)) as { readonly source: string; readonly path: string };
+    const payload = whichBashPayloadFromResponse(response);
     expect(isErrorFromResponse(response)).toBe(false);
     expect(payload.source).toBe("env");
     expect(payload.path).toBe("C:\\Tools\\Git\\bin\\bash.exe");
@@ -37,7 +55,7 @@ describe("git_bash MCP", () => {
       { platform: "darwin", env: {}, exists: () => false, where: () => [] },
     );
 
-    const payload = JSON.parse(textFromResponse(response)) as { readonly enabled: boolean; readonly status: string };
+    const payload = diagnosePayloadFromResponse(response);
     expect(isErrorFromResponse(response)).toBe(false);
     expect(payload.enabled).toBe(false);
     expect(payload.status).toContain("native Windows");
@@ -78,7 +96,7 @@ describe("git_bash MCP", () => {
       },
     );
 
-    const payload = JSON.parse(textFromResponse(response)) as { readonly stdout: string };
+    const payload = runPayloadFromResponse(response);
     expect(isErrorFromResponse(response)).toBe(false);
     expect(payload.stdout).toBe("ok\n");
     expect(captured).toEqual({
@@ -124,6 +142,41 @@ function textFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRe
   if (typeof first !== "object" || first === null || Array.isArray(first)) return "";
   const text = first.text;
   return typeof text === "string" ? text : "";
+}
+
+function whichBashPayloadFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRequest>>): WhichBashPayload {
+  const payload = jsonObjectFromResponse(response);
+  const { path, source } = payload;
+  if (typeof path !== "string" || typeof source !== "string") {
+    throw new MalformedMcpPayloadError("Expected which_bash payload with string path and source");
+  }
+  return { path, source };
+}
+
+function diagnosePayloadFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRequest>>): DiagnosePayload {
+  const payload = jsonObjectFromResponse(response);
+  const { enabled, status } = payload;
+  if (typeof enabled !== "boolean" || typeof status !== "string") {
+    throw new MalformedMcpPayloadError("Expected diagnose payload with boolean enabled and string status");
+  }
+  return { enabled, status };
+}
+
+function runPayloadFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRequest>>): RunPayload {
+  const payload = jsonObjectFromResponse(response);
+  const { stdout } = payload;
+  if (typeof stdout !== "string") {
+    throw new MalformedMcpPayloadError("Expected run payload with string stdout");
+  }
+  return { stdout };
+}
+
+function jsonObjectFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRequest>>): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(textFromResponse(response));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new MalformedMcpPayloadError("Expected MCP response text to contain a JSON object");
+  }
+  return Object.fromEntries(Object.entries(parsed));
 }
 
 function toolNamesFromResponse(response: Awaited<ReturnType<typeof handleGitBashMcpRequest>>): readonly string[] {

--- a/packages/prompts-core/src/loader.test.ts
+++ b/packages/prompts-core/src/loader.test.ts
@@ -53,7 +53,7 @@ describe("loadPrompt", () => {
     )
 
     expect(error).toBeInstanceOf(PromptFileNotFoundError)
-    expect(expectError(error).message).toContain("test-prompt/missing")
+    expect(error.message).toContain("test-prompt/missing")
   })
 
   test("#given prompt name escapes source directory #then rejects path traversal", async () => {
@@ -147,16 +147,17 @@ describe("loadPrompt", () => {
   })
 })
 
-async function captureError(operation: () => Promise<unknown>): Promise<unknown> {
+async function captureError(operation: () => Promise<unknown>): Promise<Error> {
+  let capturedError: unknown
   try {
     await operation()
-    return undefined
   } catch (error) {
-    return error
+    if (!(error instanceof Error)) {
+      throw new ExpectedErrorMissingError("Expected operation to throw an Error instance")
+    }
+    capturedError = error
   }
-}
 
-function expectError(error: unknown): Error {
-  if (error instanceof Error) return error
+  if (capturedError instanceof Error) return capturedError
   throw new ExpectedErrorMissingError("Expected operation to throw an Error instance")
 }

--- a/packages/utils/src/deep-merge.test.ts
+++ b/packages/utils/src/deep-merge.test.ts
@@ -137,14 +137,13 @@ describe("deepMerge", () => {
       const result = deepMerge(base, override)
 
       // then
-      expect(result).toBeDefined()
-      if (!result) throw new Error("expected deepMerge to return an object")
-      expect(result.b).toBe(2)
+      const merged = expectMergedObject(result)
+      expect(merged.b).toBe(2)
       if (key === "prototype") {
-        expect(result.prototype).toBeUndefined()
+        expect(merged.prototype).toBeUndefined()
         return
       }
-      expect(result[key]).not.toEqual({ polluted: true })
+      expect(merged[key]).not.toEqual({ polluted: true })
     })
   })
 
@@ -162,12 +161,20 @@ describe("deepMerge", () => {
       const result = deepMerge(base, override)
 
       // then
-      let current: AnyObject = result as AnyObject
+      let current = expectMergedObject(result)
       for (let i = 0; i < 55; i++) {
-        current = current.nested as AnyObject
+        current = expectMergedObject(current.nested)
       }
       expect(current.overrideKey).toBe("override")
       expect(current.baseKey).toBeUndefined()
     })
   })
 })
+
+function expectMergedObject(value: unknown): AnyObject {
+  if (!isPlainObject(value)) {
+    throw new Error("expected deepMerge to return a plain object")
+  }
+
+  return value
+}

--- a/packages/utils/src/port-utils.test.ts
+++ b/packages/utils/src/port-utils.test.ts
@@ -85,7 +85,11 @@ function startTrackedServer(port: number, hostname: string = DEFAULT_HOSTNAME): 
     } catch (error) {
       removeListeners()
       trackedServers.delete(server)
-      reject(error)
+      if (error instanceof Error) {
+        reject(error)
+        return
+      }
+      reject(new Error("Expected server startup failure to throw an Error instance"))
     }
   })
 }
@@ -134,7 +138,10 @@ async function canBindContiguousPorts(
     }
 
     return true
-  } catch {
+  } catch (error) {
+    if (!isExpectedBindFailure(error)) {
+      throw error
+    }
     return false
   } finally {
     await Promise.all(servers.map((server) => closeTrackedServer(server)))
@@ -173,7 +180,10 @@ async function startAlternateInterfaceBlockerWithDefaultHostFree(hostname: strin
         await closeTrackedServer(defaultHostProbe)
 
         return blocker
-      } catch {
+      } catch (error) {
+        if (!isExpectedBindFailure(error)) {
+          throw error
+        }
         if (blocker) {
           await closeTrackedServer(blocker)
         }
@@ -201,6 +211,18 @@ async function startConsecutiveBlockers(
     await Promise.all(servers.map((server) => closeTrackedServer(server)))
     throw error
   }
+}
+
+function isExpectedBindFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    throw new Error("Expected port bind failure to throw an Error instance")
+  }
+
+  if (!("code" in error)) {
+    throw error
+  }
+
+  return error.code === "EADDRINUSE" || error.code === "EACCES"
 }
 
 async function captureDefaultListenHostname(port: number): Promise<string | undefined> {


### PR DESCRIPTION
## Summary
Tightens low-risk package test helpers without changing production behavior.

## Changes
- Replaces `JSON.parse(...) as ...` casts in `packages/git-bash-mcp/src/mcp.test.ts` with payload shape helpers that throw on malformed MCP text payloads.
- Narrows `captureError()` in `packages/prompts-core/src/loader.test.ts` to return `Error` and fail loudly for non-Error/no-error cases.
- Strengthens utils test helpers in `packages/utils/src/deep-merge.test.ts` and `packages/utils/src/port-utils.test.ts` by replacing weak object extraction and catch-all bind probes with explicit expected-error handling.

## Overlap checks
- Open PR exact-file overlap: none found for all four candidate files via file-list check.
- Merged PR context: `packages/utils/src/deep-merge.test.ts` and `packages/utils/src/port-utils.test.ts` had recent merged PR hits (#4973, #4974, #4975), so this branch was based on current `origin/dev` and only cleaned remaining patterns.

## Testing
- `bun test packages/git-bash-mcp/src/mcp.test.ts packages/prompts-core/src/loader.test.ts packages/utils/src/deep-merge.test.ts packages/utils/src/port-utils.test.ts` - 54 pass, 0 fail.
- `NODE_PATH="$PWD/node_modules" bun run /Users/yeongyu/.codex/plugins/cache/sisyphuslabs/omo/4.7.5/skills/programming/scripts/typescript/check-no-excuse-rules.ts packages/git-bash-mcp/src/mcp.test.ts packages/prompts-core/src/loader.test.ts packages/utils/src/deep-merge.test.ts packages/utils/src/port-utils.test.ts` - No violations in 4 files.
- `bun run typecheck:packages` - passed.
- `bun run build` - passed.
- `git diff --check` - passed.

## Actual-use manual QA
- Git Bash MCP surface driver called `handleGitBashMcpRequest` for `which_bash`, `diagnose`, and `run`, then parsed text payloads through the same shape-checking style. Transcript: `.omo/ulw-loop/evidence/git-bash-mcp-manual-qa.txt`.
  - Observed `which.source = "env"`, expected Git Bash path, `diagnose.enabled = false` with native-Windows status, and `run.stdout = "surface:printf ok:C:\\repo:5000"`.
- Prompts-core loader surface driver exercised missing prompt and path traversal errors through `loadPrompt`. Transcript: `.omo/ulw-loop/evidence/prompts-core-loader-manual-qa.txt`.
  - Observed `PromptFileNotFoundError` with `test-prompt/missing` and `PromptPathTraversalError` for traversal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened test helpers across packages to validate payload shapes and error types, improving failure clarity without changing runtime behavior.

- **Refactors**
  - `packages/git-bash-mcp/src/mcp.test.ts`: Replace loose `JSON.parse` casts with shape-checked helpers for `which_bash`, `diagnose`, and `run`; throw on malformed MCP payloads.
  - `packages/prompts-core/src/loader.test.ts`: Make `captureError` return `Error` and fail on non-Error or no-error cases; use `error.message` directly in assertions.
  - `packages/utils/src/deep-merge.test.ts`: Add `expectMergedObject` to assert plain-object merges and simplify deep traversal checks.
  - `packages/utils/src/port-utils.test.ts`: Require `Error` on server startup failures and add `isExpectedBindFailure` to only swallow `EADDRINUSE`/`EACCES`.

<sup>Written for commit 2281d5e96d96e15067fe4bfb0daa77272560b0dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

