### PR TITLE
test: dedupe omo-codex component package smoke fixtures

### DIFF
--- a/packages/omo-codex/plugin/components/comment-checker/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/test/package-smoke.test.ts
@@ -1,44 +1,12 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly dependencies?: Record<string, unknown>;
-	readonly optionalDependencies: Record<string, string>;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
+import { readHooksJson, readPackageJson, readTextFile } from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged plugin files #when validating entrypoints #then hook command uses portable plugin root interpolation", () => {
 		// given
 		const packageJson = readPackageJson("package.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
+		const cliSource = readTextFile("src/cli.ts");
 
 		// when
 		const command = hooksJson.hooks["PostToolUse"]?.[0]?.hooks[0]?.command;
@@ -54,40 +22,3 @@ describe("plugin package metadata", () => {
 		expect(command).toBe(`node "${pluginRoot}/dist/cli.js" hook post-tool-use`);
 	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	if (!isRecord(value)) return false;
-	const dependencies = value["dependencies"];
-	return (
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringRecord(value["optionalDependencies"]) &&
-		(dependencies === undefined || isRecord(dependencies))
-	);
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -1,53 +1,12 @@
-import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly version: string;
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly dependencies: Record<string, string>;
-	readonly scripts: Record<string, string>;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-type McpServer = {
-	readonly command: string;
-	readonly args: readonly string[];
-};
-
-type McpJson = {
-	readonly mcpServers: Record<string, McpServer>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
-
-function readMcpJson(path: string): McpJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isMcpJson(parsed)) throw new TypeError(`Invalid MCP metadata: ${path}`);
-	return parsed;
-}
+import {
+	listDirectoryNames,
+	readHooksJson,
+	readMcpJson,
+	readPackageJson,
+	readTextFile,
+	requireScripts,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged component files #when validating entrypoints #then hook command stays local and MCP command references the package", () => {
@@ -55,10 +14,11 @@ describe("plugin package metadata", () => {
 		const packageJson = readPackageJson("package.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
 		const mcpJson = readMcpJson(".mcp.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
-		const codexHookCliSource = readFileSync("src/codex-hook-cli.ts", "utf8");
-		const codexHookSource = readFileSync("src/codex-hook.ts", "utf8");
-		const sourceFiles = readdirSync("src");
+		const cliSource = readTextFile("src/cli.ts");
+		const codexHookCliSource = readTextFile("src/codex-hook-cli.ts");
+		const codexHookSource = readTextFile("src/codex-hook.ts");
+		const sourceFiles = listDirectoryNames("src");
+		const scripts = requireScripts(packageJson, "package.json");
 
 		// when
 		const postToolUseCommand = hooksJson.hooks["PostToolUse"]?.[0]?.hooks[0]?.command;
@@ -74,7 +34,7 @@ describe("plugin package metadata", () => {
 		});
 		expect(packageJson.bin["omo-lsp"]).toBe("./dist/cli.js");
 		expect(packageJson.bin["codex-lsp"]).toBeUndefined();
-		expect(packageJson.scripts["build"]).toBe("node scripts/clean-dist.mjs && tsc -p tsconfig.build.json");
+		expect(scripts["build"]).toBe("node scripts/clean-dist.mjs && tsc -p tsconfig.build.json");
 		expect(cliSource.startsWith("#!/usr/bin/env node")).toBe(true);
 		expect(cliSource).toContain("Usage: omo-lsp [mcp | hook post-tool-use | hook post-compact]");
 		expect(postToolUseCommand).toBe(`node "${pluginRoot}/dist/cli.js" hook post-tool-use`);
@@ -93,7 +53,7 @@ describe("plugin package metadata", () => {
 
 	it("#given LSP skill guidance #when validating MCP tool instructions #then tool names are not framed as shell commands", () => {
 		// given
-		const skill = readFileSync("skills/lsp/SKILL.md", "utf8");
+		const skill = readTextFile("skills/lsp/SKILL.md");
 
 		// when
 		const mentionsToolInterface = skill.includes("through the tool interface");
@@ -104,54 +64,3 @@ describe("plugin package metadata", () => {
 		expect(rejectsShellExecution).toBe(true);
 	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	return (
-		isRecord(value) &&
-		typeof value["version"] === "string" &&
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringRecord(value["dependencies"]) &&
-		isStringRecord(value["scripts"])
-	);
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isMcpJson(value: unknown): value is McpJson {
-	if (!isRecord(value) || !isRecord(value["mcpServers"])) return false;
-	return Object.values(value["mcpServers"]).every(isMcpServer);
-}
-
-function isMcpServer(value: unknown): value is McpServer {
-	return (
-		isRecord(value) &&
-		typeof value["command"] === "string" &&
-		Array.isArray(value["args"]) &&
-		value["args"].every((item) => typeof item === "string")
-	);
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
@@ -1,48 +1,12 @@
-import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly files: readonly string[];
-	readonly dependencies?: Record<string, unknown>;
-};
-
-type PluginJson = {
-	readonly hooks: string;
-};
-
-type HookCommand = {
-	readonly command: string;
-};
-
-type HookEntry = {
-	readonly matcher?: string;
-	readonly hooks: readonly HookCommand[];
-};
-
-type HooksJson = {
-	readonly hooks: Record<string, readonly HookEntry[]>;
-};
-
-function readPackageJson(path: string): PackageJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function readPluginJson(path: string): PluginJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isPluginJson(parsed)) throw new TypeError(`Invalid plugin metadata: ${path}`);
-	return parsed;
-}
-
-function readHooksJson(path: string): HooksJson {
-	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
-	return parsed;
-}
+import {
+	listDirectoryNames,
+	readHooksJson,
+	readPackageJson,
+	readPluginJson,
+	readTextFile,
+	requireFiles,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("plugin package metadata", () => {
 	it("#given packaged plugin files #when validating entrypoints #then hook commands use portable plugin root interpolation", () => {
@@ -50,8 +14,9 @@ describe("plugin package metadata", () => {
 		const packageJson = readPackageJson("package.json");
 		const pluginJson = readPluginJson(".codex-plugin/plugin.json");
 		const hooksJson = readHooksJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
-		const bundledRules = readdirSync("bundled-rules").sort();
+		const cliSource = readTextFile("src/cli.ts");
+		const packageFiles = requireFiles(packageJson, "package.json");
+		const bundledRules = [...listDirectoryNames("bundled-rules")].sort();
 
 		// when
 		const hookConfig = hooksJson.hooks;
@@ -69,7 +34,7 @@ describe("plugin package metadata", () => {
 		expect(packageJson.packageManager).toBe("npm@11.12.1");
 		expect(packageJson.dependencies ?? {}).toEqual({ picomatch: "^4.0.3" });
 		expect(packageJson.bin["omo-rules"]).toBe("./dist/cli.js");
-		expect(packageJson.files).toContain("bundled-rules");
+		expect(packageFiles).toContain("bundled-rules");
 		expect(bundledRules).toContain("windows-git-bash.md");
 		expect(pluginJson.hooks).toBe("./hooks/hooks.json");
 		expect(cliSource.startsWith("#!/usr/bin/env node")).toBe(true);
@@ -106,48 +71,3 @@ describe("plugin package metadata", () => {
 		).toBe(false);
 	});
 });
-
-function isPackageJson(value: unknown): value is PackageJson {
-	if (!isRecord(value)) return false;
-	const dependencies = value["dependencies"];
-	return (
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringArray(value["files"]) &&
-		(dependencies === undefined || isRecord(dependencies))
-	);
-}
-
-function isStringArray(value: unknown): value is readonly string[] {
-	return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isPluginJson(value: unknown): value is PluginJson {
-	return isRecord(value) && typeof value["hooks"] === "string";
-}
-
-function isHooksJson(value: unknown): value is HooksJson {
-	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
-	return Object.values(value["hooks"]).every(isHookEntries);
-}
-
-function isHookEntries(value: unknown): value is readonly HookEntry[] {
-	return Array.isArray(value) && value.every(isHookEntry);
-}
-
-function isHookEntry(value: unknown): value is HookEntry {
-	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
-}
-
-function isHookCommand(value: unknown): value is HookCommand {
-	return isRecord(value) && typeof value["command"] === "string";
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}

--- a/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
+++ b/packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts
@@ -1,0 +1,158 @@
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
+
+import { readdirSync, readFileSync } from "node:fs";
+
+export type ComponentPackageJson = {
+	readonly version?: string;
+	readonly type: string;
+	readonly packageManager: string;
+	readonly bin: Record<string, string>;
+	readonly dependencies?: Record<string, string>;
+	readonly optionalDependencies?: Record<string, string>;
+	readonly scripts?: Record<string, string>;
+	readonly files?: readonly string[];
+};
+
+export type HookCommand = {
+	readonly command: string;
+};
+
+export type HookEntry = {
+	readonly matcher?: string;
+	readonly hooks: readonly HookCommand[];
+};
+
+export type HooksJson = {
+	readonly hooks: Record<string, readonly HookEntry[]>;
+};
+
+export type McpServer = {
+	readonly command: string;
+	readonly args: readonly string[];
+};
+
+export type McpJson = {
+	readonly mcpServers: Record<string, McpServer>;
+};
+
+export type PluginJson = {
+	readonly hooks: string;
+};
+
+export function readPackageJson(path: string): ComponentPackageJson {
+	const parsed = readJsonFile(path);
+	if (!isComponentPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
+	return parsed;
+}
+
+export function readHooksJson(path: string): HooksJson {
+	const parsed = readJsonFile(path);
+	if (!isHooksJson(parsed)) throw new TypeError(`Invalid hooks metadata: ${path}`);
+	return parsed;
+}
+
+export function readMcpJson(path: string): McpJson {
+	const parsed = readJsonFile(path);
+	if (!isMcpJson(parsed)) throw new TypeError(`Invalid MCP metadata: ${path}`);
+	return parsed;
+}
+
+export function readPluginJson(path: string): PluginJson {
+	const parsed = readJsonFile(path);
+	if (!isPluginJson(parsed)) throw new TypeError(`Invalid plugin metadata: ${path}`);
+	return parsed;
+}
+
+export function readJsonFile(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function readTextFile(path: string): string {
+	return readFileSync(path, "utf8");
+}
+
+export function listDirectoryNames(path: string): readonly string[] {
+	return readdirSync(path);
+}
+
+export function requireFiles(packageJson: ComponentPackageJson, path: string): readonly string[] {
+	if (packageJson.files === undefined) throw new TypeError(`Package metadata missing files: ${path}`);
+	return packageJson.files;
+}
+
+export function requireScripts(packageJson: ComponentPackageJson, path: string): Record<string, string> {
+	if (packageJson.scripts === undefined) throw new TypeError(`Package metadata missing scripts: ${path}`);
+	return packageJson.scripts;
+}
+
+export function collectHookCommandsFromValue(value: unknown): readonly string[] {
+	if (typeof value === "string") return [];
+	if (Array.isArray(value)) return value.flatMap(collectHookCommandsFromValue);
+	if (!isRecord(value)) return [];
+	const ownCommand = typeof value["command"] === "string" ? [value["command"]] : [];
+	return [...ownCommand, ...Object.values(value).flatMap(collectHookCommandsFromValue)];
+}
+
+function isComponentPackageJson(value: unknown): value is ComponentPackageJson {
+	if (!isRecord(value)) return false;
+	const dependencies = value["dependencies"];
+	const optionalDependencies = value["optionalDependencies"];
+	const scripts = value["scripts"];
+	const files = value["files"];
+	return (
+		value["type"] === "module" &&
+		value["packageManager"] === "npm@11.12.1" &&
+		isStringRecord(value["bin"]) &&
+		(dependencies === undefined || isStringRecord(dependencies)) &&
+		(optionalDependencies === undefined || isStringRecord(optionalDependencies)) &&
+		(scripts === undefined || isStringRecord(scripts)) &&
+		(files === undefined || isStringArray(files))
+	);
+}
+
+function isHooksJson(value: unknown): value is HooksJson {
+	if (!isRecord(value) || !isRecord(value["hooks"])) return false;
+	return Object.values(value["hooks"]).every(isHookEntries);
+}
+
+function isHookEntries(value: unknown): value is readonly HookEntry[] {
+	return Array.isArray(value) && value.every(isHookEntry);
+}
+
+function isHookEntry(value: unknown): value is HookEntry {
+	return isRecord(value) && Array.isArray(value["hooks"]) && value["hooks"].every(isHookCommand);
+}
+
+function isHookCommand(value: unknown): value is HookCommand {
+	return isRecord(value) && typeof value["command"] === "string";
+}
+
+function isMcpJson(value: unknown): value is McpJson {
+	if (!isRecord(value) || !isRecord(value["mcpServers"])) return false;
+	return Object.values(value["mcpServers"]).every(isMcpServer);
+}
+
+function isMcpServer(value: unknown): value is McpServer {
+	return (
+		isRecord(value) &&
+		typeof value["command"] === "string" &&
+		Array.isArray(value["args"]) &&
+		value["args"].every((item) => typeof item === "string")
+	);
+}
+
+function isPluginJson(value: unknown): value is PluginJson {
+	return isRecord(value) && typeof value["hooks"] === "string";
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/package-smoke.test.ts
@@ -1,23 +1,23 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-
-type PackageJson = {
-	readonly type: string;
-	readonly packageManager: string;
-	readonly bin: Record<string, string>;
-	readonly files: readonly string[];
-	readonly scripts: Record<string, string>;
-};
+import {
+	collectHookCommandsFromValue,
+	readJsonFile,
+	readPackageJson,
+	readTextFile,
+	requireFiles,
+	requireScripts,
+} from "../../test-support/package-smoke-fixture.js";
 
 describe("codex ultrawork package metadata", () => {
 	it("#given package metadata #when inspected #then hook ships as built TypeScript", () => {
 		// given
 		const packageJson = readPackageJson("package.json");
-		const hooksJson = readJson("hooks/hooks.json");
-		const cliSource = readFileSync("src/cli.ts", "utf8");
+		const hooksJson = readJsonFile("hooks/hooks.json");
+		const cliSource = readTextFile("src/cli.ts");
 
 		// when
-		const packageFiles = packageJson.files;
+		const packageFiles = requireFiles(packageJson, "package.json");
+		const scripts = requireScripts(packageJson, "package.json");
 		const hookCommands = collectHookCommandsFromValue(hooksJson);
 		const pluginRoot = ["$", "{PLUGIN_ROOT}"].join("");
 
@@ -25,8 +25,8 @@ describe("codex ultrawork package metadata", () => {
 		expect(packageJson.type).toBe("module");
 		expect(packageJson.packageManager).toBe("npm@11.12.1");
 		expect(packageJson.bin["omo-ultrawork"]).toBe("./dist/cli.js");
-		expect(packageJson.scripts["build"]).toBe("tsc -p tsconfig.build.json");
-		expect(packageJson.scripts["test"]).toBe("vitest --run");
+		expect(scripts["build"]).toBe("tsc -p tsconfig.build.json");
+		expect(scripts["test"]).toBe("vitest --run");
 		expect(packageFiles).toContain("dist");
 		expect(packageFiles).toContain("directive.md");
 		expect(packageFiles).not.toContain("hooks/ultrawork-detector.py");
@@ -37,7 +37,7 @@ describe("codex ultrawork package metadata", () => {
 
 	it("#given explorer guidance #when inspected #then names the packaged code-search MCP surface", () => {
 		// given
-		const explorer = readFileSync("agents/explorer.toml", "utf8");
+		const explorer = readTextFile("agents/explorer.toml");
 
 		// when
 		const guidance = explorer.toLowerCase();
@@ -49,7 +49,7 @@ describe("codex ultrawork package metadata", () => {
 
 	it("#given explorer guidance #when inspected #then starts codebase inspection with Sparkshell", () => {
 		// given
-		const explorer = readFileSync("agents/explorer.toml", "utf8");
+		const explorer = readTextFile("agents/explorer.toml");
 
 		// when
 		const guidance = explorer.toLowerCase();
@@ -68,7 +68,7 @@ describe("codex ultrawork package metadata", () => {
 
 	it("#given librarian guidance #when inspected #then names the packaged research MCP surfaces", () => {
 		// given
-		const librarian = readFileSync("agents/librarian.toml", "utf8");
+		const librarian = readTextFile("agents/librarian.toml");
 
 		// when
 		const guidance = librarian.toLowerCase();
@@ -81,8 +81,8 @@ describe("codex ultrawork package metadata", () => {
 
 	it("#given ulw-plan skill #when inspected #then requires dynamic adversarial workflow phases", () => {
 		// given
-		const skill = readFileSync("skills/ulw-plan/SKILL.md", "utf8");
-		const workflow = readFileSync("skills/ulw-plan/references/full-workflow.md", "utf8");
+		const skill = readTextFile("skills/ulw-plan/SKILL.md");
+		const workflow = readTextFile("skills/ulw-plan/references/full-workflow.md");
 		const requiredContracts = [
 			"dynamic adversarial workflow phases",
 			"stale_state",
@@ -107,44 +107,3 @@ describe("codex ultrawork package metadata", () => {
 		}
 	});
 });
-
-function readJson(path: string): unknown {
-	return JSON.parse(readFileSync(path, "utf8"));
-}
-
-function readPackageJson(path: string): PackageJson {
-	const parsed = readJson(path);
-	if (!isPackageJson(parsed)) throw new TypeError(`Invalid package metadata: ${path}`);
-	return parsed;
-}
-
-function collectHookCommandsFromValue(value: unknown): readonly string[] {
-	if (typeof value === "string") return [];
-	if (Array.isArray(value)) return value.flatMap(collectHookCommandsFromValue);
-	if (!isRecord(value)) return [];
-	const ownCommand = typeof value["command"] === "string" ? [value["command"]] : [];
-	return [...ownCommand, ...Object.values(value).flatMap(collectHookCommandsFromValue)];
-}
-
-function isPackageJson(value: unknown): value is PackageJson {
-	return (
-		isRecord(value) &&
-		value["type"] === "module" &&
-		value["packageManager"] === "npm@11.12.1" &&
-		isStringRecord(value["bin"]) &&
-		isStringArray(value["files"]) &&
-		isStringRecord(value["scripts"])
-	);
-}
-
-function isStringArray(value: unknown): value is readonly string[] {
-	return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-	return isRecord(value) && Object.values(value).every((item) => typeof item === "string");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}


### PR DESCRIPTION
## Summary

Consolidates duplicate package-smoke metadata readers and type guards across the omo-codex component smoke tests into one shared fixture.

The package-specific assertions remain in their component tests. The assertions are complementary because each component validates a different shipped surface: comment-checker verifies optional dependency packaging and PostToolUse wiring, LSP verifies MCP/package entrypoints and source imports, rules verifies plugin hook registration and matcher scope, and ultrawork verifies hook packaging plus bundled agent/skill guidance. The duplicated scaffolding was only the JSON/text/directory readers and structural guards used to reach those assertions.

## Changes

- Added `packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts` for shared metadata/text readers, hook command collection, and small required-field helpers.
- Migrated comment-checker, LSP, rules, and ultrawork package-smoke tests to use the fixture while preserving component-specific expectations.
- LOC delta: 206 insertions, 329 deletions, net -123 LOC.

## Overlap Check

- Checked 200 open PRs targeting `dev` for the four scoped package-smoke files.
- Result: no overlap.

## Testing

Baseline before edit:
- `bun test test/package-smoke.test.ts` in `components/comment-checker` passed: 1 test, 7 expects.
- `bun test test/package-smoke.test.ts` in `components/lsp` passed: 2 tests, 22 expects.
- `bun test test/package-smoke.test.ts` in `components/rules` passed: 1 test, 12 expects.
- `bun test test/package-smoke.test.ts` in `components/ultrawork` passed: 5 tests, 36 expects.

After edit:
- `bun test test/package-smoke.test.ts` in all four component directories passed.
- `bun run packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts ...` passed: no violations in 5 files.
- LSP diagnostics passed for all 5 changed TypeScript files.
- `bun run typecheck:packages` passed.
- `bun run build` passed.
- `bun run test:codex` passed: 209 tests, 0 failures.
- `git diff --check origin/dev..HEAD` passed.

## Manual QA

Saved locally at `.omo/ulw-loop/evidence/component-package-smoke-actual-use.txt` and generated through the exported shared fixture readers.

```text
comment-checker
  name: @code-yeongyu/codex-comment-checker
  bin: omo-comment-checker=./dist/cli.js
  exports: (none)
  hooks: 1
lsp
  name: @code-yeongyu/codex-lsp
  bin: omo-lsp=./dist/cli.js
  exports: (none)
  hooks: 2
rules
  name: @code-yeongyu/codex-rules
  bin: omo-rules=./dist/cli.js
  exports: (none)
  hooks: 4
ultrawork
  name: @code-yeongyu/codex-ultrawork
  bin: omo-ultrawork=./dist/cli.js
  exports: (none)
  hooks: 1
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated package-smoke test scaffolding across `omo-codex` components by introducing a shared fixture, reducing boilerplate while keeping component-specific assertions intact.

- **Refactors**
  - Added `packages/omo-codex/plugin/components/test-support/package-smoke-fixture.ts` with shared JSON/text readers, MCP and plugin metadata loaders, directory listing, hook command collector, and `requireFiles`/`requireScripts` helpers.
  - Updated package-smoke tests for `comment-checker`, `lsp`, `rules`, and `ultrawork` to use the fixture without changing expectations.
  - Net -123 LOC; build and codex tests pass.

<sup>Written for commit 22c8c9b3fb120527d99bd38ce1a936f60cb3b800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

