### PR TITLE
fix(team-mode): verify pending live delivery reached recipient context before acking on idle

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-mailbox/pending-delivery-recovery.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-mailbox/pending-delivery-recovery.ts
@@ -1,0 +1,91 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { isRecord } from "../../../shared/record-type-guard"
+import { log } from "../../../shared/logger"
+import { releaseDeliveryReservation, reserveMessageForDelivery } from "./reservation"
+
+type SessionMessagesClient = {
+  session?: {
+    messages?: (input: { path: { id: string } }) => Promise<unknown>
+  }
+}
+
+function getMessagesData(response: unknown): unknown[] {
+  if (isRecord(response) && Array.isArray(response.data)) {
+    return response.data
+  }
+  return Array.isArray(response) ? response : []
+}
+
+function valueContainsMessageId(value: unknown, messageId: string): boolean {
+  if (typeof value === "string") {
+    return value.includes(messageId)
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => valueContainsMessageId(entry, messageId))
+  }
+  if (isRecord(value)) {
+    return Object.values(value).some((entry) => valueContainsMessageId(entry, messageId))
+  }
+  return false
+}
+
+/**
+ * Returns the subset of messageIds whose live-delivery envelope is present in the
+ * recipient session's message history. A live/poll-injected peer message embeds
+ * its messageId in the injected `<peer_message messageId="...">` envelope, so a
+ * message that genuinely reached the recipient's context is detectable here.
+ *
+ * Messages NOT returned were marked "pending" (the wake/dispatch was accepted) but
+ * never actually entered context - acking those would silently lose them.
+ *
+ * On any error (or when the client cannot read messages) returns an empty set,
+ * which is the loss-safe answer: callers requeue rather than ack.
+ */
+export async function findDeliveredMessageIds(
+  client: SessionMessagesClient,
+  sessionID: string,
+  messageIds: readonly string[],
+): Promise<Set<string>> {
+  const delivered = new Set<string>()
+  if (messageIds.length === 0 || typeof client.session?.messages !== "function") {
+    return delivered
+  }
+
+  try {
+    const response = await client.session.messages({ path: { id: sessionID } })
+    const messages = getMessagesData(response)
+    for (const messageId of messageIds) {
+      if (messages.some((message) => valueContainsMessageId(message, messageId))) {
+        delivered.add(messageId)
+      }
+    }
+  } catch (error) {
+    log("[team-mailbox] failed to read session history for pending-delivery verification", {
+      sessionID,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return delivered
+}
+
+/**
+ * Returns reserved (`.delivering-<id>.json`) pending messages to the inbox as
+ * normal unread (`<id>.json`) files so the next poll-injection / wake-hint can
+ * re-deliver them. Used when a pending live delivery is found to have never
+ * reached the recipient's context.
+ */
+export async function requeuePendingLiveDeliveries(
+  teamRunId: string,
+  memberName: string,
+  messageIds: readonly string[],
+  config: TeamModeConfig,
+): Promise<void> {
+  for (const messageId of messageIds) {
+    const reservation = await reserveMessageForDelivery(teamRunId, memberName, messageId, config)
+    if (reservation === null) {
+      continue
+    }
+    await releaseDeliveryReservation(reservation)
+  }
+}

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
+import { clearTeamSessionRegistry } from "../../features/team-mode/team-session-registry"
+import { getInboxDir, resolveBaseDir } from "../../features/team-mode/team-registry/paths"
+import { loadRuntimeState, saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import type { RuntimeState } from "../../features/team-mode/types"
+import { createTeamIdleWakeHint } from "./team-idle-wake-hint"
+
+const temporaryDirectories: string[] = []
+
+function createConfig(baseDir: string): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+}
+
+function createRuntimeState(teamRunId: string, pendingInjectedMessageIds: string[]): RuntimeState {
+  return {
+    version: 1,
+    teamRunId,
+    teamName: "team-alpha",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "worker",
+        sessionId: "member-session",
+        agentType: "general-purpose",
+        status: "idle",
+        pendingInjectedMessageIds,
+      },
+    ],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
+
+async function seedReservedPendingMessage(config: TeamModeConfig, messageId: string): Promise<string> {
+  const teamRunId = randomUUID()
+  await mkdir(path.join(config.base_dir ?? "", "runtime", teamRunId), { recursive: true })
+  await saveRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+  await sendMessage({
+    version: 1,
+    messageId,
+    from: "lead",
+    to: "worker",
+    kind: "message",
+    body: "in-flight live delivery",
+    timestamp: 100,
+  }, teamRunId, config, {
+    isLead: true,
+    activeMembers: ["worker"],
+    reservedRecipients: new Set(["worker"]),
+  })
+  return teamRunId
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function driveIdle(config: TeamModeConfig, withMessagesApi: boolean): Promise<void> {
+  const session: Record<string, unknown> = {}
+  if (withMessagesApi) {
+    session.messages = async () => ({ data: [] })
+  }
+  const handler = createTeamIdleWakeHint({
+    directory: "/tmp/project",
+    client: { session },
+  } as never, config)
+  await handler({
+    event: {
+      type: "session.idle",
+      properties: { sessionID: "member-session" },
+    },
+  })
+}
+
+afterEach(async () => {
+  clearTeamSessionRegistry()
+  await Promise.all(temporaryDirectories.splice(0).map(async (directoryPath) => {
+    await rm(directoryPath, { recursive: true, force: true })
+  }))
+})
+
+describe("issue #5101 - pending live delivery must not be silently lost on idle-ack", () => {
+  test("#given a reserved (.delivering-) message pending injection that never reached the recipient #when the recipient idles #then the message stays recoverable by poll-injection", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "wake-hint-delivering-loss-"))
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const messageId = randomUUID()
+    const teamRunId = await seedReservedPendingMessage(config, messageId)
+
+    // when
+    await driveIdle(config, true)
+
+    // then
+    const unreadMessages = await listUnreadMessages(teamRunId, "worker", config)
+    expect(unreadMessages.map((message) => message.messageId)).toContain(messageId)
+    const processedPath = path.join(getInboxDir(resolveBaseDir(config), teamRunId, "worker"), "processed", `${messageId}.json`)
+    expect(await fileExists(processedPath)).toBe(false)
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+  })
+
+  test("#given the client cannot read session history #when the recipient idles #then the prior ack-all behavior is preserved (loss-safe fallback unavailable)", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "wake-hint-delivering-ackall-"))
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const messageId = randomUUID()
+    const teamRunId = await seedReservedPendingMessage(config, messageId)
+
+    // when
+    await driveIdle(config, false)
+
+    // then
+    const processedPath = path.join(getInboxDir(resolveBaseDir(config), teamRunId, "worker"), "processed", `${messageId}.json`)
+    expect(await fileExists(processedPath)).toBe(true)
+    expect(await listUnreadMessages(teamRunId, "worker", config)).toEqual([])
+  })
+})

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="bun-types" />
+
+// Regression test for the team-mailbox pending live-delivery data-loss bug:
+// the idle-wake-hint handler used to ack every pendingInjectedMessageId purely
+// because the session went idle, with no check that the message actually reached
+// the recipient's context. A wake accepted-but-not-processed was silently moved
+// to processed/ and lost. The fix verifies session.messages history and requeues
+// unconfirmed messages back to the inbox instead.
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
+import { saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import type { RuntimeState } from "../../features/team-mode/types"
+import { getInboxDir, resolveBaseDir } from "../../features/team-mode/team-registry/paths"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { createTeamIdleWakeHint } from "./team-idle-wake-hint"
+
+const tmpDirs: string[] = []
+
+afterEach(async () => {
+  releaseAllPromptAsyncReservationsForTesting()
+  await Promise.all(tmpDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+async function makeBaseDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "pending-verify-"))
+  tmpDirs.push(dir)
+  return dir
+}
+
+function makeConfig(baseDir: string): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+}
+
+function runtimeWithPending(teamRunId: string, messageId: string): RuntimeState {
+  return {
+    version: 1,
+    teamRunId,
+    teamName: "team-alpha",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "worker",
+        sessionId: "member-session",
+        agentType: "general-purpose",
+        status: "idle",
+        pendingInjectedMessageIds: [messageId],
+      },
+    ],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
+
+async function seedPendingReserved(
+  teamRunId: string,
+  config: TeamModeConfig,
+  messageId: string,
+  body: string,
+): Promise<void> {
+  await sendMessage(
+    { version: 1, messageId, from: "lead", to: "worker", kind: "message", body, timestamp: 100 },
+    teamRunId,
+    config,
+    { isLead: true, activeMembers: ["worker"], reservedRecipients: new Set(["worker"]) },
+  )
+}
+
+const idleStatus = () => async () => ({ data: { "member-session": { type: "idle" } } })
+const noopPromptAsync = async () => ({})
+
+describe("team idle-wake-hint pending live-delivery verification", () => {
+  test("unconfirmed pending message (absent from session history) is requeued to inbox, not acked/lost", async () => {
+    const baseDir = await makeBaseDir()
+    const config = makeConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState(runtimeWithPending(teamRunId, messageId), config)
+    await seedPendingReserved(teamRunId, config, messageId, "ROUND 2 CRITIQUE")
+
+    const handler = createTeamIdleWakeHint(
+      {
+        directory: "/tmp/project",
+        client: {
+          session: {
+            promptAsync: noopPromptAsync,
+            status: idleStatus(),
+            messages: async () => ({ data: [] }), // recipient never saw the message
+          },
+        },
+      },
+      config,
+      { idleSettleMs: 0 },
+    )
+
+    await handler({ event: { type: "session.idle", properties: { sessionID: "member-session" } } })
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inbox = await readdir(inboxDir)
+    const processed = await readdir(path.join(inboxDir, "processed")).catch(() => [] as string[])
+
+    // requeued as a normal unread file (recoverable by poll-inject), NOT lost to processed/
+    expect(inbox.includes(`${messageId}.json`)).toBe(true)
+    expect(inbox.includes(`.delivering-${messageId}.json`)).toBe(false)
+    expect(processed.includes(`${messageId}.json`)).toBe(false)
+  })
+
+  test("confirmed pending message (envelope present in session history) is acked to processed/", async () => {
+    const baseDir = await makeBaseDir()
+    const config = makeConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState(runtimeWithPending(teamRunId, messageId), config)
+    await seedPendingReserved(teamRunId, config, messageId, "ROUND 2 CRITIQUE")
+
+    const handler = createTeamIdleWakeHint(
+      {
+        directory: "/tmp/project",
+        client: {
+          session: {
+            promptAsync: noopPromptAsync,
+            status: idleStatus(),
+            messages: async () => ({
+              data: [
+                {
+                  role: "user",
+                  parts: [
+                    {
+                      type: "text",
+                      text: `<peer_message messageId="${messageId}" from="lead">ROUND 2 CRITIQUE</peer_message>`,
+                    },
+                  ],
+                },
+              ],
+            }),
+          },
+        },
+      },
+      config,
+      { idleSettleMs: 0 },
+    )
+
+    await handler({ event: { type: "session.idle", properties: { sessionID: "member-session" } } })
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inbox = await readdir(inboxDir)
+    const processed = await readdir(path.join(inboxDir, "processed")).catch(() => [] as string[])
+
+    expect(processed.includes(`${messageId}.json`)).toBe(true)
+    expect(inbox.includes(`${messageId}.json`)).toBe(false)
+    expect(inbox.includes(`.delivering-${messageId}.json`)).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.ts
@@ -7,6 +7,7 @@ import {
 import { ackMessages } from "../../features/team-mode/team-mailbox/ack"
 import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
 import { loadRuntimeState, transitionRuntimeState } from "../../features/team-mode/team-state-store/store"
+import { findDeliveredMessageIds, requeuePendingLiveDeliveries } from "../../features/team-mode/team-mailbox/pending-delivery-recovery"
 import { resolveSessionEventID } from "../../shared/event-session-id"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { log } from "../../shared/logger"
@@ -30,6 +31,7 @@ type TeamIdleWakeHintContext = {
     session: {
       promptAsync?: (input: PromptAsyncInput) => Promise<unknown>
       status?: () => Promise<unknown>
+      messages?: (input: { path: { id: string } }) => Promise<unknown>
     }
   }
 }
@@ -134,13 +136,24 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
           config,
         )
         if (claimedMessageIds.length > 0) {
-          await ackMessages(runtimeState.teamRunId, memberEntry.name, claimedMessageIds, config)
+          const deliveredMessageIds = typeof ctx.client.session.messages === "function"
+            ? await findDeliveredMessageIds(ctx.client, sessionID, claimedMessageIds)
+            : new Set(claimedMessageIds)
+          const ackedMessageIds = claimedMessageIds.filter((messageId) => deliveredMessageIds.has(messageId))
+          const requeuedMessageIds = claimedMessageIds.filter((messageId) => !deliveredMessageIds.has(messageId))
+          if (ackedMessageIds.length > 0) {
+            await ackMessages(runtimeState.teamRunId, memberEntry.name, ackedMessageIds, config)
+          }
+          if (requeuedMessageIds.length > 0) {
+            await requeuePendingLiveDeliveries(runtimeState.teamRunId, memberEntry.name, requeuedMessageIds, config)
+          }
           log("team idle handled pending live delivery ack", {
             event: "team-mode-idle-pending-ack",
             teamRunId: runtimeState.teamRunId,
             memberName: memberEntry.name,
             sessionID,
-            ackedCount: claimedMessageIds.length,
+            ackedCount: ackedMessageIds.length,
+            requeuedCount: requeuedMessageIds.length,
           })
         }
       }

--- a/packages/omo-opencode/src/plugin/build-team-idle-wake-hint-client.ts
+++ b/packages/omo-opencode/src/plugin/build-team-idle-wake-hint-client.ts
@@ -3,11 +3,13 @@ import type { PluginInput } from "@opencode-ai/plugin"
 type SdkSession = PluginInput["client"]["session"]
 type SdkPromptAsync = SdkSession["promptAsync"]
 type SdkStatus = SdkSession["status"]
+type SdkMessages = SdkSession["messages"]
 
 export type TeamIdleWakeHintNarrowClient = {
   session: {
     promptAsync?: SdkPromptAsync
     status?: SdkStatus
+    messages?: SdkMessages
   }
 }
 
@@ -19,7 +21,10 @@ export function buildTeamIdleWakeHintClient(client: PluginInput["client"]): Team
   const status = typeof session.status === "function"
     ? session.status.bind(session) as SdkStatus
     : undefined
+  const messages = typeof session.messages === "function"
+    ? session.messages.bind(session) as SdkMessages
+    : undefined
   return {
-    session: { promptAsync, status },
+    session: { promptAsync, status, messages },
   }
 }


### PR DESCRIPTION
Fixes #5101

## Problem
The team idle-wake-hint handler acks every `pendingInjectedMessageId` purely because the recipient session went idle, with **no verification that the message actually reached the recipient's context**. `dispatchInternalPrompt` returns "accepted" before the wake is durably processed, so a wake that is accepted-but-not-processed leaves the message marked pending. When the recipient next goes idle, `ackMessages()` renames `.delivering-<id>.json` → `processed/`, and because `listUnreadMessages()` ignores dot-prefixed files, poll-injection can never recover it. Net result: peer messages are **silently lost** (they sit in the inbox and are never injected into context).

## Fix
Before acking pending messages on idle, verify each one actually reached `session.messages` (the injected `<peer_message messageId="...">` envelope is detectable in history):
- **confirmed in history** → ack (existing behavior)
- **not in history** → requeue to the inbox via `releaseDeliveryReservation` so the next poll-injection / wake-hint re-delivers it

This mirrors the recovery already present in `team-member-error-handler.ts`. Adds `session.messages` to the idle-wake-hint client and extracts the shared logic into `pending-delivery-recovery.ts`. When the client can't read messages, the prior ack-all behavior is preserved (additive/safe).

## Test
`team-idle-wake-hint-pending-delivery-verify.test.ts`: unconfirmed pending → requeued to inbox (not lost); confirmed → acked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent silent loss of team peer messages by verifying pending live deliveries reached the recipient’s context before acking on idle. Unconfirmed deliveries are requeued to the inbox; if history can’t be read, we keep the prior ack‑all behavior.

- **Bug Fixes**
  - On idle, check each `pendingInjectedMessageId` against `session.messages`; ack confirmed, requeue missing to inbox.
  - Added `pending-delivery-recovery.ts` with `findDeliveredMessageIds` and `requeuePendingLiveDeliveries`; exposed `session.messages` via `build-team-idle-wake-hint-client`.
  - Added tests for requeue/ack paths and an end‑to‑end regression validating reserved `.delivering-` recovery and the ack‑all fallback when history is unavailable.

<sup>Written for commit 354159ded4685ba18a87b1994b0f3e0c24103e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

