### PR TITLE
fix(background-agent): requeue accepted-but-unprocessed parent wakes instead of refreshing the recovery timer forever

### DIFF
--- a/src/features/background-agent/parent-wake-dedupe.ts
+++ b/src/features/background-agent/parent-wake-dedupe.ts
@@ -14,6 +14,7 @@ export type PendingParentWake = {
   dispatchedAt?: number
   toolCallDeferralStartedAt?: number
   allowEmptyAssistantTurnRetry?: boolean
+  dispatchRetryCount?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -38,6 +39,9 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
       : {}),
     ...(wake.allowEmptyAssistantTurnRetry !== undefined
       ? { allowEmptyAssistantTurnRetry: wake.allowEmptyAssistantTurnRetry }
+      : {}),
+    ...(wake.dispatchRetryCount !== undefined
+      ? { dispatchRetryCount: wake.dispatchRetryCount }
       : {}),
   }
 }

--- a/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/src/features/background-agent/parent-wake-flush-runner.ts
@@ -46,6 +46,17 @@ export class ParentWakeFlushRunner {
     if (!latestWake) {
       return
     }
+    if (
+      latestWake.dispatchedAt !== undefined
+      && await this.deps.sessionInspector.hasAssistantOrToolOutputAfterDispatchedWake(sessionID, latestWake)
+    ) {
+      this.deps.pendingQueue.deleteWake(sessionID)
+      this.deps.dispatchedTracker.clearWake(sessionID)
+      log("[background-agent] Dropped requeued parent wake after late assistant output:", {
+        sessionID,
+      })
+      return
+    }
     if (sessionActive) {
       await this.sendParentWakePrompt(sessionID, latestWake, {
         emptyAssistantTurnRetry: false,

--- a/src/features/background-agent/parent-wake-late-error-recovery.test.ts
+++ b/src/features/background-agent/parent-wake-late-error-recovery.test.ts
@@ -111,7 +111,10 @@ describe("ParentWakeNotifier late error recovery", () => {
       const requeued = await notifier.requeueDispatchedParentWake(sessionID, "late session.error")
 
       // then
-      expect(requeued).toBe(true)
+      // The recovery window now proactively requeues an accepted-but-unprocessed wake,
+      // so by the time a late session.error arrives the wake is already pending and this
+      // call is a no-op. The wake is NOT lost — it is requeued and redispatched (asserted below).
+      expect(requeued).toBe(false)
       expect(notifier.getPendingParentWakes().get(sessionID)?.notifications).toEqual([FINAL_WAKE])
       expect(notifier.getDispatchedParentWakes().has(sessionID)).toBe(false)
       releaseParentWakeHold(sessionID)

--- a/src/features/background-agent/parent-wake-notifier.ts
+++ b/src/features/background-agent/parent-wake-notifier.ts
@@ -37,6 +37,9 @@ export class ParentWakeNotifier {
           wake,
           dispatchedTracker: this.dispatchedTracker,
           sessionInspector: this.sessionInspector,
+          requeueWake: (id, w) => this.requeueWake(id, w),
+          scheduleFlush: (id, delayMs) => this.schedulePendingParentWakeFlush(id, delayMs),
+          redispatchDelayMs: 16_000,
         }).catch((error: unknown) => {
           logParentWakeWindowRecoveryError(
             sessionID,

--- a/src/features/background-agent/parent-wake-window-recovery.ts
+++ b/src/features/background-agent/parent-wake-window-recovery.ts
@@ -2,12 +2,18 @@ import { log } from "../../shared"
 import type { PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
 import type { ParentWakeSessionInspector } from "./parent-wake-session-inspector"
+import { cloneParentWake } from "./parent-wake-dedupe"
+
+const MAX_PARENT_WAKE_REDISPATCH_ATTEMPTS = 2
 
 type ParentWakeWindowRecoveryInput = {
   readonly sessionID: string
   readonly wake: PendingParentWake
   readonly dispatchedTracker: ParentWakeDispatchedTracker
   readonly sessionInspector: ParentWakeSessionInspector
+  readonly requeueWake: (sessionID: string, wake: PendingParentWake) => void
+  readonly scheduleFlush: (sessionID: string, delayMs?: number) => void
+  readonly redispatchDelayMs: number
 }
 
 export async function handleDispatchedParentWakeWindowElapsed(
@@ -26,9 +32,24 @@ export async function handleDispatchedParentWakeWindowElapsed(
     return
   }
 
-  input.dispatchedTracker.refreshWakeTimer(input.sessionID)
-  log("[background-agent] Kept dispatched parent wake awaiting late failure or assistant output:", {
+  const retryCount = currentWake.dispatchRetryCount ?? 0
+  if (retryCount >= MAX_PARENT_WAKE_REDISPATCH_ATTEMPTS) {
+    input.dispatchedTracker.refreshWakeTimer(input.sessionID)
+    log("[background-agent] Exhausted parent wake redispatch attempts; keeping wake tracked for late output:", {
+      sessionID: input.sessionID,
+      retryCount,
+    })
+    return
+  }
+
+  const retryWake = cloneParentWake(currentWake)
+  retryWake.dispatchRetryCount = retryCount + 1
+  input.dispatchedTracker.clearWake(input.sessionID)
+  input.requeueWake(input.sessionID, retryWake)
+  input.scheduleFlush(input.sessionID, input.redispatchDelayMs)
+  log("[background-agent] Requeued accepted-but-unprocessed parent wake for redispatch:", {
     sessionID: input.sessionID,
+    attempt: retryCount + 1,
   })
 }
 


### PR DESCRIPTION
## Problem
When a background task completes, the parent wake is dispatched via `dispatchInternalPrompt` (async). "Accepted" only means `status: "dispatched" | "queued"` — not that the parent processed it. If the recovery window elapses with no assistant/tool output, `handleDispatchedParentWakeWindowElapsed()` calls `refreshWakeTimer()` and reschedules the same timer **indefinitely** — it never requeues for redispatch. So a completion notification that was accepted-but-not-processed leaves the parent **stuck idle forever**.

## Fix
Bounded requeue: when the window elapses with no output, clone the wake (carrying `dispatchedAt` + a new `dispatchRetryCount`), clear the dispatched entry, requeue, and schedule a redispatch after a delay **>** the 15s semantic-dedupe hold (so the retry isn't coalesced into a no-op). Cap at 2 redispatch attempts, then fall back to the prior keep-tracked-for-late-output behavior.

To avoid duplicate notifications if the parent was merely slow, `flushPendingParentWake()` drops the requeued wake when `hasAssistantOrToolOutputAfterDispatchedWake()` shows the parent woke after the original dispatch.

## Test
`parent-wake-late-error-recovery.test.ts` updated: after the window elapses with no output, the wake is proactively requeued and redispatches — fails on old code (refresh-forever), passes on new.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requeues accepted-but-unprocessed parent wakes instead of refreshing the timer forever, so completion notifications reliably wake the parent. Adds a bounded retry with a late-output guard to avoid duplicates.

- **Bug Fixes**
  - Added `dispatchRetryCount` to `PendingParentWake` and clone logic.
  - On window elapsed with no output: clear dispatched entry, requeue cloned wake, and schedule redispatch after 16s to avoid dedupe collisions.
  - Capped redispatch to 2 attempts; then fall back to tracking for late output.
  - Flush runner now drops requeued wakes if assistant/tool output arrived after the original dispatch.
  - Updated `parent-wake-late-error-recovery.test.ts` to assert proactive requeue behavior.

<sup>Written for commit 385818e72ba49b56239bdf51a5c503f0374f322e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

