### PR TITLE
fix(background_output): include tool-call parts in full-session output so include_tool_results shows arguments

### DIFF
--- a/packages/omo-opencode/src/tools/background-task/clients.ts
+++ b/packages/omo-opencode/src/tools/background-task/clients.ts
@@ -10,6 +10,8 @@ export type BackgroundOutputMessage = {
     content?: string | Array<{ type: string; text?: string }>
     output?: string
     name?: string
+    tool?: string
+    input?: unknown
   }>
 }
 

--- a/packages/omo-opencode/src/tools/background-task/full-session-format-tool-calls.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format-tool-calls.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="bun-types" />
+
+// Regression test: full-session output (used by background_output full_session /
+// include_tool_results) used to drop tool_use/tool parts entirely, so callers saw
+// tool RESULTS but never the tool CALLS or their arguments. The filter + renderer
+// now include tool calls (gated on includeToolResults), mirroring session-formatter.
+
+import { describe, expect, test } from "bun:test"
+import type { BackgroundTask } from "../../features/background-agent"
+import type { BackgroundOutputClient, BackgroundOutputMessagesResult } from "./clients"
+import { formatFullSession } from "./full-session-format"
+
+function makeTask(): BackgroundTask {
+  return {
+    id: "bg_test",
+    description: "test task",
+    status: "completed",
+    sessionId: "ses_test",
+  } as unknown as BackgroundTask
+}
+
+function makeClient(messages: BackgroundOutputMessagesResult): BackgroundOutputClient {
+  return { session: { messages: async () => messages } }
+}
+
+const toolMessage: BackgroundOutputMessagesResult = {
+  data: [
+    {
+      id: "m1",
+      info: { role: "assistant" },
+      parts: [
+        { type: "tool", tool: "grep", input: { pattern: "needle", path: "src" } },
+        { type: "tool_result", output: "found needle" },
+      ],
+    },
+  ],
+}
+
+describe("formatFullSession tool-call rendering", () => {
+  test("includeToolResults=true renders tool calls WITH their input arguments", async () => {
+    const output = await formatFullSession(makeTask(), makeClient(toolMessage), {
+      includeThinking: false,
+      includeToolResults: true,
+    })
+
+    expect(output).toContain("[tool: grep]")
+    expect(output).toContain("pattern")
+    expect(output).toContain("needle")
+    expect(output).toContain("[tool result] found needle")
+  })
+
+  test("includeToolResults=false omits tool calls and tool results", async () => {
+    const output = await formatFullSession(makeTask(), makeClient(toolMessage), {
+      includeThinking: false,
+      includeToolResults: false,
+    })
+
+    expect(output).not.toContain("[tool: grep]")
+    expect(output).not.toContain("[tool result]")
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/full-session-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format.ts
@@ -94,6 +94,9 @@ export async function formatFullSession(
       if (part.type === "tool_result") {
         return includeToolResults
       }
+      if (part.type === "tool_use" || part.type === "tool") {
+        return includeToolResults
+      }
       return part.type === "text"
     })
 
@@ -147,6 +150,9 @@ export async function formatFullSession(
         for (const toolText of toolTexts) {
           lines.push(`[tool result] ${toolText}`)
         }
+      } else if ((part.type === "tool_use" || part.type === "tool") && part.tool) {
+        const input = part.input === undefined ? "" : truncateText(JSON.stringify(part.input), thinkingMaxChars)
+        lines.push(`[tool: ${part.tool}] ${input}`.trimEnd())
       }
     }
   }


### PR DESCRIPTION
Fixes #5100

## Problem
`formatFullSession` (used by `background_output` `full_session` / `include_tool_results`) filters message parts to text / thinking / tool_result and **omits `tool_use`/`tool` parts entirely**. So `include_tool_results=true` shows tool RESULTS but never the tool CALLS or their input arguments.

## Fix
Include `tool_use`/`tool` parts in the filter (gated on `includeToolResults`) and render them as `[tool: <name>] <input>`, mirroring `session-formatter.ts`. Adds `tool`/`input` to the parts type.

## Test
`full-session-format-tool-calls.test.ts`: `include_tool_results=true` renders the tool call with its input; `=false` omits both calls and results.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes full-session background output to include tool-call parts so `include_tool_results` shows tool names and input arguments, not just results. Mirrors the interactive session formatter for consistent inspection.

- **Bug Fixes**
  - Include `tool_use`/`tool` parts when `includeToolResults` is true, and extend message parts with `tool` and `input`.
  - Render calls as “[tool: <name>] <input>” (JSON, truncated).
  - Add regression test to verify inclusion/exclusion with `includeToolResults` on/off.

<sup>Written for commit 296d2d142c32d097c99ffed82bb2d2a1ee776acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

