### PR TITLE
fix(ultrawork): add subagent-dependent transition barrier to directive

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -254,6 +254,31 @@ silent or ack-only, record the result as inconclusive, do not count it
 as approval/pass, close it if safe, and respawn a smaller
 `fork_turns: "none"` task with the missing deliverable.
 
+# Subagent-dependent transition barrier
+
+BEFORE advancing any state that depends on a spawned child agent, verify
+the child has returned a substantive result or been recorded as
+inconclusive. Moving dependent work forward without collecting child
+output is a defect.
+
+a) **Before marking a dependent plan step complete** via `update_plan`,
+verify that any spawned child agent owning evidence for that step has
+returned a substantive result or been recorded as inconclusive. If a
+child is still active, do NOT mark the step complete.
+
+b) **Before generating or verifying a plan**, wait for all spawned
+research/metis/explorer agents to return. Use short `wait_agent` cycles
+(<=30s each), not a single long blocking wait.
+
+c) **Before final answer**, check that no child agents are still active.
+If any are running, close them (recording the result as inconclusive if
+no output received) or wait for them.
+
+d) **Short-poll enforcement**: Always use short `wait_agent` cycles.
+Never use a single long blocking wait. After two silent waits, send a
+targeted `TASK STILL ACTIVE` follow-up. After two more silent waits,
+close the child as inconclusive and respawn a smaller task if needed.
+
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 
 Trigger when ANY apply:

--- a/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
@@ -63,6 +63,11 @@ test("#given ultrawork directive #when inspected #then reviewer fallback keeps a
 	assert.match(text, /timeout only means no new mailbox update arrived/i);
 	assert.match(text, /WORKING:/);
 	assert.match(text, /single `list_agents`/);
+	assert.match(text, /Subagent-dependent transition barrier/);
+	assert.match(text, /dependent plan step complete.*update_plan/s);
+	assert.match(text, /short `wait_agent` cycles.*<=30s/s);
+	assert.match(text, /single long blocking wait.*short `wait_agent`/s);
+	assert.match(text, /inconclusive.*close.*child/s);
 });
 
 test("#given ulw-loop workflow #when inspected #then stale review refresh keeps policy changes narrow", async () => {


### PR DESCRIPTION
## Summary

Adds an explicit `# Subagent-dependent transition barrier` section to the ultrawork directive that prevents dependent work from proceeding before spawned subagent results are collected or recorded as inconclusive.

Refs code-yeongyu/lazycodex#30

## Problem

LazyCodex/OMO subagent orchestration can spawn planning, review, or audit agents and then move dependent work forward without collecting or integrating their result. The root agent marks dependent plan steps complete, starts implementation, or generates plans before spawned children return.

The root cause is that the waiting/integration rules are prompt-level guidance without a structural barrier preventing unsafe transitions.

## Changes

- **directive.md**: New `# Subagent-dependent transition barrier` section with four rules:
  - Block `update_plan` step completion when child agents owning evidence are still active
  - Wait for all research/metis/explorer agents before plan generation, using short poll cycles (<=30s)
  - Ensure no child agents are running before final answer
  - Short-poll enforcement: short `wait_agent` cycles only, escalate after two silent waits, close as inconclusive after four

- **subagent-guidance.test.mjs**: Added 5 new assertion patterns covering the barrier section header, dependent step blocking, short-poll enforcement, and inconclusive handling.

## Testing

- ultrawork component vitest: 18/18 passed
- subagent-guidance node test: 5/5 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subagent-dependent transition barrier to the `ultrawork` directive so dependent work does not advance until child agent results are collected or marked inconclusive. Addresses code-yeongyu/lazycodex#30 and prevents unsafe plan completion, plan generation, and finalization while subagents are running.

- **Bug Fixes**
  - Block `update_plan` completion if a child agent owning evidence is still active.
  - Before plan generation, wait for all research/metis/explorer agents using short `wait_agent` polls (<=30s).
  - Before final answer, ensure no child agents are running; close or wait and record as inconclusive if needed.
  - Enforce short-poll escalation: two silent waits → targeted follow-up; two more → close as inconclusive and respawn a smaller task.
  - Added tests covering the barrier header, dependent-step blocking, short-polling, and inconclusive handling.

<sup>Written for commit 8a2ec8d0e95c9f584337f7560d2b0b58a603e33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

