### PR TITLE
fix(ultrawork): add TOML-backed subagent routing compatibility warning

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -254,6 +254,38 @@ silent or ack-only, record the result as inconclusive, do not count it
 as approval/pass, close it if safe, and respawn a smaller
 `fork_turns: "none"` task with the missing deliverable.
 
+# TOML-backed subagent routing compatibility
+
+Native Codex `spawn_agent` accepts `task_name`, `fork_turns`, and
+`message` but does NOT expose `agent_type`, `model`, or
+`reasoning_effort`. The TOML agent files in `agents/*.toml` define
+role-specific model and reasoning settings, but those settings are NOT
+applied through the `spawn_agent` surface. Observe these rules:
+
+a) **Routing unverified by default**: When spawning subagents via native
+`spawn_agent`, the task name alone does NOT guarantee the TOML-backed
+agent role (model, reasoning effort, service tier) was selected. Treat
+all subagent spawns as using the default model/config unless runtime
+evidence confirms otherwise.
+
+b) **Compatibility warning**: If the orchestrator cannot confirm
+TOML-backed routing (because `spawn_agent` does not expose
+`agent_type`/`model`/`reasoning_effort`), mark the subagent
+result as `routing-unverified` and proceed with appropriate caution.
+Do not assume role-specific model or reasoning was applied.
+
+c) **Service tier validation**: If agent TOMLs reference `service_tier`
+values unsupported by the target model (e.g. `fast` for `gpt-5.5`),
+the orchestrator should not attempt to enforce that tier. Prefer
+omitting unsupported service tiers or mapping to the runtime-supported
+tier.
+
+d) **Fallback behavior**: While TOML-backed routing is not guaranteed
+through native `spawn_agent`, the task assignment pattern
+(TASK/DELIVERABLE/SCOPE/VERIFY) still provides sufficient structure for
+reliable subagent work. The TOML files serve as documentation of
+intent, not runtime configuration for `spawn_agent`.
+
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 
 Trigger when ANY apply:

--- a/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
@@ -63,6 +63,9 @@ test("#given ultrawork directive #when inspected #then reviewer fallback keeps a
 	assert.match(text, /timeout only means no new mailbox update arrived/i);
 	assert.match(text, /WORKING:/);
 	assert.match(text, /single `list_agents`/);
+	assert.match(text, /TOML-backed/);
+	assert.match(text, /routing-unverified/);
+	assert.match(text, /service_tier/);
 });
 
 test("#given ulw-loop workflow #when inspected #then stale review refresh keeps policy changes narrow", async () => {


### PR DESCRIPTION
## Summary

Add explicit guidance that native `spawn_agent` does not guarantee TOML-backed agent role selection, and document fallback behavior.

Refs code-yeongyu/lazycodex#32

## Problem

LazyCodex/OMO guidance implies that role-named subagents (plan, reviewer, codex-ultrawork-reviewer) use the configured Codex agent TOML files. However, the native Codex `spawn_agent` surface only accepts `task_name`, `fork_turns`, and `message` — it does NOT expose `agent_type`, `model`, or `reasoning_effort`. Users can believe the TOML routing was applied when it was not.

Additionally, installed TOML files can contain `service_tier` values unsupported by the target model (e.g. `fast` for `gpt-5.5`), creating a compatibility hazard.

## Changes

- **directive.md**: New `# TOML-backed subagent routing compatibility` section with four rules:
  - Routing unverified by default
  - Compatibility warning when TOML routing cannot be confirmed
  - Service tier validation
  - Fallback behavior documentation

- **subagent-guidance.test.mjs**: Added 3 new assertion patterns for TOML-backed, routing-unverified, and service_tier.

## Testing

- ultrawork component vitest: 18/18 passed
- subagent-guidance node test: 5/5 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TOML-backed subagent routing compatibility warning to the ultrawork directive. Clarifies that native `spawn_agent` does not apply TOML agent role/model settings, documents fallback and service-tier validation, and adds tests for routing-unverified and service_tier cues.

<sup>Written for commit 230798629ce59caa8ae3c92fe94c1223db7f5fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

