### PR TITLE
fix(omo-codex): port lazycodex open issue fixes

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -66,6 +66,8 @@ Codex may still start Windows shell calls through its own defaults. The Light ed
 > To remove the Light edition after migration, run `npx lazycodex-ai uninstall`. It removes managed `sisyphuslabs` Codex cache/marketplace state, strips `omo@sisyphuslabs` plugin and hook-state blocks from `~/.codex/config.toml` with a backup, and removes managed agent TOML files from `~/.codex/agents/`. `cleanup` remains available as a backward-compatible alias.
 > If Codex still fails only inside one project with `agents.max_threads cannot be set when multi_agent_v2 is enabled`, run `npx lazycodex-ai install` from that project. The installer repairs project-local `.codex/config.toml` layers from the project root to the current directory, removes conflicting legacy `[agents] max_threads` only when MultiAgentV2 is enabled, and writes timestamped backups next to changed files.
 
+> **oh-my-codex (OMX) coexistence:** LazyCodex runs inside Codex as `omo@sisyphuslabs`; OMX wraps Codex from outside. The installer preserves unrelated `[features]`, `[tui]`, and `[shell_environment_policy]` blocks in `~/.codex/config.toml` while managing only LazyCodex marketplace/plugin/hook-state/MCP-policy/agent entries. Codex does not define hook precedence between independent lifecycle handlers, so LazyCodex does not define hook precedence for OMX keywords versus LazyCodex keywords. If `omx setup` refreshes shared config, rerun `npx lazycodex-ai install` after `omx setup`.
+
 ### A note on direct install
 
 If you insist on running the Ultimate installer yourself:

--- a/packages/omo-codex/MARKETPLACE.md
+++ b/packages/omo-codex/MARKETPLACE.md
@@ -23,6 +23,12 @@ npx lazycodex-ai install
 The installer builds `omo`, copies a clean versioned cache entry into `~/.codex/plugins/cache/sisyphuslabs/omo`, installs runtime dependencies in the cache, writes a local marketplace snapshot under `~/.codex/.tmp/marketplaces/sisyphuslabs/plugins/omo`, copies bundled-agent TOMLs into `~/.codex/agents/`, registers the `sisyphuslabs` marketplace from the local built cache, and enables `[plugins."omo@sisyphuslabs"]` in `~/.codex/config.toml`.
 It also enables both `plugins = true` and `plugin_hooks = true` under `[features]` so bundled hook files run.
 
+## oh-my-codex (OMX) coexistence
+
+LazyCodex may coexist with oh-my-codex (OMX): OMX wraps the Codex process from outside, while LazyCodex is an in-session `omo@sisyphuslabs` plugin. The installer preserves unrelated `[features]`, `[tui]`, and `[shell_environment_policy]` blocks in `~/.codex/config.toml` and only manages its own marketplace, plugin, hook-state, MCP-policy, and agent-role entries.
+
+Codex does not define hook precedence between independent handlers on the same event, so LazyCodex does not define hook precedence for OMX keywords versus LazyCodex keywords. If `omx setup` refreshes shared Codex config, rerun `npx lazycodex-ai install` after `omx setup` so the managed LazyCodex blocks are restored.
+
 If your local Codex build exposes plugin install commands, you can use those instead. For older local builds, the installer replaces the manual copy fallback:
 
 ```text

--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -37,6 +37,12 @@ To install **both** the Ultimate edition (OpenCode plugin) and the Light edition
 
 The installer copies the built plugin into `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/`, writes the local marketplace snapshot under `~/.codex/.tmp/marketplaces/sisyphuslabs/plugins/omo/`, copies bundled agent TOMLs into `~/.codex/agents/`, enables `omo@sisyphuslabs` in `~/.codex/config.toml`, and registers the `sisyphuslabs` marketplace from the local built cache. `lazycodex-ai` is the npm/bin alias and `lazycodex` is the marketplace repository; the marketplace identity remains `sisyphuslabs`.
 
+### oh-my-codex (OMX) coexistence
+
+LazyCodex can be installed beside oh-my-codex (OMX) because OMX runs outside Codex while LazyCodex runs as `omo@sisyphuslabs` inside Codex. The installer preserves unrelated `[features]`, `[tui]`, and `[shell_environment_policy]` blocks in `~/.codex/config.toml`, then adds only the LazyCodex marketplace, plugin, hook-state, MCP-policy, and managed-agent entries it owns.
+
+Codex does not define hook precedence for separate tools that listen to the same lifecycle event, so LazyCodex does not define hook precedence between OMX keywords and LazyCodex keywords. If `omx setup` rewrites shared Codex config, rerun `npx lazycodex-ai install` after `omx setup` to repair the managed `omo@sisyphuslabs` blocks.
+
 To remove managed Codex Light state, run `npx lazycodex-ai uninstall`. The backward-compatible alias is `npx lazycodex-ai cleanup`. Uninstall removes managed `sisyphuslabs` cache/marketplace directories, strips OMO marketplace/plugin/hook-state config blocks with a backup, removes managed agent TOML files from `~/.codex/agents/`, and repairs the known project-local legacy `.codex/config.toml` conflict while leaving project-owned `.codex` files in place.
 
 The Codex plugin bundle includes Context7 as a default MCP in its `.mcp.json`, using the hosted `https://mcp.context7.com/mcp` endpoint. The installer enables the `omo@sisyphuslabs` plugin MCP policy for Context7 while leaving any existing user-level `[mcp_servers.context7]` block untouched.

--- a/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus.md
+++ b/packages/omo-codex/plugin/components/rules/bundled-rules/hephaestus.md
@@ -110,6 +110,12 @@ LSP diagnostics catch type errors, not logic bugs; tests cover only what their a
 
 Reading the source and concluding "this should work" does not pass this gate. If usage reveals a defect, that defect is yours to fix in this turn - same turn, not "follow-up".
 
+# Global Review and Debugging Gate
+
+For significant implementation work and every PR handoff, run `review-work` plus a `debugging` runtime audit before declaring completion. Timeout, missing deliverable, ack-only, `BLOCKED:`, and inconclusive review lanes fail the gate. Record at least three debugging hypotheses and the runtime evidence that confirms or refutes each one.
+
+Do not print completion, create a PR, produce a PR handoff, or produce a branch handoff until the gate passes. Always redact secrets, tokens, credentials, auth headers, cookies, env dumps, private logs, and PII from ledgers, PR bodies, and handoffs.
+
 # Failure Recovery
 
 If your first approach fails, try a materially different one - different algorithm, library, or pattern, not a small tweak. Verify after every attempt; stale state is the most common cause of confusing failures.

--- a/packages/omo-codex/plugin/components/start-work-continuation/directive.md
+++ b/packages/omo-codex/plugin/components/start-work-continuation/directive.md
@@ -35,12 +35,18 @@ You are mid-flight on a Prometheus work plan. The turn just ended without finish
 - The worktree path (if set in boulder.json) governs every file edit and command. Do not stray into the main repo.
 - session_ids you write to boulder.json MUST be prefixed `codex:`. Bare ids on read are legacy `opencode:`.
 
+# Global Review and Debugging Gate
+
+Before completion, run `review-work` and a `debugging` runtime audit. Treat timeout, missing deliverable, ack-only, `BLOCKED:`, and inconclusive review lanes as failures, not progress. Record at least three debugging hypotheses and the runtime evidence that confirms or refutes each one.
+
+Do not print `ORCHESTRATION COMPLETE`. Do not create a PR, PR handoff, or branch handoff. Do not write a final completion answer until this gate passes. Always redact secrets, tokens, credentials, auth headers, cookies, env dumps, private logs, and PII from ledgers, PR bodies, and handoffs.
+
 # Stop conditions for THIS turn
 
 - A top-level checkbox flipped to `- [x]` after the 5-phase QA gate (Phase 1 read, Phase 2 automated, Phase 3 channel scenario, Phase 4 adversarial-class probing, Phase 5 gate decision). Then the Stop hook will re-evaluate; if more checkboxes remain you will be continued again.
 - 3 same-failure cycles on one sub-task → escalate via `spawn_agent(agent_type="codex-ultrawork-reviewer", fork_turns="none", ...)` and stop dispatch.
 - Safety boundary (destructive command, secret exfiltration, production write) → stop and surface a safe substitute.
-- All top-level checkboxes `- [x]` AND (if gate triggered) `codex-ultrawork-reviewer` approved unconditionally → print the ORCHESTRATION COMPLETE block and end.
+- All top-level checkboxes `- [x]` AND the Global Review and Debugging Gate passed → print the ORCHESTRATION COMPLETE block and end.
 
 # Output discipline
 

--- a/packages/omo-codex/plugin/components/ultrawork/directive.md
+++ b/packages/omo-codex/plugin/components/ultrawork/directive.md
@@ -237,6 +237,19 @@ handoff. Prefer `fork_turns: "none"` unless full history is truly
 required; paste only the context the child needs. Full-history forks can
 make the child continue old parent context instead of the delegated task.
 
+# TOML-backed subagent routing compatibility
+Treat TOML-backed role routing as **routing-unverified** unless the
+available `spawn_agent` schema lets you select or confirm `agent_type`,
+`model`, and `reasoning_effort`. A child `task_name` does not prove the
+configured TOML-backed role, model, reasoning effort, or `service_tier`
+was selected. If the schema lacks those fields, say so briefly in the
+notepad, paste the role requirements into the message, and judge the
+result from delivered evidence. Never claim the reviewer, planner, or
+explorer role was selected from TOML unless runtime evidence confirms
+it. If a `service_tier` is requested, use it only when that tier is
+supported by the selected model; otherwise omit the tier and record the
+compatibility fallback.
+
 Treat child status as a progress signal, not a timeout counter. For
 work likely to exceed one wait cycle, tell the child to send
 `WORKING: <task> - <current phase>` before long reading, testing, or
@@ -253,6 +266,19 @@ deliverable, ack-only, or no longer running. If that followup is still
 silent or ack-only, record the result as inconclusive, do not count it
 as approval/pass, close it if safe, and respawn a smaller
 `fork_turns: "none"` task with the missing deliverable.
+
+# Subagent-dependent transition barrier
+Do not mark an `update_plan` step `completed` while an active child owns
+evidence for that step. Do not start dependent implementation until the
+audit, research, or review result is integrated or explicitly recorded
+as inconclusive. Do not generate a plan before spawned research lanes
+that feed the plan have returned or been closed as inconclusive.
+Do not write the final answer, PR handoff, or completion summary while
+active child agents remain open. Use short `wait_agent` cycles.
+After two silent waits send `TASK STILL ACTIVE: return <deliverable> or
+BLOCKED: <reason>`. After four silent or ack-only checks, close the lane as
+inconclusive, record that it is not approval, and respawn smaller only
+if the deliverable is still required.
 
 # Verification gate (TRIGGERED, NOT OPTIONAL)
 

--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -87,10 +87,63 @@ export function insertCodexCompatibilityGuidance(content) {
 	return `${frontmatterMatch[0]}${codexHarnessToolCompatibility}${contentWithoutGuidance.slice(frontmatterMatch[0].length)}`;
 }
 
+const startWorkOriginalCompletion = `When all top-level checkboxes in \`## TODOs\` and \`## Final Verification Wave\` are complete:
+
+1. Run the plan's final verification commands.
+2. If worktree mode was used, sync \`.omo/\` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
+3. Remove or mark the Boulder work as completed.
+4. Print an \`ORCHESTRATION COMPLETE\` block with the plan path, verification commands, artifacts, and cleanup receipts.`;
+
+const startWorkCodexCompletion = `When all top-level checkboxes in \`## TODOs\` and \`## Final Verification Wave\` are complete:
+
+1. Run the plan's final verification commands.
+2. Complete the **Global Review and Debugging Gate** before any completion claim, PR handoff, or branch handoff:
+   - Invoke the \`review-work\` skill with the final diff, changed files, user goal, constraints, run command, and verification evidence. All five review lanes must return PASS. A timeout, missing deliverable, ack-only child, \`BLOCKED:\`, or inconclusive lane is a gate failure, not approval.
+   - Run a debugging-oriented runtime audit even when the review passes: name at least three plausible failure hypotheses for the changed surface, run the distinguishing checks against the actual artifact, and append the ruled-out or confirmed result to \`.omo/start-work/ledger.jsonl\`.
+   - If any review lane or debugging hypothesis fails, invoke the \`debugging\` skill, confirm root cause with runtime evidence, add the minimal failing test or reproduction, fix it, rerun the affected verification, then rerun the Global Review and Debugging Gate.
+   - Evidence hygiene is mandatory: redact or mask secrets and sensitive user data before writing \`.omo/start-work/ledger.jsonl\`, a PR body, or a handoff. Never include raw tokens, credentials, auth headers, cookies, API keys, env dumps, private logs, or PII; use concise summaries, lengths, hashes, or short non-sensitive prefixes instead.
+   - If the work includes creating, updating, or handing off a PR, refresh \`git status\` and the PR/branch state after the gate, and include only redacted review/debugging evidence in the PR body or handoff.
+3. If worktree mode was used, sync \`.omo/\` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
+4. Remove or mark the Boulder work as completed.
+5. Print an \`ORCHESTRATION COMPLETE\` block with the plan path, verification commands, Global Review and Debugging Gate verdict, artifacts, and cleanup receipts.`;
+
+const startWorkOriginalHardRule = "- No completion claim while an applicable ultraqa adversarial class was never probed. Each applicable class needs a captured observable result; each skipped class needs a one-line not-applicable reason in the ledger.\n- No unprefixed session ids in Boulder state. Codex sessions are always `codex:<session_id>`.";
+
+const startWorkCodexHardRule = "- No completion claim while an applicable ultraqa adversarial class was never probed. Each applicable class needs a captured observable result; each skipped class needs a one-line not-applicable reason in the ledger.\n- No `ORCHESTRATION COMPLETE`, final response, PR creation, or PR handoff before the Global Review and Debugging Gate passes with recorded evidence.\n- No unprefixed session ids in Boulder state. Codex sessions are always `codex:<session_id>`.";
+
+const reviewWorkAnchor = "Launch 5 specialized sub-agents in parallel to review completed implementation work from every angle. All 5 must pass for the review to pass. If even ONE fails, the review fails.\n";
+
+const reviewWorkCodexGate = `
+When \`review-work\` is used as a final implementation, PR, or \`$start-work\`
+gate, it is blocking. A timeout, missing deliverable, ack-only response,
+explicit \`BLOCKED:\`, or inconclusive lane is not a pass. Treat that lane as
+failed, investigate the underlying uncertainty with the \`debugging\` skill when
+runtime behavior may be wrong, fix with evidence, and rerun the affected lane
+before claiming completion or handing off a PR.
+
+Review evidence must be safe to share. Redact or mask secrets and sensitive
+user data before including evidence in logs, PR bodies, or handoffs. Never
+include raw tokens, credentials, auth headers, cookies, API keys, env dumps,
+private logs, or PII; summarize with lengths, hashes, and short non-sensitive
+prefixes when identity is needed.
+`;
+
+function applyCodexSkillOverlays(skillName, content) {
+	if (skillName === "start-work") {
+		return content
+			.replace(startWorkOriginalCompletion, startWorkCodexCompletion)
+			.replace(startWorkOriginalHardRule, startWorkCodexHardRule);
+	}
+	if (skillName === "review-work" && !content.includes("When `review-work` is used as a final implementation")) {
+		return content.replace(reviewWorkAnchor, `${reviewWorkAnchor}${reviewWorkCodexGate}`);
+	}
+	return content;
+}
+
 async function adaptSkillForCodex(skillName) {
 	const skillPath = join(skillsRoot, skillName, "SKILL.md");
 	const content = await readFile(skillPath, "utf8");
-	const adapted = insertCodexCompatibilityGuidance(content);
+	const adapted = applyCodexSkillOverlays(skillName, insertCodexCompatibilityGuidance(content));
 	if (adapted !== content) {
 		await writeFile(skillPath, adapted, "utf8");
 	}

--- a/packages/omo-codex/plugin/skills/review-work/SKILL.md
+++ b/packages/omo-codex/plugin/skills/review-work/SKILL.md
@@ -55,6 +55,19 @@ aggregate result.
 
 Launch 5 specialized sub-agents in parallel to review completed implementation work from every angle. All 5 must pass for the review to pass. If even ONE fails, the review fails.
 
+When `review-work` is used as a final implementation, PR, or `$start-work`
+gate, it is blocking. A timeout, missing deliverable, ack-only response,
+explicit `BLOCKED:`, or inconclusive lane is not a pass. Treat that lane as
+failed, investigate the underlying uncertainty with the `debugging` skill when
+runtime behavior may be wrong, fix with evidence, and rerun the affected lane
+before claiming completion or handing off a PR.
+
+Review evidence must be safe to share. Redact or mask secrets and sensitive
+user data before including evidence in logs, PR bodies, or handoffs. Never
+include raw tokens, credentials, auth headers, cookies, API keys, env dumps,
+private logs, or PII; summarize with lengths, hashes, and short non-sensitive
+prefixes when identity is needed.
+
 The 5 agents cover complementary concerns - together they form a comprehensive review that no single reviewer could match:
 
 | # | Agent | Type | Role | Focus Level |

--- a/packages/omo-codex/plugin/skills/start-work/SKILL.md
+++ b/packages/omo-codex/plugin/skills/start-work/SKILL.md
@@ -192,9 +192,15 @@ Only after verification passes:
 When all top-level checkboxes in `## TODOs` and `## Final Verification Wave` are complete:
 
 1. Run the plan's final verification commands.
-2. If worktree mode was used, sync `.omo/` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
-3. Remove or mark the Boulder work as completed.
-4. Print an `ORCHESTRATION COMPLETE` block with the plan path, verification commands, artifacts, and cleanup receipts.
+2. Complete the **Global Review and Debugging Gate** before any completion claim, PR handoff, or branch handoff:
+   - Invoke the `review-work` skill with the final diff, changed files, user goal, constraints, run command, and verification evidence. All five review lanes must return PASS. A timeout, missing deliverable, ack-only child, `BLOCKED:`, or inconclusive lane is a gate failure, not approval.
+   - Run a debugging-oriented runtime audit even when the review passes: name at least three plausible failure hypotheses for the changed surface, run the distinguishing checks against the actual artifact, and append the ruled-out or confirmed result to `.omo/start-work/ledger.jsonl`.
+   - If any review lane or debugging hypothesis fails, invoke the `debugging` skill, confirm root cause with runtime evidence, add the minimal failing test or reproduction, fix it, rerun the affected verification, then rerun the Global Review and Debugging Gate.
+   - Evidence hygiene is mandatory: redact or mask secrets and sensitive user data before writing `.omo/start-work/ledger.jsonl`, a PR body, or a handoff. Never include raw tokens, credentials, auth headers, cookies, API keys, env dumps, private logs, or PII; use concise summaries, lengths, hashes, or short non-sensitive prefixes instead.
+   - If the work includes creating, updating, or handing off a PR, refresh `git status` and the PR/branch state after the gate, and include only redacted review/debugging evidence in the PR body or handoff.
+3. If worktree mode was used, sync `.omo/` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
+4. Remove or mark the Boulder work as completed.
+5. Print an `ORCHESTRATION COMPLETE` block with the plan path, verification commands, Global Review and Debugging Gate verdict, artifacts, and cleanup receipts.
 
 ## Hard rules
 
@@ -202,5 +208,6 @@ When all top-level checkboxes in `## TODOs` and `## Final Verification Wave` are
 - No `--dry-run` as completion evidence.
 - No tests-only completion claim. A Manual-QA artifact is required.
 - No completion claim while an applicable ultraqa adversarial class was never probed. Each applicable class needs a captured observable result; each skipped class needs a one-line not-applicable reason in the ledger.
+- No `ORCHESTRATION COMPLETE`, final response, PR creation, or PR handoff before the Global Review and Debugging Gate passes with recorded evidence.
 - No unprefixed session ids in Boulder state. Codex sessions are always `codex:<session_id>`.
 - No stale-memory execution. The plan and ledger are the durable source of truth.

--- a/packages/omo-codex/plugin/test/global-review-debug-gate.test.mjs
+++ b/packages/omo-codex/plugin/test/global-review-debug-gate.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("#given start-work continuation directive #when inspected #then final handoff requires review and debugging gate", async () => {
+	const text = await readFile(join(pluginRoot, "components", "start-work-continuation", "directive.md"), "utf8");
+
+	assert.match(text, /Global Review and Debugging Gate/);
+	assert.match(text, /review-work/);
+	assert.match(text, /debugging/);
+	assert.match(text, /Do not print `ORCHESTRATION COMPLETE`/);
+	assert.match(text, /Do not create a PR, PR handoff, or branch handoff/);
+	assert.match(text, /redact.*secrets.*PII/s);
+});
+
+test("#given Hephaestus baseline rule #when inspected #then significant implementation and PR handoff require the same gate", async () => {
+	const text = await readFile(join(pluginRoot, "components", "rules", "bundled-rules", "hephaestus.md"), "utf8");
+
+	assert.match(text, /Global Review and Debugging Gate/);
+	assert.match(text, /significant implementation work/);
+	assert.match(text, /review-work/);
+	assert.match(text, /debugging/);
+	assert.match(text, /PR handoff/);
+	assert.match(text, /redact.*secrets.*PII/s);
+});

--- a/packages/omo-codex/plugin/test/start-work-skill.test.mjs
+++ b/packages/omo-codex/plugin/test/start-work-skill.test.mjs
@@ -9,6 +9,9 @@ const repoRoot = dirname(dirname(dirname(pluginRoot)));
 const startWorkSkillPaths = [
 	join(repoRoot, "packages", "shared-skills", "skills", "start-work", "SKILL.md"),
 ];
+const packagedStartWorkSkillPath = join(pluginRoot, "skills", "start-work", "SKILL.md");
+const packagedReviewWorkSkillPath = join(pluginRoot, "skills", "review-work", "SKILL.md");
+const hephaestusRulePath = join(pluginRoot, "components", "rules", "bundled-rules", "hephaestus.md");
 const stopHookPath = join(
 	pluginRoot,
 	"components",
@@ -65,6 +68,28 @@ test("#given worker done claim #when start-work contract is inspected #then adve
 
 	// then
 	assert.deepEqual(missing, []);
+});
+
+test("#given packaged start-work completion surfaces #when inspected #then global review and debugging gate blocks completion", async () => {
+	// given
+	const [startWorkSkill, reviewWorkSkill, hephaestusRule] = await Promise.all([
+		readFile(packagedStartWorkSkillPath, "utf8"),
+		readFile(packagedReviewWorkSkillPath, "utf8"),
+		readFile(hephaestusRulePath, "utf8"),
+	]);
+
+	// then
+	assert.match(startWorkSkill, /Global Review and Debugging Gate/);
+	assert.match(startWorkSkill, /\breview-work\b/);
+	assert.match(startWorkSkill, /\bdebugging\b/);
+	assert.match(startWorkSkill, /inconclusive/i);
+	assert.match(startWorkSkill, /redact|mask/i);
+	assert.match(startWorkSkill, /raw (?:tokens|credentials|auth headers|cookies)/i);
+	assert.match(startWorkSkill, /ORCHESTRATION COMPLETE/);
+	assert.match(reviewWorkSkill, /debugging/i);
+	assert.match(reviewWorkSkill, /inconclusive/i);
+	assert.match(hephaestusRule, /Global Review and Debugging Gate/);
+	assert.match(hephaestusRule, /redact.*secrets.*PII/s);
 });
 
 test("#given start-work continuation hook #when inspected #then it remains Boulder-only without planning bootstrap logic", async () => {

--- a/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
+++ b/packages/omo-codex/plugin/test/subagent-guidance.test.mjs
@@ -65,6 +65,38 @@ test("#given ultrawork directive #when inspected #then reviewer fallback keeps a
 	assert.match(text, /single `list_agents`/);
 });
 
+test("#given ultrawork directive #when inspected #then dependent subagent transitions are blocked", async () => {
+	// given
+	const directivePath = "components/ultrawork/directive.md";
+
+	// when
+	const text = await readFile(join(root, directivePath), "utf8");
+
+	// then
+	assert.match(text, /Subagent-dependent transition barrier/);
+	assert.match(text, /Do not mark.*update_plan.*completed.*active child/s);
+	assert.match(text, /Do not start dependent implementation.*audit.*research.*review.*integrated/s);
+	assert.match(text, /Do not write the final answer.*active child agents/s);
+	assert.match(text, /two silent waits.*TASK STILL ACTIVE/s);
+	assert.match(text, /four silent or ack-only checks.*inconclusive/s);
+});
+
+test("#given ultrawork directive #when inspected #then TOML-backed routing is treated as unverified when native spawn cannot select it", async () => {
+	// given
+	const directivePath = "components/ultrawork/directive.md";
+
+	// when
+	const text = await readFile(join(root, directivePath), "utf8");
+
+	// then
+	assert.match(text, /TOML-backed subagent routing compatibility/);
+	assert.match(text, /routing-unverified/);
+	assert.match(text, /task_name.*does not prove.*TOML-backed role/s);
+	assert.match(text, /spawn_agent.*schema.*agent_type.*model.*reasoning_effort/s);
+	assert.match(text, /paste the role requirements into the message/s);
+	assert.match(text, /service_tier.*supported/s);
+});
+
 test("#given ulw-loop workflow #when inspected #then stale review refresh keeps policy changes narrow", async () => {
 	// given
 	const workflowPaths = [

--- a/packages/omo-codex/plugin/test/sync-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills.test.mjs
@@ -55,6 +55,45 @@ function removeCodexCompatibilityGuidance(content) {
 	return `${content.slice(0, start)}${content.slice(end + endMarker.length)}`;
 }
 
+const startWorkOriginalCompletion = `When all top-level checkboxes in \`## TODOs\` and \`## Final Verification Wave\` are complete:
+
+1. Run the plan's final verification commands.
+2. If worktree mode was used, sync \`.omo/\` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
+3. Remove or mark the Boulder work as completed.
+4. Print an \`ORCHESTRATION COMPLETE\` block with the plan path, verification commands, artifacts, and cleanup receipts.`;
+
+const startWorkCodexCompletion = `When all top-level checkboxes in \`## TODOs\` and \`## Final Verification Wave\` are complete:
+
+1. Run the plan's final verification commands.
+2. Complete the **Global Review and Debugging Gate** before any completion claim, PR handoff, or branch handoff:
+   - Invoke the \`review-work\` skill with the final diff, changed files, user goal, constraints, run command, and verification evidence. All five review lanes must return PASS. A timeout, missing deliverable, ack-only child, \`BLOCKED:\`, or inconclusive lane is a gate failure, not approval.
+   - Run a debugging-oriented runtime audit even when the review passes: name at least three plausible failure hypotheses for the changed surface, run the distinguishing checks against the actual artifact, and append the ruled-out or confirmed result to \`.omo/start-work/ledger.jsonl\`.
+   - If any review lane or debugging hypothesis fails, invoke the \`debugging\` skill, confirm root cause with runtime evidence, add the minimal failing test or reproduction, fix it, rerun the affected verification, then rerun the Global Review and Debugging Gate.
+   - Evidence hygiene is mandatory: redact or mask secrets and sensitive user data before writing \`.omo/start-work/ledger.jsonl\`, a PR body, or a handoff. Never include raw tokens, credentials, auth headers, cookies, API keys, env dumps, private logs, or PII; use concise summaries, lengths, hashes, or short non-sensitive prefixes instead.
+   - If the work includes creating, updating, or handing off a PR, refresh \`git status\` and the PR/branch state after the gate, and include only redacted review/debugging evidence in the PR body or handoff.
+3. If worktree mode was used, sync \`.omo/\` state back to the main repo, merge or hand off exactly as requested, and remove the worktree only after successful merge or explicit handoff.
+4. Remove or mark the Boulder work as completed.
+5. Print an \`ORCHESTRATION COMPLETE\` block with the plan path, verification commands, Global Review and Debugging Gate verdict, artifacts, and cleanup receipts.`;
+
+const startWorkOriginalHardRule = "- No completion claim while an applicable ultraqa adversarial class was never probed. Each applicable class needs a captured observable result; each skipped class needs a one-line not-applicable reason in the ledger.\n- No unprefixed session ids in Boulder state. Codex sessions are always `codex:<session_id>`.";
+
+const startWorkCodexHardRule = "- No completion claim while an applicable ultraqa adversarial class was never probed. Each applicable class needs a captured observable result; each skipped class needs a one-line not-applicable reason in the ledger.\n- No `ORCHESTRATION COMPLETE`, final response, PR creation, or PR handoff before the Global Review and Debugging Gate passes with recorded evidence.\n- No unprefixed session ids in Boulder state. Codex sessions are always `codex:<session_id>`.";
+
+const reviewWorkCodexGatePattern =
+	/\nWhen `review-work` is used as a final implementation, PR, or `\$start-work`\ngate, it is blocking\. A timeout, missing deliverable, ack-only response,\nexplicit `BLOCKED:`, or inconclusive lane is not a pass\. Treat that lane as\nfailed, investigate the underlying uncertainty with the `debugging` skill when\nruntime behavior may be wrong, fix with evidence, and rerun the affected lane\nbefore claiming completion or handing off a PR\.\n\nReview evidence must be safe to share\. Redact or mask secrets and sensitive\nuser data before including evidence in logs, PR bodies, or handoffs\. Never\ninclude raw tokens, credentials, auth headers, cookies, API keys, env dumps,\nprivate logs, or PII; summarize with lengths, hashes, and short non-sensitive\nprefixes when identity is needed\.\n/;
+
+function removeCodexSkillOverlays(skillName, content) {
+	if (skillName === "start-work") {
+		return content
+			.replace(startWorkCodexCompletion, startWorkOriginalCompletion)
+			.replace(startWorkCodexHardRule, startWorkOriginalHardRule);
+	}
+	if (skillName === "review-work") {
+		return content.replace(reviewWorkCodexGatePattern, "");
+	}
+	return content;
+}
+
 async function listSkillFiles(dir) {
 	const entries = await readdir(dir, { withFileTypes: true });
 	const files = [];
@@ -135,7 +174,7 @@ test("#given shared skill package source #when aggregate Codex shared skills are
 		const sharedContent = await readFile(join(sharedSkillsRoot, skillName, "SKILL.md"), "utf8");
 		const aggregateContent = await readFile(join(aggregateSkillsRoot, skillName, "SKILL.md"), "utf8");
 		assert.equal(
-			removeCodexCompatibilityGuidance(aggregateContent),
+			removeCodexSkillOverlays(skillName, removeCodexCompatibilityGuidance(aggregateContent)),
 			removeCodexCompatibilityGuidance(sharedContent),
 			`${skillName} drifted from shared-skills`,
 		);

--- a/packages/omo-codex/scripts/install-omx-compatibility.test.mjs
+++ b/packages/omo-codex/scripts/install-omx-compatibility.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { updateCodexConfig } from "./install/config.mjs";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(packageRoot, "..", "..", "..");
+
+test("#given OMX-owned Codex config #when lazycodex updates config #then preserves OMX blocks", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-codex-omx-compat-"));
+	const configPath = join(root, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			"[features]",
+			"plugins = false",
+			"",
+			"[tui]",
+			'hud = "omx"',
+			"",
+			"[shell_environment_policy]",
+			'inherit = "core"',
+			"",
+		].join("\n"),
+	);
+
+	await updateCodexConfig({
+		configPath,
+		repoRoot: "/repo/packages/omo-codex",
+		marketplaceName: "sisyphuslabs",
+		marketplaceSource: { sourceType: "local", source: "/repo/packages/omo-codex/cache/sisyphuslabs" },
+		pluginNames: ["omo"],
+	});
+
+	const config = await readFile(configPath, "utf8");
+	assert.match(config, /\[features\][\s\S]*plugins = true/);
+	assert.match(config, /\[tui\][\s\S]*hud = "omx"/);
+	assert.match(config, /\[shell_environment_policy\][\s\S]*inherit = "core"/);
+	assert.match(config, /\[plugins\."omo@sisyphuslabs"\]/);
+});
+
+test("#given Codex Light docs #when inspected #then OMX coexistence is documented", async () => {
+	const docs = await Promise.all(
+		[
+			join(repoRoot, "packages", "omo-codex", "README.md"),
+			join(repoRoot, "packages", "omo-codex", "MARKETPLACE.md"),
+			join(repoRoot, "docs", "guide", "installation.md"),
+		].map(async (path) => [path, await readFile(path, "utf8")]),
+	);
+
+	for (const [path, text] of docs) {
+		assert.match(text, /oh-my-codex \(OMX\)/, `${path} should name OMX compatibility`);
+		assert.match(text, /preserves unrelated `?\[features\]`?, `?\[tui\]`?, and `?\[shell_environment_policy\]`? blocks/, `${path} should document config preservation`);
+		assert.match(text, /does not define hook precedence/, `${path} should document hook precedence limits`);
+		assert.match(text, /rerun `npx lazycodex-ai install` after `omx setup`/, `${path} should document repair order`);
+	}
+});


### PR DESCRIPTION
## Summary
Ports the current open `code-yeongyu/lazycodex` mirror issues and PRs into the source-of-truth `packages/omo-codex` implementation.

Covers lazycodex issues #30, #31, #32 and PRs #33, #34, #35 without merging mirror branches directly.

## Changes
- Hardens ultrawork subagent guidance so dependent transitions wait for spawned research/review/audit lanes and TOML-backed routing is treated as unverified unless the native runtime proves role selection.
- Documents oh-my-codex (OMX) coexistence and pins installer config preservation for unrelated `[features]`, `[tui]`, and `[shell_environment_policy]` blocks.
- Adds a global review/debugging gate to start-work continuation and the bundled Hephaestus rule before completion, PR handoff, or branch handoff.

## Testing
- `node --test packages/omo-codex/plugin/test/subagent-guidance.test.mjs packages/omo-codex/scripts/install-omx-compatibility.test.mjs packages/omo-codex/plugin/test/global-review-debug-gate.test.mjs`
- `bun run test:codex`
- `bun run typecheck`
- `bun run build`
- Manual tmux QA artifacts captured under `.omo/evidence/sc1-subagent-routing.txt`, `.omo/evidence/sc2-omx-compat.txt`, and `.omo/evidence/sc3-global-gate.txt` in the local worktree, with cleanup receipts.

## Related Mirror Items
- code-yeongyu/lazycodex#30
- code-yeongyu/lazycodex#31
- code-yeongyu/lazycodex#32
- code-yeongyu/lazycodex#33
- code-yeongyu/lazycodex#34
- code-yeongyu/lazycodex#35

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports open fixes from `code-yeongyu/lazycodex` into `packages/omo-codex`, hardening subagent flow and enforcing a global review/debug gate that now also blocks the packaged `start-work` skill from completing until it passes. Documents oh-my-codex coexistence and preserves its config during install.

- **Bug Fixes**
  - Block plan and implementation transitions until spawned audit/research/review lanes finish; close silent/ack-only lanes as inconclusive with short waits.
  - Treat TOML-backed role routing as unverified unless runtime proves `agent_type`, `model`, and `reasoning_effort`; record fallbacks (including `service_tier` support).

- **New Features**
  - Global Review and Debugging Gate: require `review-work` plus a `debugging` audit; forbid completion, PRs, and handoffs until it passes; always redact secrets/PII. This gate now applies to the packaged `start-work` skill and Hephaestus rule.
  - `sync-skills` injects Codex overlays into `start-work` and `review-work` so the gate ships in-package; tests verify overlays, gating behavior, and OMX config preservation while managing only `omo@sisyphuslabs`.

<sup>Written for commit f603e9d3030ae486455cb804797b7c9bf40e2faa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

