### PR TITLE
fix(runtime-skills): support Node HTTP source server

### DIFF
--- a/packages/omo-opencode/src/features/opencode-runtime-skills/source-server.test.ts
+++ b/packages/omo-opencode/src/features/opencode-runtime-skills/source-server.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 describe("runtime security skill source server", () => {
   test("serves an OpenCode skill index and markdown files with matching frontmatter names", async () => {
     // given
-    const source = createRuntimeSkillSourceServer({
+    const source = await createRuntimeSkillSourceServer({
       skills: selectRuntimeSecuritySkills(),
     })
     cleanupServer = source
@@ -43,7 +43,7 @@ describe("runtime security skill source server", () => {
 
   test("returns 404 for unknown paths", async () => {
     // given
-    const source = createRuntimeSkillSourceServer({
+    const source = await createRuntimeSkillSourceServer({
       skills: selectRuntimeSecuritySkills(),
     })
     cleanupServer = source
@@ -53,5 +53,30 @@ describe("runtime security skill source server", () => {
 
     // then
     expect(response.status).toBe(404)
+  })
+
+  test("falls back to a Node HTTP server when Bun.serve is unavailable", async () => {
+    // given
+    const source = await createRuntimeSkillSourceServer(
+      {
+        skills: selectRuntimeSecuritySkills(),
+      },
+      {},
+    )
+    cleanupServer = source
+
+    // when
+    const indexResponse = await source.fetch(new Request(new URL("index.json", source.url)))
+    const index = await indexResponse.json()
+
+    // then
+    expect(source.url).toStartWith("http://127.0.0.1:")
+    expect(indexResponse.status).toBe(200)
+    expect(index).toEqual({
+      skills: [
+        { name: "security-research", files: ["SKILL.md"] },
+        { name: "security-review", files: ["SKILL.md"] },
+      ],
+    })
   })
 })

--- a/packages/omo-opencode/src/features/opencode-runtime-skills/source-server.ts
+++ b/packages/omo-opencode/src/features/opencode-runtime-skills/source-server.ts
@@ -1,3 +1,4 @@
+import { createServer, type ServerResponse } from "node:http"
 import type { RuntimeSkillSourceEntry } from "./runtime-skill-config"
 
 export type RuntimeSkillSourceServer = {
@@ -19,7 +20,9 @@ type BunServeRuntime = {
   }): BunServeServer
 }
 
-const runtime = globalThis as typeof globalThis & { Bun?: BunServeRuntime }
+type RuntimeSkillSourceRuntime = typeof globalThis & { Bun?: BunServeRuntime }
+
+const runtime = globalThis as RuntimeSkillSourceRuntime
 
 function jsonResponse(body: unknown): Response {
   return Response.json(body, {
@@ -38,9 +41,20 @@ function markdownResponse(markdown: string): Response {
   })
 }
 
-export function createRuntimeSkillSourceServer(options: {
-  readonly skills: readonly RuntimeSkillSourceEntry[]
-}): RuntimeSkillSourceServer {
+async function writeResponse(response: Response, output: ServerResponse): Promise<void> {
+  output.writeHead(
+    response.status,
+    Object.fromEntries(response.headers.entries()),
+  )
+  output.end(new Uint8Array(await response.arrayBuffer()))
+}
+
+export async function createRuntimeSkillSourceServer(
+  options: {
+    readonly skills: readonly RuntimeSkillSourceEntry[]
+  },
+  runtimeEnv: Pick<RuntimeSkillSourceRuntime, "Bun"> = runtime,
+): Promise<RuntimeSkillSourceServer> {
   const skillMarkdownByPath = new Map(
     options.skills.map((skill) => [`/${skill.name}/SKILL.md`, skill.markdown]),
   )
@@ -49,11 +63,6 @@ export function createRuntimeSkillSourceServer(options: {
       name: skill.name,
       files: ["SKILL.md"],
     })),
-  }
-
-  const bun = runtime.Bun
-  if (!bun) {
-    throw new Error("Runtime skill source server requires Bun.serve")
   }
 
   function handleRequest(request: Request): Response | Promise<Response> {
@@ -66,6 +75,42 @@ export function createRuntimeSkillSourceServer(options: {
     if (markdown) return markdownResponse(markdown)
 
     return new Response("not found", { status: 404 })
+  }
+
+  const bun = runtimeEnv.Bun
+  if (!bun) {
+    const server = createServer(async (request, response) => {
+      try {
+        const sourceUrl = new URL(request.url ?? "/", "http://127.0.0.1")
+        await writeResponse(await handleRequest(new Request(sourceUrl.toString())), response)
+      } catch (error) {
+        response.writeHead(500, { "content-type": "text/plain; charset=utf-8" })
+        response.end(error instanceof Error ? error.message : String(error))
+      }
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error)
+      const onListening = () => {
+        server.off("error", onError)
+        resolve()
+      }
+      server.once("error", onError)
+      server.once("listening", onListening)
+      server.listen(0, "127.0.0.1")
+    })
+
+    const address = server.address()
+    if (typeof address !== "object" || address === null || typeof address.port !== "number") {
+      server.close()
+      throw new Error("Runtime skill source server failed to bind a loopback port")
+    }
+
+    return {
+      url: `http://127.0.0.1:${address.port}/`,
+      fetch: handleRequest,
+      stop: () => server.close(),
+    }
   }
 
   const server = bun.serve({

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -117,10 +117,10 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
 
     const pluginConfig = deps.loadPluginConfig(input.directory, input)
     const runtimeSecuritySkills = selectRuntimeSecuritySkills(pluginConfig)
-    let runtimeSkillSource: ReturnType<PluginModuleDeps["createRuntimeSkillSourceServer"]> | undefined
+    let runtimeSkillSource: Awaited<ReturnType<PluginModuleDeps["createRuntimeSkillSourceServer"]>> | undefined
     if (runtimeSecuritySkills.length > 0) {
       try {
-        runtimeSkillSource = deps.createRuntimeSkillSourceServer({ skills: runtimeSecuritySkills })
+        runtimeSkillSource = await deps.createRuntimeSkillSourceServer({ skills: runtimeSecuritySkills })
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error)
         console.warn(`[runtime-skills] bundled security skill source unavailable; continuing without config.skills.urls: ${detail}`)


### PR DESCRIPTION
## Summary

- keep the existing Bun.serve path for Bun runtimes
- add a Node.js `node:http` fallback for OpenCode Desktop / Electron where `globalThis.Bun` is unavailable
- await runtime skill source startup so the dynamically assigned loopback port is known before `config.skills.urls` is populated
- add coverage for the no-Bun fallback path

## Why

OpenCode Desktop loads the plugin in a Node/Electron sidecar. In published builds such as v4.7.5, `createRuntimeSkillSourceServer()` hard-requires `Bun.serve`; when `Bun` is absent, plugin startup can fail before OMO agents are registered, leaving the GUI with only native Build/Plan modes.

The current dev branch already degrades if source creation fails, but that still hides bundled runtime security skills. This change fixes the root runtime mismatch by serving the same source over Node's built-in HTTP server when Bun is not available.

This is a narrower alternative to #4720: it only touches the runtime skill source path and the direct async caller, avoiding config-context and submodule changes.

Fixes #5027.
Relates to #4732, #4662, and #4720.

## Verification

- `bun test src/features/opencode-runtime-skills/source-server.test.ts src/testing/create-plugin-module.test.ts`
- `bun run typecheck`
- `bun run build`
- Node smoke: compiled `source-server.ts` with `--target node`, started fallback server, and fetched `/index.json` via `node:http` with HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Node `node:http` fallback for the runtime skill source server when `Bun` is unavailable, so Desktop/Electron can serve bundled security skills. Also awaits server startup to get the loopback port before populating `config.skills.urls`. Fixes #5027.

- **Bug Fixes**
  - Keep `Bun.serve` for Bun; start a loopback `node:http` server otherwise, waiting for a bound port.
  - Add tests for the no-Bun path and 404 handling.
  - Allow injecting a runtime env for tests via an optional param.

- **Migration**
  - `createRuntimeSkillSourceServer` is now async; update call sites to `await` its result.

<sup>Written for commit 976be43ebf16945fd6428a444c1665347a05180d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

