### PR TITLE
feat(claude-code-hooks): apply_patch virtual hook expansion for Edit/Write compatibility

### DIFF
--- a/src/hooks/claude-code-hooks/apply-patch-adapter.test.ts
+++ b/src/hooks/claude-code-hooks/apply-patch-adapter.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, mock, afterAll } from "bun:test"
+import { restoreModuleMocksForTestFile } from "../../testing/module-mock-lifecycle"
+
+const mockFindMatchingHooks = mock(() => [])
+
+mock.module("../../shared", () => ({
+	findMatchingHooks: mockFindMatchingHooks,
+}))
+
+afterAll(() => {
+	mock.restore()
+	restoreModuleMocksForTestFile(import.meta.url)
+})
+
+const {
+	isApplyPatchTool,
+	extractVirtualEdits,
+	hasDirectApplyPatchMatcher,
+	buildVirtualToolInput,
+	deduplicateByFilePath,
+} = await import("./apply-patch-adapter")
+
+describe("apply-patch-adapter", () => {
+	describe("isApplyPatchTool", () => {
+		it("#given exact tool name #when checked #then returns true", () => {
+			expect(isApplyPatchTool("apply_patch")).toBe(true)
+		})
+
+		it("#given tool name with whitespace #when checked #then returns true", () => {
+			expect(isApplyPatchTool("  apply_patch ")).toBe(true)
+		})
+
+		it("#given uppercase tool name #when checked #then returns false", () => {
+			expect(isApplyPatchTool("Apply_Patch")).toBe(false)
+		})
+
+		it("#given different tool name #when checked #then returns false", () => {
+			expect(isApplyPatchTool("edit")).toBe(false)
+			expect(isApplyPatchTool("write")).toBe(false)
+			expect(isApplyPatchTool("bash")).toBe(false)
+		})
+	})
+
+	describe("extractVirtualEdits", () => {
+		it("#given metadata with files #when extracted #then maps to virtual edits", () => {
+			// given
+			const metadata = {
+				files: [
+					{
+						filePath: "src/a.ts",
+						before: "old content",
+						after: "new content",
+					},
+				],
+			}
+
+			// when
+			const edits = extractVirtualEdits(metadata)
+
+			// then
+			expect(edits).toHaveLength(1)
+			expect(edits[0]).toEqual({
+				filePath: "src/a.ts",
+				ccToolName: "Edit",
+				isNewFile: false,
+				before: "old content",
+				after: "new content",
+			})
+		})
+
+		it("#given metadata with new file (empty before) #when extracted #then maps to Write", () => {
+			// given
+			const metadata = {
+				files: [
+					{
+						filePath: "src/new.ts",
+						before: "",
+						after: "brand new content\n",
+					},
+				],
+			}
+
+			// when
+			const edits = extractVirtualEdits(metadata)
+
+			// then
+			expect(edits).toHaveLength(1)
+			expect(edits[0]).toEqual({
+				filePath: "src/new.ts",
+				ccToolName: "Write",
+				isNewFile: true,
+				before: "",
+				after: "brand new content\n",
+			})
+		})
+
+		it("#given no metadata and args with patchText #when extracted #then parses patch", () => {
+			// given
+			const patch =
+				"*** Begin Patch\n*** Add File: src/new.ts\n+hello\n*** End Patch"
+
+			// when
+			const edits = extractVirtualEdits(undefined, { patchText: patch })
+
+			// then
+			expect(edits).toHaveLength(1)
+			expect(edits[0].filePath).toBe("src/new.ts")
+			expect(edits[0].ccToolName).toBe("Write")
+			expect(edits[0].isNewFile).toBe(true)
+		})
+
+		it("#given no metadata and no args #when extracted #then returns empty", () => {
+			expect(extractVirtualEdits(undefined)).toHaveLength(0)
+		})
+
+		it("#given empty metadata and empty args #when extracted #then returns empty", () => {
+			expect(extractVirtualEdits({}, {})).toHaveLength(0)
+		})
+
+		it("#given metadata with delete file #when extracted #then skips delete", () => {
+			// given
+			const metadata = {
+				files: [
+					{
+						filePath: "src/deleted.ts",
+						before: "old",
+						after: "new",
+						type: "delete",
+					},
+				],
+			}
+
+			// when
+			const edits = extractVirtualEdits(metadata)
+
+			// then
+			expect(edits).toHaveLength(0)
+		})
+
+		it("#given multiple files #when extracted #then maps all", () => {
+			// given
+			const metadata = {
+				files: [
+					{ filePath: "a.ts", before: "old_a", after: "new_a" },
+					{ filePath: "b.ts", before: "", after: "new_b\n" },
+					{ filePath: "c.ts", before: "old_c", after: "new_c" },
+				],
+			}
+
+			// when
+			const edits = extractVirtualEdits(metadata)
+
+			// then
+			expect(edits).toHaveLength(3)
+			expect(edits[0].ccToolName).toBe("Edit")
+			expect(edits[1].ccToolName).toBe("Write")
+			expect(edits[2].ccToolName).toBe("Edit")
+		})
+	})
+
+	describe("hasDirectApplyPatchMatcher", () => {
+		it("#given null config #when checked #then returns false", () => {
+			expect(hasDirectApplyPatchMatcher(null, "PreToolUse")).toBe(false)
+		})
+
+		it("#given config with no matching matcher #when checked #then returns false", () => {
+			mockFindMatchingHooks.mockReturnValue([])
+			expect(hasDirectApplyPatchMatcher({}, "PreToolUse")).toBe(false)
+		})
+
+		it("#given config with ApplyPatch matcher #when checked #then returns true", () => {
+			mockFindMatchingHooks.mockReturnValue([{ matcher: "ApplyPatch", hooks: [] }])
+			expect(hasDirectApplyPatchMatcher({}, "PreToolUse")).toBe(true)
+		})
+
+		it("#given config with ApplyPatch matcher for different event #when checked for other event #then returns false", () => {
+			// PreToolUse has no match, PostToolUse has match
+			let callCount = 0
+			mockFindMatchingHooks.mockImplementation(() => {
+				callCount++
+				return callCount % 2 === 0 ? [{ matcher: "ApplyPatch", hooks: [] }] : []
+			})
+			expect(hasDirectApplyPatchMatcher({}, "PreToolUse")).toBe(false)
+		})
+	})
+
+	describe("buildVirtualToolInput", () => {
+		it("#given Edit edit #when built #then returns old_string/new_string", () => {
+			// given
+			const edit = {
+				filePath: "src/a.ts",
+				ccToolName: "Edit" as const,
+				isNewFile: false,
+				before: "old content",
+				after: "new content",
+			}
+
+			// when
+			const input = buildVirtualToolInput(edit)
+
+			// then
+			expect(input).toEqual({
+				file_path: "src/a.ts",
+				old_string: "old content",
+				new_string: "new content",
+			})
+		})
+
+		it("#given Write edit #when built #then returns content", () => {
+			// given
+			const edit = {
+				filePath: "src/new.ts",
+				ccToolName: "Write" as const,
+				isNewFile: true,
+				before: "",
+				after: "brand new content\n",
+			}
+
+			// when
+			const input = buildVirtualToolInput(edit)
+
+			// then
+			expect(input).toEqual({
+				file_path: "src/new.ts",
+				content: "brand new content\n",
+			})
+		})
+	})
+
+	describe("deduplicateByFilePath", () => {
+		it("#given unique file paths #when deduplicated #then returns all", () => {
+			// given
+			const edits = [
+				{ filePath: "a.ts", ccToolName: "Edit" as const, isNewFile: false, before: "a", after: "b" },
+				{ filePath: "b.ts", ccToolName: "Edit" as const, isNewFile: false, before: "c", after: "d" },
+			]
+
+			// when
+			const result = deduplicateByFilePath(edits)
+
+			// then
+			expect(result).toHaveLength(2)
+		})
+
+		it("#given duplicate file paths with same tool #when deduplicated #then keeps first", () => {
+			// given
+			const edits = [
+				{ filePath: "a.ts", ccToolName: "Edit" as const, isNewFile: false, before: "1", after: "2" },
+				{ filePath: "a.ts", ccToolName: "Edit" as const, isNewFile: false, before: "3", after: "4" },
+			]
+
+			// when
+			const result = deduplicateByFilePath(edits)
+
+			// then
+			expect(result).toHaveLength(1)
+			expect(result[0].before).toBe("1")
+		})
+
+		it("#given same file path with different tool #when deduplicated #then keeps both", () => {
+			// given
+			const edits = [
+				{ filePath: "a.ts", ccToolName: "Edit" as const, isNewFile: false, before: "x", after: "y" },
+				{ filePath: "a.ts", ccToolName: "Write" as const, isNewFile: true, before: "", after: "z\n" },
+			]
+
+			// when
+			const result = deduplicateByFilePath(edits)
+
+			// then
+			expect(result).toHaveLength(2)
+		})
+
+		it("#given empty array #when deduplicated #then returns empty", () => {
+			expect(deduplicateByFilePath([])).toHaveLength(0)
+		})
+	})
+})

--- a/src/hooks/claude-code-hooks/apply-patch-adapter.ts
+++ b/src/hooks/claude-code-hooks/apply-patch-adapter.ts
@@ -1,0 +1,69 @@
+import { extractApplyPatchEdits } from "@oh-my-opencode/comment-checker-core"
+import type { CheckerEdit } from "@oh-my-opencode/comment-checker-core"
+import { findMatchingHooks } from "../../shared"
+import type { ClaudeHooksConfig } from "./types"
+
+export interface ApplyPatchVirtualEdit {
+	filePath: string
+	ccToolName: "Edit" | "Write"
+	isNewFile: boolean
+	before: string
+	after: string
+}
+
+export function isApplyPatchTool(toolName: string): boolean {
+	return toolName.trim() === "apply_patch"
+}
+
+export function extractVirtualEdits(
+	metadata: unknown,
+	args?: Record<string, unknown>,
+): ApplyPatchVirtualEdit[] {
+	const edits = extractApplyPatchEdits(metadata, args)
+	if (edits.length === 0) return []
+
+	return edits.map(mapToVirtualEdit)
+}
+
+function mapToVirtualEdit(edit: CheckerEdit): ApplyPatchVirtualEdit {
+	const isNewFile = edit.before.length === 0
+	return {
+		filePath: edit.filePath,
+		ccToolName: isNewFile ? "Write" : "Edit",
+		isNewFile,
+		before: edit.before,
+		after: edit.after,
+	}
+}
+
+export function hasDirectApplyPatchMatcher(
+	config: ClaudeHooksConfig | null,
+	eventType: "PreToolUse" | "PostToolUse",
+): boolean {
+	if (!config) return false
+	return findMatchingHooks(config, eventType, "ApplyPatch").length > 0
+}
+
+export function buildVirtualToolInput(edit: ApplyPatchVirtualEdit): Record<string, unknown> {
+	if (edit.isNewFile) {
+		return {
+			file_path: edit.filePath,
+			content: edit.after,
+		}
+	}
+	return {
+		file_path: edit.filePath,
+		old_string: edit.before,
+		new_string: edit.after,
+	}
+}
+
+export function deduplicateByFilePath(edits: ApplyPatchVirtualEdit[]): ApplyPatchVirtualEdit[] {
+	const seen = new Set<string>()
+	return edits.filter((edit) => {
+		const key = `${edit.ccToolName}:${edit.filePath}`
+		if (seen.has(key)) return false
+		seen.add(key)
+		return true
+	})
+}

--- a/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.test.ts
+++ b/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.test.ts
@@ -215,4 +215,75 @@ describe("createToolExecuteAfterHandler", () => {
     // then
     expect(output.output).toBe("warning from hook")
   })
+
+  it("#given apply_patch with files in metadata #when virtual PostToolUse returns warnings #then output includes virtual sections", async () => {
+    // given
+    postToolUseResult = {
+      warnings: ["virtual warning from edit hook"],
+      hookName: "my-guard",
+      toolName: "edit",
+    }
+    const handler = createToolExecuteAfterHandler(
+      {
+        client: {
+          tui: {
+            showToast: async () => ({}),
+          },
+        },
+        directory: "/repo",
+      } as never,
+      { disabledHooks: [] }
+    )
+    const output = {
+      title: "apply_patch",
+      output: "applied patch",
+      metadata: {
+        files: [
+          { filePath: "src/a.ts", before: "old", after: "new" },
+        ],
+      },
+    }
+
+    // when
+    await handler({ tool: "apply_patch", sessionID: "ses_test", callID: "call_test" }, output)
+
+    // then — virtual warning appended after original output
+    expect(output.output).toContain("applied patch")
+    expect(output.output).toContain("virtual warning from edit hook")
+  })
+
+  it("#given apply_patch with new file #when virtual PostToolUse runs #then fires Write-type virtual hook", async () => {
+    // given
+    postToolUseResult = {
+      warnings: ["write hook warning"],
+      hookName: "write-guard",
+      toolName: "write",
+    }
+    const handler = createToolExecuteAfterHandler(
+      {
+        client: {
+          tui: {
+            showToast: async () => ({}),
+          },
+        },
+        directory: "/repo",
+      } as never,
+      { disabledHooks: [] }
+    )
+    const output = {
+      title: "apply_patch",
+      output: "",
+      metadata: {
+        files: [
+          { filePath: "src/brand_new.ts", before: "", after: "new content\n" },
+        ],
+      },
+    }
+
+    // when
+    await handler({ tool: "apply_patch", sessionID: "ses_test", callID: "call_test" }, output)
+
+    // then
+    expect(output.output).toContain("write hook warning")
+  })
 })

--- a/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.ts
+++ b/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.ts
@@ -11,6 +11,13 @@ import { appendTranscriptEntry, getTranscriptPath } from "../transcript"
 import type { PluginConfig } from "../types"
 import { isHookDisabled, log } from "../../../shared"
 import { normalizeHookText, normalizeHookTextList } from "../hook-text"
+import {
+	isApplyPatchTool,
+	extractVirtualEdits,
+	hasDirectApplyPatchMatcher,
+	buildVirtualToolInput,
+	deduplicateByFilePath,
+} from "../apply-patch-adapter"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -189,6 +196,98 @@ export function createToolExecuteAfterHandler(ctx: PluginInput, config: PluginCo
 						})
 					}
 				})
+		}
+
+		// Virtual hook expansion: apply_patch → Edit/Write for CC hook compatibility
+		if (
+			isApplyPatchTool(input.tool) &&
+			!hasDirectApplyPatchMatcher(claudeConfig, "PostToolUse")
+		) {
+			const virtualEdits = extractVirtualEdits(output.metadata, cachedInput)
+			const virtualSections: string[] = []
+
+			for (const edit of deduplicateByFilePath(virtualEdits)) {
+				const virtualPostCtx: PostToolUseContext = {
+					sessionId: input.sessionID,
+					toolName: edit.ccToolName === "Write" ? "write" : "edit",
+					toolInput: buildVirtualToolInput(edit),
+					toolOutput: {
+						title: edit.ccToolName,
+						output: output.output,
+						metadata: output.metadata as Record<string, unknown>,
+					},
+					cwd: ctx.directory,
+					transcriptPath: getTranscriptPath(input.sessionID),
+					toolUseId: input.callID,
+					client: postClient,
+					permissionMode: "bypassPermissions",
+				}
+
+				const virtualResult = await executePostToolUseHooks(virtualPostCtx, claudeConfig, extendedConfig)
+
+				if (virtualResult.block) {
+					ctx.client.tui
+						.showToast({
+							body: {
+								title: "PostToolUse Hook Warning",
+								message: `[apply_patch→${edit.ccToolName}] ${virtualResult.reason ?? "Hook returned warning"}`,
+								variant: "warning",
+								duration: 4000,
+							},
+						})
+						.catch((error: unknown) => {
+							if (error instanceof Error) {
+								log("apply_patch virtual PostToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: error.message,
+								})
+							} else {
+								log("apply_patch virtual PostToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: String(error),
+								})
+							}
+						})
+				}
+
+				virtualSections.push(
+					...(virtualResult.warnings ?? []),
+					...(() => {
+						const normalized = normalizeHookText(virtualResult.additionalContext)
+						return normalized === undefined ? [] : [normalized]
+					})(),
+					...(virtualResult.message === undefined ? [] : [virtualResult.message]),
+				)
+
+				if (virtualResult.hookName) {
+					ctx.client.tui
+						.showToast({
+							body: {
+								title: "PostToolUse Hook Executed",
+								message: `▶ ${virtualResult.toolName ?? edit.ccToolName} ${
+									virtualResult.hookName
+								} (apply_patch→${edit.ccToolName}): ${virtualResult.elapsedMs ?? 0}ms`,
+								variant: "success",
+								duration: 2000,
+							},
+						})
+						.catch((error: unknown) => {
+							if (error instanceof Error) {
+								log("apply_patch virtual PostToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: error.message,
+								})
+							} else {
+								log("apply_patch virtual PostToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: String(error),
+								})
+							}
+						})
+				}
+			}
+
+			output.output = appendHookSections(output.output, virtualSections)
 		}
 	}
 }

--- a/src/hooks/claude-code-hooks/handlers/tool-execute-before-handler.test.ts
+++ b/src/hooks/claude-code-hooks/handlers/tool-execute-before-handler.test.ts
@@ -69,6 +69,58 @@ describe("createToolExecuteBeforeHandler", () => {
 		}
 	})
 
+	it("#given apply_patch with virtual hook denial #when handler runs #then throws with reason from virtual hook", async () => {
+		// given
+		preToolUseResult = {
+			decision: "deny",
+			reason: "blocked by virtual hook",
+			toolName: "Write",
+			hookName: "guard",
+		}
+		const handler = createToolExecuteBeforeHandler(
+			{
+				client: {
+					tui: {
+						showToast: async () => ({}),
+					},
+				},
+				directory: "/repo",
+			} as never,
+			{},
+		)
+
+		// when
+		const action = handler(
+			{ tool: "apply_patch", sessionID: "ses_test", callID: "call_test" },
+			{ args: { patchText: "*** Begin Patch\n*** Add File: src/new.ts\n+hello\n*** End Patch" } },
+		)
+
+		// then
+		await expect(action).rejects.toThrow("blocked by virtual hook")
+	})
+
+	it("#given apply_patch with virtual hook allow #when handler runs #then proceeds to regular PreToolUse", async () => {
+		// given
+		preToolUseResult = { decision: "allow" }
+		const handler = createToolExecuteBeforeHandler(
+			{
+				client: {
+					tui: {
+						showToast: async () => ({}),
+					},
+				},
+				directory: "/repo",
+			} as never,
+			{},
+		)
+
+		// when/then — should not throw
+		await handler(
+			{ tool: "apply_patch", sessionID: "ses_test", callID: "call_test" },
+			{ args: { patchText: "*** Begin Patch\n*** Add File: src/new.ts\n+hello\n*** End Patch" } },
+		)
+	})
+
 	it("#given denial toast rejects with a non-Error value #when hook denies #then the hook denial still wins", async () => {
 		// given
 		const thrownValue = "toast failed"

--- a/src/hooks/claude-code-hooks/handlers/tool-execute-before-handler.ts
+++ b/src/hooks/claude-code-hooks/handlers/tool-execute-before-handler.ts
@@ -9,6 +9,13 @@ import { appendTranscriptEntry } from "../transcript"
 import { cacheToolInput } from "../tool-input-cache"
 import type { PluginConfig } from "../types"
 import { isHookDisabled, log, replaceToolArgs } from "../../../shared"
+import {
+	isApplyPatchTool,
+	extractVirtualEdits,
+	hasDirectApplyPatchMatcher,
+	buildVirtualToolInput,
+	deduplicateByFilePath,
+} from "../apply-patch-adapter"
 
 export function createToolExecuteBeforeHandler(ctx: PluginInput, config: PluginConfig) {
 	return async (
@@ -64,6 +71,55 @@ export function createToolExecuteBeforeHandler(ctx: PluginInput, config: PluginC
 
 		const claudeConfig = await loadClaudeHooksConfig()
 		const extendedConfig = await loadPluginExtendedConfig()
+
+		// Virtual hook expansion: apply_patch → Edit/Write for CC hook compatibility
+		if (
+			isApplyPatchTool(input.tool) &&
+			!hasDirectApplyPatchMatcher(claudeConfig, "PreToolUse")
+		) {
+			const virtualEdits = extractVirtualEdits(undefined, output.args)
+			for (const edit of deduplicateByFilePath(virtualEdits)) {
+				const virtualCtx: PreToolUseContext = {
+					sessionId: input.sessionID,
+					toolName: edit.ccToolName === "Write" ? "write" : "edit",
+					toolInput: buildVirtualToolInput(edit),
+					cwd: ctx.directory,
+					toolUseId: input.callID,
+				}
+				const virtualResult = await executePreToolUseHooks(virtualCtx, claudeConfig, extendedConfig)
+				if (virtualResult.decision === "deny") {
+					ctx.client.tui
+						.showToast({
+							body: {
+								title: "PreToolUse Hook Executed",
+								message: `[BLOCKED] ${virtualResult.toolName ?? edit.ccToolName} ${
+									virtualResult.hookName ?? "hook"
+								} (apply_patch→${edit.ccToolName}): ${virtualResult.elapsedMs ?? 0}ms\n${
+									virtualResult.reason ?? ""
+								}`,
+								variant: "error" as const,
+								duration: 4000,
+							},
+						})
+						.catch((error: unknown) => {
+							if (error instanceof Error) {
+								log("apply_patch virtual PreToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: error.message,
+								})
+							} else {
+								log("apply_patch virtual PreToolUse hook toast failed", {
+									sessionID: input.sessionID,
+									error: String(error),
+								})
+							}
+						})
+					throw new Error(
+						virtualResult.reason ?? "Hook blocked the operation (apply_patch virtual)",
+					)
+				}
+			}
+		}
 
 		const preCtx: PreToolUseContext = {
 			sessionId: input.sessionID,


### PR DESCRIPTION
## Summary

- Expand `apply_patch` tool calls into virtual Edit/Write hook invocations so Claude Code hooks matching `Edit|Write` patterns fire correctly when OpenCode uses `apply_patch`

## Changes

- Add `apply-patch-adapter.ts` with 5 exported functions: `isApplyPatchTool`, `extractVirtualEdits`, `hasDirectApplyPatchMatcher`, `buildVirtualToolInput`, `deduplicateByFilePath`
- Integrate virtual PreToolUse expansion in `tool-execute-before-handler.ts` — denies propagate immediately
- Integrate virtual PostToolUse expansion in `tool-execute-after-handler.ts` — warnings/blocks aggregated into output
- Skip virtual expansion when user has an explicit `ApplyPatch` matcher (prevents double-firing)
- Reuse `extractApplyPatchEdits` from `packages/comment-checker-core` for patch parsing

## Testing

```bash
bun test src/hooks/claude-code-hooks/apply-patch-adapter.test.ts
bun test src/hooks/claude-code-hooks/handlers/tool-execute-before-handler.test.ts
bun test src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.test.ts
```

30 tests, 55 assertions, 0 failures.

## Related Issues

Refs #5028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `apply_patch` into virtual Edit/Write invocations so Claude Code hooks fire correctly when OpenCode applies patches. Ensures denials, warnings, and messages from hooks are respected and surfaced. Refs #5028.

- **New Features**
  - Virtual expansion in PreToolUse and PostToolUse: per-file edits are treated as Edit or Write, with denials blocking immediately and post warnings appended to output.
  - Skips expansion when an explicit ApplyPatch matcher exists to avoid double-firing.
  - Deduplicates by file path and maps new files to Write; parses patches via `@oh-my-opencode/comment-checker-core`.
  - Adds test coverage for adapter and handlers (30 tests, all passing).

<sup>Written for commit 843761353cf2768bfc37be36754a10422e61f59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

