### PR TITLE
fix(background-agent): wake parent after stale unknown-finish assistant turn instead of deferring forever

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -8,6 +8,207 @@ import { ParentWakeNotifier } from "./parent-wake-notifier"
 type ParentWakeClient = ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
 
 describe("ParentWakeNotifier — assistant history deferral", () => {
+  test("#given stale unknown-finish assistant text with no fresh activity #when checking parent wake history #then parent wake stops deferring so a real reply can fire", async () => {
+     // given
+     const originalDateNow = Date.now
+     Date.now = () => 100_000
+     const client = unsafeTestValue<ParentWakeClient>({
+       session: {
+         messages: async () => ({
+           data: [
+             {
+               info: {
+                 role: "assistant",
+                 finish: "unknown",
+                 time: { created: 90_000 },
+               },
+               parts: [{ type: "text", text: "still streaming" }],
+             },
+           ],
+         }),
+         status: async () => ({ data: { "parent-stale-text": { type: "idle" } } }),
+         promptAsync: async () => {
+           return { data: {} }
+         },
+       },
+     })
+     const notifier = new ParentWakeNotifier(
+       {
+         client,
+         directory: "/tmp/test-omo",
+         enqueueNotificationForParent: async (_sessionID, operation) => {
+           await operation()
+         },
+       },
+       {
+         pendingRetryMs: 1_000,
+         acceptedMessageSkewMs: 5_000,
+         toolCallDeferMaxMs: 5_000,
+         failureRequeueWindowMs: 5_000,
+         userMessageInProgressWindowMs: 2_000,
+       },
+     )
+     notifier.queuePendingParentWake(
+       "parent-stale-text",
+       "task complete",
+       { agent: "sisyphus" },
+       true,
+     )
+     const pendingWake = notifier.getPendingParentWakes().get("parent-stale-text")
+     expect(pendingWake).toBeDefined()
+     if (!pendingWake) {
+       throw new Error("Missing pending parent wake")
+     }
+     pendingWake.toolCallDeferralStartedAt = 90_000
+
+     try {
+       // when
+       const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-stale-text", pendingWake)
+
+       // then
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: true })
+     } finally {
+       Date.now = originalDateNow
+       notifier.shutdown()
+       releaseAllPromptAsyncReservationsForTesting()
+     }
+   })
+ 
+   test("#given fresh unfinished assistant text has no pending tool call #when checking parent wake history #then parent wake continues deferring", async () => {
+     // given
+     const originalDateNow = Date.now
+     Date.now = () => 100_000
+     const client = unsafeTestValue<ParentWakeClient>({
+       session: {
+         messages: async () => ({
+           data: [
+             {
+               info: {
+                 role: "assistant",
+                 finish: "unknown",
+                 time: { created: 99_000 },
+               },
+               parts: [{ type: "text", text: "still streaming" }],
+             },
+           ],
+         }),
+         status: async () => ({ data: { "parent-fresh-text": { type: "idle" } } }),
+         promptAsync: async () => {
+           return { data: {} }
+         },
+       },
+     })
+     const notifier = new ParentWakeNotifier(
+       {
+         client,
+         directory: "/tmp/test-omo",
+         enqueueNotificationForParent: async (_sessionID, operation) => {
+           await operation()
+         },
+       },
+       {
+         pendingRetryMs: 1_000,
+         acceptedMessageSkewMs: 5_000,
+         toolCallDeferMaxMs: 5_000,
+         failureRequeueWindowMs: 5_000,
+         userMessageInProgressWindowMs: 2_000,
+       },
+     )
+     notifier.queuePendingParentWake(
+       "parent-fresh-text",
+       "task complete",
+       { agent: "sisyphus" },
+       true,
+     )
+     const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text")
+     expect(pendingWake).toBeDefined()
+     if (!pendingWake) {
+       throw new Error("Missing pending parent wake")
+     }
+     pendingWake.toolCallDeferralStartedAt = 98_000
+ 
+     try {
+       // when
+       const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-fresh-text", pendingWake)
+ 
+       // then
+       expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+     } finally {
+       Date.now = originalDateNow
+       notifier.shutdown()
+       releaseAllPromptAsyncReservationsForTesting()
+     }
+   })
+ 
+   test("#given stale deferral but fresh unfinished assistant text #when flushing parent wake #then wake is recorded without forking a reply", async () => {
+     // given
+     const originalDateNow = Date.now
+     Date.now = () => 100_000
+     let promptAsyncCallCount = 0
+     const client = unsafeTestValue<ParentWakeClient>({
+       session: {
+         messages: async () => ({
+           data: [
+             {
+               info: {
+                 role: "assistant",
+                 finish: "unknown",
+                 time: { created: 99_000 },
+               },
+               parts: [{ type: "text", text: "still streaming" }],
+             },
+           ],
+         }),
+         status: async () => ({ data: { "parent-fresh-text-flush": { type: "idle" } } }),
+         promptAsync: async () => {
+           promptAsyncCallCount += 1
+           return { data: {} }
+         },
+       },
+     })
+     const notifier = new ParentWakeNotifier(
+       {
+         client,
+         directory: "/tmp/test-omo",
+         enqueueNotificationForParent: async (_sessionID, operation) => {
+           await operation()
+         },
+       },
+       {
+         pendingRetryMs: 1_000,
+         acceptedMessageSkewMs: 5_000,
+         toolCallDeferMaxMs: 5_000,
+         failureRequeueWindowMs: 5_000,
+         userMessageInProgressWindowMs: 2_000,
+       },
+     )
+     notifier.queuePendingParentWake(
+       "parent-fresh-text-flush",
+       "task complete",
+       { agent: "sisyphus" },
+       true,
+     )
+     const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-text-flush")
+     expect(pendingWake).toBeDefined()
+     if (!pendingWake) {
+       throw new Error("Missing pending parent wake")
+     }
+     pendingWake.toolCallDeferralStartedAt = 90_000
+ 
+     try {
+       // when
+       await notifier.flushPendingParentWake("parent-fresh-text-flush")
+ 
+       // then
+       expect(promptAsyncCallCount).toBe(1)
+       expect(notifier.getPendingParentWakes().has("parent-fresh-text-flush")).toBe(true)
+     } finally {
+       Date.now = originalDateNow
+       notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
   test("#given parent session messages cannot be inspected #when checking parent wake history #then parent wake stays deferred", async () => {
     // given
     const client = unsafeTestValue<ParentWakeClient>({
@@ -202,6 +403,245 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
 
       // then
       expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given stale unknown-finish assistant text with no fresh activity #when flushing parent wake #then a real reply turn fires (noReply=false)", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const promptBodies: Array<{ noReply?: boolean }> = []
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "unknown",
+                time: { created: 90_000 },
+              },
+              parts: [{ type: "text", text: "done but unmarked" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-stale-unknown-flush": { type: "idle" } } }),
+        promptAsync: async (args: { body?: { noReply?: boolean } }) => {
+          promptBodies.push({ noReply: args.body?.noReply })
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-stale-unknown-flush",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-stale-unknown-flush")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-stale-unknown-flush")
+
+      // then
+      expect(promptBodies).toHaveLength(1)
+      expect(promptBodies[0]?.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has("parent-stale-unknown-flush")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given stale unknown-finish assistant turn followed by a pending internal-initiator user message #when checking parent wake history #then it keeps deferring (no duplicate wake)", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant", finish: "unknown", time: { created: 90_000 } },
+              parts: [{ type: "text", text: "done but unmarked" }],
+            },
+            {
+              info: { role: "user" },
+              parts: [{ type: "text", text: "task complete\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-internal-tail": { type: "idle" } } }),
+        promptAsync: async () => ({ data: {} }),
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake("parent-internal-tail", "task complete", { agent: "sisyphus" }, true)
+    const pendingWake = notifier.getPendingParentWakes().get("parent-internal-tail")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-internal-tail", pendingWake)
+
+      // then
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given stale created time but fresh updated time on an unknown-finish assistant turn #when checking parent wake history #then it keeps deferring (still streaming)", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant", finish: "unknown", time: { created: 90_000, updated: 99_000 } },
+              parts: [{ type: "text", text: "still actively streaming" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-fresh-updated": { type: "idle" } } }),
+        promptAsync: async () => ({ data: {} }),
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake("parent-fresh-updated", "task complete", { agent: "sisyphus" }, true)
+    const pendingWake = notifier.getPendingParentWakes().get("parent-fresh-updated")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-fresh-updated", pendingWake)
+
+      // then
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a completed assistant turn with finish true #when checking parent wake history #then it does not take the stale-unknown branch and does not defer", async () => {
+    // given
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant", finish: true, time: { created: 90_000 } },
+              parts: [{ type: "text", text: "all done" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-finish-true": { type: "idle" } } }),
+        promptAsync: async () => ({ data: {} }),
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake("parent-finish-true", "task complete", { agent: "sisyphus" }, true)
+    const pendingWake = notifier.getPendingParentWakes().get("parent-finish-true")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 90_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-finish-true", pendingWake)
+
+      // then
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: false })
     } finally {
       Date.now = originalDateNow
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-history-state.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-history-state.ts
@@ -20,7 +20,7 @@ export function latestAssistantTurnIsCompletedEmptyNoProgress(messages: readonly
       const info = isRecord(message) && isRecord(message.info) ? message.info : message
       return messageCompleted(message) && isEmptyNoProgressAssistantTurnInfo(info)
     }
-    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+    if (role === "user") {
       return false
     }
   }
@@ -83,7 +83,7 @@ export function latestAssistantTurnHasStaleUnknownSubstantiveOutput(
         && messageHasSubstantiveAssistantOutput(message)
         && !messageHasFreshActivity(message, now, maxAgeMs)
     }
-    if (role === "user" && !messageIsSyntheticOrInternalUser(message)) {
+    if (role === "user") {
       return false
     }
   }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
@@ -118,7 +118,7 @@ export function getParentWakeSessionHistoryDeferralDecision(input: {
     now - input.wake.toolCallDeferralStartedAt >= input.toolCallDeferMaxMs
     && latestAssistantTurnHasStaleUnknownSubstantiveOutput(messages, now, input.toolCallDeferMaxMs)
   ) {
-    log("[background-agent] Retrying parent wake after stale unknown-finish assistant output:", {
+    log("[background-agent] Retrying parent wake after stale unknown-finish assistant turn:", {
       sessionID: input.sessionID,
     })
     return { defer: false, skipPromptGateToolStateCheck: true }


### PR DESCRIPTION
Fixes #5401

## Problem

When a background task completes, the parent session is supposed to be woken: the `<system-reminder>` is injected **and** a model turn is triggered so the agent acts on it. In practice the reminder lands but **no turn fires** — the user must send a follow-up message to get the agent going.

Root cause is in the parent-wake history-deferral logic. `latestAssistantTurnBlocksInternalPrompt()` conservatively treats an assistant turn with `finish === undefined`/`"unknown"` as still-blocking (correct for genuinely streaming turns). When OpenCode finishes a turn but doesn't stamp `info.time.completed`, that done-but-unmarked turn is classified as blocking. The staleness escape in `getParentWakeSessionHistoryDeferralDecision()` only rescues **tool-call** deferrals (`latestAssistantTurnHasToolBlock()`), so an unknown-finish turn with no tool block never escapes — it defers forever and the wake never reaches the real-reply path.

Observed in production logs: `"Deferred parent wake because latest assistant turn blocks internal prompts"` repeating indefinitely while the wake is never delivered.

## Fix

Extend the staleness escape in `parent-wake-session-history.ts` to also cover stale **unknown-finish, substantive-output** turns that have no fresh activity:

- New helper `latestAssistantTurnHasUnknownFinishSubstantiveOutput()` in `parent-wake-history-state.ts` (finish is undefined/`"unknown"`, not `messageCompleted`, has substantive output).
- New branch after the existing tool-call staleness escape: if the deferral has aged past `toolCallDeferMaxMs`, the latest assistant turn is unknown-finish with substantive output, **and** there is no fresh activity (`latestAssistantTurnHasFreshToolActivity` — message `created` / part `time`/`state.time` within the window), clear `toolCallDeferralStartedAt` and return `{ defer: false, skipPromptGateToolStateCheck: true }` so the wake fires a real reply.

### Why this layer (and not loosening the shared gate)

`latestAssistantTurnBlocksInternalPrompt()` is a shared prompt-safety gate; it cannot distinguish "done but missing completion metadata" from "still streaming" using only `finish: "unknown"` + text, so it stays conservative. `parent-wake-session-history.ts` has the missing context (accumulated deferral age, staleness threshold) and is the right place to decide the turn has been blocking too long.

### Safety / preserved invariants

- **Freshness-gated**: a turn with recent activity stays deferred (admit-only) — genuinely streaming turns are not interrupted.
- **Empty / step-only turns** have no substantive output, so the new branch doesn't fire (their existing empty-turn retry path is unchanged).
- **Completed turns** short-circuit earlier in `latestAssistantTurnBlocksInternalPrompt()` and never reach this branch.
- User-message race / issue-#4120 macOS guard runs in the flush runner after this decision and is unaffected.

## Tests

`parent-wake-history-deferral.test.ts`:
- Updated the case that pinned "stale unknown-finish text keeps deferring" → now asserts it stops deferring (`defer: false`).
- Added a flush-level test asserting a stale unknown-finish turn with no fresh activity fires a real reply (`body.noReply === false`).
- Fresh-activity and message-inspection-failure cases remain deferred (unchanged).

Full parent-wake + task-completion suite: 81 pass / 0 fail. Project typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops indefinite deferrals on stale unknown-finish assistant turns so background reminders wake the parent by triggering a real reply. If the turn is stale with substantive text and no fresh activity, we clear the deferral and proceed.

- **Bug Fixes**
  - After `toolCallDeferMaxMs`, if the latest assistant turn is finish: `"unknown"` with substantive output and no fresh activity, clear `toolCallDeferralStartedAt` and return `{ defer: false, skipPromptGateToolStateCheck: true }` to fire a real reply.
  - History rules: treat any `user` message as a boundary for stale-unknown and empty/no-progress checks; keep deferring on fresh activity or a pending internal-initiator user tail; completed turns (`finish: true`) do not defer. Tests cover real-reply on stale unknown, continued deferral for fresh text and internal-tail, non-forking flush on fresh text, and no deferral on `finish: true`.

<sup>Written for commit 1fa2100623a091e58866c918a9a836969d8c04e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

