### PR TITLE
fix(ralph-loop): resolve agent display name mismatch in continuation prompt injection

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts
@@ -17,9 +17,9 @@ describe("ralph-loop continuation prompt agent resolution", () => {
     _resetForTesting()
   })
 
-  test("#given OpenCode registered Atlas under legacy display name #when inherited agent is config key #then prompt uses registered name", async () => {
+  test("#given OpenCode registered agent under display name #when inherited agent is config key #then prompt uses canonical display name", async () => {
     // given
-    registerAgentName("Atlas (Plan Executor)")
+    registerAgentName("Atlas - Plan Executor")
     let capturedAgent: string | undefined
     const ctx = unsafeTestValue<PluginInput>({
       client: {
@@ -42,6 +42,62 @@ describe("ralph-loop continuation prompt agent resolution", () => {
     })
 
     // then
-    expect(capturedAgent).toBe("Atlas (Plan Executor)")
+    expect(capturedAgent).toBe("Atlas - Plan Executor")
+  })
+
+  test("#when inherited agent is Sisyphus display name #then prompt uses canonical display name", async () => {
+    // given
+    registerAgentName("Sisyphus - ultraworker")
+    let capturedAgent: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      client: {
+        session: {
+          messages: async () => ({ data: [{ info: { agent: "Sisyphus - Ultraworker" } }] }),
+          promptAsync: async (input: { readonly body: { readonly agent?: string } }) => {
+            capturedAgent = input.body.agent
+            return {}
+          },
+        },
+      },
+    })
+
+    // when
+    await injectContinuationPrompt(ctx, {
+      sessionID: "ses_ralph_sisyphus_display",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then: display name with different casing is normalized to canonical
+    expect(capturedAgent).toBe("Sisyphus - ultraworker")
+  })
+
+  test("#when inherited agent is Sisyphus config key #then prompt uses canonical display name", async () => {
+    // given
+    registerAgentName("Sisyphus - ultraworker")
+    let capturedAgent: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      client: {
+        session: {
+          messages: async () => ({ data: [{ info: { agent: "sisyphus" } }] }),
+          promptAsync: async (input: { readonly body: { readonly agent?: string } }) => {
+            capturedAgent = input.body.agent
+            return {}
+          },
+        },
+      },
+    })
+
+    // when
+    await injectContinuationPrompt(ctx, {
+      sessionID: "ses_ralph_sisyphus_config_key",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then: config key is resolved to the canonical display name the SDK expects
+    expect(capturedAgent).toBe("Sisyphus - ultraworker")
   })
 })

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -194,14 +194,14 @@ describe("ralph-loop continuation prompt injector", () => {
     })
 
     // then
-    expect(promptBody?.agent).toBe("Sisyphus - Ultraworker")
+    expect(promptBody?.agent).toBe("Sisyphus - ultraworker")
     expect(promptBody?.agent).not.toContain("\u200b")
     expect(promptBody?.noReply).toBeUndefined()
     expect(promptPart?.synthetic).toBe(true)
     expect(promptPart?.metadata?.compaction_continue).toBe(true)
   })
 
-  test("#given inherited message agent has no ZWSP prefix #when injecting continuation prompt #then promptAsync receives registered display agent", async () => {
+  test("#given inherited message agent has no ZWSP prefix #when injecting continuation prompt #then promptAsync receives canonical display name", async () => {
     // given
     let promptBody: { agent?: string } | undefined
     const ctx = {
@@ -227,7 +227,7 @@ describe("ralph-loop continuation prompt injector", () => {
     })
 
     // then
-    expect(promptBody?.agent).toBe("Sisyphus - Ultraworker")
+    expect(promptBody?.agent).toBe("Sisyphus - ultraworker")
   })
 
   test("#given inherited message model includes variant #when injecting continuation prompt #then promptAsync receives variant as a top-level field", async () => {

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -10,8 +10,7 @@ import {
 	normalizeSDKResponse,
 	resolveInheritedPromptTools,
 } from "../../shared"
-import { resolveRegisteredAgentName } from "../../features/claude-code-session-state"
-import { normalizeAgentForPromptKey, stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import { normalizeAgentForPrompt, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { dispatchInternalPrompt } from "../shared/prompt-async-gate"
 
 type MessageInfo = {
@@ -66,7 +65,7 @@ function createPromptAsyncError(prefix: string, error: unknown): Error {
 }
 
 function normalizeInheritedAgentForPrompt(agent: string | undefined): string | undefined {
-	const resolvedAgent = resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)
+	const resolvedAgent = normalizeAgentForPrompt(agent)
 	if (typeof resolvedAgent !== "string") return undefined
 	const cleanAgent = stripAgentListSortPrefix(resolvedAgent).trim()
 	return cleanAgent || undefined


### PR DESCRIPTION
## Summary

The ralph-loop continuation prompt injector converts agent display names to config keys before passing them to `promptAsync`. The OpenCode SDK only recognizes registered display names, so the continuation is rejected with `UnknownError: Agent not found: "sisyphus"`.

This is the same root cause as #3743, #4140, and related to #4698 — the agent name resolution produces a value the SDK does not accept.

## Root Cause

In `src/hooks/ralph-loop/continuation-prompt-injector.ts`, `normalizeInheritedAgentForPrompt` calls:

```typescript
const resolvedAgent = resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)
```

`normalizeAgentForPromptKey` resolves any agent identifier to its **config key** (e.g., `"Sisyphus - Ultraworker"` → `"sisyphus"`). The OpenCode SDK `createUserMessage` only recognizes **display names** that it has registered (e.g., `"Sisyphus - ultraworker"`), so it throws `UnknownError`.

## Fix

Replace `resolveRegisteredAgentName(agent) ?? normalizeAgentForPromptKey(agent)` with `normalizeAgentForPrompt(agent)`, which resolves any agent identifier (config key, display name, or legacy parenthesized name) to the **canonical display name** the SDK expects:

- `"sisyphus"` → `"Sisyphus - ultraworker"`
- `"Sisyphus - Ultraworker"` → `"Sisyphus - ultraworker"` (case-normalized)
- `"Sisyphus (Ultraworker)"` → `"Sisyphus - ultraworker"` (legacy resolved)
- `"hephaestus"` → `"Hephaestus - Deep Agent"`

This function already existed in `agent-display-names.ts` but was not used in this code path.

## Changes

- `src/hooks/ralph-loop/continuation-prompt-injector.ts` — use `normalizeAgentForPrompt` instead of `resolveRegisteredAgentName` + `normalizeAgentForPromptKey`
- `src/hooks/ralph-loop/continuation-prompt-injector.test.ts` — update assertions to expect canonical display names
- `src/hooks/ralph-loop/continuation-prompt-injector-agent-resolution.test.ts` — update existing test + add regression tests for Sisyphus display name and config key resolution

## Testing

```
bun test src/hooks/ralph-loop/ --timeout 30000
→ 168 pass, 0 fail, 444 expect() calls
```

## Related

- Fixes #3743
- Fixes #4140
- Related to #4698 (same class of bug in `run` path)
- Related to #3494 (same class of bug in boulder continuation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent display name mismatches in ralph-loop continuation prompts by always sending the canonical display name to the SDK. Prevents “Agent not found” errors when the inherited agent is a config key, legacy format, or has different casing.

- **Bug Fixes**
  - Replaced mixed resolution with `normalizeAgentForPrompt` to always emit the canonical display name (handles config keys, casing differences, and legacy parenthesized names).
  - Updated tests and added regressions for Sisyphus (display name and config key resolve to "Sisyphus - ultraworker") and Atlas ("Atlas - Plan Executor").
  - Fixes #3743, #4140; related to #4698, #3494.

<sup>Written for commit 806888f4b3fa6bb672697006e4eb274fc94623b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

