### PR TITLE
fix(json-error-recovery): exclude subagent + session-content tools from JSON-error reminder

### DIFF
--- a/src/hooks/json-error-recovery/hook.ts
+++ b/src/hooks/json-error-recovery/hook.ts
@@ -11,6 +11,15 @@ export const JSON_ERROR_TOOL_EXCLUDE_LIST = [
   "websearch_web_search_exa",
   "todowrite",
   "todoread",
+  "task",
+  "call_omo_agent",
+  "background_output",
+  "session_read",
+  "session_search",
+  "session_info",
+  "session_list",
+  "skill",
+  "skill_mcp",
 ] as const
 
 export const JSON_ERROR_PATTERNS = [

--- a/src/hooks/json-error-recovery/index.test.ts
+++ b/src/hooks/json-error-recovery/index.test.ts
@@ -119,6 +119,32 @@ describe("createJsonErrorRecoveryHook", () => {
       expect(output.output).toBe("JSON parse error: unexpected end of JSON input")
     })
 
+    it("does not append reminder for subagent and session-content tools", async () => {
+      // given
+      const subagentTools = [
+        "task",
+        "call_omo_agent",
+        "background_output",
+        "session_read",
+        "session_search",
+        "session_info",
+        "session_list",
+        "skill",
+        "skill_mcp",
+      ]
+      const proseMentioningJson = "The oracle re-reviewed. Note: the JSON parse error: unexpected EOF text is spurious content embedded in the returned text, not a real system error."
+
+      for (const tool of subagentTools) {
+        const output = createOutput(proseMentioningJson)
+
+        // when
+        await hook["tool.execute.after"](createInput(tool), output)
+
+        // then
+        expect(output.output).toBe(proseMentioningJson)
+      }
+    })
+
     it("does not append reminder when reminder already exists", async () => {
       // given
       const input = createInput()
@@ -182,6 +208,11 @@ describe("createJsonErrorRecoveryHook", () => {
         "read",
         "bash",
         "webfetch",
+        "task",
+        "call_omo_agent",
+        "background_output",
+        "session_read",
+        "skill",
       ]
 
       // when


### PR DESCRIPTION
## Problem

The `json-error-recovery` hook (`tool.execute.after`) scans tool output for JSON-error patterns (`/json parse error/i`, `/json[^\n]*unexpected eof/i`, `/invalid json/i`, …) and, on a match, appends a `[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]` reminder so the agent fixes its malformed tool-call JSON.

Its exclude list (`bash`, `read`, `glob`, `grep`, `webfetch`, …) does **not** include the subagent-invocation or session-content tools. As a result, when an agent invokes a subagent (`task`, e.g. Oracle/explore) and that subagent's **prose response merely discusses** a JSON error — extremely common in debugging/log-analysis work — the hook matches the prose and appends the reminder to the returned text.

Symptom: a spurious `[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]` block at the end of subagent output, telling the calling agent it "sent invalid JSON arguments" when it did nothing of the sort. This is a false positive — the parent never malformed a tool call; the subagent's content simply mentioned JSON. It fires consistently for Oracle/subagent reviews of code, logs, or parser behavior, and can mislead an agent into a pointless "retry with valid JSON".

## Fix

Add the subagent-invocation and session-content tools to `JSON_ERROR_TOOL_EXCLUDE_LIST` in `src/hooks/json-error-recovery/hook.ts`:

`task`, `call_omo_agent`, `background_output`, `session_read`, `session_search`, `session_info`, `session_list`, `skill`, `skill_mcp`.

These tools return free-form content (a delegated agent's response, stored session messages, skill/MCP output) rather than the calling agent's tool-argument parse result, so a JSON-error substring in their output is never the caller's malformed JSON. This matches the hook's existing exclusion rationale for other content-heavy tools (`read`, `bash`, `webfetch`).

The reminder still fires for tools where the agent constructs JSON arguments that the system actually parses (e.g. `edit`, structured tools).

## Tests

`src/hooks/json-error-recovery/index.test.ts`:
- Added a test asserting that subagent/session-content tools (`task`, `call_omo_agent`, `background_output`, `session_read`, `session_search`, `session_info`, `session_list`, `skill`, `skill_mcp`) do **not** get the reminder appended even when their output contains JSON-error prose.
- Extended the `JSON_ERROR_TOOL_EXCLUDE_LIST` contract test to pin the new entries.

12 pass / 0 fail. Project typecheck clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false JSON error reminders when subagents or session-content tools mention JSON errors in prose. Extends the `json-error-recovery` hook’s exclude list so only real malformed tool-call JSON triggers the reminder.

- **Bug Fixes**
  - Added to `JSON_ERROR_TOOL_EXCLUDE_LIST`: `task`, `call_omo_agent`, `background_output`, `session_read`, `session_search`, `session_info`, `session_list`, `skill`, `skill_mcp`.
  - Keeps reminder for tools that parse agent-constructed JSON (e.g., structured tools).
  - Added tests to ensure excluded tools never append the reminder even if their output mentions JSON errors.

<sup>Written for commit 24b6e3c9fc12c68b12f75a5271b017e79cdd3a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

