### PR TITLE
fix(model-core): mark kimi-k2.6 as not supporting arbitrary temperature

### DIFF
--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -5,7 +5,7 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 		id: "kimi-k2.6",
 		family: "kimi",
 		reasoning: true,
-		temperature: true,
+		temperature: false,
 		toolCall: true,
 		modalities: {
 			input: ["text", "image", "video"],


### PR DESCRIPTION
## Summary

- Fix `kimi-k2.6` in `supplemental-entries.ts` to declare `temperature: false`, matching its `reasoning: true` capability and the existing convention this file already uses for other reasoning models.
- Unblocks any agent configured to `moonshotai/kimi-k2.6` / `kimi-for-coding/k2p6` — the session no longer dies with `invalid temperature: only 1 is allowed for this model` from Moonshot's API.

## Changes

```diff
-		temperature: true,
+		temperature: false,
```

Inside the `"kimi-k2.6"` block in [`packages/model-core/src/model-capabilities/supplemental-entries.ts`](packages/model-core/src/model-capabilities/supplemental-entries.ts). One-character change.

## Why this is the right fix

The repo already encodes "this reasoning model does not accept arbitrary `temperature`" via `temperature: false`. The capability-resolution pipeline then strips the field from the outbound request when `supportsTemperature === false`, and the OpenAI-compatible API defaults `temperature` to `1` server-side — which reasoning models accept.

The same convention is already correctly applied in this same file for `gpt-5.5` and `gpt-5.4-mini-fast` (both `reasoning: true, temperature: false`). `kimi-k2.6` was the lone outlier and the direct cause of:

- The user-visible session error `invalid temperature: only 1 is allowed for this model` reported in #3590 (closed "completed" but still reproducing in v4.7.5).
- The bug was introduced in #3559 when this supplemental entry was first added; the original issue body claimed "Temperature: supported", conflating "the API accepts the field" with "the model accepts arbitrary values".

## Testing

Hand-verified against a Moonshot OpenAI-compatible endpoint with a Momus subagent call:

```
agents.momus.model = "moonshotai/kimi-k2.6"
agents.momus.reasoning_effort = "xhigh"
```

- **Before:** `Session error: invalid temperature: only 1 is allowed for this model` (kills the session in 1–3 s, no model output).
- **After (hot-patched node_modules with the same one-char change):** request goes out with no `temperature` field, Moonshot accepts, subagent produces a normal verdict.

I'm happy to add a unit test if you want — but the existing pattern around `gpt-5.5`/`gpt-5.4-mini-fast` already exercises the same code path, so this is purely a data correction.

```bash
bun run typecheck
bun test
```

## Out of scope (separate issue)

The bundled `src/generated/model-capabilities.generated.json` snapshot (frozen at 2026-04-17 per #4717) also marks `kimi-k2-thinking`, `kimi-k2-thinking-turbo`, `kimi-k2.5-free`, and `kimi-k2-5` as `reasoning: true, temperature: true` — same class of bug. Those entries live upstream in [`anomalyco/models.dev`](https://github.com/anomalyco/models.dev) and need a separate fix there; opencode users currently get the bad values bundled because of #4717 (snapshot refresh has been blocked for 10+ weeks). I'm deliberately keeping this PR surgical — happy to follow up with supplemental overrides for the other four if you'd prefer them masked here too while #4717 is unresolved.

## Related Issues

Closes #5043

Related: #3590, #3559, #4717, #4718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `kimi-k2.6` as not supporting arbitrary `temperature` to stop Moonshot API rejections. Unblocks agents using `moonshotai/kimi-k2.6` or `kimi-for-coding/k2p6`.

- **Bug Fixes**
  - Set `temperature: false` for `kimi-k2.6` in `packages/model-core/src/model-capabilities/supplemental-entries.ts`, so the resolver strips `temperature` and the API uses the default `1` required by reasoning models.

<sup>Written for commit 756f3923ba8345feae137700c9aa00c2fc3afb83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

