### PR TITLE
fix(model-core): mark all Moonshot Kimi reasoning models as not supporting arbitrary temperature

### DIFF
--- a/packages/model-core/src/model-capabilities-bundled-snapshot.test.ts
+++ b/packages/model-core/src/model-capabilities-bundled-snapshot.test.ts
@@ -32,4 +32,48 @@ describe("bundled model capabilities snapshot", () => {
       })
     }
   })
+
+  test("marks Moonshot Kimi reasoning models as NOT supporting arbitrary temperature", () => {
+    // Moonshot's OpenAI-compatible API rejects any non-1 temperature for
+    // these reasoning models with `invalid temperature: only 1 is allowed
+    // for this model`. The capability resolver must report
+    // `supportsTemperature: false` so the chat-params layer strips the
+    // field before the outbound request, letting Moonshot default to 1.
+
+    // given
+    const bundledSnapshot = getBundledModelCapabilitiesSnapshot(bundledModelCapabilitiesSnapshotJson)
+    const cases = [
+      { providerID: "moonshotai", modelID: "kimi-k2.6" },
+      { providerID: "moonshotai", modelID: "moonshotai/kimi-k2.6" },
+      { providerID: "moonshotai", modelID: "kimi-k2-thinking" },
+      { providerID: "moonshotai", modelID: "kimi-k2-thinking-turbo" },
+      { providerID: "moonshotai", modelID: "kimi-k2.5-free" },
+      { providerID: "moonshotai", modelID: "kimi-k2-5" },
+    ]
+
+    // when
+    const results = cases.map(({ providerID, modelID }) =>
+      ({
+        modelID,
+        capabilities: getModelCapabilities({
+          providerID,
+          modelID,
+          bundledSnapshot,
+        }),
+      }),
+    )
+
+    // then
+    for (const { modelID, capabilities } of results) {
+      expect({ modelID, supportsTemperature: capabilities.supportsTemperature }).toEqual({
+        modelID,
+        supportsTemperature: false,
+      })
+      expect(capabilities.reasoning).toBe(true)
+      expect(capabilities.diagnostics).toMatchObject({
+        snapshot: { source: "bundled-snapshot" },
+        supportsTemperature: { source: "bundled-snapshot" },
+      })
+    }
+  })
 })

--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -1,11 +1,21 @@
 import type { ModelCapabilitiesSnapshotEntry } from "./types"
 
+// All Moonshot Kimi reasoning models (k2.6, k2-thinking, k2-thinking-turbo,
+// k2.5-free, k2-5) reject any `temperature` other than 1 with the OpenAI
+// o-series-style error: `invalid temperature: only 1 is allowed for this
+// model`. The bundled `model-capabilities.generated.json` snapshot inherits
+// `temperature: true` for these from upstream `anomalyco/models.dev`, which
+// is wrong for reasoning models. Until that's fixed upstream (#4717 has been
+// blocking the snapshot refresh for 10+ weeks, so a fix there can't reach
+// users), we override here so the capability resolver returns
+// `supportsTemperature: false` and the chat-params layer strips temperature
+// before the request hits Moonshot.
 export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSnapshotEntry> = {
 	"kimi-k2.6": {
 		id: "kimi-k2.6",
 		family: "kimi",
 		reasoning: true,
-		temperature: true,
+		temperature: false,
 		toolCall: true,
 		modalities: {
 			input: ["text", "image", "video"],
@@ -14,6 +24,66 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 		limit: {
 			context: 262144,
 			output: 262144,
+		},
+	},
+	"kimi-k2-thinking": {
+		id: "kimi-k2-thinking",
+		family: "kimi-thinking",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text"],
+			output: ["text"],
+		},
+		limit: {
+			context: 262144,
+			output: 262144,
+		},
+	},
+	"kimi-k2-thinking-turbo": {
+		id: "kimi-k2-thinking-turbo",
+		family: "kimi-thinking",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text"],
+			output: ["text"],
+		},
+		limit: {
+			context: 262144,
+			output: 262144,
+		},
+	},
+	"kimi-k2.5-free": {
+		id: "kimi-k2.5-free",
+		family: "kimi-free",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image", "video"],
+			output: ["text"],
+		},
+		limit: {
+			context: 262144,
+			output: 262144,
+		},
+	},
+	"kimi-k2-5": {
+		id: "kimi-k2-5",
+		family: "kimi",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 256000,
+			output: 65536,
 		},
 	},
 	"gpt-5.5": {


### PR DESCRIPTION
## Summary

- Mark every Moonshot Kimi **reasoning** model as not supporting arbitrary `temperature` so the capability resolver strips the field before the request hits Moonshot's API.
- Strict superset of #5044: `kimi-k2.6` is preserved verbatim with the same one-char fix; the four extra entries are net-new supplemental overrides covering the rest of the family.
- Adds a unit test covering all five model IDs (plus the `moonshotai/`-prefixed form of `kimi-k2.6`).

## Why

Moonshot's OpenAI-compatible API rejects any non-`1` `temperature` for reasoning models with the OpenAI o-series wording:

```
invalid temperature: only 1 is allowed for this model
```

The bundled `model-capabilities.generated.json` snapshot (frozen at `2026-04-17` per #4717 — auto-refresh has been blocked for 10+ weeks) inherits `temperature: true` from upstream [`anomalyco/models.dev`](https://github.com/anomalyco/models.dev) for **every** Moonshot reasoning model. The capability resolver already encodes the correct strip behaviour (`packages/model-core/src/model-settings-compatibility.ts` — `supportsTemperature === false` → drop `temperature`), and `gpt-5.5` / `gpt-5.4-mini-fast` in this same supplemental file are already marked correctly. This PR brings every Moonshot reasoning model in line so the resolver removes `temperature` from outbound requests and the API defaults to the accepted value of `1`.

## Models fixed

| Model | Source | Before | After |
|---|---|---|---|
| `kimi-k2.6` | supplemental (not in bundled snapshot) | `temperature: true` | `temperature: false` |
| `kimi-k2-thinking` | bundled snapshot (`reasoning: true`) | inherited `true` | overridden to `false` |
| `kimi-k2-thinking-turbo` | bundled snapshot (`reasoning: true`) | inherited `true` | overridden to `false` |
| `kimi-k2.5-free` | bundled snapshot (`reasoning: true`) | inherited `true` | overridden to `false` |
| `kimi-k2-5` | bundled snapshot (`reasoning: true`) | inherited `true` | overridden to `false` |

`gpt-5.5` and `gpt-5.4-mini-fast` are untouched — they were already correct.

## Testing

### Unit test (added in this PR)

`packages/model-core/src/model-capabilities-bundled-snapshot.test.ts` now contains `marks Moonshot Kimi reasoning models as NOT supporting arbitrary temperature`, asserting for every fixed model + the `moonshotai/`-prefixed form:

- `result.supportsTemperature === false`
- `result.reasoning === true`
- `diagnostics.snapshot.source === "bundled-snapshot"`
- `diagnostics.supportsTemperature.source === "bundled-snapshot"`

```bash
$ bun test packages/model-core/src/model-capabilities-bundled-snapshot.test.ts
 2 pass
 0 fail
```

### Full test suite

```bash
$ bun test packages/model-core/src
 263 pass
 0 fail

$ bun test     # full repo
 8541 pass
 26 fail (all pre-existing on dev: shell-env, install-codex, atlas hook,
          comment-checker, anthropic-effort — verified by re-running
          against `git stash`'d state)
```

Build + typecheck clean:

```bash
$ bun run --cwd packages/model-core typecheck   # no errors
$ bun run build                                  # dist generated
```

### End-to-end resolver behaviour

Verified with a standalone harness against the patched source: for every patched model ID, the capability resolver returns `supportsTemperature: false` from `bundled-snapshot`, and `resolveCompatibleModelSettings({ desired: { temperature: 0.7, reasoningEffort: "xhigh" } })` returns `temperature: undefined` (i.e. dropped from the outbound request).

```
OK  kimi-k2.6: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
OK  moonshotai/kimi-k2.6: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
OK  kimi-k2-thinking: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
OK  kimi-k2-thinking-turbo: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
OK  kimi-k2.5-free: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
OK  kimi-k2-5: supportsTemperature=false, outbound.temperature=<dropped>, snapshot=bundled-snapshot
```

## Relation to #5044

This PR is a strict superset:

- `kimi-k2.6` flip from `temperature: true` → `false` is preserved verbatim.
- Adds the four other Kimi reasoning models that #5044 deliberately left as "Out of scope (separate issue)" — addressing them here rather than blocking on upstream `anomalyco/models.dev` fixes for the snapshot data, since #4717 (snapshot refresh) has been blocked for 10+ weeks and users see the same failure mode on those entries today.
- Adds the unit test #5044's body offered to provide.

Either PR can be merged; if this one lands, #5044 can be closed as superseded.

## Related Issues

Closes #5043
Supersedes #5044
Related: #3559, #3590, #4717, #4718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks all Moonshot Kimi reasoning models as not supporting arbitrary temperature so requests drop the field and avoid Moonshot’s “only 1 is allowed” error. This restores successful calls by defaulting to temperature 1.

- **Bug Fixes**
  - Set `temperature: false` for: `kimi-k2.6`, `kimi-k2-thinking`, `kimi-k2-thinking-turbo`, `kimi-k2.5-free`, `kimi-k2-5`.
  - Resolver now strips `temperature` for these models; Moonshot defaults to 1.
  - Added a unit test covering the models above and the `moonshotai/kimi-k2.6` prefixed form.

<sup>Written for commit 2aff6d98306468705553443cc35d22a663f62612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

