### PR TITLE
fix(omo-codex): use bundled lsp runtime in installed cache

### DIFF
--- a/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.mjs
+++ b/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.mjs
@@ -8,11 +8,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const lspToolsDir = join(__dirname, "..", "..", "..", "..", "..", "lsp-tools-mcp");
 const packageJson = join(lspToolsDir, "package.json");
-const requiredOutputs = [
-	join(lspToolsDir, "dist", "cli.js"),
-	join(lspToolsDir, "dist", "tools.js"),
-	join(lspToolsDir, "dist", "lsp", "manager.js"),
-];
+const requiredOutputPaths = ["dist/cli.js", "dist/tools.js", "dist/lsp/manager.js"];
+const requiredOutputs = requiredOutputPaths.map((path) => join(lspToolsDir, path));
 const force = process.argv.includes("--force");
 
 if (!force && isBuildFresh(packageJson, requiredOutputs)) {
@@ -20,12 +17,13 @@ if (!force && isBuildFresh(packageJson, requiredOutputs)) {
 }
 
 if (!existsSync(packageJson)) {
-	if (!force && requiredOutputs.every((path) => existsSync(path))) {
-		console.log("Using bundled lsp-tools-mcp dist.");
+	const bundledRuntimeRoot = findBundledRuntimeRoot();
+	if (!force && bundledRuntimeRoot) {
+		console.log(`Using bundled lsp-tools-mcp dist at ${bundledRuntimeRoot}.`);
 		process.exit(0);
 	}
 	console.error(
-		`lsp-tools-mcp package metadata is missing at ${packageJson}; build packages/lsp-tools-mcp before codex-lsp`,
+		`lsp-tools-mcp package metadata is missing at ${packageJson}; checked bundled runtime dist candidates: ${getBundledRuntimeRootCandidates().join(", ")}; build packages/lsp-tools-mcp before codex-lsp`,
 	);
 	process.exit(1);
 }
@@ -43,4 +41,16 @@ function isBuildFresh(inputPath, outputPaths) {
 	if (outputPaths.some((path) => !existsSync(path))) return false;
 	const inputMtime = statSync(inputPath).mtimeMs;
 	return outputPaths.every((path) => statSync(path).mtimeMs >= inputMtime);
+}
+
+function findBundledRuntimeRoot() {
+	return getBundledRuntimeRootCandidates().find((root) => requiredOutputPaths.every((path) => existsSync(join(root, path))));
+}
+
+function getBundledRuntimeRootCandidates() {
+	return [
+		lspToolsDir,
+		join(__dirname, "..", "..", "lsp-tools-mcp"),
+		join(__dirname, "..", "..", "..", "mcp", "lsp"),
+	];
 }

--- a/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs
+++ b/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -19,9 +19,14 @@ async function makeFixture() {
 	await mkdir(fakeBin, { recursive: true });
 	const npmLog = join(root, "npm.log");
 	await writeFile(
-		join(fakeBin, "npm"),
-		`#!/usr/bin/env node\nconst { appendFileSync } = require("node:fs");\nappendFileSync(${JSON.stringify(npmLog)}, process.argv.slice(2).join(" ") + "\\n");\n`,
+		join(fakeBin, "npm.js"),
+		`const { appendFileSync } = require("node:fs");\nappendFileSync(${JSON.stringify(npmLog)}, process.argv.slice(2).join(" ") + "\\n");\n`,
 	);
+	await writeFile(
+		join(fakeBin, "npm"),
+		`#!/usr/bin/env node\nrequire("./npm.js");\n`,
+	);
+	await writeFile(join(fakeBin, "npm.cmd"), `@echo off\r\nnode "%~dp0\\npm.js" %*\r\n`);
 	await chmod(join(fakeBin, "npm"), 0o755);
 	return { root, npmLog, script: join(root, "packages", "omo-codex", "plugin", "components", "lsp", "scripts", "build-lsp-tools.mjs"), fakeBin };
 }
@@ -29,7 +34,7 @@ async function makeFixture() {
 function runScript(script, fakeBin, args = []) {
 	return spawnSync(process.execPath, [script, ...args], {
 		encoding: "utf8",
-		env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+		env: { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}` },
 	});
 }
 
@@ -101,4 +106,34 @@ test("#given packaged dist without package metadata #when bootstrapping #then it
 	assert.equal(result.status, 0, result.stderr);
 	assert.match(result.stdout, /Using bundled lsp-tools-mcp dist/);
 	assert.equal(await readFile(fixture.npmLog, "utf8"), "");
+});
+
+test("#given installed cache bundles lsp-tools component dist #when bootstrapping #then it uses bundled runtime", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "codex-lsp-cache-build-"));
+	const scriptDir = join(root, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0", "components", "lsp", "scripts");
+	const bundledDist = join(root, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0", "components", "lsp-tools-mcp", "dist");
+	const fakeBin = join(root, "bin");
+	const npmLog = join(root, "npm.log");
+	await mkdir(scriptDir, { recursive: true });
+	await mkdir(join(bundledDist, "lsp"), { recursive: true });
+	await mkdir(fakeBin, { recursive: true });
+	await copyFile(new URL("./build-lsp-tools.mjs", import.meta.url), join(scriptDir, "build-lsp-tools.mjs"));
+	await writeFile(join(bundledDist, "cli.js"), "cli\n");
+	await writeFile(join(bundledDist, "tools.js"), "tools\n");
+	await writeFile(join(bundledDist, "lsp", "manager.js"), "manager\n");
+	await writeFile(
+		join(fakeBin, "npm"),
+		`#!/usr/bin/env node\nconst { appendFileSync } = require("node:fs");\nappendFileSync(${JSON.stringify(npmLog)}, process.argv.slice(2).join(" ") + "\\n");\n`,
+	);
+	await chmod(join(fakeBin, "npm"), 0o755);
+	await writeFile(npmLog, "");
+
+	// when
+	const result = runScript(join(scriptDir, "build-lsp-tools.mjs"), fakeBin);
+
+	// then
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stdout, /components[/\\]lsp-tools-mcp/);
+	assert.equal(await readFile(npmLog, "utf8"), "");
 });


### PR DESCRIPTION
## Summary
- Fixes #5149 by making the `codex-lsp` prebuild resolver treat installed OMO/LazyCodex cache layouts as first-class runtime layouts, not as missing source checkouts.
- Preserve the existing source-repository behavior: when `packages/lsp-tools-mcp/package.json` is present and outputs are stale, the script still runs `npm ci` and `npm run build` in the source package.
- When package metadata is absent, resolve the bundled runtime outputs from the paths the installer/cache already owns: `components/lsp-tools-mcp/dist` and `mcp/lsp/dist`.
- Add a regression test for the installed cache layout and make the fake npm fixture Windows-aware by providing `npm.cmd` plus the platform PATH delimiter.

## Root cause
`components/lsp/scripts/build-lsp-tools.mjs` supported a packaged-runtime mode, but it only checked the source-repository sibling path that resolves to `packages/lsp-tools-mcp` in a checkout.

In an installed OMO/LazyCodex cache, the source package metadata is intentionally not present. The runtime dist can instead be present under the installed plugin cache itself. In that layout, the old script reported missing `lsp-tools-mcp` package metadata even though the installer had already provided the runtime outputs needed by `codex-lsp`.

This PR aligns the prebuild resolver with the cache layouts produced by the installer instead of requiring an unpackaged source-tree shape inside `~/.codex/plugins/cache`.

## Why this is standalone
- This is not a duplicate of `code-yeongyu/lazycodex#30` or `#32`. Those issues are subagent orchestration / TOML-backed routing guidance issues and are already closed via `code-yeongyu/oh-my-openagent#5031`. This PR does not touch agent routing, planner completion semantics, or issue-30/32 guidance surfaces.
- This is not the same fix as `code-yeongyu/oh-my-openagent#4763`. That PR hardened Windows cache activation, npm/npx shim resolution, and atomic install preservation. This PR addresses a separate installed-cache prebuild contract: `codex-lsp` must be able to consume the bundled `lsp-tools-mcp` runtime from the installed cache layout when source package metadata is absent.
- This is related to the still-open hook-code-1 class in `code-yeongyu/oh-my-openagent#4722`. The concrete failure here is that a Windows installed cache can have hook components needing rebuild/repair while `codex-lsp` blocks on a source-layout-only `lsp-tools-mcp` lookup.
- The LazyCodex repository is a marketplace mirror, so the implementation belongs in OMO as the source of truth instead of being patched only in the mirror.

## Verification
- `node --test packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs`
- `node --test packages/omo-codex/plugin/test/auto-update.test.mjs packages/omo-codex/plugin/test/install-time-build-runtime.test.mjs packages/omo-codex/plugin/test/node-install-surface.test.mjs`
- `node --test packages/omo-codex/scripts/install-mcp-runtime.test.mjs packages/omo-codex/scripts/install-cache-copy.test.mjs`

## Notes
- I also ran `npm test` in `packages/omo-codex/plugin`; unrelated environment failures remain because `@oh-my-opencode/shared-skills` is not installed in this checkout and Windows symlink creation is not permitted in this shell. The targeted LSP, hook updater, and installer cache tests above pass.
