### PR TITLE
fix(team-mode): treat null-valued team_create optionals as absent (fixes #5047)

### DIFF
--- a/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
+++ b/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
@@ -9,6 +9,7 @@ import type { ToolContext } from "@opencode-ai/plugin/tool"
 
 import { TeamModeConfigSchema } from "../../../config/schema/team-mode"
 import type { RuntimeState, TeamSpec } from "../types"
+import { parseTeamCreateArgs } from "./lifecycle-inline-spec"
 
 const runtimes = new Map<string, RuntimeState>()
 let nextTeamRunNumber = 1
@@ -411,5 +412,48 @@ describe("createTeamCreateTool inline_spec normalization", () => {
         { name: "agent-3-quality-process-analyst", kind: "category", category: "analysis", prompt: "Role: Quality/Process Analyst\ntests, builds, CI/CD" },
       ],
     })
+  })
+})
+
+describe("parseTeamCreateArgs null-valued optional handling", () => {
+  test("treats null inline_spec as absent when teamName is provided", () => {
+    // given the tool-calling surface serializes the unused optional as null
+    const args = parseTeamCreateArgs({ teamName: "existing-team", inline_spec: null })
+
+    // then teamName is accepted as the single provided option
+    expect(args.teamName).toBe("existing-team")
+    expect(args.inline_spec ?? undefined).toBeUndefined()
+  })
+
+  test("treats null teamName as absent when inline_spec is provided", () => {
+    // given the tool-calling surface serializes the unused optional as null
+    const inlineSpec = { name: "smoke-test-team", members: [{ name: "worker", category: "quick", prompt: "Do the assigned work." }] }
+    const args = parseTeamCreateArgs({ teamName: null, inline_spec: inlineSpec })
+
+    // then inline_spec is accepted as the single provided option
+    expect(args.teamName ?? undefined).toBeUndefined()
+    expect(args.inline_spec).toEqual(inlineSpec)
+  })
+
+  test("still rejects when both teamName and inline_spec are provided", () => {
+    let errorMessage = ""
+    try {
+      parseTeamCreateArgs({ teamName: "existing-team", inline_spec: { name: "x", members: [] } })
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(errorMessage).toContain("team_create requires exactly one of teamName or inline_spec")
+  })
+
+  test("still rejects when both teamName and inline_spec are null", () => {
+    let errorMessage = ""
+    try {
+      parseTeamCreateArgs({ teamName: null, inline_spec: null })
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(errorMessage).toContain("team_create requires exactly one of teamName or inline_spec")
   })
 })

--- a/src/features/team-mode/tools/lifecycle-inline-spec.ts
+++ b/src/features/team-mode/tools/lifecycle-inline-spec.ts
@@ -9,11 +9,11 @@ import { TeamSpecSchema, type TeamSpec } from "../types"
 export const TEAM_CREATE_USAGE = "team_create requires exactly one of teamName or inline_spec. Use team_create({ teamName: \"existing-team\" }) or team_create({ inline_spec: { name: \"team-name\", members: [{ name: \"worker\", category: \"quick\", prompt: \"Do the assigned work.\" }] } })."
 
 export const TeamCreateArgsSchema = z.object({
-  teamName: z.string().min(1).optional(),
-  inline_spec: z.unknown().optional(),
-  leadSessionId: z.string().optional(),
+  teamName: z.string().min(1).nullish(),
+  inline_spec: z.unknown().nullish(),
+  leadSessionId: z.string().nullish(),
 }).superRefine((value, ctx) => {
-  const optionCount = Number(value.teamName !== undefined) + Number(value.inline_spec !== undefined)
+  const optionCount = Number(value.teamName != null) + Number(value.inline_spec != null)
   if (optionCount !== 1) {
     ctx.addIssue({ code: "custom", message: "Provide exactly one of teamName or inline_spec." })
   }


### PR DESCRIPTION
## Summary
`team_create` always failed with `team_create requires exactly one of teamName or inline_spec`, even on valid calls. OpenCode's tool-calling surface serializes unspecified optional arguments as `null` (not as omitted keys), and the arg validator counted a `null` value as "present", so `optionCount` became 2 for every call.

## Root Cause
`src/features/team-mode/tools/lifecycle-inline-spec.ts`:

```ts
export const TeamCreateArgsSchema = z.object({
  teamName: z.string().min(1).optional(),
  inline_spec: z.unknown().optional(),
  leadSessionId: z.string().optional(),
}).superRefine((value, ctx) => {
  const optionCount = Number(value.teamName !== undefined) + Number(value.inline_spec !== undefined)
  ...
})
```

- `team_create({ teamName: "x" })` arrives as `{ teamName: "x", inline_spec: null }`. `value.inline_spec !== undefined` is `true` for `null`, so `optionCount === 2` and validation is rejected.
- `team_create({ inline_spec: { ... } })` arrives as `{ teamName: null, inline_spec: { ... } }`. `z.string().min(1).optional()` rejects `null` outright, so `safeParse` fails before `superRefine` even runs.

Both paths reproduce exactly the symptoms reported in the issue.

## Changes
| File | Change |
|------|--------|
| `src/features/team-mode/tools/lifecycle-inline-spec.ts` | Make the three optionals `nullish()` and count presence with `!= null`, so a `null`-serialized optional is treated as absent. |
| `src/features/team-mode/tools/lifecycle-inline-spec.test.ts` | Add `parseTeamCreateArgs` unit tests: null `inline_spec`, null `teamName`, both-present, both-null. |

`leadSessionId` is included because it is affected by the same null-serialization mechanism; the downstream `args.leadSessionId ?? sessionID` and `args.teamName ? ... : parseInlineTeamSpec(...)` reads already treat `null` as falsy/nullish, so behavior is preserved.

## Relationship to #4467
This is **not** a duplicate of #4467. #4467 fixes a different layer: OpenAI-compatible providers reject all-optional tool schemas (`required: null`) with a 500 before execution, addressed by promoting `leadSessionId` to required in the tool definition. That does not touch the `teamName`/`inline_spec` `superRefine` count, so #5047's runtime `exactly one of...` failure persists even with #4467 applied (both remain optional and are still serialized as `null`). The two changes are complementary and touch different files with no overlap.

## Reproduction (before fix)
```
(fail) parseTeamCreateArgs null-valued optional handling > treats null inline_spec as absent when teamName is provided
(fail) parseTeamCreateArgs null-valued optional handling > treats null teamName as absent when inline_spec is provided
error: team_create requires exactly one of teamName or inline_spec.
  at parseTeamCreateArgs (src/features/team-mode/tools/lifecycle-inline-spec.ts:42:38)
 2 pass / 2 fail
```

## Verification (after fix)
```
bun test src/features/team-mode/tools/lifecycle-inline-spec.test.ts
 14 pass / 0 fail

bun test src/features/team-mode/tools/   # whole team-mode tools suite
 69 pass / 0 fail

bun run typecheck   # exit 0
```

## Test
- Regression tests: `src/features/team-mode/tools/lifecycle-inline-spec.test.ts` (4 new cases for `parseTeamCreateArgs`).
- Related suite: `bun test src/features/team-mode/tools/` — 69 pass.
- Typecheck: `bun run typecheck` — clean.

Fixes #5047


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `team_create` validation by treating null-serialized optional args as absent to stop false “exactly one of teamName or inline_spec” errors. Fixes #5047.

- **Bug Fixes**
  - Updated `TeamCreateArgsSchema` to use `.nullish()` for `teamName`, `inline_spec`, and `leadSessionId`, and count presence with `!= null`.
  - Added unit tests for null-handling and for rejecting both provided or both null.

<sup>Written for commit 60935a5b723a871149e80618b15108ad491975fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

