### PR TITLE
fix(cli): tighten OpenAI-only provider detection

### DIFF
--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 
-import { generateModelConfig } from "./model-fallback"
+import { generateModelConfig, shouldShowChatGPTOnlyWarning } from "./model-fallback"
 import type { InstallConfig } from "./types"
 
 function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
@@ -804,4 +804,44 @@ describe("generateModelConfig", () => {
       )
     })
   })
+})
+
+describe("shouldShowChatGPTOnlyWarning", () => {
+  test("returns true when OpenAI is the only configured provider", () => {
+    // #given
+    const config = createConfig({ hasOpenAI: true })
+
+    // #when
+    const result = shouldShowChatGPTOnlyWarning(config)
+
+    // #then
+    expect(result).toBe(true)
+  })
+
+  const mixedProviderCases: Array<{ name: string; overrides: Partial<InstallConfig> }> = [
+    { name: "Claude", overrides: { hasClaude: true } },
+    { name: "Gemini", overrides: { hasGemini: true } },
+    { name: "Copilot", overrides: { hasCopilot: true } },
+    { name: "OpenCode Zen", overrides: { hasOpencodeZen: true } },
+    { name: "Z.ai Coding Plan", overrides: { hasZaiCodingPlan: true } },
+    { name: "Kimi for Coding", overrides: { hasKimiForCoding: true } },
+    { name: "OpenCode Go", overrides: { hasOpencodeGo: true } },
+    { name: "Bailian Coding Plan", overrides: { hasBailianCodingPlan: true } },
+    { name: "MiniMax CN Coding Plan", overrides: { hasMinimaxCnCodingPlan: true } },
+    { name: "MiniMax Coding Plan", overrides: { hasMinimaxCodingPlan: true } },
+    { name: "Vercel AI Gateway", overrides: { hasVercelAiGateway: true } },
+  ]
+
+  for (const { name, overrides } of mixedProviderCases) {
+    test(`returns false when OpenAI is configured with ${name}`, () => {
+      // #given
+      const config = createConfig({ hasOpenAI: true, ...overrides })
+
+      // #when
+      const result = shouldShowChatGPTOnlyWarning(config)
+
+      // #then
+      expect(result).toBe(false)
+    })
+  }
 })

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -227,5 +227,5 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
 }
 
 export function shouldShowChatGPTOnlyWarning(config: InstallConfig): boolean {
-  return !config.hasClaude && !config.hasGemini && config.hasOpenAI
+  return isOpenAiOnlyAvailability(toProviderAvailability(config))
 }

--- a/src/cli/openai-only-model-catalog.test.ts
+++ b/src/cli/openai-only-model-catalog.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test"
 
 import { generateModelConfig } from "./model-fallback"
+import { isOpenAiOnlyAvailability } from "./openai-only-model-catalog"
+import { toProviderAvailability } from "./provider-availability"
 import type { InstallConfig } from "./types"
 
 function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
   return {
+    platform: "opencode",
+    hasOpenCode: true,
+    hasCodex: false,
+    codexAutonomous: false,
     hasClaude: false,
     isMax20: false,
     hasOpenAI: false,
@@ -14,11 +20,20 @@ function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
     hasOpencodeGo: false,
-      hasBailianCodingPlan: false,
+    hasBailianCodingPlan: false,
+    hasMinimaxCnCodingPlan: false,
+    hasMinimaxCodingPlan: false,
     hasVercelAiGateway: false,
     ...overrides,
   }
 }
+
+const mixedProviderCases: Array<{ name: string; overrides: Partial<InstallConfig> }> = [
+  { name: "Bailian Coding Plan", overrides: { hasBailianCodingPlan: true } },
+  { name: "MiniMax CN Coding Plan", overrides: { hasMinimaxCnCodingPlan: true } },
+  { name: "MiniMax Coding Plan", overrides: { hasMinimaxCodingPlan: true } },
+  { name: "Vercel AI Gateway", overrides: { hasVercelAiGateway: true } },
+]
 
 describe("generateModelConfig OpenAI-only model catalog", () => {
   test("fills remaining OpenAI-only agent gaps with OpenAI models", () => {
@@ -61,4 +76,19 @@ describe("generateModelConfig OpenAI-only model catalog", () => {
     expect(result.agents?.librarian).not.toMatchObject({ variant: "medium" })
     expect(result.categories?.quick).toMatchObject({ model: "openai/gpt-5.4-mini" })
   })
+
+  for (const { name, overrides } of mixedProviderCases) {
+    test(`does not apply OpenAI-only overrides when ${name} is also available`, () => {
+      // #given
+      const config = createConfig({ hasOpenAI: true, ...overrides })
+
+      // #when
+      const availability = toProviderAvailability(config)
+      const result = generateModelConfig(config)
+
+      // #then
+      expect(isOpenAiOnlyAvailability(availability)).toBe(false)
+      expect(result.categories?.writing).not.toEqual({ model: "openai/gpt-5.5", variant: "medium" })
+    })
+  }
 })

--- a/src/cli/openai-only-model-catalog.ts
+++ b/src/cli/openai-only-model-catalog.ts
@@ -21,7 +21,11 @@ export function isOpenAiOnlyAvailability(availability: ProviderAvailability): bo
     !availability.opencodeZen &&
     !availability.copilot &&
     !availability.zai &&
-    !availability.kimiForCoding
+    !availability.kimiForCoding &&
+    !availability.bailianCodingPlan &&
+    !availability.minimaxCnCodingPlan &&
+    !availability.minimaxCodingPlan &&
+    !availability.vercelAiGateway
   )
 }
 


### PR DESCRIPTION
## Summary

- Treat OpenAI as OpenAI-only only when every non-OpenAI provider flag is absent.
- Reuse the same provider-availability predicate for the ChatGPT-only installer warning.
- Add regression coverage for Bailian, MiniMax, MiniMax CN, Vercel, and other mixed-provider installs.

Closes #5035
Closes #5036

## Verification

```bash
bun test src/cli/openai-only-model-catalog.test.ts src/cli/model-fallback.test.ts
bun run typecheck
bun run build
```

Local note: full `bun test` on Windows with local Bun 1.3.8 hit a Bun runtime segfault after passing many suites; the previously failing delegate-task assertion passed when rerun directly. CI uses the repo workflow environment and should be the authoritative full-suite gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI-only detection in the CLI so it only applies when no other providers are configured, and prevents OpenAI-only catalog overrides in mixed-provider installs. Also aligns the ChatGPT-only installer warning with the same predicate and adds regression tests for Bailian, MiniMax (CN/global), and Vercel AI Gateway.

- **Bug Fixes**
  - Use shared predicate `isOpenAiOnlyAvailability(toProviderAvailability(config))` for the ChatGPT-only installer warning.
  - Expand OpenAI-only check to exclude Bailian, MiniMax (CN/global), Vercel AI Gateway, and other providers to avoid incorrect OpenAI-only overrides.

<sup>Written for commit 55b806d37461f28f0e87cc960850564a5c8528fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

