### PR TITLE
fix(todo-continuation): preserve ZWSP Atlas registry alias

### DIFF
--- a/src/hooks/todo-continuation-enforcer/continuation-injection-agent-resolution.test.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection-agent-resolution.test.ts
@@ -51,4 +51,39 @@ describe("todo continuation registered agent resolution", () => {
     // then
     expect(capturedAgent).toBe("Atlas (Plan Executor)")
   })
+
+  test("#given OpenCode registered Atlas with a zero-width sort prefix #when continuation inherits config key #then prompt keeps the registered name", async () => {
+    // given
+    registerAgentName("\u200BAtlas (Plan Executor)")
+    let capturedAgent: string | undefined
+    const ctx = unsafeTestValue<PluginInput>({
+      directory: "/tmp/test",
+      client: {
+        session: {
+          todo: async () => ({ data: [{ id: "1", content: "todo", status: "pending", priority: "high" }] }),
+          promptAsync: async (input: { readonly body: { readonly agent?: string } }) => {
+            capturedAgent = input.body.agent
+            return {}
+          },
+        },
+      },
+    })
+    const sessionStateStore = {
+      getExistingState: () => ({ inFlight: false, lastInjectedAt: 0, consecutiveFailures: 0 }),
+    }
+
+    // when
+    await injectContinuation({
+      ctx,
+      sessionID: "ses_todo_registered_zwsp_atlas",
+      resolvedInfo: {
+        agent: "atlas",
+        model: { providerID: "openai", modelID: "gpt-5.5" },
+      },
+      sessionStateStore: unsafeTestValue(sessionStateStore),
+    })
+
+    // then
+    expect(capturedAgent).toBe("\u200BAtlas (Plan Executor)")
+  })
 })

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -21,7 +21,6 @@ import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   getAgentConfigKey,
   normalizeAgentForPrompt,
-  stripAgentListSortPrefix,
 } from "../../shared/agent-display-names"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../shared/prompt-async-gate"
 
@@ -139,7 +138,6 @@ export async function injectContinuation(args: {
   const promptAgent = registeredAgentName !== undefined && registeredAgentName !== agentConfigKey
     ? registeredAgentName
     : normalizeAgentForPrompt(agentName)
-  const launchAgent = promptAgent ? stripAgentListSortPrefix(promptAgent).trim() || undefined : undefined
 
   if (promptAgent && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: agentName })
@@ -181,7 +179,7 @@ ${todoList}`
   try {
     log(`[${HOOK_NAME}] Injecting continuation`, {
       sessionID,
-      agent: launchAgent ?? promptAgent,
+      agent: promptAgent,
       model,
       incompleteCount: freshIncompleteCount,
     })
@@ -204,7 +202,7 @@ ${todoList}`
       input: {
         path: { id: sessionID },
         body: {
-          agent: launchAgent ?? promptAgent,
+          agent: promptAgent,
           ...(launchModel ? { model: launchModel } : {}),
           ...(launchVariant ? { variant: launchVariant } : {}),
           ...(inheritedTools ? { tools: inheritedTools } : {}),


### PR DESCRIPTION
﻿## Summary
- Fixes #4700 by keeping the exact registered OpenCode agent alias when todo-continuation dispatches an internal prompt.
- Adds regression coverage for an Atlas registry entry prefixed with U+200B zero-width space.
- Removes the final strip step that turned the registered alias back into an unregistered clean display name.

## Why
OpenCode can register Atlas as `\u200BAtlas (Plan Executor)`. `resolveRegisteredAgentName("atlas")` already returns that raw registered alias, but todo-continuation stripped the zero-width prefix before calling `promptAsync`, causing `Agent not found: "Atlas (Plan Executor)"` and then fallback lookup failures.

## Commits
- `test(todo-continuation): cover ZWSP Atlas registry alias`
- `fix(todo-continuation): preserve registered Atlas alias`

## Testing
- `bun test src/hooks/todo-continuation-enforcer/` - 121 pass, 0 fail
- `bun run typecheck` - pass
- `bun run build` - pass
- `bun test src/tools/delegate-task/tools.test.ts -t "browserProvider propagation"` - 2 pass, 0 fail

## Local full-suite note
- `bun test` on local Windows/Bun 1.3.8 did not produce a reliable full-suite result: one run exited 1 with output truncated near `src/tools/delegate-task/tools.test.ts`, and a retry redirected to log exceeded 15 minutes and had to be stopped. The isolated suspected `browserProvider propagation` tests passed.

Fixes #4700


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the exact registered agent alias during todo continuation prompts to prevent “Agent not found” when aliases include zero‑width prefixes. Fixes #4700.

- **Bug Fixes**
  - Removed the alias-stripping step and always pass the registered alias (`promptAgent`) to `promptAsync`.
  - Added a regression test for `\u200BAtlas (Plan Executor)` in continuation injection.

<sup>Written for commit 6febf33969739e3bd8cab051fa36c829e6caf393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

