### PR TITLE
fix(cli): cap Copilot GPT fallback variants

### DIFF
--- a/packages/model-core/src/model-capabilities/get-model-capabilities.ts
+++ b/packages/model-core/src/model-capabilities/get-model-capabilities.ts
@@ -20,6 +20,11 @@ import type {
 } from "./types"
 
 const MODEL_ID_OVERRIDES: Record<string, ModelCapabilityOverride> = {}
+const GITHUB_COPILOT_GPT5_MODEL = /(?:^|\/)gpt-5(?:[.-]|$)/
+const GITHUB_COPILOT_GPT5_OVERRIDE: ModelCapabilityOverride = {
+	variants: ["low", "medium", "high"],
+	reasoningEfforts: ["none", "minimal", "low", "medium", "high"],
+}
 
 function normalizeLookupModelID(modelID: string): string {
 	return modelID.trim().toLowerCase()
@@ -29,9 +34,17 @@ function getOverride(modelID: string): ModelCapabilityOverride | undefined {
 	return MODEL_ID_OVERRIDES[normalizeLookupModelID(modelID)]
 }
 
+function getProviderOverride(providerID: string, modelID: string): ModelCapabilityOverride | undefined {
+	if (providerID.trim().toLowerCase() !== "github-copilot") return undefined
+	return GITHUB_COPILOT_GPT5_MODEL.test(normalizeLookupModelID(modelID))
+		? GITHUB_COPILOT_GPT5_OVERRIDE
+		: undefined
+}
+
 export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCapabilities {
 	const canonicalization = resolveModelIDAlias(input.modelID)
 	const override = getOverride(input.modelID)
+	const providerOverride = getProviderOverride(input.providerID, canonicalization.canonicalModelID)
 	const runtimeModel = readRuntimeModel(
 		input.runtimeModel ?? input.providerCache?.findProviderModelMetadata(input.providerID, input.modelID),
 	)
@@ -59,9 +72,9 @@ export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCap
 	const familySource: ModelCapabilitiesDiagnostics["family"]["source"] =
 		snapshotEntry?.family ? "snapshot" : heuristicFamily?.family ? "heuristic" : "none"
 	const variantsSource: ModelCapabilitiesDiagnostics["variants"]["source"] =
-		runtimeVariants ? "runtime" : override?.variants ? "override" : heuristicFamily?.variants ? "heuristic" : "none"
+		runtimeVariants ? "runtime" : providerOverride?.variants ? "override" : override?.variants ? "override" : heuristicFamily?.variants ? "heuristic" : "none"
 	const reasoningEffortsSource: ModelCapabilitiesDiagnostics["reasoningEfforts"]["source"] =
-		override?.reasoningEfforts ? "override" : heuristicFamily?.reasoningEfforts ? "heuristic" : "none"
+		providerOverride?.reasoningEfforts ? "override" : override?.reasoningEfforts ? "override" : heuristicFamily?.reasoningEfforts ? "heuristic" : "none"
 	const reasoningSource: ModelCapabilitiesDiagnostics["reasoning"]["source"] =
 		runtimeReasoning === undefined ? snapshotEntry?.reasoning === undefined ? "none" : snapshotSource : "runtime"
 	const supportsThinkingSource: ModelCapabilitiesDiagnostics["supportsThinking"]["source"] =
@@ -107,8 +120,8 @@ export function getModelCapabilities(input: GetModelCapabilitiesInput): ModelCap
 		requestedModelID: canonicalization.requestedModelID,
 		canonicalModelID: canonicalization.canonicalModelID,
 		family: snapshotEntry?.family ?? heuristicFamily?.family,
-		variants: runtimeVariants ?? override?.variants ?? heuristicFamily?.variants,
-		reasoningEfforts: override?.reasoningEfforts ?? heuristicFamily?.reasoningEfforts,
+		variants: runtimeVariants ?? providerOverride?.variants ?? override?.variants ?? heuristicFamily?.variants,
+		reasoningEfforts: providerOverride?.reasoningEfforts ?? override?.reasoningEfforts ?? heuristicFamily?.reasoningEfforts,
 		reasoning: runtimeReasoning ?? snapshotEntry?.reasoning,
 		supportsThinking: override?.supportsThinking ?? runtimeThinking ?? snapshotEntry?.reasoning ?? heuristicFamily?.supportsThinking,
 		supportsTemperature: runtimeTemperature ?? override?.supportsTemperature ?? snapshotEntry?.temperature,

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -321,37 +321,39 @@ describe("resolveCompatibleModelSettings", () => {
     })
   })
 
-  test("GitHub Copilot GPT-5 variants downgrade xhigh to high", () => {
+  test("GitHub Copilot GPT-5 high-tier variants downgrade to high", () => {
     for (const modelID of ["gpt-5.4", "gpt-5.5"]) {
-      const capabilities = getModelCapabilities({
-        providerID: "github-copilot",
-        modelID,
-      })
-      const result = resolveCompatibleModelSettings({
-        providerID: "github-copilot",
-        modelID,
-        desired: { variant: "xhigh", reasoningEffort: "xhigh" },
-        capabilities,
-      })
+      for (const requested of ["xhigh", "max"]) {
+        const capabilities = getModelCapabilities({
+          providerID: "github-copilot",
+          modelID,
+        })
+        const result = resolveCompatibleModelSettings({
+          providerID: "github-copilot",
+          modelID,
+          desired: { variant: requested, reasoningEffort: requested },
+          capabilities,
+        })
 
-      expect(result).toEqual({
-        variant: "high",
-        reasoningEffort: "high",
-        changes: [
-          {
-            field: "variant",
-            from: "xhigh",
-            to: "high",
-            reason: "unsupported-by-model-metadata",
-          },
-          {
-            field: "reasoningEffort",
-            from: "xhigh",
-            to: "high",
-            reason: "unsupported-by-model-metadata",
-          },
-        ],
-      })
+        expect(result).toEqual({
+          variant: "high",
+          reasoningEffort: "high",
+          changes: [
+            {
+              field: "variant",
+              from: requested,
+              to: "high",
+              reason: "unsupported-by-model-metadata",
+            },
+            {
+              field: "reasoningEffort",
+              from: requested,
+              to: "high",
+              reason: "unsupported-by-model-metadata",
+            },
+          ],
+        })
+      }
     }
   })
   test("DeepSeek keeps canonical high and max reasoningEffort values", () => {

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -321,6 +321,39 @@ describe("resolveCompatibleModelSettings", () => {
     })
   })
 
+  test("GitHub Copilot GPT-5 variants downgrade xhigh to high", () => {
+    for (const modelID of ["gpt-5.4", "gpt-5.5"]) {
+      const capabilities = getModelCapabilities({
+        providerID: "github-copilot",
+        modelID,
+      })
+      const result = resolveCompatibleModelSettings({
+        providerID: "github-copilot",
+        modelID,
+        desired: { variant: "xhigh", reasoningEffort: "xhigh" },
+        capabilities,
+      })
+
+      expect(result).toEqual({
+        variant: "high",
+        reasoningEffort: "high",
+        changes: [
+          {
+            field: "variant",
+            from: "xhigh",
+            to: "high",
+            reason: "unsupported-by-model-metadata",
+          },
+          {
+            field: "reasoningEffort",
+            from: "xhigh",
+            to: "high",
+            reason: "unsupported-by-model-metadata",
+          },
+        ],
+      })
+    }
+  })
   test("DeepSeek keeps canonical high and max reasoningEffort values", () => {
     for (const reasoningEffort of ["high", "max"]) {
       const result = resolveCompatibleModelSettings({

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -1448,7 +1448,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "github-copilot/gpt-5-nano",
@@ -1632,7 +1632,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "github-copilot/gpt-5-nano",
@@ -2114,7 +2114,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "github-copilot/claude-opus-4.7",
@@ -2620,7 +2620,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "fallback_models": [
@@ -3010,7 +3010,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "opencode/gpt-5.5",
@@ -3555,7 +3555,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "opencode/gpt-5.5",

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -28,6 +28,12 @@ function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
   }
 }
 
+function flattenConfiguredModels(result: ReturnType<typeof generateModelConfig>) {
+  return [
+    ...Object.values(result.agents ?? {}),
+    ...Object.values(result.categories ?? {}),
+  ].flatMap((entry) => [entry, ...(entry.fallback_models ?? [])])
+}
 describe("generateModelConfig", () => {
   describe("no providers available", () => {
     test("returns ULTIMATE_FALLBACK for all agents and categories when no providers", () => {
@@ -188,6 +194,35 @@ describe("generateModelConfig", () => {
       expect(result).toMatchSnapshot()
     })
 
+    test("downgrades unsupported GitHub Copilot GPT high-tier variants", () => {
+      // #given only GitHub Copilot is available
+      const config = createConfig({ hasCopilot: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then Copilot GPT routes should not receive variants that hang the provider
+      const unsupportedEntries = flattenConfiguredModels(result).filter(
+        (entry) =>
+          entry.model.startsWith("github-copilot/gpt-5.") &&
+          (entry.variant === "max" || entry.variant === "xhigh")
+      )
+      expect(unsupportedEntries).toEqual([])
+      expect(result.agents?.momus).toEqual({
+        model: "github-copilot/gpt-5.5",
+        variant: "high",
+        fallback_models: [
+          {
+            model: "github-copilot/claude-opus-4.7",
+            variant: "max",
+          },
+          {
+            model: "github-copilot/gemini-3.1-pro-preview",
+            variant: "high",
+          },
+        ],
+      })
+    })
     test("omits librarian when only ZAI is available", () => {
       // #given only ZAI is available
       const config = createConfig({ hasZaiCodingPlan: true })

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -4,6 +4,7 @@ import {
 } from "./model-fallback-requirements"
 import type { FallbackModelObject } from "../config/schema/fallback-models"
 import type { FallbackEntry } from "../shared/model-requirements"
+import { getModelCapabilities, resolveCompatibleModelSettings } from "@oh-my-opencode/model-core"
 import type { InstallConfig } from "./types"
 
 import type { AgentConfig, CategoryConfig, GeneratedOmoConfig } from "./model-fallback-types"
@@ -23,15 +24,70 @@ export type { GeneratedOmoConfig } from "./model-fallback-types"
 const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 
-function toFallbackModelObject(entry: FallbackEntry, provider: string): FallbackModelObject {
+type CompatibleFallbackSettings = {
+  variant?: string
+  reasoningEffort?: FallbackModelObject["reasoningEffort"]
+  temperature?: number
+  top_p?: number
+  maxTokens?: number
+  thinking?: FallbackModelObject["thinking"]
+}
+
+function resolveCompatibleFallbackSettings(
+  providerID: string,
+  modelID: string,
+  desired: CompatibleFallbackSettings,
+): CompatibleFallbackSettings {
+  const compatibility = resolveCompatibleModelSettings({
+    providerID,
+    modelID,
+    desired: {
+      variant: desired.variant,
+      reasoningEffort: desired.reasoningEffort,
+      temperature: desired.temperature,
+      topP: desired.top_p,
+      maxTokens: desired.maxTokens,
+      thinking: desired.thinking,
+    },
+    capabilities: getModelCapabilities({ providerID, modelID }),
+  })
+
   return {
-    model: `${provider}/${transformModelForProvider(provider, entry.model)}`,
-    ...(entry.variant ? { variant: entry.variant } : {}),
-    ...(entry.reasoningEffort ? { reasoningEffort: entry.reasoningEffort as FallbackModelObject["reasoningEffort"] } : {}),
-    ...(entry.temperature !== undefined ? { temperature: entry.temperature } : {}),
-    ...(entry.top_p !== undefined ? { top_p: entry.top_p } : {}),
-    ...(entry.maxTokens !== undefined ? { maxTokens: entry.maxTokens } : {}),
-    ...(entry.thinking ? { thinking: entry.thinking } : {}),
+    ...(compatibility.variant ? { variant: compatibility.variant } : {}),
+    ...(compatibility.reasoningEffort ? { reasoningEffort: compatibility.reasoningEffort as FallbackModelObject["reasoningEffort"] } : {}),
+    ...(compatibility.temperature !== undefined ? { temperature: compatibility.temperature } : {}),
+    ...(compatibility.topP !== undefined ? { top_p: compatibility.topP } : {}),
+    ...(compatibility.maxTokens !== undefined ? { maxTokens: compatibility.maxTokens } : {}),
+    ...(compatibility.thinking !== undefined ? { thinking: compatibility.thinking as FallbackModelObject["thinking"] } : {}),
+  }
+}
+
+function toCompatibleModelConfig(model: string, desired: Pick<CompatibleFallbackSettings, "variant">): AgentConfig {
+  const slashIndex = model.indexOf("/")
+  if (slashIndex === -1) {
+    return desired.variant ? { model, variant: desired.variant } : { model }
+  }
+
+  const providerID = model.slice(0, slashIndex)
+  const modelID = model.slice(slashIndex + 1)
+  const compatible = resolveCompatibleFallbackSettings(providerID, modelID, desired)
+  return compatible.variant ? { model, variant: compatible.variant } : { model }
+}
+
+function toFallbackModelObject(entry: FallbackEntry, provider: string): FallbackModelObject {
+  const modelID = transformModelForProvider(provider, entry.model)
+  const compatible = resolveCompatibleFallbackSettings(provider, modelID, {
+    variant: entry.variant,
+    reasoningEffort: entry.reasoningEffort as FallbackModelObject["reasoningEffort"] | undefined,
+    temperature: entry.temperature,
+    top_p: entry.top_p,
+    maxTokens: entry.maxTokens,
+    thinking: entry.thinking,
+  })
+
+  return {
+    model: `${provider}/${modelID}`,
+    ...compatible,
   }
 }
 
@@ -129,7 +185,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     if (role === "librarian") {
       const resolved = resolveModelFromChain(req.fallbackChain, avail)
       if (resolved) {
-        const agentConfig = resolved.variant ? { model: resolved.model, variant: resolved.variant } : { model: resolved.model }
+        const agentConfig = toCompatibleModelConfig(resolved.model, { variant: resolved.variant })
         agents[role] = attachFallbackModels(agentConfig, req.fallbackChain, avail)
       }
       continue
@@ -151,7 +207,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
         const resolved = resolveModelFromChain(req.fallbackChain, avail)
         if (resolved) {
           const variant = resolved.variant ?? req.variant
-          agentConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
+          agentConfig = toCompatibleModelConfig(resolved.model, { variant })
         } else {
           agentConfig = { model: "opencode/gpt-5-nano" }
         }
@@ -168,7 +224,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       const resolved = resolveModelFromChain(fallbackChain, avail)
       if (resolved) {
         const variant = resolved.variant ?? req.variant
-        const agentConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
+        const agentConfig = toCompatibleModelConfig(resolved.model, { variant })
         agents[role] = attachFallbackModels(agentConfig, fallbackChain, avail)
       }
       continue
@@ -184,7 +240,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     const resolved = resolveModelFromChain(req.fallbackChain, avail)
     if (resolved) {
       const variant = resolved.variant ?? req.variant
-      const agentConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
+      const agentConfig = toCompatibleModelConfig(resolved.model, { variant })
       agents[role] = attachFallbackModels(agentConfig, req.fallbackChain, avail)
     } else {
       agents[role] = { model: ULTIMATE_FALLBACK }
@@ -208,7 +264,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
     const resolved = resolveModelFromChain(fallbackChain, avail)
     if (resolved) {
       const variant = resolved.variant ?? req.variant
-      const categoryConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
+      const categoryConfig = toCompatibleModelConfig(resolved.model, { variant })
       categories[cat] = attachFallbackModels(categoryConfig, fallbackChain, avail)
     } else {
       categories[cat] = { model: ULTIMATE_FALLBACK }


### PR DESCRIPTION
## Summary

- add a GitHub Copilot provider capability override so GPT-5 family variants/reasoning efforts cap at `high`
- run installer-generated primary and fallback model settings through the existing compatibility resolver
- cover Copilot-only generated config so `github-copilot/gpt-5.*` no longer receives `max` or `xhigh`

Fixes #4708

## Verification

- `bun test packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-capabilities.test.ts packages/model-core/src/model-capabilities-snapshot.test.ts`
- `bun test src/cli/model-fallback.test.ts`
- `bun test src/cli/config-manager/generate-omo-config.test.ts src/cli/provider-model-id-transform.test.ts`
- `bun test src/plugin/chat-params.test.ts packages/model-core/src/provider-model-id-transform.test.ts`
- `bun run typecheck`
- `bun run build`

## Note

- Full local `bun test` on Windows ran for about 73 seconds with many passing tests, then Bun 1.3.8 crashed with a segmentation fault and no assertion failure shown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps variants and reasoning efforts for `github-copilot/gpt-5.*` at high and sanitizes CLI‑generated configs so Copilot never gets `xhigh`/`max`, preventing hangs in primary and fallback selections.

- **Bug Fixes**
  - Added provider-level override in `@oh-my-opencode/model-core` for `github-copilot` `gpt-5.*`: variants = `["low","medium","high"]`, reasoningEfforts = `["none","minimal","low","medium","high"]` (takes precedence over heuristics).
  - Routed CLI agent/category and fallback settings through `resolveCompatibleModelSettings` (`src/cli/model-fallback.ts`) to coerce unsupported fields and emit compatible `{ variant, reasoningEffort, temperature, top_p, maxTokens, thinking }`.
  - Expanded tests to ensure `gpt-5.4`/`gpt-5.5` downgrade both `xhigh` and `max` to `high` for variant and reasoningEffort; updated snapshots so no Copilot GPT‑5 entries use `xhigh`/`max`.

<sup>Written for commit 8f3eeba588ffacae98ac91a2231bf9a39ebd7a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

