### PR TITLE
docs(install): clarify install caches and config paths

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -15,6 +15,41 @@ Most users want **Ultimate**. Pick **Light** if you are already invested in Code
 
 `lazycodex-ai` defaults to the Codex Light installer and runs through Node/npm. `--platform` on the shared `omo` CLI still defaults to `opencode` (Ultimate). `lazycodex-ai` is the npm/bin alias; `lazycodex` is the GitHub repository that hosts the marketplace bundle. Neither is the Codex marketplace name.
 
+## Where Things Live
+
+`bunx oh-my-openagent install` is a package-runner invocation. It does not create a supported global `oh-my-openagent` install. Bun may keep its own package cache, but OmO's durable state is the OpenCode plugin registration and the OmO config files listed below.
+
+### Ultimate Edition paths
+
+| Thing | Location | Notes |
+| ----- | -------- | ----- |
+| OpenCode plugin registration | Active OpenCode config dir, `opencode.json` or `opencode.jsonc` | Usually `~/.config/opencode` for the OpenCode CLI unless `OPENCODE_CONFIG_DIR` is set. OpenCode Desktop uses its app config dir unless an existing CLI config is detected. |
+| OmO user config | Active OpenCode config dir, `oh-my-openagent.json[c]` | Legacy `oh-my-opencode.json[c]` still loads during the rename transition. Prefer the `oh-my-openagent` basename for new configs. |
+| OmO project config | `<project>/.opencode/oh-my-openagent.json[c]` | The loader walks from the working directory up to `$HOME`; closer project configs override farther ones. Root-level `oh-my-openagent.json` is not a project config. |
+| OpenCode provider auth | OpenCode-managed auth storage | Use `opencode auth list` and `opencode auth login`; OmO does not store provider tokens in its plugin config. |
+
+To inspect the active state, run:
+
+```bash
+bunx oh-my-openagent doctor
+bunx oh-my-openagent version
+opencode auth list
+opencode agent list
+```
+
+### Light Edition paths
+
+| Thing | Location | Notes |
+| ----- | -------- | ----- |
+| Codex home | `CODEX_HOME` or `~/.codex` | Codex CLI owns this directory. The Light installer writes managed plugin state inside it. |
+| Plugin cache | `~/.codex/plugins/cache/sisyphuslabs/omo/<version>/` | Safe to regenerate by rerunning `npx lazycodex-ai install`. |
+| Marketplace snapshot | `~/.codex/.tmp/marketplaces/sisyphuslabs/` | Local marketplace metadata for Codex plugin discovery. |
+| Codex config | `~/.codex/config.toml` | Contains `[marketplaces.sisyphuslabs]`, `[plugins."omo@sisyphuslabs"]`, hook trust hashes, managed agent blocks, and optional autonomous permission settings. |
+| Codex agent roles | `~/.codex/agents/*.toml` | Managed entries are tracked so uninstall can remove them safely. |
+| Component CLIs | `~/.local/bin` or `$CODEX_LOCAL_BIN_DIR` | Add this directory to `PATH` if hook commands cannot find `omo-*` binaries. |
+
+For cleanup, prefer `npx lazycodex-ai uninstall` or `omo cleanup --platform=codex`. If you only need to clear a broken cache before reinstall, remove `~/.codex/plugins/cache/sisyphuslabs` and rerun the installer. Do not blindly delete project-local `.codex/` or generated `AGENTS.md` files; the cleanup command reports project-local artifacts and only repairs known config conflicts automatically.
+
 ## For Humans
 
 **Strongly recommended: let an LLM agent install Ultimate for you.** Ultimate setup involves subscription detection, model selection across 11 agents, provider authentication, and config migration — humans fat-finger these. An LLM agent reads the full guide and walks every step correctly.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,15 +43,23 @@ Complete reference for Oh My OpenCode plugin configuration. During the rename tr
 
 ### File Locations
 
+`opencode.json` registers the plugin with OpenCode. `oh-my-openagent.json[c]` configures OmO itself. Keep those files separate.
+
 User config loads first. Project configs are discovered by walking from the working directory up to `$HOME`; closer configs win. If the working directory is outside `$HOME`, only that directory is checked.
 
-1. Walked configs: `.opencode/oh-my-openagent.json[c]` or legacy `.opencode/oh-my-opencode.json[c]`
-2. User config (`.jsonc` preferred over `.json`):
+1. User config (`.jsonc` preferred over `.json`):
 
-| Platform    | Path candidates |
-| ----------- | --------------- |
-| macOS/Linux | `~/.config/opencode/oh-my-openagent.json[c]`, `~/.config/opencode/oh-my-opencode.json[c]` |
-| Windows     | `%APPDATA%\opencode\oh-my-openagent.json[c]`, `%APPDATA%\opencode\oh-my-opencode.json[c]` |
+| Source | Path candidates |
+| ------ | --------------- |
+| Explicit OpenCode profile | `$OPENCODE_CONFIG_DIR/oh-my-openagent.json[c]`, `$OPENCODE_CONFIG_DIR/oh-my-opencode.json[c]` |
+| OpenCode CLI default | `$XDG_CONFIG_HOME/opencode/oh-my-openagent.json[c]` or `~/.config/opencode/oh-my-openagent.json[c]` |
+| Legacy basename | Same directories, `oh-my-opencode.json[c]` |
+
+2. Walked project configs: `<cwd-or-ancestor>/.opencode/oh-my-openagent.json[c]` or legacy `<cwd-or-ancestor>/.opencode/oh-my-opencode.json[c]`
+
+The OpenCode CLI default is `~/.config/opencode` on all platforms when `XDG_CONFIG_HOME` and `OPENCODE_CONFIG_DIR` are unset, including Windows. OpenCode Desktop has its own app config directory for host registration, but OmO project overrides still live under `.opencode/` in the workspace.
+
+Do not place project config at `<project>/oh-my-openagent.json`; it will not be discovered. Use `<project>/.opencode/oh-my-openagent.jsonc`.
 
 **Security note:** `mcp_env_allowlist` is user-only. Walked configs cannot extend it.
 


### PR DESCRIPTION
## Summary
- add a quick reference for Ultimate and Light edition install/cache/config locations
- document inspection commands for active OpenCode/Codex state
- clarify OmO config discovery in the configuration reference, including `OPENCODE_CONFIG_DIR`, CLI defaults, and project `.opencode/` paths

Fixes #3847

## Verification
- `git diff --check upstream/dev...HEAD`

## Notes
- docs-only; no installer or runtime behavior changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: adds quick path references for Ultimate and Light, clarifies that `bunx oh-my-openagent install` isn’t a global install, and shows where plugin registration, user/project configs, and auth live. Updates discovery order and defaults (`OPENCODE_CONFIG_DIR`, `~/.config/opencode` across platforms, Desktop vs CLI), correct `.opencode/` paths, inspection commands, Light bin path, and safe cleanup (`npx lazycodex-ai uninstall` or `omo cleanup --platform=codex`).

<sup>Written for commit af0f075dfde0a72a8fded9bf9bc26447082b4c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

