### PR TITLE
test(codex): stabilize Git Bash preflight installer tests

### DIFF
--- a/src/cli/install-codex/install-codex-git-bash-preflight.test.ts
+++ b/src/cli/install-codex/install-codex-git-bash-preflight.test.ts
@@ -10,6 +10,7 @@ import type { CommandRunOptions } from "./types"
 
 const WINDOWS_GIT_BASH_PATH = "C:\\Program Files\\Git\\bin\\bash.exe"
 const LSP_CLI_PATH = join(process.cwd(), "packages", "lsp-tools-mcp", "dist", "cli.js")
+const INSTALLER_INTEGRATION_TIMEOUT_MS = 15_000
 
 async function withBundledLspRuntimeForTest<T>(run: () => Promise<T>): Promise<T> {
   let lspCliAlreadyPresent = true
@@ -101,7 +102,7 @@ describe("install-codex Git Bash preflight", () => {
     expect(runCalls).toContain(`winget install --id Git.Git -e --source winget ${process.cwd()}`)
     expect(resolveCallCount).toBe(2)
     expect(result.gitBashPath).toBe(WINDOWS_GIT_BASH_PATH)
-  })
+  }, { timeout: INSTALLER_INTEGRATION_TIMEOUT_MS })
 
   test("#given non-Windows install #when running installer #then winget is never called", async () => {
     // given
@@ -124,7 +125,7 @@ describe("install-codex Git Bash preflight", () => {
     // then
     expect(result.gitBashPath).toBeNull()
     expect(runCalls.some((command) => command.startsWith("winget "))).toBe(false)
-  })
+  }, { timeout: INSTALLER_INTEGRATION_TIMEOUT_MS })
 
   test("#given Windows with Git Bash #when installing Codex profile #then proceeds and reports detected path", async () => {
     // given
@@ -144,7 +145,7 @@ describe("install-codex Git Bash preflight", () => {
     // then
     expect(result.gitBashPath).toBe(WINDOWS_GIT_BASH_PATH)
     expect(await readFile(join(codexHome, "config.toml"), "utf8")).toContain("[marketplaces.sisyphuslabs]")
-  })
+  }, { timeout: INSTALLER_INTEGRATION_TIMEOUT_MS })
 
   test("#given Windows env override in installer options #when no custom resolver is provided #then default resolver uses it", async () => {
     // given
@@ -165,7 +166,7 @@ describe("install-codex Git Bash preflight", () => {
 
     // then
     expect(result.gitBashPath).toBe(gitBashPath)
-  })
+  }, { timeout: INSTALLER_INTEGRATION_TIMEOUT_MS })
 
   test("#given non-Windows install #when Git Bash resolver would fail #then installer keeps existing behavior", async () => {
     // given
@@ -189,5 +190,5 @@ describe("install-codex Git Bash preflight", () => {
     // then
     expect(result.gitBashPath).toBeNull()
     expect(await readFile(join(codexHome, "config.toml"), "utf8")).toContain("[marketplaces.sisyphuslabs]")
-  })
+  }, { timeout: INSTALLER_INTEGRATION_TIMEOUT_MS })
 })


### PR DESCRIPTION
## Summary
- raise the timeout for the Windows Git Bash preflight integration cases that exercise the full Codex installer path
- keep the preflight assertions intact while avoiding Windows CI flake from the default 5s Bun test limit

Related to the Windows test failure observed on PR #5054.

## Verification
- `bun test src/cli/install-codex/install-codex-git-bash-preflight.test.ts`
- `git diff --check upstream/dev...HEAD`

## Notes
- this is a test-stability change, not a production behavior change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the timeout for Windows Git Bash preflight installer integration tests to 15s to prevent CI flakes caused by `bun test`’s 5s default. Assertions and logic are unchanged; this only affects test stability.

<sup>Written for commit 57717a8202c8bf982aed74a92d3d2b21a17e6612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

