### PR TITLE
fix(codex): preserve agent service tier customizations

### DIFF
--- a/packages/omo-codex/scripts/install-agent-links.test.mjs
+++ b/packages/omo-codex/scripts/install-agent-links.test.mjs
@@ -253,6 +253,47 @@ test(
 );
 
 test(
+	"#given user removed installed ultrawork service tier #when reinstalling after snapshot refresh #then removal survives",
+	async () => {
+		const repoRoot = await makeTempDir();
+		const codexHome = await makeTempDir();
+		const codexPackageRoot = join(repoRoot, "packages", "omo-codex");
+		const pluginRoot = join(codexPackageRoot, "plugin");
+		const agentsRoot = join(pluginRoot, "components", "ultrawork", "agents");
+
+		await writeJson(join(codexPackageRoot, "marketplace.json"), {
+			name: "sisyphuslabs",
+			plugins: [{ name: "omo", source: "./plugins/omo" }],
+		});
+		await writePluginAt(pluginRoot, "omo", "0.1.0");
+		await mkdir(agentsRoot, { recursive: true });
+		await writeFile(
+			join(agentsRoot, "explorer.toml"),
+			'name = "explorer"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "low"\nservice_tier = "fast"\n',
+		);
+
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+		await writeFile(join(codexHome, "agents", "explorer.toml"), 'name = "explorer"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "low"\n');
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+
+		const installedExplorer = await readFile(join(codexHome, "agents", "explorer.toml"), "utf8");
+		assert.equal(installedExplorer.includes("service_tier"), false);
+	},
+);
+
+test(
 	"#given user edited installed ultrawork plan #when reinstalling after snapshot refresh #then bundled snapshot target retains xhigh",
 	async () => {
 		const repoRoot = await makeTempDir();

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -13,7 +13,7 @@ import {
 	pruneMarketplacePluginCaches,
 } from "./install/cache.mjs";
 import { agentSourceRootsForInstall } from "./install/agent-source-roots.mjs";
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./install/agents.mjs";
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./install/agents.mjs";
 import { writeCachedMarketplaceManifest } from "./install/cached-marketplace-manifest.mjs";
 import { updateCodexConfig } from "./install/config.mjs";
 import {
@@ -125,10 +125,11 @@ export async function installMarketplaceLocally(options = {}) {
 	}
 
 	const preservedReasoning = await capturePreservedAgentReasoning({ codexHome });
+	const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome });
 	const agentSourceRoots = await agentSourceRootsForInstall({ codexHome, marketplace, installed, pluginSources });
 	for (const plugin of installed) {
 		const pluginRoot = agentSourceRoots.get(plugin.name) ?? plugin.path;
-		const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning });
+		const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning, preservedServiceTier });
 		for (const link of agentLinks) {
 			log(`Linked agent ${link.name} -> ${link.target}`);
 			const agentName = agentNameFromToml(link.name);

--- a/packages/omo-codex/scripts/install/agents.mjs
+++ b/packages/omo-codex/scripts/install/agents.mjs
@@ -22,7 +22,22 @@ export async function capturePreservedAgentReasoning({ codexHome }) {
 	return preserved;
 }
 
-export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedReasoning = new Map() }) {
+export async function capturePreservedAgentServiceTier({ codexHome }) {
+	const agentsDir = join(codexHome, "agents");
+	if (!(await exists(agentsDir))) return new Map();
+
+	const preserved = new Map();
+	const agentEntries = await readdir(agentsDir, { withFileTypes: true });
+	for (const entry of agentEntries) {
+		if (!entry.name.endsWith(".toml")) continue;
+		const content = await readTextIfExists(join(agentsDir, entry.name));
+		if (content === null) continue;
+		preserved.set(agentNameFromToml(entry.name), extractServiceTier(content));
+	}
+	return preserved;
+}
+
+export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedReasoning = new Map(), preservedServiceTier = new Map() }) {
 	const bundledAgents = await discoverBundledAgents(pluginRoot);
 	if (bundledAgents.length === 0) {
 		await writeManifest(pluginRoot, []);
@@ -38,10 +53,24 @@ export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedR
 		const linkPath = join(agentsDir, agentFileName);
 		await replaceWithCopy(linkPath, agentPath);
 		await restorePreservedReasoning({ linkPath, target: agentPath, value: preservedReasoning.get(agentName) });
+		await restorePreservedServiceTier({
+			linkPath,
+			preserved: preservedServiceTier.has(agentName),
+			value: preservedServiceTier.get(agentName) ?? null,
+		});
 		linked.push({ name: agentFileName, path: linkPath, target: agentPath });
 	}
 	await writeManifest(pluginRoot, linked.map((entry) => entry.path));
 	return linked;
+}
+
+async function restorePreservedServiceTier({ linkPath, preserved, value }) {
+	if (!preserved) return;
+	const content = await readFile(linkPath, "utf8");
+	if (extractServiceTier(content) === value) return;
+	const replacement = replaceServiceTier(content, value);
+	if (!replacement.replaced) return;
+	await writeFile(linkPath, replacement.content);
 }
 
 async function discoverBundledAgents(pluginRoot) {
@@ -106,27 +135,71 @@ async function readTextIfExists(path) {
 }
 
 function extractReasoningEffort(content) {
+	return extractTopLevelStringSetting(content, "model_reasoning_effort");
+}
+
+function extractServiceTier(content) {
+	return extractTopLevelStringSetting(content, "service_tier");
+}
+
+function extractTopLevelStringSetting(content, key) {
 	for (const line of content.split(/\n/)) {
 		if (isSectionHeader(line)) return null;
-		const match = line.match(/^\s*model_reasoning_effort\s*=\s*("(?:[^"\\]|\\.)*")/);
-		if (match === null) continue;
-		return JSON.parse(match[1]);
+		const rawValue = topLevelStringSettingRawValue(line, key);
+		if (rawValue === undefined) continue;
+		return JSON.parse(rawValue);
 	}
 	return null;
 }
 
 function replaceReasoningEffort(content, value) {
+	return replaceTopLevelStringSetting(content, "model_reasoning_effort", value, { insertIfMissing: false });
+}
+
+function replaceServiceTier(content, value) {
+	return replaceTopLevelStringSetting(content, "service_tier", value, { insertIfMissing: true });
+}
+
+function replaceTopLevelStringSetting(content, key, value, options) {
 	let replaced = false;
 	const lines = content.split(/\n/);
 	for (let index = 0; index < lines.length; index += 1) {
 		const line = lines[index];
 		if (isSectionHeader(line)) break;
-		if (!/^\s*model_reasoning_effort\s*=/.test(line)) continue;
+		if (topLevelStringSettingRawValue(line, key) === undefined) continue;
+		if (value === null) {
+			lines.splice(index, 1);
+			replaced = true;
+			break;
+		}
 		lines[index] = line.replace(/=\s*"(?:[^"\\]|\\.)*"/, `= ${JSON.stringify(value)}`);
 		replaced = true;
 		break;
 	}
+	if (!replaced && value !== null && options.insertIfMissing) {
+		lines.splice(topLevelInsertionIndex(lines), 0, `${key} = ${JSON.stringify(value)}`);
+		replaced = true;
+	}
 	return { content: lines.join("\n"), replaced };
+}
+
+function topLevelStringSettingRawValue(line, key) {
+	const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*("(?:[^"\\]|\\.)*")/);
+	if (match === null) return undefined;
+	const settingKey = match[1];
+	const rawValue = match[2];
+	if (settingKey !== key || rawValue === undefined) return undefined;
+	return rawValue;
+}
+
+function topLevelInsertionIndex(lines) {
+	const sectionIndex = lines.findIndex((line) => isSectionHeader(line));
+	const topLevelEnd = sectionIndex === -1 ? lines.length : sectionIndex;
+	let insertionIndex = topLevelEnd;
+	while (insertionIndex > 0 && lines[insertionIndex - 1] === "") {
+		insertionIndex -= 1;
+	}
+	return insertionIndex;
 }
 
 function isSectionHeader(line) {

--- a/packages/omo-opencode/src/cli/install-codex/AGENTS.md
+++ b/packages/omo-opencode/src/cli/install-codex/AGENTS.md
@@ -15,7 +15,7 @@ Installs the `omo` plugin into `~/.codex/` for the Codex CLI Light edition. Entr
 | `codex-marketplace.ts` | Reads `packages/omo-codex/marketplace.json` and per-plugin `.codex-plugin/plugin.json`; validates path segments |
 | `codex-cache-install.ts` | Builds source, copies to temp cache dir, runs `npm ci --omit=dev`, rewrites MCP manifest, atomically promotes to `~/.codex/plugins/cache/{marketplace}/{name}/{version}/` |
 | `codex-cache-bins.ts` | Discovers `package.json` `bin` entries, links component CLIs into bin dir; writes `omo` runtime wrapper (POSIX shell / Windows `.cmd`) |
-| `link-cached-plugin-agents.ts` | Discovers bundled agent TOMLs under `components/*/agents/`, copies to `~/.codex/agents/`, preserves existing `model_reasoning_effort`, writes `.installed-agents.json` manifest |
+| `link-cached-plugin-agents.ts` | Discovers bundled agent TOMLs under `components/*/agents/`, copies to `~/.codex/agents/`, preserves existing `model_reasoning_effort` and `service_tier`, writes `.installed-agents.json` manifest |
 | `codex-marketplace-snapshot.ts` | Writes local marketplace snapshot to `~/.codex/.tmp/marketplaces/{marketplace}/` |
 | `codex-config-toml.ts` | Mutates `~/.codex/config.toml`: enables features, sets marketplace/plugin/agent/hook-trust blocks, optional autonomous permissions |
 | `codex-cleanup.ts` | Uninstall orchestrator: removes cache, agents, config blocks, project-local artifacts |

--- a/packages/omo-opencode/src/cli/install-codex/install-codex.ts
+++ b/packages/omo-opencode/src/cli/install-codex/install-codex.ts
@@ -7,7 +7,7 @@ import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
 import { trustedHookStatesForPlugin } from "./codex-hook-trust"
 import { prepareGitBashForInstall, resolveGitBashForCurrentProcess } from "./git-bash"
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./link-cached-plugin-agents"
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./link-cached-plugin-agents"
 import { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
 import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource } from "./codex-marketplace-snapshot"
 import {
@@ -105,6 +105,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   }
 
   const preservedReasoning = await capturePreservedAgentReasoning({ codexHome })
+  const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome })
   const agentSourceRoots = await agentSourceRootsForInstall({
     codexHome,
     marketplace,
@@ -113,7 +114,13 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   })
   for (const plugin of installed) {
     const pluginRoot = agentSourceRoots.get(plugin.name) ?? plugin.path
-    const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning })
+    const agentLinks = await linkCachedPluginAgents({
+      codexHome,
+      pluginRoot,
+      platform,
+      preservedReasoning,
+      preservedServiceTier,
+    })
     for (const link of agentLinks) {
       log(`Linked agent ${link.name} -> ${link.target}`)
       const agentName = agentNameFromToml(link.name)

--- a/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.test.ts
+++ b/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test"
 import { lstat, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./link-cached-plugin-agents"
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./link-cached-plugin-agents"
 
 async function makeFixture(): Promise<{ codexHome: string; pluginRoot: string }> {
   const root = await mkdtemp(join(tmpdir(), "omo-codex-agents-"))
@@ -140,6 +140,30 @@ describe("linkCachedPluginAgents", () => {
     const content = await readFile(join(agentsDir, "planner.toml"), "utf8")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).not.toContain('model_reasoning_effort = "xhigh"')
+    expect((await lstat(join(agentsDir, "planner.toml"))).isSymbolicLink()).toBe(false)
+  })
+
+  test("preserves removed installed agent service tier when reinstalling file copies", async () => {
+    // given
+    const { codexHome, pluginRoot } = await makeFixture()
+    const agentsDir = join(codexHome, "agents")
+    await mkdir(agentsDir, { recursive: true })
+    await writeFile(
+      join(pluginRoot, "components", "ulw-loop", "agents", "planner.toml"),
+      'name = "planner"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\nservice_tier = "fast"\n',
+    )
+    await writeFile(
+      join(agentsDir, "planner.toml"),
+      'name = "planner"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+    )
+    const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome })
+
+    // when
+    await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "linux", preservedServiceTier })
+
+    // then
+    const content = await readFile(join(agentsDir, "planner.toml"), "utf8")
+    expect(content).not.toContain("service_tier")
     expect((await lstat(join(agentsDir, "planner.toml"))).isSymbolicLink()).toBe(false)
   })
 

--- a/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts
+++ b/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts
@@ -29,11 +29,29 @@ export async function capturePreservedAgentReasoning(input: {
   return preserved
 }
 
+export async function capturePreservedAgentServiceTier(input: {
+  readonly codexHome: string
+}): Promise<ReadonlyMap<string, string | null>> {
+  const agentsDir = join(input.codexHome, "agents")
+  if (!(await exists(agentsDir))) return new Map()
+
+  const preserved = new Map<string, string | null>()
+  const agentEntries = await readdir(agentsDir, { withFileTypes: true })
+  for (const entry of agentEntries) {
+    if (!entry.name.endsWith(".toml")) continue
+    const content = await readTextIfExists(join(agentsDir, entry.name))
+    if (content === null) continue
+    preserved.set(agentNameFromToml(entry.name), extractServiceTier(content))
+  }
+  return preserved
+}
+
 export async function linkCachedPluginAgents(input: {
   readonly codexHome: string
   readonly pluginRoot: string
   readonly platform?: LinkPlatform
   readonly preservedReasoning?: ReadonlyMap<string, string>
+  readonly preservedServiceTier?: ReadonlyMap<string, string | null>
 }): Promise<readonly LinkedAgent[]> {
   const bundledAgents = await discoverBundledAgents(input.pluginRoot)
   if (bundledAgents.length === 0) {
@@ -54,6 +72,11 @@ export async function linkCachedPluginAgents(input: {
       target: agentPath,
       value: input.preservedReasoning?.get(agentName),
     })
+    await restorePreservedServiceTier({
+      linkPath,
+      preserved: input.preservedServiceTier?.has(agentName) ?? false,
+      value: input.preservedServiceTier?.get(agentName) ?? null,
+    })
     linked.push({ name: agentFileName, path: linkPath, target: agentPath })
   }
   await writeManifest(
@@ -61,6 +84,19 @@ export async function linkCachedPluginAgents(input: {
     linked.map((entry) => entry.path),
   )
   return linked
+}
+
+async function restorePreservedServiceTier(input: {
+  readonly linkPath: string
+  readonly preserved: boolean
+  readonly value: string | null
+}): Promise<void> {
+  if (!input.preserved) return
+  const content = await readFile(input.linkPath, "utf8")
+  if (extractServiceTier(content) === input.value) return
+  const replacement = replaceServiceTier(content, input.value)
+  if (!replacement.replaced) return
+  await writeFile(input.linkPath, replacement.content)
 }
 
 async function discoverBundledAgents(pluginRoot: string): Promise<readonly string[]> {
@@ -140,10 +176,17 @@ async function readTextIfExists(path: string): Promise<string | null> {
 }
 
 function extractReasoningEffort(content: string): string | null {
+  return extractTopLevelStringSetting(content, "model_reasoning_effort")
+}
+
+function extractServiceTier(content: string): string | null {
+  return extractTopLevelStringSetting(content, "service_tier")
+}
+
+function extractTopLevelStringSetting(content: string, key: string): string | null {
   for (const line of content.split(/\n/)) {
     if (isSectionHeader(line)) return null
-    const match = line.match(/^\s*model_reasoning_effort\s*=\s*("(?:[^"\\]|\\.)*")/)
-    const rawValue = match?.[1]
+    const rawValue = topLevelStringSettingRawValue(line, key)
     if (rawValue === undefined) continue
     const parsed = parseJsonString(rawValue)
     if (parsed !== null) return parsed
@@ -152,15 +195,54 @@ function extractReasoningEffort(content: string): string | null {
 }
 
 function replaceReasoningEffort(content: string, value: string): { readonly content: string; readonly replaced: boolean } {
+  return replaceTopLevelStringSetting(content, "model_reasoning_effort", value, { insertIfMissing: false })
+}
+
+function replaceServiceTier(content: string, value: string | null): { readonly content: string; readonly replaced: boolean } {
+  return replaceTopLevelStringSetting(content, "service_tier", value, { insertIfMissing: true })
+}
+
+function replaceTopLevelStringSetting(
+  content: string,
+  key: string,
+  value: string | null,
+  options: { readonly insertIfMissing: boolean },
+): { readonly content: string; readonly replaced: boolean } {
   const lines = content.split(/\n/)
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]
     if (line === undefined || isSectionHeader(line)) break
-    if (!/^\s*model_reasoning_effort\s*=/.test(line)) continue
+    if (topLevelStringSettingRawValue(line, key) === undefined) continue
+    if (value === null) {
+      lines.splice(index, 1)
+      return { content: lines.join("\n"), replaced: true }
+    }
     lines[index] = line.replace(/=\s*"(?:[^"\\]|\\.)*"/, `= ${JSON.stringify(value)}`)
     return { content: lines.join("\n"), replaced: true }
   }
-  return { content, replaced: false }
+
+  if (value === null || !options.insertIfMissing) return { content, replaced: false }
+  lines.splice(topLevelInsertionIndex(lines), 0, `${key} = ${JSON.stringify(value)}`)
+  return { content: lines.join("\n"), replaced: true }
+}
+
+function topLevelStringSettingRawValue(line: string, key: string): string | undefined {
+  const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*("(?:[^"\\]|\\.)*")/)
+  if (match === null) return undefined
+  const settingKey = match[1]
+  const rawValue = match[2]
+  if (settingKey !== key || rawValue === undefined) return undefined
+  return rawValue
+}
+
+function topLevelInsertionIndex(lines: readonly string[]): number {
+  const sectionIndex = lines.findIndex((line) => isSectionHeader(line))
+  const topLevelEnd = sectionIndex === -1 ? lines.length : sectionIndex
+  let insertionIndex = topLevelEnd
+  while (insertionIndex > 0 && lines[insertionIndex - 1] === "") {
+    insertionIndex -= 1
+  }
+  return insertionIndex
 }
 
 function isSectionHeader(line: string): boolean {


### PR DESCRIPTION
## Summary
- Preserve installed Codex agent `service_tier` customizations during LazyCodex reinstall and auto-update paths.
- Treat removed `service_tier` as an intentional preserved state so bundled `service_tier = fast` is not reintroduced.
- Apply the same preservation behavior to the TypeScript Codex installer helper and the packaged `omo-codex` installer script.

Fixes #5020

## Verification
- `bun test packages/omo-codex/scripts/install-agent-links.test.mjs src/cli/install-codex/link-cached-plugin-agents.test.ts`
- `git diff --check upstream/dev...HEAD`

## Local Notes
- `bun test src/cli/install-codex/install-codex.test.ts` is blocked in this worktree because `packages/ast-grep-mcp/dist` is not built.
- `bun run typecheck` is blocked in this worktree by missing `@oh-my-opencode/omo-codex/telemetry` module resolution before this change is checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Codex and LazyCodex agent `service_tier` customizations during reinstall and auto-update. If a user removed `service_tier`, it stays removed so the bundled `fast` value isn’t reintroduced.

- **Bug Fixes**
  - Capture and restore per-agent `service_tier` on reinstall for both installers, mirroring existing `model_reasoning_effort` handling.
  - Treat a missing `service_tier` as intentional; never insert `service_tier = "fast"`.
  - Implemented in `packages/omo-opencode` CLI and `packages/omo-codex` installer scripts; add tests for both paths and update `AGENTS.md`.
  - Fixes #5020

<sup>Written for commit ef563f09dd6673729df6d0943aa4449753d72d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

