### PR TITLE
docs(uninstall): clarify disable and verification steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,19 +372,25 @@ Add your own under `.opencode/skills/*/SKILL.md` or `~/.config/opencode/skills/*
 
 ## Uninstallation
 
-If you only want to disable oh-my-openagent temporarily, remove the plugin entry from `opencode.json` and leave the config files in place. Restart OpenCode after editing the file. On Desktop, fully quit and reopen the app so the plugin process is recreated.
+If you only want to disable oh-my-openagent temporarily, remove the plugin entries from `opencode.json` and `tui.json`, then leave the plugin config files in place. Restart OpenCode after editing the files. On Desktop, fully quit and reopen the app so the plugin process is recreated.
 
 To remove oh-my-openagent:
 
 1. **Remove the plugin from your OpenCode config**
 
-   Edit `~/.config/opencode/opencode.json` (or `opencode.jsonc`) and remove either `"oh-my-openagent"` or the legacy `"oh-my-opencode"` entry from the `plugin` array:
+   Edit `~/.config/opencode/opencode.json` (or `opencode.jsonc`) and remove either `"oh-my-openagent"` or the legacy `"oh-my-opencode"` entry from the `plugin` array. If `~/.config/opencode/tui.json` exists, remove the same plugin entry there too so the TUI sidebar/plugin surface is disabled:
 
    ```bash
-   # Using jq
+   # Using jq for the server plugin entry
    jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
+
+   # If present, remove the TUI plugin entry as well
+   test ! -f ~/.config/opencode/tui.json || \
+     jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+       ~/.config/opencode/tui.json > /tmp/tui.json && \
+       mv /tmp/tui.json ~/.config/opencode/tui.json
    ```
 
 2. **Remove configuration files (optional)**
@@ -403,10 +409,11 @@ To remove oh-my-openagent:
 
    ```bash
    bunx oh-my-openagent doctor --status
-   grep -R "oh-my-openagent\|oh-my-opencode" ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc 2>/dev/null
+   grep -R "oh-my-openagent\|oh-my-opencode" \
+     ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc ~/.config/opencode/tui.json 2>/dev/null
    ```
 
-   The doctor output should report that the plugin is not registered, and the `grep` command should print no active OpenCode plugin entry. If OpenCode still shows oh-my-openagent agents, restart the terminal or Desktop app after saving `opencode.json`.
+   The doctor output should report that the plugin is not registered, and the `grep` command should print no active OpenCode or TUI plugin entry. If OpenCode still shows oh-my-openagent agents or sidebar UI, restart the terminal or Desktop app after saving both config files.
 
 4. **Remove omo-codex (Codex CLI Light edition)**
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ Add your own under `.opencode/skills/*/SKILL.md` or `~/.config/opencode/skills/*
 
 ## Uninstallation
 
+If you only want to disable oh-my-openagent temporarily, remove the plugin entry from `opencode.json` and leave the config files in place. Restart OpenCode after editing the file. On Desktop, fully quit and reopen the app so the plugin process is recreated.
+
 To remove oh-my-openagent:
 
 1. **Remove the plugin from your OpenCode config**
@@ -400,9 +402,11 @@ To remove oh-my-openagent:
 3. **Verify removal**
 
    ```bash
-   opencode --version
-   # Plugin should no longer be loaded
+   bunx oh-my-openagent doctor --status
+   grep -R "oh-my-openagent\|oh-my-opencode" ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc 2>/dev/null
    ```
+
+   The doctor output should report that the plugin is not registered, and the `grep` command should print no active OpenCode plugin entry. If OpenCode still shows oh-my-openagent agents, restart the terminal or Desktop app after saving `opencode.json`.
 
 4. **Remove omo-codex (Codex CLI Light edition)**
 
@@ -417,6 +421,8 @@ To remove oh-my-openagent:
    ```
 
    The uninstall command removes managed `sisyphuslabs` Codex cache/marketplace state, strips `omo@sisyphuslabs` plugin and hook-state blocks from `~/.codex/config.toml` after writing a backup, and removes agent TOML links listed in the install manifest. If a specific project still has old project-local Codex plugin state, run the command from that project or pass `--project <path>`; it repairs known project-local `.codex/config.toml` conflicts and reports project-local `.codex` artifacts without deleting project-owned files.
+
+   To verify Codex Light removal, check that `~/.codex/config.toml` no longer contains `sisyphuslabs` or `omo@sisyphuslabs`, then start a new Codex session from the project that previously failed.
 
 ## Features
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -813,11 +813,19 @@ See [Privacy Policy](../legal/privacy-policy.md) and [Terms of Service](../legal
 
 ### Remove the OpenCode plugin
 
+If you only want to disable oh-my-openagent temporarily, remove the plugin entries from `opencode.json` and `tui.json`, then leave the plugin config files in place. Restart OpenCode after editing the files. On Desktop, fully quit and reopen the app so the plugin process is recreated.
+
 ```bash
-# 1. Remove the plugin entry from opencode.json
+# 1. Remove the server plugin entry from opencode.json
 jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
     ~/.config/opencode/opencode.json > /tmp/oc.json && \
     mv /tmp/oc.json ~/.config/opencode/opencode.json
+
+# If present, remove the TUI plugin entry as well
+test ! -f ~/.config/opencode/tui.json || \
+  jq '.plugin = [.plugin[] | select(. != "oh-my-openagent" and . != "oh-my-opencode")]' \
+    ~/.config/opencode/tui.json > /tmp/tui.json && \
+    mv /tmp/tui.json ~/.config/opencode/tui.json
 
 # 2. Remove plugin config files (optional)
 rm -f ~/.config/opencode/oh-my-openagent.jsonc ~/.config/opencode/oh-my-openagent.json \
@@ -828,9 +836,12 @@ rm -f .opencode/oh-my-openagent.jsonc .opencode/oh-my-openagent.json \
       .opencode/oh-my-opencode.jsonc .opencode/oh-my-opencode.json
 
 # 4. Verify removal
-opencode --version
-# Plugin should no longer be loaded
+bunx oh-my-openagent doctor --status
+grep -R "oh-my-openagent\|oh-my-opencode" \
+  ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc ~/.config/opencode/tui.json 2>/dev/null
 ```
+
+The doctor output should report that the plugin is not registered, and the `grep` command should print no active OpenCode or TUI plugin entry. If OpenCode still shows oh-my-openagent agents or sidebar UI, restart the terminal or Desktop app after saving both config files.
 
 ### Remove the Codex CLI Light edition
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -95,7 +95,7 @@ For the full Codex Light event inventory, collected properties, local state path
 
 Removes managed Codex Light state. `cleanup` remains available as a backward-compatible alias.
 
-For the OpenCode plugin, temporary disable is just a config edit: remove `"oh-my-openagent"` or legacy `"oh-my-opencode"` from the `plugin` array in `~/.config/opencode/opencode.json[c]`, then restart OpenCode. Keep the plugin config files if you plan to re-enable later.
+For the OpenCode plugin, temporary disable is just a config edit: remove `"oh-my-openagent"` or legacy `"oh-my-opencode"` from the `plugin` arrays in `~/.config/opencode/opencode.json[c]` and, when present, `~/.config/opencode/tui.json`, then restart OpenCode. Keep the plugin config files if you plan to re-enable later.
 
 ### Usage
 
@@ -119,11 +119,12 @@ The command removes the managed `sisyphuslabs` plugin cache and marketplace snap
 
 ```bash
 bunx oh-my-openagent doctor --status
-grep -R "oh-my-openagent\|oh-my-opencode" ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc 2>/dev/null
+grep -R "oh-my-openagent\|oh-my-opencode" \
+  ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc ~/.config/opencode/tui.json 2>/dev/null
 grep -R "sisyphuslabs\|omo@sisyphuslabs" ~/.codex/config.toml 2>/dev/null
 ```
 
-The OpenCode grep should print no active plugin entry after disabling or uninstalling the OpenCode plugin. The Codex grep should print no managed `sisyphuslabs` plugin state after `uninstall` / `cleanup`. If project-local Codex config still fails with a legacy `multi_agent_v2` conflict, rerun cleanup from that project or pass `--project <path>`.
+The OpenCode grep should print no active server or TUI plugin entry after disabling or uninstalling the OpenCode plugin. The Codex grep should print no managed `sisyphuslabs` plugin state after `uninstall` / `cleanup`. If project-local Codex config still fails with a legacy `multi_agent_v2` conflict, rerun cleanup from that project or pass `--project <path>`.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -95,6 +95,8 @@ For the full Codex Light event inventory, collected properties, local state path
 
 Removes managed Codex Light state. `cleanup` remains available as a backward-compatible alias.
 
+For the OpenCode plugin, temporary disable is just a config edit: remove `"oh-my-openagent"` or legacy `"oh-my-opencode"` from the `plugin` array in `~/.config/opencode/opencode.json[c]`, then restart OpenCode. Keep the plugin config files if you plan to re-enable later.
+
 ### Usage
 
 ```bash
@@ -112,6 +114,16 @@ omo uninstall --platform=codex
 | `--json` | Output structured JSON result |
 
 The command removes the managed `sisyphuslabs` plugin cache and marketplace snapshot, strips `omo@sisyphuslabs` plugin, hook-state, and managed agent blocks from `~/.codex/config.toml` after writing a backup, and removes managed agent TOML files from `~/.codex/agents/`, including orphaned files whose install manifest is already gone. Project-owned `.codex` artifacts are reported, not deleted.
+
+### Verify Removal
+
+```bash
+bunx oh-my-openagent doctor --status
+grep -R "oh-my-openagent\|oh-my-opencode" ~/.config/opencode/opencode.json ~/.config/opencode/opencode.jsonc 2>/dev/null
+grep -R "sisyphuslabs\|omo@sisyphuslabs" ~/.codex/config.toml 2>/dev/null
+```
+
+The OpenCode grep should print no active plugin entry after disabling or uninstalling the OpenCode plugin. The Codex grep should print no managed `sisyphuslabs` plugin state after `uninstall` / `cleanup`. If project-local Codex config still fails with a legacy `multi_agent_v2` conflict, rerun cleanup from that project or pass `--project <path>`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document how to temporarily disable the OpenCode plugin without deleting saved config.
- Add concrete verification commands for OpenCode plugin removal and Codex Light cleanup.
- Clarify that Desktop needs a full restart after editing `opencode.json`.

Fixes #4159

## Verification
- `git diff --check upstream/dev...HEAD`

## Notes
- docs-only; no runtime behavior changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to temporarily disable and uninstall the OpenCode plugin (`oh-my-openagent`/`oh-my-opencode`) across server (`opencode.json[c]`) and TUI (`tui.json`) configs, plus Codex Light cleanup. Aligns uninstall verification in README, install guide, and CLI docs (doctor + grep) and calls out a full OpenCode/Desktop restart after saving both configs (fixes #4159).

<sup>Written for commit 1579447f4a3604827f6f886a75faffadcaa709b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

