### PR TITLE
fix(model-core): recognize Mimo model aliases

### DIFF
--- a/packages/model-core/src/model-capabilities.test.ts
+++ b/packages/model-core/src/model-capabilities.test.ts
@@ -332,6 +332,24 @@ describe("getModelCapabilities", () => {
     })
   })
 
+  test("falls back to MiniMax heuristic rules for Mimo model aliases", () => {
+    const result = getModelCapabilities({
+      providerID: "opencode-go",
+      modelID: "mimo-v2.5-pro",
+      bundledSnapshot,
+    })
+
+    expect(result).toMatchObject({
+      canonicalModelID: "mimo-v2.5-pro",
+      family: "minimax",
+      variants: ["low", "medium", "high"],
+    })
+    expect(result.diagnostics).toMatchObject({
+      resolutionMode: "heuristic-backed",
+      family: { source: "heuristic" },
+    })
+  })
+
   test("prefers snapshot reasoning over heuristic supportsThinking for MiniMax M2.7", () => {
     // given
     const modelID = "minimax-m2.7"

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -75,7 +75,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   },
   {
     family: "minimax",
-    includes: ["minimax"],
+    includes: ["minimax", "mimo-"],
     variants: ["low", "medium", "high"],
     supportsThinking: false,
   },

--- a/packages/model-core/src/model-family-detectors.test.ts
+++ b/packages/model-core/src/model-family-detectors.test.ts
@@ -76,6 +76,8 @@ describe("model family detectors", () => {
   test("#given MiniMax model ids #then detects MiniMax family only", () => {
     expect(isMiniMaxModel("opencode/minimax-m2.7")).toBe(true)
     expect(isMiniMaxModel("minimax-m2.7-highspeed")).toBe(true)
+    expect(isMiniMaxModel("opencode-go/mimo-v2.5")).toBe(true)
+    expect(isMiniMaxModel("opencode-go/mimo-v2.5-pro")).toBe(true)
     expect(isMiniMaxModel("moonshotai/kimi-k2.6")).toBe(false)
   })
 })

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -48,7 +48,7 @@ export function isKimiK2Model(model: string): boolean {
 
 export function isMiniMaxModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase()
-  return modelName.includes("minimax")
+  return modelName.includes("minimax") || modelName.startsWith("mimo-")
 }
 
 export function isGlmModel(model: string): boolean {

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -258,6 +258,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Mimo", modelID: "mimo-v2.5-pro", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },

--- a/packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts
@@ -303,6 +303,8 @@ describe("model-resolution check", () => {
       const info = getModelResolutionInfoWithOverrides({
         agents: {
           sisyphus: { model: "kimi-for-coding/k2pb" },
+          librarian: { model: "opencode-go/mimo-v2.5" },
+          oracle: { model: "opencode-go/mimo-v2.5-pro" },
           metis: { model: "github-copilot/claude-opus-4.7" },
         },
         categories: {


### PR DESCRIPTION
﻿## Summary
- recognize Mimo model IDs such as `mimo-v2.5` and `mimo-v2.5-pro` as MiniMax-family aliases
- make capability resolution heuristic-backed instead of unknown for Mimo aliases
- cover the doctor false positive so configured Mimo models no longer trigger compatibility fallback warnings

Fixes #4584

## Verification
- `bun test packages/model-core/src/model-family-detectors.test.ts packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-capabilities.test.ts src/cli/doctor/checks/model-resolution.test.ts` (failed before fix, passes after fix)
- `git diff --check upstream/dev...HEAD`

## Local limitation
- `bun run typecheck` is blocked in this worktree by existing module resolution for `@oh-my-opencode/omo-codex/telemetry` from `src/cli/install-codex/install-codex.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes Mimo model IDs (e.g., `mimo-v2.5`, `mimo-v2.5-pro`) as MiniMax aliases to fix capability detection and compatibility checks. Capability resolution for these models is now heuristic-backed, and the doctor no longer flags them (fixes #4584).

- **Bug Fixes**
  - Detect `mimo-*` as MiniMax in family detectors and the heuristic registry.
  - Resolve capabilities via MiniMax heuristics (variants: low, medium, high; supportsThinking: false).
  - Update compatibility and doctor tests to cover `opencode-go/mimo-v2.5` and `opencode-go/mimo-v2.5-pro`, removing fallback warnings.

<sup>Written for commit 32b64297b26ccab26a961f2afa1f8f84347fbce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

