### PR TITLE
fix(omo-codex): inject static rule bodies instead of references

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/rules/formatter.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules/formatter.ts
@@ -75,19 +75,8 @@ export function formatStaticBlock(rules: ReadonlyArray<LoadedRule>, options: For
 	}
 
 	const orderedRules = orderStaticRules(uniqueRulesByBody(rules));
-	const hephaestusRules = orderedRules.filter(isHephaestusRule);
-	const otherRules = orderedRules.filter((rule) => !isHephaestusRule(rule));
-	const blocks: string[] = [];
 
-	if (hephaestusRules.length > 0) {
-		blocks.push(truncateRules(hephaestusRules, options).map(formatRule).join("\n\n"));
-	}
-
-	if (otherRules.length > 0) {
-		blocks.push(["## Project Instructions", "", "must read project rules:", otherRules.map(formatStaticRuleReference).join("\n")].join("\n"));
-	}
-
-	return blocks.join("\n\n");
+	return ["## Project Instructions", "", truncateRules(orderedRules, options).map(formatRule).join("\n\n")].join("\n");
 }
 
 function orderStaticRules(rules: ReadonlyArray<LoadedRule>): LoadedRule[] {
@@ -105,10 +94,6 @@ function orderStaticRules(rules: ReadonlyArray<LoadedRule>): LoadedRule[] {
 
 function isHephaestusRule(rule: LoadedRule): boolean {
 	return displayFilename(rule).toLowerCase() === "hephaestus.md";
-}
-
-function formatStaticRuleReference(rule: LoadedRule): string {
-	return `- [${displayFilename(rule)}]{${rule.path}}`;
 }
 
 function displayFilename(rule: LoadedRule): string {

--- a/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
@@ -164,7 +164,7 @@ describe("plugin bundled rules", () => {
 		expect(output).toContain('"hookEventName":"SessionStart"');
 		expect(output).toContain(`Instructions from: ${bundledRulePath}`);
 		expect(output).toContain(BUNDLED_BODY);
-		expect(output).not.toContain("## Project Instructions");
+		expect(output).toContain("## Project Instructions");
 		expect(output).not.toContain("must read project rules:");
 		expect(output).not.toContain(`- [hephaestus.md]{${bundledRulePath}}`);
 	});
@@ -251,7 +251,7 @@ describe("plugin bundled rules", () => {
 		expect(output).not.toContain("[Truncated. Full:");
 	});
 
-	it("#given project rule body exceeds per-rule cap #when SessionStart runs #then static context lists the file without body", async () => {
+	it("#given project rule body exceeds per-rule cap #when SessionStart runs #then static context injects a truncated body", async () => {
 		// given
 		const root = mkdtempSync(join(tmpdir(), "codex-rules-project-large-project-"));
 		const pluginRoot = mkdtempSync(join(tmpdir(), "codex-rules-project-large-plugin-"));
@@ -275,8 +275,9 @@ describe("plugin bundled rules", () => {
 		});
 
 		// then
-		expect(output).toContain(`- [oversized.md]{${projectRulePath}}`);
+		expect(output).toContain(`Instructions from: ${projectRulePath}`);
+		expect(output).toContain("The project rule body is intentionally oversized for the cap test.");
+		expect(output).toContain("[Truncated. Full:");
 		expect(output).not.toContain(tailMarker);
-		expect(output).not.toContain("[Truncated. Full:");
 	});
 });

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-budget.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("codex rules post-compaction context budget", () => {
-	it("#given oversized project rules already injected #when static recovery runs after compaction #then it emits no duplicate compact index", async () => {
+	it("#given oversized project rules already injected #when static recovery runs after compaction #then it emits no duplicate static injection", async () => {
 		// given
 		const { root, pluginData } = makeOversizedProject();
 		const firstOutput = await runSessionStartHook(sessionStartInput(root), {
@@ -46,10 +46,10 @@ describe("codex rules post-compaction context budget", () => {
 		});
 
 		// then
-		expect(firstContext).toContain("must read project rules:");
-		expect(firstContext).toContain(`- [CONTEXT.md]{${path.join(root, "CONTEXT.md")}}`);
-		expect(firstContext).not.toContain("Project rule");
-		expect(firstContext.length).toBeLessThan(1_000);
+		expect(firstContext).toContain(`Instructions from: ${path.join(root, "CONTEXT.md")}`);
+		expect(firstContext).toContain("Project rule");
+		expect(firstContext).toContain("[Truncated. Full:");
+		expect(firstContext.length).toBeLessThan(31_000);
 		expect(output).toBe("");
 	});
 });

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-context.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-context.test.ts
@@ -38,9 +38,9 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const postCompactContext = readAdditionalContext(output);
 		expect(postCompactContext.length).toBeLessThan(5_000);
-		expect(postCompactContext).toContain("must read project rules:");
-		expect(postCompactContext).toContain("- [CONTEXT.md]{");
-		expect(postCompactContext).not.toContain("Project rule");
+		expect(postCompactContext).toContain("Instructions from:");
+		expect(postCompactContext).toContain("CONTEXT.md");
+		expect(postCompactContext).toContain("Project rule");
 	});
 
 	it("#given compacted context warning and near-full transcript #when compact source starts twice #then handles compacted context warning once", async () => {
@@ -65,8 +65,8 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const firstContext = readOptionalAdditionalContext(firstOutput);
 		expect(firstContext.length).toBeLessThan(1_000);
-		expect(firstContext).toContain("must read project rules:");
-		expect(firstContext).toContain("- [CONTEXT.md]{");
+		expect(firstContext).toContain("Instructions from:");
+		expect(firstContext).toContain("CONTEXT.md");
 		expect(secondOutput).toBe("");
 	});
 
@@ -88,8 +88,8 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("must read project rules:");
-		expect(context).toContain("- [CONTEXT.md]{");
+		expect(context).toContain("Instructions from:");
+		expect(context).toContain("CONTEXT.md");
 	});
 
 	it("#given compact SessionStart without prior PostCompact state #when context-pressure transcript is present #then emits emergency-sized context", async () => {
@@ -106,8 +106,8 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("must read project rules:");
-		expect(context).toContain("- [CONTEXT.md]{");
+		expect(context).toContain("Instructions from:");
+		expect(context).toContain("CONTEXT.md");
 	});
 
 	it("#given malformed context-too-large transcript and empty session data #when compact source starts #then ignores malformed oversize markers safely", async () => {
@@ -128,8 +128,8 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("must read project rules:");
-		expect(context).toContain("- [CONTEXT.md]{");
+		expect(context).toContain("Instructions from:");
+		expect(context).toContain("CONTEXT.md");
 	});
 
 	it("#given concurrent compact SessionStart triggers #when both recover context-too-large state #then deduplicates concurrent context-too-large recovery", async () => {
@@ -157,7 +157,7 @@ describe("codex rules compacted context recovery", () => {
 		const contexts = outputs.map(readOptionalAdditionalContext);
 		expect(contexts.filter((context) => context.length > 0)).toHaveLength(1);
 		expect(contexts.join("").length).toBeLessThan(1_000);
-		expect(contexts.join("")).toContain("must read project rules:");
-		expect(contexts.join("")).toContain("- [CONTEXT.md]{");
+		expect(contexts.join("")).toContain("Instructions from:");
+		expect(contexts.join("")).toContain("CONTEXT.md");
 	});
 });

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook.test.ts
@@ -218,11 +218,10 @@ describe("codex rules hooks", () => {
 		const parsed = parseHookOutput(output);
 		expect(parsed.hookSpecificOutput?.hookEventName).toBe("SessionStart");
 		expect(parsed.hookSpecificOutput?.additionalContext).toContain("## Project Instructions");
-		expect(parsed.hookSpecificOutput?.additionalContext).toContain("must read project rules:");
 		expect(parsed.hookSpecificOutput?.additionalContext).toContain(
-			`- [CONTEXT.md]{${path.join(root, "CONTEXT.md")}}`,
+			`Instructions from: ${path.join(root, "CONTEXT.md")}`,
 		);
-		expect(parsed.hookSpecificOutput?.additionalContext).not.toContain("Always wear safety goggles");
+		expect(parsed.hookSpecificOutput?.additionalContext).toContain("Always wear safety goggles");
 	});
 
 	it("#given default auto sources #when SessionStart runs #then native Codex AGENTS.md is not duplicated", async () => {
@@ -314,9 +313,9 @@ describe("codex rules hooks", () => {
 		// then
 		expect(resumeOutput).toBe("");
 		const clearContext = parseHookOutput(clearOutput).hookSpecificOutput?.additionalContext ?? "";
-		expect(clearContext).toContain("must read project rules:");
-		expect(clearContext).toContain(`- [CONTEXT.md]{${path.join(root, "CONTEXT.md")}}`);
-		expect(clearContext).not.toContain("Always wear safety goggles");
+		expect(clearContext).toContain("## Project Instructions");
+		expect(clearContext).toContain(`Instructions from: ${path.join(root, "CONTEXT.md")}`);
+		expect(clearContext).toContain("Always wear safety goggles");
 	});
 
 	it("#given static context remains in transcript but cache is missing #when SessionStart runs #then it emits no duplicate context", async () => {

--- a/packages/omo-codex/plugin/components/rules/test/formatter.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/formatter.test.ts
@@ -42,7 +42,7 @@ describe("rules formatter hook context", () => {
 		);
 	});
 
-	it("#given static rules #when formatting SessionStart context #then it lists files to read without rule bodies", () => {
+	it("#given static rules #when formatting SessionStart context #then it injects rule bodies inline", () => {
 		// given
 		const rule = loadedRule({
 			path: "/repo/CONTEXT.md",
@@ -55,9 +55,14 @@ describe("rules formatter hook context", () => {
 
 		// then
 		expect(block).toBe(
-			["## Project Instructions", "", "must read project rules:", "- [CONTEXT.md]{/repo/CONTEXT.md}"].join("\n"),
+			[
+				"## Project Instructions",
+				"",
+				"Instructions from: /repo/CONTEXT.md",
+				"",
+				"Keep generated hook context readable.",
+			].join("\n"),
 		);
-		expect(block).not.toContain("Keep generated hook context readable.");
 	});
 
 	it("#given CRLF and bare CR rule bodies #when formatting context #then it normalizes line endings", () => {
@@ -74,7 +79,7 @@ describe("rules formatter hook context", () => {
 		expect(block).not.toContain("\r");
 	});
 
-	it("#given duplicate static rules with different line endings #when formatting context #then it lists one file to read", () => {
+	it("#given duplicate static rules with different line endings #when formatting context #then it injects one copy", () => {
 		// given
 		const lfRule = loadedRule({
 			path: "/repo/CONTEXT.md",
@@ -91,12 +96,12 @@ describe("rules formatter hook context", () => {
 		const block = formatStaticBlock([lfRule, crlfRule], FORMAT_OPTIONS);
 
 		// then
-		expect(occurrenceCount(block, "- [CONTEXT.md]{/repo/CONTEXT.md}")).toBe(1);
-		expect(block).not.toContain("Shared rule\nKeep one copy.");
+		expect(occurrenceCount(block, "Instructions from: /repo/CONTEXT.md")).toBe(1);
+		expect(occurrenceCount(block, "Shared rule\nKeep one copy.")).toBe(1);
 		expect(block).not.toContain("/repo/packages/CONTEXT.md");
 	});
 
-	it("#given a Hephaestus static rule #when formatting SessionStart context #then it expands inline before other rule links", () => {
+	it("#given a Hephaestus static rule #when formatting SessionStart context #then it injects its body before other rule bodies", () => {
 		// given
 		const rules = [
 			loadedRule({ path: "/repo/alpha.md", relativePath: "alpha.md", body: "Alpha guidance." }),
@@ -114,10 +119,11 @@ describe("rules formatter hook context", () => {
 		// then
 		expect(block).toContain("Instructions from: /repo/bundled-rules/hephaestus.md");
 		expect(block).toContain("Hephaestus guidance.");
-		expect(block).toContain("must read project rules:");
-		expect(block.indexOf("Hephaestus guidance.")).toBeLessThan(block.indexOf("must read project rules:"));
-		expect(block.indexOf("must read project rules:")).toBeLessThan(block.indexOf("- [alpha.md]{/repo/alpha.md}"));
-		expect(block.indexOf("- [alpha.md]{/repo/alpha.md}")).toBeLessThan(block.indexOf("- [beta.md]{/repo/beta.md}"));
+		expect(block).toContain("Alpha guidance.");
+		expect(block).toContain("Beta guidance.");
+		expect(block.indexOf("Hephaestus guidance.")).toBeLessThan(block.indexOf("Alpha guidance."));
+		expect(block.indexOf("Alpha guidance.")).toBeLessThan(block.indexOf("Beta guidance."));
+		expect(block).not.toContain("must read project rules:");
 		expect(block).not.toContain("- [hephaestus.md]");
 	});
 

--- a/packages/omo-codex/plugin/components/rules/test/windows-git-bash-bundled-rule.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/windows-git-bash-bundled-rule.test.ts
@@ -72,7 +72,7 @@ describe("Windows Git Bash bundled rule", () => {
 		expect(candidates.map((candidate) => candidate.relativePath)).not.toContain(WINDOWS_RULE_PATH);
 	});
 
-	it("#given bundled rules enabled on Windows #when SessionStart runs #then Windows Git Bash guidance file is listed once", async () => {
+	it("#given bundled rules enabled on Windows #when SessionStart runs #then Windows Git Bash guidance is injected once", async () => {
 		const { root, pluginData } = makeProject();
 
 		const output = await runSessionStartHook(sessionStartInput(root), {
@@ -81,8 +81,8 @@ describe("Windows Git Bash bundled rule", () => {
 			platform: "win32",
 		});
 
-		expect(occurrenceCount(output, `- [windows-git-bash.md]{${join(process.cwd(), WINDOWS_RULE_PATH)}}`)).toBe(1);
-		expect(output).not.toContain(WINDOWS_GUIDANCE);
+		expect(occurrenceCount(output, `Instructions from: ${join(process.cwd(), WINDOWS_RULE_PATH)}`)).toBe(1);
+		expect(output).toContain(WINDOWS_GUIDANCE);
 	});
 
 	it("#given bundled rules enabled off Windows #when SessionStart runs #then Windows Git Bash guidance is not injected", async () => {
@@ -116,8 +116,8 @@ describe("Windows Git Bash bundled rule", () => {
 			platform: "win32",
 		});
 
-		expect(output).toContain(`- [windows-git-bash.md]{${projectRulePath}}`);
-		expect(output).not.toContain(projectGuidance);
+		expect(output).toContain(`Instructions from: ${projectRulePath}`);
+		expect(output).toContain(projectGuidance);
 		expect(output).not.toContain(WINDOWS_GUIDANCE);
 	});
 });


### PR DESCRIPTION
## Problem

Pre-publish review (codex session `019ea65c…`) flagged a release **blocker**: Codex Rules static injection emitted only a `must read project rules:` reference list for every static project rule except `hephaestus.md`, while `static-injection.ts` still marked those rules as injected. Result: **non-hephaestus project rule bodies never entered model context and could never be re-injected** — violating the documented contract (`README.md`, `skills/rules/SKILL.md` both state the plugin *injects* rule content).

Introduced by `041b27aad` ("compact static rule injection").

## Fix

- `formatStaticBlock` now injects **full bodies for all static rules** under the `## Project Instructions` header, hephaestus ordered first, sharing the truncation budget across rules (same shape as the dynamic block).
- Removed the now-dead `formatStaticRuleReference` helper (deslop). `orderStaticRules` / `isHephaestusRule` / `displayFilename` remain (ordering).
- No change needed in `static-injection.ts`: marking rules injected is now correct because bodies are actually present; the transcript filter already dedupes on body + `Instructions from:` marker.

## Tests (TDD: red → green → refactor)

Flipped 6 test files from reference-assertions to body-assertions (bodies present, ordering, dedup, truncation marker). Post-compact size thresholds recalibrated to the truncated-body budget rather than the old reference size.

## Verification

- `bunx vitest run` (rules component): **148 passed**
- `tsc --noEmit`: clean
- `biome check` (changed source): clean
- `formatter.ts`: 130 pure LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects full bodies for all static project rules in `omo-codex`, replacing the reference list so rule content actually reaches model context. Keeps `hephaestus.md` first and aligns behavior with the documented contract.

- **Bug Fixes**
  - `formatStaticBlock` now outputs full bodies under "## Project Instructions", with shared truncation across rules and `hephaestus.md` first.
  - Removed the reference-list path by deleting `formatStaticRuleReference`; ordering helpers remain.
  - Static injection marking is now accurate; transcript deduping continues via body + "Instructions from:".
  - Tests updated to assert bodies and recalibrated compact size thresholds.

<sup>Written for commit 96105b139f635eedab244fc07e82c203c5ae0406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

