### PR TITLE
fix(session-manager): retry transient SDK failures before file fallback (fixes #4622)

### DIFF
--- a/src/tools/session-manager/sdk-storage.ts
+++ b/src/tools/session-manager/sdk-storage.ts
@@ -17,13 +17,33 @@ function throwOnNonFallbackableSdkError(response: unknown): void {
   throw error
 }
 
+const SDK_TRANSIENT_RETRY_ATTEMPTS = 3
+
+// session_read issues two SDK calls (session.list for existence + session.messages),
+// so a single transient HTTP failure on either call would fall back to file storage,
+// which does not exist for pure-sqlite sessions and surfaces a false "Session not found".
+// Retry only on transient/unavailable errors; semantic errors (e.g. "session not found")
+// still throw immediately so the caller can decide between fallback and rethrow.
+async function fetchSdkResponse(operation: () => Promise<unknown>): Promise<unknown> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= SDK_TRANSIENT_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const response = await operation()
+      throwOnNonFallbackableSdkError(response)
+      return response
+    } catch (error) {
+      lastError = error
+      if (!isSessionSdkUnavailableError(error)) throw error
+    }
+  }
+  throw lastError
+}
+
 export async function getSdkMainSessions(
   client: PluginInput["client"],
   directory?: string,
 ): Promise<SessionMetadata[]> {
-  const response = await client.session.list()
-  const error = unwrapSdkResponseError(response)
-  if (error) throw error
+  const response = await fetchSdkResponse(() => client.session.list())
 
   const sessions = normalizeSDKResponse(response, [] as SessionMetadata[])
   const mainSessions = sessions.filter((session) => !session.parentID)
@@ -37,15 +57,13 @@ export async function getSdkMainSessions(
 }
 
 export async function getSdkAllSessions(client: PluginInput["client"]): Promise<string[]> {
-  const response = await client.session.list()
-  throwOnNonFallbackableSdkError(response)
+  const response = await fetchSdkResponse(() => client.session.list())
   const sessions = normalizeSDKResponse(response, [] as SessionMetadata[])
   return sessions.map((session) => session.id)
 }
 
 export async function sdkSessionExists(client: PluginInput["client"], sessionID: string): Promise<boolean> {
-  const response = await client.session.list()
-  throwOnNonFallbackableSdkError(response)
+  const response = await fetchSdkResponse(() => client.session.list())
   const sessions = normalizeSDKResponse(response, [] as Array<{ id?: string }>)
   return sessions.some((session) => session.id === sessionID)
 }
@@ -54,8 +72,7 @@ export async function getSdkSessionMessages(
   client: PluginInput["client"],
   sessionID: string,
 ): Promise<SessionMessage[]> {
-  const response = await client.session.messages({ path: { id: sessionID } })
-  throwOnNonFallbackableSdkError(response)
+  const response = await fetchSdkResponse(() => client.session.messages({ path: { id: sessionID } }))
 
   const rawMessages = normalizeSDKResponse(response, [] as Array<{
     info?: {
@@ -112,8 +129,7 @@ export async function getSdkSessionMessages(
 }
 
 export async function getSdkSessionTodos(client: PluginInput["client"], sessionID: string): Promise<TodoItem[]> {
-  const response = await client.session.todo({ path: { id: sessionID } })
-  throwOnNonFallbackableSdkError(response)
+  const response = await fetchSdkResponse(() => client.session.todo({ path: { id: sessionID } }))
 
   const data = normalizeSDKResponse(response, [] as Array<{
     id?: string

--- a/src/tools/session-manager/storage-fallback.test.ts
+++ b/src/tools/session-manager/storage-fallback.test.ts
@@ -245,4 +245,52 @@ describe("session-manager storage fallback", () => {
 
     await expect(storage.readSessionMessages("ses_missing")).rejects.toThrow("session not found")
   })
+
+  test("#given SDK list fails transiently then recovers #when sessionExists runs #then retries SDK and avoids false-negative file fallback", async () => {
+    // given a pure-sqlite session present in the SDK but absent from file storage
+    let attempts = 0
+    mockClient.session.list.mockImplementation(() => {
+      attempts += 1
+      if (attempts === 1) return Promise.reject(createSdkUnavailableError("fetch failed"))
+      return Promise.resolve({ data: [{ id: "ses_sqlite_only" }] })
+    })
+
+    // when sessionExists hits a single transient SDK failure
+    const exists = await storage.sessionExists("ses_sqlite_only")
+
+    // then it retries the SDK and confirms existence instead of dropping to nonexistent file storage
+    expect(exists).toBe(true)
+    expect(attempts).toBe(2)
+  })
+
+  test("#given SDK messages fail transiently then recover #when readSessionMessages runs #then retries SDK instead of returning empty file storage", async () => {
+    // given messages that live only in the SDK (pure-sqlite), not on disk
+    let attempts = 0
+    mockClient.session.messages.mockImplementation(() => {
+      attempts += 1
+      if (attempts === 1) return Promise.reject(createSdkUnavailableError("socket hang up"))
+      return Promise.resolve({
+        data: [{ info: { id: "msg_sdk", role: "user", time: { created: 5_000 } }, parts: [] }],
+      })
+    })
+
+    // when readSessionMessages hits a single transient SDK failure
+    const messages = await storage.readSessionMessages("ses_sqlite_only")
+
+    // then it retries the SDK and returns the real messages
+    expect(messages).toHaveLength(1)
+    expect(messages[0].id).toBe("msg_sdk")
+    expect(attempts).toBe(2)
+  })
+
+  test("#given non-transient SDK error #when readSessionMessages runs #then does not retry and rethrows immediately", async () => {
+    let attempts = 0
+    mockClient.session.messages.mockImplementation(() => {
+      attempts += 1
+      return Promise.resolve({ error: new Error("session not found") })
+    })
+
+    await expect(storage.readSessionMessages("ses_missing")).rejects.toThrow("session not found")
+    expect(attempts).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
`session_read` returns "Session not found" for a session that `session_info` reports fine, when the OpenCode SDK HTTP API has a transient failure. The SDK call had no retry, so a momentary network blip fell straight through to file storage, which does not exist for pure-sqlite sessions.

## Root Cause
`session_read` makes **two** SDK calls (`session.list()` for the `sessionExists` preflight, then `session.messages()`), while `session_info` makes only one (`session.messages()`). Each call site in `src/tools/session-manager/sdk-storage.ts` ran the SDK request once; on a transient throw the caller in `storage.ts` falls back to file storage. For pure-sqlite sessions there is no file fallback, so the extra `session.list()` call in `session_read` turns a transient blip into a false `Session not found` while `session_info` happens to succeed.

## Changes
| File | Change |
|------|--------|
| `src/tools/session-manager/sdk-storage.ts` | Add `fetchSdkResponse()` retry wrapper (3 attempts) used by all session SDK calls; retries only transient/unavailable errors (`isSessionSdkUnavailableError`), rethrows semantic errors immediately |
| `src/tools/session-manager/storage-fallback.test.ts` | Regression tests: transient-then-recover for `sessionExists` + `readSessionMessages`, and a non-transient no-retry guard |

## Reproduction (before fix)
```
(fail) session-manager storage fallback > ...sessionExists...retries SDK and avoids false-negative file fallback
  expect(received).toBe(expected)  Expected: true   (got false)
(fail) session-manager storage fallback > ...readSessionMessages...retries SDK instead of returning empty file storage
  expect(received).toHaveLength(expected)  Expected length: 1
 13 pass, 2 fail
```

## Verification (after fix)
```
bun test src/tools/session-manager/   ->  63 pass, 0 fail
bun run typecheck                      ->  exit 0
```

## Test
- Regression tests: `src/tools/session-manager/storage-fallback.test.ts` (newly added: 2 transient-recovery + 1 no-retry guard)
- Existing fallback + semantic-rethrow tests still pass (transient errors that never recover still fall back to file; semantic errors still rethrow)
- Typecheck: `bun run typecheck` clean

Fixes #4622


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add transient retry for OpenCode SDK calls in the session manager to prevent false "Session not found" on network blips, especially for pure-sqlite sessions. Fixes #4622.

- **Bug Fixes**
  - Added `fetchSdkResponse` (3 attempts) around `session.list`, `session.messages`, and `session.todo`.
  - Retries only transient/unavailable errors (`isSessionSdkUnavailableError`); semantic errors rethrow immediately.
  - Added regression tests for transient recovery and a no-retry guard.

<sup>Written for commit d984ccd5b9de36c4eb44bfa4bda903ae83be0988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

