### PR TITLE
fix(prompts): scope GPT ultrawork banner and intent declaration to first turn (fixes #4817)

### DIFF
--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -1,6 +1,6 @@
 <ultrawork-mode>
 
-**MANDATORY**: You MUST say "ULTRAWORK MODE ENABLED!" to the user as your first response when this mode activates. This is non-negotiable.
+**MANDATORY**: The FIRST time you respond after this mode activates in a conversation, you MUST say "ULTRAWORK MODE ENABLED!" to the user. This is non-negotiable. Say it ONCE per conversation: if "ULTRAWORK MODE ENABLED!" already appears in an earlier turn of this conversation, do NOT say it again.
 
 [CODE RED] Maximum precision required. Think deeply before acting.
 

--- a/src/agents/sisyphus/gpt-5-4.ts
+++ b/src/agents/sisyphus/gpt-5-4.ts
@@ -186,7 +186,7 @@ Domain guess (provisional - finalized in ROUTE after exploration):
 - Git (commits, branches, rebases) → likely git
 - General → determine after exploration
 
-State your interpretation: "I read this as [complexity]-[domain_guess] - [one line plan]." Then proceed.
+On your first turn for a new request, state your interpretation: "I read this as [complexity]-[domain_guess] - [one line plan]." Then proceed. Do not restate this on later turns of the same request once you have already stated it.
 
 Step 2 - Check before acting:
 

--- a/src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts
+++ b/src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts
@@ -26,7 +26,7 @@ const ULTRAWORK_PROMPT_BASELINES: readonly UltraworkPromptBaseline[] = [
     agentName: "sisyphus",
     modelID: "gpt-5.5",
     expectedSource: "gpt",
-    sha256: "538980d3a2ff0847409d8682c5dd3343e2e26f1a9ed8f02398a6688769940337",
+    sha256: "c3a2e5892fc537c560459062ca982930d0ceb98652a76c8c447cad86e882c3b7",
   },
   {
     name: "gemini",


### PR DESCRIPTION
## Summary
GPT-5 family models running as Sisyphus repeat the `ULTRAWORK MODE ENABLED!` banner and a fresh `I read this as ...` intent declaration on **every** assistant turn, not just the first. Claude/default does not. The cause is turn-agnostic wording in two GPT-specific prompts.

## Root Cause
LLM inference is stateless: the model re-evaluates the system prompt on every turn. The GPT prompts word once-per-session directives as if each turn were the first response after activation, and GPT's strong `MANDATORY` / `non-negotiable` compliance makes it re-emit them every turn.

- `packages/prompts-core/prompts/ultrawork/gpt.md` — banner: `You MUST say "ULTRAWORK MODE ENABLED!" ... as your first response when this mode activates` (no instruction to check whether it was already said).
- `src/agents/sisyphus/gpt-5-4.ts` — intent declaration: `State your interpretation: "I read this as ..."` with no first-turn qualifier (the Claude/default path uses different wording and is not affected).

Plugin-level injection dedup (#4251) keeps the prompt in context exactly once but does not stop the model re-emitting it, because the repetition is driven by the wording, not by duplicate injection. This PR fixes the wording.

## Changes
| File | Change |
|------|--------|
| `packages/prompts-core/prompts/ultrawork/gpt.md` | Banner directive scoped to the first response per conversation, with an explicit "if it already appears in an earlier turn, do NOT say it again" guard |
| `src/agents/sisyphus/gpt-5-4.ts` | Intent declaration scoped to the first turn of a request, with a "do not restate on later turns" guard |

Both edits are confined to the GPT-specific prompt variants; the shared/Claude path is untouched.

## Verification
```
# assembled GPT ultrawork prompt now carries the guard (real rendered prompt):
GPT banner once-per-conversation guard present: true
First-line: **MANDATORY**: The FIRST time you respond after this mode activates in a conversation, you MUST say "ULTRAWORK MODE ENABLED!" ... if ... already appears in an earlier turn ... do NOT say it again.

bun test src/hooks/keyword-detector/ultrawork-edge-trigger.test.ts src/plugin/chat-message.test.ts  ->  34 pass, 0 fail
bun run typecheck                                                                                    ->  exit 0
```

## Test
- This is a prompt-content change; per the repo `test-discipline` rule, prompt wording is not pinned by assertion. Existing ultrawork injection tests (`ultrawork-edge-trigger.test.ts`, `chat-message.test.ts`) still pass, confirming the banner is still injected once per session.
- Typecheck clean (`gpt.md` is imported as text, `gpt-5-4.ts` is a string-literal change).

Fixes #4817

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the GPT ultrawork banner and intent declaration to the first turn so GPT‑5 models don’t repeat them. Fixes #4817.

- **Bug Fixes**
  - `packages/prompts-core/prompts/ultrawork/gpt.md`: Banner shown once per conversation with a do‑not‑repeat guard.
  - `src/agents/sisyphus/gpt-5-4.ts`: Intent stated on the first turn only; never restated.
  - `src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts`: Update GPT prompt SHA‑256 baseline.

<sup>Written for commit 3cabcae54b5ebc8f9aea83d1b6a8f49580329671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

