### PR TITLE
feat: add CodeGraph priority rule for all agent prompts

### DIFF
--- a/packages/omo-opencode/src/agents/dynamic-agent-core-sections.ts
+++ b/packages/omo-opencode/src/agents/dynamic-agent-core-sections.ts
@@ -48,6 +48,15 @@ export function buildToolSelectionTable(
 ): string {
   const rows: string[] = ["### Tool & Agent Selection:", ""]
 
+  const hasCodegraph = tools.some((tool) => tool.category === "codegraph")
+
+  if (hasCodegraph) {
+    rows.push(
+      "**⚠️ CodeGraph Priority Rule**: When `codegraph_*` tools are available, use them as the **PRIMARY** code exploration tool. `codegraph_explore` replaces multiple grep/read calls with a single semantic query. Use grep/glob/read ONLY when CodeGraph lacks the needed data or for non-code files.",
+    )
+    rows.push("")
+  }
+
   if (tools.length > 0) {
     rows.push(
       `- ${getToolsPromptDisplay(tools)} - **FREE** - Not Complex, Scope Clear, No Implicit Assumptions`,
@@ -69,7 +78,11 @@ export function buildToolSelectionTable(
   }
 
   rows.push("")
-  rows.push("**Default flow**: explore/librarian (background) + tools → oracle (if required)")
+  if (hasCodegraph) {
+    rows.push("**Default flow**: codegraph (first choice for code) / explore/librarian (background) → oracle (if required)")
+  } else {
+    rows.push("**Default flow**: explore/librarian (background) + tools → oracle (if required)")
+  }
 
   return rows.join("\n")
 }
@@ -81,13 +94,19 @@ export function buildExploreSection(agents: AvailableAgent[]): string {
   }
 
   const useWhen = exploreAgent.metadata.useWhen || []
-  const avoidWhen = exploreAgent.metadata.avoidWhen || []
+  const avoidWhen = exploreAgent.metadata.useWhen || []
 
   return `### Explore Agent = Contextual Grep
 
 Use it as a **peer tool**, not a fallback. Fire liberally for discovery, not for files you already know.
 
 **Delegation Trust Rule:** Once you fire an explore agent for a search, do **not** manually perform that same search yourself. Use direct tools only for non-overlapping work or when you intentionally skipped delegation.
+
+**CodeGraph vs Explore vs Direct Tools priority:**
+1. \`codegraph_explore\` — FIRST choice for understanding code structure, finding symbols, tracing dependencies (single call replaces multiple grep/read chains)
+2. \`codegraph_search\` / \`codegraph_node\` — For targeted symbol lookups and source retrieval
+3. \`explore\` agent — For complex multi-angle searches that benefit from agent reasoning
+4. \`grep\` / \`glob\` / \`Read\` — For non-code files, known exact locations, or when CodeGraph lacks coverage
 
 **Use Direct Tools when:**
 ${avoidWhen.map((entry) => `- ${entry}`).join("\n")}

--- a/packages/omo-opencode/src/agents/dynamic-agent-prompt-types.ts
+++ b/packages/omo-opencode/src/agents/dynamic-agent-prompt-types.ts
@@ -8,7 +8,7 @@ export interface AvailableAgent {
 
 export interface AvailableTool {
   name: string
-  category: "lsp" | "ast" | "search" | "session" | "command" | "other"
+  category: "lsp" | "ast" | "codegraph" | "search" | "session" | "command" | "other"
 }
 
 export interface AvailableSkill {

--- a/packages/omo-opencode/src/agents/dynamic-agent-tool-categorization.ts
+++ b/packages/omo-opencode/src/agents/dynamic-agent-tool-categorization.ts
@@ -5,6 +5,8 @@ export function categorizeTools(toolNames: string[]): AvailableTool[] {
     let category: AvailableTool["category"] = "other"
     if (name.startsWith("lsp_")) {
       category = "lsp"
+    } else if (name.startsWith("codegraph_codegraph_")) {
+      category = "codegraph"
     } else if (name.startsWith("ast_grep")) {
       category = "ast"
     } else if (name === "grep" || name === "glob") {
@@ -19,11 +21,16 @@ export function categorizeTools(toolNames: string[]): AvailableTool[] {
 }
 
 function formatToolsForPrompt(tools: AvailableTool[]): string {
+  const codegraphTools = tools.filter((tool) => tool.category === "codegraph")
   const lspTools = tools.filter((tool) => tool.category === "lsp")
   const astTools = tools.filter((tool) => tool.category === "ast")
   const searchTools = tools.filter((tool) => tool.category === "search")
 
   const parts: string[] = []
+
+  if (codegraphTools.length > 0) {
+    parts.push("`codegraph_*` (semantic code navigation)")
+  }
 
   if (searchTools.length > 0) {
     parts.push(...searchTools.map((tool) => `\`${tool.name}\``))

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-4.ts
@@ -178,6 +178,7 @@ ${exploreSection}
 ${librarianSection}
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian = background grep. ALWAYS \`run_in_background=true\`, ALWAYS parallel
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/hephaestus/gpt.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt.ts
@@ -180,6 +180,7 @@ ${librarianSection}
 **Parallelize EVERYTHING. Independent reads, searches, and agents run SIMULTANEOUSLY.**
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian = background grep. ALWAYS \`run_in_background=true\`, ALWAYS parallel
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-exploration.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-exploration.ts
@@ -15,6 +15,7 @@ ${sections.librarianSection}
 **Parallelize EVERYTHING. Independent reads, searches, and agents run SIMULTANEOUSLY.**
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When `codegraph_*` tools are available, use `codegraph_explore` as the primary code exploration tool. One `codegraph_explore` call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian = background grep. ALWAYS \`run_in_background=true\`, ALWAYS parallel
 - Fire 2-5 explore/librarian agents in parallel for any non-trivial codebase question

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gemini.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gemini.ts
@@ -77,6 +77,7 @@ Before responding, ask yourself: What tools do I need to call? What am I assumin
 - **Truly impossible to proceed** - Ask ONE precise question (LAST RESORT)
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian via call_omo_agent = background research. Fire them and continue only with non-overlapping work
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
@@ -63,6 +63,7 @@ When blocked: try a different approach → decompose the problem → challenge a
 - **Truly impossible to proceed** - Ask ONE precise question (LAST RESORT)
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian via call_omo_agent = background research. Fire them and continue only with non-overlapping work
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
@@ -60,6 +60,7 @@ When blocked: try a different approach → decompose the problem → challenge a
 - **Truly impossible to proceed** - Ask ONE precise question (LAST RESORT)
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian via call_omo_agent = background research. Fire them and continue only with non-overlapping work
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
@@ -85,6 +85,7 @@ The verbalization step runs every turn. Output adapts to context.
 - **Truly impossible to proceed** - Ask ONE precise question (LAST RESORT)
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian via call_omo_agent = background research. Fire them and continue only with non-overlapping work
 - After any file edit: restate what changed, where, and what validation follows

--- a/packages/omo-opencode/src/agents/sisyphus/default.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/default.ts
@@ -295,6 +295,7 @@ ${librarianSection}
 **Parallelize EVERYTHING. Independent reads, searches, and agents run SIMULTANEOUSLY.**
 
 <tool_usage_rules>
+- **CodeGraph FIRST**: When \`codegraph_*\` tools are available, use \`codegraph_explore\` as the primary code exploration tool. One call replaces 3-5 grep/read chains. Use grep/glob/read ONLY for non-code files or when CodeGraph lacks coverage.
 - Parallelize independent tool calls: multiple file reads, grep searches, agent fires - all at once
 - Explore/Librarian = background grep. ALWAYS \`run_in_background=true\`, ALWAYS parallel
 - Fire 2-5 explore/librarian agents in parallel for any non-trivial codebase question

--- a/packages/prompts-core/prompts/atlas/default.md
+++ b/packages/prompts-core/prompts/atlas/default.md
@@ -109,6 +109,7 @@ Every `task()` prompt MUST include ALL 6 sections:
 - [tool]: [what to search/check]
 - context7: Look up [library] docs
 - ast-grep: `sg --pattern '[pattern]' --lang [lang]`
+- **codegraph**: Use `codegraph_explore` FIRST for code structure/dependencies/symbols. Only fall back to grep/read for non-code files.
 
 ## 4. MUST DO
 - Follow pattern in [reference file:lines]

--- a/packages/prompts-core/prompts/atlas/gemini.md
+++ b/packages/prompts-core/prompts/atlas/gemini.md
@@ -136,6 +136,7 @@ Every `task()` prompt MUST include ALL 6 sections:
 - [tool]: [what to search/check]
 - context7: Look up [library] docs
 - ast-grep: `sg --pattern '[pattern]' --lang [lang]`
+- **codegraph**: Use `codegraph_explore` FIRST for code structure/dependencies/symbols. Only fall back to grep/read for non-code files.
 
 ## 4. MUST DO
 - Follow pattern in [reference file:lines]

--- a/packages/prompts-core/prompts/atlas/gpt.md
+++ b/packages/prompts-core/prompts/atlas/gpt.md
@@ -119,6 +119,7 @@ Every `task()` prompt MUST include ALL 6 sections:
 - [tool]: [what to search/check]
 - context7: Look up [library] docs
 - ast-grep: `sg --pattern '[pattern]' --lang [lang]`
+- **codegraph**: Use `codegraph_explore` FIRST for code structure/dependencies/symbols. Only fall back to grep/read for non-code files.
 
 ## 4. MUST DO
 - Follow pattern in [reference file:lines]

--- a/packages/prompts-core/prompts/atlas/kimi.md
+++ b/packages/prompts-core/prompts/atlas/kimi.md
@@ -124,6 +124,7 @@ Every `task()` prompt MUST include ALL 6 sections:
 - [tool]: [what to search/check]
 - context7: Look up [library] docs
 - ast-grep: `sg --pattern '[pattern]' --lang [lang]`
+- **codegraph**: Use `codegraph_explore` FIRST for code structure/dependencies/symbols. Only fall back to grep/read for non-code files.
 
 ## 4. MUST DO
 - Follow pattern in [reference file:lines]

--- a/packages/prompts-core/prompts/atlas/opus-4-7.md
+++ b/packages/prompts-core/prompts/atlas/opus-4-7.md
@@ -117,6 +117,7 @@ Every `task()` prompt MUST include ALL 6 sections:
 - [tool]: [what to search/check]
 - context7: Look up [library] docs
 - ast-grep: `sg --pattern '[pattern]' --lang [lang]`
+- **codegraph**: Use `codegraph_explore` FIRST for code structure/dependencies/symbols. Only fall back to grep/read for non-code files.
 
 ## 4. MUST DO
 - Follow pattern in [reference file:lines]


### PR DESCRIPTION
## Problem

When CodeGraph MCP tools (`codegraph_*`) are available, agents default to using grep/glob/read as the primary code exploration tools. This wastes context budget on multiple grep → Read chains that a single `codegraph_explore` call could replace.

The root cause:
1. `categorizeTools()` classifies `codegraph_codegraph_*` as `category: "other"` — they\'re invisible to the prompt builder
2. `formatToolsForPrompt()` skips `"other"` category entirely — CodeGraph never appears in the Tool Selection section
3. `buildToolSelectionTable()` shows "Default flow: explore/librarian + tools → oracle" with no CodeGraph mention
4. `buildExploreSection()` has "Use Direct Tools when you know what to search" — legitimizes grep-first behavior
5. No `<tool_usage_rules>` across any agent variant mentions CodeGraph

## Solution

### 1. Tool Categorization (`dynamic-agent-tool-categorization.ts`)
- Add `"codegraph"` category for `codegraph_codegraph_*` tools
- Include `codegraph_*` in prompt display as `codegraph_* (semantic code navigation)`

### 2. Shared Prompt Builders (`dynamic-agent-core-sections.ts`)
- **buildToolSelectionTable**: When CodeGraph tools are detected, inject priority warning and update default flow
- **buildExploreSection**: Add explicit priority: CodeGraph > Explore Agent > Direct Tools

### 3. All Agent Variants
Add `**CodeGraph FIRST**` rule at the top of `<tool_usage_rules>` in:
- **Sisyphus**: default.ts, sisyphus-dynamic-prompt-exploration.ts
- **Hephaestus**: gpt.ts, gpt-5-4.ts
- **Sisyphus-Junior**: gemini.ts, gpt.ts, gpt-5-4.ts, kimi-k2-6.ts
- **Atlas** (all 5 variants): REQUIRED TOOLS section

### Files Changed (16)

```
packages/prompts-core/prompts/atlas/default.md     +1
packages/prompts-core/prompts/atlas/gemini.md      +1
packages/prompts-core/prompts/atlas/gpt.md         +1
packages/prompts-core/prompts/atlas/kimi.md        +1
packages/prompts-core/prompts/atlas/opus-4-7.md    +1
src/agents/dynamic-agent-core-sections.ts          +23
src/agents/dynamic-agent-prompt-types.ts           +2
src/agents/dynamic-agent-tool-categorization.ts    +7
src/agents/hephaestus/gpt-5-4.ts                   +1
src/agents/hephaestus/gpt.ts                       +1
src/agents/sisyphus-dynamic-prompt-exploration.ts  +1
src/agents/sisyphus-junior/gemini.ts               +1
src/agents/sisyphus-junior/gpt-5-4.ts              +1
src/agents/sisyphus-junior/gpt.ts                  +1
src/agents/sisyphus-junior/kimi-k2-6.ts            +1
src/agents/sisyphus/default.ts                     +1
```

## Impact

- **Zero breaking change**: When CodeGraph tools are NOT available, behavior is identical
- **Context savings**: Agents with CodeGraph will use 1 call instead of 3-5 grep/read chains
- **Covers all contexts**: Direct work, delegation (task()), and team mode (team_task)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes `codegraph_*` tools across all agents so `codegraph_explore` is used first for code exploration, replacing multi-step grep/read chains. When CodeGraph isn’t available, behavior stays the same.

- New Features
  - Added `codegraph` tool category and prompt display (`codegraph_* (semantic code navigation)`), and updated types to include `codegraph`.
  - Updated Tool Selection to show a CodeGraph priority warning when detected; default flow now favors CodeGraph first.
  - Explore section adds explicit priority: CodeGraph > Explore agent > Direct tools.
  - Inserted a “CodeGraph FIRST” rule in `<tool_usage_rules>` for Sisyphus, Hephaestus, Sisyphus‑Junior, and Atlas; Atlas prompts include a REQUIRED TOOLS note for CodeGraph.

<sup>Written for commit 51061d8e0ea54614bdfcd7cfd8141935e5be0c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

