### PR TITLE
fix(session): preserve selected main-session model

### DIFF
--- a/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.ts
@@ -129,7 +129,7 @@ export function createRecoveryLogic(
 
       updateSessionAgent(sessionID, expectedPromptConfig.agent)
       if (model) {
-        setSessionModel(sessionID, model)
+        setSessionModel(sessionID, model, expectedPromptConfig.agent)
       }
       if (tools) {
         setSessionTools(sessionID, tools)

--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -13,7 +13,7 @@ import { createStartWorkHook } from "../hooks/start-work"
 import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
 import { OMO_INTERNAL_INITIATOR_MARKER } from "../shared/internal-initiator-marker"
-import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
+import { clearSessionModel, getSessionModel, getStoredSessionModel, setSessionModel } from "../shared/session-model-state"
 import { createChatMessageHandler } from "./chat-message"
 import type { PluginContext } from "./types"
 
@@ -879,7 +879,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
   test("reuses the stored main-session model over explicit agent model overrides", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" }, "sisyphus")
     const args = createMockHandlerArgs({
       shouldOverride: false,
       pluginConfig: {
@@ -903,7 +903,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
   test("reuses the stored main-session model with prefixed list-display agent names", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" }, "prometheus")
     const args = createMockHandlerArgs({
       shouldOverride: false,
       pluginConfig: {
@@ -941,6 +941,34 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     //#then
     expect(output.message["model"]).toBeUndefined()
     expect(getSessionModel("test-session")).toEqual(nextModel)
+  })
+
+  test("does not reuse a previous agent model when switching to another configured agent", async () => {
+    //#given
+    setMainSession("test-session")
+    setSessionModel("test-session", { providerID: "anthropic", modelID: "claude-opus-4-7" }, "sisyphus")
+    const args = createMockHandlerArgs({
+      shouldOverride: false,
+      pluginConfig: {
+        agents: {
+          hephaestus: { model: "openai/gpt-5.5" },
+        },
+      },
+    })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus")
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.message["model"]).toBeUndefined()
+    expect(getStoredSessionModel("test-session")).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-7",
+      agent: "sisyphus",
+    })
   })
 
   test("strips legacy ZWSP-prefixed agent names from persisted prompt body session state (GH-3259)", async () => {

--- a/packages/omo-opencode/src/plugin/chat-message.test.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.test.ts
@@ -876,7 +876,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     expect(getSessionModel("subagent-session")).toBeUndefined()
   })
 
-  test("does not override explicit agent model overrides with stored session model", async () => {
+  test("reuses the stored main-session model over explicit agent model overrides", async () => {
     //#given
     setMainSession("test-session")
     setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
@@ -896,11 +896,11 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     await handler(input, output)
 
     //#then
-    expect(output.message["model"]).toBeUndefined()
+    expect(output.message["model"]).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
   })
 
-  test("treats prefixed list-display agent names as explicit model overrides", async () => {
+  test("reuses the stored main-session model with prefixed list-display agent names", async () => {
     //#given
     setMainSession("test-session")
     setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
@@ -920,7 +920,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     await handler(input, output)
 
     //#then
-    expect(output.message["model"]).toBeUndefined()
+    expect(output.message["model"]).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(getSessionAgent("test-session")).toBe("Prometheus - Plan Builder")
   })

--- a/packages/omo-opencode/src/plugin/chat-message.ts
+++ b/packages/omo-opencode/src/plugin/chat-message.ts
@@ -101,11 +101,7 @@ export function createChatMessageHandler(args: {
       firstMessageVariantGate.markApplied(input.sessionID)
     }
 
-    const storedMainSessionModel = getStoredMainSessionModel(
-      input,
-      pluginConfig,
-      isFirstMessage,
-    )
+    const storedMainSessionModel = getStoredMainSessionModel(input, isFirstMessage)
     if (storedMainSessionModel) {
       output.message.model = storedMainSessionModel
     }

--- a/packages/omo-opencode/src/plugin/chat-message/session-model.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/session-model.ts
@@ -1,27 +1,9 @@
-import type { OhMyOpenCodeConfig } from "../../config"
 import { subagentSessions, getMainSessionID } from "../../features/claude-code-session-state"
-import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { getSessionModel, setSessionModel } from "../../shared/session-model-state"
 import type { ChatMessageHandlerOutput, ChatMessageInput, SessionModelOverride } from "./types"
 
-function hasExplicitAgentModelOverride(
-  agent: string | undefined,
-  pluginConfig: OhMyOpenCodeConfig,
-): boolean {
-  const configuredAgents = pluginConfig.agents
-  const normalizedAgent = typeof agent === "string" ? getAgentConfigKey(agent) : undefined
-  if (!normalizedAgent || !configuredAgents || !(normalizedAgent in configuredAgents)) {
-    return false
-  }
-
-  const configuredAgent = configuredAgents[normalizedAgent as keyof typeof configuredAgents]
-  const configuredModel = configuredAgent?.model
-  return typeof configuredModel === "string" && configuredModel.trim().length > 0
-}
-
 export function getStoredMainSessionModel(
   input: ChatMessageInput,
-  pluginConfig: OhMyOpenCodeConfig,
   isFirstMessage: boolean,
 ): SessionModelOverride | undefined {
   if (isFirstMessage) {
@@ -37,10 +19,6 @@ export function getStoredMainSessionModel(
   }
 
   if (input.model) {
-    return undefined
-  }
-
-  if (hasExplicitAgentModelOverride(input.agent, pluginConfig)) {
     return undefined
   }
 

--- a/packages/omo-opencode/src/plugin/chat-message/session-model.ts
+++ b/packages/omo-opencode/src/plugin/chat-message/session-model.ts
@@ -1,6 +1,24 @@
-import { subagentSessions, getMainSessionID } from "../../features/claude-code-session-state"
-import { getSessionModel, setSessionModel } from "../../shared/session-model-state"
+import { getSessionAgent, subagentSessions, getMainSessionID } from "../../features/claude-code-session-state"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { getStoredSessionModel, setSessionModel } from "../../shared/session-model-state"
 import type { ChatMessageHandlerOutput, ChatMessageInput, SessionModelOverride } from "./types"
+
+function resolveCurrentAgent(input: ChatMessageInput): string | undefined {
+  return input.agent ?? getSessionAgent(input.sessionID)
+}
+
+function hasMatchingAgentOwner(input: ChatMessageInput, storedAgent: string | undefined): boolean {
+  if (!storedAgent) {
+    return true
+  }
+
+  const currentAgent = resolveCurrentAgent(input)
+  if (!currentAgent) {
+    return false
+  }
+
+  return getAgentConfigKey(storedAgent) === getAgentConfigKey(currentAgent)
+}
 
 export function getStoredMainSessionModel(
   input: ChatMessageInput,
@@ -22,11 +40,17 @@ export function getStoredMainSessionModel(
     return undefined
   }
 
-  return getSessionModel(input.sessionID)
+  const storedModel = getStoredSessionModel(input.sessionID)
+  if (!storedModel || !hasMatchingAgentOwner(input, storedModel.agent)) {
+    return undefined
+  }
+
+  return { providerID: storedModel.providerID, modelID: storedModel.modelID }
 }
 
 export function recordSessionModel(input: ChatMessageInput, output: ChatMessageHandlerOutput): void {
   const modelOverride = output.message.model
+  const agent = resolveCurrentAgent(input)
   if (
     modelOverride &&
     typeof modelOverride === "object" &&
@@ -36,9 +60,9 @@ export function recordSessionModel(input: ChatMessageInput, output: ChatMessageH
     const providerID = (modelOverride as { readonly providerID?: string }).providerID
     const modelID = (modelOverride as { readonly modelID?: string }).modelID
     if (typeof providerID === "string" && typeof modelID === "string") {
-      setSessionModel(input.sessionID, { providerID, modelID })
+      setSessionModel(input.sessionID, { providerID, modelID }, agent)
     }
   } else if (input.model) {
-    setSessionModel(input.sessionID, input.model)
+    setSessionModel(input.sessionID, input.model, agent)
   }
 }

--- a/packages/omo-opencode/src/plugin/event-session-lifecycle.ts
+++ b/packages/omo-opencode/src/plugin/event-session-lifecycle.ts
@@ -146,7 +146,7 @@ export function handleMessageUpdatedSessionState(args: {
     const modelID = info?.modelID as string | undefined;
     if (providerID && modelID && !isCompactionMessage) {
       args.noteSessionModel(sessionID, { providerID, modelID });
-      setSessionModel(sessionID, { providerID, modelID });
+      setSessionModel(sessionID, { providerID, modelID }, agent);
     }
     args.clearUserAbortRecovery(sessionID);
   }

--- a/packages/omo-opencode/src/shared/session-model-state.test.ts
+++ b/packages/omo-opencode/src/shared/session-model-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { clearSessionModel, getSessionModel, setSessionModel } from "./session-model-state"
+import { clearSessionModel, getSessionModel, getStoredSessionModel, setSessionModel } from "./session-model-state"
 
 describe("session-model-state", () => {
   test("stores and retrieves a session model", () => {
@@ -13,6 +13,25 @@ describe("session-model-state", () => {
     expect(getSessionModel(sessionID)).toEqual({
       providerID: "github-copilot",
       modelID: "gpt-4.1",
+    })
+  })
+
+  test("keeps agent ownership metadata out of the public session model", () => {
+    //#given
+    const sessionID = "ses_owned"
+
+    //#when
+    setSessionModel(sessionID, { providerID: "openai", modelID: "gpt-5.4" }, "sisyphus")
+
+    //#then
+    expect(getSessionModel(sessionID)).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+    })
+    expect(getStoredSessionModel(sessionID)).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      agent: "sisyphus",
     })
   })
 

--- a/packages/omo-opencode/src/shared/session-model-state.ts
+++ b/packages/omo-opencode/src/shared/session-model-state.ts
@@ -1,12 +1,24 @@
 export type SessionModel = { providerID: string; modelID: string }
+export type StoredSessionModel = SessionModel & { agent?: string }
 
-const sessionModels = new Map<string, SessionModel>()
+const sessionModels = new Map<string, StoredSessionModel>()
 
-export function setSessionModel(sessionID: string, model: SessionModel): void {
-  sessionModels.set(sessionID, model)
+export function setSessionModel(sessionID: string, model: SessionModel, agent?: string): void {
+  const normalizedAgent = agent?.trim()
+  sessionModels.set(sessionID, normalizedAgent ? { ...model, agent: normalizedAgent } : model)
 }
 
 export function getSessionModel(sessionID: string): SessionModel | undefined {
+  const storedModel = sessionModels.get(sessionID)
+  if (!storedModel) return undefined
+
+  return {
+    providerID: storedModel.providerID,
+    modelID: storedModel.modelID,
+  }
+}
+
+export function getStoredSessionModel(sessionID: string): StoredSessionModel | undefined {
   return sessionModels.get(sessionID)
 }
 


### PR DESCRIPTION
## Summary
- preserve the stored main-session model on later parent prompts even when the agent has a configured default model
- keep first-message, explicit input.model, and subagent-session isolation behavior unchanged
- update chat-message regression coverage to lock the selected-model persistence behavior

## Why
Manual parent model selection could be recorded but then ignored on a later prompt when the prompt did not carry input.model. The explicit agent-model guard forced OpenCode back to the configured agent default, which made parent sessions snap back to Anthropic while subagents continued to use their fallback path.

## Verification
- bun test src/plugin/chat-message.test.ts
- bun run typecheck

## Context
This is isolated from the broader runtime/model fallback work and is branched from refreshed dev.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the user-selected main-session model for parent prompts and only reuses it when the same agent owns it. Prevents snapbacks to agent defaults and cross-agent model leakage, including with prefixed agent names.

- **Bug Fixes**
  - Reuse the stored main-session model on later parent prompts instead of falling back to the agent’s default.
  - Store agent ownership with the session model (setSessionModel now accepts an agent) and keep it out of the public getter; added getStoredSessionModel for internal checks.
  - Simplified getStoredMainSessionModel (removed pluginConfig) and gated reuse by matching agent owner, with normalized names and prefixed display-name handling.
  - Record and persist agent-owned model updates across the chat handler, session lifecycle, and recovery; do not reuse when switching to a different agent; expanded tests cover agent switches and prefixed names.

<sup>Written for commit 30e3ebc1ae48a97993fd22d64c96581ae454c4e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

