### PR TITLE
fix(cli-run): dispatch registered agent names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,17 +44,17 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "4.7.5",
-        "oh-my-opencode-darwin-x64": "4.7.5",
-        "oh-my-opencode-darwin-x64-baseline": "4.7.5",
-        "oh-my-opencode-linux-arm64": "4.7.5",
-        "oh-my-opencode-linux-arm64-musl": "4.7.5",
-        "oh-my-opencode-linux-x64": "4.7.5",
-        "oh-my-opencode-linux-x64-baseline": "4.7.5",
-        "oh-my-opencode-linux-x64-musl": "4.7.5",
-        "oh-my-opencode-linux-x64-musl-baseline": "4.7.5",
-        "oh-my-opencode-windows-x64": "4.7.5",
-        "oh-my-opencode-windows-x64-baseline": "4.7.5",
+        "oh-my-opencode-darwin-arm64": "4.8.0",
+        "oh-my-opencode-darwin-x64": "4.8.0",
+        "oh-my-opencode-darwin-x64-baseline": "4.8.0",
+        "oh-my-opencode-linux-arm64": "4.8.0",
+        "oh-my-opencode-linux-arm64-musl": "4.8.0",
+        "oh-my-opencode-linux-x64": "4.8.0",
+        "oh-my-opencode-linux-x64-baseline": "4.8.0",
+        "oh-my-opencode-linux-x64-musl": "4.8.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "4.8.0",
+        "oh-my-opencode-windows-x64": "4.8.0",
+        "oh-my-opencode-windows-x64-baseline": "4.8.0",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -442,27 +442,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.7.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2l2FY47nSsy3V9ed1+vZOw7kgQVDH3Bn+6M03sciahTJFmk8wTPva3TEVbTF1xkP55DGiO437bujBWTqHQy5dw=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@4.8.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DX0ncb0ZT3kIeuUY8YvwnOxliJokHMOHdxGucr5jXzcpAZA2zpMo+YajTcNmgIjwJ91awMGmUNvLjdGn9GH9PQ=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.7.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kZGyRhh2Ni7xvbJ30clwHOqUjxy3K34bf+b1I2jxayDo/KXgM9uU00CAbqHmRUAf78zwq4tXonz9gFoeoQVow=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@4.8.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-9pxgt3ioW0tjikgSEumJH31Imq4kQz9npfwU4Zp526Ter0ic7KDZxAKAr7PuuSTfWLa2ojl972lU+olk+P3HkA=="],
 
-    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.7.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-HGQH5akl9YV0jKQ3baJ+XeKAK9aAbjZ3LMzSz7E0vEYVz6F125HOUBGutCodIdkmkJckJRoXdnUy4tOXDxhtFg=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@4.8.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-OG+bXf2n0cseTVRa//x9/bp7NN8OYO2eIuVoun2TKROMkR5n9c22wv22Zg2vWKsRYFUJ0FLo/FUFNHSauLoTRg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.7.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-SJL4kZ5Os7OJANrrtDDcjLqD7OvyaLzc4BcDi/2YT1UF44r75z4G1sFPHka4+gtzUNDtAyPURqR5pUtdShcJoQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@4.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/8bSgCL7eCq971euOrAEVGeWc7n+6blXMGkuBzY3e7Xgc61LUd352pJMo6DYM7xBXjitvzKVt4T85Si08zWTcg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.7.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-cf02+lQF53eE6dvBopDmb4J+wcR38fjFFj5UnBo0ZucUVsvV6ZGSQ97IlR8cTnxWoclSMnmFneKyeOo3SmcJRA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@4.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-M+xtIfXiERhXtqwPmJXijTFFir4ETqQGgQ85HiF7QvpAsB1mguN9r8AS8ddOe0MhVdu6SKToY7vqWmU0ee/9hg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.7.5", "", { "os": "linux", "cpu": "x64" }, "sha512-dARRLbhndybqlf2IiZ12mkqgqmkpUd6ovhCOkLC8IH92CsiPhWaUJVGeFhh0OBg5qH1kNuP84KglYMk8m5tKiQ=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@4.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-jImyND2SDQaN19oSplABBtq1WywgqKTrQSlutF1FX/DrEY7jpX1d7kZ8DhGuGihiio5GwyI2PK6Sfk1LIHpBAw=="],
 
-    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.7.5", "", { "os": "linux", "cpu": "x64" }, "sha512-oiNGny5MgtOCJWDE5cbZqqY7Mf4f+gfBfVA5ktSJvq4KZgR5xXbA3Y6vy3mhYXuN5A//l8bS2I9qWfKc9ma4og=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@4.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IjWtCaN6/EAbqjO1jcYo/Ui6NFw+zMkyOBewO04KM7sOJLdCnlSyguXCa36Hbqao7rDN8aT8EVs/S27XVISwCw=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.7.5", "", { "os": "linux", "cpu": "x64" }, "sha512-0/yNCzSvfusk6zXcR7myyqoH8pcuh3tIV2pHl3B5lV7C8vrwMD+ZtYYonpSzxXHoEuQz6jleIIsj34hJnLIETQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@4.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-G4bAM5eTPT2BJiy2lmiau1FfXABkG9rqg9bb5bvfGBjARK4UUJ8XGi3kef1nY8ArpX5DwfUryn5y301D/zo+YA=="],
 
-    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.7.5", "", { "os": "linux", "cpu": "x64" }, "sha512-KBuk9x2ACQHd+AVcwuSKnLzlnye87Na34jL6Cb9zSnVmvyv13NQt9jItJdywavM0jMTlxOYrmfyKJhiBF/RiCQ=="],
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@4.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GddkV8WrM5VumTrUpuTSP+r/Zy6GzbHrMl4qWPEm7Yi/sD7VJqcdREJjp8Q0hDl2+u4Xw19PSPRgm/9Jom4m+w=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.7.5", "", { "os": "win32", "cpu": "x64" }, "sha512-KB1toCQYPZNt553scXDNkVZqJKRv6B1oB7OsO+anb8Ap7kEzNtZ8W86pCwRvttTVuTM94g3lMUG+BUQp/FDaRA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@4.8.0", "", { "os": "win32", "cpu": "x64" }, "sha512-TYKm5b93FKaHdJIYeDQqX3kqNGRyJVhsjEt14tU7y8QyO0LRNEN9dtZRH/fEM0g7qyDgx2l1B+sL7urzoWcXdw=="],
 
-    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.7.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+sLVU+gz/aIELLlENPVGrnu1ZccYUMlS2gQGEU0oJyNkwvgc9vq6cJu8gZdO5sNbbC1/fnG1v+bBks9iASqwLA=="],
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@4.8.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dMAmOAaB+VpnPWWYYdjxWaFNa4FF4ZRNsAH332iBxuJy8DSH1Jgmq6o6lQ5th5VvsAlRnOd5NwMT3oscGNL3Yw=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/cli/run/runnable-agent-resolver.test.ts
+++ b/src/cli/run/runnable-agent-resolver.test.ts
@@ -48,6 +48,23 @@ describe("resolveRunnableRunAgent", () => {
     expect(agent).toBe("Sisyphus - ultraworker")
   })
 
+  it("#given built-in agent has configured display name #when resolving config key #then returns configured server name", async () => {
+    // given
+    const client = createClient(["总指挥"])
+
+    // when
+    const agent = await resolveRunnableRunAgent(client, "sisyphus", {
+      agents: {
+        sisyphus: {
+          displayName: "总指挥",
+        },
+      },
+    })
+
+    // then
+    expect(agent).toBe("总指挥")
+  })
+
   it("#given agent list lookup fails with Error #when resolving runnable agent #then preserves pre-resolved run agent", async () => {
     // given
     const client = unsafeTestValue<RunAgentListClient>({

--- a/src/cli/run/runnable-agent-resolver.test.ts
+++ b/src/cli/run/runnable-agent-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, mock } from "bun:test"
+import { unsafeTestValue } from "../../../test-support/unsafe-test-value"
+import { resolveRunnableRunAgent, type RunAgentListClient } from "./runnable-agent-resolver"
+
+function createClient(agentNames: readonly string[]): RunAgentListClient {
+  return unsafeTestValue<RunAgentListClient>({
+    app: {
+      agents: mock(() =>
+        Promise.resolve({
+          data: agentNames.map((name) => ({ name })),
+        })
+      ),
+    },
+  })
+}
+
+describe("resolveRunnableRunAgent", () => {
+  it("#given server exposes Sisyphus by display name #when run agent is config key #then returns registered display name", async () => {
+    // given
+    const client = createClient(["Sisyphus - ultraworker", "general"])
+
+    // when
+    const agent = await resolveRunnableRunAgent(client, "sisyphus")
+
+    // then
+    expect(agent).toBe("Sisyphus - ultraworker")
+  })
+
+  it("#given requested custom agent exists exactly #when resolving runnable agent #then preserves custom name", async () => {
+    // given
+    const client = createClient(["custom-agent", "Sisyphus - ultraworker"])
+
+    // when
+    const agent = await resolveRunnableRunAgent(client, "custom-agent")
+
+    // then
+    expect(agent).toBe("custom-agent")
+  })
+
+  it("#given known display-name input #when resolving runnable agent #then returns server registered casing", async () => {
+    // given
+    const client = createClient(["Sisyphus - ultraworker"])
+
+    // when
+    const agent = await resolveRunnableRunAgent(client, "Sisyphus - Ultraworker")
+
+    // then
+    expect(agent).toBe("Sisyphus - ultraworker")
+  })
+
+  it("#given agent list lookup fails with Error #when resolving runnable agent #then preserves pre-resolved run agent", async () => {
+    // given
+    const client = unsafeTestValue<RunAgentListClient>({
+      app: {
+        agents: mock(() => Promise.reject(new Error("server unavailable"))),
+      },
+    })
+
+    // when
+    const agent = await resolveRunnableRunAgent(client, "sisyphus")
+
+    // then
+    expect(agent).toBe("sisyphus")
+  })
+})

--- a/src/cli/run/runnable-agent-resolver.ts
+++ b/src/cli/run/runnable-agent-resolver.ts
@@ -1,0 +1,37 @@
+import { normalizeSDKResponse } from "../../shared"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+
+interface AgentListItem {
+  readonly name?: string
+}
+
+export interface RunAgentListClient {
+  readonly app: {
+    readonly agents: () => Promise<unknown>
+  }
+}
+
+export async function resolveRunnableRunAgent(
+  client: RunAgentListClient,
+  resolvedAgent: string,
+): Promise<string> {
+  try {
+    const agentsRes = await client.app.agents()
+    const agents = normalizeSDKResponse(agentsRes, [] as readonly AgentListItem[], {
+      preferResponseOnMissingData: true,
+    })
+    const exactAgent = agents.find((agent) => agent.name === resolvedAgent)?.name
+    if (exactAgent) return exactAgent
+
+    const resolvedConfigKey = getAgentConfigKey(resolvedAgent)
+    return agents.find((agent) => {
+      if (!agent.name) return false
+      return getAgentConfigKey(agent.name) === resolvedConfigKey
+    })?.name ?? resolvedAgent
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+    return resolvedAgent
+  }
+}

--- a/src/cli/run/runnable-agent-resolver.ts
+++ b/src/cli/run/runnable-agent-resolver.ts
@@ -11,9 +11,14 @@ export interface RunAgentListClient {
   }
 }
 
+export interface RunAgentDisplayNameConfig {
+  readonly agents?: Readonly<Record<string, { readonly displayName?: string } | undefined>>
+}
+
 export async function resolveRunnableRunAgent(
   client: RunAgentListClient,
   resolvedAgent: string,
+  config: RunAgentDisplayNameConfig = {},
 ): Promise<string> {
   try {
     const agentsRes = await client.app.agents()
@@ -24,6 +29,13 @@ export async function resolveRunnableRunAgent(
     if (exactAgent) return exactAgent
 
     const resolvedConfigKey = getAgentConfigKey(resolvedAgent)
+    const configuredDisplayName = config.agents?.[resolvedConfigKey]?.displayName
+    const configuredAgent = agents.find((agent) => {
+      if (!agent.name || !configuredDisplayName) return false
+      return agent.name === configuredDisplayName
+    })?.name
+    if (configuredAgent) return configuredAgent
+
     return agents.find((agent) => {
       if (!agent.name) return false
       return getAgentConfigKey(agent.name) === resolvedConfigKey

--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -89,6 +89,17 @@ describe("resolveRunAgent", () => {
     // then
     expect(agent).toBe("sisyphus")
   })
+
+  it("#given unknown custom agent #when resolving run agent #then leaves the custom prompt agent untouched", () => {
+    // given
+    const config = createConfig()
+
+    // when
+    const agent = resolveRunAgent({ message: "test", agent: "custom-agent" }, config, {})
+
+    // then
+    expect(agent).toBe("custom-agent")
+  })
 })
 
 describe("waitForEventProcessorShutdown", () => {

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -94,7 +94,7 @@ export async function run(options: RunOptions): Promise<number> {
         sessionId: options.sessionId,
         directory,
       })
-      const runnableAgent = await resolveRunnableRunAgent(client, resolvedAgent)
+      const runnableAgent = await resolveRunnableRunAgent(client, resolvedAgent, pluginConfig)
 
       console.log(pc.dim(`Session: ${sessionID}`))
 

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -16,6 +16,7 @@ import { createTimestampedStdoutController } from "./timestamp-output"
 import { createCliPostHog, getPostHogDistinctId } from "../../shared/posthog"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
+import { resolveRunnableRunAgent } from "./runnable-agent-resolver"
 
 export { resolveRunAgent }
 
@@ -93,6 +94,7 @@ export async function run(options: RunOptions): Promise<number> {
         sessionId: options.sessionId,
         directory,
       })
+      const runnableAgent = await resolveRunnableRunAgent(client, resolvedAgent)
 
       console.log(pc.dim(`Session: ${sessionID}`))
 
@@ -124,7 +126,7 @@ export async function run(options: RunOptions): Promise<number> {
         input: {
           path: { id: sessionID },
           body: {
-            agent: resolvedAgent,
+            agent: runnableAgent,
             ...(resolvedModel ? { model: resolvedModel } : {}),
             tools: {
               question: false,


### PR DESCRIPTION
Fixes #4698.

## Summary

- Keep `resolveRunAgent` policy resolution as config-key aware, preserving disabled/config behavior.
- Before dispatching the `run` prompt, query the server's registered agents and translate config keys such as `sisyphus` to the runnable registered name such as `Sisyphus - ultraworker`.
- Honor configured built-in display-name overrides like `agents.sisyphus.displayName` before falling back to static built-in display-name matching.
- Preserve exact custom agent names and fall back to the pre-resolved agent when the server agent list is temporarily unavailable.
- Sync `bun.lock` platform optional dependency entries from `4.7.5` to `4.8.0` so `bun install --frozen-lockfile` passes on the current `dev` release base.

## Verification

- RED: `bun test src/cli/run/runnable-agent-resolver.test.ts src/cli/run/runner.test.ts` failed before implementation because `./runnable-agent-resolver` did not exist.
- GREEN: `bun test src/cli/run/runnable-agent-resolver.test.ts src/cli/run/runner.test.ts` -> 15 pass before review fix, 16 pass after configured display-name regression.
- `bun test src/cli/run` -> 191 pass before review fix, 192 pass after review fix.
- `bun run typecheck` -> pass.
- `bun run build` -> pass.
- `git diff --check` -> pass.
- `bun run build:lsp-tools-mcp` -> pass, to satisfy the full-suite Codex installer fixture prerequisite.
- `bun test src/cli/install-codex src/cli/install-codex.test.ts` -> 124 pass.
- `bun test` -> 8586 pass, 1 skip, 0 fail.
- `bun install --frozen-lockfile` -> failed before lock sync, passes after lock sync.
- Review-work gate: reviewer found a configured display-name override gap; fixed in `ce908a235`; reviewer re-check found no remaining blocking findings.

## Manual QA

Latest HEAD live smoke through the real `run` surface:

```bash
OPENCODE_CONFIG_DIR="$HOME/.config/opencode/profiles/today" \
CI=true \
OMO_DISABLE_POSTHOG=1 \
OMO_SEND_ANONYMOUS_TELEMETRY=0 \
bun src/cli/index.ts run --verbose --json \
  -d "$PWD" \
  -a Sisyphus \
  "Reply with exactly OMO_HEADLESS_START_OK and nothing else."
```

Evidence: transcript shows `message.updated` for `Sisyphus - ultraworker` user and assistant turns, no `Agent not found: "sisyphus"` failure, final JSON `success: true`, and summary `OMO_HEADLESS_START_OK`. QA tmux session and port listener were cleaned up afterward.
