### PR TITLE
fix(prompts): replace hardcoded tool commands with language-agnostic procedural detection

### DIFF
--- a/packages/omo-opencode/src/agents/atlas/prompt-byte-preservation.test.ts
+++ b/packages/omo-opencode/src/agents/atlas/prompt-byte-preservation.test.ts
@@ -59,32 +59,32 @@ const VARIANT_PROMPT_CASES = [
   {
     variant: "default",
     model: "anthropic/claude-sonnet-4-6",
-    expectedHash: "b29612f266994284487c37342c8e253f158b5d08daf95266e71651cbfcf1b9f9",
-    expectedLength: 25847,
+    expectedHash: "4b3d24c5542e3d8af0a0825caa56f047ce34e5abd6ced367f988f4d7e77fb94c",
+    expectedLength: 26141,
   },
   {
     variant: "gpt",
     model: "openai/gpt-5.5",
-    expectedHash: "187a6d5f63dd166c88b568e9c2e142205eb4d8537386e1c81a38707e4ac59efb",
-    expectedLength: 24707,
+    expectedHash: "089333c55e704d19a5a7ef1b8f29633f456c0871dce84dc7b6eb8062d8ea62ab",
+    expectedLength: 24795,
   },
   {
     variant: "gemini",
     model: "google/gemini-3.1-pro",
-    expectedHash: "194f4508da8c5a885a44a8d253cb6f6504190cf60d634cc42801a794bc4c8d33",
-    expectedLength: 27579,
+    expectedHash: "a67474b903e27eb9eddb5e5ec4303d94c255896854c9295d3149b6ed5b67aca5",
+    expectedLength: 27588,
   },
   {
     variant: "kimi",
     model: "moonshotai/kimi-k2.6",
-    expectedHash: "2d1d3e3fb665493e624f5d810a693e2df637346b3dab7800b9a689b6ed7932bf",
-    expectedLength: 26107,
+    expectedHash: "c8e5d343965d3a0af5df0bdaf3393bd24223ff89f77c910c38649656e2c2db1e",
+    expectedLength: 26352,
   },
   {
     variant: "opus-4-7",
     model: "anthropic/claude-opus-4-7",
-    expectedHash: "353bd5d9ceaeb2b4eb53cb851d65d206a777643c6542505ab32e0bd1993c3de2",
-    expectedLength: 26729,
+    expectedHash: "ffefdcb2ddf1b6031518b66a2e3099befd6ff29a5f72fde71284bbea7acbc945",
+    expectedLength: 26974,
   },
 ] satisfies readonly VariantPromptCase[]
 

--- a/packages/omo-opencode/src/agents/prometheus/prometheus-byte-exactness.test.ts
+++ b/packages/omo-opencode/src/agents/prometheus/prometheus-byte-exactness.test.ts
@@ -17,14 +17,14 @@ const PROMETHEUS_PROMPT_BASELINES: readonly PrometheusPromptBaseline[] = [
     name: "default-enabled",
     model: undefined,
     disabledTools: [],
-    sha256: "c1c68ab2121e1e77aca291657aafca0bc88cad006abe64c3c5ef0a8c3595ee07",
+    sha256: "1061d8805e5832a43de2f94a601b47e3bb05b1462f4a1abef4998d925db9b4c5",
     shouldContainQuestionTool: true,
   },
   {
     name: "default-question-disabled",
     model: undefined,
     disabledTools: ["question"],
-    sha256: "72e95540669b48007e39973b99843fb8630ae701b68ac98b6d56ab0b14e3884a",
+    sha256: "66bf7ec9829997908ed73d089ddec74ea66202d07b565c9b2e6bf3d336c1a5cb",
     shouldContainQuestionTool: false,
   },
   {

--- a/packages/omo-opencode/src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts
@@ -19,14 +19,14 @@ const ULTRAWORK_PROMPT_BASELINES: readonly UltraworkPromptBaseline[] = [
     agentName: "sisyphus",
     modelID: "claude-sonnet-4-6",
     expectedSource: "default",
-    sha256: "4485ef94d3b4b0835b20e42f2874e12b886a0dbed7256c0a2ce37d5e35aa6692",
+    sha256: "3c8ad63bff52e04a2e3d60f1250843be0f3f1693f8ee925b882e180247c40fec",
   },
   {
     name: "gpt",
     agentName: "sisyphus",
     modelID: "gpt-5.5",
     expectedSource: "gpt",
-    sha256: "c3a2e5892fc537c560459062ca982930d0ceb98652a76c8c447cad86e882c3b7",
+    sha256: "eaee5b959a225ca477ad2526b7eb0d8966110880db205130c6b64dafc97bc833",
   },
   {
     name: "gemini",

--- a/packages/prompts-core/prompts/atlas/default.md
+++ b/packages/prompts-core/prompts/atlas/default.md
@@ -280,9 +280,9 @@ For a parallel batch, fire ALL of these in ONE response.
 After EVERY delegation, complete ALL of these steps - no shortcuts:
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors across scanned TypeScript files (directory scans are capped at 50 files; not a full-project guarantee)
-2. `bun run build` or `bun run typecheck` → exit code 0
-3. `bun test` → ALL tests pass
+1. `lsp_diagnostics` on the project → ZERO errors (directory scans are capped at 50 files; not a full-project guarantee).
+2. Build command from the plan's "Success Criteria" section → exit code 0. If the plan does not specify one, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" section → ALL tests pass. If the plan does not specify one, examine the project root for build configuration files and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review (NON-NEGOTIABLE)
 
@@ -439,7 +439,7 @@ You read every changed file because static checks miss logic bugs. You run user-
 - Trust subagent claims without verification
 - Use run_in_background=true for task execution
 - Send prompts under 30 lines
-- Skip lsp_diagnostics after delegation (use `filePath=".", extension=".ts"` for TypeScript projects; directory scans are capped at 50 files)
+- Skip lsp_diagnostics after delegation (use `filePath="."` to scan the project directory; directory scans are capped at 50 files)
 - Batch multiple tasks in one delegation
 - Start fresh session for failures/follow-ups - use `task_id` instead
 - Default to sequential when tasks have no named dependency

--- a/packages/prompts-core/prompts/atlas/gemini.md
+++ b/packages/prompts-core/prompts/atlas/gemini.md
@@ -312,7 +312,7 @@ Do NOT run tests yet. Read the code FIRST so you know what you're testing.
    - Does this code ACTUALLY do what the task required? (Re-read the task, compare line by line)
    - Any stubs, TODOs, placeholders, hardcoded values? (`Grep` for TODO, FIXME, HACK, xxx)
    - Logic errors? Trace the happy path AND the error path in your head.
-   - Anti-patterns? (`Grep` for `as any`, `@ts-ignore`, empty catch, console.log in changed files)
+   - Anti-patterns? (`Grep` for suppressed type/lint checks, empty catch, console.log, debug logging in changed files)
    - Scope creep? Did the subagent touch things or add features NOT in the task spec?
 4. Cross-check every claim:
    - Said "Updated X" → READ X. Actually updated, or just superficially touched?
@@ -464,7 +464,7 @@ Subagents CLAIM "done" when:
 - Trust subagent claims without verification
 - Use run_in_background=true for task execution
 - Send prompts under 30 lines
-- Skip scanned-file lsp_diagnostics (use 'filePath=".", extension=".ts"' for TypeScript projects; directory scans are capped at 50 files)
+- Skip scanned-file lsp_diagnostics (use `filePath="."` to scan the project directory; directory scans are capped at 50 files)
 - Batch multiple tasks in one delegation
 - Start fresh session for failures (use `task_id` to resume)
 

--- a/packages/prompts-core/prompts/atlas/gpt.md
+++ b/packages/prompts-core/prompts/atlas/gpt.md
@@ -282,9 +282,9 @@ If you cannot explain every changed line, you have NOT reviewed it.
 #### PHASE 2: AUTOMATED VERIFICATION
 
 1. `lsp_diagnostics` per changed file → ZERO new errors
-2. Targeted tests (`bun test src/changed-module`) → pass
-3. Full suite (`bun test`) → pass
-4. Build/typecheck → exit 0
+2. Targeted tests (from the plan's "Success Criteria", scoped to changed modules) → pass
+3. Full test suite (from the plan's "Success Criteria") → pass
+4. Build (from the plan's "Success Criteria") → exit 0
 
 If Phase 1 found issues but Phase 2 passes: Phase 2 is incomplete. Fix the code.
 

--- a/packages/prompts-core/prompts/atlas/kimi.md
+++ b/packages/prompts-core/prompts/atlas/kimi.md
@@ -289,9 +289,9 @@ task(category="...", load_skills=[...], run_in_background=false, prompt="[6-SECT
 You are the QA gate. Subagents lie. Run the 4 phases below in order. Stop at the first failing phase, fix, resume.
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors
-2. `bun run build` or `bun run typecheck` → exit 0
-3. `bun test` → ALL pass
+1. `lsp_diagnostics` on the project → ZERO errors.
+2. Build command from the plan's "Success Criteria" → exit 0. If absent, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" → ALL pass. If absent, examine the project root and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review
 

--- a/packages/prompts-core/prompts/atlas/opus-4-7.md
+++ b/packages/prompts-core/prompts/atlas/opus-4-7.md
@@ -284,9 +284,9 @@ A batch of 5 independent tasks = 5 `task()` calls in ONE response. No exceptions
 You are the QA gate. Subagents lie. Run the FULL protocol on EACH completed task — not just the first one in the batch.
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors
-2. `bun run build` or `bun run typecheck` → exit 0
-3. `bun test` → ALL pass
+1. `lsp_diagnostics` on the project → ZERO errors.
+2. Build command from the plan's "Success Criteria" → exit 0. If absent, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" → ALL pass. If absent, examine the project root and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review (NON-NEGOTIABLE)
 

--- a/packages/prompts-core/prompts/prometheus/default.md
+++ b/packages/prompts-core/prompts/prometheus/default.md
@@ -1455,7 +1455,7 @@ Max Concurrent: 7 (Waves 1 & 2)
   Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
 
 - [ ] F2. **Code Quality Review** — `unspecified-high`
-  Run `tsc --noEmit` + linter + `bun test`. Review all changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code, unused imports. Check AI slop: excessive comments, over-abstraction, generic names (data/result/item/temp).
+  Run the build, lint, and test commands from the plan's "Success Criteria" section. If absent, examine the project root for build configuration files and run the standard commands for that ecosystem. Review all changed files for: type suppression, empty catches, debug logging in prod, commented-out code, unused imports. Check AI slop: excessive comments, over-abstraction, generic names (data/result/item/temp).
   Output: `Build [PASS/FAIL] | Lint [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
 
 - [ ] F3. **Real Manual QA** — `unspecified-high` (+ `playwright` skill if UI)

--- a/packages/prompts-core/prompts/ultrawork/default.md
+++ b/packages/prompts-core/prompts/ultrawork/default.md
@@ -156,7 +156,7 @@ task(task_id="ses_abc123", load_skills=[], run_in_background=false, prompt="Here
 task(category="visual-engineering", load_skills=["frontend-ui-ux"], run_in_background=true)
 
 // Complex logic
-task(category="ultrabrain", load_skills=["typescript-programmer"], run_in_background=true)
+task(category="ultrabrain", load_skills=[...], run_in_background=true)
 
 // Quick fixes
 task(category="quick", load_skills=["git-master"], run_in_background=true)
@@ -173,7 +173,7 @@ task(category="quick", load_skills=["git-master"], run_in_background=true)
 
 ## EXECUTION RULES
 - **TODO format**: `path: <action> for <scenario-id> — verify by <check>` encoding WHERE / WHY (which scenario it advances) / HOW / VERIFY. Exactly ONE in_progress at a time. Mark completed IMMEDIATELY — never batch.
-  - GOOD pair (test-first, ordered): `foo.test.ts: Write FAILING case invalid-email→ValidationError for S2 — verify by RED with assertion msg` → `src/foo/bar.ts: Implement validateEmail() for S2 — verify by foo.test.ts GREEN + curl 400 body`
+  - GOOD pair (test-first, ordered): `module.test: Write FAILING case invalid-email→ValidationError for S2 — verify by RED with assertion msg` → `src/module: Implement validateEmail() for S2 — verify by module.test GREEN + curl 400 body`
   - BAD: "Implement feature" / "Fix bug" / "Add tests later" / production code before its failing test → rewrite.
 - **PARALLEL**: Fire independent agent calls simultaneously via task(run_in_background=true) — NEVER wait sequentially. But NEVER parallelise RED and GREEN of the same scenario.
 - **BACKGROUND FIRST**: Use task for exploration/research agents (10+ concurrent if needed).

--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -88,7 +88,7 @@ task(subagent_type="librarian", load_skills=[], prompt="I'm working with [TECHNO
 
 // WHILE THEY RUN - use direct tools for immediate context
 grep(pattern="relevant_pattern", path="src/")
-read_file(filePath="known/important/file.ts")
+read_file(filePath="known/important/file")
 
 // Collect background results when ready
 deep_context = background_output(task_id=...)


### PR DESCRIPTION
## Problem

Atlas and Prometheus agent prompts hardcoded JavaScript/TypeScript tooling (`bun test`, `bun run build`, `tsc --noEmit`, `extension=".ts"`, `as any`/`@ts-ignore`, `typescript-programmer` skill), causing verification to silently fail on non-JS/TS projects (Go, Python, Rust, etc.).

## Fix

Remove ALL tool names and language anchors from verification instructions. Replace them with a procedural approach:

1. Read the plan's "Success Criteria" for the exact build/test/lint commands
2. If absent, examine the project root for build configuration files and run the standard commands for that ecosystem

The replacement text contains **zero tool names** — not as positive instructions, not as negative anchors.

## Changes (8 files, +19/-19)

| File | Change |
|------|--------|
| `atlas/default.md` | `bun test`/`bun run build`/`extension=".ts"` → procedural instructions |
| `atlas/kimi.md` | Same |
| `atlas/opus-4-7.md` | Same |
| `atlas/gpt.md` | Same |
| `atlas/gemini.md` | `as any`/`@ts-ignore` → `suppressed type/lint checks`; `.ts` → generic |
| `prometheus/default.md` | `tsc --noEmit + bun test` → procedural instructions |
| `ultrawork/default.md` | `typescript-programmer` → `[...]`; `.test.ts` → `.test` |
| `ultrawork/gpt.md` | `file.ts` → `file` |

## Related

- Closes #5074
- Related: #1038 (TypeScript-specific token waste)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded JS/TS verification commands with language-agnostic, procedural checks driven by the plan’s “Success Criteria” or project config to prevent silent failures on non-JS projects. Updated prompts and byte-exactness tests to reflect the changes.

- **Bug Fixes**
  - Procedural verification: use build/test/lint from the plan; if absent, detect standard commands from project root config.
  - Generalize `lsp_diagnostics` to project-level scans; remove `extension=".ts"`.
  - Remove language-specific anchors across Atlas/Prometheus/Ultrawork prompts; update anti-pattern wording to “suppressed type/lint checks”.
  - Refresh byte-exactness baselines in tests: `src/agents/atlas/prompt-byte-preservation.test.ts`, `src/agents/prometheus/prometheus-byte-exactness.test.ts`, `src/hooks/keyword-detector/ultrawork/ultrawork-byte-exactness.test.ts`.

<sup>Written for commit 9c388b43315ea30a7b7b66cf7c414864339fa30a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

