### PR TITLE
fix(model-core): recognize claude-opus-4-8 as GA 1M-context model (fixes #5070)

### DIFF
--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -51,6 +51,28 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(1_000_000)
   })
 
+  it("returns GA 1M for Anthropic claude-opus-4-8 without explicit 1M mode", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4-8", {
+      anthropicContext1MEnabled: false,
+    })
+
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for Anthropic claude-opus-4-8-high without explicit 1M mode", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4-8-high", {
+      anthropicContext1MEnabled: false,
+    })
+
+    expect(actualLimit).toBe(1_000_000)
+  })
+
   it("returns GA 1M for Antigravity Claude models served by google", () => {
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -25,7 +25,7 @@ function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState):
 }
 
 function hasGA1MContext(modelID: string): boolean {
-  return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7)(?:-high)?$/.test(modelID)
+  return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7|8)(?:-high)?$/.test(modelID)
 }
 
 export function resolveActualContextLimit(


### PR DESCRIPTION
## Summary
`hasGA1MContext()` in `packages/model-core/src/context-limit-resolver.ts` gated 1M-context detection on a regex matching only Opus/Sonnet `4-6` and `4-7`, so `claude-opus-4-8` was treated as a 200K model. This extends the version alternation to include `8`.

## Root Cause
`context-limit-resolver.ts:28` had:

```ts
return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7)(?:-high)?$/.test(modelID)
```

`claude-opus-4-8` did not match, so `resolveActualContextLimit()` skipped the `ANTHROPIC_GA_1M_LIMIT` branch and returned `DEFAULT_ANTHROPIC_ACTUAL_LIMIT` (200000) unless `ANTHROPIC_1M_CONTEXT=true` was set (which forces 1M onto every Anthropic model, including 200K-only ones). This is the same class of gap previously closed by the `4-6` -> `4-7` bump in #3486.

## Changes
| File | Change |
|------|--------|
| `packages/model-core/src/context-limit-resolver.ts` | Add `8` to the version alternation: `(?:6\|7)` -> `(?:6\|7\|8)` |
| `packages/model-core/src/context-limit-resolver.test.ts` | Add regression tests for `claude-opus-4-8` and `claude-opus-4-8-high` returning the 1M GA limit |

## Reproduction (before fix)
```
(fail) resolveActualContextLimit > returns GA 1M for Anthropic claude-opus-4-8 without explicit 1M mode
error: expect(received).toBe(expected)
Expected: 1000000
Received: 200000
```

## Verification (after fix)
```
9 pass
0 fail
Ran 9 tests across 1 file.
```

## Test
- Regression tests: `packages/model-core/src/context-limit-resolver.test.ts` (newly added, 2 cases)
- Related suite: `bun test packages/model-core/` - 265 pass, 0 fail
- Typecheck: `bunx tsgo --noEmit -p packages/model-core/tsconfig.json` - clean (exit 0)

## Note
The minimal additive regex bump matches the accepted pattern from #3486. The broader metadata-driven approach tracked in #2922 would eventually supersede this gate, but `claude-opus-4-8` needs 1M recognition now.

Fixes #5070

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognize `claude-opus-4-8` and `claude-opus-4-8-high` as GA 1M-context models to prevent fallback to the 200K limit. Fixes #5070.

- **Bug Fixes**
  - Expanded regex in `packages/model-core/src/context-limit-resolver.ts` to include `4-8` for `claude-(opus|sonnet)` variants.
  - Added tests for `claude-opus-4-8` and `claude-opus-4-8-high` asserting the 1M limit.

<sup>Written for commit be949458764dc1eab0b20b7116aeb9fb90d184dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

