### PR TITLE
fix(sisyphus): route claude-opus-4-8 to the Opus 4.7+ tuned prompt

### DIFF
--- a/src/agents/sisyphus-agent-factory.test.ts
+++ b/src/agents/sisyphus-agent-factory.test.ts
@@ -50,6 +50,10 @@ describe("createSisyphusAgent", () => {
           model: "anthropic/claude-opus-4-7",
           promptAnchors: ["<use_parallel_tool_calls>", "<Task_Management>"],
         },
+        {
+          model: "anthropic/claude-opus-4-8",
+          promptAnchors: ["<use_parallel_tool_calls>", "<Task_Management>"],
+        },
       ];
 
       for (const { model, promptAnchors } of cases) {
@@ -85,10 +89,12 @@ describe("createSisyphusAgent", () => {
     test("#when creating agents #then preserves current thinking config split", () => {
       // given
       const opus47Agent = createSisyphusAgent("anthropic/claude-opus-4-7");
+      const opus48Agent = createSisyphusAgent("anthropic/claude-opus-4-8");
       const sonnetAgent = createSisyphusAgent("anthropic/claude-sonnet-4-6");
 
       // then
       expect(opus47Agent.thinking).toBeUndefined();
+      expect(opus48Agent.thinking).toBeUndefined();
       expect(sonnetAgent.thinking).toEqual({
         type: "enabled",
         budgetTokens: 32000,

--- a/src/agents/sisyphus-agent-factory.ts
+++ b/src/agents/sisyphus-agent-factory.ts
@@ -16,7 +16,7 @@ import { buildGpt55SisyphusPrompt } from "./sisyphus/gpt-5-5";
 import { buildKimiK26SisyphusPrompt } from "./sisyphus/kimi-k2-6";
 import type { AgentMode } from "./types";
 import {
-  isClaudeOpus47Model,
+  isClaudeOpus47OrLaterModel,
   isGpt5_5Model,
   isGptModel,
   isGptNativeSisyphusModel,
@@ -62,7 +62,7 @@ export function createSisyphusAgent(
     );
   }
 
-  if (isClaudeOpus47Model(model)) {
+  if (isClaudeOpus47OrLaterModel(model)) {
     return buildClaudeSisyphusAgentConfig(
       MODE,
       model,


### PR DESCRIPTION
## Summary

- Fixes Sisyphus prompt routing for `claude-opus-4-8`: today 4.8 users silently fall through to the generic fallback prompt because the factory routes via the literal `isClaudeOpus47Model` check.
- Switches the call site to the existing `isClaudeOpus47OrLaterModel` detector, which already classifies 4.8 as 4.7+ (and is used the same way by `buildClaudeThinkingConfig`).
- Deliberately narrow scope: no default-model change, no migrations, no doc churn, no generated capabilities rebuild.

## Changes

- [`src/agents/sisyphus-agent-factory.ts`](./src/agents/sisyphus-agent-factory.ts): swap the routing predicate from `isClaudeOpus47Model` to `isClaudeOpus47OrLaterModel` (and update the import).
- [`src/agents/sisyphus-agent-factory.test.ts`](./src/agents/sisyphus-agent-factory.test.ts): add `anthropic/claude-opus-4-8` to the routed-prompt anchor test and to the Claude-family thinking-config test.

### Why this is a bug

`packages/model-core/src/model-family-detectors.ts` exposes two detectors:

```ts
export function isClaudeOpus47Model(model: string): boolean {
  // literal includes-check; only matches claude-opus-4-7
}

export function isClaudeOpus47OrLaterModel(model: string): boolean {
  // regex: major > 4 || (major === 4 && minor >= 7); matches 4-7, 4-8, 5-0, ...
}
```

`sisyphus-agent-factory.ts` was using the literal one to decide whether to apply the model-tuned `buildClaudeOpus47SisyphusPrompt`. Result: a user on `claude-opus-4-8` gets `buildFallbackSisyphusPrompt` (generic) instead of the tuned prompt, even though `buildClaudeThinkingConfig` in `src/agents/types.ts` already treats 4.8 the same as 4.7 via `isClaudeOpus47OrLaterModel` (intentionally, per #4614).

This is silent prompt-quality degradation for any 4.8 user. The fix uses the detector that was already written for exactly this intent.

### Why scope is narrow

- The function name `isClaudeOpus47Model` would become misleading if it also matched 4.8, and other callers (e.g. `packages/prompts-core/src/variant-resolver.ts` which uses it as the matcher for the `"opus-4-7"` variant key) may want strict-4.7 semantics. Not touched.
- This PR does not change any user-visible default model. The broader question of promoting `claude-opus-4-8` to canonical default (with migrations, docs, regenerated capabilities, ~70 test rebaselines, etc., following the #3486 pattern) is tracked separately in #5084 and needs a maintainer call on whether 4.8 should reuse the current 4.7-tuned prompt file or get its own variant.

## Screenshots

N/A - this is an internal routing fix with no UI surface.

## Testing

```bash
bun run typecheck                                                    # clean
bun test src/agents/sisyphus-agent-factory.test.ts \
         packages/model-core/src/model-family-detectors.test.ts      # 12 pass, 0 fail
bun test src/agents/ packages/model-core/                            # 685 pass, 0 fail
```

The full `bun test` suite is also green for everything touched by this change. The 29 failures observed in the full run are pre-existing on `dev` and unrelated (verified by stashing this PR's changes and rerunning `src/cli/install-codex/` to reproduce 12 of them on a clean tree; the rest cluster in `src/cli/doctor/spawn-with-timeout.test.ts` which passes in isolation, indicating a known test-isolation issue rather than a regression introduced here).

## Related Issues

Related: #5084 (feature request to promote `claude-opus-4-8` to canonical default; this PR is the surgical first step that delivers user value without pre-empting the maintainer's call on prompt-tuning).

Adjacent (no line overlap, no merge conflict):

- #5070 / PR #5080 (1M-context regex fix for 4.8)
- #4614 (CLOSED) / PR #4616 (MERGED) (adaptive thinking for Opus 4.7+)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `anthropic/claude-opus-4-8` to the Opus 4.7+ tuned Sisyphus prompt instead of the generic fallback, fixing degraded prompt quality for 4.8 users. Scope is limited to routing and tests.

- **Bug Fixes**
  - Switch routing check from `isClaudeOpus47Model` to `isClaudeOpus47OrLaterModel` in `src/agents/sisyphus-agent-factory.ts`.
  - Update `src/agents/sisyphus-agent-factory.test.ts` to cover `anthropic/claude-opus-4-8` prompt anchors and confirm thinking config behavior.

<sup>Written for commit cee84a7873909ad1bf3e94c02adf4d78d8fcaf19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

