### PR TITLE
feat(meta-governor): define 5 type contracts (PR 1 of 8)

### DIFF
--- a/src/features/meta-governor/index.ts
+++ b/src/features/meta-governor/index.ts
@@ -1,0 +1,1 @@
+export * from "./types"

--- a/src/features/meta-governor/types.test.ts
+++ b/src/features/meta-governor/types.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AgentMemoryRead,
+  AmbientContext,
+  BoulderStateRead,
+  Decision,
+  DecisionContext,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceSource,
+  MagicContextRead,
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+  SlotMemory,
+  TokenPrediction,
+  TokenRecommendation,
+} from "./types"
+
+describe("meta-governor types", () => {
+  describe("DecisionContext", () => {
+    test("S1: accepts fully populated context with oracle verified + no progress + deviations + 80% iterations + 2 lessons", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: true,
+        noProgress: false,
+        deviations: [
+          { severity: "leve", category: "lint", detail: "minor style" },
+          { severity: "grave", category: "config-change", detail: "touched config.ts" },
+        ],
+        iterationRatio: 0.8,
+        lessonsRelevant: [
+          { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          { id: "L2", title: "continue when oracle verified", advice: "continue", confidence: 0.6, concepts: ["oracle-verified"] },
+        ],
+        slotMemory: {
+          lastDecision: {
+            action: "continue",
+            score: 0.4,
+            reasoning: "ok",
+            evidence: [],
+            shouldEscalateTo: null,
+          },
+          consecutiveStops: 0,
+          consecutiveContinues: 2,
+          lastUpdatedISO: "2026-06-09T12:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_test",
+          directory: "/tmp/test",
+          mode: "ultrawork",
+          agentName: "sisyphus",
+          iteration: 8,
+          maxIterations: 10,
+        },
+      }
+
+      // when
+      const isPopulated =
+        ctx.oracleVerified === true &&
+        ctx.iterationRatio === 0.8 &&
+        ctx.deviations.length === 2 &&
+        ctx.lessonsRelevant.length === 2 &&
+        ctx.ambient.iteration === 8
+
+      // then
+      expect(isPopulated).toBe(true)
+    })
+
+    test("S1b: empty arrays are valid (signals, not bugs)", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: false,
+        noProgress: true,
+        deviations: [],
+        iterationRatio: 0.0,
+        lessonsRelevant: [],
+        slotMemory: {
+          consecutiveStops: 0,
+          consecutiveContinues: 0,
+          lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_empty",
+          directory: "/tmp/empty",
+          mode: "simple",
+          agentName: "build",
+          iteration: 1,
+          maxIterations: 50,
+        },
+      }
+
+      // when
+      const hasEmptySignals = ctx.deviations.length === 0 && ctx.lessonsRelevant.length === 0
+
+      // then
+      expect(hasEmptySignals).toBe(true)
+    })
+  })
+
+  describe("Decision", () => {
+    test("S2: carries all required fields and supports every action variant", () => {
+      // given
+      const decisions: Decision[] = [
+        {
+          action: "continue",
+          score: 0.5,
+          reasoning: "all clear",
+          evidence: [],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "warn",
+          score: -0.4,
+          reasoning: "deviation grave",
+          evidence: [
+            { source: "deviation-detector", value: "config-change", confidence: 0.9, weight: 0.5 },
+          ],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "escalate",
+          score: -0.7,
+          reasoning: "needs oracle verification",
+          evidence: [
+            { source: "oracle-verified", value: "false", confidence: 1.0, weight: 0.4 },
+          ],
+          shouldEscalateTo: "oracle",
+        },
+        {
+          action: "stop",
+          score: -0.9,
+          reasoning: "no progress 3 turns",
+          evidence: [
+            { source: "no-progress-detector", value: "true", confidence: 0.95, weight: 0.6 },
+          ],
+          shouldEscalateTo: null,
+        },
+      ]
+
+      // when
+      const allValid = decisions.every(
+        (d) =>
+          typeof d.score === "number" &&
+          d.score >= -1 &&
+          d.score <= 1 &&
+          d.reasoning.length > 0 &&
+          Array.isArray(d.evidence),
+      )
+      const actions = new Set(decisions.map((d) => d.action))
+
+      // then
+      expect(allValid).toBe(true)
+      expect(actions.size).toBe(4)
+      expect(actions.has("continue")).toBe(true)
+      expect(actions.has("warn")).toBe(true)
+      expect(actions.has("escalate")).toBe(true)
+      expect(actions.has("stop")).toBe(true)
+    })
+
+    test("S2b: when action is escalate, shouldEscalateTo must be oracle or user (not null)", () => {
+      // given
+      const targets: EscalationTarget[] = ["oracle", "user"]
+
+      // when
+      const isStrictSubset = targets.every((t) => t === "oracle" || t === "user")
+
+      // then
+      expect(isStrictSubset).toBe(true)
+    })
+  })
+
+  describe("Evidence", () => {
+    test("S3: shape has source, value, confidence, weight all required", () => {
+      // given
+      const sources: EvidenceSource[] = [
+        "oracle-verified",
+        "no-progress-detector",
+        "deviation-detector",
+        "iteration-budget",
+        "lesson-recall",
+        "slot-memory",
+        "ambient",
+        "token-predictor",
+      ]
+      const sample: Evidence = {
+        source: "oracle-verified",
+        value: "true",
+        confidence: 0.95,
+        weight: 0.4,
+      }
+
+      // when
+      const hasAllFields =
+        typeof sample.source === "string" &&
+        typeof sample.value === "string" &&
+        sample.confidence >= 0 &&
+        sample.confidence <= 1 &&
+        sample.weight >= 0 &&
+        sample.weight <= 1
+
+      // then
+      expect(hasAllFields).toBe(true)
+      expect(sources.length).toBe(8)
+    })
+  })
+
+  describe("MemoryRead", () => {
+    test("S4: aggregates agentmemory + magicContext + boulderState, marks degraded sources", () => {
+      // given
+      const read: MemoryRead = {
+        query: "ralph-loop continue after config-change",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        agentmemory: {
+          available: true,
+          lessons: [
+            { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          ],
+        },
+        magicContext: {
+          available: true,
+          slots: [{ label: "meta_state", content: "{}" }],
+        },
+        boulderState: {
+          available: false,
+          tasks: [],
+          planProgress: 0,
+          errorMessage: "no .omo/boulder.json",
+        },
+        degradedSources: ["boulderState"],
+      }
+
+      // when
+      const oneDegraded = read.degradedSources.length === 1
+      const agentmemoryOk = read.agentmemory.available === true
+      const boulderDown = read.boulderState.available === false
+
+      // then
+      expect(oneDegraded).toBe(true)
+      expect(agentmemoryOk).toBe(true)
+      expect(boulderDown).toBe(true)
+      expect(read.degradedSources[0]).toBe<MemorySource>("boulderState")
+    })
+  })
+
+  describe("TokenPrediction", () => {
+    test("S5: has currentUsage, burnRate, budgetLeft, willOverflowAt, recommendation, confidence", () => {
+      // given
+      const predictions: TokenPrediction[] = [
+        {
+          currentUsage: 50_000,
+          burnRate: 200,
+          budgetLeft: 150_000,
+          willOverflowAt: null,
+          recommendation: "no-action",
+          confidence: 0.95,
+          modelLimit: 200_000,
+          windowRemaining: 150_000,
+        },
+        {
+          currentUsage: 180_000,
+          burnRate: 5_000,
+          budgetLeft: 20_000,
+          willOverflowAt: "2026-06-09T12:05:00.000Z",
+          recommendation: "compact-now",
+          confidence: 0.85,
+          modelLimit: 200_000,
+          windowRemaining: 20_000,
+        },
+        {
+          currentUsage: 90_000,
+          burnRate: 3_000,
+          budgetLeft: 110_000,
+          willOverflowAt: "2026-06-09T12:30:00.000Z",
+          recommendation: "switch-model",
+          confidence: 0.7,
+          modelLimit: 200_000,
+          windowRemaining: 110_000,
+        },
+        {
+          currentUsage: 120_000,
+          burnRate: 2_000,
+          budgetLeft: 80_000,
+          willOverflowAt: "2026-06-09T12:40:00.000Z",
+          recommendation: "delegate-to-subagent",
+          confidence: 0.65,
+          modelLimit: 200_000,
+          windowRemaining: 80_000,
+        },
+      ]
+      const recommendations: TokenRecommendation[] = [
+        "compact-now",
+        "switch-model",
+        "delegate-to-subagent",
+        "no-action",
+      ]
+
+      // when
+      const allHaveFields = predictions.every(
+        (p) =>
+          typeof p.currentUsage === "number" &&
+          typeof p.burnRate === "number" &&
+          typeof p.budgetLeft === "number" &&
+          (p.willOverflowAt === null || typeof p.willOverflowAt === "string") &&
+          p.confidence >= 0 &&
+          p.confidence <= 1,
+      )
+      const allRecommendations = new Set(predictions.map((p) => p.recommendation))
+
+      // then
+      expect(allHaveFields).toBe(true)
+      expect(allRecommendations.size).toBe(4)
+      for (const r of recommendations) {
+        expect(allRecommendations.has(r)).toBe(true)
+      }
+    })
+
+    test("S5b: willOverflowAt is null when recommendation is no-action", () => {
+      // given
+      const p: TokenPrediction = {
+        currentUsage: 1_000,
+        burnRate: 0,
+        budgetLeft: 199_000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.99,
+        modelLimit: 200_000,
+        windowRemaining: 199_000,
+      }
+
+      // then
+      expect(p.willOverflowAt).toBeNull()
+      expect(p.recommendation).toBe("no-action")
+    })
+  })
+
+  describe("auxiliary types", () => {
+    test("SlotMemory consecutive counters default to 0 and are read by judge for paralysis detection", () => {
+      // given
+      const slot: SlotMemory = {
+        consecutiveStops: 3,
+        consecutiveContinues: 0,
+        lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+      }
+
+      // when
+      const isParalyzed = slot.consecutiveStops >= 3
+
+      // then
+      expect(isParalyzed).toBe(true)
+    })
+
+    test("AmbientContext carries mode for judge to factor in (ultrawork stricter than simple)", () => {
+      // given
+      const modes: AmbientContext["mode"][] = ["ultrawork", "ulw", "simple", "ralph-loop"]
+
+      // when
+      const allListed = modes.every((m) =>
+        ["ultrawork", "ulw", "simple", "ralph-loop"].includes(m),
+      )
+
+      // then
+      expect(allListed).toBe(true)
+    })
+
+    test("Deviation severity uses the 3-level taxonomy (leve/media/grave) from prior moderator-gate", () => {
+      // given
+      const deviations: Deviation[] = [
+        { severity: "leve", category: "lint", detail: "minor" },
+        { severity: "media", category: "refactor-scope", detail: "broader than expected" },
+        { severity: "grave", category: "config-change", detail: "touched config.ts" },
+      ]
+
+      // when
+      const severities = new Set(deviations.map((d) => d.severity))
+
+      // then
+      expect(severities.size).toBe(3)
+      expect(severities.has("grave")).toBe(true)
+    })
+
+    test("RelevantLesson carries id, title, advice, confidence, concepts for preflight matching", () => {
+      // given
+      const lesson: RelevantLesson = {
+        id: "L42",
+        title: "fix X for error Y",
+        advice: "warn",
+        confidence: 0.6,
+        concepts: ["tool_timeout", "bash", "retry"],
+      }
+
+      // when
+      const matchesBash = lesson.concepts.includes("bash")
+
+      // then
+      expect(matchesBash).toBe(true)
+      expect(lesson.advice).toBe("warn")
+    })
+
+    test("AgentMemoryRead and MagicContextRead report available=false with errorMessage when degraded", () => {
+      // given
+      const am: AgentMemoryRead = {
+        available: false,
+        lessons: [],
+        errorMessage: "agentmemory MCP not connected",
+      }
+      const mc: MagicContextRead = {
+        available: false,
+        slots: [],
+        errorMessage: "magic-context slot not initialised",
+      }
+
+      // then
+      expect(am.available).toBe(false)
+      expect(am.errorMessage).toBeTruthy()
+      expect(mc.available).toBe(false)
+      expect(mc.errorMessage).toBeTruthy()
+    })
+
+    test("BoulderStateRead reports planProgress in 0..1", () => {
+      // given
+      const bs: BoulderStateRead = {
+        available: true,
+        tasks: [{ id: "T1", status: "done", title: "fix bug" }],
+        planProgress: 0.5,
+      }
+
+      // when
+      const inRange = bs.planProgress >= 0 && bs.planProgress <= 1
+
+      // then
+      expect(inRange).toBe(true)
+    })
+  })
+})

--- a/src/features/meta-governor/types.ts
+++ b/src/features/meta-governor/types.ts
@@ -1,0 +1,212 @@
+/**
+ * MetaGovernor type contracts.
+ *
+ * PR 1 of 8. Defines ONLY the type surface that later PRs implement against.
+ * No logic, no I/O, no MCP calls. This file is the source of truth for the
+ * MetaGovernor architecture; later PRs import these types and conform to them.
+ *
+ * Architectural invariants (from AGENTS.md, must respect):
+ * - All session.promptAsync calls go through prompt-async-gate (not enforced here)
+ * - MetaGovernor composes AFT + agentmemory + magic-context + boulder-state
+ * - 5 recovery hooks wrap into post-repair-recorder (not enforced here)
+ *
+ * Public surface (5 contracts):
+ * - DecisionContext: input to score()
+ * - Decision: output of score()
+ * - Evidence: atomic evidence unit attached to a Decision
+ * - MemoryRead: cross-system read result
+ * - TokenPrediction: token burn rate prediction
+ *
+ * All enums/actions are union string types (no enums) for Zod compat and
+ * JSON-serialisability across the prompt-async-gate.
+ */
+
+/**
+ * What the judge sees when deciding continue|warn|escalate|stop.
+ *
+ * All fields are required. `undefined` is not a valid DecisionContext —
+ * collectors must fill every field even if the value is an empty array,
+ * false, or 0. Empty inputs are signals, not bugs.
+ */
+export interface DecisionContext {
+  /** Whether the last Oracle invocation returned verified=true. */
+  readonly oracleVerified: boolean
+  /** Whether the last assistant turn produced no progress (zero tokens, no content). */
+  readonly noProgress: boolean
+  /** Detected deviations from expected behavior. Empty array = no deviations. */
+  readonly deviations: readonly Deviation[]
+  /** iteration / maxIterations. 0..1. 1.0 = at the cap. */
+  readonly iterationRatio: number
+  /** Lessons retrieved from agentmemory that match the current decision pattern. */
+  readonly lessonsRelevant: readonly RelevantLesson[]
+  /** Cross-session memory snapshot from the meta_state slot. */
+  readonly slotMemory: SlotMemory
+  /** Free-form context the calling site can attach (sessionID, directory, mode). */
+  readonly ambient: AmbientContext
+}
+
+/**
+ * Decision the judge returns. Always carries evidence (cite-or-abstain).
+ *
+ * Score ∈ [-1, +1]:
+ *   >= +0.3 → continue silently
+ *   -0.3..+0.3 → continue with log
+ *   -0.6..-0.3 → continue with warn
+ *   -0.8..-0.6 → escalate (oracle or user)
+ *   < -0.8 → stop loop
+ *
+ * Note: actual thresholds are config-driven in PR 8. Defaults are above.
+ */
+export interface Decision {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly score: number
+  /** Human-readable one-sentence explanation. Required, never empty. */
+  readonly reasoning: string
+  /** Cite-or-abstain: at least 1 evidence unit when action !== "continue" silently. */
+  readonly evidence: readonly Evidence[]
+  /** When action === "escalate", which actor should be invoked. */
+  readonly shouldEscalateTo: EscalationTarget | null
+}
+
+export type EscalationTarget = "oracle" | "user"
+
+/**
+ * Atomic evidence unit. Carries provenance so the judge can be audited.
+ *
+ * `confidence` ∈ [0, 1]: how sure the source is about `value`.
+ * `weight` ∈ [0, 1]: how much this evidence influences the score
+ *  (assigned by the scoring function, not the collector).
+ */
+export interface Evidence {
+  readonly source: EvidenceSource
+  readonly value: string
+  readonly confidence: number
+  readonly weight: number
+}
+
+export type EvidenceSource =
+  | "oracle-verified"
+  | "no-progress-detector"
+  | "deviation-detector"
+  | "iteration-budget"
+  | "lesson-recall"
+  | "slot-memory"
+  | "ambient"
+  | "token-predictor"
+
+/**
+ * A deviation from expected behavior. Severity follows the prior
+ * moderator-gate (PR 4405) taxonomy for backward compat.
+ */
+export interface Deviation {
+  readonly severity: "leve" | "media" | "grave"
+  readonly category: string
+  readonly detail: string
+  readonly filePath?: string
+}
+
+/**
+ * A lesson retrieved from agentmemory.lesson_recall. Confidence is the
+ * stored confidence in the memory store, not the relevance to this query.
+ */
+export interface RelevantLesson {
+  readonly id: string
+  readonly title: string
+  readonly advice: "continue" | "stop" | "warn" | "info"
+  readonly confidence: number
+  readonly concepts: readonly string[]
+}
+
+/**
+ * Cross-session state held in the magic-context `meta_state` slot.
+ *
+ * `consecutiveStops` is read by the judge to detect paralysis (3 stops
+ * in a row → force continue with warning, prevents infinite conservatism).
+ */
+export interface SlotMemory {
+  readonly lastDecision?: Decision
+  readonly consecutiveStops: number
+  readonly consecutiveContinues: number
+  readonly lastUpdatedISO: string
+}
+
+/**
+ * Free-form context the calling site can attach. Used for audit trails
+ * and to enable the judge to factor in mode (ultrawork vs simple) or
+ * session state. Fields are optional to keep the contract lean.
+ */
+export interface AmbientContext {
+  readonly sessionID: string
+  readonly directory: string
+  readonly mode: "ultrawork" | "ulw" | "simple" | "ralph-loop"
+  readonly agentName: string
+  readonly iteration: number
+  readonly maxIterations: number
+}
+
+/**
+ * Cross-system memory read result. All three sources read in parallel;
+ * any of them may be unavailable (graceful degradation in PR 2).
+ *
+ * `query` is echoed back so callers can correlate the read with the
+ * query that produced it.
+ */
+export interface MemoryRead {
+  readonly query: string
+  readonly timestampISO: string
+  readonly agentmemory: AgentMemoryRead
+  readonly magicContext: MagicContextRead
+  readonly boulderState: BoulderStateRead
+  readonly degradedSources: readonly MemorySource[]
+}
+
+export type MemorySource = "agentmemory" | "magicContext" | "boulderState"
+
+export interface AgentMemoryRead {
+  readonly available: boolean
+  readonly lessons: readonly RelevantLesson[]
+  readonly errorMessage?: string
+}
+
+export interface MagicContextRead {
+  readonly available: boolean
+  readonly slots: readonly { readonly label: string; readonly content: string }[]
+  readonly errorMessage?: string
+}
+
+export interface BoulderStateRead {
+  readonly available: boolean
+  readonly tasks: readonly { readonly id: string; readonly status: string; readonly title: string }[]
+  readonly planProgress: number
+  readonly errorMessage?: string
+}
+
+/**
+ * Token burn rate prediction. Computed from recent turn metrics.
+ *
+ * `willOverflowAt` is an ISO timestamp predicted from current usage +
+ * burn rate + model limit. `null` when not expected to overflow.
+ *
+ * `recommendation` is action-typed; the caller (PR 7 integration) maps
+ * these to actual hook invocations:
+ *   - "compact-now" → invoke preemptive-compaction-degradation-monitor
+ *   - "switch-model" → invoke model-fallback chat-message-fallback-handler
+ *   - "delegate-to-subagent" → invoke delegate-task with a sub-scope
+ *   - "no-action" → silent
+ */
+export interface TokenPrediction {
+  readonly currentUsage: number
+  readonly burnRate: number
+  readonly budgetLeft: number
+  readonly willOverflowAt: string | null
+  readonly recommendation: TokenRecommendation
+  readonly confidence: number
+  readonly modelLimit: number
+  readonly windowRemaining: number
+}
+
+export type TokenRecommendation =
+  | "compact-now"
+  | "switch-model"
+  | "delegate-to-subagent"
+  | "no-action"


### PR DESCRIPTION
## Summary

PR 1 of 8 for the **MetaGovernor** architecture — the autonomy layer that makes OMO self-judge, self-repair, persistent-memory, learn-from-errors, and token-aware.

This PR defines **ONLY the type surface** (no logic, no I/O, no MCP). 15 exported types across 5 contracts that PRs 2-8 implement against.

## 5 contracts

| Contract | Shape |
|---|---|
| `DecisionContext` | Input to score() — oracleVerified, noProgress, deviations, iterationRatio, lessonsRelevant, slotMemory, ambient |
| `Decision` | Output of score() — action ∈ {continue, warn, escalate, stop}, score ∈ [-1,+1], reasoning, evidence[], shouldEscalateTo |
| `Evidence` | Atomic evidence unit — source, value, confidence, weight |
| `MemoryRead` | Cross-system read (agentmemory + magicContext + boulderState) with degradedSources[] |
| `TokenPrediction` | Burn rate + recommendation ∈ {compact-now, switch-model, delegate-to-subagent, no-action} |

## Verification

- `bun test src/features/meta-governor/types.test.ts` → **14 pass, 0 fail, 34 expect() calls**
- `bunx tsgo --noEmit` global → **0 errors** (no regressions introduced)
- Smoke import of all 15 types via barrel `src/features/meta-governor/index.ts` → all importable

## Why type-only first?

PRs 2-8 (memory-aggregator, closed-loop, token-predictor, score/judge, post-repair-recorder, integration, schema+UI) all implement against these types. The 14 tests are the **regression guard preventing contract drift** — later PRs cannot break the shape without the test suite screaming.

## Roadmap (8 PRs total)

1. ✅ `feat/meta-governor-types` ← this PR
2. `feat/meta-governor-memory-aggregator` (cross-system read)
3. `feat/meta-governor-closed-loop` (lesson save + preflight)
4. `feat/meta-governor-token-predictor` (burn-rate → action)
5. `feat/meta-governor-score` (the judge function — pure, no I/O)
6. `feat/meta-governor-post-repair-recorder` (wraps 5 recovery hooks)
7. `feat/meta-governor-integration` (wire into ralph-loop + chat.message)
8. `feat/meta-governor-schema-and-ui` (config + toast feedback)

Each phase ships behind feature flag `meta_governor.enabled = false` (default). Flipped to true in PR 8 after stability.

## Compatibility

- ✅ Zero existing tests broken (ralph-loop suite, recovery suite, etc. all untouched)
- ✅ Zero existing files modified — only new files in `src/features/meta-governor/`
- ✅ Zero AGENTS.md invariant violations (prompt-async-gate, hashline, 5-tier hooks all respected)
- ✅ No dependency additions

@code-yeongyu — calling you to review + merge as the architecture foundation for the rest of the series. Happy to adjust naming/scope per your feedback before PR 2 lands.

🤖 Generated with [Claude Code](https://claude.ai/code) via [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines MetaGovernor’s type surface with 15 exported types across 5 contracts to standardize judging, memory reads, and token usage predictions. Pure types only; 14 tests lock shapes, no logic or dependency changes.

- **New Features**
  - `DecisionContext` — input to `score()`: oracleVerified, noProgress, deviations, iterationRatio, lessonsRelevant, slotMemory, ambient.
  - `Decision` — output of `score()`: action (continue|warn|escalate|stop), score [-1,+1], reasoning, evidence[], shouldEscalateTo.
  - `Evidence` — source, value, confidence, weight.
  - `MemoryRead` — cross-system read of agentmemory + magicContext + boulderState with degradedSources[].
  - `TokenPrediction` — usage, burnRate, budgetLeft, willOverflowAt, recommendation (compact-now|switch-model|delegate-to-subagent|no-action), plus modelLimit and windowRemaining.

<sup>Written for commit f97098ccba40882688504a8c9c0172cb8c8a7d0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

