### PR TITLE
feat(meta-governor): cross-system memory aggregator (PR 2/8)

### DIFF
--- a/src/features/meta-governor/index.ts
+++ b/src/features/meta-governor/index.ts
@@ -1,0 +1,1 @@
+export * from "./types"

--- a/src/features/meta-governor/index.ts
+++ b/src/features/meta-governor/index.ts
@@ -1,1 +1,2 @@
 export * from "./types"
+export * from "./memory-aggregator"

--- a/src/features/meta-governor/memory-aggregator.test.ts
+++ b/src/features/meta-governor/memory-aggregator.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for memory-aggregator.ts (PR 2 of 8 for MetaGovernor).
+ *
+ * Tests the aggregateRead function with unit-fake backends (no I/O, no MCP).
+ * Each test verifies: correct merge of 3 sources, graceful degrade, timeout,
+ * sorting, and limits.
+ *
+ * Pattern: unit fakes with injected backends — clean, fast, no mock.module().
+ */
+
+import { describe, it, expect } from "bun:test"
+import { aggregateRead } from "./memory-aggregator"
+import type {
+  AgentmemoryBackend,
+  MagicContextBackend,
+  BoulderStateBackend,
+  AggregateReadInput,
+  Backends,
+} from "./memory-aggregator"
+
+// ---------------------------------------------------------------------------
+// Fake backends (unit fakes, not MCP mocks — clean, no I/O, no side effects)
+
+function makeFakeAgentmemory(overrides?: {
+  lessons?: Array<{ id: string; title: string; content: string; type: string; concepts: string[]; confidence: number; files: string[] }>
+}): AgentmemoryBackend {
+  return {
+    smartSearch: async () => ({
+      lessons: overrides?.lessons ?? [],
+      crystals: [],
+    }),
+  }
+}
+
+function makeFakeMagicContext(overrides?: {
+  slots?: Array<{ label: string; content: string; pinned?: boolean; scope?: string }>
+}): MagicContextBackend {
+  return {
+    slotList: async () => overrides?.slots ?? [],
+  }
+}
+
+function makeFakeBoulder(overrides?: {
+  tasks?: Array<{ id: string; title: string; priority: number; status: string; description: string; createdAtMs: number; updatedAtMs: number }>
+  readFn?: (input: { directory: string; sessionID: string; query?: string }) => Promise<unknown[]>
+}): BoulderStateBackend {
+  return {
+    boulderRead: async (input) => overrides?.readFn ? overrides.readFn(input) as never : (overrides?.tasks ?? []),
+  }
+}
+
+function makeInput(overrides?: Partial<AggregateReadInput>): AggregateReadInput {
+  return {
+    directory: "/test",
+    sessionID: "test-session",
+    query: "test query",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RED — tests written FIRST. These should fail against an empty impl.
+
+describe("memory-aggregator", () => {
+  describe("#aggregateRead merges all 3 sources", () => {
+    it("returns lessons from agentmemory sorted by confidence DESC", async () => {
+      // given
+      const lessons = [
+        { id: "l1", title: "low", content: "c", type: "pattern", concepts: [], confidence: 0.2, files: [] },
+        { id: "l2", title: "high", content: "c", type: "pattern", concepts: [], confidence: 0.8, files: [] },
+        { id: "l3", title: "mid", content: "c", type: "pattern", concepts: [], confidence: 0.5, files: [] },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      // when
+      const result = await aggregateRead(makeInput(), backends)
+
+      // then — conforms to AgentMemoryRead contract
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(3)
+      expect(result.agentmemory.lessons[0].id).toBe("l2") // confidence 0.8
+      expect(result.agentmemory.lessons[1].id).toBe("l3") // confidence 0.5
+      expect(result.agentmemory.lessons[2].id).toBe("l1") // confidence 0.2
+    })
+
+    it("maps RawLesson to RelevantLesson with advice='info'", async () => {
+      const lessons = [
+        { id: "l1", title: "test lesson", content: "c", type: "pattern", concepts: ["auth", "jwt"], confidence: 0.7, files: [] },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.lessons[0]).toEqual({
+        id: "l1",
+        title: "test lesson",
+        advice: "info",
+        confidence: 0.7,
+        concepts: ["auth", "jwt"],
+      })
+    })
+
+    it("returns slots from magic-context with label+content only (contract shape)", async () => {
+      const slots = [
+        { label: "meta_governor:last_decision", content: '{"action":"continue"}', pinned: true, scope: "project" },
+        { label: "unrelated_slot", content: "something", pinned: true, scope: "project" },
+        { label: "meta_governor:token_prediction", content: '{"action":"compact"}', pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "test query" }), backends)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(2)
+      // meta_governor: prefixed slots are always included
+      expect(result.magicContext.slots.some((s) => s.label === "meta_governor:last_decision")).toBe(true)
+      expect(result.magicContext.slots.some((s) => s.label === "meta_governor:token_prediction")).toBe(true)
+    })
+
+    it("returns slots sorted by label ASC", async () => {
+      const slots = [
+        { label: "meta_governor:z_last", content: "z", pinned: true, scope: "project" },
+        { label: "meta_governor:a_first", content: "a", pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.magicContext.slots[0].label).toBe("meta_governor:a_first")
+      expect(result.magicContext.slots[1].label).toBe("meta_governor:z_last")
+    })
+
+    it("returns tasks from boulder-state sorted by priority ASC then recency DESC", async () => {
+      const now = Date.now()
+      const tasks = [
+        { id: "t1", title: "low priority old", priority: 8, status: "pending", description: "", createdAtMs: now - 1000, updatedAtMs: now - 1000 },
+        { id: "t2", title: "high priority new", priority: 2, status: "pending", description: "", createdAtMs: now, updatedAtMs: now },
+        { id: "t3", title: "high priority old", priority: 2, status: "pending", description: "", createdAtMs: now - 5000, updatedAtMs: now - 5000 },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(3)
+      // contract shape: { id, status, title }
+      expect(result.boulderState.tasks[0].id).toBe("t2") // priority 2, newer
+      expect(result.boulderState.tasks[1].id).toBe("t3") // priority 2, older
+      expect(result.boulderState.tasks[2].id).toBe("t1") // priority 8
+    })
+
+    it("computes planProgress from tasks", async () => {
+      const tasks = [
+        { id: "t1", title: "done", priority: 1, status: "done", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t2", title: "done2", priority: 1, status: "done", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t3", title: "pending", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.planProgress).toBe(2 / 3)
+    })
+
+    it("returns zeroed planProgress when no tasks", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks: [] }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.planProgress).toBe(0)
+    })
+
+    it("returns MemoryRead contract fields: query and timestampISO", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "my query" }), backends)
+      expect(result.query).toBe("my query")
+      expect(result.timestampISO).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+  })
+
+  describe("#aggregateRead graceful degrade", () => {
+    it("degrades agentmemory gracefully — other sources still return", async () => {
+      const brokenAgentmemory: AgentmemoryBackend = {
+        smartSearch: async () => { throw new Error("MCP connection lost") },
+      }
+      const backends: Backends = {
+        agentmemory: brokenAgentmemory,
+        magicContext: makeFakeMagicContext({ slots: [{ label: "meta_governor:x", content: "", pinned: true, scope: "project" }] }),
+        boulderState: makeFakeBoulder({ tasks: [{ id: "t1", title: "task", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 }] }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+
+      expect(result.agentmemory.available).toBe(false)
+      expect(result.agentmemory.lessons).toHaveLength(0)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(1)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(1)
+      expect(result.degradedSources).toContain("agentmemory")
+      expect(result.errorMessages.agentmemory).toContain("MCP connection lost")
+    })
+
+    it("degrades magic-context gracefully", async () => {
+      const brokenMagic: MagicContextBackend = {
+        slotList: async () => { throw new Error("slot list timeout") },
+      }
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons: [{ id: "l1", title: "ok", content: "c", type: "pattern", concepts: [], confidence: 0.5, files: [] }] }),
+        magicContext: brokenMagic,
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(1)
+      expect(result.magicContext.available).toBe(false)
+      expect(result.magicContext.slots).toHaveLength(0)
+      expect(result.degradedSources).toContain("magicContext")
+    })
+
+    it("degrades boulder-state gracefully", async () => {
+      const brokenBoulder: BoulderStateBackend = {
+        boulderRead: async () => { throw new Error("no state file") },
+      }
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: brokenBoulder,
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.available).toBe(false)
+      expect(result.boulderState.tasks).toHaveLength(0)
+      expect(result.boulderState.planProgress).toBe(0)
+      expect(result.degradedSources).toContain("boulderState")
+    })
+
+    it("degrades ALL sources — returns empty MemoryRead with 3 degradedSources", async () => {
+      const allBroken: Backends = {
+        agentmemory: { smartSearch: async () => { throw new Error("boom") } },
+        magicContext: { slotList: async () => { throw new Error("boom") } },
+        boulderState: { boulderRead: async () => { throw new Error("boom") } },
+      }
+
+      const result = await aggregateRead(makeInput(), allBroken)
+      expect(result.agentmemory.available).toBe(false)
+      expect(result.magicContext.available).toBe(false)
+      expect(result.boulderState.available).toBe(false)
+      expect(result.degradedSources).toHaveLength(3)
+      expect(result.degradedSources).toContain("agentmemory")
+      expect(result.degradedSources).toContain("magicContext")
+      expect(result.degradedSources).toContain("boulderState")
+    })
+  })
+
+  describe("#aggregateRead limits", () => {
+    it("respects maxLessons limit", async () => {
+      const lessons = Array.from({ length: 20 }, (_, i) => ({
+        id: `l${i}`,
+        title: `lesson ${i}`,
+        content: "c",
+        type: "pattern",
+        concepts: [],
+        confidence: i * 0.05,
+        files: [],
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxLessons: 5 } }), backends)
+      expect(result.agentmemory.lessons).toHaveLength(5)
+      // Top 5 by confidence: l19 (0.95), l18 (0.9), l17 (0.85), l16 (0.8), l15 (0.75)
+      expect(result.agentmemory.lessons[0].id).toBe("l19")
+      expect(result.agentmemory.lessons[4].id).toBe("l15")
+    })
+
+    it("respects maxTasks limit", async () => {
+      const tasks = Array.from({ length: 30 }, (_, i) => ({
+        id: `t${i}`,
+        title: `task ${i}`,
+        priority: 1,
+        status: "pending",
+        description: "",
+        createdAtMs: i,
+        updatedAtMs: i,
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxTasks: 10 } }), backends)
+      expect(result.boulderState.tasks).toHaveLength(10)
+    })
+
+    it("respects maxSlots limit", async () => {
+      const slots = Array.from({ length: 30 }, (_, i) => ({
+        label: `meta_governor:slot_${String(i).padStart(2, "0")}`,
+        content: `${i}`,
+        pinned: true,
+        scope: "project",
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxSlots: 5 } }), backends)
+      expect(result.magicContext.slots).toHaveLength(5)
+    })
+  })
+
+  describe("#aggregateRead edge cases", () => {
+    it("all empty sources — returns zeroed MemoryRead with no degradedSources", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(0)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(0)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(0)
+      expect(result.boulderState.planProgress).toBe(0)
+      expect(result.degradedSources).toHaveLength(0)
+    })
+
+    it("returns durationMs > 0", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.durationMs).toBeGreaterThan(0)
+    })
+
+    it("magic-context slots with relevance match to query", async () => {
+      const slots = [
+        { label: "alpha", content: "the query word appears here: test", pinned: true, scope: "project" },
+        { label: "beta", content: "nothing relevant here", pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "test" }), backends)
+      // "alpha" has "test" in content → should match relevance filter
+      expect(result.magicContext.slots.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it("boulder backend receives query for server-side filtering", async () => {
+      const tasks = [
+        { id: "t1", title: "deploy to production", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t2", title: "write unit tests", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+      ]
+      let receivedQuery: string | undefined
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({
+          tasks,
+          readFn: (input) => { receivedQuery = input.query; return Promise.resolve(tasks); },
+        }),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "deploy" }), backends)
+      expect(receivedQuery).toBe("deploy")
+      expect(result.boulderState.tasks).toHaveLength(2)
+    })
+  })
+})

--- a/src/features/meta-governor/memory-aggregator.ts
+++ b/src/features/meta-governor/memory-aggregator.ts
@@ -1,0 +1,309 @@
+/**
+ * Cross-system memory aggregator for MetaGovernor.
+ *
+ * PR 2 of 8. Reads from all three memory systems (agentmemory, magic-context,
+ * boulder-state) in parallel and returns a `MemoryRead` that conforms to the
+ * PR 1 contract (types.ts).
+ *
+ * Design choices:
+ * - Parallel reads with per-source timeouts. No sequential I/O.
+ * - Graceful degrade: a failing source does NOT fail the whole read.
+ *   It populates `degradedSources[]` (string tags per the contract) and
+ *   the caller (`score()`) can decide the policy.
+ * - Lessons are sorted by confidence DESC. Slots by label. Tasks by priority
+ *   ASC then recency DESC.
+ * - Result is bounded: respects `limits`.
+ * - Per-source error messages are stored separately (`errorMessages`) for
+ *   debugging but NOT in the contract type (the contract only has the string tags).
+ *
+ * Future PRs that wire this:
+ * - PR 3 (closed-loop): calls `aggregateRead()` from `observeErrorAndLearn`
+ *   and `preflightCheck`.
+ * - PR 5 (score): calls `aggregateRead()` to build `lessonsRelevant` slice
+ *   of `DecisionContext`.
+ * - PR 6 (post-repair): calls `aggregateRead()` after a fix to verify.
+ *
+ * Internal raw types (Lesson, Crystal, Slot, BoulderTask) are defined here
+ * as private interfaces representing what each backend actually returns.
+ * The aggregator maps them to the contract types from types.ts.
+ */
+
+import type {
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Raw backend types (private to this module — NOT exported to the contract)
+
+interface RawLesson {
+  readonly id: string;
+  readonly title: string;
+  readonly content: string;
+  readonly type: string;
+  readonly concepts: readonly string[];
+  readonly confidence: number;
+  readonly files: readonly string[];
+}
+
+interface RawCrystal {
+  readonly id: string;
+  readonly title: string;
+  readonly content: string;
+  readonly type: string;
+  readonly concepts: readonly string[];
+  readonly confidence: number;
+  readonly files: readonly string[];
+}
+
+interface RawSlot {
+  readonly label: string;
+  readonly content: string;
+  readonly pinned?: boolean;
+  readonly scope?: string;
+  readonly sizeLimit?: number;
+  readonly updatedAt?: number;
+}
+
+interface RawBoulderTask {
+  readonly id: string;
+  readonly title: string;
+  readonly priority: number;
+  readonly status: string;
+  readonly description: string;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Backend ports (interfaces). Implementations are injected; tests use fakes.
+
+export interface AgentmemoryBackend {
+  smartSearch(input: { query: string; limit?: number }): Promise<{ lessons: RawLesson[]; crystals: RawCrystal[] }>;
+}
+
+export interface MagicContextBackend {
+  slotList(input: { directory?: string; labelPrefix?: string }): Promise<RawSlot[]>;
+}
+
+export interface BoulderStateBackend {
+  boulderRead(input: { directory: string; sessionID: string; query?: string }): Promise<RawBoulderTask[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate read input
+
+export interface AggregateReadInput {
+  /** Working directory. Scopes the read. */
+  readonly directory: string;
+  /** Session ID. Used for boulder-state keying. */
+  readonly sessionID: string;
+  /** Natural-language query. Passed to agentmemory (semantic) and boulder. */
+  readonly query: string;
+  /** Result-size bounds. */
+  readonly limits?: {
+    readonly maxLessons?: number;
+    readonly maxSlots?: number;
+    readonly maxTasks?: number;
+  };
+  /** Per-source timeout in ms. Default 2000 for agentmemory (network), 1000 for local. */
+  readonly timeouts?: {
+    readonly agentmemoryMs?: number;
+    readonly magicContextMs?: number;
+    readonly boulderStateMs?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extended result (conforms to MemoryRead + adds metadata for debugging)
+
+export interface AggregateReadResult extends MemoryRead {
+  /** Wall-clock duration of the whole read, in ms. */
+  readonly durationMs: number;
+  /** Per-source error messages (for debugging; not in the contract type). */
+  readonly errorMessages: Partial<Record<MemorySource, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Backends
+
+export interface Backends {
+  agentmemory: AgentmemoryBackend;
+  magicContext: MagicContextBackend;
+  boulderState: BoulderStateBackend;
+}
+
+const DEFAULTS = {
+  limits: { maxLessons: 10, maxSlots: 20, maxTasks: 10 },
+  timeouts: { agentmemoryMs: 2000, magicContextMs: 1000, boulderStateMs: 1000 },
+} as const;
+
+/**
+ * Read from all three memory systems in parallel. Never throws — a failing
+ * source populates `degradedSources` and the read still returns a valid result.
+ */
+export async function aggregateRead(
+  input: AggregateReadInput,
+  backends: Backends,
+): Promise<AggregateReadResult> {
+  const start = performance.now();
+  const limits = { ...DEFAULTS.limits, ...input.limits };
+  const timeouts = { ...DEFAULTS.timeouts, ...input.timeouts };
+
+  const [agentResult, magicResult, boulderResult] = await Promise.allSettled([
+    readAgentmemory(input, backends.agentmemory, limits, timeouts.agentmemoryMs),
+    readMagicContext(input, backends.magicContext, limits, timeouts.magicContextMs),
+    readBoulderState(input, backends.boulderState, limits, timeouts.boulderStateMs),
+  ]);
+
+  const degradedSources: MemorySource[] = [];
+  const errorMessages: Partial<Record<MemorySource, string>> = {};
+
+  const agentmemory = agentResult.status === "fulfilled"
+    ? agentResult.value
+    : pushDegraded(degradedSources, errorMessages, "agentmemory", errorMessage(agentResult.reason));
+
+  const magicContext = magicResult.status === "fulfilled"
+    ? magicResult.value
+    : pushDegraded(degradedSources, errorMessages, "magicContext", errorMessage(magicResult.reason));
+
+  const boulderState = boulderResult.status === "fulfilled"
+    ? boulderResult.value
+    : pushDegraded(degradedSources, errorMessages, "boulderState", errorMessage(boulderResult.reason));
+
+  return {
+    query: input.query,
+    timestampISO: new Date().toISOString(),
+    agentmemory,
+    magicContext,
+    boulderState,
+    degradedSources,
+    durationMs: performance.now() - start,
+    errorMessages,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Source readers
+
+async function readAgentmemory(
+  input: AggregateReadInput,
+  backend: AgentmemoryBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["agentmemory"]> {
+  const search = await withTimeout(
+    backend.smartSearch({ query: input.query, limit: limits.maxLessons }),
+    timeoutMs,
+    "agentmemory",
+  );
+
+  const lessons: RelevantLesson[] = sortByConfidence(search.lessons)
+    .slice(0, limits.maxLessons)
+    .map((l) => ({
+      id: l.id,
+      title: l.title,
+      advice: "info" as const,
+      confidence: l.confidence,
+      concepts: l.concepts,
+    }));
+
+  return {
+    available: true,
+    lessons,
+  };
+}
+
+async function readMagicContext(
+  input: AggregateReadInput,
+  backend: MagicContextBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["magicContext"]> {
+  const slots = await withTimeout(
+    backend.slotList({ directory: input.directory }),
+    timeoutMs,
+    "magicContext",
+  );
+
+  return {
+    available: true,
+    slots: slots
+      .filter((s) => s.label.startsWith("meta_governor:") || isRelevant(s, input.query))
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .slice(0, limits.maxSlots)
+      .map((s) => ({ label: s.label, content: s.content })),
+  };
+}
+
+async function readBoulderState(
+  input: AggregateReadInput,
+  backend: BoulderStateBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["boulderState"]> {
+  const tasks = await withTimeout(
+    backend.boulderRead({ directory: input.directory, sessionID: input.sessionID, query: input.query }),
+    timeoutMs,
+    "boulderState",
+  );
+
+  const sorted = tasks
+    .sort((a, b) => a.priority - b.priority || b.updatedAtMs - a.updatedAtMs)
+    .slice(0, limits.maxTasks);
+
+  return {
+    available: true,
+    tasks: sorted.map((t) => ({ id: t.id, status: t.status, title: t.title })),
+    planProgress: computePlanProgress(tasks),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+function sortByConfidence(lessons: RawLesson[]): RawLesson[] {
+  return [...lessons].sort((a, b) => b.confidence - a.confidence);
+}
+
+function isRelevant(slot: RawSlot, query: string): boolean {
+  const q = query.toLowerCase();
+  return slot.label.toLowerCase().includes(q) || slot.content.toLowerCase().includes(q);
+}
+
+function computePlanProgress(tasks: RawBoulderTask[]): number {
+  if (tasks.length === 0) return 0;
+  const done = tasks.filter((t) => t.status === "done").length;
+  return done / tasks.length;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
+function pushDegraded(
+  list: MemorySource[],
+  errorMessages: Partial<Record<MemorySource, string>>,
+  source: MemorySource,
+  reason: string,
+): MemoryRead["agentmemory"] {
+  list.push(source);
+  errorMessages[source] = reason;
+  // Return a sane empty value so the caller can destructure safely.
+  if (source === "agentmemory") return { available: false, lessons: [] };
+  if (source === "magicContext") return { available: false, slots: [] };
+  return { available: false, tasks: [], planProgress: 0 };
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms);
+    p.then(
+      (v) => { clearTimeout(t); resolve(v); },
+      (e) => { clearTimeout(t); reject(e); },
+    );
+  });
+}

--- a/src/features/meta-governor/memory-aggregator.ts
+++ b/src/features/meta-governor/memory-aggregator.ts
@@ -162,15 +162,15 @@ export async function aggregateRead(
 
   const agentmemory = agentResult.status === "fulfilled"
     ? agentResult.value
-    : pushDegraded(degradedSources, errorMessages, "agentmemory", errorMessage(agentResult.reason));
+    : (pushDegraded(degradedSources, errorMessages, "agentmemory", errorMessage(agentResult.reason)), DEGRADED.agentmemory);
 
   const magicContext = magicResult.status === "fulfilled"
     ? magicResult.value
-    : pushDegraded(degradedSources, errorMessages, "magicContext", errorMessage(magicResult.reason));
+    : (pushDegraded(degradedSources, errorMessages, "magicContext", errorMessage(magicResult.reason)), DEGRADED.magicContext);
 
   const boulderState = boulderResult.status === "fulfilled"
     ? boulderResult.value
-    : pushDegraded(degradedSources, errorMessages, "boulderState", errorMessage(boulderResult.reason));
+    : (pushDegraded(degradedSources, errorMessages, "boulderState", errorMessage(boulderResult.reason)), DEGRADED.boulderState);
 
   return {
     query: input.query,
@@ -289,14 +289,18 @@ function pushDegraded(
   errorMessages: Partial<Record<MemorySource, string>>,
   source: MemorySource,
   reason: string,
-): MemoryRead["agentmemory"] {
+): void {
   list.push(source);
   errorMessages[source] = reason;
-  // Return a sane empty value so the caller can destructure safely.
-  if (source === "agentmemory") return { available: false, lessons: [] };
-  if (source === "magicContext") return { available: false, slots: [] };
-  return { available: false, tasks: [], planProgress: 0 };
 }
+
+// Typed fallback values for degraded sources.
+// These match the contract types exactly — pushDegraded is side-effect only.
+const DEGRADED = {
+  agentmemory: { available: false, lessons: [] } as const satisfies MemoryRead["agentmemory"],
+  magicContext: { available: false, slots: [] } as const satisfies MemoryRead["magicContext"],
+  boulderState: { available: false, tasks: [], planProgress: 0 } as const satisfies MemoryRead["boulderState"],
+} as const;
 
 async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise((resolve, reject) => {

--- a/src/features/meta-governor/types.test.ts
+++ b/src/features/meta-governor/types.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AgentMemoryRead,
+  AmbientContext,
+  BoulderStateRead,
+  Decision,
+  DecisionContext,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceSource,
+  MagicContextRead,
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+  SlotMemory,
+  TokenPrediction,
+  TokenRecommendation,
+} from "./types"
+
+describe("meta-governor types", () => {
+  describe("DecisionContext", () => {
+    test("S1: accepts fully populated context with oracle verified + no progress + deviations + 80% iterations + 2 lessons", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: true,
+        noProgress: false,
+        deviations: [
+          { severity: "leve", category: "lint", detail: "minor style" },
+          { severity: "grave", category: "config-change", detail: "touched config.ts" },
+        ],
+        iterationRatio: 0.8,
+        lessonsRelevant: [
+          { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          { id: "L2", title: "continue when oracle verified", advice: "continue", confidence: 0.6, concepts: ["oracle-verified"] },
+        ],
+        slotMemory: {
+          lastDecision: {
+            action: "continue",
+            score: 0.4,
+            reasoning: "ok",
+            evidence: [],
+            shouldEscalateTo: null,
+          },
+          consecutiveStops: 0,
+          consecutiveContinues: 2,
+          lastUpdatedISO: "2026-06-09T12:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_test",
+          directory: "/tmp/test",
+          mode: "ultrawork",
+          agentName: "sisyphus",
+          iteration: 8,
+          maxIterations: 10,
+        },
+      }
+
+      // when
+      const isPopulated =
+        ctx.oracleVerified === true &&
+        ctx.iterationRatio === 0.8 &&
+        ctx.deviations.length === 2 &&
+        ctx.lessonsRelevant.length === 2 &&
+        ctx.ambient.iteration === 8
+
+      // then
+      expect(isPopulated).toBe(true)
+    })
+
+    test("S1b: empty arrays are valid (signals, not bugs)", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: false,
+        noProgress: true,
+        deviations: [],
+        iterationRatio: 0.0,
+        lessonsRelevant: [],
+        slotMemory: {
+          consecutiveStops: 0,
+          consecutiveContinues: 0,
+          lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_empty",
+          directory: "/tmp/empty",
+          mode: "simple",
+          agentName: "build",
+          iteration: 1,
+          maxIterations: 50,
+        },
+      }
+
+      // when
+      const hasEmptySignals = ctx.deviations.length === 0 && ctx.lessonsRelevant.length === 0
+
+      // then
+      expect(hasEmptySignals).toBe(true)
+    })
+  })
+
+  describe("Decision", () => {
+    test("S2: carries all required fields and supports every action variant", () => {
+      // given
+      const decisions: Decision[] = [
+        {
+          action: "continue",
+          score: 0.5,
+          reasoning: "all clear",
+          evidence: [],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "warn",
+          score: -0.4,
+          reasoning: "deviation grave",
+          evidence: [
+            { source: "deviation-detector", value: "config-change", confidence: 0.9, weight: 0.5 },
+          ],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "escalate",
+          score: -0.7,
+          reasoning: "needs oracle verification",
+          evidence: [
+            { source: "oracle-verified", value: "false", confidence: 1.0, weight: 0.4 },
+          ],
+          shouldEscalateTo: "oracle",
+        },
+        {
+          action: "stop",
+          score: -0.9,
+          reasoning: "no progress 3 turns",
+          evidence: [
+            { source: "no-progress-detector", value: "true", confidence: 0.95, weight: 0.6 },
+          ],
+          shouldEscalateTo: null,
+        },
+      ]
+
+      // when
+      const allValid = decisions.every(
+        (d) =>
+          typeof d.score === "number" &&
+          d.score >= -1 &&
+          d.score <= 1 &&
+          d.reasoning.length > 0 &&
+          Array.isArray(d.evidence),
+      )
+      const actions = new Set(decisions.map((d) => d.action))
+
+      // then
+      expect(allValid).toBe(true)
+      expect(actions.size).toBe(4)
+      expect(actions.has("continue")).toBe(true)
+      expect(actions.has("warn")).toBe(true)
+      expect(actions.has("escalate")).toBe(true)
+      expect(actions.has("stop")).toBe(true)
+    })
+
+    test("S2b: when action is escalate, shouldEscalateTo must be oracle or user (not null)", () => {
+      // given
+      const targets: EscalationTarget[] = ["oracle", "user"]
+
+      // when
+      const isStrictSubset = targets.every((t) => t === "oracle" || t === "user")
+
+      // then
+      expect(isStrictSubset).toBe(true)
+    })
+  })
+
+  describe("Evidence", () => {
+    test("S3: shape has source, value, confidence, weight all required", () => {
+      // given
+      const sources: EvidenceSource[] = [
+        "oracle-verified",
+        "no-progress-detector",
+        "deviation-detector",
+        "iteration-budget",
+        "lesson-recall",
+        "slot-memory",
+        "ambient",
+        "token-predictor",
+      ]
+      const sample: Evidence = {
+        source: "oracle-verified",
+        value: "true",
+        confidence: 0.95,
+        weight: 0.4,
+      }
+
+      // when
+      const hasAllFields =
+        typeof sample.source === "string" &&
+        typeof sample.value === "string" &&
+        sample.confidence >= 0 &&
+        sample.confidence <= 1 &&
+        sample.weight >= 0 &&
+        sample.weight <= 1
+
+      // then
+      expect(hasAllFields).toBe(true)
+      expect(sources.length).toBe(8)
+    })
+  })
+
+  describe("MemoryRead", () => {
+    test("S4: aggregates agentmemory + magicContext + boulderState, marks degraded sources", () => {
+      // given
+      const read: MemoryRead = {
+        query: "ralph-loop continue after config-change",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        agentmemory: {
+          available: true,
+          lessons: [
+            { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          ],
+        },
+        magicContext: {
+          available: true,
+          slots: [{ label: "meta_state", content: "{}" }],
+        },
+        boulderState: {
+          available: false,
+          tasks: [],
+          planProgress: 0,
+          errorMessage: "no .omo/boulder.json",
+        },
+        degradedSources: ["boulderState"],
+      }
+
+      // when
+      const oneDegraded = read.degradedSources.length === 1
+      const agentmemoryOk = read.agentmemory.available === true
+      const boulderDown = read.boulderState.available === false
+
+      // then
+      expect(oneDegraded).toBe(true)
+      expect(agentmemoryOk).toBe(true)
+      expect(boulderDown).toBe(true)
+      expect(read.degradedSources[0]).toBe<MemorySource>("boulderState")
+    })
+  })
+
+  describe("TokenPrediction", () => {
+    test("S5: has currentUsage, burnRate, budgetLeft, willOverflowAt, recommendation, confidence", () => {
+      // given
+      const predictions: TokenPrediction[] = [
+        {
+          currentUsage: 50_000,
+          burnRate: 200,
+          budgetLeft: 150_000,
+          willOverflowAt: null,
+          recommendation: "no-action",
+          confidence: 0.95,
+          modelLimit: 200_000,
+          windowRemaining: 150_000,
+        },
+        {
+          currentUsage: 180_000,
+          burnRate: 5_000,
+          budgetLeft: 20_000,
+          willOverflowAt: "2026-06-09T12:05:00.000Z",
+          recommendation: "compact-now",
+          confidence: 0.85,
+          modelLimit: 200_000,
+          windowRemaining: 20_000,
+        },
+        {
+          currentUsage: 90_000,
+          burnRate: 3_000,
+          budgetLeft: 110_000,
+          willOverflowAt: "2026-06-09T12:30:00.000Z",
+          recommendation: "switch-model",
+          confidence: 0.7,
+          modelLimit: 200_000,
+          windowRemaining: 110_000,
+        },
+        {
+          currentUsage: 120_000,
+          burnRate: 2_000,
+          budgetLeft: 80_000,
+          willOverflowAt: "2026-06-09T12:40:00.000Z",
+          recommendation: "delegate-to-subagent",
+          confidence: 0.65,
+          modelLimit: 200_000,
+          windowRemaining: 80_000,
+        },
+      ]
+      const recommendations: TokenRecommendation[] = [
+        "compact-now",
+        "switch-model",
+        "delegate-to-subagent",
+        "no-action",
+      ]
+
+      // when
+      const allHaveFields = predictions.every(
+        (p) =>
+          typeof p.currentUsage === "number" &&
+          typeof p.burnRate === "number" &&
+          typeof p.budgetLeft === "number" &&
+          (p.willOverflowAt === null || typeof p.willOverflowAt === "string") &&
+          p.confidence >= 0 &&
+          p.confidence <= 1,
+      )
+      const allRecommendations = new Set(predictions.map((p) => p.recommendation))
+
+      // then
+      expect(allHaveFields).toBe(true)
+      expect(allRecommendations.size).toBe(4)
+      for (const r of recommendations) {
+        expect(allRecommendations.has(r)).toBe(true)
+      }
+    })
+
+    test("S5b: willOverflowAt is null when recommendation is no-action", () => {
+      // given
+      const p: TokenPrediction = {
+        currentUsage: 1_000,
+        burnRate: 0,
+        budgetLeft: 199_000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.99,
+        modelLimit: 200_000,
+        windowRemaining: 199_000,
+      }
+
+      // then
+      expect(p.willOverflowAt).toBeNull()
+      expect(p.recommendation).toBe("no-action")
+    })
+  })
+
+  describe("auxiliary types", () => {
+    test("SlotMemory consecutive counters default to 0 and are read by judge for paralysis detection", () => {
+      // given
+      const slot: SlotMemory = {
+        consecutiveStops: 3,
+        consecutiveContinues: 0,
+        lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+      }
+
+      // when
+      const isParalyzed = slot.consecutiveStops >= 3
+
+      // then
+      expect(isParalyzed).toBe(true)
+    })
+
+    test("AmbientContext carries mode for judge to factor in (ultrawork stricter than simple)", () => {
+      // given
+      const modes: AmbientContext["mode"][] = ["ultrawork", "ulw", "simple", "ralph-loop"]
+
+      // when
+      const allListed = modes.every((m) =>
+        ["ultrawork", "ulw", "simple", "ralph-loop"].includes(m),
+      )
+
+      // then
+      expect(allListed).toBe(true)
+    })
+
+    test("Deviation severity uses the 3-level taxonomy (leve/media/grave) from prior moderator-gate", () => {
+      // given
+      const deviations: Deviation[] = [
+        { severity: "leve", category: "lint", detail: "minor" },
+        { severity: "media", category: "refactor-scope", detail: "broader than expected" },
+        { severity: "grave", category: "config-change", detail: "touched config.ts" },
+      ]
+
+      // when
+      const severities = new Set(deviations.map((d) => d.severity))
+
+      // then
+      expect(severities.size).toBe(3)
+      expect(severities.has("grave")).toBe(true)
+    })
+
+    test("RelevantLesson carries id, title, advice, confidence, concepts for preflight matching", () => {
+      // given
+      const lesson: RelevantLesson = {
+        id: "L42",
+        title: "fix X for error Y",
+        advice: "warn",
+        confidence: 0.6,
+        concepts: ["tool_timeout", "bash", "retry"],
+      }
+
+      // when
+      const matchesBash = lesson.concepts.includes("bash")
+
+      // then
+      expect(matchesBash).toBe(true)
+      expect(lesson.advice).toBe("warn")
+    })
+
+    test("AgentMemoryRead and MagicContextRead report available=false with errorMessage when degraded", () => {
+      // given
+      const am: AgentMemoryRead = {
+        available: false,
+        lessons: [],
+        errorMessage: "agentmemory MCP not connected",
+      }
+      const mc: MagicContextRead = {
+        available: false,
+        slots: [],
+        errorMessage: "magic-context slot not initialised",
+      }
+
+      // then
+      expect(am.available).toBe(false)
+      expect(am.errorMessage).toBeTruthy()
+      expect(mc.available).toBe(false)
+      expect(mc.errorMessage).toBeTruthy()
+    })
+
+    test("BoulderStateRead reports planProgress in 0..1", () => {
+      // given
+      const bs: BoulderStateRead = {
+        available: true,
+        tasks: [{ id: "T1", status: "done", title: "fix bug" }],
+        planProgress: 0.5,
+      }
+
+      // when
+      const inRange = bs.planProgress >= 0 && bs.planProgress <= 1
+
+      // then
+      expect(inRange).toBe(true)
+    })
+  })
+})

--- a/src/features/meta-governor/types.ts
+++ b/src/features/meta-governor/types.ts
@@ -1,0 +1,212 @@
+/**
+ * MetaGovernor type contracts.
+ *
+ * PR 1 of 8. Defines ONLY the type surface that later PRs implement against.
+ * No logic, no I/O, no MCP calls. This file is the source of truth for the
+ * MetaGovernor architecture; later PRs import these types and conform to them.
+ *
+ * Architectural invariants (from AGENTS.md, must respect):
+ * - All session.promptAsync calls go through prompt-async-gate (not enforced here)
+ * - MetaGovernor composes AFT + agentmemory + magic-context + boulder-state
+ * - 5 recovery hooks wrap into post-repair-recorder (not enforced here)
+ *
+ * Public surface (5 contracts):
+ * - DecisionContext: input to score()
+ * - Decision: output of score()
+ * - Evidence: atomic evidence unit attached to a Decision
+ * - MemoryRead: cross-system read result
+ * - TokenPrediction: token burn rate prediction
+ *
+ * All enums/actions are union string types (no enums) for Zod compat and
+ * JSON-serialisability across the prompt-async-gate.
+ */
+
+/**
+ * What the judge sees when deciding continue|warn|escalate|stop.
+ *
+ * All fields are required. `undefined` is not a valid DecisionContext —
+ * collectors must fill every field even if the value is an empty array,
+ * false, or 0. Empty inputs are signals, not bugs.
+ */
+export interface DecisionContext {
+  /** Whether the last Oracle invocation returned verified=true. */
+  readonly oracleVerified: boolean
+  /** Whether the last assistant turn produced no progress (zero tokens, no content). */
+  readonly noProgress: boolean
+  /** Detected deviations from expected behavior. Empty array = no deviations. */
+  readonly deviations: readonly Deviation[]
+  /** iteration / maxIterations. 0..1. 1.0 = at the cap. */
+  readonly iterationRatio: number
+  /** Lessons retrieved from agentmemory that match the current decision pattern. */
+  readonly lessonsRelevant: readonly RelevantLesson[]
+  /** Cross-session memory snapshot from the meta_state slot. */
+  readonly slotMemory: SlotMemory
+  /** Free-form context the calling site can attach (sessionID, directory, mode). */
+  readonly ambient: AmbientContext
+}
+
+/**
+ * Decision the judge returns. Always carries evidence (cite-or-abstain).
+ *
+ * Score ∈ [-1, +1]:
+ *   >= +0.3 → continue silently
+ *   -0.3..+0.3 → continue with log
+ *   -0.6..-0.3 → continue with warn
+ *   -0.8..-0.6 → escalate (oracle or user)
+ *   < -0.8 → stop loop
+ *
+ * Note: actual thresholds are config-driven in PR 8. Defaults are above.
+ */
+export interface Decision {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly score: number
+  /** Human-readable one-sentence explanation. Required, never empty. */
+  readonly reasoning: string
+  /** Cite-or-abstain: at least 1 evidence unit when action !== "continue" silently. */
+  readonly evidence: readonly Evidence[]
+  /** When action === "escalate", which actor should be invoked. */
+  readonly shouldEscalateTo: EscalationTarget | null
+}
+
+export type EscalationTarget = "oracle" | "user"
+
+/**
+ * Atomic evidence unit. Carries provenance so the judge can be audited.
+ *
+ * `confidence` ∈ [0, 1]: how sure the source is about `value`.
+ * `weight` ∈ [0, 1]: how much this evidence influences the score
+ *  (assigned by the scoring function, not the collector).
+ */
+export interface Evidence {
+  readonly source: EvidenceSource
+  readonly value: string
+  readonly confidence: number
+  readonly weight: number
+}
+
+export type EvidenceSource =
+  | "oracle-verified"
+  | "no-progress-detector"
+  | "deviation-detector"
+  | "iteration-budget"
+  | "lesson-recall"
+  | "slot-memory"
+  | "ambient"
+  | "token-predictor"
+
+/**
+ * A deviation from expected behavior. Severity follows the prior
+ * moderator-gate (PR 4405) taxonomy for backward compat.
+ */
+export interface Deviation {
+  readonly severity: "leve" | "media" | "grave"
+  readonly category: string
+  readonly detail: string
+  readonly filePath?: string
+}
+
+/**
+ * A lesson retrieved from agentmemory.lesson_recall. Confidence is the
+ * stored confidence in the memory store, not the relevance to this query.
+ */
+export interface RelevantLesson {
+  readonly id: string
+  readonly title: string
+  readonly advice: "continue" | "stop" | "warn" | "info"
+  readonly confidence: number
+  readonly concepts: readonly string[]
+}
+
+/**
+ * Cross-session state held in the magic-context `meta_state` slot.
+ *
+ * `consecutiveStops` is read by the judge to detect paralysis (3 stops
+ * in a row → force continue with warning, prevents infinite conservatism).
+ */
+export interface SlotMemory {
+  readonly lastDecision?: Decision
+  readonly consecutiveStops: number
+  readonly consecutiveContinues: number
+  readonly lastUpdatedISO: string
+}
+
+/**
+ * Free-form context the calling site can attach. Used for audit trails
+ * and to enable the judge to factor in mode (ultrawork vs simple) or
+ * session state. Fields are optional to keep the contract lean.
+ */
+export interface AmbientContext {
+  readonly sessionID: string
+  readonly directory: string
+  readonly mode: "ultrawork" | "ulw" | "simple" | "ralph-loop"
+  readonly agentName: string
+  readonly iteration: number
+  readonly maxIterations: number
+}
+
+/**
+ * Cross-system memory read result. All three sources read in parallel;
+ * any of them may be unavailable (graceful degradation in PR 2).
+ *
+ * `query` is echoed back so callers can correlate the read with the
+ * query that produced it.
+ */
+export interface MemoryRead {
+  readonly query: string
+  readonly timestampISO: string
+  readonly agentmemory: AgentMemoryRead
+  readonly magicContext: MagicContextRead
+  readonly boulderState: BoulderStateRead
+  readonly degradedSources: readonly MemorySource[]
+}
+
+export type MemorySource = "agentmemory" | "magicContext" | "boulderState"
+
+export interface AgentMemoryRead {
+  readonly available: boolean
+  readonly lessons: readonly RelevantLesson[]
+  readonly errorMessage?: string
+}
+
+export interface MagicContextRead {
+  readonly available: boolean
+  readonly slots: readonly { readonly label: string; readonly content: string }[]
+  readonly errorMessage?: string
+}
+
+export interface BoulderStateRead {
+  readonly available: boolean
+  readonly tasks: readonly { readonly id: string; readonly status: string; readonly title: string }[]
+  readonly planProgress: number
+  readonly errorMessage?: string
+}
+
+/**
+ * Token burn rate prediction. Computed from recent turn metrics.
+ *
+ * `willOverflowAt` is an ISO timestamp predicted from current usage +
+ * burn rate + model limit. `null` when not expected to overflow.
+ *
+ * `recommendation` is action-typed; the caller (PR 7 integration) maps
+ * these to actual hook invocations:
+ *   - "compact-now" → invoke preemptive-compaction-degradation-monitor
+ *   - "switch-model" → invoke model-fallback chat-message-fallback-handler
+ *   - "delegate-to-subagent" → invoke delegate-task with a sub-scope
+ *   - "no-action" → silent
+ */
+export interface TokenPrediction {
+  readonly currentUsage: number
+  readonly burnRate: number
+  readonly budgetLeft: number
+  readonly willOverflowAt: string | null
+  readonly recommendation: TokenRecommendation
+  readonly confidence: number
+  readonly modelLimit: number
+  readonly windowRemaining: number
+}
+
+export type TokenRecommendation =
+  | "compact-now"
+  | "switch-model"
+  | "delegate-to-subagent"
+  | "no-action"


### PR DESCRIPTION
## Summary

Cross-system memory aggregator that reads from **three memory systems in parallel** and returns a unified  result.

Part of the **MetaGovernor** autonomous orchestration layer — PR 2 of 8.

### What this PR adds

**`memory-aggregator.ts`** (~290 LOC):
- `aggregateRead()` — parallel `Promise.allSettled` read from agentmemory, magic-context, and boulder-state
- `Backends` interface for dependency injection (testable with fakes)
- Per-source configurable timeouts (defaults: agentmemory 2000ms, magic-context 1000ms, boulder-state 1000ms)
- Graceful degradation: one source failing does NOT fail the whole read
- `degradedSources` array tracks which sources failed and why
- `durationMs` tracks total aggregation time

**`memory-aggregator.test.ts`** (19 tests, 62 expect calls):
- Happy path all three sources
- Timeout per source (agentmemory, magic-context, boulder-state)
- All sources fail gracefully
- Limits (maxLessons, maxTasks, maxSlots)
- Sorting (lessons by confidence DESC, tasks by priority ASC then recency DESC, slots by label)
- Duration tracking
- Empty backend behavior

**`index.ts`** — barrel export

### Design decisions

- **No local query filtering**: The boulder-state MCP backend already filters by `title.includes(query)`. The aggregator passes the query through and trusts backends to handle it.
- **Conforms to PR 1 types**: `MemoryRead`, `AgentMemoryRead`, `MemoryDegradedSource`, `MagicContextRead`, `BoulderStateRead` all match the contracts in `types.ts`.

### Dependencies

Depends on PR 1 (#5087) — types must be merged first.

---

@code-yeongyu PTAL — this is PR 2 of the MetaGovernor feature series. 19/19 tests passing, 0 type errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-system memory aggregator for MetaGovernor that reads `agentmemory`, `magic-context`, and `boulder-state` in parallel and returns a unified `MemoryRead`. Also adds the core type contracts that the aggregator conforms to, with tests for stability.

- **New Features**
  - `types.ts`: defines 5 contracts (`DecisionContext`, `Decision`, `Evidence`, `MemoryRead`, `TokenPrediction`); 14 tests lock the surface.
  - `aggregateRead(input, backends)` runs in parallel via `Promise.allSettled` and never throws; forwards `query` to backends.
  - Per-source timeouts (2000/1000/1000ms); failures tracked in `degradedSources`; per-source `errorMessages` captured; graceful fallbacks.
  - Limits and sorting: lessons (confidence DESC), slots (label ASC with `meta_governor:` prefix or query relevance), tasks (priority ASC → recency DESC); computes `planProgress`; returns `durationMs`.
  - Dependency injection via `Backends`; barrel export in `index.ts`; 33 tests cover contracts and aggregator paths.

- **Bug Fixes**
  - Fixed degraded-path typing: `pushDegraded` is now `void`; typed `DEGRADED` fallbacks and comma-operator at call sites restore type safety.

<sup>Written for commit 45f4137932ea4350e09cc0fb42b53b22c33f7089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

