### PR TITLE
fix(thinking): defer to adaptive thinking for Claude Fable/Mythos models

### DIFF
--- a/packages/model-core/src/model-family-detectors.test.ts
+++ b/packages/model-core/src/model-family-detectors.test.ts
@@ -4,6 +4,7 @@ import {
   isClaudeOpus46Model,
   isClaudeOpus47Model,
   isClaudeOpus47OrLaterModel,
+  isClaudeFableOrMythosModel,
   isClaudeOpus48Model,
   isGeminiModel,
   isGlmModel,
@@ -93,6 +94,17 @@ describe("model family detectors", () => {
     expect(isClaudeOpus47OrLaterModel("anthropic/claude-opus-4-6")).toBe(false)
     expect(isClaudeOpus47OrLaterModel("anthropic/claude-sonnet-4-6")).toBe(false)
     expect(isClaudeOpus47OrLaterModel("openai/gpt-5.5")).toBe(false)
+  })
+
+  test("#given Claude Fable/Mythos model ids #then detects fable and mythos families", () => {
+    expect(isClaudeFableOrMythosModel("anthropic/claude-fable-5")).toBe(true)
+    expect(isClaudeFableOrMythosModel("claude-fable-5")).toBe(true)
+    expect(isClaudeFableOrMythosModel("anthropic.claude-fable-5")).toBe(true)
+    expect(isClaudeFableOrMythosModel("anthropic/claude-mythos-5")).toBe(true)
+    expect(isClaudeFableOrMythosModel("anthropic/claude-mythos-preview")).toBe(true)
+    expect(isClaudeFableOrMythosModel("anthropic/claude-opus-4-8")).toBe(false)
+    expect(isClaudeFableOrMythosModel("anthropic/claude-sonnet-4-6")).toBe(false)
+    expect(isClaudeFableOrMythosModel("openai/gpt-5.5")).toBe(false)
   })
 
   test("#given MiniMax model ids #then detects MiniMax family only", () => {

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -44,6 +44,19 @@ export function isClaudeOpus47OrLaterModel(model: string): boolean {
   return major > 4 || (major === 4 && minor >= 7)
 }
 
+/**
+ * Claude Fable / Mythos family (e.g. claude-fable-5, claude-mythos-5,
+ * claude-mythos-preview). Like Opus 4.7+, these are adaptive-only: they reject
+ * thinking.type "enabled" with a 400 and require adaptive thinking + effort,
+ * which OpenCode core derives from the model variant.
+ */
+const CLAUDE_FABLE_OR_MYTHOS_RE = /claude-(?:fable|mythos)-(?:\d+|preview)/
+
+export function isClaudeFableOrMythosModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase().replaceAll(".", "-")
+  return CLAUDE_FABLE_OR_MYTHOS_RE.test(modelName)
+}
+
 export function isKimiK2Model(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase()
   if (modelName.includes("kimi")) return true

--- a/packages/omo-opencode/src/agents/types.ts
+++ b/packages/omo-opencode/src/agents/types.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk";
 
 import {
   isClaudeFable5Model,
+  isClaudeFableOrMythosModel,
   isClaudeOpus46Model,
   isClaudeOpus47Model,
   isClaudeOpus47OrLaterModel,
@@ -16,6 +17,7 @@ import {
 
 export {
   isClaudeFable5Model,
+  isClaudeFableOrMythosModel,
   isClaudeOpus46Model,
   isClaudeOpus47Model,
   isClaudeOpus47OrLaterModel,
@@ -31,15 +33,16 @@ export {
 const CLAUDE_THINKING_BUDGET_TOKENS = 32000;
 
 /**
- * Anthropic Opus 4.7+ rejects thinking.type "enabled"; it requires adaptive
- * thinking plus an effort, which OpenCode core derives from the model variant.
- * For those models emit no thinking config and let core drive it (issue #4614).
- * All other Claude models keep the explicit enabled-thinking budget.
+ * Anthropic Opus 4.7+, Fable, and Mythos models reject thinking.type "enabled";
+ * they require adaptive thinking plus an effort, which OpenCode core derives from
+ * the model variant. For those models emit no thinking config and let core drive
+ * it (issue #4614; opencode core #31546). All other Claude models keep the
+ * explicit enabled-thinking budget.
  */
 export function buildClaudeThinkingConfig(
   model: string,
 ): { thinking: { type: "enabled"; budgetTokens: number } } | Record<string, never> {
-  if (isClaudeOpus47OrLaterModel(model)) {
+  if (isClaudeOpus47OrLaterModel(model) || isClaudeFableOrMythosModel(model)) {
     return {};
   }
   return { thinking: { type: "enabled", budgetTokens: CLAUDE_THINKING_BUDGET_TOKENS } };


### PR DESCRIPTION
Fixes #5400

## Problem

Claude Fable 5 (`claude-fable-5`, GA 2026-06-09) and the Mythos models
(`claude-mythos-5`, `claude-mythos-preview`) are **adaptive-only**: the Anthropic
Messages API rejects the legacy `thinking: { type: "enabled", budget_tokens: N }`
with a 400:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Running any built-in agent (Sisyphus, Oracle, Momus, Metis, Sisyphus-Junior) on
`anthropic/claude-fable-5` currently fails with this error.

## Root cause

`buildClaudeThinkingConfig` (`src/agents/types.ts`) emits
`{ thinking: { type: "enabled", budgetTokens: 32000 } }` for every Claude model that
is **not** Opus 4.7+. Fable/Mythos fall through that branch, so the agent forces
`type:"enabled"` — which these models reject, and which also overrides OpenCode core's
adaptive path. This is the same failure mode #4614 fixed for Opus 4.7/4.8.

## Fix

Mirror the Opus 4.7+ handling: add an `isClaudeFableOrMythosModel` detector and
**defer** (emit no thinking config) for Fable/Mythos, letting OpenCode core supply
adaptive thinking + effort. Core already supports this (see opencode `#31546` /
`c4bc902`, which adds `fable-5` to its adaptive-effort logic).

- `packages/model-core/src/model-family-detectors.ts`: new `isClaudeFableOrMythosModel`
  matching `claude-fable-N`, `claude-mythos-N`, and `claude-mythos-preview`. Normalized
  like the sibling detectors, so Bedrock-style `anthropic.claude-fable-5` also matches.
- `src/agents/types.ts`: `buildClaudeThinkingConfig` defers for fable/mythos in addition
  to Opus 4.7+.

## Scope

Opus 4.6 / Sonnet 4.6 are intentionally left on `type:"enabled"` — they still **accept**
it (deprecated but functional), so they don't 400. They can migrate to adaptive later
when Anthropic removes `enabled`.

## Testing

- `bun test packages/model-core/src/model-family-detectors.test.ts` → 8 pass (incl. new fable/mythos cases)
- `bun test src/agents/utils.test.ts` (thinking config) → 71 pass
- `bun run typecheck` → clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400s on Claude Fable/Mythos by deferring to adaptive thinking so core sets effort automatically. Opus 4.6/Sonnet 4.6 stay on enabled thinking to avoid breaking changes.

- Bug Fixes
  - Added `isClaudeFableOrMythosModel` detector (matches `claude-fable-N`, `claude-mythos-N`, `claude-mythos-preview`, and Bedrock-style IDs like `anthropic.claude-fable-5`) in `packages/model-core/src/model-family-detectors.ts`.
  - Updated `buildClaudeThinkingConfig` in `packages/omo-opencode/src/agents/types.ts` to defer for Fable/Mythos and Opus 4.7+, letting core provide adaptive thinking and effort.

<sup>Written for commit 2397913814ecf294b55f3ee7dc04309938fcd8bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

