### PR TITLE
fix(cli): align TUI Claude hint with ultimate fallback

### DIFF
--- a/packages/omo-opencode/src/cli/model-fallback.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.ts
@@ -21,7 +21,7 @@ import { transformModelForProvider } from "./provider-model-id-transform"
 
 export type { GeneratedOmoConfig } from "./model-fallback-types"
 
-const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
+export const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 
 type CompatibleFallbackSettings = {

--- a/packages/omo-opencode/src/cli/tui-install-prompts.test.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import * as p from "@clack/prompts"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
 import * as prompts from "./tui-install-prompts"
 import type { DetectedConfig, InstallConfig, InstallPlatform } from "./types"
 
@@ -136,6 +137,22 @@ describe("promptInstallConfig platform branching", () => {
       expect(selectSpy).toHaveBeenCalledTimes(12)
     },
   )
+
+  test("Claude subscription No option hint uses ultimate fallback", async () => {
+    // given
+    const selectSpy = spyOn(p, "select").mockResolvedValue("no")
+
+    // when
+    await prompts.promptInstallConfig(createDetectedConfig(), "opencode")
+
+    // then
+    const firstCall = selectSpy.mock.calls[0]?.[0]
+    expect(firstCall?.message).toBe("Do you have a Claude Pro/Max subscription?")
+    const options = firstCall?.options as Array<{ value: string; hint?: string }>
+    const noOption = options?.find((o) => o.value === "no")
+    expect(noOption?.hint).toContain(ULTIMATE_FALLBACK)
+    expect(noOption?.hint).not.toContain("big-pickle")
+  })
 
   test("uses explicit Codex autonomous override without asking", async () => {
     // given

--- a/packages/omo-opencode/src/cli/tui-install-prompts.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.ts
@@ -7,6 +7,7 @@ import type {
   InstallPlatform,
 } from "./types"
 import { detectedToInitialValues } from "./install-validators"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
 
 async function selectOrCancel<TValue extends Readonly<string | boolean | number>>(params: {
   message: string
@@ -80,7 +81,7 @@ export async function promptInstallConfig(
   const claude = await selectOrCancel<ClaudeSubscription>({
     message: "Do you have a Claude Pro/Max subscription?",
     options: [
-      { value: "no", label: "No", hint: "Will use opencode/big-pickle as fallback" },
+      { value: "no", label: "No", hint: `Will use ${ULTIMATE_FALLBACK} as fallback` },
       { value: "yes", label: "Yes (standard)", hint: "Claude Opus 4.5 for orchestration" },
       { value: "max20", label: "Yes (max20 mode)", hint: "Full power with Claude Sonnet 4.6 for Librarian" },
     ],


### PR DESCRIPTION
## Summary
Follow-up split from #5042 review scope: TUI installer Claude "No" option hint still said `opencode/big-pickle` on `dev`.

## Changes
- Export `ULTIMATE_FALLBACK` from `model-fallback.ts` (minimal surface for hint copy)
- `tui-install-prompts.ts`: hint uses `opencode/gpt-5-nano`

## Related
- #5037 / #5042 kept to installer end-of-run warning + Bailian predicate (no `tui-install-prompts` in that PR after narrow)

## Testing
- No dedicated test (string in TUI options); pair with #5042 or add test in follow-up if requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI installer’s Claude prompt so the "No" option shows the actual ultimate fallback model. Replaces the outdated `opencode/big-pickle` hint with `opencode/gpt-5-nano`.

- **Bug Fixes**
  - Exported `ULTIMATE_FALLBACK` from `model-fallback.ts` and used it in the Claude "No" option hint.
  - Added a unit test to assert the hint references `ULTIMATE_FALLBACK` and not `big-pickle`.

<sup>Written for commit c15c9251283645e040238a5e1340e5a7d286a2f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

