### PR TITLE
feat(codex-rules): post-compact read directive + per-event injection budgets

### DIFF
--- a/packages/omo-codex/plugin/components/rules/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/rules/src/codex-hook.ts
@@ -3,6 +3,7 @@ import { configFromEnvironment } from "./config.js";
 import { hasContextPressureMarker, transcriptHasContextPressureMarker } from "./context-pressure.js";
 import { createHookDebugTimer } from "./debug-log.js";
 import { fingerprintDynamicTargets } from "./dynamic-target-fingerprints.js";
+import { withDynamicBudget } from "./event-budget.js";
 import { formatAdditionalContextOutput } from "./hook-output.js";
 import { displayPath, uniqueStrings } from "./path-utils.js";
 import {
@@ -175,11 +176,12 @@ export async function runPostToolUseHook(
 		debugTimer.done({ outputBytes: 0, reason: "post-compact-recovery-in-progress" });
 		return "";
 	}
+	const dynamicConfig = withDynamicBudget(config);
 	const engine = createRulesEngine(
 		options,
 		completedPostCompactKind !== undefined
-			? withPostCompactBudget(config, { model: input.model, transcriptPath: input.transcript_path })
-			: config,
+			? withPostCompactBudget(dynamicConfig, { model: input.model, transcriptPath: input.transcript_path })
+			: dynamicConfig,
 	);
 	hydrateEngineState(engine, cachePath);
 	debugTimer.lap("hydrate", {

--- a/packages/omo-codex/plugin/components/rules/src/config.ts
+++ b/packages/omo-codex/plugin/components/rules/src/config.ts
@@ -21,6 +21,19 @@ export function configFromEnvironment(env: NodeJS.ProcessEnv = process.env): PiR
 		parsePositiveInteger(
 			firstEnv(env, "CODEX_RULES_POST_COMPACT_MAX_RESULT_CHARS", "PI_RULES_POST_COMPACT_MAX_RESULT_CHARS"),
 		) ?? config.postCompactMaxResultChars;
+	config.dynamicMaxRuleChars =
+		parsePositiveInteger(firstEnv(env, "CODEX_RULES_DYNAMIC_MAX_RULE_CHARS", "PI_RULES_DYNAMIC_MAX_RULE_CHARS")) ??
+		config.dynamicMaxRuleChars;
+	config.dynamicMaxResultChars =
+		parsePositiveInteger(
+			firstEnv(env, "CODEX_RULES_DYNAMIC_MAX_RESULT_CHARS", "PI_RULES_DYNAMIC_MAX_RESULT_CHARS"),
+		) ?? config.dynamicMaxResultChars;
+	config.promptMaxRuleChars =
+		parsePositiveInteger(firstEnv(env, "CODEX_RULES_PROMPT_MAX_RULE_CHARS", "PI_RULES_PROMPT_MAX_RULE_CHARS")) ??
+		config.promptMaxRuleChars;
+	config.promptMaxResultChars =
+		parsePositiveInteger(firstEnv(env, "CODEX_RULES_PROMPT_MAX_RESULT_CHARS", "PI_RULES_PROMPT_MAX_RESULT_CHARS")) ??
+		config.promptMaxResultChars;
 	config.enabledSources = parseEnabledSources(
 		firstEnv(env, "CODEX_RULES_ENABLED_SOURCES", "PI_RULES_ENABLED_SOURCES"),
 		disableBundledRules,

--- a/packages/omo-codex/plugin/components/rules/src/event-budget.ts
+++ b/packages/omo-codex/plugin/components/rules/src/event-budget.ts
@@ -1,0 +1,17 @@
+import type { PiRulesConfig } from "./rules/types.js";
+
+export function withDynamicBudget(config: PiRulesConfig): PiRulesConfig {
+	return {
+		...config,
+		maxRuleChars: Math.min(config.maxRuleChars, config.dynamicMaxRuleChars),
+		maxResultChars: Math.min(config.maxResultChars, config.dynamicMaxResultChars),
+	};
+}
+
+export function withPromptBudget(config: PiRulesConfig): PiRulesConfig {
+	return {
+		...config,
+		maxRuleChars: Math.min(config.maxRuleChars, config.promptMaxRuleChars),
+		maxResultChars: Math.min(config.maxResultChars, config.promptMaxResultChars),
+	};
+}

--- a/packages/omo-codex/plugin/components/rules/src/persistent-cache.ts
+++ b/packages/omo-codex/plugin/components/rules/src/persistent-cache.ts
@@ -68,8 +68,11 @@ export function clearSessionState(cachePath: string): void {
 
 export function markSessionCompacted(cachePath: string): void {
 	const state = readSessionState(cachePath);
+	// Compaction drops injected static rule bodies, so pre-compaction static
+	// dedup marks must not suppress the post-compact recovery directive.
+	// Dynamic dedup survives: those rules are recovered as read-directive paths.
 	writeSessionState(cachePath, {
-		staticDedup: state.staticDedup,
+		staticDedup: [],
 		dynamicDedup: state.dynamicDedup,
 		...(state.dynamicTargetFingerprints === undefined
 			? {}

--- a/packages/omo-codex/plugin/components/rules/src/post-compact-directive.ts
+++ b/packages/omo-codex/plugin/components/rules/src/post-compact-directive.ts
@@ -1,0 +1,39 @@
+import { uniqueStrings } from "./path-utils.js";
+
+const DIRECTIVE_HEADER = [
+	"## MANDATORY: POST-COMPACTION RULE RECOVERY",
+	"",
+	"Context compaction DROPPED the project rule files listed below from your context.",
+	"YOU MUST READ THE FOLLOWING RULES with your file-reading tool RIGHT NOW, BEFORE ANY OTHER ACTION. NO EXCUSES.",
+	"Do not plan, answer, edit, or run anything until EVERY file below has been read end to end:",
+	"",
+].join("\n");
+
+const DIRECTIVE_FOOTER =
+	"\nOperating without these rules is a protocol violation. Reconstructing them from memory is NOT reading. READ THEM ALL. NO EXCUSES.";
+
+export function buildPostCompactReadDirective(rulePaths: ReadonlyArray<string>, maxChars: number): string {
+	const paths = uniqueStrings([...rulePaths]);
+	if (paths.length === 0) {
+		return "";
+	}
+
+	const lines: string[] = [];
+	let usedChars = DIRECTIVE_HEADER.length + DIRECTIVE_FOOTER.length;
+	let omittedCount = 0;
+	for (const rulePath of paths) {
+		const line = `- ${rulePath}`;
+		if (lines.length > 0 && usedChars + line.length + 1 > maxChars) {
+			omittedCount += 1;
+			continue;
+		}
+		lines.push(line);
+		usedChars += line.length + 1;
+	}
+	if (omittedCount > 0) {
+		lines.push(
+			`- (+${omittedCount} more rule files omitted - rescan the project rule directories and read those too)`,
+		);
+	}
+	return `${DIRECTIVE_HEADER}${lines.join("\n")}${DIRECTIVE_FOOTER}`;
+}

--- a/packages/omo-codex/plugin/components/rules/src/rules/constants.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules/constants.ts
@@ -88,6 +88,22 @@ export const DEFAULT_POST_COMPACT_MAX_RULE_CHARS = 3500;
 export const DEFAULT_POST_COMPACT_MAX_RESULT_CHARS = 4000;
 
 /**
+ * Per-rule / total caps for dynamic (PostToolUse) injection. Kept far below the
+ * static defaults so mid-session rule matches stay lightweight.
+ */
+export const DEFAULT_DYNAMIC_MAX_RULE_CHARS = 4000;
+
+export const DEFAULT_DYNAMIC_MAX_RESULT_CHARS = 10000;
+
+/**
+ * Per-rule / total caps for UserPromptSubmit static injection. SessionStart
+ * keeps the full budget; prompt-time stragglers inject at a reduced size.
+ */
+export const DEFAULT_PROMPT_MAX_RULE_CHARS = 6000;
+
+export const DEFAULT_PROMPT_MAX_RESULT_CHARS = 16000;
+
+/**
  * Truncation marker template. `{path}` is replaced with the relative path.
  */
 export const TRUNCATION_NOTICE = "\n\n[Truncated. Full: {path}]";

--- a/packages/omo-codex/plugin/components/rules/src/rules/engine.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules/engine.ts
@@ -7,10 +7,14 @@ import {
 	markStaticInjected as markStaticInjectedInState,
 } from "./cache.js";
 import {
+	DEFAULT_DYNAMIC_MAX_RESULT_CHARS,
+	DEFAULT_DYNAMIC_MAX_RULE_CHARS,
 	DEFAULT_MAX_RESULT_CHARS,
 	DEFAULT_MAX_RULE_CHARS,
 	DEFAULT_POST_COMPACT_MAX_RESULT_CHARS,
 	DEFAULT_POST_COMPACT_MAX_RULE_CHARS,
+	DEFAULT_PROMPT_MAX_RESULT_CHARS,
+	DEFAULT_PROMPT_MAX_RULE_CHARS,
 } from "./constants.js";
 import { loadDynamicCandidates } from "./engine-dynamic-loader.js";
 import { loadStaticCandidates } from "./engine-static-loader.js";
@@ -29,6 +33,10 @@ export function defaultConfig(): PiRulesConfig {
 		maxResultChars: DEFAULT_MAX_RESULT_CHARS,
 		postCompactMaxRuleChars: DEFAULT_POST_COMPACT_MAX_RULE_CHARS,
 		postCompactMaxResultChars: DEFAULT_POST_COMPACT_MAX_RESULT_CHARS,
+		dynamicMaxRuleChars: DEFAULT_DYNAMIC_MAX_RULE_CHARS,
+		dynamicMaxResultChars: DEFAULT_DYNAMIC_MAX_RESULT_CHARS,
+		promptMaxRuleChars: DEFAULT_PROMPT_MAX_RULE_CHARS,
+		promptMaxResultChars: DEFAULT_PROMPT_MAX_RESULT_CHARS,
 		enabledSources: "auto",
 	};
 }

--- a/packages/omo-codex/plugin/components/rules/src/rules/types.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules/types.ts
@@ -112,6 +112,10 @@ export interface PiRulesConfig {
 	maxResultChars: number;
 	postCompactMaxRuleChars: number;
 	postCompactMaxResultChars: number;
+	dynamicMaxRuleChars: number;
+	dynamicMaxResultChars: number;
+	promptMaxRuleChars: number;
+	promptMaxResultChars: number;
 	enabledSources: RuleSource[] | "auto";
 }
 

--- a/packages/omo-codex/plugin/components/rules/src/static-injection.ts
+++ b/packages/omo-codex/plugin/components/rules/src/static-injection.ts
@@ -1,12 +1,20 @@
+import { existsSync } from "node:fs";
+
 import type { CodexRulesHookOptions } from "./codex-hook-options.js";
 import { configFromEnvironment } from "./config.js";
+import { withPromptBudget } from "./event-budget.js";
 import { formatAdditionalContextOutput } from "./hook-output.js";
 import { completePostCompactRecovery, hydrateEngineState, persistEngineState } from "./persistent-cache.js";
 import { withPostCompactBudget } from "./post-compact-budget.js";
+import { buildPostCompactReadDirective } from "./post-compact-directive.js";
+import type { Engine } from "./rules/engine.js";
+import { isNeverTruncatedRule } from "./rules/truncator.js";
+import type { LoadedRule, PiRulesConfig } from "./rules/types.js";
 import { createRulesEngine } from "./rules-engine-factory.js";
 import { getSparkShellRuntimeAwareness, SPARKSHELL_AWARENESS_DEDUP_KEY } from "./sparkshell-awareness.js";
-import { filterRulesAlreadyInTranscript } from "./transcript-rule-filter.js";
+import { filterRulesAlreadyInTranscript, filterRulesNotInTranscriptText } from "./transcript-rule-filter.js";
 import type { TranscriptSearchOptions } from "./transcript-search.js";
+import { readTranscriptSearchText } from "./transcript-search.js";
 
 export function runStaticInjection(
 	cwd: string,
@@ -26,10 +34,20 @@ export function runStaticInjection(
 		return "";
 	}
 
-	const effectiveConfig =
-		completedPostCompactChannel === undefined
-			? config
-			: withPostCompactBudget(config, { model: model ?? "", transcriptPath });
+	if (completedPostCompactChannel !== undefined) {
+		return runPostCompactRecovery({
+			cwd,
+			transcriptPath,
+			eventName,
+			cachePath,
+			options,
+			channel: completedPostCompactChannel,
+			model: model ?? "",
+			config,
+		});
+	}
+
+	const effectiveConfig = eventName === "UserPromptSubmit" ? withPromptBudget(config) : config;
 	const engine = createRulesEngine(options, effectiveConfig);
 	hydrateEngineState(engine, cachePath);
 	engine.state.cwd = cwd;
@@ -47,7 +65,7 @@ export function runStaticInjection(
 		? ""
 		: getSparkShellRuntimeAwareness(options.env);
 	if (rules.length === 0 && sparkshellAwareness.length === 0) {
-		persistEngineState(engine, cachePath, completedPostCompactChannel);
+		persistEngineState(engine, cachePath);
 		return "";
 	}
 
@@ -58,8 +76,110 @@ export function runStaticInjection(
 	if (sparkshellAwareness.length > 0) {
 		engine.state.staticDedup.add(SPARKSHELL_AWARENESS_DEDUP_KEY);
 	}
-	persistEngineState(engine, cachePath, completedPostCompactChannel);
+	persistEngineState(engine, cachePath);
 	return formatAdditionalContextOutput(eventName, combineStaticContext(block, sparkshellAwareness));
+}
+
+interface PostCompactRecoveryInput {
+	cwd: string;
+	transcriptPath: string | null;
+	eventName: "SessionStart" | "UserPromptSubmit";
+	cachePath: string;
+	options: CodexRulesHookOptions;
+	channel: "static";
+	model: string;
+	config: PiRulesConfig;
+}
+
+function runPostCompactRecovery(input: PostCompactRecoveryInput): string {
+	const effectiveConfig = withPostCompactBudget(input.config, {
+		model: input.model,
+		transcriptPath: input.transcriptPath,
+	});
+	const engine = createRulesEngine(input.options, effectiveConfig);
+	hydrateEngineState(engine, input.cachePath);
+	engine.state.cwd = input.cwd;
+
+	const loaded = engine.loadStaticRules(input.cwd);
+	const transcriptText = readRecoveryTranscriptText(input.transcriptPath);
+	const missingRules = filterRulesNotInTranscriptText(
+		loaded.rules.filter((rule) => !engine.isStaticInjected(rule)),
+		transcriptText,
+		(rule) => {
+			engine.markStaticInjected(rule);
+		},
+	);
+	const dynamicRulePaths = recoverDynamicRulePaths(engine, transcriptText, loaded.rules);
+	const sparkshellAwareness = engine.state.staticDedup.has(SPARKSHELL_AWARENESS_DEDUP_KEY)
+		? ""
+		: getSparkShellRuntimeAwareness(input.options.env);
+
+	if (missingRules.length === 0 && dynamicRulePaths.length === 0 && sparkshellAwareness.length === 0) {
+		persistEngineState(engine, input.cachePath, input.channel);
+		return "";
+	}
+
+	const fullBodyRules = missingRules.filter((rule) => isNeverTruncatedRule(ruleDisplayPath(rule)));
+	const listedRules = missingRules.filter((rule) => !isNeverTruncatedRule(ruleDisplayPath(rule)));
+	const bodyBlock = fullBodyRules.length === 0 ? "" : engine.formatStatic(fullBodyRules);
+	const directive = buildPostCompactReadDirective(
+		[...listedRules.map((rule) => rule.path), ...dynamicRulePaths],
+		effectiveConfig.maxResultChars,
+	);
+	for (const rule of missingRules) {
+		engine.markStaticInjected(rule);
+	}
+	if (sparkshellAwareness.length > 0) {
+		engine.state.staticDedup.add(SPARKSHELL_AWARENESS_DEDUP_KEY);
+	}
+	persistEngineState(engine, input.cachePath, input.channel);
+	return formatAdditionalContextOutput(
+		input.eventName,
+		combineStaticContext(bodyBlock, directive, sparkshellAwareness),
+	);
+}
+
+function readRecoveryTranscriptText(transcriptPath: string | null): string | null {
+	if (transcriptPath === null) {
+		return null;
+	}
+	return (
+		readTranscriptSearchText(transcriptPath, { latestCompactedReplacementOnly: true }) ??
+		readTranscriptSearchText(transcriptPath)
+	);
+}
+
+function recoverDynamicRulePaths(
+	engine: Engine,
+	transcriptText: string | null,
+	staticRules: ReadonlyArray<LoadedRule>,
+): string[] {
+	const staticRulePaths = new Set(staticRules.map((rule) => rule.realPath));
+	const recoveredPaths = new Set<string>();
+	for (const dedupKeys of engine.state.dynamicDedup.values()) {
+		for (const dedupKey of dedupKeys) {
+			const separatorIndex = dedupKey.lastIndexOf("::");
+			if (separatorIndex <= 0) {
+				continue;
+			}
+			const rulePath = dedupKey.slice(0, separatorIndex);
+			if (staticRulePaths.has(rulePath)) {
+				continue;
+			}
+			if (transcriptText !== null && transcriptText.includes(rulePath)) {
+				continue;
+			}
+			if (!existsSync(rulePath)) {
+				continue;
+			}
+			recoveredPaths.add(rulePath);
+		}
+	}
+	return [...recoveredPaths].sort();
+}
+
+function ruleDisplayPath(rule: LoadedRule): string {
+	return rule.relativePath.length > 0 ? rule.relativePath : rule.path;
 }
 
 function combineStaticContext(...blocks: readonly string[]): string {

--- a/packages/omo-codex/plugin/components/rules/src/transcript-rule-filter.ts
+++ b/packages/omo-codex/plugin/components/rules/src/transcript-rule-filter.ts
@@ -13,7 +13,15 @@ export function filterRulesAlreadyInTranscript(
 	}
 
 	const transcriptText = readTranscriptSearchText(transcriptPath, options);
-	if (transcriptText === null) {
+	return filterRulesNotInTranscriptText(rules, transcriptText, markInjected);
+}
+
+export function filterRulesNotInTranscriptText(
+	rules: ReadonlyArray<LoadedRule>,
+	transcriptText: string | null,
+	markInjected: (rule: LoadedRule) => void,
+): LoadedRule[] {
+	if (rules.length === 0 || transcriptText === null) {
 		return [...rules];
 	}
 

--- a/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
@@ -200,7 +200,7 @@ describe("plugin bundled rules", () => {
 		expect(output).toBe("");
 	});
 
-	it("#given bundled static context already injected #when UserPromptSubmit runs after PostCompact #then it emits no duplicate bundled context", async () => {
+	it("#given bundled static context dropped by compaction #when UserPromptSubmit runs after PostCompact #then it re-injects the bundled persona body in full", async () => {
 		// given
 		const { root, pluginData, bundledRulePath } = makeFixture();
 		const firstOutput = await runSessionStartHook(sessionStartInput(root), {
@@ -219,7 +219,9 @@ describe("plugin bundled rules", () => {
 
 		// then
 		expect(compactOutput).toBe("");
-		expect(output).toBe("");
+		expect(output).toContain(`Instructions from: ${bundledRulePath}`);
+		expect(output).toContain(BUNDLED_BODY);
+		expect(output).not.toContain("[Truncated. Full:");
 	});
 
 	it("#given bundled Hephaestus rule body exceeds per-rule cap #when SessionStart runs #then static context expands the body within result budget", async () => {

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-budget.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("codex rules post-compaction context budget", () => {
-	it("#given oversized project rules already injected #when static recovery runs after compaction #then it emits no duplicate static injection", async () => {
+	it("#given oversized project rules already injected #when static recovery runs after compaction #then it emits a mandatory read directive instead of rule bodies", async () => {
 		// given
 		const { root, pluginData } = makeOversizedProject();
 		const firstOutput = await runSessionStartHook(sessionStartInput(root), {
@@ -50,7 +50,12 @@ describe("codex rules post-compaction context budget", () => {
 		expect(firstContext).toContain("Project rule");
 		expect(firstContext).toContain("[Truncated. Full:");
 		expect(firstContext.length).toBeLessThan(31_000);
-		expect(output).toBe("");
+		const recoveryContext = readAdditionalContext(output);
+		expect(recoveryContext).toContain("MUST READ");
+		expect(recoveryContext).toContain("NO EXCUSES");
+		expect(recoveryContext).toContain(path.join(root, "CONTEXT.md"));
+		expect(recoveryContext).not.toContain("Project rule");
+		expect(recoveryContext.length).toBeLessThan(2_000);
 	});
 });
 

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-context.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-context.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 describe("codex rules compacted context recovery", () => {
-	it("#given compacted session source after PostCompact #when static rules re-inject #then output uses the compact recovery budget", async () => {
+	it("#given compacted session source after PostCompact #when static recovery runs #then output is a mandatory read directive", async () => {
 		// given
 		const { root, pluginData } = makeOversizedProject("compact-source");
 		const transcriptPath = writeCompactedTranscript(root, "summary dropped injected rules");
@@ -37,10 +37,10 @@ describe("codex rules compacted context recovery", () => {
 
 		// then
 		const postCompactContext = readAdditionalContext(output);
-		expect(postCompactContext.length).toBeLessThan(5_000);
-		expect(postCompactContext).toContain("Instructions from:");
+		expect(postCompactContext.length).toBeLessThan(2_000);
+		expect(postCompactContext).toContain("MUST READ");
 		expect(postCompactContext).toContain("CONTEXT.md");
-		expect(postCompactContext).toContain("Project rule");
+		expect(postCompactContext).not.toContain("Project rule");
 	});
 
 	it("#given compacted context warning and near-full transcript #when compact source starts twice #then handles compacted context warning once", async () => {
@@ -65,7 +65,7 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const firstContext = readOptionalAdditionalContext(firstOutput);
 		expect(firstContext.length).toBeLessThan(1_000);
-		expect(firstContext).toContain("Instructions from:");
+		expect(firstContext).toContain("MUST READ");
 		expect(firstContext).toContain("CONTEXT.md");
 		expect(secondOutput).toBe("");
 	});
@@ -88,7 +88,7 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("Instructions from:");
+		expect(context).toContain("MUST READ");
 		expect(context).toContain("CONTEXT.md");
 	});
 
@@ -106,7 +106,7 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("Instructions from:");
+		expect(context).toContain("MUST READ");
 		expect(context).toContain("CONTEXT.md");
 	});
 
@@ -128,7 +128,7 @@ describe("codex rules compacted context recovery", () => {
 		// then
 		const context = readOptionalAdditionalContext(output);
 		expect(context.length).toBeLessThan(1_000);
-		expect(context).toContain("Instructions from:");
+		expect(context).toContain("MUST READ");
 		expect(context).toContain("CONTEXT.md");
 	});
 
@@ -157,7 +157,7 @@ describe("codex rules compacted context recovery", () => {
 		const contexts = outputs.map(readOptionalAdditionalContext);
 		expect(contexts.filter((context) => context.length > 0)).toHaveLength(1);
 		expect(contexts.join("").length).toBeLessThan(1_000);
-		expect(contexts.join("")).toContain("Instructions from:");
+		expect(contexts.join("")).toContain("MUST READ");
 		expect(contexts.join("")).toContain("CONTEXT.md");
 	});
 });

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-dedup.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-dedup.test.ts
@@ -93,7 +93,7 @@ describe("codex rules PostCompact deduplication", () => {
 		expect(output).toBe("");
 	});
 
-	it("#given startup already injected static context #when UserPromptSubmit runs after PostCompact #then it emits no duplicate static context", async () => {
+	it("#given startup static context dropped by compaction #when UserPromptSubmit runs after PostCompact #then it emits a mandatory read directive without rule bodies", async () => {
 		// given
 		const { root, pluginData } = makeTempProject();
 		await runSessionStartHook(sessionStartInput(root), {
@@ -113,10 +113,13 @@ describe("codex rules PostCompact deduplication", () => {
 		});
 
 		// then
-		expect(output).toBe("");
+		const context = readAdditionalContext(output);
+		expect(context).toContain("MUST READ");
+		expect(context).toContain("CONTEXT.md");
+		expect(context).not.toContain("Instructions from:");
 	});
 
-	it("#given startup already injected static context #when compact SessionStart runs after PostCompact #then it emits no duplicate static context", async () => {
+	it("#given startup static context dropped by compaction #when compact SessionStart runs after PostCompact #then it emits a mandatory read directive without rule bodies", async () => {
 		// given
 		const { root, pluginData } = makeTempProject();
 		await runSessionStartHook(sessionStartInput(root), {
@@ -136,7 +139,10 @@ describe("codex rules PostCompact deduplication", () => {
 		});
 
 		// then
-		expect(output).toBe("");
+		const context = readAdditionalContext(output);
+		expect(context).toContain("MUST READ");
+		expect(context).toContain("CONTEXT.md");
+		expect(context).not.toContain("Instructions from:");
 	});
 });
 

--- a/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-directive.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/codex-hook-post-compact-directive.test.ts
@@ -1,0 +1,241 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	type CodexPostCompactInput,
+	type CodexPostToolUseInput,
+	type CodexSessionStartInput,
+	type CodexUserPromptSubmitInput,
+	runPostCompactHook,
+	runPostToolUseHook,
+	runSessionStartHook,
+	runUserPromptSubmitHook,
+} from "../src/codex-hook.js";
+
+const tempDirectories: string[] = [];
+const PROJECT_ONLY_ENV = {
+	CODEX_RULES_ENABLED_SOURCES: "CONTEXT.md,.omo/rules",
+};
+const SESSION_ID = "session-post-compact-directive";
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("codex rules post-compaction read directive", () => {
+	it("#given injected rules dropped by compaction #when UserPromptSubmit recovers #then it lists rule paths in a mandatory read directive instead of bodies", async () => {
+		// given
+		const { root, pluginData } = makeProject();
+		await runSessionStartHook(sessionStartInput(root), { pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV });
+		const dynamicOutput = await runPostToolUseHook(postToolUseInput(root, path.join(root, "src", "app.ts")), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+		const transcriptPath = writeCompactedTranscript(root, "summary that dropped every injected rule");
+		await runPostCompactHook(
+			{ ...postCompactInput(root), transcript_path: transcriptPath },
+			{ pluginDataRoot: pluginData },
+		);
+
+		// when
+		const output = await runUserPromptSubmitHook(userPromptSubmitInput(root, transcriptPath), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		expect(dynamicOutput).toContain("TypeScript rule");
+		const context = readAdditionalContext(output);
+		expect(context).toContain("MUST READ");
+		expect(context).toContain("NO EXCUSES");
+		expect(context).toContain("CONTEXT.md");
+		expect(context).toContain(".omo/rules/typescript.md");
+		expect(context).not.toContain("A".repeat(50));
+		expect(context).not.toContain("B".repeat(50));
+		expect(context.length).toBeLessThan(2_000);
+	});
+
+	it("#given recovery directive already emitted #when UserPromptSubmit runs again #then it emits nothing", async () => {
+		// given
+		const { root, pluginData } = makeProject();
+		await runSessionStartHook(sessionStartInput(root), { pluginDataRoot: pluginData, env: PROJECT_ONLY_ENV });
+		const transcriptPath = writeCompactedTranscript(root, "summary that dropped every injected rule");
+		await runPostCompactHook(
+			{ ...postCompactInput(root), transcript_path: transcriptPath },
+			{ pluginDataRoot: pluginData },
+		);
+		await runUserPromptSubmitHook(userPromptSubmitInput(root, transcriptPath), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// when
+		const secondOutput = await runUserPromptSubmitHook(userPromptSubmitInput(root, transcriptPath), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		expect(secondOutput).toBe("");
+	});
+
+	it("#given rules retained in compacted replacement #when UserPromptSubmit recovers #then it emits nothing", async () => {
+		// given
+		const { root, pluginData } = makeProject();
+		const firstOutput = await runSessionStartHook(sessionStartInput(root), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+		const transcriptPath = writeCompactedTranscript(root, readAdditionalContext(firstOutput));
+		await runPostCompactHook(
+			{ ...postCompactInput(root), transcript_path: transcriptPath },
+			{ pluginDataRoot: pluginData },
+		);
+
+		// when
+		const output = await runUserPromptSubmitHook(userPromptSubmitInput(root, transcriptPath), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		expect(output).toBe("");
+	});
+
+	it("#given bundled hephaestus rule dropped by compaction #when compact SessionStart recovers #then hephaestus body is re-injected in full alongside the directive", async () => {
+		// given
+		const { root, pluginData } = makeProject();
+		const env = { CODEX_RULES_ENABLED_SOURCES: "CONTEXT.md,plugin-bundled" };
+		await runSessionStartHook(sessionStartInput(root), { pluginDataRoot: pluginData, env });
+		const transcriptPath = writeCompactedTranscript(root, "summary that dropped every injected rule");
+		await runPostCompactHook(
+			{ ...postCompactInput(root), transcript_path: transcriptPath },
+			{ pluginDataRoot: pluginData },
+		);
+
+		// when
+		const output = await runSessionStartHook(compactSessionStartInput(root, transcriptPath), {
+			pluginDataRoot: pluginData,
+			env,
+		});
+
+		// then
+		const context = readAdditionalContext(output);
+		expect(context).toContain("You are Hephaestus");
+		expect(context).not.toContain("[Truncated. Full:");
+		expect(context).toContain("MUST READ");
+		expect(context).toContain("CONTEXT.md");
+	});
+});
+
+function makeProject(): { root: string; pluginData: string } {
+	const root = mkdtempSync(path.join(tmpdir(), "codex-rules-directive-project-"));
+	const pluginData = mkdtempSync(path.join(tmpdir(), "codex-rules-directive-data-"));
+	tempDirectories.push(root, pluginData);
+	writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fixture" }));
+	writeFileSync(path.join(root, "CONTEXT.md"), `Project rule\n${"A".repeat(8_000)}`);
+	mkdirSync(path.join(root, ".omo", "rules"), { recursive: true });
+	writeFileSync(
+		path.join(root, ".omo", "rules", "typescript.md"),
+		["---", 'globs: "**/*.ts"', "---", "", `TypeScript rule\n${"B".repeat(2_000)}`].join("\n"),
+	);
+	mkdirSync(path.join(root, "src"), { recursive: true });
+	writeFileSync(path.join(root, "src", "app.ts"), "export const app = 1;\n");
+	return { root, pluginData };
+}
+
+function sessionStartInput(root: string): CodexSessionStartInput {
+	return {
+		session_id: SESSION_ID,
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "SessionStart",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		source: "startup",
+	};
+}
+
+function compactSessionStartInput(root: string, transcriptPath: string): CodexSessionStartInput {
+	return {
+		session_id: SESSION_ID,
+		transcript_path: transcriptPath,
+		cwd: root,
+		hook_event_name: "SessionStart",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		source: "compact",
+	};
+}
+
+function postCompactInput(root: string): CodexPostCompactInput {
+	return {
+		session_id: SESSION_ID,
+		turn_id: "turn-compact",
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "PostCompact",
+		model: "gpt-5.5",
+		trigger: "auto",
+	};
+}
+
+function userPromptSubmitInput(root: string, transcriptPath: string): CodexUserPromptSubmitInput {
+	return {
+		session_id: SESSION_ID,
+		turn_id: "turn-after-compact",
+		transcript_path: transcriptPath,
+		cwd: root,
+		hook_event_name: "UserPromptSubmit",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		prompt: "continue",
+	};
+}
+
+function postToolUseInput(root: string, filePath: string): CodexPostToolUseInput {
+	return {
+		session_id: SESSION_ID,
+		turn_id: "turn-tool",
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "PostToolUse",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		tool_name: "apply_patch",
+		tool_input: { path: filePath },
+		tool_response: {},
+		tool_use_id: "tool-use-1",
+	};
+}
+
+function writeCompactedTranscript(root: string, retainedText: string): string {
+	const transcriptPath = path.join(root, "transcript-compacted.jsonl");
+	writeFileSync(
+		transcriptPath,
+		`${JSON.stringify({
+			type: "compacted",
+			payload: {
+				message: "summary",
+				replacement_history: [{ type: "message", role: "user", content: retainedText }],
+			},
+		})}\n`,
+	);
+	return transcriptPath;
+}
+
+function readAdditionalContext(output: string): string {
+	if (output.trim().length === 0) {
+		throw new Error("Expected hook output to include additional context.");
+	}
+	const parsed: unknown = JSON.parse(output);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return "";
+	const hookSpecificOutput = (parsed as Record<string, unknown>)["hookSpecificOutput"];
+	if (typeof hookSpecificOutput !== "object" || hookSpecificOutput === null) return "";
+	const additionalContext = (hookSpecificOutput as Record<string, unknown>)["additionalContext"];
+	return typeof additionalContext === "string" ? additionalContext : "";
+}

--- a/packages/omo-codex/plugin/components/rules/test/event-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/event-budget.test.ts
@@ -1,0 +1,168 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	type CodexPostToolUseInput,
+	type CodexSessionStartInput,
+	type CodexUserPromptSubmitInput,
+	runPostToolUseHook,
+	runSessionStartHook,
+	runUserPromptSubmitHook,
+} from "../src/codex-hook.js";
+
+const tempDirectories: string[] = [];
+const PROJECT_ONLY_ENV = {
+	CODEX_RULES_ENABLED_SOURCES: "CONTEXT.md,.omo/rules",
+};
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("codex rules per-event injection budgets", () => {
+	it("#given an oversized glob rule #when PostToolUse injects dynamically #then the block is truncated to the dynamic budget", async () => {
+		// given
+		const { root, pluginData } = makeProject({ dynamicRuleChars: 30_000 });
+
+		// when
+		const output = await runPostToolUseHook(postToolUseInput(root, path.join(root, "src", "app.ts")), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		const context = readAdditionalContext(output);
+		expect(context).toContain("[Truncated. Full:");
+		expect(context.length).toBeLessThan(11_000);
+	});
+
+	it("#given a mid-sized static rule #when SessionStart injects #then the body is not truncated", async () => {
+		// given
+		const { root, pluginData } = makeProject({ staticRuleChars: 8_000 });
+
+		// when
+		const output = await runSessionStartHook(sessionStartInput(root), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		const context = readAdditionalContext(output);
+		expect(context).not.toContain("[Truncated. Full:");
+		expect(context.length).toBeGreaterThan(8_000);
+	});
+
+	it("#given the same mid-sized static rule #when UserPromptSubmit injects on a fresh session #then the body is truncated to the prompt budget", async () => {
+		// given
+		const { root, pluginData } = makeProject({ staticRuleChars: 8_000 });
+
+		// when
+		const output = await runUserPromptSubmitHook(userPromptSubmitInput(root), {
+			pluginDataRoot: pluginData,
+			env: PROJECT_ONLY_ENV,
+		});
+
+		// then
+		const context = readAdditionalContext(output);
+		expect(context).toContain("[Truncated. Full:");
+		expect(context.length).toBeLessThan(7_000);
+	});
+
+	it("#given dynamic budget env overrides #when PostToolUse injects #then the override budget wins", async () => {
+		// given
+		const { root, pluginData } = makeProject({ dynamicRuleChars: 30_000 });
+
+		// when
+		const output = await runPostToolUseHook(postToolUseInput(root, path.join(root, "src", "app.ts")), {
+			pluginDataRoot: pluginData,
+			env: {
+				...PROJECT_ONLY_ENV,
+				CODEX_RULES_DYNAMIC_MAX_RULE_CHARS: "1000",
+				CODEX_RULES_DYNAMIC_MAX_RESULT_CHARS: "1500",
+			},
+		});
+
+		// then
+		const context = readAdditionalContext(output);
+		expect(context).toContain("[Truncated. Full:");
+		expect(context.length).toBeLessThan(2_000);
+	});
+});
+
+function makeProject(sizes: { staticRuleChars?: number; dynamicRuleChars?: number }): {
+	root: string;
+	pluginData: string;
+} {
+	const root = mkdtempSync(path.join(tmpdir(), "codex-rules-event-budget-project-"));
+	const pluginData = mkdtempSync(path.join(tmpdir(), "codex-rules-event-budget-data-"));
+	tempDirectories.push(root, pluginData);
+	writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fixture" }));
+	writeFileSync(path.join(root, "CONTEXT.md"), `Project rule\n${"A".repeat(sizes.staticRuleChars ?? 100)}`);
+	mkdirSync(path.join(root, ".omo", "rules"), { recursive: true });
+	writeFileSync(
+		path.join(root, ".omo", "rules", "typescript.md"),
+		["---", 'globs: "**/*.ts"', "---", "", `TypeScript rule\n${"B".repeat(sizes.dynamicRuleChars ?? 100)}`].join(
+			"\n",
+		),
+	);
+	mkdirSync(path.join(root, "src"), { recursive: true });
+	writeFileSync(path.join(root, "src", "app.ts"), "export const app = 1;\n");
+	return { root, pluginData };
+}
+
+function sessionStartInput(root: string): CodexSessionStartInput {
+	return {
+		session_id: `session-budget-${path.basename(root)}`,
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "SessionStart",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		source: "startup",
+	};
+}
+
+function userPromptSubmitInput(root: string): CodexUserPromptSubmitInput {
+	return {
+		session_id: `session-budget-${path.basename(root)}`,
+		turn_id: "turn-1",
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "UserPromptSubmit",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		prompt: "continue",
+	};
+}
+
+function postToolUseInput(root: string, filePath: string): CodexPostToolUseInput {
+	return {
+		session_id: `session-budget-${path.basename(root)}`,
+		turn_id: "turn-tool",
+		transcript_path: null,
+		cwd: root,
+		hook_event_name: "PostToolUse",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		tool_name: "apply_patch",
+		tool_input: { path: filePath },
+		tool_response: {},
+		tool_use_id: "tool-use-1",
+	};
+}
+
+function readAdditionalContext(output: string): string {
+	if (output.trim().length === 0) {
+		throw new Error("Expected hook output to include additional context.");
+	}
+	const parsed: unknown = JSON.parse(output);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return "";
+	const hookSpecificOutput = (parsed as Record<string, unknown>)["hookSpecificOutput"];
+	if (typeof hookSpecificOutput !== "object" || hookSpecificOutput === null) return "";
+	const additionalContext = (hookSpecificOutput as Record<string, unknown>)["additionalContext"];
+	return typeof additionalContext === "string" ? additionalContext : "";
+}

--- a/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
@@ -14,6 +14,10 @@ const CONFIG: PiRulesConfig = {
 	maxResultChars: 50_000,
 	postCompactMaxRuleChars: 12_000,
 	postCompactMaxResultChars: 20_000,
+	dynamicMaxRuleChars: 4_000,
+	dynamicMaxResultChars: 10_000,
+	promptMaxRuleChars: 6_000,
+	promptMaxResultChars: 16_000,
 	enabledSources: "auto",
 };
 


### PR DESCRIPTION
## Problem

Three context-budget problems in the LazyCodex rules component (`packages/omo-codex/plugin/components/rules`):

1. **Rules injected before compaction were permanently lost.** Static/dynamic dedup state survives compaction, so once a rule was injected, recovery refused to re-inject it even though compaction had just dropped it from context — the old `codex-hook-post-compact-budget` test even pinned this as expected behavior (`output === ""`). After any compaction the model silently ran without project rules.
2. **Post-compact recovery (when it did fire) re-injected truncated rule *bodies*** under a 3.5k/4k budget — paying thousands of chars right when context is tightest, for content the model could just re-read from disk.
3. **PostToolUse dynamic injection and UserPromptSubmit static injection used the full SessionStart budget** (12k per rule / 40k per result), making mid-session injections far more aggressive than they need to be.

## Change

1. **Post-compact recovery now emits a mandatory read directive instead of rule bodies.** The static recovery channel (compact `SessionStart` / next `UserPromptSubmit`) collects the rule files actually missing from the compacted transcript — static rules plus previously injected dynamic rules (paths recovered from persisted `dynamicDedup` keys, skipped if retained in the transcript, deleted from disk, or covered by a static rule) — and injects:

   ```
   ## MANDATORY: POST-COMPACTION RULE RECOVERY

   Context compaction DROPPED the project rule files listed below from your context.
   YOU MUST READ THE FOLLOWING RULES with your file-reading tool RIGHT NOW, BEFORE ANY OTHER ACTION. NO EXCUSES.
   Do not plan, answer, edit, or run anything until EVERY file below has been read end to end:
   - /path/to/CONTEXT.md
   - /path/to/.omo/rules/typescript.md
   Operating without these rules is a protocol violation. Reconstructing them from memory is NOT reading. READ THEM ALL. NO EXCUSES.
   ```

   ~550 chars instead of up to 4k of truncated bodies. The path list is capped by the post-compact result budget with an explicit `+N more` overflow marker. Exception: never-truncated rules (`hephaestus.md` persona) still get full-body re-injection — baseline discipline should not depend on the model deciding to read a file.
2. **`markSessionCompacted` resets static dedup**, making dropped rules recoverable at all (fixes problem 1). Recovery marks the listed rules as injected afterwards, which keeps the directive idempotent across repeated compactions, double `SessionStart(source=compact)` invocations, and concurrent hook processes (existing lock/dedup/process tests now pin this). Dynamic dedup intentionally survives: those rules come back as directive paths, not re-injected bodies. Recovery transcript search falls back from latest-compacted-replacement to the full transcript when no `compacted` entry exists, mirroring `post-compact-budget.ts`.
3. **Per-event injection budgets**, all env-overridable (`CODEX_RULES_*` with `PI_*` aliases):

   | Event | Per rule | Per result | Override |
   |---|---|---|---|
   | SessionStart (static) | 12,000 | 40,000 | unchanged |
   | UserPromptSubmit (static) | 6,000 | 16,000 | `CODEX_RULES_PROMPT_MAX_{RULE,RESULT}_CHARS` |
   | PostToolUse (dynamic) | 4,000 | 10,000 | `CODEX_RULES_DYNAMIC_MAX_{RULE,RESULT}_CHARS` |

   Budgets compose by `min()` with the existing global and post-compact budgets, so explicit user overrides still win downward.

## Manual QA

Drove the built `dist/cli.js` with real hook JSON over stdin (tmux transcript) against a temp project (8k `CONTEXT.md`, 30k glob-scoped `.omo/rules/typescript.md`):

- `SessionStart(startup)` → 8,098 chars, no truncation (full budget intact).
- `PostToolUse(apply_patch src/app.ts)` → 4,131 chars with `[Truncated. Full: …]` (dynamic budget).
- `PostCompact` → next `UserPromptSubmit` → 556-char MUST READ directive listing **both** the static `CONTEXT.md` and the previously injected dynamic `typescript.md` paths, no bodies.
- Second `UserPromptSubmit` → 0 bytes (idempotent).
- Fresh-session `UserPromptSubmit` → 6,085 chars truncated (prompt budget).

## Tests

TDD: new `codex-hook-post-compact-directive.test.ts` (directive content, idempotence, retained-transcript silence, hephaestus full-body) and `event-budget.test.ts` (per-event truncation + env overrides) written first and confirmed RED. Ten legacy tests that pinned the old lost-rules behavior updated to the new semantics. 157/157 vitest, `npm run check` (tsc + biome + build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
