### PR TITLE
fix(runtime-fallback): retry reserved session with backoff before giving up

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -8,6 +8,7 @@ import { createInternalAgentContinuationTextPart } from "../../shared/internal-i
 import {
   dispatchInternalPrompt,
   isInternalPromptDispatchAccepted,
+  type InternalPromptDispatchResult,
 } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { resolveOriginalUserRetryMetadata } from "./auto-retry-metadata"
@@ -135,7 +136,7 @@ export function createAutoRetryDispatcher(
         // Retry with linear backoff until the reservation is released.
         const MAX_RESERVED_RETRIES = 6
         const BASE_DELAY_MS = 500
-        let reservedResult = promptResult
+        let reservedResult: InternalPromptDispatchResult = promptResult
         for (let attempt = 0; attempt < MAX_RESERVED_RETRIES; attempt++) {
           const delay = BASE_DELAY_MS * (attempt + 1)
           log(`[${HOOK_NAME}] Session reserved, retrying fallback dispatch in ${delay}ms (${source})`, {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -130,7 +130,50 @@ export function createAutoRetryDispatcher(
         }
         throw promptResult.error
       }
-      if (!isInternalPromptDispatchAccepted(promptResult)) {
+      if (promptResult.status === "reserved") {
+        // Session still has an active reservation from the cancelled stream.
+        // Retry with linear backoff until the reservation is released.
+        const MAX_RESERVED_RETRIES = 6
+        const BASE_DELAY_MS = 500
+        let reservedResult = promptResult
+        for (let attempt = 0; attempt < MAX_RESERVED_RETRIES; attempt++) {
+          const delay = BASE_DELAY_MS * (attempt + 1)
+          log(`[${HOOK_NAME}] Session reserved, retrying fallback dispatch in ${delay}ms (${source})`, {
+            sessionID,
+            attempt: attempt + 1,
+            maxAttempts: MAX_RESERVED_RETRIES,
+          })
+          await new Promise((r) => setTimeout(r, delay))
+          reservedResult = await dispatchInternalPrompt({
+            mode: "async",
+            client: ctx.client,
+            sessionID,
+            source: `runtime-fallback:${source}:reserved-retry-${attempt + 1}`,
+            settleMs: 0,
+            queueBehavior: "defer",
+            input: {
+              path: { id: sessionID },
+              body: {
+                ...(launchAgent ? { agent: launchAgent } : {}),
+                ...retryModelPayload,
+                ...(retryPayload.system ? { system: retryPayload.system } : {}),
+                ...(retryPayload.tools ? { tools: retryPayload.tools } : {}),
+                ...(retryMessageID ? { messageID: retryMessageID } : {}),
+                parts: retryParts,
+              },
+              query: { directory: ctx.directory },
+            },
+          })
+          if (reservedResult.status !== "reserved") break
+        }
+        if (!isInternalPromptDispatchAccepted(reservedResult)) {
+          log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate after reserved retries (${source})`, {
+            sessionID,
+            status: reservedResult.status,
+          })
+          return
+        }
+      } else if (!isInternalPromptDispatchAccepted(promptResult)) {
         log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate (${source})`, {
           sessionID,
           status: promptResult.status,


### PR DESCRIPTION
## Summary

Fixes #5109

When the primary model fails with a quota error (e.g. 1308) and OMO dispatches a fallback prompt, `dispatchInternalPrompt` may return `{status: "reserved"}` because the cancelled stream's reservation has not yet been cleaned up. Previously, the auto-retry dispatcher logged `"skipped by promptAsync gate"` and **silently gave up**, leaving the session in a dead state with no response.

## Changes

**`src/hooks/runtime-fallback/auto-retry-dispatch.ts`**

Added a linear backoff retry loop for the `"reserved"` dispatch status:

- Up to 6 retry attempts
- 500ms base delay with linear increase (500ms → 1000ms → 1500ms → 2000ms → 2500ms → 3000ms)
- Total worst-case wait: ~10.5 seconds
- Breaks immediately when reservation is released
- Falls through to existing rejection handling if all retries exhausted

## Test Plan

1. Configure a primary model that will return a quota error (e.g. Zhipu GLM after 5-hour quota exhausted)
2. Configure a working fallback model in the chain
3. Send a message after quota is exhausted
4. **Before fix:** Toast shows "Switching to X" but session dies silently
5. **After fix:** Toast shows "Switching to X" and fallback model responds after a brief delay

## Reproduction

This was observed in production with:
- Primary: `zhipu-coding-plan/glm-5.1` (returned error 1308)
- Fallback: `modelscope/Kimi-K2.5`
- Result: Session dead for ~2 hours until primary quota recovered

See issue #5109 for full timeline and logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries fallback dispatch when a session is temporarily “reserved” after a quota error, so the fallback model can respond instead of the session dying. Also fixes a TypeScript narrowing issue by annotating the retry result.

- **Bug Fixes**
  - Retries on `reserved` from `dispatchInternalPrompt` with linear backoff (6 attempts, 500ms → 3000ms; worst case ~10.5s), exiting early once the dispatch is accepted.
  - Avoids the immediate “skipped by promptAsync gate” when still reserved; after retries, if not accepted, logs and returns as before.
  - Adds explicit `InternalPromptDispatchResult` typing for `reservedResult` to prevent TS2322 from narrowing and allow reassignment in the retry loop.

<sup>Written for commit fb12f4ece9f61ba606fcebea08ac8a1c963672a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

