### PR TITLE
test(publish): align LazyCodex workflow test with stable-release sync gate

### DIFF
--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -44,9 +44,7 @@ describe("LazyCodex publish workflow", () => {
     const stampsCodexPluginMetadata =
       workflow.includes("jq --arg v \"$VERSION\" '.version = $v' packages/omo-codex/plugin/.codex-plugin/plugin.json") &&
       workflow.includes("jq --arg v \"$VERSION\" '.version = $v' packages/omo-codex/plugin/package.json")
-    const lazycodexReleaseDefaultsOn = workflow.includes("sync_lazycodex_marketplace:") &&
-      workflow.includes('description: "Release the LazyCodex Codex marketplace repository when the omo-codex payload changed"') &&
-      workflow.includes("default: true")
+    const lazycodexSyncHasNoManualOptOut = !workflow.includes("sync_lazycodex_marketplace")
     const publishAliasDefaultsOn = workflow.includes("publish_lazycodex:") &&
       workflow.includes('description: "Publish the lazycodex-ai npm alias"') &&
       workflow.includes("default: true")
@@ -81,8 +79,9 @@ describe("LazyCodex publish workflow", () => {
       publishLazycodexStep.includes("if: inputs.publish_lazycodex == true && steps.check-lazycodex.outputs.skip != 'true'") &&
       publishLazycodexStep.includes("npm publish --access public --provenance --tag latest --loglevel verbose") &&
       !publishLazycodexStep.includes("continue-on-error: true")
-    const syncsLazycodexMarketplaceWhenEnabled = workflow.includes("name: Sync LazyCodex Codex marketplace") &&
-      workflow.includes("if: inputs.sync_lazycodex_marketplace != false")
+    const syncsLazycodexMarketplaceOnStableReleases = workflow.includes("name: Sync LazyCodex Codex marketplace") &&
+      syncMarketplaceStep.includes("if: needs.release-metadata.outputs.dist_tag == ''") &&
+      lazycodexReleaseStateStep.includes("if: needs.release-metadata.outputs.dist_tag == ''")
     const tokenRequirementBeforePublish = workflow.indexOf("name: Require LazyCodex sync token") <
       workflow.indexOf("publish-main:")
     const requiresLazycodexSyncToken = workflow.includes("LAZYCODEX_SYNC_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}") &&
@@ -104,14 +103,19 @@ describe("LazyCodex publish workflow", () => {
       lazycodexReleaseStateStep.includes("lazycodex_changed=false") &&
       lazycodexReleaseStateStep.includes("previous_lazycodex_version=${PREVIOUS_LAZYCODEX_VERSION}")
     const createsLazycodexReleaseOnlyWhenChanged =
-      lazycodexReleaseStep.includes("if: inputs.sync_lazycodex_marketplace != false && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'") &&
+      lazycodexReleaseStep.includes(
+        "if: needs.release-metadata.outputs.dist_tag == '' && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'",
+      ) &&
       lazycodexReleaseStep.includes("GH_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}") &&
       lazycodexReleaseStep.includes('gh release create "v${VERSION}" --repo code-yeongyu/lazycodex') &&
       lazycodexReleaseStep.includes("--notes-file /tmp/lazycodex-release-notes.md")
 
     // #then
     expect(stampsCodexPluginMetadata, "LazyCodex plugin metadata must be stamped with the release version").toBe(true)
-    expect(lazycodexReleaseDefaultsOn, "LazyCodex marketplace release must default to enabled").toBe(true)
+    expect(
+      lazycodexSyncHasNoManualOptOut,
+      "LazyCodex marketplace sync must not expose a manual opt-out input",
+    ).toBe(true)
     expect(publishAliasDefaultsOn, "LazyCodex npm alias publish must stay enabled by default").toBe(true)
     expect(syncsLazycodexMarketplace, "release must sync the LazyCodex marketplace bundle").toBe(true)
     expect(syncBuildsMcpDists, "release must build bundled MCP dists before LazyCodex marketplace sync").toBe(true)
@@ -122,7 +126,10 @@ describe("LazyCodex publish workflow", () => {
     expect(pushesLazycodexMarketplace, "release must target the LazyCodex repository").toBe(true)
     expect(alwaysChecksLazycodexNpm, "release must always check lazycodex using the release version").toBe(true)
     expect(publishesLazycodexNpm, "lazycodex npm publish must be part of the normal release, tag stable releases as latest, and fail loudly").toBe(true)
-    expect(syncsLazycodexMarketplaceWhenEnabled, "LazyCodex marketplace sync must be explicitly skippable").toBe(true)
+    expect(
+      syncsLazycodexMarketplaceOnStableReleases,
+      "LazyCodex marketplace sync must run on every stable release (empty dist_tag)",
+    ).toBe(true)
     expect(requiresLazycodexSyncToken, "release must require a cross-repo token for LazyCodex push").toBe(true)
     expect(capturesPreviousLazycodexBeforePublishing, "release metadata must capture the previous lazycodex-ai version before publishing the new one").toBe(true)
     expect(comparesAgainstPreviousLazycodexVersion, "LazyCodex release state must compare current payload with the previous lazycodex-ai package").toBe(true)


### PR DESCRIPTION
## Problem

Every push to `dev` has had a red `test` job (all 3 OSes) since f1ac07d58 (`ci(publish): always sync Codex marketplace on stable releases`). That commit removed the `sync_lazycodex_marketplace` manual opt-out input from `publish.yml` and re-gated the marketplace sync, payload resolve, token preflight, and LazyCodex GitHub release on stable releases (`needs.release-metadata.outputs.dist_tag == ''`) — but `script/publish-lazycodex-workflow.test.ts` was not updated and still asserts the old input and `if: inputs.sync_lazycodex_marketplace != false` conditions:

```
(fail) LazyCodex publish workflow > publishes a LazyCodex GitHub release only when the marketplace payload changed
error: LazyCodex marketplace release must default to enabled
```

This also made PR CI red for unrelated changes (e.g. #5108).

## Change

Test-only. Assert the workflow's new contract instead of the removed one:

- `sync_lazycodex_marketplace` must NOT appear anywhere (no manual opt-out remains).
- The marketplace sync and payload-resolve steps gate on `if: needs.release-metadata.outputs.dist_tag == ''`.
- The LazyCodex GitHub release gates on `if: needs.release-metadata.outputs.dist_tag == '' && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'`.

## Tests

`bun test script/publish-lazycodex-workflow.test.ts` → 6 pass / 0 fail (was 5/1 on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes red CI by updating the LazyCodex publish workflow test to match the stable-release gate and removal of the manual opt-out. This unblocks `dev` and PR builds.

- **Bug Fixes**
  - Remove assertions for the `sync_lazycodex_marketplace` input; require it to be absent.
  - Assert marketplace sync and payload resolve run only when `needs.release-metadata.outputs.dist_tag == ''`.
  - Assert the LazyCodex GitHub release runs only when `needs.release-metadata.outputs.dist_tag == ''` and `steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'`.

<sup>Written for commit 6fba05c413391acce2521893ac5142b949138839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

