### PR TITLE
fix(sync-subagent): abort session on completion to prevent todo-continuation re-awakening

### DIFF
--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
@@ -199,6 +199,17 @@ export async function executeSync(
       syncSubagentSessions.delete(sessionID)
       deleteSessionTools(sessionID)
       clearSessionAgent(sessionID)
+
+      // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
+      // When a sync subagent finishes, its session may still exist and have incomplete
+      // todos; without an explicit abort, the continuation hook sees session.idle and
+      // injects a continuation prompt, causing the subagent to resume after the parent
+      // has already moved on. This creates a race where two agents work concurrently.
+      if (typeof ctx.client.session.abort === "function") {
+        void ctx.client.session.abort({ path: { id: sessionID } }).catch((error: unknown) => {
+          log(`[call_omo_agent] Failed to abort completed sync session:`, error)
+        })
+      }
     }
   }
 }

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -1,6 +1,7 @@
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
 import type { FallbackEntry } from "../../shared/model-requirements"
+import { log } from "../../shared/logger"
 import { formatDetailedError } from "./error-formatting"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import { reserveSyncSubagentSpawn } from "./sync-spawn-reservation"
@@ -152,6 +153,17 @@ export async function executeSyncTask(
   } finally {
     if (syncSessionID) {
       cleanupSyncSessionSideEffects(syncSessionID, executorCtx)
+
+      // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
+      // When a sync subagent finishes, its session may still exist and have incomplete
+      // todos; without an explicit abort, the continuation hook sees session.idle and
+      // injects a continuation prompt, causing the subagent to resume after the parent
+      // has already moved on. This creates a race where two agents work concurrently.
+      if (typeof client.session.abort === "function") {
+        void client.session.abort({ path: { id: syncSessionID } }).catch((error: unknown) => {
+          log(`[task] Failed to abort completed sync session:`, error)
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes race condition where `todo-continuation-enforcer` re-awakens completed sync subagents after the parent has already moved on.

## Problem

When a synchronous subagent (`run_in_background=false`) finishes, its OpenCode session may still exist and have incomplete todos. Without an explicit abort, `todo-continuation-enforcer` sees the `session.idle` event and injects a continuation prompt, causing the subagent to resume after the parent has already moved on. This creates a race where two agents work concurrently on the same codebase.

## Changes

- `src/tools/call-omo-agent/sync-executor.ts`: Abort session in finally block after parent receives result
- `src/tools/delegate-task/sync-task.ts`: Abort session in finally block after parent receives result
- Added safety check `typeof client.session.abort === 'function'` for test environment compatibility

## Why This Works

- `session.abort()` signals OpenCode to terminate the session
- `todo-continuation-enforcer` will not inject into an aborted session
- Existing `session_id` continuation (reusing existing sessions) is unaffected because we only abort when `createdSessionForExecution === true`

## Testing

- `sync-executor.test.ts`: 18 pass, 0 fail
- `sync-task.test.ts`: 17 pass, 0 fail

## Related Issues

Closes #5112
- #4163 - Similar issue but focused on parent session continuation before background descendants finish
- #4615 - Fixed: sync delegation returning before background descendants quiesce

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort completed sync subagent sessions to stop `todo-continuation-enforcer` from re-awakening them after the parent finishes. This removes a race where a finished sync subagent resumes and runs concurrently.

- **Bug Fixes**
  - Abort the session in finally after returning the result in `packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts` and `packages/omo-opencode/src/tools/delegate-task/sync-task.ts`.
  - Guard with `typeof client.session.abort === 'function'` and log abort errors (added `log` import in sync-task).
  - Blocks continuation prompts on `session.idle` for completed sync subagents.

<sup>Written for commit a5e86b18293bc2206b3380826fa118e3a73c7315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

