### PR TITLE
fix(plugin): load native skills via raw fallback when PluginInput.skills absent

### DIFF
--- a/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry-core-tools.ts
@@ -12,6 +12,54 @@ import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
 import { log } from "../shared"
 import { getSisyphusJuniorModelOverride } from "./tool-registry-team-tools"
 
+type NativeSkillAccessor = NonNullable<SkillLoadOptions["nativeSkills"]>
+type NativeSkillList = Awaited<ReturnType<NativeSkillAccessor["all"]>>
+type NativeSkillResponse = NativeSkillList | { data?: NativeSkillList | null }
+
+type RawSkillClient = {
+  _client?: {
+    get?: (input: { url: string; query: { directory: string } }) => Promise<NativeSkillResponse>
+  }
+}
+
+function createNativeSkillAccessor(ctx: PluginContext, disabledSkills?: Set<string>): NativeSkillAccessor | undefined {
+  if ("skills" in ctx) {
+    return (ctx as { skills?: NativeSkillAccessor }).skills
+  }
+
+  const rawClient = (ctx.client as unknown as RawSkillClient | undefined)?._client
+  const rawGet = rawClient?.get
+  if (typeof rawGet !== "function") return undefined
+
+  const dir = ctx.directory
+  let listPromise: Promise<NativeSkillList> | undefined
+
+  const all = async (): Promise<NativeSkillList> => {
+    const response = await rawGet.call(rawClient, { url: "/skill", query: { directory: dir } })
+    let list: NativeSkillList = []
+    if (Array.isArray(response)) {
+      list = response
+    } else if (response && typeof response === "object" && Array.isArray((response as { data: unknown }).data)) {
+      list = (response as { data: NativeSkillList }).data
+    }
+    if (!disabledSkills || disabledSkills.size === 0) return list
+    return list.filter((skill) => !disabledSkills.has(skill.name))
+  }
+
+  return {
+    all() {
+      listPromise ??= all()
+      return listPromise
+    },
+    async get(name) {
+      return (await this.all()).find((skill) => skill.name === name)
+    },
+    dirs() {
+      return []
+    },
+  }
+}
+
 export function createCoreTools(args: {
   readonly ctx: PluginContext
   readonly pluginConfig: OhMyOpenCodeConfig
@@ -21,6 +69,7 @@ export function createCoreTools(args: {
   readonly factories: ToolRegistryFactories
 }): Record<string, ToolDefinition> {
   const { ctx, pluginConfig, managers, skillContext, availableCategories, factories } = args
+  const nativeSkills = createNativeSkillAccessor(ctx, skillContext.disabledSkills)
   const backgroundTools = factories.createBackgroundTools(managers.backgroundManager, ctx.client)
   const callOmoAgent = factories.createCallOmoAgent(
     ctx,
@@ -46,7 +95,7 @@ export function createCoreTools(args: {
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
     availableCategories,
     availableSkills: skillContext.availableSkills,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
@@ -100,7 +149,7 @@ export function createCoreTools(args: {
     gitMasterConfig: pluginConfig.git_master,
     browserProvider: skillContext.browserProvider,
     teamModeEnabled: pluginConfig.team_mode?.enabled ?? false,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    nativeSkills,
     pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
     enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
     includeSkillsInDescription: true,

--- a/packages/omo-opencode/src/plugin/tool-registry.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-registry.test.ts
@@ -3,6 +3,8 @@ import { tool } from "@opencode-ai/plugin"
 
 import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "../config"
 import * as openclawRuntimeDispatch from "../openclaw/runtime-dispatch"
+import type { DelegateTaskToolOptions } from "../tools/delegate-task/types"
+import type { SkillLoadOptions } from "../tools/skill/types"
 import type { ToolsRecord } from "./types"
 
 const fakeTool = tool({
@@ -221,6 +223,273 @@ describe("#given the OMO skill tool overrides OpenCode native skill discovery", 
         },
       ],
     })
+  })
+
+  test("#when PluginInput lacks skills but raw client can list skills #then skill and task tools share a native skill accessor", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    const capturedDelegateTaskOptions: DelegateTaskToolOptions[] = []
+    const nativeSkillEntries = [
+      {
+        name: "customize-opencode",
+        description: "Customize OpenCode configuration",
+        location: "<built-in>",
+        content: "# Customizing opencode",
+      },
+      {
+        name: "disabled-native",
+        description: "Disabled native skill",
+        location: "<built-in>",
+        content: "# Disabled",
+      },
+    ]
+    let resolveNativeSkills: (value: { data: typeof nativeSkillEntries }) => void = () => {}
+    const nativeSkillsPromise = new Promise<{ data: typeof nativeSkillEntries }>((resolve) => {
+      resolveNativeSkills = resolve
+    })
+    const rawGet = mock((input: { url: string; query: { directory: string } }) => {
+      expect(input).toEqual({ url: "/skill", query: { directory: "/tmp/project" } })
+      return nativeSkillsPromise
+    })
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+      createDelegateTask: mock((options: DelegateTaskToolOptions) => {
+        capturedDelegateTaskOptions.push(options)
+        return delegateTaskTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: {
+          app: {},
+          _client: {
+            get: rawGet,
+          },
+        },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(["disabled-native"]),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    const skillToolOptions = capturedSkillToolOptions[0]
+    const delegateTaskOptions = capturedDelegateTaskOptions[0]
+    const nativeSkills = skillToolOptions?.nativeSkills
+
+    expect(nativeSkills).toBeDefined()
+    expect(delegateTaskOptions?.nativeSkills).toBe(nativeSkills)
+
+    resolveNativeSkills({ data: nativeSkillEntries })
+    await expect(nativeSkills?.all()).resolves.toEqual([nativeSkillEntries[0]])
+    await expect(nativeSkills?.get("customize-opencode")).resolves.toEqual(nativeSkillEntries[0])
+    await expect(nativeSkills?.get("disabled-native")).resolves.toBeUndefined()
+    expect(await nativeSkills?.dirs()).toEqual([])
+  })
+
+  test("#when raw client returns a direct array #then skills are normalized", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    const nativeSkillEntries = [{ name: "direct-skill", description: "Direct", location: "<built-in>", content: "# Direct" }]
+    const rawGet = mock(async () => nativeSkillEntries)
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: { app: {}, _client: { get: rawGet } },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    const nativeSkills = capturedSkillToolOptions[0]?.nativeSkills
+    await expect(nativeSkills?.all()).resolves.toEqual(nativeSkillEntries)
+  })
+
+  test("#when raw client returns an empty object #then skills list is empty", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    const rawGet = mock(async () => ({ data: null }))
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: { app: {}, _client: { get: rawGet } },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    const nativeSkills = capturedSkillToolOptions[0]?.nativeSkills
+    await expect(nativeSkills?.all()).resolves.toEqual([])
+  })
+
+  test("#when raw file is absent #then nativeSkills is undefined", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: { app: {} },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    expect(capturedSkillToolOptions[0]?.nativeSkills).toBeUndefined()
+  })
+
+  test("#when raw file is present but get is missing #then nativeSkills is undefined", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: { app: {}, _client: {} },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    expect(capturedSkillToolOptions[0]?.nativeSkills).toBeUndefined()
+  })
+
+  test("#when two concurrent all() calls race #then only one HTTP request is issued", async () => {
+    const capturedSkillToolOptions: SkillLoadOptions[] = []
+    let resolveRaw: (value: { data: { name: string; description: string; location: string; content: string }[] }) => void = () => {}
+    const rawPromise = new Promise<{ data: { name: string; description: string; location: string; content: string }[] }>((resolve) => {
+      resolveRaw = resolve
+    })
+    const rawGet = mock(() => rawPromise)
+    const localToolFactories = {
+      ...toolFactories,
+      createSkillTool: mock((options: SkillLoadOptions) => {
+        capturedSkillToolOptions.push(options)
+        return fakeTool
+      }),
+    }
+
+    createToolRegistry({
+      ctx: {
+        directory: "/tmp/project",
+        client: { app: {}, _client: { get: rawGet } },
+      } as unknown as Parameters<typeof createToolRegistry>[0]["ctx"],
+      pluginConfig: createPluginConfig(),
+      managers: {
+        backgroundManager: {},
+        tmuxSessionManager: {},
+        skillMcpManager: {},
+      } as Parameters<typeof createToolRegistry>[0]["managers"],
+      skillContext: {
+        mergedSkills: [],
+        availableSkills: [],
+        browserProvider: "playwright",
+        disabledSkills: new Set(),
+      },
+      availableCategories: [],
+      toolFactories: localToolFactories,
+    })
+
+    const nativeSkills = capturedSkillToolOptions[0]?.nativeSkills
+    const p1 = nativeSkills?.all()
+    const p2 = nativeSkills?.all()
+
+    expect(rawGet).toHaveBeenCalledTimes(1)
+
+    const entries = [{ name: "dedup", description: "D", location: "<built-in>", content: "# D" }]
+    resolveRaw({ data: entries })
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1).toEqual(entries)
+    expect(r2).toEqual(entries)
   })
 })
 


### PR DESCRIPTION
## Summary

OMO currently retrieves native skills via `"skills" in ctx ? ctx.skills : undefined`, but the OpenCode plugin SDK `PluginInput` type does not include a `skills` property (confirmed absent from v1.15.13 through v1.17.0). This means `nativeSkills` is always `undefined`. Specific impact:

- `customize-opencode`: visible in the available skills list but fails to load (`location: "<built-in>"`)
- Skills registered via `"plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]` in `opencode.json`: completely invisible

This PR adds a `createNativeSkillAccessor` function: if `ctx.skills` exists it is passed through directly (host is responsible for filtering); otherwise falls back to `ctx.client._client.get("/skill")` to fetch the full native skill list from OpenCode's HTTP API, normalizes the response, and filters by `disabledSkills`.

## Screenshots

Before: `customize-opencode` fails to load, Superpowers skill not visible. After: both work correctly.

| Before | After |
|:---:|:---:|
| <img width="1309" height="1098" alt="1Capture_2026-06-10_16 51 53" src="https://github.com/user-attachments/assets/06edcc27-f4c1-425e-8263-44152d782a2d" />| <img width="1282" height="993" alt="1Capture_2026-06-10_16 49 46" src="https://github.com/user-attachments/assets/afa3c658-7892-432d-830b-4f61b17b1175" /> |

## Changes

- `src/plugin/tool-registry-core-tools.ts` (+53/-0): add `createNativeSkillAccessor` function, supporting types, replace two inline `"skills" in ctx ? ... : undefined` expressions
- `src/plugin/tool-registry.test.ts` (+269/-0): 6 test cases covering success path with disabled filter and shared accessor, direct array normalization, `{data:null}` empty fallback, missing `_client`, missing `_client.get`, and concurrent dedup

## Testing

```bash
bun test src/plugin/tool-registry.test.ts
```

15 pass / 0 fail (9 existing + 6 new)