### PR TITLE
refactor(packages): remove programming-rule violations and AI slop across packages

### DIFF
--- a/packages/ast-grep-mcp/src/mcp-lifecycle-log.test.ts
+++ b/packages/ast-grep-mcp/src/mcp-lifecycle-log.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { mcpLifecycleLogPath, writeMcpLifecycleLog } from "./mcp-lifecycle-log";
+
+const TMP_ENV_KEYS = ["TMPDIR", "TMP", "TEMP"] as const;
+const ORIGINAL_TMP_ENV: Record<string, string | undefined> = Object.fromEntries(
+  TMP_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function setTempRoot(path: string): void {
+  for (const key of TMP_ENV_KEYS) process.env[key] = path;
+}
+
+afterEach(() => {
+  for (const key of TMP_ENV_KEYS) {
+    const original = ORIGINAL_TMP_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+});
+
+describe("writeMcpLifecycleLog best-effort semantics", () => {
+  it("#given an invalid log directory #when logging #then it swallows the fs error and does not throw", () => {
+    // given: the temp root resolves under a directory that cannot exist, so both
+    // the rotation stat and the append target an unwritable path
+    setTempRoot("/omo-ast-grep-mcp-nonexistent-root/no/such/dir");
+    expect(mcpLifecycleLogPath()).toContain("omo-ast-grep-mcp-nonexistent-root");
+
+    // when / then
+    expect(() => writeMcpLifecycleLog("characterization_event", { attempt: 1 })).not.toThrow();
+  });
+
+  it("#given a normal temp directory #when logging #then it does not throw", () => {
+    // given the inherited temp root (restored by afterEach)
+    expect(() => writeMcpLifecycleLog("characterization_event_ok")).not.toThrow();
+  });
+});

--- a/packages/ast-grep-mcp/src/mcp-lifecycle-log.ts
+++ b/packages/ast-grep-mcp/src/mcp-lifecycle-log.ts
@@ -16,9 +16,8 @@ export function writeMcpLifecycleLog(event: string, fields: Record<string, LogFi
   try {
     rotateLogIfNeeded(path);
     appendFileSync(path, `${JSON.stringify({ ts: new Date().toISOString(), event, pid: process.pid, ppid: process.ppid, ...fields })}\n`);
-  } catch (error) {
-    if (error instanceof Error) return;
-    return;
+  } catch {
+    // best-effort log write — never throws
   }
 }
 
@@ -26,8 +25,7 @@ function rotateLogIfNeeded(path: string): void {
   try {
     if (statSync(path).size < MAX_LOG_BYTES) return;
     renameSync(path, `${path}.1`);
-  } catch (error) {
-    if (error instanceof Error) return;
-    return;
+  } catch {
+    // best-effort log rotation — never throws
   }
 }

--- a/packages/omo-codex/src/install/index.ts
+++ b/packages/omo-codex/src/install/index.ts
@@ -1,4 +1,4 @@
-// Codex install module entry point. Implemented in subsequent commits.
+// Codex install module entry point.
 // Hosts the TypeScript port of scripts/install-local.mjs invoked from the
 // omodex CLI when the user passes `--platform=codex` to `bunx oh-my-openagent install`.
 export {}

--- a/packages/omo-opencode/src/cli/install-codex/install-codex.ts
+++ b/packages/omo-opencode/src/cli/install-codex/install-codex.ts
@@ -274,8 +274,7 @@ async function trackCodexInstallTelemetry(): Promise<void> {
     const posthog = createInstallPostHog()
     posthog.trackActive(getPostHogDistinctId(), "install_completed")
     await posthog.shutdown()
-  } catch (error) {
-    if (error instanceof Error) return
+  } catch {
     return
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -3048,7 +3048,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
     function createMockClient() {
       return {
         session: {
-          create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
+          create: async (_args?: unknown) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
           get: async () => ({ data: { directory: "/test/dir" } }),
           prompt: async () => ({}),
           promptAsync: async () => ({}),
@@ -3066,7 +3066,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
     ) {
       return {
         session: {
-          create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
+          create: async (_args?: unknown) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
           get: async ({ path }: { path: { id: string } }) => {
             if (options?.sessionLookupError) {
               throw options.sessionLookupError
@@ -3348,7 +3348,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
   describe("task transitions pending→running when slot available", () => {
     test("does not override parent session permission when creating child session", async () => {
       // given
-      const createCalls: any[] = []
+      const createCalls: Array<{ body?: { permission?: unknown } }> = []
       const parentPermission = [
         { permission: "question", action: "allow" as const, pattern: "*" },
         { permission: "plan_enter", action: "deny" as const, pattern: "*" },
@@ -3356,7 +3356,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 
       const customClient = {
         session: {
-          create: async (args?: any) => {
+          create: async (args: { body?: { permission?: unknown } }) => {
             createCalls.push(args)
             return { data: { id: `ses_${crypto.randomUUID()}` } }
           },

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -2184,12 +2184,12 @@ The task was re-queued on a fallback model after a retryable failure.
       // - "tool" with .state.output property (tool call results)
       // - "text" with .text property (final text output)
       // - "step-start"/"step-finish" (metadata, no content)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const hasContent = messages.some((m: any) => {
+      type SessionPart = { type?: string; text?: string; content?: string | unknown[] }
+      type SessionMessage = { info?: { role?: string }; parts?: SessionPart[] }
+      const hasContent = messages.some((m: SessionMessage) => {
         if (m.info?.role !== "assistant" && m.info?.role !== "tool") return false
         const parts = m.parts ?? []
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return parts.some((p: any) =>
+      return parts.some((p: SessionPart) =>
         // Text content (final output)
         (p.type === "text" && p.text && p.text.trim().length > 0) ||
         // Reasoning content (thinking blocks)

--- a/packages/omo-opencode/src/features/background-agent/spawner.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.test.ts
@@ -7,6 +7,19 @@ import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt
 import { buildFallbackBody, createTask, isAgentNotFoundError, startTask } from "./spawner"
 import type { BackgroundTask } from "./types"
 
+type PromptRequest = {
+  path?: { id?: string }
+  query?: { directory?: string }
+  body: {
+    agent?: string
+    parts?: unknown
+    tools?: Record<string, boolean>
+    model?: { providerID: string; modelID: string }
+    variant?: string
+    options?: unknown
+  }
+}
+
 /**
  * Poll until `fn()` returns true or timeout elapses.
  * Replaces fixed `setTimeout(resolve, 50)` waits that cause flaky CI failures
@@ -34,14 +47,14 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
   test("retries with 'general' agent when promptAsync fails with Agent not found", async () => {
     //#given
-    const promptCalls: any[] = []
+    const promptCalls: PromptRequest[] = []
     let callCount = 0
 
     const client = {
       session: {
         get: async () => ({ data: { directory: "/tmp/test" } }),
         create: async () => ({ data: { id: "session-fallback" } }),
-        promptAsync: async (args: any) => {
+        promptAsync: async (args: PromptRequest) => {
           callCount++
           promptCalls.push({ body: { ...args.body }, path: { ...args.path } })
           if (callCount === 1) {
@@ -123,13 +136,13 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
   test("does not retry for non-agent-not-found errors", async () => {
     //#given
-    const promptCalls: any[] = []
+    const promptCalls: PromptRequest[] = []
 
     const client = {
       session: {
         get: async () => ({ data: { directory: "/tmp/test" } }),
         create: async () => ({ data: { id: "session-fallback" } }),
-        promptAsync: async (args: any) => {
+        promptAsync: async (args: PromptRequest) => {
           promptCalls.push(args)
           throw new Error("Connection timeout")
         },
@@ -230,14 +243,14 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
   test("retries on agent.name/undefined error variant", async () => {
     //#given
-    const promptCalls: any[] = []
+    const promptCalls: PromptRequest[] = []
     let callCount = 0
 
     const client = {
       session: {
         get: async () => ({ data: { directory: "/tmp/test" } }),
         create: async () => ({ data: { id: "session-fallback" } }),
-        promptAsync: async (args: any) => {
+        promptAsync: async (args: PromptRequest) => {
           callCount++
           promptCalls.push({ body: { ...args.body } })
           if (callCount === 1) {
@@ -293,14 +306,14 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
   test("detects agent error from plain object with message field", async () => {
     //#given
-    const promptCalls: any[] = []
+    const promptCalls: PromptRequest[] = []
     let callCount = 0
 
     const client = {
       session: {
         get: async () => ({ data: { directory: "/tmp/test" } }),
         create: async () => ({ data: { id: "session-fallback" } }),
-        promptAsync: async (args: any) => {
+        promptAsync: async (args: PromptRequest) => {
           callCount++
           promptCalls.push({ body: { ...args.body } })
           if (callCount === 1) {
@@ -361,12 +374,12 @@ describe("background-agent spawner fallback model promotion", () => {
 
   test("passes promoted fallback model settings through supported prompt channels", async () => {
     //#given
-    let promptArgs: any
+    let promptArgs!: PromptRequest
     const client = {
       session: {
         get: mock(async () => ({ data: { directory: "/tmp/test" } })),
         create: mock(async () => ({ data: { id: "session-123" } })),
-        promptAsync: mock(async (input: any) => {
+        promptAsync: mock(async (input: PromptRequest) => {
           promptArgs = input
           return { data: {} }
         }),
@@ -443,13 +456,13 @@ describe("background-agent spawner fallback model promotion", () => {
 
   test("keeps agent when explicit model is configured", async () => {
     //#given
-    const promptCalls: any[] = []
+    const promptCalls: PromptRequest[] = []
 
     const client = {
       session: {
         get: async () => ({ data: { directory: "/parent/dir" } }),
         create: async () => ({ data: { id: "ses_child" } }),
-        promptAsync: async (args?: any) => {
+        promptAsync: async (args: PromptRequest) => {
           promptCalls.push(args)
           return {}
         },

--- a/packages/omo-opencode/src/features/skill-mcp-manager/plugin-reload-mcp-survival.test.ts
+++ b/packages/omo-opencode/src/features/skill-mcp-manager/plugin-reload-mcp-survival.test.ts
@@ -88,10 +88,10 @@ afterEach(async () => {
     for (const managed of state.clients.values()) {
       try {
         await managed.client.close()
-      } catch {}
+      } catch {} // no-excuse-ok: catch — best-effort teardown; mock client may already be closed
       try {
         await managed.transport.close()
-      } catch {}
+      } catch {} // no-excuse-ok: catch — best-effort teardown; mock transport may already be closed
     }
     state.clients.clear()
     state.pendingConnections.clear()

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -53,19 +53,9 @@ async function pathExists(filePath: string): Promise<boolean> {
   try {
     await access(filePath)
     return true
-  } catch (error) {
-    if (error instanceof Error) return false
+  } catch {
     return false
   }
-}
-
-function ignoreTeamSessionSweepFailure(error: unknown): void {
-  if (error instanceof Error) return
-}
-
-function resolveRuntimeStateLoadFailure(error: unknown): undefined {
-  if (error instanceof Error) return undefined
-  return undefined
 }
 
 async function resolveSpecSource(spec: TeamSpec, ctx: ExecutorContext, config: TeamModeConfig): Promise<"project" | "user"> {
@@ -78,7 +68,7 @@ async function resolveSpecSource(spec: TeamSpec, ctx: ExecutorContext, config: T
 async function findExistingRuntime(spec: TeamSpec, leadSessionId: string, config: TeamModeConfig): Promise<RuntimeState | undefined> {
   for (const candidate of await listActiveTeams(config)) {
     if (candidate.teamName !== spec.name || (candidate.status !== "creating" && candidate.status !== "active")) continue
-    const runtimeState = await loadRuntimeState(candidate.teamRunId, config).catch(resolveRuntimeStateLoadFailure)
+    const runtimeState = await loadRuntimeState(candidate.teamRunId, config).catch(() => undefined)
     if (runtimeState?.leadSessionId === leadSessionId && !hasUnresolvedTeamMembers(runtimeState.members)) return runtimeState
   }
 }
@@ -117,6 +107,20 @@ function buildMemberPrompt(
   return promptLines.join("\n")
 }
 
+async function updateMemberInRuntimeState(
+  teamRunId: string,
+  memberName: string,
+  patch: (member: RuntimeState["members"][number]) => RuntimeState["members"][number],
+  config: TeamModeConfig,
+): Promise<RuntimeState> {
+  return transitionRuntimeState(teamRunId, (currentState) => ({
+    ...currentState,
+    members: currentState.members.map((member) =>
+      member.name === memberName ? patch(member) : member,
+    ),
+  }), config)
+}
+
 export async function createTeamRun(
   spec: TeamSpec,
   leadSessionId: string,
@@ -131,7 +135,7 @@ export async function createTeamRun(
 
   const activeTeams = await listActiveTeams(config)
   const activeRunIds = new Set(activeTeams.map((t) => t.teamRunId))
-  sweepStaleTeamSessions(activeRunIds).catch(ignoreTeamSessionSweepFailure)
+  sweepStaleTeamSessions(activeRunIds).catch(() => {})
 
   const baseDir = resolveBaseDir(config)
   await ensureBaseDirs(baseDir)
@@ -145,16 +149,11 @@ export async function createTeamRun(
       memberName: spec.leadAgentId,
       role: "lead",
     })
-    runtimeState = await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
-      ...currentState,
-      members: currentState.members.map((member) => member.name === spec.leadAgentId
-        ? {
-            ...member,
-            sessionId: leadSessionId,
-            status: "running",
-            ...(callerLeadSubagentType ? { subagent_type: callerLeadSubagentType } : {}),
-          }
-        : member),
+    runtimeState = await updateMemberInRuntimeState(runtimeState.teamRunId, spec.leadAgentId, (member) => ({
+      ...member,
+      sessionId: leadSessionId,
+      status: "running",
+      ...(callerLeadSubagentType ? { subagent_type: callerLeadSubagentType } : {}),
     }), config)
   }
   await Promise.all(spec.members.map((member) => mkdir(getInboxDir(baseDir, runtimeState.teamRunId, member.name), { recursive: true })))
@@ -185,11 +184,9 @@ export async function createTeamRun(
           if (member.worktreePath) resource.worktreePath = await createMemberWorktree(member.worktreePath, ctx.directory)
           if (reusesCallerLeadSession && member.name === spec.leadAgentId) {
             if (resource.worktreePath) {
-              await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
-                ...currentState,
-                members: currentState.members.map((currentMember) => currentMember.name === member.name
-                  ? { ...currentMember, worktreePath: resource.worktreePath }
-                  : currentMember),
+              await updateMemberInRuntimeState(runtimeState.teamRunId, member.name, (currentMember) => ({
+                ...currentMember,
+                worktreePath: resource.worktreePath,
               }), config)
             }
             continue
@@ -214,11 +211,10 @@ export async function createTeamRun(
                 memberName: member.name,
                 role: member.name === spec.leadAgentId ? "lead" : "member",
               })
-              runtimeState = await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
-                ...currentState,
-                members: currentState.members.map((currentMember) => currentMember.name === member.name
-                  ? { ...currentMember, sessionId, status: "running" }
-                  : currentMember),
+              runtimeState = await updateMemberInRuntimeState(runtimeState.teamRunId, member.name, (currentMember) => ({
+                ...currentMember,
+                sessionId,
+                status: "running",
               }), config)
             },
           })
@@ -241,19 +237,14 @@ export async function createTeamRun(
                 ...(resolvedMember.model.thinking ? { thinking: resolvedMember.model.thinking } : {}),
               }
             : undefined
-          await transitionRuntimeState(runtimeState.teamRunId, (currentState) => ({
-            ...currentState,
-            members: currentState.members.map((currentMember) => currentMember.name === member.name
-              ? {
-                  ...currentMember,
-                  sessionId,
-                  status: "running",
-                  worktreePath: resource.worktreePath,
-                  subagent_type: resolvedMember.agentToUse,
-                  ...(member.kind === "category" ? { category: member.category } : {}),
-                  ...(persistedModel ? { model: persistedModel } : {}),
-                }
-              : currentMember),
+          await updateMemberInRuntimeState(runtimeState.teamRunId, member.name, (currentMember) => ({
+            ...currentMember,
+            sessionId,
+            status: "running",
+            worktreePath: resource.worktreePath,
+            subagent_type: resolvedMember.agentToUse,
+            ...(member.kind === "category" ? { category: member.category } : {}),
+            ...(persistedModel ? { model: persistedModel } : {}),
           }), config)
         } catch (error) {
           failure = error instanceof Error ? error : new Error(String(error))

--- a/packages/omo-opencode/src/features/tmux-subagent/failed-readiness-cache.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/failed-readiness-cache.ts
@@ -1,0 +1,114 @@
+export interface FailedReadinessSessionSeed {
+  sessionId: string
+  title: string
+}
+
+export interface FailedReadinessSession extends FailedReadinessSessionSeed {
+  rememberedAt: number
+}
+
+export interface FailedReadinessCacheOptions {
+  ttlMs: number
+  sweepIntervalMs: number
+  log: (message: string, data?: unknown) => void
+}
+
+export class FailedReadinessCache {
+  private readonly sessions = new Map<string, FailedReadinessSession>()
+  private sweepInterval?: ReturnType<typeof setInterval>
+  private readonly ttlMs: number
+  private readonly sweepIntervalMs: number
+  private readonly log: (message: string, data?: unknown) => void
+
+  constructor(options: FailedReadinessCacheOptions) {
+    this.ttlMs = options.ttlMs
+    this.sweepIntervalMs = options.sweepIntervalMs
+    this.log = options.log
+  }
+
+  remember(session: FailedReadinessSessionSeed): void {
+    this.sessions.set(session.sessionId, {
+      ...session,
+      rememberedAt: Date.now(),
+    })
+    this.startSweep()
+  }
+
+  clear(sessionId: string): void {
+    this.sessions.delete(sessionId)
+    if (this.sessions.size === 0) {
+      this.stopSweep()
+    }
+  }
+
+  get(sessionId: string): FailedReadinessSession | undefined {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      return undefined
+    }
+
+    if (!this.isExpired(session, Date.now())) {
+      return session
+    }
+
+    this.sessions.delete(sessionId)
+    this.log("[tmux-session-manager] expired failed readiness session on access", {
+      sessionId,
+      ttlMs: this.ttlMs,
+    })
+
+    if (this.sessions.size === 0) {
+      this.stopSweep()
+    }
+
+    return undefined
+  }
+
+  clearAll(): void {
+    this.sessions.clear()
+    this.stopSweep()
+  }
+
+  private isExpired(session: FailedReadinessSession, now: number): boolean {
+    return now - session.rememberedAt >= this.ttlMs
+  }
+
+  private startSweep(): void {
+    if (this.sweepInterval) {
+      return
+    }
+
+    this.sweepInterval = setInterval(() => {
+      this.sweepExpired()
+    }, this.sweepIntervalMs)
+  }
+
+  private stopSweep(): void {
+    if (!this.sweepInterval) {
+      return
+    }
+
+    clearInterval(this.sweepInterval)
+    this.sweepInterval = undefined
+  }
+
+  private sweepExpired(): void {
+    const now = Date.now()
+
+    for (const [sessionId, session] of this.sessions.entries()) {
+      if (!this.isExpired(session, now)) {
+        continue
+      }
+
+      this.sessions.delete(sessionId)
+      this.log("[tmux-session-manager] expired failed readiness session", {
+        sessionId,
+        ttlMs: this.ttlMs,
+      })
+    }
+
+    if (this.sessions.size === 0) {
+      this.stopSweep()
+    }
+  }
+}

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
@@ -237,8 +237,9 @@ function getTrackedSessions(manager: object): Map<string, { paneId: string; clos
   return Reflect.get(manager, 'sessions') as Map<string, { paneId: string; closePending: boolean; closeRetryCount: number }>
 }
 
-function getFailedReadinessSessions(manager: object): Map<string, { sessionId: string; title: string }> {
-  return Reflect.get(manager, 'failedReadinessSessions') as Map<string, { sessionId: string; title: string }>
+function getFailedReadinessSessions(manager: object): Map<string, { sessionId: string; title: string; rememberedAt: number }> {
+  const cache = Reflect.get(manager, 'failedReadinessCache') as object
+  return Reflect.get(cache, 'sessions') as Map<string, { sessionId: string; title: string; rememberedAt: number }>
 }
 
 describe('TmuxSessionManager', () => {
@@ -1686,7 +1687,7 @@ describe('TmuxSessionManager', () => {
         mockTmuxDeps,
       )
 
-      Reflect.get(manager, 'failedReadinessSessions').set('ses_bounce', {
+      getFailedReadinessSessions(manager).set('ses_bounce', {
         sessionId: 'ses_bounce',
         title: 'Bounce Session',
         rememberedAt: Date.now(),

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.ts
@@ -22,6 +22,8 @@ import { createTrackedSession, markTrackedSessionClosePending } from "./tracked-
 import { waitForSessionReady } from "./session-ready-waiter"
 import { isAttachableSessionStatus } from "./attachable-session-status"
 import { parseSessionStatusResponse } from "./session-status-parser"
+import { FailedReadinessCache, type FailedReadinessSessionSeed } from "./failed-readiness-cache"
+import { resolveServerUrl } from "./resolve-server-url"
 type OpencodeClient = PluginInput["client"]
 
 type SpawnStage =
@@ -40,15 +42,6 @@ interface DeferredSession {
   title: string
   queuedAt: Date
   retryIsolatedContainer: boolean
-}
-
-interface FailedReadinessSessionSeed {
-  sessionId: string
-  title: string
-}
-
-interface FailedReadinessSession extends FailedReadinessSessionSeed {
-  rememberedAt: number
 }
 
 export interface TmuxUtilDeps {
@@ -120,9 +113,8 @@ export class TmuxSessionManager {
   private sourcePaneId: string | undefined
   private sessions = new Map<string, TrackedSession>()
   private pendingSessions = new Set<string>()
-  private failedReadinessSessions = new Map<string, FailedReadinessSession>()
   private closedByPolling = new Set<string>()
-  private failedReadinessSweepInterval?: ReturnType<typeof setInterval>
+  private readonly failedReadinessCache: FailedReadinessCache
   private spawnQueue: Promise<void> = Promise.resolve()
   private deferredSessions = new Map<string, DeferredSession>()
   private deferredQueue: string[] = []
@@ -149,39 +141,14 @@ export class TmuxSessionManager {
     this.projectDirectory = ctx.directory || process.cwd()
     this.deps = { ...defaultTmuxDeps, ...deps }
     this.shouldSkipSession = options.shouldSkipSession ?? (() => false)
-    const configuredPort = process.env.OPENCODE_PORT
-    const parsedPort = configuredPort ? Number(configuredPort) : 4096
-    const defaultPort = Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535
-      ? String(parsedPort)
-      : "4096"
-    const fallbackUrl = `http://localhost:${defaultPort}`
+    this.failedReadinessCache = new FailedReadinessCache({
+      ttlMs: FAILED_READINESS_SESSION_TTL_MS,
+      sweepIntervalMs: FAILED_READINESS_SWEEP_INTERVAL_MS,
+      log: this.deps.log,
+    })
     const rawServerUrl = ctx.serverUrl?.toString()
     this.ctxServerUrl = rawServerUrl
-    try {
-      if (rawServerUrl) {
-        const parsed = new URL(rawServerUrl)
-        const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
-        if (port === '0') {
-          this.deps.log(
-            "[tmux-session-manager] ctx.serverUrl has port 0; falling back. " +
-              "team_mode tmux visualization will silently skip if nothing is listening on the fallback URL. " +
-              "Launch opencode with --port N and OPENCODE_PORT=N to bind a real port (see issue #3963).",
-            { kind: "warning", ctxServerUrl: rawServerUrl, fallbackUrl },
-          )
-          this.serverUrl = fallbackUrl
-        } else {
-          this.serverUrl = rawServerUrl
-        }
-      } else {
-        this.serverUrl = fallbackUrl
-      }
-    } catch (error) {
-      this.deps.log("[tmux-session-manager] failed to parse server URL, using fallback", {
-        serverUrl: rawServerUrl,
-        error: String(error),
-      })
-      this.serverUrl = fallbackUrl
-    }
+    this.serverUrl = resolveServerUrl(rawServerUrl, process.env, this.deps.log)
     this.sourcePaneId = this.deps.getCurrentPaneId()
     this.pollingManager = new TmuxPollingManager(
       this.client,
@@ -617,7 +584,7 @@ export class TmuxSessionManager {
     retryIsolatedContainer = false,
   ): void {
     if (this.shouldSkipRespawnAfterPollingClose(sessionId, "deferred enqueue")) {
-      this.clearFailedReadinessSession(sessionId)
+      this.failedReadinessCache.clear(sessionId)
       return
     }
 
@@ -755,92 +722,6 @@ export class TmuxSessionManager {
     }
   }
 
-  private rememberFailedReadinessSession(
-    session: FailedReadinessSessionSeed,
-  ): void {
-    this.failedReadinessSessions.set(session.sessionId, {
-      ...session,
-      rememberedAt: Date.now(),
-    })
-    this.startFailedReadinessSweep()
-  }
-
-  private clearFailedReadinessSession(sessionId: string): void {
-    this.failedReadinessSessions.delete(sessionId)
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-  }
-
-  private startFailedReadinessSweep(): void {
-    if (this.failedReadinessSweepInterval) {
-      return
-    }
-
-    this.failedReadinessSweepInterval = setInterval(() => {
-      this.sweepExpiredFailedReadinessSessions()
-    }, FAILED_READINESS_SWEEP_INTERVAL_MS)
-  }
-
-  private stopFailedReadinessSweep(): void {
-    if (!this.failedReadinessSweepInterval) {
-      return
-    }
-
-    clearInterval(this.failedReadinessSweepInterval)
-    this.failedReadinessSweepInterval = undefined
-  }
-
-  private isFailedReadinessSessionExpired(
-    session: FailedReadinessSession,
-    now: number,
-  ): boolean {
-    return now - session.rememberedAt >= FAILED_READINESS_SESSION_TTL_MS
-  }
-
-  private sweepExpiredFailedReadinessSessions(): void {
-    const now = Date.now()
-
-    for (const [sessionId, failedReadinessSession] of this.failedReadinessSessions.entries()) {
-      if (!this.isFailedReadinessSessionExpired(failedReadinessSession, now)) {
-        continue
-      }
-
-      this.failedReadinessSessions.delete(sessionId)
-      this.deps.log("[tmux-session-manager] expired failed readiness session", {
-        sessionId,
-        ttlMs: FAILED_READINESS_SESSION_TTL_MS,
-      })
-    }
-
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-  }
-
-  private getFailedReadinessSession(sessionId: string): FailedReadinessSession | undefined {
-    const failedReadinessSession = this.failedReadinessSessions.get(sessionId)
-    if (!failedReadinessSession) {
-      return undefined
-    }
-
-    if (!this.isFailedReadinessSessionExpired(failedReadinessSession, Date.now())) {
-      return failedReadinessSession
-    }
-
-    this.failedReadinessSessions.delete(sessionId)
-    this.deps.log("[tmux-session-manager] expired failed readiness session on access", {
-      sessionId,
-      ttlMs: FAILED_READINESS_SESSION_TTL_MS,
-    })
-
-    if (this.failedReadinessSessions.size === 0) {
-      this.stopFailedReadinessSweep()
-    }
-
-    return undefined
-  }
-
   private async spawnPendingSession(args: {
     session: FailedReadinessSessionSeed
     stage: SpawnStage
@@ -852,7 +733,7 @@ export class TmuxSessionManager {
     const readyForSpawn = await this.ensureSessionReadyBeforeSpawn(sessionId, stage)
     if (!readyForSpawn) {
       if (rememberReadinessFailure) {
-        this.rememberFailedReadinessSession(session)
+        this.failedReadinessCache.remember(session)
       }
       return
     }
@@ -865,12 +746,12 @@ export class TmuxSessionManager {
         status: sessionStatus,
       })
       if (rememberReadinessFailure) {
-        this.rememberFailedReadinessSession(session)
+        this.failedReadinessCache.remember(session)
       }
       return
     }
 
-    this.clearFailedReadinessSession(sessionId)
+    this.failedReadinessCache.clear(sessionId)
 
     const isolatedPaneId = await this.spawnInIsolatedContainer(sessionId, title)
     if (isolatedPaneId) {
@@ -978,7 +859,7 @@ export class TmuxSessionManager {
           description: title,
         }),
       )
-      this.clearFailedReadinessSession(sessionId)
+      this.failedReadinessCache.clear(sessionId)
       this.deps.log("[tmux-session-manager] pane spawned and tracked", {
         sessionId,
         paneId: result.spawnedPaneId,
@@ -1027,7 +908,7 @@ export class TmuxSessionManager {
       return
     }
 
-    const failedReadinessSession = this.getFailedReadinessSession(sessionId)
+    const failedReadinessSession = this.failedReadinessCache.get(sessionId)
     if (!failedReadinessSession) {
       return
     }
@@ -1048,7 +929,7 @@ export class TmuxSessionManager {
             return
           }
 
-          this.clearFailedReadinessSession(sessionId)
+          this.failedReadinessCache.clear(sessionId)
           await this.spawnPendingSession({
             session: failedReadinessSession,
             stage: "session.idle.retry",
@@ -1298,7 +1179,7 @@ export class TmuxSessionManager {
     if (!this.isEnabled()) return
 
     this.closedByPolling.delete(event.sessionID)
-    this.clearFailedReadinessSession(event.sessionID)
+    this.failedReadinessCache.clear(event.sessionID)
     this.removeDeferredSession(event.sessionID)
 
     if (!this.getEffectiveSourcePaneId()) return
@@ -1421,9 +1302,8 @@ export class TmuxSessionManager {
     this.stopDeferredAttachLoop()
     this.deferredQueue = []
     this.deferredSessions.clear()
-    this.failedReadinessSessions.clear()
     this.closedByPolling.clear()
-    this.stopFailedReadinessSweep()
+    this.failedReadinessCache.clearAll()
     this.pollingManager.stopPolling()
 
     if (this.sessions.size > 0) {

--- a/packages/omo-opencode/src/features/tmux-subagent/resolve-server-url.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/resolve-server-url.ts
@@ -1,0 +1,38 @@
+type ServerUrlEnv = Record<string, string | undefined>
+
+export function resolveServerUrl(
+  rawServerUrl: string | undefined,
+  env: ServerUrlEnv,
+  log: (message: string, data?: unknown) => void,
+): string {
+  const configuredPort = env.OPENCODE_PORT
+  const parsedPort = configuredPort ? Number(configuredPort) : 4096
+  const defaultPort = Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535
+    ? String(parsedPort)
+    : "4096"
+  const fallbackUrl = `http://localhost:${defaultPort}`
+
+  try {
+    if (rawServerUrl) {
+      const parsed = new URL(rawServerUrl)
+      const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
+      if (port === '0') {
+        log(
+          "[tmux-session-manager] ctx.serverUrl has port 0; falling back. " +
+            "team_mode tmux visualization will silently skip if nothing is listening on the fallback URL. " +
+            "Launch opencode with --port N and OPENCODE_PORT=N to bind a real port (see issue #3963).",
+          { kind: "warning", ctxServerUrl: rawServerUrl, fallbackUrl },
+        )
+        return fallbackUrl
+      }
+      return rawServerUrl
+    }
+    return fallbackUrl
+  } catch (error) {
+    log("[tmux-session-manager] failed to parse server URL, using fallback", {
+      serverUrl: rawServerUrl,
+      error: String(error),
+    })
+    return fallbackUrl
+  }
+}

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -3,11 +3,25 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:
 import { OhMyOpenCodeConfigSchema } from "../../config"
 import { executeCompact } from "./executor"
 import type { AutoCompactState } from "./types"
+import type { Client } from "./client"
 import * as recoveryStrategy from "./recovery-strategy"
 import * as messagesReader from "../session-recovery/storage/messages-reader"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
-type TimerCallback = (...args: any[]) => void
+type MockClient = {
+  session: {
+    status: ReturnType<typeof mock>
+    messages: ReturnType<typeof mock>
+    summarize: ReturnType<typeof mock>
+    revert: ReturnType<typeof mock>
+    promptAsync: ReturnType<typeof mock>
+  }
+  tui: { showToast: ReturnType<typeof mock> }
+}
+
+const asClient = (client: MockClient): Client => unsafeTestValue<Client>(client)
+
+type TimerCallback = (...args: unknown[]) => void
 
 interface FakeTimeouts {
   advanceBy: (ms: number) => Promise<void>
@@ -22,7 +36,7 @@ const TRUE_ORIGINAL_CLEAR_TIMEOUT = globalThis.clearTimeout
 function createFakeTimeouts(): FakeTimeouts {
   let now = 0
   let nextId = 1
-  const timers = new Map<number, { id: number; time: number; callback: TimerCallback; args: any[] }>()
+  const timers = new Map<number, { id: number; time: number; callback: TimerCallback; args: unknown[] }>()
   const cleared = new Set<number>()
 
   const normalizeDelay = (delay?: number) => {
@@ -30,7 +44,7 @@ function createFakeTimeouts(): FakeTimeouts {
     return delay < 0 ? 0 : delay
   }
 
-  globalThis.setTimeout = ((callback: TimerCallback, delay?: number, ...args: any[]) => {
+  globalThis.setTimeout = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
     const id = nextId++
     timers.set(id, {
       id,
@@ -50,7 +64,7 @@ function createFakeTimeouts(): FakeTimeouts {
   const advanceBy = async (ms: number) => {
     const target = now + Math.max(0, ms)
     while (true) {
-      let next: { id: number; time: number; callback: TimerCallback; args: any[] } | undefined
+      let next: { id: number; time: number; callback: TimerCallback; args: unknown[] } | undefined
       for (const timer of timers.values()) {
         if (timer.time <= target && (!next || timer.time < next.time)) {
           next = timer
@@ -80,7 +94,7 @@ function createFakeTimeouts(): FakeTimeouts {
 
 describe("executeCompact lock management", () => {
   let autoCompactState: AutoCompactState
-  let mockClient: any
+  let mockClient: MockClient
   let fakeTimeouts: FakeTimeouts
   let pluginConfig: ReturnType<typeof OhMyOpenCodeConfigSchema.parse>
   const sessionID = "test-session-123"
@@ -129,7 +143,7 @@ describe("executeCompact lock management", () => {
     })
 
     // when: Execute compaction successfully
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     expect(mockClient.session.summarize).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -152,7 +166,7 @@ describe("executeCompact lock management", () => {
     })
 
     // when: The delayed auto-compact callback fires before OpenCode reaches idle
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // then: OMO leaves recovery pending for the real session.idle event instead of racing summarize
     expect(mockClient.session.summarize).not.toHaveBeenCalled()
@@ -173,7 +187,7 @@ describe("executeCompact lock management", () => {
     })
 
     // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     expect(mockClient.session.summarize).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,7 +205,7 @@ describe("executeCompact lock management", () => {
     autoCompactState.compactionInProgress.add(sessionID)
 
     // when: Try to execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // then: Toast should be shown with warning message
     expect(mockClient.tui.showToast).toHaveBeenCalledWith(
@@ -219,7 +233,7 @@ describe("executeCompact lock management", () => {
     })
 
     //#when - Execute compaction (fixEmptyMessages will be called)
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     //#then - Lock should be cleared
     expect(autoCompactState.compactionInProgress.has(sessionID)).toBe(false)
@@ -245,7 +259,7 @@ describe("executeCompact lock management", () => {
       sessionID,
       msg,
       autoCompactState,
-      mockClient,
+      asClient(mockClient),
       directory,
       pluginConfig,
       experimental,
@@ -261,12 +275,12 @@ describe("executeCompact lock management", () => {
     autoCompactState.compactionInProgress.add(sessionID)
 
     // when: Try to execute compaction while lock is held
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // then: Toast should be shown
-    const toastCalls = (unsafeTestValue(mockClient.tui.showToast)).mock.calls
+    const toastCalls = mockClient.tui.showToast.mock.calls
     const blockedToast = toastCalls.find(
-      (call: any) => call[0]?.body?.title === "Compact In Progress",
+      (call) => call[0]?.body?.title === "Compact In Progress",
     )
     expect(blockedToast).toBeDefined()
 
@@ -294,12 +308,12 @@ describe("executeCompact lock management", () => {
     })
 
     // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // then: Should show failure toast
-    const toastCalls = (unsafeTestValue(mockClient.tui.showToast)).mock.calls
+    const toastCalls = mockClient.tui.showToast.mock.calls
     const failureToast = toastCalls.find(
-      (call: any) => call[0]?.body?.title === "Auto Compact Failed",
+      (call) => call[0]?.body?.title === "Auto Compact Failed",
     )
     expect(failureToast).toBeDefined()
 
@@ -319,7 +333,7 @@ describe("executeCompact lock management", () => {
     })
 
     // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // then: Lock should be cleared even if toast fails
     expect(autoCompactState.compactionInProgress.has(sessionID)).toBe(false)
@@ -337,7 +351,7 @@ describe("executeCompact lock management", () => {
     })
 
     // when: Execute compaction
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     // Wait for setTimeout callback
     await fakeTimeouts.advanceBy(600)
@@ -372,7 +386,7 @@ describe("executeCompact lock management", () => {
       sessionID,
       msg,
       autoCompactState,
-      mockClient,
+      asClient(mockClient),
       directory,
       pluginConfig,
       experimental,
@@ -412,7 +426,7 @@ describe("executeCompact lock management", () => {
     }))
 
     //#when - Execute compaction without experimental config (default behavior)
-    await executeCompact(sessionID, msg, autoCompactState, mockClient, directory, pluginConfig)
+    await executeCompact(sessionID, msg, autoCompactState, asClient(mockClient), directory, pluginConfig)
 
     //#then - Aggressive truncation must be skipped per docs (defaults false)
     expect(truncateSpy).not.toHaveBeenCalled()
@@ -448,7 +462,7 @@ describe("executeCompact lock management", () => {
       sessionID,
       msg,
       autoCompactState,
-      mockClient,
+      asClient(mockClient),
       directory,
       pluginConfig,
       experimental,
@@ -500,7 +514,7 @@ describe("executeCompact lock management", () => {
       sessionID,
       msg,
       autoCompactState,
-      mockClient,
+      asClient(mockClient),
       directory,
       pluginConfig,
       experimental,

--- a/packages/omo-opencode/src/hooks/legacy-plugin-toast/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/legacy-plugin-toast/hook.test.ts
@@ -15,8 +15,10 @@ const mockAutoMigrate = mock((): MigrationResult => ({
   configPath: null,
 }))
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockShowToast = mock((_arg: any) => Promise.resolve())
+const mockShowToast = mock(
+  (_arg: { body: { title: string; message: string; variant: string; duration: number } }) =>
+    Promise.resolve(),
+)
 const mockLog = mock(() => {})
 
 afterAll(() => {

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -12,7 +12,7 @@ import {
   MAX_STAGNATION_COUNT,
 } from "./constants"
 
-type TimerCallback = (...args: any[]) => void
+type TimerCallback = (...args: unknown[]) => void
 type FakeTimerID = number & ReturnType<typeof setTimeout> & ReturnType<typeof setInterval>
 
 interface FakeTimers {
@@ -27,7 +27,7 @@ function createFakeTimers(): FakeTimers {
   let clockNow = originalNow
   let timerNow = 0
   let nextId = 1
-  const timers = new Map<number, { id: number; time: number; interval: number | null; callback: TimerCallback; args: any[] }>()
+  const timers = new Map<number, { id: number; time: number; interval: number | null; callback: TimerCallback; args: unknown[] }>()
   const cleared = new Set<number>()
 
   const original = {
@@ -49,7 +49,7 @@ function createFakeTimers(): FakeTimers {
     }
   }
 
-  const schedule = (callback: TimerCallback, delay: number | undefined, interval: number | null, args: any[]) => {
+  const schedule = (callback: TimerCallback, delay: number | undefined, interval: number | null, args: unknown[]) => {
     const id = nextId++
     timers.set(id, {
       id,
@@ -67,7 +67,7 @@ function createFakeTimers(): FakeTimers {
     timers.delete(id)
   }
 
-  globalThis.setTimeout = ((callback: TimerCallback, delay?: number, ...args: any[]) => {
+  globalThis.setTimeout = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
     const normalized = normalizeDelay(delay)
     if (normalized < FAKE_MIN_DELAY_MS) {
       return original.setTimeout(callback, delay, ...args)
@@ -78,7 +78,7 @@ function createFakeTimers(): FakeTimers {
     return schedule(callback, normalized, null, args)
   }) as typeof setTimeout
 
-  globalThis.setInterval = ((callback: TimerCallback, delay?: number, ...args: any[]) => {
+  globalThis.setInterval = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
     const interval = normalizeDelay(delay)
     if (interval < FAKE_MIN_DELAY_MS) {
       return original.setInterval(callback, delay, ...args)
@@ -114,7 +114,7 @@ function createFakeTimers(): FakeTimers {
       clockNow += clamped
     }
     while (true) {
-      let next: { id: number; time: number; interval: number | null; callback: TimerCallback; args: any[] } | undefined
+      let next: { id: number; time: number; interval: number | null; callback: TimerCallback; args: unknown[] } | undefined
       for (const timer of timers.values()) {
         if (timer.time <= target && (!next || timer.time < next.time)) {
           next = timer
@@ -262,7 +262,7 @@ describe("todo-continuation-enforcer", () => {
     // given
     const originalSetInterval = globalThis.setInterval
     let setIntervalCalls = 0
-    globalThis.setInterval = ((callback: TimerCallback, delay?: number, ...args: any[]) => {
+    globalThis.setInterval = ((callback: TimerCallback, delay?: number, ...args: unknown[]) => {
       setIntervalCalls += 1
       return originalSetInterval(callback, delay, ...args)
     }) as typeof setInterval

--- a/packages/omo-opencode/src/plugin/event.model-fallback-pin-agent.test.ts
+++ b/packages/omo-opencode/src/plugin/event.model-fallback-pin-agent.test.ts
@@ -40,15 +40,19 @@ function expectSyntheticContinuation(body: PromptBody["body"]): void {
 
 describe("createEventHandler - model-fallback auto-continuation pins agent/model/variant", () => {
   const createHandler = (args?: {
-    hooks?: any
-    pluginConfig?: any
+    hooks?: unknown
+    pluginConfig?: unknown
     withPromptAsync?: boolean
   }) => {
     setupConnectedProviderCacheMocks()
     const promptAsyncBodies: PromptBody[] = []
     const promptBodies: PromptBody[] = []
 
-    const sessionClient: Record<string, any> = {
+    const sessionClient: {
+      abort: () => Promise<unknown>
+      prompt: (input: PromptBody) => Promise<unknown>
+      promptAsync?: (input: PromptBody) => Promise<unknown>
+    } = {
       abort: async () => ({}),
       prompt: async (input: PromptBody) => {
         promptBodies.push(input)
@@ -81,7 +85,7 @@ describe("createEventHandler - model-fallback auto-continuation pins agent/model
           disconnectSession: async () => {},
         },
       }),
-      hooks: args?.hooks ?? (unsafeTestValue({})),
+      hooks: unsafeTestValue(args?.hooks ?? {}),
     })
 
     return { handler, promptAsyncBodies, promptBodies }

--- a/packages/omo-opencode/src/plugin/event.model-fallback.test.ts
+++ b/packages/omo-opencode/src/plugin/event.model-fallback.test.ts
@@ -33,8 +33,8 @@ function setupConnectedProviderCacheMocks(): void {
 
 describe("createEventHandler - model fallback", () => {
   const createHandler = (args?: {
-    hooks?: any
-    pluginConfig?: any
+    hooks?: unknown
+    pluginConfig?: unknown
     abort?: (input: { path: { id: string } }) => Promise<unknown>
     promptAsync?: (input: { path: { id: string } }) => Promise<unknown>
   }) => {
@@ -86,7 +86,7 @@ describe("createEventHandler - model fallback", () => {
           disconnectSession: async () => {},
         },
       }),
-      hooks: args?.hooks ?? (unsafeTestValue({})),
+      hooks: unsafeTestValue(args?.hooks ?? {}),
     })
     const handler = (input: EventInput): Promise<void> => eventHandler(asEventHandlerInput(input))
 

--- a/packages/omo-opencode/src/plugin/normalize-tool-arg-schemas.test.ts
+++ b/packages/omo-opencode/src/plugin/normalize-tool-arg-schemas.test.ts
@@ -93,7 +93,9 @@ describe("normalizeToolArgSchemas", () => {
     expect(afterQuery?.description).toBe("Free-text search query")
     expect(afterQuery?.title).toBe("Query")
     expect(afterQuery?.examples).toEqual(["issue 2314"])
-  })
+    // loadSeparateHostZodModule cpSync-copies the whole zod package; Windows CI
+    // runners exceed the 5s default on that copy alone
+  }, 15000)
 })
 
 describe("sanitizeJsonSchema", () => {

--- a/packages/omo-opencode/src/shared/model-availability.ts
+++ b/packages/omo-opencode/src/shared/model-availability.ts
@@ -1,9 +1,13 @@
+import type { PluginInput } from "@opencode-ai/plugin"
 import { existsSync, readFileSync } from "fs"
 import { join } from "path"
 import { log } from "./logger"
 import { getOpenCodeCacheDir } from "./data-path"
 import * as connectedProvidersCache from "./connected-providers-cache"
 import { normalizeSDKResponse } from "./normalize-sdk-response"
+
+type OpencodeClient = PluginInput["client"]
+type ModelListClient = OpencodeClient & { model?: { list?: () => Promise<unknown> } }
 
 function normalizeModelName(name: string): string {
 	return name
@@ -103,7 +107,7 @@ export function isModelAvailable(
 	return fuzzyMatchModel(targetModel, availableModels) !== null
 }
 
-export async function getConnectedProviders(client: any): Promise<string[]> {
+export async function getConnectedProviders(client: OpencodeClient): Promise<string[]> {
 	if (!client?.provider?.list) {
 		log("[getConnectedProviders] client.provider.list not available")
 		return []
@@ -121,7 +125,7 @@ export async function getConnectedProviders(client: any): Promise<string[]> {
 }
 
 export async function fetchAvailableModels(
-	client?: any,
+	client?: ModelListClient,
 	options?: { connectedProviders?: string[] | null }
 ): Promise<Set<string>> {
 	let connectedProviders = options?.connectedProviders ?? null

--- a/packages/omo-opencode/src/shared/opencode-message-dir.test.ts
+++ b/packages/omo-opencode/src/shared/opencode-message-dir.test.ts
@@ -31,11 +31,11 @@ describe("getMessageDir", () => {
   })
 
   afterEach(() => {
-    try { rmSync(TEST_MESSAGE_STORAGE, { recursive: true, force: true }) } catch {}
+    try { rmSync(TEST_MESSAGE_STORAGE, { recursive: true, force: true }) } catch {} // no-excuse-ok: catch — best-effort temp-dir cleanup
   })
 
   afterAll(() => {
-    try { rmSync(TEST_STORAGE, { recursive: true, force: true }) } catch {}
+    try { rmSync(TEST_STORAGE, { recursive: true, force: true }) } catch {} // no-excuse-ok: catch — best-effort temp-dir cleanup
   })
 
   it("returns null when sessionID does not start with ses_", () => {

--- a/packages/omo-opencode/src/shared/opencode-storage-detection.test.ts
+++ b/packages/omo-opencode/src/shared/opencode-storage-detection.test.ts
@@ -47,7 +47,7 @@ describe("isSqliteBackend", () => {
     resetSqliteBackendCache()
     versionCheckCalls = []
     versionReturnValue = true
-    try { rmSync(TEST_DATA_DIR, { recursive: true, force: true }) } catch {}
+    try { rmSync(TEST_DATA_DIR, { recursive: true, force: true }) } catch {} // no-excuse-ok: catch — best-effort temp-dir cleanup
   })
 
   it("returns false when version is below threshold", () => {

--- a/packages/omo-opencode/src/tools/call-omo-agent/tools-edge-cases.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/tools-edge-cases.test.ts
@@ -11,7 +11,8 @@ const { describe, test, expect, mock, beforeEach } = require("bun:test")
 const { createCallOmoAgent } = require("./tools")
 const { clearCallableAgentsCache } = require("./agent-resolver")
 
-type PluginInput = { client: any; directory: string }
+type OpencodeClient = import("@opencode-ai/plugin").PluginInput["client"]
+type PluginInput = { client: OpencodeClient; directory: string }
 
 function createMockCtx(agents: Array<{ name: string; mode?: string }> = []): PluginInput {
   return {
@@ -19,7 +20,7 @@ function createMockCtx(agents: Array<{ name: string; mode?: string }> = []): Plu
       app: {
         agents: mock(() => Promise.resolve({ data: agents })),
       },
-    },
+    } as unknown as OpencodeClient,
     directory: "/test",
     }
 }

--- a/packages/omo-opencode/src/tools/call-omo-agent/tools.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/tools.test.ts
@@ -2,7 +2,8 @@ const { beforeEach, describe, test, expect, mock } = require("bun:test")
 const { createCallOmoAgent } = require("./tools")
 const { clearCallableAgentsCache } = require("./agent-resolver")
 
-type PluginInput = { client: any; directory: string }
+type OpencodeClient = import("@opencode-ai/plugin").PluginInput["client"]
+type PluginInput = { client: OpencodeClient; directory: string }
 type BackgroundManager = {
   assertCanSpawn: Function
   reserveSubagentSpawn: Function
@@ -16,7 +17,7 @@ function createMockCtx(agents: Array<{ name: string; mode?: string }> = []): Plu
       app: {
         agents: mock(() => Promise.resolve({ data: agents })),
       },
-    },
+    } as unknown as OpencodeClient,
     directory: "/test",
     }
 }
@@ -27,7 +28,7 @@ function createFailingMockCtx(error: Error = new Error("API unavailable")): Plug
       app: {
         agents: mock(() => Promise.reject(error)),
       },
-    },
+    } as unknown as OpencodeClient,
     directory: "/test",
     }
 }

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -25,7 +25,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("does not emit synthetic pending session metadata when session id is unresolved", async () => {
     //#given - launched task without resolved subagent session id
-    const metadataCalls: any[] = []
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
     const manager = {
       launch: async () => ({
         id: "bg_unresolved",
@@ -47,7 +47,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       {
         sessionID: "ses_parent",
         callID: "call_1",
-        metadata: async (value: any) => metadataCalls.push(value),
+        metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
         abort: new AbortController().signal,
       },
       { manager },
@@ -68,7 +68,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("emits task metadata session_id when real session id is available", async () => {
     //#given - launched task with resolved subagent session id
-    const metadataCalls: any[] = []
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
     const manager = {
       launch: async () => ({
         id: "bg_resolved",
@@ -90,7 +90,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       {
         sessionID: "ses_parent",
         callID: "call_2",
-        metadata: async (value: any) => metadataCalls.push(value),
+        metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
         abort: new AbortController().signal,
       },
       { manager },
@@ -159,7 +159,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("captures late-resolved session id and emits synced metadata", async () => {
     //#given - background task session id appears after launch via manager polling
-    const metadataCalls: any[] = []
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
     let reads = 0
     const manager = {
       launch: async () => ({
@@ -185,7 +185,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       {
         sessionID: "ses_parent",
         callID: "call_3",
-        metadata: async (value: any) => metadataCalls.push(value),
+        metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
         abort: new AbortController().signal,
       },
       { manager },
@@ -208,9 +208,9 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("passes question-deny session permission when launching delegate task", async () => {
     //#given - delegate task background launch should deny question at session creation time
-    const launchCalls: any[] = []
+    const launchCalls: Array<{ sessionPermission: unknown }> = []
     const manager = {
-      launch: async (input: any) => {
+      launch: async (input: { sessionPermission: unknown }) => {
         launchCalls.push(input)
         return {
           id: "bg_permission",
@@ -298,7 +298,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("keeps launched background task alive when parent aborts before session id resolves", async () => {
     //#given - parallel tool execution can abort the parent call after launch succeeds
-    const metadataCalls: any[] = []
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
     const abortController = new AbortController()
     const manager = {
       launch: async () => ({
@@ -325,7 +325,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       {
         sessionID: "ses_parent",
         callID: "call_abort_after_launch",
-        metadata: async (value: any) => metadataCalls.push(value),
+        metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
         abort: abortController.signal,
       },
       { manager },
@@ -439,7 +439,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
   testFn("reports failure when manager marks task as error during session startup", async () => {
     //#given - session created but startTask throws before prompt is sent
-    const metadataCalls: any[] = []
+    const metadataCalls: Array<{ metadata: Record<string, unknown> }> = []
     let reads = 0
     const manager = {
       launch: async () => ({
@@ -469,7 +469,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       {
         sessionID: "ses_parent",
         callID: "call_crash",
-        metadata: async (value: any) => metadataCalls.push(value),
+        metadata: async (value: { metadata: Record<string, unknown> }) => metadataCalls.push(value),
         abort: new AbortController().signal,
       },
       { manager },

--- a/packages/omo-opencode/src/tools/delegate-task/category-resolver.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/category-resolver.ts
@@ -56,6 +56,19 @@ export interface CategoryResolutionResult {
   error?: string
 }
 
+function categoryResolutionError(error: string): CategoryResolutionResult {
+  return {
+    agentToUse: "",
+    categoryModel: undefined,
+    categoryPromptAppend: undefined,
+    maxPromptTokens: undefined,
+    modelInfo: undefined,
+    actualModel: undefined,
+    isUnstableAgent: false,
+    error,
+  }
+}
+
 export async function resolveCategoryExecution(
   args: DelegateTaskArgs,
   executorCtx: ExecutorContext,
@@ -70,16 +83,7 @@ export async function resolveCategoryExecution(
 
   if (!categoryExists) {
     const allCategoryNames = Object.keys(enabledCategories).join(", ")
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      categoryPromptAppend: undefined,
-      maxPromptTokens: undefined,
-      modelInfo: undefined,
-      actualModel: undefined,
-      isUnstableAgent: false,
-      error: `Unknown category: "${categoryName}". Available: ${allCategoryNames}`,
-    }
+    return categoryResolutionError(`Unknown category: "${categoryName}". Available: ${allCategoryNames}`)
   }
 
   const availableModels = await getAvailableModelsForDelegateTask(client)
@@ -96,34 +100,16 @@ export async function resolveCategoryExecution(
     const allCategoryNames = Object.keys(enabledCategories).join(", ")
 
     if (categoryExists && requirement?.requiresModel) {
-      return {
-        agentToUse: "",
-        categoryModel: undefined,
-        categoryPromptAppend: undefined,
-        maxPromptTokens: undefined,
-        modelInfo: undefined,
-        actualModel: undefined,
-        isUnstableAgent: false,
-        error: `Category "${categoryName}" requires model "${requirement.requiresModel}" which is not available.
+      return categoryResolutionError(`Category "${categoryName}" requires model "${requirement.requiresModel}" which is not available.
 
 To use this category:
 1. Connect a provider with this model: ${requirement.requiresModel}
 2. Or configure an alternative model in your ${CONFIG_BASENAME}.json for this category
 
-Available categories: ${allCategoryNames}`,
-      }
+Available categories: ${allCategoryNames}`)
     }
 
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      categoryPromptAppend: undefined,
-      maxPromptTokens: undefined,
-      modelInfo: undefined,
-      actualModel: undefined,
-      isUnstableAgent: false,
-      error: `Unknown category: "${categoryName}". Available: ${allCategoryNames}`,
-    }
+    return categoryResolutionError(`Unknown category: "${categoryName}". Available: ${allCategoryNames}`)
   }
 
   const requirement = CATEGORY_MODEL_REQUIREMENTS[args.category!]
@@ -188,16 +174,7 @@ Available categories: ${allCategoryNames}`,
       actualModel = resolvedModel
 
       if (!parseModelString(actualModel)) {
-        return {
-          agentToUse: "",
-          categoryModel: undefined,
-          categoryPromptAppend: undefined,
-          maxPromptTokens: undefined,
-          modelInfo: undefined,
-          actualModel: undefined,
-          isUnstableAgent: false,
-          error: `Invalid model format "${actualModel}". Expected "provider/model" format (e.g., "anthropic/claude-sonnet-4-6").`,
-        }
+        return categoryResolutionError(`Invalid model format "${actualModel}". Expected "provider/model" format (e.g., "anthropic/claude-sonnet-4-6").`)
       }
 
       const type: "user-defined" | "inherited" | "category-default" | "system-default" =
@@ -237,15 +214,7 @@ Available categories: ${allCategoryNames}`,
 
   if (!categoryModel && !actualModel && !isModelResolutionSkipped) {
     const categoryNames = Object.keys(enabledCategories)
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      categoryPromptAppend: undefined,
-      maxPromptTokens: undefined,
-      modelInfo: undefined,
-      actualModel: undefined,
-      isUnstableAgent: false,
-      error: `Model not configured for category "${args.category}".
+    return categoryResolutionError(`Model not configured for category "${args.category}".
 
 Configure in one of:
 1. OpenCode: Set "model" in opencode.json
@@ -253,8 +222,7 @@ Configure in one of:
 3. Provider: Connect a provider with available models
 
 Current category: ${args.category}
-Available categories: ${categoryNames.join(", ")}`,
-    }
+Available categories: ${categoryNames.join(", ")}`)
   }
 
   const resolvedModel = actualModel?.toLowerCase()

--- a/packages/omo-opencode/src/tools/delegate-task/metadata-model-unification.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/metadata-model-unification.test.ts
@@ -7,15 +7,17 @@ import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-4-6" }
 const MODEL_WITH_VARIANT = { providerID: "google", modelID: "gemini-3.1-pro", variant: "high" }
 
-function makeMockCtx(): ToolContextWithMetadata & { captured: any[] } {
-  const captured: any[] = []
+type CapturedMetadata = { title?: string; metadata: Record<string, unknown> }
+
+function makeMockCtx(): ToolContextWithMetadata & { captured: CapturedMetadata[] } {
+  const captured: CapturedMetadata[] = []
   return {
     sessionID: "ses_parent",
     messageID: "msg_parent",
     agent: "sisyphus",
     abort: new AbortController().signal,
     callID: "call_001",
-    metadata: async (input: any) => { captured.push(input) },
+    metadata: async (input: { title?: string; metadata?: Record<string, unknown> }) => { captured.push(input as CapturedMetadata) },
     captured,
   }
 }
@@ -51,7 +53,7 @@ describe("metadata model unification", () => {
           onSyncSessionCreated: null,
         }, parentContext, "explore", MODEL, undefined, undefined, undefined, deps)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -74,7 +76,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, "explore", MODEL, undefined)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -114,7 +116,7 @@ describe("metadata model unification", () => {
           parentContext, "explore", MODEL, undefined, "anthropic/claude-sonnet-4-6",
         )
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -136,7 +138,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -165,7 +167,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, deps)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -194,7 +196,7 @@ describe("metadata model unification", () => {
           onSyncSessionCreated: null,
         }, parentContext, "explore", undefined, undefined, undefined, undefined, deps)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -217,7 +219,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, "explore", undefined, undefined)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -258,7 +260,7 @@ describe("metadata model unification", () => {
           parentContext, "explore", undefined, undefined, "anthropic/claude-sonnet-4-6",
         )
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -280,7 +282,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -307,7 +309,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, deps)
 
-        const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+        const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL)
       })
@@ -341,7 +343,7 @@ describe("metadata model unification", () => {
         onSyncSessionCreated: null,
       }, parentContextWithoutModel, "explore", undefined, undefined, undefined, undefined, deps)
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.model).toBeUndefined()
     })
@@ -369,7 +371,7 @@ describe("metadata model unification", () => {
           onSyncSessionCreated: null,
         }, parentContext, "explore", MODEL_WITH_VARIANT, undefined, undefined, undefined, deps)
 
-        const meta = ctx.captured.find((metadataEvent: any) => metadataEvent.metadata?.sessionId)
+        const meta = ctx.captured.find((metadataEvent: CapturedMetadata) => metadataEvent.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL_WITH_VARIANT)
       })
@@ -392,7 +394,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, "explore", MODEL_WITH_VARIANT, undefined)
 
-        const meta = ctx.captured.find((metadataEvent: any) => metadataEvent.metadata?.sessionId)
+        const meta = ctx.captured.find((metadataEvent: CapturedMetadata) => metadataEvent.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL_WITH_VARIANT)
       })
@@ -433,7 +435,7 @@ describe("metadata model unification", () => {
           parentContext, "explore", MODEL_WITH_VARIANT, undefined, "google/gemini-3.1-pro high",
         )
 
-        const meta = ctx.captured.find((metadataEvent: any) => metadataEvent.metadata?.sessionId)
+        const meta = ctx.captured.find((metadataEvent: CapturedMetadata) => metadataEvent.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL_WITH_VARIANT)
       })
@@ -455,7 +457,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext)
 
-        const meta = ctx.captured.find((metadataEvent: any) => metadataEvent.metadata?.sessionId)
+        const meta = ctx.captured.find((metadataEvent: CapturedMetadata) => metadataEvent.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL_WITH_VARIANT)
       })
@@ -484,7 +486,7 @@ describe("metadata model unification", () => {
           },
         }), parentContext, deps)
 
-        const meta = ctx.captured.find((metadataEvent: any) => metadataEvent.metadata?.sessionId)
+        const meta = ctx.captured.find((metadataEvent: CapturedMetadata) => metadataEvent.metadata?.sessionId)!
         expect(meta).toBeDefined()
         expect(meta.metadata.model).toEqual(MODEL_WITH_VARIANT)
       })

--- a/packages/omo-opencode/src/tools/delegate-task/metadata-task-id-consistency.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/metadata-task-id-consistency.test.ts
@@ -6,15 +6,17 @@ import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
 const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-4-6" }
 
-function makeMockCtx(): ToolContextWithMetadata & { captured: any[] } {
-  const captured: any[] = []
+type CapturedMetadata = { title?: string; metadata: Record<string, unknown> }
+
+function makeMockCtx(): ToolContextWithMetadata & { captured: CapturedMetadata[] } {
+  const captured: CapturedMetadata[] = []
   return {
     sessionID: "ses_parent",
     messageID: "msg_parent",
     agent: "sisyphus",
     abort: new AbortController().signal,
     callID: "call_001",
-    metadata: async (input: any) => { captured.push(input) },
+    metadata: async (input: { title?: string; metadata?: Record<string, unknown> }) => { captured.push(input as CapturedMetadata) },
     captured,
   }
 }
@@ -48,7 +50,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         onSyncSessionCreated: null,
       }, parentContext, "explore", MODEL, undefined, undefined, undefined, deps)
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.taskId).toBe("ses_sync")
       expect(meta.metadata.sessionId).toBe("ses_sync")
@@ -75,7 +77,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, "explore", MODEL, undefined)
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.taskId).toBe("ses_xyz789")
       expect(meta.metadata.sessionId).toBe("ses_xyz789")
@@ -120,7 +122,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         parentContext, "explore", MODEL, undefined, "anthropic/claude-sonnet-4-6",
       )
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.taskId).toBe("ses_unstable_xyz")
       expect(meta.metadata.sessionId).toBe("ses_unstable_xyz")
@@ -146,7 +148,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext)
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.taskId).toBe("ses_resumed_x")
       expect(meta.metadata.sessionId).toBe("ses_resumed_x")
@@ -170,7 +172,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.category).toBe("deep")
     })
@@ -197,7 +199,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.requested_subagent_type).toBe("oracle")
     })
@@ -228,7 +230,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, deps)
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.sessionId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.taskId).toBe("ses_cont_abc")
       expect(meta.metadata.sessionId).toBe("ses_cont_abc")
@@ -258,7 +260,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, deps)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.agent).toBe("explore")
     })
@@ -287,7 +289,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, deps)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.category).toBe("quick")
     })
@@ -321,7 +323,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, deps)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.requested_subagent_type).toBe("oracle")
     })
@@ -352,7 +354,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         onSyncSessionCreated: null,
       }, parentContext, "Sisyphus-Junior", MODEL, undefined, undefined, undefined, deps)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.requested_subagent_type).toBe("oracle")
     })
@@ -379,7 +381,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext, "Sisyphus-Junior", MODEL, undefined)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.requested_subagent_type).toBe("oracle")
     })
@@ -424,7 +426,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         parentContext, "Sisyphus-Junior", MODEL, undefined, "anthropic/claude-sonnet-4-6",
       )
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.requested_subagent_type).toBe("oracle")
     })
@@ -448,7 +450,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         },
       }), parentContext)
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.title).toBe("continue work")
     })
@@ -475,7 +477,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
         fetchSyncResult: async () => ({ ok: true as const, textContent: "done" }),
       })
 
-      const meta = ctx.captured.find((item: any) => item.metadata?.sessionId)
+      const meta = ctx.captured.find((item: CapturedMetadata) => item.metadata?.sessionId)!
       expect(meta).toBeDefined()
       expect(meta.title).toBe("continue sync")
     })
@@ -504,7 +506,7 @@ describe("taskId and backgroundTaskId metadata consistency", () => {
       const bgOutput = createBackgroundOutput(unsafeTestValue(manager), unsafeTestValue(client))
       await bgOutput.execute(unsafeTestValue({ task_id: "bg_output_xyz" }), unsafeTestValue(ctx))
 
-      const meta = ctx.captured.find((m: any) => m.metadata?.backgroundTaskId)
+      const meta = ctx.captured.find((m: CapturedMetadata) => m.metadata?.backgroundTaskId)!
       expect(meta).toBeDefined()
       expect(meta.metadata.backgroundTaskId).toBe("bg_output_xyz")
       expect(meta.metadata.sessionId).toBe("ses_bg_session")

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
@@ -15,9 +15,11 @@ const TEAM_TOOL_DENIALS = {
   team_list: false,
 }
 
+type AddTaskArg = Parameters<import("../../features/task-toast-manager/manager").TaskToastManager["addTask"]>[0]
+
 describe("executeSyncContinuation - toast cleanup error paths", () => {
   let removeTaskCalls: string[] = []
-  let addTaskCalls: any[] = []
+  let addTaskCalls: AddTaskArg[] = []
   let resetToastManager: (() => void) | null = null
 
   beforeEach(() => {
@@ -43,7 +45,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
       tui: { showToast: mock(() => Promise.resolve()) },
     })
 
-    spyOn(toastManager, "addTask").mockImplementation((task: any) => {
+    spyOn(toastManager, "addTask").mockImplementation((task: AddTaskArg) => {
       addTaskCalls.push(task)
     })
     spyOn(toastManager, "removeTask").mockImplementation((id: string) => {
@@ -110,7 +112,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
     }
 
     //#when - executeSyncContinuation with fetchSyncResult throwing
-    let error: any = null
+    let error: unknown = null
     let result: string | null = null
     try {
       result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
@@ -120,7 +122,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
 
     //#then - error should be thrown but toast should still be removed
     expect(error).not.toBeNull()
-    expect(error.message).toBe("Network error")
+    expect((error as Error).message).toBe("Network error")
     expect(removeTaskCalls.length).toBe(1)
     expect(removeTaskCalls[0]).toBe("resume_sync_ses_test")
   })
@@ -173,7 +175,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
     }
 
     //#when - executeSyncContinuation with pollSyncSession throwing
-    let error: any = null
+    let error: unknown = null
     let result: string | null = null
     try {
       result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
@@ -183,7 +185,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
 
     //#then - error should be thrown but toast should still be removed
     expect(error).not.toBeNull()
-    expect(error.message).toBe("Poll error")
+    expect((error as Error).message).toBe("Poll error")
     expect(removeTaskCalls.length).toBe(1)
     expect(removeTaskCalls[0]).toBe("resume_sync_ses_test")
   })
@@ -505,7 +507,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
     const { executeSyncContinuation } = require("./sync-continuation")
 
     const deps = {
-      pollSyncSession: async (_ctx: any, _client: any, input: any) => {
+      pollSyncSession: async (_ctx: unknown, _client: unknown, input: { toastManager?: { removeTask: (id: string) => void } | null; taskId?: string }) => {
         if (input.toastManager && input.taskId) {
           input.toastManager.removeTask(input.taskId)
         }
@@ -592,7 +594,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
     }
 
     //#when - executeSyncContinuation with null toastManager
-    let error: any = null
+    let error: unknown = null
     let result: string | null = null
     try {
       result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
@@ -11,6 +11,18 @@ const {
   getSessionPromptParams,
 } = require("../../shared/session-prompt-params-state")
 
+type PromptArgs = {
+  body: {
+    agent?: string
+    model?: unknown
+    variant?: string
+    tools: Record<string, boolean>
+    options?: unknown
+    maxOutputTokens?: number
+    temperature?: number
+  }
+}
+
 bunDescribe("sendSyncPrompt", () => {
   bunAfterEach(() => {
     clearSessionPromptParams("test-session")
@@ -59,8 +71,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptAsync = bunMock(async (input: any) => {
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
       promptArgs = input
       return { data: {} }
     })
@@ -99,8 +111,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptAsync = bunMock(async (input: any) => {
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
       promptArgs = input
       return { data: {} }
     })
@@ -140,8 +152,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptAsync = bunMock(async (input: any) => {
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
       promptArgs = input
       return { data: {} }
     })
@@ -181,8 +193,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptAsync = bunMock(async (input: any) => {
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
       promptArgs = input
       return { data: {} }
     })
@@ -222,8 +234,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptAsync = bunMock(async (input: any) => {
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
       promptArgs = input
       return { data: {} }
     })
@@ -272,8 +284,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptWithModelSuggestionRetry = bunMock(async (_client: any, input: any) => {
+    let promptArgs!: PromptArgs
+    const promptWithModelSuggestionRetry = bunMock(async (_client: unknown, input: PromptArgs) => {
       promptArgs = input
     })
 
@@ -337,8 +349,8 @@ bunDescribe("sendSyncPrompt", () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
 
-    let promptArgs: any
-    const promptWithModelSuggestionRetry = bunMock(async (_client: any, input: any) => {
+    let promptArgs!: PromptArgs
+    const promptWithModelSuggestionRetry = bunMock(async (_client: unknown, input: PromptArgs) => {
       promptArgs = input
     })
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
@@ -545,7 +545,7 @@ describe("pollSyncSession", () => {
       const { isSessionComplete } = require("./sync-session-poller")
 
       // given: empty messages array
-      const messages: any[] = []
+      const messages: unknown[] = []
 
       // when: calling isSessionComplete
       const result = isSessionComplete(messages)

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.test.ts
@@ -7,9 +7,12 @@ function clearRequireCache(modulePath: string): void {
   }
 }
 
+type AddTaskArg = Parameters<import("../../features/task-toast-manager/manager").TaskToastManager["addTask"]>[0]
+type CapturedMetadata = { title?: string; metadata: Record<string, unknown> }
+
 describe("executeSyncTask - cleanup on error paths", () => {
   let removeTaskCalls: string[] = []
-  let addTaskCalls: any[] = []
+  let addTaskCalls: AddTaskArg[] = []
   let deleteCalls: string[] = []
   let addCalls: string[] = []
   let resetToastManager: (() => void) | null = null
@@ -40,7 +43,7 @@ describe("executeSyncTask - cleanup on error paths", () => {
       tui: { showToast: mock(() => Promise.resolve()) },
     })
 
-    spyOn(toastManager, "addTask").mockImplementation((task: any) => {
+    spyOn(toastManager, "addTask").mockImplementation((task: AddTaskArg) => {
       addTaskCalls.push(task)
     })
     spyOn(toastManager, "removeTask").mockImplementation((id: string) => {
@@ -637,11 +640,11 @@ describe("executeSyncTask - cleanup on error paths", () => {
       fetchSyncResult: async (_client: unknown, sessionID: string) => ({ ok: true as const, textContent: `Result from ${sessionID}` }),
     }
 
-    const metadataCalls: any[] = []
+    const metadataCalls: CapturedMetadata[] = []
     const mockCtx = {
       sessionID: "parent-session",
       callID: "call-123",
-      metadata: (input: any) => { metadataCalls.push(input) },
+      metadata: (input: { title?: string; metadata?: Record<string, unknown> }) => { metadataCalls.push(input as CapturedMetadata) },
     }
 
     const mockExecutorCtx = {
@@ -844,11 +847,11 @@ describe("executeSyncTask - cleanup on error paths", () => {
       fetchSyncResult: async (_client: unknown, sessionID: string) => ({ ok: true as const, textContent: `Result from ${sessionID}` }),
     }
 
-    const metadataCalls: any[] = []
+    const metadataCalls: CapturedMetadata[] = []
     const mockCtx = {
       sessionID: "parent-session",
       callID: "call-123",
-      metadata: (input: any) => { metadataCalls.push(input) },
+      metadata: (input: { title?: string; metadata?: Record<string, unknown> }) => { metadataCalls.push(input as CapturedMetadata) },
     }
 
     const mockExecutorCtx = {
@@ -885,7 +888,7 @@ describe("executeSyncTask - cleanup on error paths", () => {
     }, "sisyphus-junior", initialModel, undefined, undefined, fallbackChain, deps)
 
     expect(result).toContain("Result from ses_second")
-    expect(onSyncSessionCreated.mock.calls.map((call: any[]) => call[0])).toEqual([
+    expect(onSyncSessionCreated.mock.calls.map((call: unknown[]) => call[0])).toEqual([
       { sessionID: "ses_first", parentID: "parent-session", title: "test task" },
       { sessionID: "ses_second", parentID: "parent-session", title: "test task" },
     ])
@@ -918,11 +921,11 @@ describe("executeSyncTask - cleanup on error paths", () => {
       fetchSyncResult: async () => ({ ok: true as const, textContent: "unused" }),
     }
 
-    const metadataCalls: any[] = []
+    const metadataCalls: CapturedMetadata[] = []
     const mockCtx = {
       sessionID: "parent-session",
       callID: "call-123",
-      metadata: (input: any) => { metadataCalls.push(input) },
+      metadata: (input: { title?: string; metadata?: Record<string, unknown> }) => { metadataCalls.push(input as CapturedMetadata) },
     }
 
     const mockExecutorCtx = {
@@ -1056,11 +1059,11 @@ describe("executeSyncTask - cleanup on error paths", () => {
       fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
     }
 
-    const metadataCalls: any[] = []
+    const metadataCalls: CapturedMetadata[] = []
     const mockCtx = {
       sessionID: "parent-session",
       callID: "call-123",
-      metadata: (input: any) => { metadataCalls.push(input) },
+      metadata: (input: { title?: string; metadata?: Record<string, unknown> }) => { metadataCalls.push(input as CapturedMetadata) },
     }
 
     const mockExecutorCtx = {
@@ -1086,7 +1089,7 @@ describe("executeSyncTask - cleanup on error paths", () => {
 
     //#then - the spawnDepth recorded in metadata MUST match what reserveSubagentSpawn returned
     expect(reservedDepth).toBe(3)
-    const taskMeta = metadataCalls.find((c) => c.metadata?.spawnDepth !== undefined)
+    const taskMeta = metadataCalls.find((c) => c.metadata?.spawnDepth !== undefined)!
     expect(taskMeta).toBeDefined()
     expect(taskMeta.metadata.spawnDepth).toBe(3) // NOT 1 (the fallback value)
   })

--- a/packages/omo-opencode/src/tools/look-at/tools.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.test.ts
@@ -4,6 +4,9 @@ import { clearVisionCapableModelsCache, setVisionCapableModelsCache } from "../.
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
+type LookAtPart = { type: string; url: string; mime: string; filename: string; text: string }
+type LookAtPromptBody = { model?: unknown; tools: Record<string, boolean>; parts: LookAtPart[] }
+
 describe("look-at tool", () => {
   afterEach(() => {
     clearVisionCapableModelsCache()
@@ -263,7 +266,7 @@ describe("look-at tool", () => {
     test("passes multimodal-looker model to sync prompt when available", async () => {
       setVisionCapableModelsCache(new Map([["google/gemini-3-flash", { providerID: "google", modelID: "gemini-3-flash" }]]))
 
-      let promptBody: any
+      let promptBody!: LookAtPromptBody
 
       const mockClient = {
         app: {
@@ -280,7 +283,7 @@ describe("look-at tool", () => {
         session: {
           get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_model_passthrough" } }),
-          prompt: async (input: any) => {
+          prompt: async (input: { body: LookAtPromptBody }) => {
             promptBody = input.body
             return { data: {} }
           },
@@ -574,7 +577,7 @@ describe("look-at tool", () => {
     // when LookAt tool executed
     // then should send data URL to sync prompt
     test("sends data URL when image_data provided", async () => {
-      let promptBody: any
+      let promptBody!: LookAtPromptBody
 
       const mockClient = {
         app: {
@@ -583,7 +586,7 @@ describe("look-at tool", () => {
         session: {
           get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_image_data_test" } }),
-          prompt: async (input: any) => {
+          prompt: async (input: { body: LookAtPromptBody }) => {
             promptBody = input.body
             return { data: {} }
           },
@@ -616,7 +619,7 @@ describe("look-at tool", () => {
         toolContext
       )
 
-      const filePart = promptBody.parts.find((p: any) => p.type === "file")
+      const filePart = promptBody.parts.find((p: LookAtPart) => p.type === "file")!
       expect(filePart).toBeDefined()
       expect(filePart.url).toContain("data:image/png;base64")
       expect(filePart.mime).toBe("image/png")
@@ -627,7 +630,7 @@ describe("look-at tool", () => {
     // when LookAt tool executed
     // then should detect mime type and create proper data URL
     test("handles raw base64 without data URI prefix", async () => {
-      let promptBody: any
+      let promptBody!: LookAtPromptBody
 
       const mockClient = {
         app: {
@@ -636,7 +639,7 @@ describe("look-at tool", () => {
         session: {
           get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_raw_base64_test" } }),
-          prompt: async (input: any) => {
+          prompt: async (input: { body: LookAtPromptBody }) => {
             promptBody = input.body
             return { data: {} }
           },
@@ -669,7 +672,7 @@ describe("look-at tool", () => {
         toolContext
       )
 
-      const filePart = promptBody.parts.find((p: any) => p.type === "file")
+      const filePart = promptBody.parts.find((p: LookAtPart) => p.type === "file")!
       expect(filePart).toBeDefined()
       expect(filePart.url).toContain("data:")
       expect(filePart.url).toContain("base64")
@@ -678,7 +681,7 @@ describe("look-at tool", () => {
 
   describe("createLookAt prompt conditional on Read availability", () => {
     const captureLastPromptBody = () => {
-      const captured: { body: any } = { body: undefined }
+      const captured: { body: LookAtPromptBody } = { body: undefined as unknown as LookAtPromptBody }
       const mockClient = {
         app: {
           agents: async () => ({ data: [] }),
@@ -686,7 +689,7 @@ describe("look-at tool", () => {
         session: {
           get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_prompt_conditional" } }),
-          prompt: async (input: any) => {
+          prompt: async (input: { body: LookAtPromptBody }) => {
             captured.body = input.body
             return { data: {} }
           },
@@ -728,7 +731,7 @@ describe("look-at tool", () => {
       )
 
       expect(captured.body.tools.read).toBe(false)
-      const promptPart = captured.body.parts.find((p: any) => p.type === "text")
+      const promptPart = captured.body.parts.find((p: LookAtPart) => p.type === "text")!
       expect(promptPart).toBeDefined()
       const promptText: string = promptPart.text
       expect(promptText).toContain("attached")
@@ -753,7 +756,7 @@ describe("look-at tool", () => {
       )
 
       expect(captured.body.tools.read).toBe(false)
-      const promptPart = captured.body.parts.find((p: any) => p.type === "text")
+      const promptPart = captured.body.parts.find((p: LookAtPart) => p.type === "text")!
       expect(promptPart).toBeDefined()
       const promptText: string = promptPart.text
       expect(promptText).toContain("attached")
@@ -777,7 +780,7 @@ describe("look-at tool", () => {
         buildToolContext(),
       )
 
-      const promptPart = captured.body.parts.find((p: any) => p.type === "text")
+      const promptPart = captured.body.parts.find((p: LookAtPart) => p.type === "text")!
       const promptText: string = promptPart.text
       // The prompt must mention the agent cannot use Read so the agent does not hallucinate
       expect(promptText.toLowerCase()).toContain("read tool")

--- a/packages/omo-opencode/src/tools/task/todo-sync.test.ts
+++ b/packages/omo-opencode/src/tools/task/todo-sync.test.ts
@@ -1,11 +1,16 @@
 /// <reference types="bun-types/test-globals" />
 import type { Task } from "../../features/claude-tasks/types";
+import type { PluginInput } from "@opencode-ai/plugin";
 import {
   syncTaskToTodo,
   syncAllTasksToTodos,
   syncTaskTodoUpdate,
   type TodoInfo,
 } from "./todo-sync";
+
+type MockTodoCtx = PluginInput & {
+  client: { session: { todo: { mockResolvedValue: (value: unknown) => void; mockRejectedValue: (value: unknown) => void } } };
+};
 
 describe("syncTaskToTodo", () => {
   it("converts pending task to pending todo", () => {
@@ -200,7 +205,7 @@ describe("syncTaskToTodo", () => {
 });
 
 describe("syncTaskTodoUpdate", () => {
-  let mockCtx: any;
+  let mockCtx: MockTodoCtx;
 
   beforeEach(() => {
     mockCtx = {
@@ -209,7 +214,7 @@ describe("syncTaskTodoUpdate", () => {
           todo: vi.fn(),
         },
       },
-    };
+    } as unknown as MockTodoCtx;
   });
 
   it("writes updated todo and preserves existing items", async () => {
@@ -283,7 +288,7 @@ describe("syncTaskTodoUpdate", () => {
 });
 
 describe("syncAllTasksToTodos", () => {
-  let mockCtx: any;
+  let mockCtx: MockTodoCtx;
 
   beforeEach(() => {
     mockCtx = {
@@ -292,7 +297,7 @@ describe("syncAllTasksToTodos", () => {
           todo: vi.fn(),
         },
       },
-    };
+    } as unknown as MockTodoCtx;
   });
 
   it("fetches current todos from OpenCode", async () => {


### PR DESCRIPTION
## Summary

Package-by-package `/programming`-rule violation cleanup + AI-slop removal across `packages/*`, executed by a purpose-split agent team in an isolated worktree with behavior locked before every edit.

- **fix(omo-opencode)**: the only 4 real production `any` violations in the entire packages tree — `model-availability.ts` client params typed as `OpencodeClient` (plus a `ModelListClient` intersection adding the optional `model.list` member the base plugin client type lacks — verified necessary via a tsgo probe), `background-agent/manager.ts` session callbacks typed structurally, 2 `eslint-disable no-explicit-any` removed.
- **refactor(omo-opencode)**: triage-approved structural fixes only — category-resolver error-literal dedup (5 sites); tmux-subagent `FailedReadinessCache` + `resolveServerUrl` extracted into concept-named modules (114/38 raw LOC, both well under the 250 pure-LOC cap); team-runtime transition dedup via `updateMemberInRuntimeState` (4 sites); 4 no-op `instanceof` guards removed.
- **test(omo-opencode)**: all 134 test-tier `any` hits eliminated (precise types / `unknown` + narrowing / `as unknown as X`); intentional teardown catches annotated `no-excuse-ok`. Assertions and test flow unchanged.
- **refactor(ast-grep-mcp)**: dead-branch catches simplified, pinned first by a new no-throw characterization test.
- **chore(omo-codex)**: stale planning comment trimmed.

Scanned, verified case-by-case, and intentionally NOT changed: 26 self-referential lint-script hits + 24 prompt-template/comment string hits (not code); the `background-agent/manager.ts` god-class split (HIGH risk: stateful singleton, 76 importers — deferred); optional `lsp-tools-mcp/tools.ts` split (triage: mild/borderline, deprioritized); 5 giant test files (healthy structure, leave-as-is).

## Verification (all green)

| Gate | Result |
|---|---|
| Typecheck (root + script + 13 package tsconfigs) | exit 0 |
| Full `bun test` | 8622 pass / 1 skip / 0 fail (baseline 8608; +12 dist-dependent now passing, +2 new lock tests) |
| Manual QA byte-diff (6 real surfaces: CLI help/version, sparkshell, doctor, lsp-tools-mcp stdio `initialize`+`tools/list`, codex installer help under sandboxed HOME) | all 6 byte-identical pre vs post (cmp + sha256) |
| Behavior locks | every edited area green before AND after; 2 new characterization tests added where coverage was missing |

## Independent review

A dedicated reviewer agent audited the full diff against the evidence trail and issued an **unconditional OKAY**: re-ran both package typechecks (exit 0), three test batches covering every touched file (1067 tests, 0 fail), independently re-verified all 6 QA surfaces byte-identical, and hand-verified the prod type fixes are type-position-only, the extractions mechanically behavior-preserving (each dedup helper has ≥2 call sites), and no test assertion weakened. Non-blocking follow-ups it flagged: an identical no-op helper surviving in untouched `team-mode/tools/lifecycle-participant.ts` (out of scope here), and the cosmetic bare-`return` catch in `install-codex.ts`.

Known flake encountered (pre-existing, not in diff): `openclaw/reply-listener` daemon-restart test under parallel load — passes isolated 13/13 and in clean full rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
