### PR TITLE
test(model-core): repoint test:model-capabilities globs to relocated suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prepare": "bun run build",
     "postinstall": "node postinstall.mjs",
     "prepublishOnly": "bun run clean && bun run build:lsp-tools-mcp && bun run build:lsp-daemon && bun run build",
-    "test:model-capabilities": "bun test packages/omo-opencode/src/shared/model-capability-aliases.test.ts packages/omo-opencode/src/shared/model-capability-guardrails.test.ts packages/omo-opencode/src/shared/model-capabilities.test.ts packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts --bail",
+    "test:model-capabilities": "bun test packages/model-core/src/model-capability-aliases.test.ts packages/model-core/src/model-capability-guardrails.test.ts packages/model-core/src/model-capabilities.test.ts packages/omo-opencode/src/cli/doctor/checks/model-resolution.test.ts --bail",
     "typecheck": "tsgo --noEmit && bun run typecheck:script && bun run typecheck:packages",
     "typecheck:packages": "tsgo --noEmit -p packages/rules-engine/tsconfig.json && tsgo --noEmit -p packages/ast-grep-core/tsconfig.json && tsgo --noEmit -p packages/ast-grep-mcp/tsconfig.json && tsgo --noEmit -p packages/git-bash-mcp/tsconfig.json && tsgo --noEmit -p packages/utils/tsconfig.json && tsgo --noEmit -p packages/model-core/tsconfig.json && tsgo --noEmit -p packages/prompts-core/tsconfig.json && tsgo --noEmit -p packages/comment-checker-core/tsconfig.json && tsgo --noEmit -p packages/hashline-core/tsconfig.json && tsgo --noEmit -p packages/boulder-state/tsconfig.json && tsgo --noEmit -p packages/agents-md-core/tsconfig.json && tsgo --noEmit -p packages/omo-codex/tsconfig.json && tsgo --noEmit -p packages/omo-opencode/tsconfig.json",
     "typecheck:script": "tsgo --noEmit -p script/tsconfig.json",


### PR DESCRIPTION
## Summary

The `test:model-capabilities` script in root `package.json` still pointed at three test files under `packages/omo-opencode/src/shared/` that were relocated to `packages/model-core/src/` during the multi-harness refactor. `bun test` silently ignores missing path arguments and exits 0, so the `refresh-model-capabilities` cron's guardrail step (`.github/workflows/refresh-model-capabilities.yml:32`) ran only 1 of the 4 intended files (`model-resolution.test.ts`, 17 tests) while reporting green — the alias/guardrail/capabilities suites protecting the snapshot refresh were never exercised.

Partially addresses #3635 (dead test globs); snapshot regen blocked by #4717 infra (workflow PR-create permission is a repo setting, and `script/build-model-capabilities.ts` requires a live `models.dev` fetch).

## Changes

- `package.json`: repoint the three dead paths in `test:model-capabilities` to `packages/model-core/src/{model-capability-aliases,model-capability-guardrails,model-capabilities}.test.ts` (the `model-resolution.test.ts` path was already correct and is unchanged)

## Verification

- RED (base @ 6f4aa197c): the three globbed paths do not exist; `bun test` on them alone → "The following filters did not match any test files" (exit 1); full script false-greens with `Ran 17 tests across 1 file`
- GREEN: `bun run test:model-capabilities` → **53 pass / 0 fail, Ran 53 tests across 4 files**
- QA: exact script run end-to-end (same command the cron executes), exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `test:model-capabilities` script to point at the relocated model-core test suites so CI runs all four files instead of silently skipping three. Restores the refresh guardrail, increasing coverage from 17 to 53 tests.

- **Bug Fixes**
  - Updated `package.json` script to use `packages/model-core/src/{model-capability-aliases,model-capability-guardrails,model-capabilities}.test.ts` (kept `model-resolution.test.ts` path).
  - Partially addresses #3635 (dead test globs). Snapshot refresh remains blocked by #4717.

<sup>Written for commit e89029da6bbbed44cac9cfc1d68c491d001c8d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

