### PR TITLE
fix(cli-run): clear main-session error latch when live status shows recovery

### DIFF
--- a/packages/omo-opencode/src/cli/run/poll-for-completion.test.ts
+++ b/packages/omo-opencode/src/cli/run/poll-for-completion.test.ts
@@ -412,6 +412,60 @@ describe("pollForCompletion", () => {
     expect(result).toBe(1)
   })
 
+  it("clears the error latch and completes when the session retries after an error (runtime fallback in flight)", async () => {
+    //#given - quota error latched, live status reports 'retry' then the session recovers to idle
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.mainSessionError = true
+    eventState.lastError = "kimi usage limit reached"
+    eventState.hasReceivedMeaningfulWork = true
+    let statusCalls = 0
+    ;(unsafeTestValue(ctx.client.session)).status = mock(async () => {
+      statusCalls++
+      if (statusCalls <= 3) {
+        return { data: { "test-session": { type: "retry" } } }
+      }
+      return { data: { "test-session": { type: "idle" } } }
+    })
+    const abortController = new AbortController()
+
+    //#when
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 1,
+      minStabilizationMs: 10,
+    })
+
+    //#then - fallback recovery resumed the session; run completes instead of exiting 1
+    expect(result).toBe(0)
+    expect(eventState.mainSessionError).toBe(false)
+  })
+
+  it("does not exit 1 while the session is busy again after an error (fallback dispatch rearmed the session)", async () => {
+    //#given - error latched but live status reports the session is busy again
+    const ctx = createMockContext({
+      statuses: { "test-session": { type: "busy" } },
+    })
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.mainSessionError = true
+    eventState.lastError = "quota error"
+    eventState.hasReceivedMeaningfulWork = true
+    const abortController = new AbortController()
+
+    //#when - poll well past ERROR_GRACE_CYCLES, then abort
+    abortAfter(abortController, 100)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then - aborted by the test (130), not terminated with exit 1
+    expect(result).toBe(130)
+    expect(eventState.mainSessionError).toBe(false)
+  })
+
   it("returns 1 when CLI run requires meaningful work but the prompt never produces output", async () => {
     //#given
     const ctx = createMockContext()

--- a/packages/omo-opencode/src/cli/run/poll-for-completion.ts
+++ b/packages/omo-opencode/src/cli/run/poll-for-completion.ts
@@ -64,6 +64,16 @@ export async function pollForCompletion(
     }
 
     if (eventState.mainSessionError) {
+      // A session.error is only terminal while the session stays idle:
+      // runtime fallback rearms the session (status "busy"/"retry") after
+      // retryable errors, so a live recovery clears the latch (#3745).
+      const statusDuringError = await getMainSessionStatus(ctx)
+      if (statusDuringError === "busy" || statusDuringError === "retry") {
+        eventState.mainSessionError = false
+        eventState.mainSessionIdle = false
+        errorCycleCount = 0
+        continue
+      }
       errorCycleCount++
       if (errorCycleCount >= ERROR_GRACE_CYCLES) {
         console.error(


### PR DESCRIPTION
## Summary

Headless `oh-my-opencode run` exited 1 within ~1.5s of any main-session error — even when a configured runtime-fallback chain was actively recovering the session from a retryable quota/usage-limit error (e.g. Kimi/Moonshot).

Root cause (verified at `6f4aa197c`):
- `eventState.mainSessionError` is a **write-once latch**: set on any main-session `session.error` (`event-session-handlers.ts:38`) and on any error toast (`event-toast-handlers.ts:14`), never reset anywhere.
- `pollForCompletion` checks the latch FIRST each poll cycle and returns exit 1 after `ERROR_GRACE_CYCLES = 3` (~1.5s), `continue`-ing **before** the session-status (`retry`/`busy`) consultation — so the fallback's recovery was never observed.

## Fix

Inside the error grace window, consult the live session status via the existing `getMainSessionStatus` helper:
- status `busy`/`retry` → the session was rearmed (runtime fallback / native retry): clear the latch, reset the grace counter, keep polling.
- status `idle` (or unavailable) → error remains terminal: unchanged exit-1 behavior, so runs without a fallback chain (or with an exhausted chain) still fail fast.

No new options, no behavior change for terminal errors.

## Evidence (TDD)

- RED (`.ulw/evidence/i3745-red.txt`): 2 new tests fail at base — `expect(result).toBe(0)` received `1` (latch exit despite live `retry` status), `expect(result).toBe(130)` received `1` (latch exit despite live `busy` status).
- GREEN (`.ulw/evidence/i3745-green.txt`): 20/20 pass in `poll-for-completion.test.ts`; full `cli/run` directory suite 194/194; LSP diagnostics clean on both changed files.
- QA (`.ulw/evidence/i3745-qa.txt`): adapted the sweep repro (`/tmp/omo-issue-sweep/repro/issue-3745`) to the fixed build — drives the real `createEventState` + `handleSessionError/Status/Idle` + `pollForCompletion` with a stubbed SDK client reporting `retry`→`idle`: exit code 0, latch cleared, **VERDICT=NOT-REPRODUCED** (was REPRODUCED at base).

## Known residual (documented, out of scope)

If fallback rearm takes longer than the ~1.5s grace window **while the live status reads `idle` the whole time** (e.g. a stale promptAsync reservation delaying the fallback dispatch, #5109), exit 1 can still occur. The fix makes the error-cycle check status-aware each cycle, which covers the normal rearm path; widening the grace window is an orthogonal tuning decision.

Closes #3745

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes premature exit in headless oh-my-opencode run by clearing the main-session error latch when live status shows recovery. Runs now continue during fallback `busy`/`retry` and still fail fast on terminal `idle` (fixes #3745).

- **Bug Fixes**
  - During the error grace window, check live session status; if `busy` or `retry`, clear `mainSessionError`, reset the grace counter, and keep polling.
  - Terminal errors unchanged: if status stays `idle`, exit 1 as before.

<sup>Written for commit a334988dada36dd2c9a89a5b981715ab6f1b8ef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

