### PR TITLE
fix(prompts): language-agnostic verification commands in Atlas/Prometheus (#5074)

### DIFF
--- a/packages/prompts-core/prompts/atlas/default.md
+++ b/packages/prompts-core/prompts/atlas/default.md
@@ -280,9 +280,9 @@ For a parallel batch, fire ALL of these in ONE response.
 After EVERY delegation, complete ALL of these steps - no shortcuts:
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors across scanned TypeScript files (directory scans are capped at 50 files; not a full-project guarantee)
-2. `bun run build` or `bun run typecheck` → exit code 0
-3. `bun test` → ALL tests pass
+1. `lsp_diagnostics` on the project → ZERO errors (directory scans are capped at 50 files; not a full-project guarantee).
+2. Build command from the plan's "Success Criteria" section → exit code 0. If the plan does not specify one, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" section → ALL tests pass. If the plan does not specify one, examine the project root for build configuration files and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review (NON-NEGOTIABLE)
 
@@ -439,7 +439,7 @@ You read every changed file because static checks miss logic bugs. You run user-
 - Trust subagent claims without verification
 - Use run_in_background=true for task execution
 - Send prompts under 30 lines
-- Skip lsp_diagnostics after delegation (use `filePath=".", extension=".ts"` for TypeScript projects; directory scans are capped at 50 files)
+- Skip lsp_diagnostics after delegation (use `filePath="."` to scan the project directory; directory scans are capped at 50 files)
 - Batch multiple tasks in one delegation
 - Start fresh session for failures/follow-ups - use `task_id` instead
 - Default to sequential when tasks have no named dependency

--- a/packages/prompts-core/prompts/atlas/gemini.md
+++ b/packages/prompts-core/prompts/atlas/gemini.md
@@ -312,7 +312,7 @@ Do NOT run tests yet. Read the code FIRST so you know what you're testing.
    - Does this code ACTUALLY do what the task required? (Re-read the task, compare line by line)
    - Any stubs, TODOs, placeholders, hardcoded values? (`Grep` for TODO, FIXME, HACK, xxx)
    - Logic errors? Trace the happy path AND the error path in your head.
-   - Anti-patterns? (`Grep` for `as any`, `@ts-ignore`, empty catch, console.log in changed files)
+   - Anti-patterns? (`Grep` for suppressed type/lint checks, empty catch, console.log, debug logging in changed files)
    - Scope creep? Did the subagent touch things or add features NOT in the task spec?
 4. Cross-check every claim:
    - Said "Updated X" → READ X. Actually updated, or just superficially touched?
@@ -464,7 +464,7 @@ Subagents CLAIM "done" when:
 - Trust subagent claims without verification
 - Use run_in_background=true for task execution
 - Send prompts under 30 lines
-- Skip scanned-file lsp_diagnostics (use 'filePath=".", extension=".ts"' for TypeScript projects; directory scans are capped at 50 files)
+- Skip scanned-file lsp_diagnostics (use `filePath="."` to scan the project directory; directory scans are capped at 50 files)
 - Batch multiple tasks in one delegation
 - Start fresh session for failures (use `task_id` to resume)
 

--- a/packages/prompts-core/prompts/atlas/gpt.md
+++ b/packages/prompts-core/prompts/atlas/gpt.md
@@ -282,9 +282,9 @@ If you cannot explain every changed line, you have NOT reviewed it.
 #### PHASE 2: AUTOMATED VERIFICATION
 
 1. `lsp_diagnostics` per changed file → ZERO new errors
-2. Targeted tests (`bun test src/changed-module`) → pass
-3. Full suite (`bun test`) → pass
-4. Build/typecheck → exit 0
+2. Targeted tests (from the plan's "Success Criteria", scoped to changed modules) → pass
+3. Full test suite (from the plan's "Success Criteria") → pass
+4. Build (from the plan's "Success Criteria") → exit 0
 
 If Phase 1 found issues but Phase 2 passes: Phase 2 is incomplete. Fix the code.
 

--- a/packages/prompts-core/prompts/atlas/kimi.md
+++ b/packages/prompts-core/prompts/atlas/kimi.md
@@ -289,9 +289,9 @@ task(category="...", load_skills=[...], run_in_background=false, prompt="[6-SECT
 You are the QA gate. Subagents lie. Run the 4 phases below in order. Stop at the first failing phase, fix, resume.
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors
-2. `bun run build` or `bun run typecheck` → exit 0
-3. `bun test` → ALL pass
+1. `lsp_diagnostics` on the project → ZERO errors.
+2. Build command from the plan's "Success Criteria" → exit 0. If absent, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" → ALL pass. If absent, examine the project root and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review
 

--- a/packages/prompts-core/prompts/atlas/opus-4-7.md
+++ b/packages/prompts-core/prompts/atlas/opus-4-7.md
@@ -284,9 +284,9 @@ A batch of 5 independent tasks = 5 `task()` calls in ONE response. No exceptions
 You are the QA gate. Subagents lie. Run the FULL protocol on EACH completed task — not just the first one in the batch.
 
 #### A. Automated Verification
-1. `lsp_diagnostics(filePath=".", extension=".ts")` → ZERO errors
-2. `bun run build` or `bun run typecheck` → exit 0
-3. `bun test` → ALL pass
+1. `lsp_diagnostics` on the project → ZERO errors.
+2. Build command from the plan's "Success Criteria" → exit 0. If absent, examine the project root for build configuration files and run the standard build command for that ecosystem.
+3. Test command from the plan's "Success Criteria" → ALL pass. If absent, examine the project root and run the standard test command for that ecosystem.
 
 #### B. Manual Code Review (NON-NEGOTIABLE)
 

--- a/packages/prompts-core/prompts/prometheus/default.md
+++ b/packages/prompts-core/prompts/prometheus/default.md
@@ -1455,7 +1455,7 @@ Max Concurrent: 7 (Waves 1 & 2)
   Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
 
 - [ ] F2. **Code Quality Review** — `unspecified-high`
-  Run `tsc --noEmit` + linter + `bun test`. Review all changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code, unused imports. Check AI slop: excessive comments, over-abstraction, generic names (data/result/item/temp).
+  Run the build, lint, and test commands from the plan's "Success Criteria" section. If absent, examine the project root for build configuration files and run the standard commands for that ecosystem. Review all changed files for: type suppression, empty catches, debug logging in prod, commented-out code, unused imports. Check AI slop: excessive comments, over-abstraction, generic names (data/result/item/temp).
   Output: `Build [PASS/FAIL] | Lint [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
 
 - [ ] F3. **Real Manual QA** — `unspecified-high` (+ `playwright` skill if UI)

--- a/packages/prompts-core/prompts/ultrawork/default.md
+++ b/packages/prompts-core/prompts/ultrawork/default.md
@@ -156,7 +156,7 @@ task(task_id="ses_abc123", load_skills=[], run_in_background=false, prompt="Here
 task(category="visual-engineering", load_skills=["frontend-ui-ux"], run_in_background=true)
 
 // Complex logic
-task(category="ultrabrain", load_skills=["typescript-programmer"], run_in_background=true)
+task(category="ultrabrain", load_skills=[...], run_in_background=true)
 
 // Quick fixes
 task(category="quick", load_skills=["git-master"], run_in_background=true)
@@ -173,7 +173,7 @@ task(category="quick", load_skills=["git-master"], run_in_background=true)
 
 ## EXECUTION RULES
 - **TODO format**: `path: <action> for <scenario-id> — verify by <check>` encoding WHERE / WHY (which scenario it advances) / HOW / VERIFY. Exactly ONE in_progress at a time. Mark completed IMMEDIATELY — never batch.
-  - GOOD pair (test-first, ordered): `foo.test.ts: Write FAILING case invalid-email→ValidationError for S2 — verify by RED with assertion msg` → `src/foo/bar.ts: Implement validateEmail() for S2 — verify by foo.test.ts GREEN + curl 400 body`
+  - GOOD pair (test-first, ordered): `module.test: Write FAILING case invalid-email→ValidationError for S2 — verify by RED with assertion msg` → `src/module: Implement validateEmail() for S2 — verify by module.test GREEN + curl 400 body`
   - BAD: "Implement feature" / "Fix bug" / "Add tests later" / production code before its failing test → rewrite.
 - **PARALLEL**: Fire independent agent calls simultaneously via task(run_in_background=true) — NEVER wait sequentially. But NEVER parallelise RED and GREEN of the same scenario.
 - **BACKGROUND FIRST**: Use task for exploration/research agents (10+ concurrent if needed).

--- a/packages/prompts-core/prompts/ultrawork/default.md
+++ b/packages/prompts-core/prompts/ultrawork/default.md
@@ -173,7 +173,7 @@ task(category="quick", load_skills=["git-master"], run_in_background=true)
 
 ## EXECUTION RULES
 - **TODO format**: `path: <action> for <scenario-id> — verify by <check>` encoding WHERE / WHY (which scenario it advances) / HOW / VERIFY. Exactly ONE in_progress at a time. Mark completed IMMEDIATELY — never batch.
-  - GOOD pair (test-first, ordered): `module.test: Write FAILING case invalid-email→ValidationError for S2 — verify by RED with assertion msg` → `src/module: Implement validateEmail() for S2 — verify by module.test GREEN + curl 400 body`
+  - GOOD pair (test-first, ordered): `module.test: Write FAILING case invalid-email→ValidationError for S2 - verify by RED with assertion msg` → `src/module: Implement validateEmail() for S2 - verify by module.test GREEN + curl 400 body`
   - BAD: "Implement feature" / "Fix bug" / "Add tests later" / production code before its failing test → rewrite.
 - **PARALLEL**: Fire independent agent calls simultaneously via task(run_in_background=true) — NEVER wait sequentially. But NEVER parallelise RED and GREEN of the same scenario.
 - **BACKGROUND FIRST**: Use task for exploration/research agents (10+ concurrent if needed).

--- a/packages/prompts-core/prompts/ultrawork/gpt.md
+++ b/packages/prompts-core/prompts/ultrawork/gpt.md
@@ -88,7 +88,7 @@ task(subagent_type="librarian", load_skills=[], prompt="I'm working with [TECHNO
 
 // WHILE THEY RUN - use direct tools for immediate context
 grep(pattern="relevant_pattern", path="src/")
-read_file(filePath="known/important/file.ts")
+read_file(filePath="known/important/file")
 
 // Collect background results when ready
 deep_context = background_output(task_id=...)


### PR DESCRIPTION
## Problem

Atlas/Prometheus verification prompts hardcoded bun/TypeScript commands (`lsp_diagnostics(extension=".ts")`, `bun run build`/`bun run typecheck`, `bun test`, `tsc --noEmit`) in the MANDATORY post-delegation verification steps (`packages/prompts-core/prompts/atlas/default.md:283-285,442` and variants), mis-instructing agents on Go/Python/Rust/any non-JS project.

Closes #5074
Builds on #5075 by @LYY — his three commits are cherry-picked verbatim (authorship preserved): language-agnostic procedural detection replaces the hardcoded commands, plus updated byte-exactness hash baselines.

## Top-up on #5075

- Converted the two pre-existing em dashes carried through on the single PR-touched ultrawork line (`packages/prompts-core/prompts/ultrawork/default.md:176`) to plain hyphens, per the reviewer's request on #5075 and the AGENTS.md content convention ("Never em dashes / en dashes ... in generated content"), and updated the affected ultrawork `default` byte-exactness baseline.
- Verified: `git diff origin/dev` contains zero em/en dashes on added lines.

## Evidence

- RED (base `6f4aa197c`): static prompt-content repro → `VERDICT: REPRODUCED` (verification block hardcodes bun build/test + `.ts`, no language guard, all 5 Atlas variants affected).
- GREEN: `bun test packages/omo-opencode/src/agents/atlas/ packages/omo-opencode/src/agents/prometheus/ packages/omo-opencode/src/hooks/keyword-detector/` → 172 pass, 0 fail (includes all byte-exactness/preservation suites).
- QA (real surface): rendered the actual agent prompts via `createAtlasAgent({model})` for all 5 variant models and `getPrometheusPrompt()` — zero hardcoded bun/tsc/`.ts` verification commands in any rendered prompt; sweep repro now `NOT-REPRODUCED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Atlas and Prometheus verification prompts truly language-agnostic by removing all JS/TS-specific commands and tool names. Prompts now use plan-driven build/test steps with a fallback to inferring standard commands from project files; Ultrawork examples are generalized.

- **Bug Fixes**
  - Removed `bun`/`tsc`/`.ts` anchors; verification now: run `lsp_diagnostics` on the project, then build/test from the plan’s “Success Criteria” or infer standard commands from project files. No tool names remain in the text.
  - Generalized guidance across Atlas variants: use `filePath="."` for scans; updated anti-patterns to non-TS phrasing (e.g., suppressed type/lint checks, empty catches, debug logging).
  - Ultrawork: replaced `typescript-programmer` and `.ts` examples with language-agnostic ones; made `read_file` example extensionless; converted em dashes to hyphens; refreshed byte-exactness baselines.

<sup>Written for commit 0761fb88b7de56ec89402d8cd20806d2b5698660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

