### PR TITLE
fix(omo-opencode): inject agent variant from config into chat.params message

### DIFF
--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -82,7 +82,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
   {
     family: "deepseek",
     includes: ["deepseek"],
-    variants: ["low", "medium", "high"],
+    variants: ["low", "medium", "high", "max"],
     reasoningEfforts: ["high", "max"],
     reasoningEffortAliases: {
       low: "high",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -258,7 +258,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
-      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
+      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high", "max"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Llama", modelID: "llama-4-maverick", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -278,15 +278,28 @@ describe("resolveCompatibleModelSettings", () => {
       })
 
       test(`${name} (${modelID}): downgrades unsupported variant`, () => {
+        const highest = expectedVariants[expectedVariants.length - 1]
+        // If "max" is supported, test with an invalid variant like "super-max-invalid"
+        // Wait, "super-max-invalid" is not a recognized variant string so it gets dropped (undefined).
+        // Let's use a known variant that is higher than the supported ones.
+        // Actually, if the model supports "max", there is no "higher" variant to downgrade from.
+        // So we can just skip the downgrade test or assert it keeps "max".
+        const desiredVariant = expectedVariants.includes("max") ? "super-max-invalid" : "max"
+        
         const result = resolveCompatibleModelSettings({
           providerID: "any-provider",
           modelID,
-          desired: { variant: "max" },
+          desired: { variant: desiredVariant },
         })
 
-        const highest = expectedVariants[expectedVariants.length - 1]
-        expect(result.variant).toBe(highest)
-        expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        if (expectedVariants.includes("max")) {
+            // For invalid variant "super-max-invalid", it gets dropped entirely.
+            expect(result.variant).toBeUndefined()
+            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        } else {
+            expect(result.variant).toBe(highest)
+            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        }
       })
 
       test(`${name} (${modelID}): ${hasReasoningEffort ? "keeps" : "drops"} reasoningEffort`, () => {

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -278,28 +278,20 @@ describe("resolveCompatibleModelSettings", () => {
       })
 
       test(`${name} (${modelID}): downgrades unsupported variant`, () => {
-        const highest = expectedVariants[expectedVariants.length - 1]
-        // If "max" is supported, test with an invalid variant like "super-max-invalid"
-        // Wait, "super-max-invalid" is not a recognized variant string so it gets dropped (undefined).
-        // Let's use a known variant that is higher than the supported ones.
-        // Actually, if the model supports "max", there is no "higher" variant to downgrade from.
-        // So we can just skip the downgrade test or assert it keeps "max".
-        const desiredVariant = expectedVariants.includes("max") ? "super-max-invalid" : "max"
-        
+        const supportsMax = expectedVariants.includes("max")
+        const desiredVariant = supportsMax ? "xhigh" : "max"
+        const expectedDowngrade = supportsMax
+          ? "high"
+          : expectedVariants[expectedVariants.length - 1]
+
         const result = resolveCompatibleModelSettings({
           providerID: "any-provider",
           modelID,
           desired: { variant: desiredVariant },
         })
 
-        if (expectedVariants.includes("max")) {
-            // For invalid variant "super-max-invalid", it gets dropped entirely.
-            expect(result.variant).toBeUndefined()
-            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
-        } else {
-            expect(result.variant).toBe(highest)
-            expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
-        }
+        expect(result.variant).toBe(expectedDowngrade)
+        expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
       })
 
       test(`${name} (${modelID}): ${hasReasoningEffort ? "keeps" : "drops"} reasoningEffort`, () => {

--- a/packages/omo-opencode/src/plugin-interface.test.ts
+++ b/packages/omo-opencode/src/plugin-interface.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -302,5 +302,71 @@ describe("createPluginInterface - backward compatibility", () => {
 
     // then
     expect(getSessionAgent("ses-legacy-zwsp")).toBe("Hephaestus - Deep Agent")
+  })
+})
+
+describe("createPluginInterface - chat.params variant injection", () => {
+  test("injects variant from agent config into chat.params message", async () => {
+    // given
+    const pluginInterface = createPluginInterface({
+      ctx: { client: {} } as never,
+      pluginConfig: {
+        agents: {
+          oracle: { variant: "high" },
+        },
+      } as never,
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {} as never,
+      hooks: {
+        anthropicEffort: { "chat.params": async () => {} },
+      } as never,
+      tools: {},
+    })
+
+    const input = { agent: "oracle", message: {} }
+    const output = {}
+
+    // when
+    await pluginInterface["chat.params"]?.(input as never, output as never)
+
+    // then
+    expect((input.message as Record<string, unknown>).variant).toBe("high")
+  })
+
+  test("does not overwrite existing variant in chat.params message", async () => {
+    // given
+    const pluginInterface = createPluginInterface({
+      ctx: { client: {} } as never,
+      pluginConfig: {
+        agents: {
+          oracle: { variant: "high" },
+        },
+      } as never,
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {} as never,
+      hooks: {
+        anthropicEffort: { "chat.params": async () => {} },
+      } as never,
+      tools: {},
+    })
+
+    const input = { agent: "oracle", message: { variant: "max" } }
+    const output = {}
+
+    // when
+    await pluginInterface["chat.params"]?.(input as never, output as never)
+
+    // then
+    expect((input.message as Record<string, unknown>).variant).toBe("max")
   })
 })

--- a/packages/omo-opencode/src/plugin-interface.test.ts
+++ b/packages/omo-opencode/src/plugin-interface.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -312,7 +312,7 @@ describe("createPluginInterface - chat.params variant injection", () => {
       ctx: { client: {} } as never,
       pluginConfig: {
         agents: {
-          oracle: { variant: "high" },
+          sisyphus: { variant: "max" },
         },
       } as never,
       firstMessageVariantGate: {
@@ -322,20 +322,23 @@ describe("createPluginInterface - chat.params variant injection", () => {
         clear: () => {},
       },
       managers: {} as never,
-      hooks: {
-        anthropicEffort: { "chat.params": async () => {} },
-      } as never,
+      hooks: {} as never,
       tools: {},
     })
-
-    const input = { agent: "oracle", message: {} }
-    const output = {}
+    const input = {
+      sessionID: "ses-variant-inject",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
+      provider: { id: "anthropic" },
+      message: {} as { variant?: string },
+    }
+    const output = { options: {} }
 
     // when
     await pluginInterface["chat.params"]?.(input as never, output as never)
 
     // then
-    expect((input.message as Record<string, unknown>).variant).toBe("high")
+    expect(input.message.variant).toBe("max")
   })
 
   test("does not overwrite existing variant in chat.params message", async () => {
@@ -344,7 +347,7 @@ describe("createPluginInterface - chat.params variant injection", () => {
       ctx: { client: {} } as never,
       pluginConfig: {
         agents: {
-          oracle: { variant: "high" },
+          sisyphus: { variant: "max" },
         },
       } as never,
       firstMessageVariantGate: {
@@ -354,19 +357,22 @@ describe("createPluginInterface - chat.params variant injection", () => {
         clear: () => {},
       },
       managers: {} as never,
-      hooks: {
-        anthropicEffort: { "chat.params": async () => {} },
-      } as never,
+      hooks: {} as never,
       tools: {},
     })
-
-    const input = { agent: "oracle", message: { variant: "max" } }
-    const output = {}
+    const input = {
+      sessionID: "ses-variant-keep",
+      agent: "sisyphus",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
+      provider: { id: "anthropic" },
+      message: { variant: "high" } as { variant?: string },
+    }
+    const output = { options: {} }
 
     // when
     await pluginInterface["chat.params"]?.(input as never, output as never)
 
     // then
-    expect((input.message as Record<string, unknown>).variant).toBe("max")
+    expect(input.message.variant).toBe("high")
   })
 })

--- a/packages/omo-opencode/src/plugin-interface.ts
+++ b/packages/omo-opencode/src/plugin-interface.ts
@@ -1,7 +1,7 @@
 import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 import type { OhMyOpenCodeConfig } from "./config"
-import type { AgentOverrides } from "./config/schema/agent-overrides"
 
+import { applyAgentVariant } from "./shared/agent-variant"
 import { createChatParamsHandler } from "./plugin/chat-params"
 import { createChatHeadersHandler } from "./plugin/chat-headers"
 import { createChatMessageHandler } from "./plugin/chat-message"
@@ -41,17 +41,12 @@ export function createPluginInterface(args: {
         agent?: string | { name?: string }
         message?: { variant?: string }
       }
-      if (chatParamsInput.agent && pluginConfig?.agents) {
-        const agentName =
-          typeof chatParamsInput.agent === "string"
-            ? chatParamsInput.agent
-            : chatParamsInput.agent?.name
-        if (agentName && pluginConfig.agents[agentName as keyof AgentOverrides]?.variant) {
-          if (chatParamsInput.message && !chatParamsInput.message.variant) {
-            chatParamsInput.message.variant =
-              pluginConfig.agents[agentName as keyof AgentOverrides]!.variant
-          }
-        }
+      const agentName =
+        typeof chatParamsInput.agent === "string"
+          ? chatParamsInput.agent
+          : chatParamsInput.agent?.name
+      if (chatParamsInput.message) {
+        applyAgentVariant(pluginConfig, agentName, chatParamsInput.message)
       }
       const handler = createChatParamsHandler({
         client: ctx.client,

--- a/packages/omo-opencode/src/plugin-interface.ts
+++ b/packages/omo-opencode/src/plugin-interface.ts
@@ -1,5 +1,6 @@
 import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 import type { OhMyOpenCodeConfig } from "./config"
+import type { AgentOverrides } from "./config/schema/agent-overrides"
 
 import { createChatParamsHandler } from "./plugin/chat-params"
 import { createChatHeadersHandler } from "./plugin/chat-headers"
@@ -36,6 +37,22 @@ export function createPluginInterface(args: {
     tool: tools,
 
     "chat.params": async (input: unknown, output: unknown) => {
+      const chatParamsInput = input as {
+        agent?: string | { name?: string }
+        message?: { variant?: string }
+      }
+      if (chatParamsInput.agent && pluginConfig?.agents) {
+        const agentName =
+          typeof chatParamsInput.agent === "string"
+            ? chatParamsInput.agent
+            : chatParamsInput.agent?.name
+        if (agentName && pluginConfig.agents[agentName as keyof AgentOverrides]?.variant) {
+          if (chatParamsInput.message && !chatParamsInput.message.variant) {
+            chatParamsInput.message.variant =
+              pluginConfig.agents[agentName as keyof AgentOverrides]!.variant
+          }
+        }
+      }
       const handler = createChatParamsHandler({
         client: ctx.client,
       })


### PR DESCRIPTION
## Summary

`agents.<name>.variant` in `oh-my-opencode.json` was silently ignored for the main agent: the `applyAgentVariant` helper existed but had zero production call sites, and the `chat.params` handler reads the desired variant solely from `message.variant`, which nothing populated from config.

This wires the injection into the `chat.params` hook in `plugin-interface.ts` before the params handler runs, via the existing `applyAgentVariant` helper (case-insensitive key lookup, invisible-char stripping, category variant fallback; never overwrites an explicitly set `message.variant`).

Builds on #4126 by @EmiyaKiritsugu3 (commit cherry-picked with authorship preserved), with the review feedback applied as a top-up:

- removed the banned `!` non-null assertion by delegating to `applyAgentVariant`
- removed the inline duplicate of the agents-config lookup
- removed the AI-slop narration in the variant-downgrade test; replaced the nonsense `super-max-invalid` case with a real `xhigh` → `high` downgrade for max-supporting families
- dropped the stale `src/hooks/anthropic-effort/index.test.ts` hunk (file no longer exists on `dev`)
- injection tests now exercise the full `chat.params` handler path (real input shape through `buildChatParamsInput` + compatibility resolution)

Closes #4125

## Evidence

- RED at base (`origin/dev` @ 6f4aa197c): injection test fails — `message.variant` stays `undefined` while config says `max` (`.ulw/evidence/i4125-red.txt`)
- GREEN after fix: 91 pass / 0 fail across `plugin-interface.test.ts`, `agent-variant.test.ts`, `model-settings-compatibility.test.ts`; full `packages/model-core` suite 265 pass; `bun run typecheck` clean (`.ulw/evidence/i4125-green.txt`)
- QA: production `createPluginInterface` driven in an isolated XDG sandbox — config variant injected (`max`), explicit variant preserved, case-insensitive key honored, helper no longer dead code; VERDICT NOT-REPRODUCED (`.ulw/evidence/i4125-qa.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `agents.<name>.variant` from `oh-my-opencode.json` was ignored. The variant is now injected into `chat.params.message`, while preserving any explicit `message.variant`.

- **Bug Fixes**
  - Inject variant in `chat.params` via `applyAgentVariant` (case-insensitive lookup, invisible-char stripping, category fallback; no overwrite).
  - Add DeepSeek "max" to `model-core` family variants and update compatibility tests (real `xhigh` → `high` downgrade).
  - Add tests in `omo-opencode` for the full `chat.params` path covering injection and keep-existing behavior.

<sup>Written for commit 127d16b92e7ca78decdb4cad14c98767f0a3f35d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

