### PR TITLE
fix(team-mode): treat host-injected empty optionals as absent in team_create

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-registry/team-spec-input-normalizer.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-registry/team-spec-input-normalizer.test.ts
@@ -191,4 +191,45 @@ describe("normalizeTeamSpecInput", () => {
       ],
     })
   })
+
+  test("strips empty-string optional fields injected by the tool host", () => {
+    // given
+    const rawSpec = {
+      name: "hyperplan-smoke-test",
+      members: [
+        { name: "worker", kind: "category", category: "quick", subagent_type: "", prompt: "Temporary smoke test member.", cwd: "", worktreePath: "", color: "" },
+      ],
+      leadAgentId: "",
+      sessionPermission: "",
+    }
+
+    // when
+    const normalizedSpec = normalizeTeamSpecInput(rawSpec) as Record<string, unknown>
+
+    // then
+    expect(normalizedSpec).toMatchObject({
+      leadAgentId: "worker",
+      members: [{ name: "worker", kind: "category", category: "quick", prompt: "Temporary smoke test member." }],
+    })
+    expect(JSON.stringify(normalizedSpec.members)).not.toContain("subagent_type")
+    expect(normalizedSpec.sessionPermission ?? undefined).toBeUndefined()
+  })
+
+  test("treats an all-empty lead object as absent", () => {
+    // given
+    const rawSpec = {
+      name: "hyperplan-smoke-test",
+      members: [{ name: "worker", kind: "category", category: "quick", prompt: "Temporary smoke test member." }],
+      lead: { name: "", kind: "", category: "", subagent_type: "", prompt: "" },
+    }
+
+    // when
+    const normalizedSpec = normalizeTeamSpecInput(rawSpec)
+
+    // then no bogus lead member is prepended and the single member becomes the lead
+    expect(normalizedSpec).toMatchObject({
+      leadAgentId: "worker",
+      members: [{ name: "worker", kind: "category", category: "quick" }],
+    })
+  })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-registry/team-spec-input-normalizer.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-registry/team-spec-input-normalizer.ts
@@ -11,8 +11,8 @@ function isJsonRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function cloneJsonRecord(value: JsonRecord): JsonRecord {
-  return { ...value }
+function omitEmptyStringFields(record: JsonRecord): JsonRecord {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== ""))
 }
 
 function getMemberName(value: unknown): string | undefined {
@@ -128,6 +128,7 @@ function buildPromptFromNaturalMember(member: JsonRecord): string {
 }
 
 function normalizeInlineMember(member: JsonRecord, options?: NormalizeTeamSpecInputOptions): JsonRecord {
+  const strippedMember = omitEmptyStringFields(member)
   const {
     capabilities: _capabilities,
     description: _description,
@@ -139,7 +140,7 @@ function normalizeInlineMember(member: JsonRecord, options?: NormalizeTeamSpecIn
     systemPrompt: _systemPrompt,
     system_prompt: _systemPromptSnakeCase,
     ...normalizedMember
-  } = member
+  } = strippedMember
 
   const rawKind = normalizedMember.kind
 
@@ -167,7 +168,7 @@ function normalizeInlineMember(member: JsonRecord, options?: NormalizeTeamSpecIn
   }
 
   if (normalizedMember.kind === "category" && normalizedMember.prompt === undefined) {
-    normalizedMember.prompt = buildPromptFromNaturalMember(member)
+    normalizedMember.prompt = buildPromptFromNaturalMember(strippedMember)
   }
 
   return normalizedMember
@@ -178,16 +179,18 @@ export function normalizeTeamSpecInput(raw: unknown, options?: NormalizeTeamSpec
     return raw
   }
 
-  const normalizedSpec = cloneJsonRecord(raw)
+  const normalizedSpec = omitEmptyStringFields(raw)
   if (typeof normalizedSpec.name === "string") {
     normalizedSpec.name = normalizeNameStem(normalizedSpec.name)
   }
 
   const rawMembers = raw.members
-  const rawLead = raw.lead
-  let leadAgentId = typeof raw.leadAgentId === "string" ? raw.leadAgentId : undefined
+  const rawLead = isJsonRecord(raw.lead) && Object.keys(omitEmptyStringFields(raw.lead)).length > 0
+    ? raw.lead
+    : undefined
+  let leadAgentId = typeof normalizedSpec.leadAgentId === "string" ? normalizedSpec.leadAgentId : undefined
   const hasExplicitLead = leadAgentId !== undefined
-    || isJsonRecord(rawLead)
+    || rawLead !== undefined
     || (Array.isArray(rawMembers) && hasMemberLeadFlag(rawMembers))
 
   if (Array.isArray(rawMembers)) {

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-spec.test.ts
@@ -366,6 +366,42 @@ describe("createTeamCreateTool inline_spec normalization", () => {
     })
   })
 
+  test("accepts inline_spec when the host injects empty optional fields", async () => {
+    // given the verbatim issue #4699 payload: a host serializing omitted optionals as empty strings
+    const createTeamCreateTool = await loadCreateTeamCreateTool()
+    const config = createConfig()
+    const teamCreateTool = createTeamCreateToolForTest(createTeamCreateTool, config)
+    const rawArgs = {
+      teamName: "",
+      inline_spec: {
+        name: "hyperplan-smoke-test",
+        members: [
+          { name: "worker", kind: "category", category: "quick", subagent_type: "", prompt: "Temporary smoke test member." },
+        ],
+        lead: { name: "", kind: "", category: "", subagent_type: "", prompt: "" },
+        leadAgentId: "",
+        teamAllowedPaths: [],
+        sessionPermission: "",
+      },
+      leadSessionId: "",
+    }
+
+    // when
+    await teamCreateTool.execute(rawArgs, createToolContext("lead-session", "Sisyphus"))
+    const firstCall = createTeamRunMock.mock.calls[0]
+
+    // then the empty-string optionals are treated as absent and the all-empty lead is dropped
+    expect(firstCall?.[0]).toMatchObject({
+      name: "hyperplan-smoke-test",
+      leadAgentId: "lead",
+      members: [
+        { name: "lead", kind: "subagent_type" },
+        { name: "worker", kind: "category", category: "quick", prompt: "Temporary smoke test member." },
+      ],
+    })
+    expect(firstCall?.[1]).toBe("lead-session")
+  })
+
   test("accepts role and capabilities style members with the configured fallback category", async () => {
     // given
     const createTeamCreateTool = await loadCreateTeamCreateTool()
@@ -412,6 +448,39 @@ describe("createTeamCreateTool inline_spec normalization", () => {
         { name: "agent-3-quality-process-analyst", kind: "category", category: "analysis", prompt: "Role: Quality/Process Analyst\ntests, builds, CI/CD" },
       ],
     })
+  })
+})
+
+describe("parseTeamCreateArgs empty-string optional handling", () => {
+  test("treats empty-string teamName and leadSessionId as absent when inline_spec is provided", () => {
+    // given the tool-calling host serializes omitted optionals as empty strings
+    const inlineSpec = { name: "smoke-test-team", members: [{ name: "worker", category: "quick", prompt: "Do the assigned work." }] }
+    const args = parseTeamCreateArgs({ teamName: "", inline_spec: inlineSpec, leadSessionId: "" })
+
+    // then inline_spec is accepted as the single provided option
+    expect(args.teamName ?? undefined).toBeUndefined()
+    expect(args.leadSessionId ?? undefined).toBeUndefined()
+    expect(args.inline_spec).toEqual(inlineSpec)
+  })
+
+  test("treats empty-string inline_spec as absent when teamName is provided", () => {
+    // given the tool-calling host serializes the unused optional as an empty string
+    const args = parseTeamCreateArgs({ teamName: "existing-team", inline_spec: "" })
+
+    // then teamName is accepted as the single provided option
+    expect(args.teamName).toBe("existing-team")
+    expect(args.inline_spec ?? undefined).toBeUndefined()
+  })
+
+  test("still rejects when teamName and inline_spec are both empty strings", () => {
+    let errorMessage = ""
+    try {
+      parseTeamCreateArgs({ teamName: "", inline_spec: "" })
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    expect(errorMessage).toContain("team_create requires exactly one of teamName or inline_spec")
   })
 })
 

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-spec.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle-inline-spec.ts
@@ -8,7 +8,15 @@ import { TeamSpecSchema, type TeamSpec } from "../types"
 
 export const TEAM_CREATE_USAGE = "team_create requires exactly one of teamName or inline_spec. Use team_create({ teamName: \"existing-team\" }) or team_create({ inline_spec: { name: \"team-name\", members: [{ name: \"worker\", category: \"quick\", prompt: \"Do the assigned work.\" }] } })."
 
-export const TeamCreateArgsSchema = z.object({
+function omitEmptyStringArgs(rawArgs: unknown): unknown {
+  if (typeof rawArgs !== "object" || rawArgs === null || Array.isArray(rawArgs)) {
+    return rawArgs
+  }
+
+  return Object.fromEntries(Object.entries(rawArgs).filter(([, value]) => value !== ""))
+}
+
+export const TeamCreateArgsSchema = z.preprocess(omitEmptyStringArgs, z.object({
   teamName: z.string().min(1).nullish(),
   inline_spec: z.unknown().nullish(),
   leadSessionId: z.string().nullish(),
@@ -17,7 +25,7 @@ export const TeamCreateArgsSchema = z.object({
   if (optionCount !== 1) {
     ctx.addIssue({ code: "custom", message: "Provide exactly one of teamName or inline_spec." })
   }
-})
+}))
 
 export type TeamCreateArgs = z.infer<typeof TeamCreateArgsSchema>
 

--- a/packages/omo-opencode/src/features/team-mode/tools/lifecycle.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/lifecycle.test.ts
@@ -147,14 +147,33 @@ describe("team lifecycle tools", () => {
     expect(result.runtimeState.members[0]).toMatchObject({ name: "lead", agentType: "leader" })
   })
 
-  test("team_create rejects an empty leadSessionId override", async () => {
+  test("team_create treats an empty leadSessionId override as absent and uses the context session", async () => {
+    // given
+    const teamCreateTool = createTeamCreateToolForTest()
+
+    // when
+    await teamCreateTool.execute({ inline_spec: createSpec(), leadSessionId: "" }, createToolContext("lead-session"))
+
+    // then
+    expect(createTeamRunMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "lead-session",
+      expect.anything(),
+      config,
+      expect.anything(),
+      undefined,
+      { callerAgentTypeId: undefined, parentMessageID: expect.any(String) },
+    )
+  })
+
+  test("team_create rejects when neither leadSessionId nor a context session is available", async () => {
     // given
     const teamCreateTool = createTeamCreateToolForTest()
 
     // when
     let errorMessage = ""
     try {
-      await teamCreateTool.execute({ inline_spec: createSpec(), leadSessionId: "" }, createToolContext("lead-session"))
+      await teamCreateTool.execute({ inline_spec: createSpec(), leadSessionId: "" }, createToolContext(""))
     } catch (error) {
       errorMessage = error instanceof Error ? error.message : String(error)
     }


### PR DESCRIPTION
## Summary

`team_create` failed when a tool host serialized omitted optional fields as empty strings (surfaced by `hyperplan`'s documented `team_create({ inline_spec: ... })` form):

- `teamName: ""` counted as present → `team_create requires exactly one of teamName or inline_spec`
- `leadSessionId: ""` tripped the session guard instead of falling back to the context session
- inline members kept `subagent_type: ""` etc., failing the strict member schemas (`Unrecognized key`, `Too small`)
- an all-empty `lead` object became a bogus lead member

## Fix

Empty-string optionals are treated as absent before validation, at both layers:

- `lifecycle-inline-spec.ts`: `TeamCreateArgsSchema` now strips `""`-valued args via `z.preprocess` before the exactly-one refinement
- `team-spec-input-normalizer.ts`: `normalizeTeamSpecInput`/`normalizeInlineMember` strip `""`-valued spec and member fields, and a `lead` object whose fields are all empty is dropped

`lifecycle.test.ts`'s `rejects an empty leadSessionId override` pinned the pre-fix symptom; it now asserts the fallback-to-context-session behavior, with the no-session guard still covered by a dedicated test.

Closes #4699

## Evidence

- RED (base): 5 targeted tests fail — top-level `""` rejected with the exactly-one error; `subagent_type: ""` preserved; all-empty lead became a `member` lead (`.ulw/evidence/i4699-red.txt`)
- GREEN: 28/28 in the two touched test files; full team-mode package 297 pass / 0 fail (`i4699-green.txt`)
- QA: verbatim issue payload through the real `parseTeamCreateArgs` + `parseInlineTeamSpec` pipeline in an isolated XDG sandbox → NOT-REPRODUCED, 10/10 checks (`i4699-qa.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats empty-string optional fields from tool hosts as absent in `team_create`, fixing false validation errors and bogus lead/member data. Addresses #4699 and restores expected inline-spec and session behavior.

- **Bug Fixes**
  - Args: drop `""` values before `TeamCreateArgsSchema` validation to enforce the “exactly one of `teamName` or `inline_spec`” rule correctly.
  - Spec: `normalizeTeamSpecInput`/`normalizeInlineMember` remove `""` fields; an all-empty `lead` object is ignored.
  - Sessions: `leadSessionId: ""` is treated as missing and falls back to the context session; still rejects when no session is available.

<sup>Written for commit a0c5b5e31039eadc1ff73016133033eac3d649a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

