### PR TITLE
fix(doctor): detect plugin installs under OpenCode packages/<name>@<tag> dirs

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -133,6 +133,61 @@ describe("system loaded version", () => {
       expect(loadedVersion.loadedVersion).toBe("5.6.7")
     })
 
+    it("detects installs under OpenCode's packages/<name>@<tag> directory", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-")
+      const cacheDir = join(cacheHome, "opencode")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      const taggedInstallDir = join(cacheDir, "packages", `${PLUGIN_NAME}@latest`)
+      writeJson(join(taggedInstallDir, "package.json"), {
+        dependencies: { [PLUGIN_NAME]: "8.8.8" },
+      })
+      writeJson(join(taggedInstallDir, "node_modules", PLUGIN_NAME, "package.json"), {
+        version: "8.8.8",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.installedPackagePath).toBe(expectedPath(join(taggedInstallDir, "node_modules", PLUGIN_NAME, "package.json")))
+      expect(loadedVersion.cachePackagePath).toBe(expectedPath(join(taggedInstallDir, "package.json")))
+      expect(loadedVersion.expectedVersion).toBe("8.8.8")
+      expect(loadedVersion.loadedVersion).toBe("8.8.8")
+    })
+
+    it("prefers the flat node_modules install over a packages/<name>@<tag> install in the same root", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-")
+      const cacheDir = join(cacheHome, "opencode")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      writeJson(join(cacheDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "3.3.3" },
+      })
+      writeJson(join(cacheDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "3.3.3",
+      })
+      const taggedInstallDir = join(cacheDir, "packages", `${PLUGIN_NAME}@latest`)
+      writeJson(join(taggedInstallDir, "node_modules", PLUGIN_NAME, "package.json"), {
+        version: "8.8.8",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.installedPackagePath).toBe(expectedPath(join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")))
+      expect(loadedVersion.loadedVersion).toBe("3.3.3")
+    })
+
     it("falls back to require.resolve when neither config nor cache directory has an install", () => {
       //#given
       const configDir = createTemporaryDirectory("omo-config-")

--- a/packages/omo-opencode/src/cli/doctor/checks/system-loaded-version.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/system-loaded-version.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { createRequire } from "node:module"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -82,6 +82,29 @@ function createPackageCandidates(rootDir: string): PackageCandidate[] {
   }))
 }
 
+function createTaggedInstallCandidates(rootDir: string): InstallCandidate[] {
+  const packagesDir = join(rootDir, "packages")
+  if (!existsSync(packagesDir)) return []
+
+  const candidates: InstallCandidate[] = []
+  for (const entryName of readdirSync(packagesDir).sort()) {
+    const packageName = ACCEPTED_PACKAGE_NAMES.find((name) => entryName.startsWith(`${name}@`))
+    if (packageName === undefined) continue
+    const installDir = join(packagesDir, entryName)
+    candidates.push({
+      cacheDir: installDir,
+      cachePackagePath: join(installDir, "package.json"),
+      packageCandidates: [
+        {
+          packageName,
+          installedPackagePath: join(installDir, "node_modules", packageName, "package.json"),
+        },
+      ],
+    })
+  }
+  return candidates
+}
+
 function selectInstalledPackage(candidate: InstallCandidate): PackageCandidate {
   return candidate.packageCandidates.find((packageCandidate) => existsSync(packageCandidate.installedPackagePath))
     ?? candidate.packageCandidates[0]
@@ -128,11 +151,13 @@ export function getLoadedPluginVersion(): LoadedVersionInfo {
       cachePackagePath: join(configDir, "package.json"),
       packageCandidates: createPackageCandidates(configDir),
     },
+    ...createTaggedInstallCandidates(configDir),
     {
       cacheDir,
       cachePackagePath: join(cacheDir, "package.json"),
       packageCandidates: createPackageCandidates(cacheDir),
     },
+    ...createTaggedInstallCandidates(cacheDir),
   ]
 
   const selectedCandidate = candidates.find((candidate) => candidate.packageCandidates.some((packageCandidate) => existsSync(packageCandidate.installedPackagePath)))


### PR DESCRIPTION
## Summary

`bunx oh-my-openagent doctor` reported `oh-my-openagent unknown` when the plugin was installed via OpenCode's package manager into `~/.cache/opencode/packages/oh-my-openagent@latest/`. `getLoadedPluginVersion()` in `system-loaded-version.ts` only built candidates at `<root>/node_modules/<name>/package.json` for the config/cache roots and never traversed OpenCode's `packages/<name>@<tag>/node_modules/` layout; the `require.resolve`/`findPackageJsonUp` fallback doesn't cover that directory either. Display-only defect — the plugin itself loads fine.

Closes #4413

Supersedes #4515: that PR patches `getPackageVersionFromBinary()` in `shared/opencode-version.ts`, which resolves the **OpenCode binary** version — the issue's own debug output shows that part already working (`opencode 1.15.10`). The `unknown` comes from the plugin-version resolution in `system-loaded-version.ts`, which #4515 does not touch; #4515 also conflicts with `dev` (pre-monorepo paths) and carries unrelated `bun.lock` churn.

## Changes

- `system-loaded-version.ts`: add `createTaggedInstallCandidates()` — scans `<root>/packages/` for entries named `<acceptedName>@<tag>` and adds `<entry>/node_modules/<name>/package.json` candidates (with `<entry>/package.json` as the expected-version source), spliced after each root's flat candidate so existing precedence is preserved (config root → cache root, flat → tagged, sorted, first-existing wins)
- `system-loaded-version.test.ts`: two tests — tagged-layout detection (`packages/oh-my-openagent@latest/...` → version + expected version resolved) and flat-over-tagged precedence guard

## Verification

- RED (base @ 6f4aa197c): new tagged-layout test fails — `installedPackagePath` falls back to the repo's own `package.json`, version not detected from the tagged install
- GREEN: file suite 10 pass / 0 fail; full doctor checks dir 125 pass / 0 fail; repo typecheck clean
- QA (real surface): sandboxed `doctor --json` (isolated `OPENCODE_CONFIG_DIR` + `XDG_*`) against a simulated `packages/oh-my-openagent@latest/` install reports `Plugin loaded: 8.8.8` with zero `unknown` occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `doctor` showing `oh-my-openagent unknown` when installed via OpenCode’s tagged layout (e.g., `~/.cache/opencode/packages/oh-my-openagent@latest`). Now detects tagged installs and reports the correct loaded and expected version. Fixes #4413.

- **Bug Fixes**
  - Update `getLoadedPluginVersion()` to scan `<root>/packages/<name>@<tag>/node_modules/<name>/package.json`, using `<root>/packages/<name>@<tag>/package.json` for the expected version.
  - Keep precedence: config over cache, flat `node_modules` over tagged, deterministic sort; existing fallbacks unchanged.
  - Add tests for tagged detection and flat-over-tagged precedence.

<sup>Written for commit be5fdb35bfdee3b743b2d9999dc28799c580ec23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

