### PR TITLE
fix(runtime-fallback): retry reserved fallback dispatch with backoff and preserve ambiguous failures

### DIFF
--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
+import { setPromptReservation } from "../../shared/prompt-async-gate/reservations"
+import { createAutoRetryHelpers } from "./auto-retry"
+import { createFallbackState } from "./fallback-state"
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+
+function createContext(promptCalls: { count: number }): RuntimeFallbackPluginInput {
+  const session = {
+    abort: async () => ({}),
+    messages: async () => ({
+      data: [
+        {
+          info: { role: "user" },
+          parts: [{ type: "text", text: "retry this" }],
+        },
+      ],
+    }),
+    promptAsync: async () => {
+      promptCalls.count += 1
+      return {}
+    },
+    status: async () => ({ data: {} }),
+  }
+  return {
+    client: {
+      session,
+      tui: {
+        showToast: async () => ({}),
+      },
+    },
+    directory: "/test/dir",
+  }
+}
+
+function createDeps(promptCalls: { count: number }): HookDeps {
+  return {
+    ctx: createContext(promptCalls),
+    config: {
+      enabled: true,
+      retry_on_errors: [429, 503, 529],
+      max_fallback_attempts: 3,
+      cooldown_seconds: 60,
+      timeout_seconds: 0,
+      notify_on_fallback: false,
+    },
+    options: undefined,
+    pluginConfig: undefined,
+    sessionStates: new Map(),
+    sessionLastAccess: new Map(),
+    sessionRetryInFlight: new Set(),
+    sessionAwaitingFallbackResult: new Set(),
+    sessionFallbackTimeouts: new Map(),
+    sessionStatusRetryKeys: new Map(),
+    internallyAbortedSessions: new Set(),
+  }
+}
+
+function reserveSession(sessionID: string, holdMs: number): void {
+  setPromptReservation(sessionID, {
+    source: "user-prompt",
+    dedupeKey: "stale-cancelled-stream",
+    reservedAt: Date.now(),
+    token: Symbol("stale-cancelled-stream"),
+    expiresAt: Date.now() + holdMs,
+  })
+}
+
+describe("createAutoRetryDispatcher reserved-session retry (#5109)", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
+  test("#given a stale promptAsync reservation that releases shortly after #when auto retry runs #then the fallback dispatch is retried instead of silently abandoned", async () => {
+    // given
+    const promptCalls = { count: 0 }
+    const deps = createDeps(promptCalls)
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-reserved-then-released"
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    deps.sessionStates.set(sessionID, state)
+    reserveSession(sessionID, 250)
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+
+    // then
+    expect(promptCalls.count).toBe(1)
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
+    expect(state.pendingFallbackModel).toBe("openai/gpt-5.4")
+  })
+
+  test("#given the retried dispatch fails ambiguously after the reservation releases #when auto retry runs #then the pending fallback is preserved as possibly accepted", async () => {
+    // given
+    const promptCalls = { count: 0 }
+    const deps = createDeps(promptCalls)
+    deps.ctx.client.session.promptAsync = async () => {
+      promptCalls.count += 1
+      throw new Error("JSON Parse error: Unexpected EOF")
+    }
+    const helpers = createAutoRetryHelpers(deps)
+    const sessionID = "session-reserved-then-ambiguous-failure"
+    const state = createFallbackState("anthropic/claude-opus-4-7")
+    state.pendingFallbackModel = "openai/gpt-5.4"
+    deps.sessionStates.set(sessionID, state)
+    reserveSession(sessionID, 250)
+
+    // when
+    await helpers.autoRetryWithFallback(sessionID, "openai/gpt-5.4", undefined, "session.error")
+
+    // then
+    expect(promptCalls.count).toBe(1)
+    expect(deps.sessionAwaitingFallbackResult.has(sessionID)).toBe(true)
+    expect(state.pendingFallbackPromptMayHaveBeenAccepted).toBe(true)
+  })
+})

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -8,6 +8,7 @@ import { createInternalAgentContinuationTextPart } from "../../shared/internal-i
 import {
   dispatchInternalPrompt,
   isInternalPromptDispatchAccepted,
+  type InternalPromptDispatchResult,
 } from "../shared/prompt-async-gate"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { resolveOriginalUserRetryMetadata } from "./auto-retry-metadata"
@@ -135,7 +136,7 @@ export function createAutoRetryDispatcher(
         // Retry with linear backoff until the reservation is released.
         const MAX_RESERVED_RETRIES = 6
         const BASE_DELAY_MS = 500
-        let reservedResult = promptResult
+        let reservedResult: InternalPromptDispatchResult = promptResult
         for (let attempt = 0; attempt < MAX_RESERVED_RETRIES; attempt++) {
           const delay = BASE_DELAY_MS * (attempt + 1)
           log(`[${HOOK_NAME}] Session reserved, retrying fallback dispatch in ${delay}ms (${source})`, {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -167,6 +167,16 @@ export function createAutoRetryDispatcher(
           })
           if (reservedResult.status !== "reserved") break
         }
+        if (reservedResult.status === "failed") {
+          if (isAmbiguousPostDispatchPromptFailure(reservedResult)) {
+            retryMayHaveBeenAccepted = true
+            log(`[${HOOK_NAME}] Auto-retry prompt failed after dispatch may have been accepted (${source}); preserving fallback state`, {
+              sessionID,
+              error: String(reservedResult.error),
+            })
+          }
+          throw reservedResult.error
+        }
         if (!isInternalPromptDispatchAccepted(reservedResult)) {
           log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate after reserved retries (${source})`, {
             sessionID,

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-dispatch.ts
@@ -130,7 +130,50 @@ export function createAutoRetryDispatcher(
         }
         throw promptResult.error
       }
-      if (!isInternalPromptDispatchAccepted(promptResult)) {
+      if (promptResult.status === "reserved") {
+        // Session still has an active reservation from the cancelled stream.
+        // Retry with linear backoff until the reservation is released.
+        const MAX_RESERVED_RETRIES = 6
+        const BASE_DELAY_MS = 500
+        let reservedResult = promptResult
+        for (let attempt = 0; attempt < MAX_RESERVED_RETRIES; attempt++) {
+          const delay = BASE_DELAY_MS * (attempt + 1)
+          log(`[${HOOK_NAME}] Session reserved, retrying fallback dispatch in ${delay}ms (${source})`, {
+            sessionID,
+            attempt: attempt + 1,
+            maxAttempts: MAX_RESERVED_RETRIES,
+          })
+          await new Promise((r) => setTimeout(r, delay))
+          reservedResult = await dispatchInternalPrompt({
+            mode: "async",
+            client: ctx.client,
+            sessionID,
+            source: `runtime-fallback:${source}:reserved-retry-${attempt + 1}`,
+            settleMs: 0,
+            queueBehavior: "defer",
+            input: {
+              path: { id: sessionID },
+              body: {
+                ...(launchAgent ? { agent: launchAgent } : {}),
+                ...retryModelPayload,
+                ...(retryPayload.system ? { system: retryPayload.system } : {}),
+                ...(retryPayload.tools ? { tools: retryPayload.tools } : {}),
+                ...(retryMessageID ? { messageID: retryMessageID } : {}),
+                parts: retryParts,
+              },
+              query: { directory: ctx.directory },
+            },
+          })
+          if (reservedResult.status !== "reserved") break
+        }
+        if (!isInternalPromptDispatchAccepted(reservedResult)) {
+          log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate after reserved retries (${source})`, {
+            sessionID,
+            status: reservedResult.status,
+          })
+          return
+        }
+      } else if (!isInternalPromptDispatchAccepted(promptResult)) {
         log(`[${HOOK_NAME}] Auto-retry skipped by promptAsync gate (${source})`, {
           sessionID,
           status: promptResult.status,


### PR DESCRIPTION
## Summary

Builds on #5110 by @wjiuxing (both commits cherry-picked with authorship preserved), completing it with tests and one mechanical gap fix.

When the primary model fails with a quota error and the cancelled stream still holds a promptAsync reservation, `dispatchInternalPrompt` returns `{status: "reserved"}`. At `dev`, `createAutoRetryDispatcher` treated that as not-accepted and returned immediately; the `finally` block then wiped `sessionAwaitingFallbackResult`, the fallback timeout, and `pendingFallbackModel` — the fallback was silently abandoned and the session left dead after the "Switching to <fallback>" toast.

## Changes

1. **Cherry-picked from #5110** (`@wjiuxing`): linear-backoff retry of the fallback dispatch while the session is reserved (6 attempts, 500ms→3000ms, ~10.5s worst case — within the 30s default fallback session timeout), falling through to the existing rejection handling when exhausted.
2. **Top-up (gap fix)**: a dispatch that failed *inside* the retry loop bypassed the `isAmbiguousPostDispatchPromptFailure` preservation path the initial dispatch already has — an ambiguous post-dispatch failure (e.g. EOF mid-response) during a reserved retry wiped the fallback state. Loop failures are now routed through the identical check (no new behavior policy).
3. **Top-up (tests)**: new `auto-retry-dispatch.test.ts` drives the **real** prompt-async gate with a self-expiring stale reservation:
   - reserved → released → fallback dispatched, awaiting-state retained;
   - reserved → released → ambiguous dispatch failure → pending fallback preserved as possibly accepted.

## Evidence (TDD)

- RED at base (`.ulw/evidence/i5109-red.txt`): both tests fail — gate consulted once, `promptAsync` never called, state wiped.
- Intermediate (PR #5110 only, captured in `.ulw/evidence/i5109-green.txt`): retry test passes; ambiguous-failure test still fails (`sessionAwaitingFallbackResult` wiped) — proves the gap.
- GREEN (`.ulw/evidence/i5109-green.txt`): 2/2 new tests; full `runtime-fallback` suite 228/228; LSP diagnostics clean.
- QA (`.ulw/evidence/i5109-qa.txt`): adapted sweep repro against this branch — reservation released after 2 attempts → `dispatchCalls=3`, fallback dispatched, state retained; never-released reservation → bounded 7 attempts (~10.5s) then clean abandonment. **VERDICT=NOT-REPRODUCED** (was REPRODUCED at base).

Closes #5109
Builds on #5110 by @wjiuxing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries reserved fallback dispatches with linear backoff and preserves ambiguous failures to prevent dead sessions after switching to a fallback. Fixes Linear #5109.

- **Bug Fixes**
  - When `dispatchInternalPrompt` returns `{status: "reserved"}`, retry the fallback dispatch with linear backoff (6 attempts, 500–3000ms; ~10.5s max) before giving up.
  - If a reserved-retry fails ambiguously (e.g., EOF mid-response), preserve fallback state (`sessionAwaitingFallbackResult`, mark as possibly accepted) instead of wiping it.
  - Added `auto-retry-dispatch.test.ts` to cover reserved→released and ambiguous failure paths.

<sup>Written for commit fa3711ccb72ae8ffe50ba27b82d79110dcdbe8e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

