### PR TITLE
fix(plugin-hooks): inject CLAUDE_PLUGIN_ROOT into plugin-sourced hook spawn (#4458)

### DIFF
--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { loadPluginHooksConfigs } from "./hook-loader"
+import type { LoadedPlugin } from "./types"
+
+// Regression coverage for #4458 — every command/http action loaded from a
+// plugin's hooks config must carry the plugin's installPath as `pluginRoot`
+// so the downstream dispatcher can export CLAUDE_PLUGIN_ROOT on the spawn.
+describe("loadPluginHooksConfigs pluginRoot stamping (#4458)", () => {
+  let tempDirectory = ""
+
+  beforeEach(() => {
+    tempDirectory = mkdtempSync(join(tmpdir(), "omo-hook-loader-"))
+  })
+
+  afterEach(() => {
+    rmSync(tempDirectory, { recursive: true, force: true })
+  })
+
+  function makePlugin(pluginName: string, hooksJson: unknown): LoadedPlugin {
+    const installPath = join(tempDirectory, pluginName)
+    const hooksPath = join(installPath, "hooks.json")
+    // Use mkdir via writeFileSync target dir trick — easier to just create the
+    // install dir explicitly.
+    rmSync(installPath, { recursive: true, force: true })
+    const fs = require("node:fs") as typeof import("node:fs")
+    fs.mkdirSync(installPath, { recursive: true })
+    writeFileSync(hooksPath, JSON.stringify(hooksJson), "utf-8")
+    return {
+      name: pluginName,
+      version: "0.0.0",
+      scope: "user",
+      installPath,
+      pluginKey: `${pluginName}@test`,
+      hooksPath,
+    }
+  }
+
+  test("#given a plugin hooks config #when loaded #then every command action carries pluginRoot=installPath", () => {
+    // given
+    const plugin = makePlugin("hello-plugin", {
+      hooks: {
+        UserPromptSubmit: [
+          {
+            matcher: "*",
+            hooks: [
+              { type: "command", command: "echo hi" },
+              { type: "command", command: "${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh" },
+            ],
+          },
+        ],
+      },
+    })
+
+    // when
+    const configs = loadPluginHooksConfigs([plugin])
+
+    // then
+    expect(configs).toHaveLength(1)
+    const matchers = configs[0]?.hooks?.UserPromptSubmit ?? []
+    expect(matchers).toHaveLength(1)
+    const actions = matchers[0]?.hooks ?? []
+    expect(actions).toHaveLength(2)
+    for (const action of actions) {
+      expect(action.type).toBe("command")
+      // Type narrowing for the test: command-type entries should carry pluginRoot.
+      expect((action as { pluginRoot?: string }).pluginRoot).toBe(plugin.installPath)
+    }
+  })
+
+  test("#given an http action #when loaded #then it also carries pluginRoot", () => {
+    // given
+    const plugin = makePlugin("http-plugin", {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "http", url: "https://example.test/hook" },
+            ],
+          },
+        ],
+      },
+    })
+
+    // when
+    const configs = loadPluginHooksConfigs([plugin])
+
+    // then
+    const action = configs[0]?.hooks?.PostToolUse?.[0]?.hooks?.[0]
+    expect(action?.type).toBe("http")
+    expect((action as { pluginRoot?: string }).pluginRoot).toBe(plugin.installPath)
+  })
+})

--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { loadPluginHooksConfigs } from "./hook-loader"
 import type { LoadedPlugin } from "./types"
 
-// Regression coverage for #4458 — every command/http action loaded from a
+// Regression coverage for #4458 - every command/http action loaded from a
 // plugin's hooks config must carry the plugin's installPath as `pluginRoot`
 // so the downstream dispatcher can export CLAUDE_PLUGIN_ROOT on the spawn.
 describe("loadPluginHooksConfigs pluginRoot stamping (#4458)", () => {
@@ -22,7 +22,7 @@ describe("loadPluginHooksConfigs pluginRoot stamping (#4458)", () => {
   function makePlugin(pluginName: string, hooksJson: unknown): LoadedPlugin {
     const installPath = join(tempDirectory, pluginName)
     const hooksPath = join(installPath, "hooks.json")
-    // Use mkdir via writeFileSync target dir trick — easier to just create the
+    // Use mkdir via writeFileSync target dir trick - easier to just create the
     // install dir explicitly.
     rmSync(installPath, { recursive: true, force: true })
     const fs = require("node:fs") as typeof import("node:fs")

--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/hook-loader.ts
@@ -1,7 +1,28 @@
 import { existsSync, readFileSync } from "fs"
 import { log } from "../../shared/logger"
-import type { HooksConfig, LoadedPlugin } from "./types"
+import type { HookEntry, HooksConfig, LoadedPlugin } from "./types"
 import { resolvePluginPaths } from "./plugin-path-resolver"
+
+/**
+ * Stamp every action with the plugin's installPath so that the downstream
+ * dispatcher can set CLAUDE_PLUGIN_ROOT on the spawned hook process (#4458).
+ * The plugin association is otherwise lost once configs are merged together.
+ */
+function stampPluginRoot(config: HooksConfig, pluginRoot: string): void {
+  const eventMap = config.hooks
+  if (!eventMap) return
+  for (const matchers of Object.values(eventMap)) {
+    if (!Array.isArray(matchers)) continue
+    for (const matcher of matchers) {
+      if (!Array.isArray(matcher?.hooks)) continue
+      for (const action of matcher.hooks as HookEntry[]) {
+        if (action && (action.type === "command" || action.type === "http")) {
+          action.pluginRoot = pluginRoot
+        }
+      }
+    }
+  }
+}
 
 export function loadPluginHooksConfigs(plugins: LoadedPlugin[]): HooksConfig[] {
   const configs: HooksConfig[] = []
@@ -14,6 +35,7 @@ export function loadPluginHooksConfigs(plugins: LoadedPlugin[]): HooksConfig[] {
       let config = JSON.parse(content) as HooksConfig
 
       config = resolvePluginPaths(config, plugin.installPath)
+      stampPluginRoot(config, plugin.installPath)
 
       configs.push(config)
       log(`Loaded plugin hooks config from ${plugin.name}`, { path: plugin.hooksPath })

--- a/packages/omo-opencode/src/features/claude-code-plugin-loader/types.ts
+++ b/packages/omo-opencode/src/features/claude-code-plugin-loader/types.ts
@@ -115,10 +115,10 @@ export interface PluginManifest {
  * Hooks configuration
  */
 export type HookEntry =
-  | { type: "command"; command?: string }
+  | { type: "command"; command?: string; allowedEnvVars?: string[]; pluginRoot?: string }
   | { type: "prompt"; prompt?: string }
   | { type: "agent"; agent?: string }
-  | { type: "http"; url: string; headers?: Record<string, string>; allowedEnvVars?: string[]; timeout?: number }
+  | { type: "http"; url: string; headers?: Record<string, string>; allowedEnvVars?: string[]; timeout?: number; pluginRoot?: string }
 
 export interface HookMatcher {
   matcher?: string

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/dispatch-hook.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/dispatch-hook.ts
@@ -26,6 +26,9 @@ export async function dispatchHook(
   if (cmdHook.allowedEnvVars) {
     options.allowedEnvVars = cmdHook.allowedEnvVars
   }
+  if (cmdHook.pluginRoot) {
+    options.pluginRoot = cmdHook.pluginRoot
+  }
 
   return executeHookCommand(
     hook.command,

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/types.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/types.ts
@@ -27,6 +27,8 @@ export interface HookCommand {
   command: string
   /** Env vars allowed to pass through to the spawned process (plugin-sourced hooks are intersected with mcp_env_allowlist) */
   allowedEnvVars?: string[]
+  /** Plugin install path. When set, CLAUDE_PLUGIN_ROOT is injected into the spawn env and substituted in the command string. */
+  pluginRoot?: string
 }
 
 export interface HookHttp {
@@ -35,6 +37,8 @@ export interface HookHttp {
   headers?: Record<string, string>
   allowedEnvVars?: string[]
   timeout?: number
+  /** Plugin install path. Recorded for diagnostics; HTTP hooks do not spawn a child process. */
+  pluginRoot?: string
 }
 
 export type HookAction = HookCommand | HookHttp

--- a/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
+++ b/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
@@ -78,6 +78,56 @@ describe("executeHookCommand", () => {
     expect(result.stderr).toContain("Hook command timed out after 20ms")
     expect(Date.now() - startedAt).toBeLessThan(1000)
   })
+
+  // Regression coverage for #4458 — plugin-sourced hooks must run with
+  // CLAUDE_PLUGIN_ROOT exported into the child env (so scripts can read
+  // process.env.CLAUDE_PLUGIN_ROOT) AND substituted in the command string
+  // (so commands written as `$CLAUDE_PLUGIN_ROOT/scripts/foo.sh` resolve).
+  test("#given pluginRoot option #when executing command #then CLAUDE_PLUGIN_ROOT is exported into env", async () => {
+    // when
+    const result = await executeHookCommand(
+      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-x" },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("plugin-root=/tmp/plugin-x")
+  })
+
+  test("#given pluginRoot option with allowedEnvVars #when executing command #then CLAUDE_PLUGIN_ROOT survives the env scrub", async () => {
+    // when
+    const result = await executeHookCommand(
+      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-y", allowedEnvVars: [] },
+    )
+
+    // then - the empty allowedEnvVars list scrubs everything except HOME/PATH,
+    // but CLAUDE_PLUGIN_ROOT must still be present because pluginRoot is
+    // honored independently of the allowlist.
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("plugin-root=/tmp/plugin-y")
+  })
+
+  test("#given pluginRoot option #when command references ${CLAUDE_PLUGIN_ROOT} #then it is substituted before spawn", async () => {
+    // when - shell-style ${VAR} would normally also expand at spawn time, but
+    // we substitute earlier so the form works even in commands that disable
+    // shell variable expansion downstream.
+    const result = await executeHookCommand(
+      'echo "rooted=${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"',
+      "",
+      tempDirectory,
+      { pluginRoot: "/tmp/plugin-z" },
+    )
+
+    // then
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("rooted=/tmp/plugin-z/scripts/foo.sh")
+  })
 })
 
 export {}

--- a/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
+++ b/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
@@ -79,7 +79,7 @@ describe("executeHookCommand", () => {
     expect(Date.now() - startedAt).toBeLessThan(1000)
   })
 
-  // Regression coverage for #4458 — plugin-sourced hooks must run with
+  // Regression coverage for #4458 - plugin-sourced hooks must run with
   // CLAUDE_PLUGIN_ROOT exported into the child env (so scripts can read
   // process.env.CLAUDE_PLUGIN_ROOT) AND substituted in the command string
   // (so commands written as `$CLAUDE_PLUGIN_ROOT/scripts/foo.sh` resolve).

--- a/packages/omo-opencode/src/shared/command-executor/execute-hook-command.ts
+++ b/packages/omo-opencode/src/shared/command-executor/execute-hook-command.ts
@@ -20,6 +20,13 @@ export interface ExecuteHookOptions {
   killGraceMs?: number;
   /** When provided, scrub process.env to only include these vars plus HOME/PATH/etc. Used for plugin-sourced hooks. */
   allowedEnvVars?: string[];
+  /**
+   * Plugin install path. When set, CLAUDE_PLUGIN_ROOT is exported into the
+   * spawn env and substituted in the command string so plugin-sourced hooks
+   * can reference $CLAUDE_PLUGIN_ROOT / ${CLAUDE_PLUGIN_ROOT} the same way
+   * Claude Code's CLI does (#4458).
+   */
+  pluginRoot?: string;
 }
 
 export async function executeHookCommand(
@@ -32,11 +39,18 @@ export async function executeHookCommand(
   const timeoutMs = options?.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
   const killGraceMs = options?.killGraceMs ?? SIGKILL_GRACE_MS;
 
-  const expandedCommand = command
+  const pluginRoot = options?.pluginRoot;
+  let expandedCommand = command
     .replace(/^~(?=\/|$)/g, home)
     .replace(/\s~(?=\/)/g, ` ${home}`)
     .replace(/\$CLAUDE_PROJECT_DIR/g, cwd)
     .replace(/\$\{CLAUDE_PROJECT_DIR\}/g, cwd);
+
+  if (pluginRoot) {
+    expandedCommand = expandedCommand
+      .replace(/\$CLAUDE_PLUGIN_ROOT/g, pluginRoot)
+      .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
+  }
 
   let finalCommand = expandedCommand;
 
@@ -62,7 +76,7 @@ export async function executeHookCommand(
 
     // Keys that are always set from normalized sources and must not be
     // overwritten by ambient process.env values during the allowlist merge.
-    const PROTECTED_ENV_KEYS = new Set(["HOME", "CLAUDE_PROJECT_DIR"]);
+    const PROTECTED_ENV_KEYS = new Set(["HOME", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT"]);
 
     let env: Record<string, string | undefined>;
     if (options?.allowedEnvVars) {
@@ -79,6 +93,10 @@ export async function executeHookCommand(
       }
     } else {
       env = { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd };
+    }
+
+    if (pluginRoot) {
+      env.CLAUDE_PLUGIN_ROOT = pluginRoot;
     }
 
     const proc = spawn(finalCommand, {


### PR DESCRIPTION
## Problem

`${CLAUDE_PLUGIN_ROOT}` was only string-rewritten inside plugin config FIELDS by `resolvePluginPaths` at load time. The variable was never exported into the spawned hook subprocess env and never substituted at dispatch time, so plugin-sourced hook commands like `bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh` (and scripts reading `process.env.CLAUDE_PLUGIN_ROOT`) resolved against an empty path (`/scripts/setup.sh`).

Closes #4458
Builds on #4489 by @ZeyuFu — his commit is cherry-picked verbatim (authorship preserved): the loader stamps each action with `pluginRoot=installPath`, `dispatchHook` forwards it, and `executeHookCommand` both exports `CLAUDE_PLUGIN_ROOT` into the child env (protected from the allowlist scrub via `PROTECTED_ENV_KEYS`) and substitutes `$CLAUDE_PLUGIN_ROOT`/`${CLAUDE_PLUGIN_ROOT}` in the command string.

## Top-up on #4489 (mechanical only)

- Relocated the new `hook-loader.test.ts` to `packages/omo-opencode/src/features/claude-code-plugin-loader/` (the PR predates the `src/` → `packages/omo-opencode/src/` refactor; all source hunks rename-applied cleanly).
- Resolved the both-added-at-end conflict in `execute-hook-command.test.ts` (kept dev's timeout test AND the PR's three #4458 regression tests).

Settings.json-sourced hooks intentionally keep the empty expansion: `CLAUDE_PLUGIN_ROOT` is plugin-scoped in Claude Code's spec, and only plugin-sourced hooks carry a plugin root.

## Evidence

- RED (base `6f4aa197c`): adapted sweep repro against the real `executeHookCommand`/`loadPluginHooksConfigs` → 3 contract failures (`plugin-root=` empty env, `rooted=/scripts/foo.sh` broken substitution, `stamped=undefined`).
- GREEN: same repro → all 4 contracts pass; `bun test` on `shared/command-executor/` + `features/claude-code-plugin-loader/` + `hooks/claude-code-hooks/` → 180 pass, 0 fail; LSP diagnostics clean on every changed production file.
- QA (real surface): `hooks.json` on disk → `loadPluginHooksConfigs` → `dispatchHook` → spawned shell prints `env-root=[<real install path>]` and the substituted script path; an unstamped settings-style hook stays `env-root=[]` per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject `CLAUDE_PLUGIN_ROOT` into plugin-sourced hook processes and substitute it in commands so hooks resolve their install path correctly. Fixes broken paths like `${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh`. Fixes #4458.

- **Bug Fixes**
  - Stamp each plugin hook action with `pluginRoot` (plugin installPath) during load to preserve plugin association.
  - Forward `pluginRoot` through the dispatcher to the command executor.
  - In the executor, export `CLAUDE_PLUGIN_ROOT` and substitute `$CLAUDE_PLUGIN_ROOT`/`${CLAUDE_PLUGIN_ROOT}` in the command; protect it from the allowlist scrub.
  - Keep settings-sourced hooks with an empty `CLAUDE_PLUGIN_ROOT` by design.
  - Add regression tests for loader stamping and env/substitution behavior; tidy test punctuation to match repo style.

<sup>Written for commit 4e58e67aa1fd0d68d7268048f1277fd30302c974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

