### PR TITLE
fix(lsp-tools-mcp): bind sourcekit-lsp to real Objective-C extensions

### DIFF
--- a/packages/lsp-tools-mcp/src/lsp/server-definitions.ts
+++ b/packages/lsp-tools-mcp/src/lsp/server-definitions.ts
@@ -102,7 +102,7 @@ export const BUILTIN_SERVERS: Record<string, Omit<LspServerConfig, "id">> = {
 	zls: { command: ["zls"], extensions: [".zig", ".zon"] },
 	csharp: { command: ["csharp-ls"], extensions: [".cs"] },
 	fsharp: { command: ["fsautocomplete"], extensions: [".fs", ".fsi", ".fsx", ".fsscript"] },
-	"sourcekit-lsp": { command: ["sourcekit-lsp"], extensions: [".swift", ".objc", ".objcpp"] },
+	"sourcekit-lsp": { command: ["sourcekit-lsp"], extensions: [".swift", ".m", ".mm"] },
 	rust: { command: ["rust-analyzer"], extensions: [".rs"] },
 	clangd: {
 		command: ["clangd", "--background-index", "--clang-tidy"],

--- a/packages/lsp-tools-mcp/test/server-definitions.test.ts
+++ b/packages/lsp-tools-mcp/test/server-definitions.test.ts
@@ -80,4 +80,14 @@ describe("BUILTIN_SERVERS", () => {
 		expect(kotlin?.command).toEqual(["kotlin-lsp", "--stdio"]);
 		expect(kotlin?.extensions).toEqual([".kt", ".kts"]);
 	});
+
+	it("#given sourcekit-lsp #when looking it up #then binds Swift and Objective-C file extensions", () => {
+		// given
+		const sourcekit = BUILTIN_SERVERS["sourcekit-lsp"];
+
+		// when / then
+		expect(sourcekit).toBeDefined();
+		expect(sourcekit?.command[0]).toBe("sourcekit-lsp");
+		expect(sourcekit?.extensions).toEqual([".swift", ".m", ".mm"]);
+	});
 });

--- a/packages/lsp-tools-mcp/test/server-resolution.test.ts
+++ b/packages/lsp-tools-mcp/test/server-resolution.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { findServerForExtension } from "../src/lsp/server-resolution.js";
+
+describe("findServerForExtension", () => {
+	it("#given an Objective-C .m extension #when resolving the server #then sourcekit-lsp is selected", () => {
+		// given / when
+		const result = findServerForExtension(".m");
+
+		// then
+		expect(result.status).not.toBe("not_configured");
+		if (result.status !== "not_configured") {
+			expect(result.server.id).toBe("sourcekit-lsp");
+		}
+	});
+
+	it("#given an Objective-C++ .mm extension #when resolving the server #then sourcekit-lsp is selected", () => {
+		// given / when
+		const result = findServerForExtension(".mm");
+
+		// then
+		expect(result.status).not.toBe("not_configured");
+		if (result.status !== "not_configured") {
+			expect(result.server.id).toBe("sourcekit-lsp");
+		}
+	});
+
+	it("#given the bogus .objc extension #when resolving the server #then no server is configured", () => {
+		// given / when
+		const result = findServerForExtension(".objc");
+
+		// then
+		expect(result.status).toBe("not_configured");
+	});
+});


### PR DESCRIPTION
## Summary

- `sourcekit-lsp` was registered with the non-existent `.objc`/`.objcpp` extensions, so Objective-C `.m`/`.mm` files never resolved a language server — `findServerForExtension` matches exactly on `extname`, and nothing real ever produces `.objc`/`.objcpp`. Result: `No language server available for file type` for all Objective-C files.
- Fix binds `sourcekit-lsp` to `[".swift", ".m", ".mm"]`. No conflict with `clangd`, whose extension list contains no `.m`/`.mm`.

Partially addresses #2821 (extension bindings half); the config-surface half (honoring `oh-my-opencode.jsonc` `lsp` bindings in lsp-tools-mcp, which today only reads `.codex/lsp-client.json`) is intentionally **not** included — it adds new config surface and needs a separate design decision.

## Changes

- `src/lsp/server-definitions.ts` — `sourcekit-lsp` extensions `['.swift', '.objc', '.objcpp']` → `['.swift', '.m', '.mm']`.
- `test/server-definitions.test.ts` — registry assertion for the sourcekit-lsp binding.
- `test/server-resolution.test.ts` — new: `.m`/`.mm` resolve to `sourcekit-lsp`; bogus `.objc` resolves to `not_configured`.

## Evidence

- RED (base): 4 failing assertions — sourcekit extensions `['.swift','.objc','.objcpp']`, `.m`/`.mm` → `not_configured`, `.objc` → `found`.
- GREEN: 10/10 in the touched files; full `packages/lsp-tools-mcp` suite 86/86 (also after rebuilding the package dist).
- QA (adapted from the issue's repro, isolated request-context with sandboxed config paths): `.m`/`.mm` → `found/sourcekit-lsp`, `.swift` unchanged, `.objc` → `not_configured`. Verdict: NOT-REPRODUCED for the extensions half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind `sourcekit-lsp` to real Objective-C extensions `.m` and `.mm` in `lsp-tools-mcp`. Fixes server resolution for ObjC/ObjC++ without affecting `clangd`, and partially addresses #2821.

- **Bug Fixes**
  - Update `src/lsp/server-definitions.ts` to `['.swift', '.m', '.mm']`.
  - Add tests to verify `.m`/`.mm` resolve to `sourcekit-lsp` and `.objc` is not configured.

<sup>Written for commit 7822ea042b576ad51832b62310d3c056f2ee92be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

