### PR TITLE
fix(tmux): close orphaned subagent panes on completion and after hard timeout (#4773, #5071)

### DIFF
--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -140,6 +140,20 @@ export function createManagers(args: {
 
         log("[create-managers] onSubagentSessionCreated callback completed")
     },
+    onSubagentSessionDeleted: async (event: { sessionID: string }) => {
+      log("[create-managers] onSubagentSessionDeleted callback received", {
+        sessionID: event.sessionID,
+      })
+
+      await tmuxSessionManager.onSessionDeleted(event).catch((error) => {
+        log("[create-managers] onSubagentSessionDeleted callback error:", {
+          sessionID: event.sessionID,
+          error: String(error),
+        })
+      })
+
+      log("[create-managers] onSubagentSessionDeleted callback completed")
+    },
     onShutdown: async () => {
       await cleanupTeamModeRuns().catch((error) => {
         log("[create-managers] team-mode cleanup error during shutdown:", error)

--- a/packages/omo-opencode/src/features/background-agent/index.ts
+++ b/packages/omo-opencode/src/features/background-agent/index.ts
@@ -1,4 +1,4 @@
 export * from "./types"
-export { BackgroundManager, type SubagentSessionCreatedEvent, type OnSubagentSessionCreated } from "./manager"
+export { BackgroundManager, type SubagentSessionCreatedEvent, type OnSubagentSessionCreated, type SubagentSessionDeletedEvent, type OnSubagentSessionDeleted } from "./manager"
 export { waitForTaskSessionID } from "./wait-for-task-session"
 export type { WaitForTaskSessionIDOptions } from "./wait-for-task-session"

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -2374,6 +2374,45 @@ describe("BackgroundManager.tryCompleteTask", () => {
     expect(abortedSessionIDs).toEqual(["session-1"])
   })
 
+  test("should fire onSubagentSessionDeleted callback on completion", async () => {
+    // #given
+    const deletedSessionIDs: string[] = []
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    manager.shutdown()
+    manager = new BackgroundManager({
+      pluginContext: createPluginInput(client),
+      onSubagentSessionDeleted: async (event) => {
+        deletedSessionIDs.push(event.sessionID)
+      },
+    })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-deleted-callback",
+      sessionId: "session-deleted-cb",
+      parentSessionId: "session-parent",
+      parentMessageId: "msg-1",
+      description: "test task for deleted callback",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+
+    // #when
+    await tryCompleteTaskForTest(manager, task)
+
+    // #then
+    expect(deletedSessionIDs).toEqual(["session-deleted-cb"])
+  })
+
   test("should clean pendingByParent even when promptAsync notification fails", async () => {
     // given
     const client = {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -216,6 +216,12 @@ export interface SubagentSessionCreatedEvent {
 
 export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>
 
+export interface SubagentSessionDeletedEvent {
+  sessionID: string
+}
+
+export type OnSubagentSessionDeleted = (event: SubagentSessionDeletedEvent) => Promise<void>
+
 const MAX_TASK_REMOVAL_RESCHEDULES = 6
 const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 100
 const PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS = 5_000
@@ -225,6 +231,7 @@ export interface BackgroundManagerConfig {
   config?: BackgroundTaskConfig
   tmuxConfig?: TmuxConfig
   onSubagentSessionCreated?: OnSubagentSessionCreated
+  onSubagentSessionDeleted?: OnSubagentSessionDeleted
   onShutdown?: () => void | Promise<void>
   enableParentSessionNotifications?: boolean
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
@@ -248,6 +255,7 @@ export class BackgroundManager {
   private config?: BackgroundTaskConfig
   private tmuxEnabled: boolean
   private onSubagentSessionCreated?: OnSubagentSessionCreated
+  private onSubagentSessionDeleted?: OnSubagentSessionDeleted
   private onShutdown?: () => void | Promise<void>
 
   private queuesByKey: Map<string, QueueItem[]> = new Map()
@@ -283,6 +291,7 @@ export class BackgroundManager {
     this.config = options.config
     this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false
     this.onSubagentSessionCreated = options?.onSubagentSessionCreated
+    this.onSubagentSessionDeleted = options?.onSubagentSessionDeleted
     this.onShutdown = options?.onShutdown
     this.rootDescendantCounts = new Map()
     this.preStartDescendantReservations = new Set()
@@ -2479,6 +2488,13 @@ The task was re-queued on a fallback model after a retryable failure.
     if (task.sessionId) {
       // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT)
       await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
+
+      // @allow Notify tmux to close the pane immediately. client.session.abort() does not
+      // reliably emit session.deleted, so the polling fallback (60-min SESSION_TIMEOUT_MS)
+      // leaves panes orphaned for too long. See #4773.
+      await this.onSubagentSessionDeleted?.({ sessionID: task.sessionId }).catch((error) => {
+        log("[background-agent] onSubagentSessionDeleted callback failed:", { taskId: task.id, sessionID: task.sessionId, error: String(error) })
+      })
 
       clearDelegatedChildSessionBootstrap(task.sessionId)
       SessionCategoryRegistry.remove(task.sessionId)

--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager-hard-timeout.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager-hard-timeout.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "bun:test"
+import { TmuxPollingManager } from "./polling-manager"
+import { SESSION_TIMEOUT_MS } from "../../shared/tmux"
+import type { OpencodeClient } from "../../tools/delegate-task/types"
+import type { TrackedSession } from "./types"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+
+function createTrackedSession(sessionId: string, createdAt: Date): TrackedSession {
+  return {
+    sessionId,
+    paneId: "%1",
+    description: "test",
+    attachActivated: false,
+    createdAt,
+    lastSeenAt: createdAt,
+    closePending: false,
+    closeRetryCount: 0,
+  }
+}
+
+function createStatuslessClient(): OpencodeClient {
+  return unsafeTestValue<OpencodeClient>({
+    session: {
+      status: async () => ({ data: {} }),
+      messages: async () => ({ data: [] }),
+    },
+  })
+}
+
+describe("TmuxPollingManager never-activated pane hard timeout (#4773, #5071)", () => {
+  test("closes a never-focused pane with no session status once SESSION_TIMEOUT_MS elapses", async () => {
+    //#given a pane past the hard timeout that was never attach-activated and never reported a status
+    const pastHardTimeout = new Date(Date.now() - SESSION_TIMEOUT_MS - 60_000)
+    const sessions = new Map<string, TrackedSession>()
+    sessions.set("ses-unfocused-timed-out", createTrackedSession("ses-unfocused-timed-out", pastHardTimeout))
+
+    const closedSessionIds: string[] = []
+    const manager = new TmuxPollingManager(createStatuslessClient(), sessions, async (sessionId) => {
+      closedSessionIds.push(sessionId)
+    })
+
+    //#when
+    await unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions()
+
+    //#then
+    expect(closedSessionIds).toEqual(["ses-unfocused-timed-out"])
+  })
+
+  test("keeps a young never-focused pane with no session status open", async () => {
+    //#given a 30s-old placeholder pane that was never attach-activated and has no status yet
+    const thirtySecondsAgo = new Date(Date.now() - 30_000)
+    const sessions = new Map<string, TrackedSession>()
+    sessions.set("ses-unfocused-young", createTrackedSession("ses-unfocused-young", thirtySecondsAgo))
+
+    const closedSessionIds: string[] = []
+    const manager = new TmuxPollingManager(createStatuslessClient(), sessions, async (sessionId) => {
+      closedSessionIds.push(sessionId)
+    })
+
+    //#when
+    await unsafeTestValue<{ pollSessions: () => Promise<void> }>(manager).pollSessions()
+
+    //#then
+    expect(closedSessionIds).toEqual([])
+  })
+})

--- a/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/polling-manager.ts
@@ -81,11 +81,23 @@ export class TmuxPollingManager {
         const status = allStatuses[sessionId]
         const elapsedMs = now - tracked.createdAt.getTime()
         if (!tracked.attachActivated && !status) {
-          log("[tmux-session-manager] placeholder pane has not been activated yet; skipping close checks", {
+          if (elapsedMs <= SESSION_TIMEOUT_MS) {
+            log("[tmux-session-manager] placeholder pane has not been activated yet; skipping close checks", {
+              sessionId,
+              paneId: tracked.paneId,
+              elapsedMs,
+            })
+            continue
+          }
+          log("[tmux-session-manager] never-activated pane exceeded hard timeout; closing", {
             sessionId,
             paneId: tracked.paneId,
             elapsedMs,
           })
+          if (!tracked.closePending) {
+            tracked.closePending = true
+            sessionsToClose.push(sessionId)
+          }
           continue
         }
 


### PR DESCRIPTION
## Summary

Tmux subagent panes orphan instead of closing (#4773), and a never-focused pane whose session never reports a status outlives even the hard timeout indefinitely (#5071). This PR fixes both halves:

1. **Event-driven close on background-task completion** — cherry-picked from #4850: `BackgroundManager.tryCompleteTask()` now fires `onSubagentSessionDeleted` → `TmuxSessionManager.onSessionDeleted()`, closing the pane immediately instead of waiting for a `session.deleted` event that `client.session.abort()` does not reliably emit. Builds on #4850 by @EvangelosMoschou (his commits and authorship preserved).
2. **Hard-timeout escape for never-activated panes** (top-up): `pollSessions()` short-circuited at the `if (!tracked.attachActivated && !status) continue` guard *before* all three close nets (`missingTooLong` / `isTimedOut` / stability), so a never-focused, status-less pane was never closed — not even after `SESSION_TIMEOUT_MS`. The guard now lets the hard timeout through while keeping the placeholder grace for young panes. Activation and status-driven behavior is unchanged.

Note for reviewers: `polling-manager.ts` uses `SESSION_TIMEOUT_MS` from `shared/tmux/constants.ts` (60 min), not the 10-min constant in `tmux-subagent/polling-constants.ts` (that one belongs to `polling.ts`) — issue texts citing "~10 min" trace to the latter.

Closes #4773
Closes #5071

## Evidence (RED → GREEN + QA)

- RED at `origin/dev` (6f4aa197c): new test `polling-manager-hard-timeout.test.ts` fails — a never-focused, status-less pane past `SESSION_TIMEOUT_MS` is not closed (`expect(closedSessionIds).toEqual(["ses-unfocused-timed-out"])` received `[]`). Still red after cherry-picking #4850 alone, proving the guard fix is a distinct mechanism.
- GREEN: new test 2/2; tmux-subagent directory 152/0; background-agent directory 668/0; `create-managers.test.ts` 5/5; `bun run typecheck` clean; LSP diagnostics clean on all changed files.
- QA: drove the real `pollSessions()` (adapted issue repro) — never-focused status-less pane past the hard timeout now closes; a 30s-old placeholder stays open; an attach-activated status-less pane still closes via `missingTooLong`. Verdict: NOT-REPRODUCED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes orphaned tmux subagent panes by closing them immediately on task completion and by enforcing the hard timeout for never‑activated panes. Prevents panes from lingering indefinitely (fixes #4773, #5071).

- **Bug Fixes**
  - Added optional `onSubagentSessionDeleted` callback to `BackgroundManager` and wired it in `create-managers`; fired on task completion to call `TmuxSessionManager.onSessionDeleted` and close the pane immediately.
  - Updated `TmuxPollingManager.pollSessions()` to let `SESSION_TIMEOUT_MS` close never‑activated panes with no status; keeps grace for young placeholder panes.

<sup>Written for commit 935121d1ca69874d75e38fb65d5ba1121342defb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

