### PR TITLE
fix(codex): preserve agent service tier customizations across reinstalls

### DIFF
--- a/packages/omo-codex/scripts/install-agent-links.test.mjs
+++ b/packages/omo-codex/scripts/install-agent-links.test.mjs
@@ -253,6 +253,47 @@ test(
 );
 
 test(
+	"#given user removed installed ultrawork service tier #when reinstalling after snapshot refresh #then removal survives",
+	async () => {
+		const repoRoot = await makeTempDir();
+		const codexHome = await makeTempDir();
+		const codexPackageRoot = join(repoRoot, "packages", "omo-codex");
+		const pluginRoot = join(codexPackageRoot, "plugin");
+		const agentsRoot = join(pluginRoot, "components", "ultrawork", "agents");
+
+		await writeJson(join(codexPackageRoot, "marketplace.json"), {
+			name: "sisyphuslabs",
+			plugins: [{ name: "omo", source: "./plugins/omo" }],
+		});
+		await writePluginAt(pluginRoot, "omo", "0.1.0");
+		await mkdir(agentsRoot, { recursive: true });
+		await writeFile(
+			join(agentsRoot, "explorer.toml"),
+			'name = "explorer"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "low"\nservice_tier = "fast"\n',
+		);
+
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+		await writeFile(join(codexHome, "agents", "explorer.toml"), 'name = "explorer"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "low"\n');
+		await installMarketplaceLocally({
+			repoRoot,
+			codexHome,
+			platform: "linux",
+			runCommand: async () => {},
+			log: () => {},
+		});
+
+		const installedExplorer = await readFile(join(codexHome, "agents", "explorer.toml"), "utf8");
+		assert.equal(installedExplorer.includes("service_tier"), false);
+	},
+);
+
+test(
 	"#given user edited installed ultrawork plan #when reinstalling after snapshot refresh #then bundled snapshot target retains xhigh",
 	async () => {
 		const repoRoot = await makeTempDir();

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -13,7 +13,7 @@ import {
 	pruneMarketplacePluginCaches,
 } from "./install/cache.mjs";
 import { agentSourceRootsForInstall } from "./install/agent-source-roots.mjs";
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./install/agents.mjs";
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./install/agents.mjs";
 import { writeCachedMarketplaceManifest } from "./install/cached-marketplace-manifest.mjs";
 import { updateCodexConfig } from "./install/config.mjs";
 import {
@@ -116,10 +116,11 @@ export async function installMarketplaceLocally(options = {}) {
 	}
 
 	const preservedReasoning = await capturePreservedAgentReasoning({ codexHome });
+	const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome });
 	const agentSourceRoots = await agentSourceRootsForInstall({ codexHome, marketplace, installed, pluginSources });
 	for (const plugin of installed) {
 		const pluginRoot = agentSourceRoots.get(plugin.name) ?? plugin.path;
-		const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning });
+		const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning, preservedServiceTier });
 		for (const link of agentLinks) {
 			log(`Linked agent ${link.name} -> ${link.target}`);
 			const agentName = agentNameFromToml(link.name);

--- a/packages/omo-codex/scripts/install/agents.mjs
+++ b/packages/omo-codex/scripts/install/agents.mjs
@@ -22,7 +22,22 @@ export async function capturePreservedAgentReasoning({ codexHome }) {
 	return preserved;
 }
 
-export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedReasoning = new Map() }) {
+export async function capturePreservedAgentServiceTier({ codexHome }) {
+	const agentsDir = join(codexHome, "agents");
+	if (!(await exists(agentsDir))) return new Map();
+
+	const preserved = new Map();
+	const agentEntries = await readdir(agentsDir, { withFileTypes: true });
+	for (const entry of agentEntries) {
+		if (!entry.name.endsWith(".toml")) continue;
+		const content = await readTextIfExists(join(agentsDir, entry.name));
+		if (content === null) continue;
+		preserved.set(agentNameFromToml(entry.name), extractServiceTier(content));
+	}
+	return preserved;
+}
+
+export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedReasoning = new Map(), preservedServiceTier = new Map() }) {
 	const bundledAgents = await discoverBundledAgents(pluginRoot);
 	if (bundledAgents.length === 0) {
 		await writeManifest(pluginRoot, []);
@@ -38,10 +53,24 @@ export async function linkCachedPluginAgents({ codexHome, pluginRoot, preservedR
 		const linkPath = join(agentsDir, agentFileName);
 		await replaceWithCopy(linkPath, agentPath);
 		await restorePreservedReasoning({ linkPath, target: agentPath, value: preservedReasoning.get(agentName) });
+		await restorePreservedServiceTier({
+			linkPath,
+			preserved: preservedServiceTier.has(agentName),
+			value: preservedServiceTier.get(agentName) ?? null,
+		});
 		linked.push({ name: agentFileName, path: linkPath, target: agentPath });
 	}
 	await writeManifest(pluginRoot, linked.map((entry) => entry.path));
 	return linked;
+}
+
+async function restorePreservedServiceTier({ linkPath, preserved, value }) {
+	if (!preserved) return;
+	const content = await readFile(linkPath, "utf8");
+	if (extractServiceTier(content) === value) return;
+	const replacement = replaceServiceTier(content, value);
+	if (!replacement.replaced) return;
+	await writeFile(linkPath, replacement.content);
 }
 
 async function discoverBundledAgents(pluginRoot) {
@@ -106,27 +135,71 @@ async function readTextIfExists(path) {
 }
 
 function extractReasoningEffort(content) {
+	return extractTopLevelStringSetting(content, "model_reasoning_effort");
+}
+
+function extractServiceTier(content) {
+	return extractTopLevelStringSetting(content, "service_tier");
+}
+
+function extractTopLevelStringSetting(content, key) {
 	for (const line of content.split(/\n/)) {
 		if (isSectionHeader(line)) return null;
-		const match = line.match(/^\s*model_reasoning_effort\s*=\s*("(?:[^"\\]|\\.)*")/);
-		if (match === null) continue;
-		return JSON.parse(match[1]);
+		const rawValue = topLevelStringSettingRawValue(line, key);
+		if (rawValue === undefined) continue;
+		return JSON.parse(rawValue);
 	}
 	return null;
 }
 
 function replaceReasoningEffort(content, value) {
+	return replaceTopLevelStringSetting(content, "model_reasoning_effort", value, { insertIfMissing: false });
+}
+
+function replaceServiceTier(content, value) {
+	return replaceTopLevelStringSetting(content, "service_tier", value, { insertIfMissing: true });
+}
+
+function replaceTopLevelStringSetting(content, key, value, options) {
 	let replaced = false;
 	const lines = content.split(/\n/);
 	for (let index = 0; index < lines.length; index += 1) {
 		const line = lines[index];
 		if (isSectionHeader(line)) break;
-		if (!/^\s*model_reasoning_effort\s*=/.test(line)) continue;
+		if (topLevelStringSettingRawValue(line, key) === undefined) continue;
+		if (value === null) {
+			lines.splice(index, 1);
+			replaced = true;
+			break;
+		}
 		lines[index] = line.replace(/=\s*"(?:[^"\\]|\\.)*"/, `= ${JSON.stringify(value)}`);
 		replaced = true;
 		break;
 	}
+	if (!replaced && value !== null && options.insertIfMissing) {
+		lines.splice(topLevelInsertionIndex(lines), 0, `${key} = ${JSON.stringify(value)}`);
+		replaced = true;
+	}
 	return { content: lines.join("\n"), replaced };
+}
+
+function topLevelStringSettingRawValue(line, key) {
+	const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*("(?:[^"\\]|\\.)*")/);
+	if (match === null) return undefined;
+	const settingKey = match[1];
+	const rawValue = match[2];
+	if (settingKey !== key || rawValue === undefined) return undefined;
+	return rawValue;
+}
+
+function topLevelInsertionIndex(lines) {
+	const sectionIndex = lines.findIndex((line) => isSectionHeader(line));
+	const topLevelEnd = sectionIndex === -1 ? lines.length : sectionIndex;
+	let insertionIndex = topLevelEnd;
+	while (insertionIndex > 0 && lines[insertionIndex - 1] === "") {
+		insertionIndex -= 1;
+	}
+	return insertionIndex;
 }
 
 function isSectionHeader(line) {

--- a/packages/omo-opencode/src/cli/install-codex/AGENTS.md
+++ b/packages/omo-opencode/src/cli/install-codex/AGENTS.md
@@ -15,7 +15,7 @@ Installs the `omo` plugin into `~/.codex/` for the Codex CLI Light edition. Entr
 | `codex-marketplace.ts` | Reads `packages/omo-codex/marketplace.json` and per-plugin `.codex-plugin/plugin.json`; validates path segments |
 | `codex-cache-install.ts` | Builds source, copies to temp cache dir, runs `npm ci --omit=dev`, rewrites MCP manifest, atomically promotes to `~/.codex/plugins/cache/{marketplace}/{name}/{version}/` |
 | `codex-cache-bins.ts` | Discovers `package.json` `bin` entries, links component CLIs into bin dir; writes `omo` runtime wrapper (POSIX shell / Windows `.cmd`) |
-| `link-cached-plugin-agents.ts` | Discovers bundled agent TOMLs under `components/*/agents/`, copies to `~/.codex/agents/`, preserves existing `model_reasoning_effort`, writes `.installed-agents.json` manifest |
+| `link-cached-plugin-agents.ts` | Discovers bundled agent TOMLs under `components/*/agents/`, copies to `~/.codex/agents/`, preserves existing `model_reasoning_effort` and `service_tier`, writes `.installed-agents.json` manifest |
 | `codex-marketplace-snapshot.ts` | Writes local marketplace snapshot to `~/.codex/.tmp/marketplaces/{marketplace}/` |
 | `codex-config-toml.ts` | Mutates `~/.codex/config.toml`: enables features, sets marketplace/plugin/agent/hook-trust blocks, optional autonomous permissions |
 | `codex-cleanup.ts` | Uninstall orchestrator: removes cache, agents, config blocks, project-local artifacts |

--- a/packages/omo-opencode/src/cli/install-codex/install-codex.ts
+++ b/packages/omo-opencode/src/cli/install-codex/install-codex.ts
@@ -7,7 +7,7 @@ import { shouldBuildSourcePackages } from "./codex-package-layout"
 import { updateCodexConfig } from "./codex-config-toml"
 import { trustedHookStatesForPlugin } from "./codex-hook-trust"
 import { prepareGitBashForInstall, resolveGitBashForCurrentProcess } from "./git-bash"
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./link-cached-plugin-agents"
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./link-cached-plugin-agents"
 import { readMarketplace, readPluginManifest, resolvePluginSource, validatePathSegment } from "./codex-marketplace"
 import { writeInstalledMarketplaceSnapshot, type MarketplaceSnapshotPluginSource } from "./codex-marketplace-snapshot"
 import {
@@ -106,6 +106,7 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   }
 
   const preservedReasoning = await capturePreservedAgentReasoning({ codexHome })
+  const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome })
   const agentSourceRoots = await agentSourceRootsForInstall({
     codexHome,
     marketplace,
@@ -114,7 +115,13 @@ export async function runCodexInstaller(options: CodexInstallOptions = {}): Prom
   })
   for (const plugin of installed) {
     const pluginRoot = agentSourceRoots.get(plugin.name) ?? plugin.path
-    const agentLinks = await linkCachedPluginAgents({ codexHome, pluginRoot, platform, preservedReasoning })
+    const agentLinks = await linkCachedPluginAgents({
+      codexHome,
+      pluginRoot,
+      platform,
+      preservedReasoning,
+      preservedServiceTier,
+    })
     for (const link of agentLinks) {
       log(`Linked agent ${link.name} -> ${link.target}`)
       const agentName = agentNameFromToml(link.name)

--- a/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.test.ts
+++ b/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test"
 import { lstat, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { capturePreservedAgentReasoning, linkCachedPluginAgents } from "./link-cached-plugin-agents"
+import { capturePreservedAgentReasoning, capturePreservedAgentServiceTier, linkCachedPluginAgents } from "./link-cached-plugin-agents"
 
 async function makeFixture(): Promise<{ codexHome: string; pluginRoot: string }> {
   const root = await mkdtemp(join(tmpdir(), "omo-codex-agents-"))
@@ -140,6 +140,30 @@ describe("linkCachedPluginAgents", () => {
     const content = await readFile(join(agentsDir, "planner.toml"), "utf8")
     expect(content).toContain('model_reasoning_effort = "high"')
     expect(content).not.toContain('model_reasoning_effort = "xhigh"')
+    expect((await lstat(join(agentsDir, "planner.toml"))).isSymbolicLink()).toBe(false)
+  })
+
+  test("preserves removed installed agent service tier when reinstalling file copies", async () => {
+    // given
+    const { codexHome, pluginRoot } = await makeFixture()
+    const agentsDir = join(codexHome, "agents")
+    await mkdir(agentsDir, { recursive: true })
+    await writeFile(
+      join(pluginRoot, "components", "ulw-loop", "agents", "planner.toml"),
+      'name = "planner"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\nservice_tier = "fast"\n',
+    )
+    await writeFile(
+      join(agentsDir, "planner.toml"),
+      'name = "planner"\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+    )
+    const preservedServiceTier = await capturePreservedAgentServiceTier({ codexHome })
+
+    // when
+    await linkCachedPluginAgents({ codexHome, pluginRoot, platform: "linux", preservedServiceTier })
+
+    // then
+    const content = await readFile(join(agentsDir, "planner.toml"), "utf8")
+    expect(content).not.toContain("service_tier")
     expect((await lstat(join(agentsDir, "planner.toml"))).isSymbolicLink()).toBe(false)
   })
 

--- a/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts
+++ b/packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts
@@ -29,11 +29,29 @@ export async function capturePreservedAgentReasoning(input: {
   return preserved
 }
 
+export async function capturePreservedAgentServiceTier(input: {
+  readonly codexHome: string
+}): Promise<ReadonlyMap<string, string | null>> {
+  const agentsDir = join(input.codexHome, "agents")
+  if (!(await exists(agentsDir))) return new Map()
+
+  const preserved = new Map<string, string | null>()
+  const agentEntries = await readdir(agentsDir, { withFileTypes: true })
+  for (const entry of agentEntries) {
+    if (!entry.name.endsWith(".toml")) continue
+    const content = await readTextIfExists(join(agentsDir, entry.name))
+    if (content === null) continue
+    preserved.set(agentNameFromToml(entry.name), extractServiceTier(content))
+  }
+  return preserved
+}
+
 export async function linkCachedPluginAgents(input: {
   readonly codexHome: string
   readonly pluginRoot: string
   readonly platform?: LinkPlatform
   readonly preservedReasoning?: ReadonlyMap<string, string>
+  readonly preservedServiceTier?: ReadonlyMap<string, string | null>
 }): Promise<readonly LinkedAgent[]> {
   const bundledAgents = await discoverBundledAgents(input.pluginRoot)
   if (bundledAgents.length === 0) {
@@ -54,6 +72,11 @@ export async function linkCachedPluginAgents(input: {
       target: agentPath,
       value: input.preservedReasoning?.get(agentName),
     })
+    await restorePreservedServiceTier({
+      linkPath,
+      preserved: input.preservedServiceTier?.has(agentName) ?? false,
+      value: input.preservedServiceTier?.get(agentName) ?? null,
+    })
     linked.push({ name: agentFileName, path: linkPath, target: agentPath })
   }
   await writeManifest(
@@ -61,6 +84,19 @@ export async function linkCachedPluginAgents(input: {
     linked.map((entry) => entry.path),
   )
   return linked
+}
+
+async function restorePreservedServiceTier(input: {
+  readonly linkPath: string
+  readonly preserved: boolean
+  readonly value: string | null
+}): Promise<void> {
+  if (!input.preserved) return
+  const content = await readFile(input.linkPath, "utf8")
+  if (extractServiceTier(content) === input.value) return
+  const replacement = replaceServiceTier(content, input.value)
+  if (!replacement.replaced) return
+  await writeFile(input.linkPath, replacement.content)
 }
 
 async function discoverBundledAgents(pluginRoot: string): Promise<readonly string[]> {
@@ -140,10 +176,17 @@ async function readTextIfExists(path: string): Promise<string | null> {
 }
 
 function extractReasoningEffort(content: string): string | null {
+  return extractTopLevelStringSetting(content, "model_reasoning_effort")
+}
+
+function extractServiceTier(content: string): string | null {
+  return extractTopLevelStringSetting(content, "service_tier")
+}
+
+function extractTopLevelStringSetting(content: string, key: string): string | null {
   for (const line of content.split(/\n/)) {
     if (isSectionHeader(line)) return null
-    const match = line.match(/^\s*model_reasoning_effort\s*=\s*("(?:[^"\\]|\\.)*")/)
-    const rawValue = match?.[1]
+    const rawValue = topLevelStringSettingRawValue(line, key)
     if (rawValue === undefined) continue
     const parsed = parseJsonString(rawValue)
     if (parsed !== null) return parsed
@@ -152,15 +195,54 @@ function extractReasoningEffort(content: string): string | null {
 }
 
 function replaceReasoningEffort(content: string, value: string): { readonly content: string; readonly replaced: boolean } {
+  return replaceTopLevelStringSetting(content, "model_reasoning_effort", value, { insertIfMissing: false })
+}
+
+function replaceServiceTier(content: string, value: string | null): { readonly content: string; readonly replaced: boolean } {
+  return replaceTopLevelStringSetting(content, "service_tier", value, { insertIfMissing: true })
+}
+
+function replaceTopLevelStringSetting(
+  content: string,
+  key: string,
+  value: string | null,
+  options: { readonly insertIfMissing: boolean },
+): { readonly content: string; readonly replaced: boolean } {
   const lines = content.split(/\n/)
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]
     if (line === undefined || isSectionHeader(line)) break
-    if (!/^\s*model_reasoning_effort\s*=/.test(line)) continue
+    if (topLevelStringSettingRawValue(line, key) === undefined) continue
+    if (value === null) {
+      lines.splice(index, 1)
+      return { content: lines.join("\n"), replaced: true }
+    }
     lines[index] = line.replace(/=\s*"(?:[^"\\]|\\.)*"/, `= ${JSON.stringify(value)}`)
     return { content: lines.join("\n"), replaced: true }
   }
-  return { content, replaced: false }
+
+  if (value === null || !options.insertIfMissing) return { content, replaced: false }
+  lines.splice(topLevelInsertionIndex(lines), 0, `${key} = ${JSON.stringify(value)}`)
+  return { content: lines.join("\n"), replaced: true }
+}
+
+function topLevelStringSettingRawValue(line: string, key: string): string | undefined {
+  const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*("(?:[^"\\]|\\.)*")/)
+  if (match === null) return undefined
+  const settingKey = match[1]
+  const rawValue = match[2]
+  if (settingKey !== key || rawValue === undefined) return undefined
+  return rawValue
+}
+
+function topLevelInsertionIndex(lines: readonly string[]): number {
+  const sectionIndex = lines.findIndex((line) => isSectionHeader(line))
+  const topLevelEnd = sectionIndex === -1 ? lines.length : sectionIndex
+  let insertionIndex = topLevelEnd
+  while (insertionIndex > 0 && lines[insertionIndex - 1] === "") {
+    insertionIndex -= 1
+  }
+  return insertionIndex
 }
 
 function isSectionHeader(line: string): boolean {


### PR DESCRIPTION
## Summary

LazyCodex reinstall/auto-update unconditionally copies the bundled agent TOMLs over the user's files and then restores only `model_reasoning_effort` — there is no preservation path for `service_tier`, so a user who removed `service_tier` (e.g. because `fast` is rejected for gpt-5.5: "Service tier fast is not supported for model gpt-5.5") gets it silently reintroduced on every install/update. The same gap exists in both code paths: the packaged installer script (`packages/omo-codex/scripts/install/agents.mjs`) and the TypeScript installer helper (`packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts`).

Closes #5020

Builds on #5058 by @Hungdoan565 — all five commits cherry-picked with original authorship. This branch is the same fix rebased onto current `dev`, addressing the review feedback on #5058:

- **CI**: the `codex-compatibility` failures on #5058 were stale-base — the identical check failed on unrelated open PRs touching zero codex code, and `dev` is green. On this branch, the full `bun run test:codex` gate passes locally (exit 0; final stage 244 pass / 0 fail).
- **Scope**: confirmed single concern — the 7 touched files are the same `service_tier` preservation mirrored in the `.mjs` installer + the TS installer, their tests, and one `AGENTS.md` table row.

## Behavior

`capturePreservedAgentServiceTier` records each existing user TOML's `service_tier` state (value **or** absence) before the copy, and `restorePreservedServiceTier` reapplies it afterwards — so user removals survive, user-set values survive, and bundled defaults still apply on fresh installs. Mirrors the existing `model_reasoning_effort` preservation introduced in #4712.

## Verification

- RED (base = current `dev` @ 165b534a3, test commits only): `.mjs` test fails — `service_tier` present after reinstall (`actual: true, expected: false`); TS test fails likewise (1 fail)
- GREEN (all commits): `install-agent-links.test.mjs` 8 pass / 0 fail; `link-cached-plugin-agents.test.ts` 13 pass / 0 fail; full `bun run test:codex` exit 0
- QA: sandboxed functional reinstall through the real `installMarketplaceLocally` entrypoint with the real bundled TOMLs — user removes `service_tier`, reinstall does **not** reintroduce it, `model_reasoning_effort="high"` preserved (3/3 PASS, NOT-REPRODUCED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves agent `service_tier` customizations across installs/reinstalls so user removals or choices aren’t overwritten. Addresses #5020 by preventing `fast` from being reintroduced for models like `gpt-5.5` that don’t support it.

- **Bug Fixes**
  - Capture and restore per-agent `service_tier` (value or absence) during install, mirroring existing `model_reasoning_effort` preservation.
  - Implemented in both paths: `packages/omo-codex/scripts/install/agents.mjs` and `packages/omo-opencode/src/cli/install-codex/link-cached-plugin-agents.ts`, with call sites updated.
  - Added tests for reinstall preservation in both codepaths and updated `AGENTS.md` to document the behavior.

<sup>Written for commit 27d712362573b727b3eca9155ffb5f06dec89268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

