### PR TITLE
fix(session-inspection): include tool-call parts in full-session output

### DIFF
--- a/packages/omo-opencode/src/tools/background-task/clients.ts
+++ b/packages/omo-opencode/src/tools/background-task/clients.ts
@@ -10,6 +10,8 @@ export type BackgroundOutputMessage = {
     content?: string | Array<{ type: string; text?: string }>
     output?: string
     name?: string
+    tool?: string
+    input?: unknown
   }>
 }
 

--- a/packages/omo-opencode/src/tools/background-task/full-session-format-tool-calls.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format-tool-calls.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="bun-types" />
+
+// Regression test: full-session output (used by background_output full_session /
+// include_tool_results) used to drop tool_use/tool parts entirely, so callers saw
+// tool RESULTS but never the tool CALLS or their arguments. The filter + renderer
+// now include tool calls (gated on includeToolResults), mirroring session-formatter.
+
+import { describe, expect, test } from "bun:test"
+import type { BackgroundTask } from "../../features/background-agent"
+import type { BackgroundOutputClient, BackgroundOutputMessagesResult } from "./clients"
+import { formatFullSession } from "./full-session-format"
+
+function makeTask(): BackgroundTask {
+  return {
+    id: "bg_test",
+    description: "test task",
+    status: "completed",
+    sessionId: "ses_test",
+  } as unknown as BackgroundTask
+}
+
+function makeClient(messages: BackgroundOutputMessagesResult): BackgroundOutputClient {
+  return { session: { messages: async () => messages } }
+}
+
+const toolMessage: BackgroundOutputMessagesResult = {
+  data: [
+    {
+      id: "m1",
+      info: { role: "assistant" },
+      parts: [
+        { type: "tool", tool: "grep", input: { pattern: "needle", path: "src" } },
+        { type: "tool_result", output: "found needle" },
+      ],
+    },
+  ],
+}
+
+describe("formatFullSession tool-call rendering", () => {
+  test("includeToolResults=true renders tool calls WITH their input arguments", async () => {
+    const output = await formatFullSession(makeTask(), makeClient(toolMessage), {
+      includeThinking: false,
+      includeToolResults: true,
+    })
+
+    expect(output).toContain("[tool: grep]")
+    expect(output).toContain("pattern")
+    expect(output).toContain("needle")
+    expect(output).toContain("[tool result] found needle")
+  })
+
+  test("includeToolResults=false omits tool calls and tool results", async () => {
+    const output = await formatFullSession(makeTask(), makeClient(toolMessage), {
+      includeThinking: false,
+      includeToolResults: false,
+    })
+
+    expect(output).not.toContain("[tool: grep]")
+    expect(output).not.toContain("[tool result]")
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/full-session-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/full-session-format.ts
@@ -94,6 +94,9 @@ export async function formatFullSession(
       if (part.type === "tool_result") {
         return includeToolResults
       }
+      if (part.type === "tool_use" || part.type === "tool") {
+        return includeToolResults
+      }
       return part.type === "text"
     })
 
@@ -147,6 +150,9 @@ export async function formatFullSession(
         for (const toolText of toolTexts) {
           lines.push(`[tool result] ${toolText}`)
         }
+      } else if ((part.type === "tool_use" || part.type === "tool") && part.tool) {
+        const input = part.input === undefined ? "" : truncateText(JSON.stringify(part.input), thinkingMaxChars)
+        lines.push(`[tool: ${part.tool}] ${input}`.trimEnd())
       }
     }
   }


### PR DESCRIPTION
## Summary

`background_output(full_session=true, include_tool_results=true)` rendered tool RESULTS but silently dropped the tool CALLS (`tool_use`/`tool` parts) — callers could never see which tool ran or with what arguments (#5100).

Builds on #5024 by @sjawhar (cherry-picked, authorship preserved): the full-session part filter and renderer now include tool-call parts, gated on `include_tool_results`, rendering `[tool: name] {json input}` — byte-mirroring the existing `session-formatter.ts` convention.

## Top-up over #5024

Pure path-rename fallout, as expected: the new regression test landed at the pre-refactor `src/tools/background-task/` path; relocated to `packages/omo-opencode/src/tools/background-task/` (zero content changes — relative imports already correct). The review blocker on #5024 was only the missing linked issue, which this PR carries.

## Evidence

- RED (base, PR's test relocated): output contained `[tool result] found needle` but no `[tool: grep]` line (`.ulw/evidence/i5100-red.txt`)
- GREEN: background-task package 37 pass / 0 fail (`i5100-green.txt`)
- QA: real `background_output` tool execution in an isolated XDG sandbox — output shows `[tool: grep] {"pattern":"needle","path":"src"}` alongside the result, and omits both when `include_tool_results=false`; 5/5 checks, NOT-REPRODUCED (`i5100-qa.txt`)

Closes #5100

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing tool-call details in full-session output so `background_output(full_session=true, include_tool_results=true)` shows the tool name and input, not just results; closes #5100.

- **Bug Fixes**
  - Include `tool_use`/`tool` parts when `includeToolResults=true`, rendering `[tool: name] {json input}` before existing `[tool result] ...`.
  - Extend `BackgroundOutputMessage` part shape to include `tool` and `input`.
  - Omit both tool calls and results when `includeToolResults=false`; added a regression test to cover both paths.

<sup>Written for commit ccc4fa01a725f834a4d4511935e6913c00f5aee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

