### PR TITLE
fix(tool-metadata-store): recover metadata across diverging session ids

### DIFF
--- a/packages/omo-opencode/src/features/tool-metadata-store/recover-tool-metadata.test.ts
+++ b/packages/omo-opencode/src/features/tool-metadata-store/recover-tool-metadata.test.ts
@@ -44,4 +44,46 @@ describe("recoverToolMetadata", () => {
     expect(missing).toBeUndefined()
     expect(blank).toBeUndefined()
   })
+
+  test("#given metadata stored under a diverging session id #when recovering with the same call id #then the payload is recovered once", () => {
+    // given
+    const payload = { title: "Background explore", metadata: { sessionId: "ses_child_explore" } }
+    storeToolMetadata("ses_child_explore", "call_abc123", payload)
+
+    // when
+    const recovered = recoverToolMetadata("ses_parent_main", { callID: "call_abc123" })
+    const consumedAgain = recoverToolMetadata("ses_child_explore", { callID: "call_abc123" })
+
+    // then
+    expect(recovered).toEqual(payload)
+    expect(consumedAgain).toBeUndefined()
+  })
+
+  test("#given the same call id stored in own and foreign sessions #when recovering #then the own session entry wins", () => {
+    // given
+    const ownPayload = { title: "Own session" }
+    const foreignPayload = { title: "Foreign session" }
+    storeToolMetadata("ses_own", "call_dup", ownPayload)
+    storeToolMetadata("ses_foreign", "call_dup", foreignPayload)
+
+    // when
+    const recovered = recoverToolMetadata("ses_own", { callID: "call_dup" })
+
+    // then
+    expect(recovered).toEqual(ownPayload)
+  })
+
+  test("#given the same call id pending in multiple foreign sessions #when recovering #then the ambiguous match is declined", () => {
+    // given
+    storeToolMetadata("ses_a", "call_collide", { title: "A" })
+    storeToolMetadata("ses_b", "call_collide", { title: "B" })
+
+    // when
+    const recovered = recoverToolMetadata("ses_other", { callID: "call_collide" })
+
+    // then
+    expect(recovered).toBeUndefined()
+    expect(recoverToolMetadata("ses_a", { callID: "call_collide" })).toEqual({ title: "A" })
+    expect(recoverToolMetadata("ses_b", { callID: "call_collide" })).toEqual({ title: "B" })
+  })
 })

--- a/packages/omo-opencode/src/features/tool-metadata-store/store.ts
+++ b/packages/omo-opencode/src/features/tool-metadata-store/store.ts
@@ -54,19 +54,50 @@ export function storeToolMetadata(
 /**
  * Consume stored metadata (one-time read, removes from store).
  * Called from tool.execute.after hook.
+ *
+ * For background/child sessions the after-hook's sessionID can diverge
+ * from the execute() sessionID, so an exact-key miss falls back to the
+ * callID alone — but only when exactly one session holds that callID,
+ * declining ambiguous cross-session collisions.
  */
 export function consumeToolMetadata(
   sessionID: string,
   callID: string
 ): PendingToolMetadata | undefined {
-  const key = makeKey(sessionID, callID)
+  const stored = takeEntry(makeKey(sessionID, callID)) ?? takeUnambiguousCallIDEntry(callID)
+  if (!stored) {
+    return undefined
+  }
+  const { storedAt: _, ...data } = stored
+  return data
+}
+
+function takeEntry(key: string): (PendingToolMetadata & { storedAt: number }) | undefined {
   const stored = pendingStore.get(key)
   if (stored) {
     pendingStore.delete(key)
-    const { storedAt: _, ...data } = stored
-    return data
   }
-  return undefined
+  return stored
+}
+
+function callIDOfKey(key: string): string {
+  return key.slice(key.indexOf(":") + 1)
+}
+
+function takeUnambiguousCallIDEntry(
+  callID: string
+): (PendingToolMetadata & { storedAt: number }) | undefined {
+  let matchedKey: string | undefined
+  for (const key of pendingStore.keys()) {
+    if (callIDOfKey(key) !== callID) {
+      continue
+    }
+    if (matchedKey !== undefined) {
+      return undefined
+    }
+    matchedKey = key
+  }
+  return matchedKey === undefined ? undefined : takeEntry(matchedKey)
 }
 
 /**

--- a/packages/omo-opencode/src/features/tool-metadata-store/store.ts
+++ b/packages/omo-opencode/src/features/tool-metadata-store/store.ts
@@ -57,7 +57,7 @@ export function storeToolMetadata(
  *
  * For background/child sessions the after-hook's sessionID can diverge
  * from the execute() sessionID, so an exact-key miss falls back to the
- * callID alone — but only when exactly one session holds that callID,
+ * callID alone - but only when exactly one session holds that callID,
  * declining ambiguous cross-session collisions.
  */
 export function consumeToolMetadata(


### PR DESCRIPTION
## Summary

- `tool.execute.before`/`execute()` stores pending tool metadata under execute()'s `ctx.sessionID` (`publish-tool-metadata.ts:26`), but `tool.execute.after` recovers with the after-hook's `input.sessionID` (`plugin/tool-execute-after.ts:81`). For background/child sessions (explore/librarian) those diverge, so the `sessionID:callID` lookup missed → `[tool-execute-after] Unable to recover stored metadata and no native session linkage was present` → tool-pair-validator synthetic repairs re-trigger validation → infinite repair loop / UI hang.
- Fix: on an exact-key miss, `consumeToolMetadata` falls back to matching the `callID` alone — consuming the entry only when **exactly one** session holds that callID, and declining ambiguous cross-session collisions (which then behave exactly as today). Exact same-session matches always win.

## On callID uniqueness

`callID` is opencode's `options.toolCallId` (opencode `packages/opencode/src/session/tools.ts:45`, verified at opencode `8a2cfc00c`), i.e. the AI SDK tool-call id — a provider-generated random token (`toolu_*` for Anthropic, `call_*` for OpenAI) or AI-SDK `generateId()` fallback. Uniqueness across sessions is therefore probabilistic, not contractual (degenerate OpenAI-compatible proxies can emit sequential ids like `call_0`). The fallback is designed for that reality: it only fires after an exact miss, and only when the callID match is unambiguous — under a real cross-session collision it declines and behavior equals the current HEAD behavior, so it can never do worse than today.

## Supersedes #4637

PR #4637 attempted this fix but (a) restructuring the store to `Map<sessionID, Map<callID, ...>>` still requires the **same** sessionID at recovery, so the verified divergent-sessionID miss persists, and (b) its committed file content does not compile (`metadata>: Record<...>`, `):=void {`, `pendingStore.get(sessionID)!nset(...)`, `STALE_TOLIMEN_MS`). This PR is a fresh implementation.

## Changes

- `src/features/tool-metadata-store/store.ts` — exact-key consume extracted to `takeEntry`; new `takeUnambiguousCallIDEntry` fallback.
- `src/features/tool-metadata-store/recover-tool-metadata.test.ts` — divergent-session recovery (the bug), own-session priority over foreign duplicates, ambiguous-collision declination with entries left intact.

## Evidence

- RED (base): divergent-session recovery `expected {title: "Background explore", ...} / received undefined`.
- GREEN: 6/6 in the touched test file; full `src/features/tool-metadata-store` 35/35; consumer `src/plugin/tool-execute-after.test.ts` 6/6; LSP diagnostics clean.
- QA (adapted from the issue-sweep repro, run against this branch): cross-session recovery returns the stored metadata, one-time consume preserved, ambiguous collisions declined with both entries intact. Verdict: NOT-REPRODUCED.

Note: the full end-to-end infinite repair loop needs live background child sessions with a real provider; per the sweep SOP the proven mechanism one level below (the structurally unrecoverable metadata) is what this fixes.

## Related Issues

Closes #4636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery of pending tool metadata when `execute()` and `after` hooks see different `sessionID`s, preventing infinite repair loops and UI hangs. Closes #4636.

- **Bug Fixes**
  - `consumeToolMetadata` now falls back to a callID-only lookup on exact-key miss, consuming only when exactly one session holds that callID; ambiguous matches are declined. Exact same-session matches still win.
  - Extracted exact-key consume to `takeEntry`; added `takeUnambiguousCallIDEntry`.
  - Added tests for cross-session recovery, own-session priority over foreign duplicates, and declining ambiguous collisions.

- **Refactors**
  - Replaced em dash with hyphen in comments per repo convention.

<sup>Written for commit 442c171e84610a5ffdf5798a602d7da0e35203a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

