### PR TITLE
fix(cli): align installer no-provider warning with ultimate fallback and Bailian

### DIFF
--- a/packages/omo-opencode/src/cli/cli-installer.test.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import * as configManager from "./config-manager"
 import * as codexInstaller from "./install-codex"
 import { runCliInstaller } from "./cli-installer"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
+import { getNoModelProvidersWarning } from "./provider-availability"
 import type { InstallArgs } from "./types"
 
 describe("runCliInstaller", () => {
@@ -234,6 +236,68 @@ describe("runCliInstaller", () => {
     expect(result).toBe(0)
     const output = mockConsoleLog.mock.calls.map((call) => call.join(" ")).join("\n")
     expect(output).not.toContain("No model providers configured")
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+  })
+
+  it("warns with ultimate fallback when no providers are configured", async () => {
+    const restoreSpies = [
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        installedVersion: null,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.4.0"),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+    ]
+
+    const args: InstallArgs = {
+      tui: false,
+      platform: "opencode",
+      claude: "no",
+      openai: "no",
+      gemini: "no",
+      copilot: "no",
+      opencodeZen: "no",
+      zaiCodingPlan: "no",
+      kimiForCoding: "no",
+      opencodeGo: "no",
+      bailianCodingPlan: "no",
+      minimaxCnCodingPlan: "no",
+      minimaxCodingPlan: "no",
+      vercelAiGateway: "no",
+    }
+
+    const result = await runCliInstaller(args, "3.4.0")
+
+    expect(result).toBe(0)
+    const output = mockConsoleLog.mock.calls.map((call) => call.join(" ")).join("\n")
+    expect(output).toContain(getNoModelProvidersWarning())
+    expect(output).toContain(ULTIMATE_FALLBACK)
+    expect(output).not.toContain("opencode/big-pickle")
 
     for (const spy of restoreSpies) {
       spy.mockRestore()

--- a/packages/omo-opencode/src/cli/cli-installer.test.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.test.ts
@@ -179,4 +179,64 @@ describe("runCliInstaller", () => {
     writeConfigSpy.mockRestore()
     codexSpy.mockRestore()
   })
+
+  it("does not warn about missing providers when only Bailian is configured", async () => {
+    const restoreSpies = [
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        installedVersion: null,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.4.0"),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+    ]
+
+    const args: InstallArgs = {
+      tui: false,
+      platform: "opencode",
+      claude: "no",
+      openai: "no",
+      gemini: "no",
+      copilot: "no",
+      opencodeZen: "no",
+      zaiCodingPlan: "no",
+      kimiForCoding: "no",
+      opencodeGo: "no",
+      bailianCodingPlan: "yes",
+      minimaxCnCodingPlan: "no",
+      minimaxCodingPlan: "no",
+      vercelAiGateway: "no",
+    }
+
+    const result = await runCliInstaller(args, "3.4.0")
+
+    expect(result).toBe(0)
+    const output = mockConsoleLog.mock.calls.map((call) => call.join(" ")).join("\n")
+    expect(output).not.toContain("No model providers configured")
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+  })
 })

--- a/packages/omo-opencode/src/cli/cli-installer.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.ts
@@ -26,6 +26,7 @@ import {
 import { getUnsupportedOpenCodeVersionMessage } from "./minimum-opencode-version"
 import { runCodexInstaller } from "./install-codex"
 import { starGitHubRepositories } from "./star-request"
+import { getNoModelProvidersWarning, hasAnyConfiguredProvider } from "./provider-availability"
 
 export async function runCliInstaller(args: InstallArgs, version: string): Promise<number> {
   const validation = validateNonTuiArgs(args)
@@ -126,21 +127,8 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     )
   }
 
-  if (
-    config.hasOpenCode &&
-    !config.hasClaude &&
-    !config.hasOpenAI &&
-    !config.hasGemini &&
-    !config.hasCopilot &&
-    !config.hasOpencodeZen &&
-    !config.hasZaiCodingPlan &&
-    !config.hasKimiForCoding &&
-    !config.hasOpencodeGo &&
-    !config.hasMinimaxCnCodingPlan &&
-    !config.hasMinimaxCodingPlan &&
-    !config.hasVercelAiGateway
-  ) {
-    printWarning("No model providers configured. Using opencode/big-pickle as fallback.")
+  if (config.hasOpenCode && !hasAnyConfiguredProvider(config)) {
+    printWarning(getNoModelProvidersWarning())
   }
 
   console.log(`${SYMBOLS.star} ${color.bold(color.green(isUpdate ? "Configuration updated!" : "Installation complete!"))}`)

--- a/packages/omo-opencode/src/cli/model-fallback.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.ts
@@ -21,7 +21,7 @@ import { transformModelForProvider } from "./provider-model-id-transform"
 
 export type { GeneratedOmoConfig } from "./model-fallback-types"
 
-const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
+export const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 
 type CompatibleFallbackSettings = {

--- a/packages/omo-opencode/src/cli/provider-availability.test.ts
+++ b/packages/omo-opencode/src/cli/provider-availability.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test"
 
 import { ULTIMATE_FALLBACK } from "./model-fallback"
 import {
-	getClaudeNoSubscriptionHint,
 	getNoModelProvidersWarning,
 	hasAnyConfiguredProvider,
 	isProviderAvailable,
@@ -47,7 +46,6 @@ describe("provider availability", () => {
     expect(getNoModelProvidersWarning()).toBe(
       `No model providers configured. Using ${ULTIMATE_FALLBACK} as fallback.`,
     )
-    expect(getClaudeNoSubscriptionHint()).toBe(`Will use ${ULTIMATE_FALLBACK} as fallback`)
   })
 
   test("hasAnyConfiguredProvider treats Bailian-only config as configured", () => {

--- a/packages/omo-opencode/src/cli/provider-availability.test.ts
+++ b/packages/omo-opencode/src/cli/provider-availability.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test"
 
-import { isProviderAvailable, toProviderAvailability } from "./provider-availability"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
+import {
+	getClaudeNoSubscriptionHint,
+	getNoModelProvidersWarning,
+	hasAnyConfiguredProvider,
+	isProviderAvailable,
+	toProviderAvailability,
+} from "./provider-availability"
 import type { InstallConfig } from "./types"
 
 function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
@@ -34,5 +41,17 @@ describe("provider availability", () => {
     // #when / #then
     expect(isProviderAvailable("bailian-coding-plan", availability)).toBe(true)
     expect(isProviderAvailable("minimax-coding-plan", availability)).toBe(false)
+  })
+
+  test("installer warning copy uses ultimate fallback constant", () => {
+    expect(getNoModelProvidersWarning()).toBe(
+      `No model providers configured. Using ${ULTIMATE_FALLBACK} as fallback.`,
+    )
+    expect(getClaudeNoSubscriptionHint()).toBe(`Will use ${ULTIMATE_FALLBACK} as fallback`)
+  })
+
+  test("hasAnyConfiguredProvider treats Bailian-only config as configured", () => {
+    expect(hasAnyConfiguredProvider(createConfig({ hasBailianCodingPlan: true }))).toBe(true)
+    expect(hasAnyConfiguredProvider(createConfig())).toBe(false)
   })
 })

--- a/packages/omo-opencode/src/cli/provider-availability.ts
+++ b/packages/omo-opencode/src/cli/provider-availability.ts
@@ -1,5 +1,6 @@
 import type { InstallConfig } from "./types"
 import type { ProviderAvailability } from "./model-fallback-types"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
 
 export function toProviderAvailability(config: InstallConfig): ProviderAvailability {
 	return {
@@ -37,4 +38,30 @@ export function isProviderAvailable(provider: string, availability: ProviderAvai
 		vercel: availability.vercelAiGateway,
 	}
 	return mapping[provider] ?? false
+}
+
+export function hasAnyConfiguredProvider(config: InstallConfig): boolean {
+	const availability = toProviderAvailability(config)
+	return (
+		availability.native.claude ||
+		availability.native.openai ||
+		availability.native.gemini ||
+		availability.copilot ||
+		availability.opencodeZen ||
+		availability.zai ||
+		availability.kimiForCoding ||
+		availability.opencodeGo ||
+		availability.bailianCodingPlan ||
+		availability.minimaxCnCodingPlan ||
+		availability.minimaxCodingPlan ||
+		availability.vercelAiGateway
+	)
+}
+
+export function getNoModelProvidersWarning(): string {
+	return `No model providers configured. Using ${ULTIMATE_FALLBACK} as fallback.`
+}
+
+export function getClaudeNoSubscriptionHint(): string {
+	return `Will use ${ULTIMATE_FALLBACK} as fallback`
 }

--- a/packages/omo-opencode/src/cli/provider-availability.ts
+++ b/packages/omo-opencode/src/cli/provider-availability.ts
@@ -61,7 +61,3 @@ export function hasAnyConfiguredProvider(config: InstallConfig): boolean {
 export function getNoModelProvidersWarning(): string {
 	return `No model providers configured. Using ${ULTIMATE_FALLBACK} as fallback.`
 }
-
-export function getClaudeNoSubscriptionHint(): string {
-	return `Will use ${ULTIMATE_FALLBACK} as fallback`
-}

--- a/packages/omo-opencode/src/cli/tui-install-prompts.test.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import * as p from "@clack/prompts"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
 import * as prompts from "./tui-install-prompts"
 import type { DetectedConfig, InstallConfig, InstallPlatform } from "./types"
 
@@ -136,6 +137,22 @@ describe("promptInstallConfig platform branching", () => {
       expect(selectSpy).toHaveBeenCalledTimes(12)
     },
   )
+
+  test("Claude subscription No option hint uses ultimate fallback", async () => {
+    // given
+    const selectSpy = spyOn(p, "select").mockResolvedValue("no")
+
+    // when
+    await prompts.promptInstallConfig(createDetectedConfig(), "opencode")
+
+    // then
+    const firstCall = selectSpy.mock.calls[0]?.[0]
+    expect(firstCall?.message).toBe("Do you have a Claude Pro/Max subscription?")
+    const options = firstCall?.options as Array<{ value: string; hint?: string }>
+    const noOption = options?.find((o) => o.value === "no")
+    expect(noOption?.hint).toContain(ULTIMATE_FALLBACK)
+    expect(noOption?.hint).not.toContain("big-pickle")
+  })
 
   test("uses explicit Codex autonomous override without asking", async () => {
     // given

--- a/packages/omo-opencode/src/cli/tui-install-prompts.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.ts
@@ -7,6 +7,7 @@ import type {
   InstallPlatform,
 } from "./types"
 import { detectedToInitialValues } from "./install-validators"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
 
 async function selectOrCancel<TValue extends Readonly<string | boolean | number>>(params: {
   message: string
@@ -80,7 +81,7 @@ export async function promptInstallConfig(
   const claude = await selectOrCancel<ClaudeSubscription>({
     message: "Do you have a Claude Pro/Max subscription?",
     options: [
-      { value: "no", label: "No", hint: "Will use opencode/big-pickle as fallback" },
+      { value: "no", label: "No", hint: `Will use ${ULTIMATE_FALLBACK} as fallback` },
       { value: "yes", label: "Yes (standard)", hint: "Claude Opus 4.5 for orchestration" },
       { value: "max20", label: "Yes (max20 mode)", hint: "Full power with Claude Sonnet 4.6 for Librarian" },
     ],

--- a/packages/omo-opencode/src/cli/tui-install-prompts.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.ts
@@ -7,7 +7,6 @@ import type {
   InstallPlatform,
 } from "./types"
 import { detectedToInitialValues } from "./install-validators"
-import { getClaudeNoSubscriptionHint } from "./provider-availability"
 
 async function selectOrCancel<TValue extends Readonly<string | boolean | number>>(params: {
   message: string
@@ -81,7 +80,7 @@ export async function promptInstallConfig(
   const claude = await selectOrCancel<ClaudeSubscription>({
     message: "Do you have a Claude Pro/Max subscription?",
     options: [
-      { value: "no", label: "No", hint: getClaudeNoSubscriptionHint() },
+      { value: "no", label: "No", hint: "Will use opencode/big-pickle as fallback" },
       { value: "yes", label: "Yes (standard)", hint: "Claude Opus 4.5 for orchestration" },
       { value: "max20", label: "Yes (max20 mode)", hint: "Full power with Claude Sonnet 4.6 for Librarian" },
     ],

--- a/packages/omo-opencode/src/cli/tui-install-prompts.ts
+++ b/packages/omo-opencode/src/cli/tui-install-prompts.ts
@@ -7,6 +7,7 @@ import type {
   InstallPlatform,
 } from "./types"
 import { detectedToInitialValues } from "./install-validators"
+import { getClaudeNoSubscriptionHint } from "./provider-availability"
 
 async function selectOrCancel<TValue extends Readonly<string | boolean | number>>(params: {
   message: string
@@ -80,7 +81,7 @@ export async function promptInstallConfig(
   const claude = await selectOrCancel<ClaudeSubscription>({
     message: "Do you have a Claude Pro/Max subscription?",
     options: [
-      { value: "no", label: "No", hint: "Will use opencode/big-pickle as fallback" },
+      { value: "no", label: "No", hint: getClaudeNoSubscriptionHint() },
       { value: "yes", label: "Yes (standard)", hint: "Claude Opus 4.5 for orchestration" },
       { value: "max20", label: "Yes (max20 mode)", hint: "Full power with Claude Sonnet 4.6 for Librarian" },
     ],

--- a/packages/omo-opencode/src/cli/tui-installer.test.ts
+++ b/packages/omo-opencode/src/cli/tui-installer.test.ts
@@ -3,7 +3,10 @@ import * as p from "@clack/prompts"
 import * as configManager from "./config-manager"
 import * as starRequest from "./star-request"
 import * as tuiInstallPrompts from "./tui-install-prompts"
+import { ULTIMATE_FALLBACK } from "./model-fallback"
+import { getNoModelProvidersWarning } from "./provider-availability"
 import { runTuiInstaller } from "./tui-installer"
+import type { InstallConfig } from "./types"
 
 function createMockSpinner(): ReturnType<typeof p.spinner> {
   return {
@@ -145,6 +148,143 @@ describe("runTuiInstaller", () => {
     for (const spy of restoreSpies) {
       spy.mockRestore()
     }
+  })
+
+  function createOpenCodeInstallConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
+    return {
+      platform: "opencode",
+      hasOpenCode: true,
+      hasClaude: false,
+      isMax20: false,
+      hasOpenAI: false,
+      hasGemini: false,
+      hasCopilot: false,
+      hasCodex: false,
+      hasOpencodeZen: false,
+      hasZaiCodingPlan: false,
+      hasKimiForCoding: false,
+      hasOpencodeGo: false,
+      hasBailianCodingPlan: false,
+      hasMinimaxCnCodingPlan: false,
+      hasMinimaxCodingPlan: false,
+      hasVercelAiGateway: false,
+      codexAutonomous: false,
+      ...overrides,
+    }
+  }
+
+  it("does not warn about missing providers when only Bailian is configured", async () => {
+    const warnSpy = spyOn(p.log, "warn").mockImplementation(() => undefined)
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(false),
+      spyOn(p, "outro").mockImplementation(() => undefined),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("opencode"),
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        installedVersion: null,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.4.0"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue(
+        createOpenCodeInstallConfig({ hasBailianCodingPlan: true }),
+      ),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+    ]
+
+    const result = await runTuiInstaller({ tui: true }, "3.16.0")
+
+    expect(result).toBe(0)
+    const warnMessages = warnSpy.mock.calls.map((call) => String(call[0]))
+    expect(warnMessages.some((m) => m.includes("No model providers configured"))).toBe(false)
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    warnSpy.mockRestore()
+  })
+
+  it("warns with ultimate fallback when no providers are configured", async () => {
+    const warnSpy = spyOn(p.log, "warn").mockImplementation(() => undefined)
+    const restoreSpies = [
+      spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
+      spyOn(p, "intro").mockImplementation(() => undefined),
+      spyOn(p.log, "info").mockImplementation(() => undefined),
+      spyOn(p.log, "success").mockImplementation(() => undefined),
+      spyOn(p.log, "message").mockImplementation(() => undefined),
+      spyOn(p, "note").mockImplementation(() => undefined),
+      spyOn(p, "confirm").mockResolvedValue(false),
+      spyOn(p, "outro").mockImplementation(() => undefined),
+      spyOn(tuiInstallPrompts, "promptInstallPlatform").mockResolvedValue("opencode"),
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        installedVersion: null,
+        hasClaude: false,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasCodex: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+        hasBailianCodingPlan: false,
+        hasMinimaxCnCodingPlan: false,
+        hasMinimaxCodingPlan: false,
+        hasVercelAiGateway: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.4.0"),
+      spyOn(tuiInstallPrompts, "promptInstallConfig").mockResolvedValue(createOpenCodeInstallConfig()),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+    ]
+
+    const result = await runTuiInstaller({ tui: true }, "3.16.0")
+
+    expect(result).toBe(0)
+    const warnMessages = warnSpy.mock.calls.map((call) => String(call[0]))
+    expect(warnMessages.some((m) => m.includes(getNoModelProvidersWarning()))).toBe(true)
+    expect(warnMessages.some((m) => m.includes(ULTIMATE_FALLBACK))).toBe(true)
+    expect(warnMessages.some((m) => m.includes("big-pickle"))).toBe(false)
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+    warnSpy.mockRestore()
   })
 
   it("skips OpenCode checks and writes when platform is codex", async () => {

--- a/packages/omo-opencode/src/cli/tui-installer.ts
+++ b/packages/omo-opencode/src/cli/tui-installer.ts
@@ -14,6 +14,7 @@ import { getUnsupportedOpenCodeVersionMessage } from "./minimum-opencode-version
 import { promptInstallConfig, promptInstallPlatform } from "./tui-install-prompts"
 import { detectCodexInstallation, formatCodexInstallationWarning, runCodexInstaller } from "./install-codex"
 import { starGitHubRepositories } from "./star-request"
+import { getNoModelProvidersWarning, hasAnyConfiguredProvider } from "./provider-availability"
 
 export async function runTuiInstaller(args: InstallArgs, version: string): Promise<number> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -106,21 +107,8 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     )
   }
 
-  if (
-    config.hasOpenCode &&
-    !config.hasClaude &&
-    !config.hasOpenAI &&
-    !config.hasGemini &&
-    !config.hasCopilot &&
-    !config.hasOpencodeZen &&
-    !config.hasZaiCodingPlan &&
-    !config.hasKimiForCoding &&
-    !config.hasOpencodeGo &&
-    !config.hasMinimaxCnCodingPlan &&
-    !config.hasMinimaxCodingPlan &&
-    !config.hasVercelAiGateway
-  ) {
-    p.log.warn("No model providers configured. Using opencode/big-pickle as fallback.")
+  if (config.hasOpenCode && !hasAnyConfiguredProvider(config)) {
+    p.log.warn(getNoModelProvidersWarning())
   }
 
   p.note(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")


### PR DESCRIPTION
## Summary

Two installer-end inconsistencies introduced when #4370 manually expanded the no-provider condition:

1. The no-provider warning in both installers was a stale hardcoded literal naming `opencode/big-pickle`, while the actual ultimate fallback is `ULTIMATE_FALLBACK = "opencode/gpt-5-nano"` (`model-fallback.ts:24`). Same stale literal in the TUI Claude "No" option hint.
2. The no-provider predicate omitted `hasBailianCodingPlan`, so Bailian-only installs got a false "No model providers configured" warning.

Closes #5037

Builds on #5042 and #5106 by @islee23520 — all five commits cherry-picked with original authorship onto current `dev`. The two PRs were a deliberate complementary split (#5042: end-of-run warnings + Bailian predicate; #5106: TUI Claude hint); this branch combines them. Re the breadth review on #5042: all touched files are on-topic — `provider-availability.ts` gains the two helpers (`hasAnyConfiguredProvider`, including Bailian, and `getNoModelProvidersWarning` derived from `ULTIMATE_FALLBACK`), both installers swap their hand-rolled predicate + literal for those helpers, `model-fallback.ts` exports the existing const, and `tui-install-prompts.ts` uses it in the hint; the rest are their tests.

## Verification

- RED (base = `dev` @ 743ebc7a0): probe mirroring the PR assertions — Bailian-only install still prints `[!] No model providers configured. Using opencode/big-pickle as fallback.` (with `[OK] Bailian Coding Plan` in the same summary), and the no-provider warning names `big-pickle`, not `gpt-5-nano` (2 fail)
- GREEN: `cli-installer.test.ts` + `tui-installer.test.ts` + `provider-availability.test.ts` + `tui-install-prompts.test.ts` → 22 pass / 0 fail; repo typecheck clean
- QA (real surface, sandboxed `OPENCODE_CONFIG_DIR` + `XDG_*`): non-interactive `install` run with no providers → warning now reads `Using opencode/gpt-5-nano as fallback`; Bailian-only run → zero "No model providers configured" occurrences (both exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the installer’s “no provider” flow: uses the real ultimate fallback model `opencode/gpt-5-nano` and no longer warns on Bailian-only installs. Also updates the TUI Claude “No” hint to match. Fixes #5037.

- **Bug Fixes**
  - Added `hasAnyConfiguredProvider()` (includes Bailian) and switched both installers to use it.
  - Centralized warning copy via `getNoModelProvidersWarning()` and wired it to exported `ULTIMATE_FALLBACK` (`opencode/gpt-5-nano`); removed the stale `opencode/big-pickle` literal.
  - TUI Claude subscription “No” option hint now references `ULTIMATE_FALLBACK`.
  - Expanded test coverage for CLI/TUI warnings and the Claude hint.

<sup>Written for commit 3a85f8dfba4fb294a34cd5774fa2b79d6fa1b956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

