### PR TITLE
fix(look-at): send json files as text parts

### DIFF
--- a/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-input-preparer.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { basename } from "node:path"
 import { pathToFileURL } from "node:url"
 import type { LookAtArgs } from "./types"
@@ -21,8 +22,15 @@ export interface LookAtFilePart {
   filename: string
 }
 
+export interface LookAtTextPart {
+  type: "text"
+  text: string
+}
+
+export type LookAtInputPart = LookAtFilePart | LookAtTextPart
+
 export interface PreparedLookAtInput {
-  readonly fileParts: LookAtFilePart[]
+  readonly inputParts: LookAtInputPart[]
   readonly sourceDescription: string
   cleanup(): void
 }
@@ -49,6 +57,14 @@ function getTemporaryConversionPath(error: unknown): string | null {
   return null
 }
 
+function createJsonTextPart(filePath: string): LookAtTextPart {
+  const fileContent = readFileSync(filePath, "utf-8")
+  return {
+    type: "text",
+    text: `Attached JSON file (${basename(filePath)}):\n\n${fileContent}`,
+  }
+}
+
 export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
   const filePaths = args.file_paths ?? (args.file_path ? [args.file_path] : [])
   const imageDataList = args.image_data_list ?? (args.image_data ? [args.image_data] : [])
@@ -61,13 +77,18 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
     }
   }
 
-  const fileParts: LookAtFilePart[] = []
+  const inputParts: LookAtInputPart[] = []
   const tempFilesToCleanup: string[] = []
 
   for (const filePath of filePaths) {
     let mimeType = inferMimeTypeFromFilePath(filePath)
     let actualFilePath = filePath
     let tempConversionPath: string | null = null
+
+    if (mimeType === "application/json") {
+      inputParts.push(createJsonTextPart(filePath))
+      continue
+    }
 
     if (needsConversion(mimeType)) {
       log(`[look_at] Detected unsupported format: ${mimeType}, converting to JPEG...`)
@@ -94,7 +115,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       tempFilesToCleanup.push(tempConversionPath)
     }
 
-    fileParts.push({
+    inputParts.push({
       type: "file",
       mime: mimeType,
       url: pathToFileURL(actualFilePath).href,
@@ -125,7 +146,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
       }
     }
 
-    fileParts.push({
+    inputParts.push({
       type: "file",
       mime: finalMimeType,
       url: `data:${finalMimeType};base64,${finalBase64Data}`,
@@ -142,7 +163,7 @@ export function prepareLookAtInput(args: LookAtArgs): PrepareLookAtInputResult {
   return {
     ok: true,
     value: {
-      fileParts,
+      inputParts,
       sourceDescription,
       cleanup() {
         for (const temporaryFile of tempFilesToCleanup) {

--- a/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
+++ b/packages/omo-opencode/src/tools/look-at/look-at-session-runner.ts
@@ -4,7 +4,7 @@ import { isAmbiguousPromptDispatchFailure, log, promptSyncWithModelSuggestionRet
 import { extractLatestAssistantText } from "./assistant-message-extractor"
 import { MULTIMODAL_LOOKER_AGENT } from "./constants"
 import { READ_ENABLED, buildLookAtPrompt } from "./look-at-prompt"
-import type { LookAtFilePart } from "./look-at-input-preparer"
+import type { LookAtFilePart, LookAtInputPart } from "./look-at-input-preparer"
 import { resolveMultimodalLookerAgentMetadata } from "./multimodal-agent-metadata"
 import { waitForLookAtSessionResult } from "./session-poller"
 
@@ -12,15 +12,16 @@ interface RunLookAtSessionInput {
   ctx: PluginInput
   toolContext: ToolContext
   goal: string
-  fileParts: LookAtFilePart[]
+  inputParts: LookAtInputPart[]
 }
 
 export async function runLookAtSession({
   ctx,
   toolContext,
   goal,
-  fileParts,
+  inputParts,
 }: RunLookAtSessionInput): Promise<string> {
+  const fileParts = inputParts.filter((part): part is LookAtFilePart => part.type === "file")
   const prompt = buildLookAtPrompt(goal, fileParts)
   const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
 
@@ -73,7 +74,7 @@ Original error: ${createResult.error}`
         },
         parts: [
           { type: "text", text: prompt },
-          ...fileParts,
+          ...inputParts,
         ],
         ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
         ...(agentVariant ? { variant: agentVariant } : {}),

--- a/packages/omo-opencode/src/tools/look-at/tools.test.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test, mock } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { clearVisionCapableModelsCache, setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
 import type { LookAtArgs } from "./types"
@@ -613,6 +616,51 @@ describe("look-at tool", () => {
       )
       expect(result).toContain("Error")
       expect(result).toContain("string error thrown")
+    })
+
+    test("sends JSON files as text instead of unsupported application/json file parts", async () => {
+      const temporaryDirectory = mkdtempSync(join(tmpdir(), "omo-look-at-json-"))
+      const jsonPath = join(temporaryDirectory, "sample.json")
+      writeFileSync(jsonPath, JSON.stringify({ hello: "world" }), "utf-8")
+
+      let promptBody: { parts: Array<{ type: string; text?: string; mime?: string }> } | undefined
+      const mockClient = {
+        app: {
+          agents: async () => ({ data: [] }),
+        },
+        session: {
+          get: async () => ({ data: { directory: temporaryDirectory } }),
+          create: async () => ({ data: { id: "ses_json_text" } }),
+          prompt: async (input: { body: { parts: Array<{ type: string; text?: string; mime?: string }> } }) => {
+            promptBody = input.body
+            return { data: {} }
+          },
+          messages: async () => ({
+            data: [
+              { info: { role: "assistant", time: { created: 1 } }, parts: [{ type: "text", text: "ok" }] },
+            ],
+          }),
+        },
+      }
+
+      try {
+        const tool = createLookAt(unsafeTestValue({
+          client: mockClient,
+          directory: temporaryDirectory,
+        }))
+
+        const result = await tool.execute(
+          { file_path: jsonPath, goal: "summarize json" },
+          createToolContext(),
+        )
+
+        expect(result).toBe("ok")
+        expect(promptBody).toBeDefined()
+        expect(promptBody?.parts.some((part) => part.type === "file" && part.mime === "application/json")).toBe(false)
+        expect(promptBody?.parts.some((part) => part.type === "text" && part.text?.includes('{"hello":"world"}'))).toBe(true)
+      } finally {
+        rmSync(temporaryDirectory, { recursive: true, force: true })
+      }
     })
   })
 

--- a/packages/omo-opencode/src/tools/look-at/tools.ts
+++ b/packages/omo-opencode/src/tools/look-at/tools.ts
@@ -42,7 +42,7 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
           ctx,
           toolContext,
           goal: args.goal,
-          fileParts: preparedInput.fileParts,
+          inputParts: preparedInput.inputParts,
         })
       } catch (error) {
         const missingFilePath = getMissingLookAtFilePath(error, args)


### PR DESCRIPTION
## Summary

- `look_at` emitted non-image files as `{ type: 'file', mime }` parts with their literal mime; for `.json` that is `application/json`, which `@ai-sdk/openai-compatible` rejects as a file-part media type → `AI_UnsupportedFunctionalityError` on **all** providers.
- Fix (from #4284): `.json` inputs are read and inlined as a single text part (`Attached JSON file (<name>): ...`); the look_at input type generalizes from `filePart` to `inputPart` (file or text) through the preparer, session runner, and tool wiring. Regression test asserts no `application/json` file part is ever sent.

Builds on #4284 by @SpencerJung — both commits cherry-picked with original authorship preserved. That PR was already approved and its test/typecheck CI was green on all three OSes; its only blocker was a failing `codex-compatibility` check caused by a stale branch base (omo-codex `sync-skills` aggregate mismatch, unrelated to the diff). Rebasing onto current `dev` (this branch) resolves that.

## Evidence

- RED at base (`origin/dev` @ 743ebc7a0, before cherry-pick): `prepareLookAtInput({file_path: sample.json})` → `{"type":"file","mime":"application/json",...}` — REPRODUCED.
- GREEN: PR's regression test passes; `src/tools/look-at` 66 pass / 2 fail, where the 2 failures (`createLookAt prompt conditional on Read availability` suite, `captured.body` undefined) fail **identically at base without the cherry-pick** — pre-existing on current dev, outside this diff.
- QA: same repro against this branch → `{"type":"text","text":"Attached JSON file (sample.json): ..."}` — NOT-REPRODUCED.
- LSP diagnostics clean on all changed source files.

## Related Issues

Closes #4249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON handling in `look_at`: `.json` files are now inlined as text instead of sent as `application/json` file parts, preventing `AI_UnsupportedFunctionalityError` in `@ai-sdk/openai-compatible` and other providers. Fixes #4249.

- **Bug Fixes**
  - Inline `.json` inputs as a single text part: "Attached JSON file (<name>): …".
  - Generalize input from `filePart` to `inputPart` (file or text) across preparer, session runner, and tool wiring.
  - Add a regression test to verify no `application/json` file part is sent and the JSON content appears in the text part.

<sup>Written for commit 7e21226d1425bbb91198d28d75c25c407c4e3371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

