### PR TITLE
fix(todo-continuation): stop re-awakening handed-back sync subagents

### DIFF
--- a/packages/omo-opencode/src/features/claude-code-session-state/state.ts
+++ b/packages/omo-opencode/src/features/claude-code-session-state/state.ts
@@ -2,6 +2,7 @@ import { getAgentConfigKey } from "../../shared/agent-display-names"
 
 export const subagentSessions = new Set<string>()
 export const syncSubagentSessions = new Set<string>()
+export const handedBackSyncSessions = new Set<string>()
 
 let _mainSessionID: string | undefined
 
@@ -77,6 +78,7 @@ export function _resetForTesting(): void {
   _mainSessionID = undefined
   subagentSessions.clear()
   syncSubagentSessions.clear()
+  handedBackSyncSessions.clear()
   sessionAgentMap.clear()
   registeredAgentNames.clear()
   registeredAgentAliases.clear()

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -3,6 +3,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import {
   getSessionAgent,
+  handedBackSyncSessions,
   resolveRegisteredAgentName,
 } from "../../features/claude-code-session-state"
 import {
@@ -73,6 +74,11 @@ export async function injectContinuation(args: {
 
   if (state?.wasCancelled) {
     log(`[${HOOK_NAME}] Skipped injection: session was cancelled`, { sessionID })
+    return
+  }
+
+  if (handedBackSyncSessions.has(sessionID)) {
+    log(`[${HOOK_NAME}] Skipped injection: sync subagent already handed back to parent`, { sessionID })
     return
   }
 

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/handler.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 
 import type { BackgroundManager } from "../../features/background-agent"
+import { handedBackSyncSessions } from "../../features/claude-code-session-state"
 import {
   clearContinuationMarker,
 } from "../../features/run-continuation-state"
@@ -132,6 +133,7 @@ export function createTodoContinuationHandler(args: {
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
         clearContinuationMarker(ctx.directory, sessionID)
+        handedBackSyncSessions.delete(sessionID)
       }
     }
 

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
-import { getSessionAgent } from "../../features/claude-code-session-state"
+import { getSessionAgent, handedBackSyncSessions } from "../../features/claude-code-session-state"
 import { normalizeSDKResponse } from "../../shared"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { log } from "../../shared/logger"
@@ -51,6 +51,11 @@ export async function handleSessionIdle(args: {
 
   if (state.wasCancelled) {
     log(`[${HOOK_NAME}] Skipped: session was cancelled`, { sessionID })
+    return
+  }
+
+  if (handedBackSyncSessions.has(sessionID)) {
+    log(`[${HOOK_NAME}] Skipped: sync subagent already handed back to parent`, { sessionID })
     return
   }
 

--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor-reawaken-guard.test.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor-reawaken-guard.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, mock, test } from "bun:test"
+
+import { _resetForTesting } from "../../features/claude-code-session-state"
+import { handleSessionIdle } from "../../hooks/todo-continuation-enforcer/idle-event"
+import { createSessionStateStore } from "../../hooks/todo-continuation-enforcer/session-state"
+import { executeSync } from "./sync-executor"
+
+function createDependencies(sessionID: string, isNew: boolean) {
+  return {
+    createOrGetSession: mock(async () => ({ sessionID, isNew })),
+    waitForCompletion: mock(async () => {}),
+    processMessages: mock(async () => "agent response"),
+    setSessionFallbackChain: mock(() => {}),
+    clearSessionFallbackChain: mock(() => {}),
+  }
+}
+
+function createToolContext() {
+  return {
+    sessionID: "parent-session",
+    messageID: "msg-1",
+    agent: "sisyphus",
+    abort: new AbortController().signal,
+    metadata: mock(async () => {}),
+  }
+}
+
+function createExecuteContext(abortMock: ReturnType<typeof mock>) {
+  const promptAsync = mock(async () => ({ data: {} }))
+  return {
+    client: {
+      session: {
+        prompt: promptAsync,
+        promptAsync,
+        abort: abortMock,
+      },
+    },
+  }
+}
+
+function createEnforcerContext() {
+  return {
+    directory: "/tmp",
+    client: {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "user", id: "m1", time: { created: 1 } }, parts: [{ type: "text", text: "implement feature" }] },
+            { info: { role: "assistant", id: "m2", time: { created: 2, completed: 3 } }, parts: [{ type: "text", text: "did part of the work" }] },
+          ],
+        }),
+        todo: async () => ({
+          data: [
+            { id: "t1", content: "step one", status: "completed" },
+            { id: "t2", content: "step two", status: "pending" },
+          ],
+        }),
+      },
+      tui: { showToast: mock(async () => ({})) },
+    },
+  }
+}
+
+async function driveEnforcerIdle(sessionID: string): Promise<boolean> {
+  const store = createSessionStateStore()
+  await handleSessionIdle({
+    ctx: createEnforcerContext() as never,
+    sessionID,
+    sessionStateStore: store,
+    backgroundManager: { getTasksByParentSession: () => [] } as never,
+  })
+  const countdownArmed = store.getState(sessionID).countdownStartedAt !== undefined
+  store.cancelCountdown(sessionID)
+  return countdownArmed
+}
+
+const args = {
+  subagent_type: "explore",
+  description: "test task",
+  prompt: "find something",
+  run_in_background: false,
+}
+
+describe("issue #5112 - completed sync subagent must not be re-awakened", () => {
+  afterEach(() => {
+    _resetForTesting()
+  })
+
+  test("#given a created sync subagent that completed with incomplete todos #when its post-handoff session.idle fires #then todo-continuation does not re-awaken it", async () => {
+    //#given
+    const childSessionID = "ses-sync-child-created"
+    const abortMock = mock(async () => ({ data: true }))
+    await executeSync(args, createToolContext(), createExecuteContext(abortMock) as never, createDependencies(childSessionID, true))
+
+    //#when
+    const reawakened = await driveEnforcerIdle(childSessionID)
+
+    //#then
+    expect(reawakened).toBe(false)
+  })
+
+  test("#given a created sync subagent completed #when the handoff finishes #then the child session is aborted (PR #5113)", async () => {
+    //#given
+    const childSessionID = "ses-sync-child-abort"
+    const abortMock = mock(async () => ({ data: true }))
+
+    //#when
+    await executeSync(args, createToolContext(), createExecuteContext(abortMock) as never, createDependencies(childSessionID, true))
+
+    //#then
+    expect(abortMock).toHaveBeenCalledWith({ path: { id: childSessionID } })
+  })
+
+  test("#given the sync run reused an existing session (isNew=false) #when the run finishes #then it is neither aborted nor exempted from continuation", async () => {
+    //#given
+    const childSessionID = "ses-sync-child-reused"
+    const abortMock = mock(async () => ({ data: true }))
+    await executeSync(args, createToolContext(), createExecuteContext(abortMock) as never, createDependencies(childSessionID, false))
+
+    //#when
+    const reawakened = await driveEnforcerIdle(childSessionID)
+
+    //#then
+    expect(abortMock).not.toHaveBeenCalled()
+    expect(reawakened).toBe(true)
+  })
+})

--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { clearSessionAgent, setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
+import { clearSessionAgent, handedBackSyncSessions, setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
 import { getAgentToolRestrictions, isAmbiguousPostDispatchPromptFailure, log } from "../../shared"
 import { normalizeAgentForPrompt, stripAgentListSortPrefix } from "../../shared/agent-display-names"
@@ -96,6 +96,7 @@ export async function executeSync(
     createdSessionForExecution = session.isNew
     subagentSessions.add(sessionID)
     syncSubagentSessions.add(sessionID)
+    handedBackSyncSessions.delete(sessionID)
 
     if (session.isNew) {
       spawnReservation?.commit()
@@ -199,12 +200,16 @@ export async function executeSync(
       syncSubagentSessions.delete(sessionID)
       deleteSessionTools(sessionID)
       clearSessionAgent(sessionID)
+      handedBackSyncSessions.add(sessionID)
 
       // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
       // When a sync subagent finishes, its session may still exist and have incomplete
       // todos; without an explicit abort, the continuation hook sees session.idle and
       // injects a continuation prompt, causing the subagent to resume after the parent
       // has already moved on. This creates a race where two agents work concurrently.
+      // Aborting an already-idle session emits no error event (opencode re-publishes
+      // session.idle), so handedBackSyncSessions is the signal the enforcer keys on;
+      // the abort still cancels the child's opencode-side background jobs.
       if (typeof ctx.client.session.abort === "function") {
         void ctx.client.session.abort({ path: { id: sessionID } }).catch((error: unknown) => {
           log(`[call_omo_agent] Failed to abort completed sync session:`, error)

--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
@@ -199,6 +199,17 @@ export async function executeSync(
       syncSubagentSessions.delete(sessionID)
       deleteSessionTools(sessionID)
       clearSessionAgent(sessionID)
+
+      // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
+      // When a sync subagent finishes, its session may still exist and have incomplete
+      // todos; without an explicit abort, the continuation hook sees session.idle and
+      // injects a continuation prompt, causing the subagent to resume after the parent
+      // has already moved on. This creates a race where two agents work concurrently.
+      if (typeof ctx.client.session.abort === "function") {
+        void ctx.client.session.abort({ path: { id: sessionID } }).catch((error: unknown) => {
+          log(`[call_omo_agent] Failed to abort completed sync session:`, error)
+        })
+      }
     }
   }
 }

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -1,4 +1,4 @@
-import { setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
+import { handedBackSyncSessions, setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import {
   clearDelegatedChildSessionBootstrap,
   registerDelegatedChildSessionBootstrap,
@@ -21,6 +21,7 @@ export async function registerSyncSessionSideEffects(input: {
 }): Promise<void> {
   subagentSessions.add(input.sessionID)
   syncSubagentSessions.add(input.sessionID)
+  handedBackSyncSessions.delete(input.sessionID)
   setSessionAgent(input.sessionID, input.agentToUse)
   registerDelegatedChildSessionBootstrap({
     sessionID: input.sessionID,

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task-reawaken-guard.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task-reawaken-guard.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+import { _resetForTesting } from "../../features/claude-code-session-state"
+import { handleSessionIdle } from "../../hooks/todo-continuation-enforcer/idle-event"
+import { createSessionStateStore } from "../../hooks/todo-continuation-enforcer/session-state"
+import { executeSyncTask } from "./sync-task"
+
+const CHILD_SESSION_ID = "ses_test_5112_child"
+
+function createDeps() {
+  return {
+    createSyncSession: async () => ({ ok: true as const, sessionID: CHILD_SESSION_ID, parentDirectory: "/tmp" }),
+    sendSyncPrompt: async () => null,
+    pollSyncSession: async () => null,
+    fetchSyncResult: async () => ({ ok: false as const, error: "Fetch failed" }),
+  }
+}
+
+function createEnforcerContext() {
+  return {
+    directory: "/tmp",
+    client: {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "user", id: "m1", time: { created: 1 } }, parts: [{ type: "text", text: "implement feature" }] },
+            { info: { role: "assistant", id: "m2", time: { created: 2, completed: 3 } }, parts: [{ type: "text", text: "did part of the work" }] },
+          ],
+        }),
+        todo: async () => ({
+          data: [
+            { id: "t1", content: "step one", status: "completed" },
+            { id: "t2", content: "step two", status: "pending" },
+          ],
+        }),
+      },
+      tui: { showToast: mock(async () => ({})) },
+    },
+  }
+}
+
+describe("issue #5112 - delegate-task sync child must not be re-awakened after handoff", () => {
+  beforeEach(() => {
+    const { __setTimingConfig } = require("./timing")
+    __setTimingConfig({
+      POLL_INTERVAL_MS: 10,
+      MIN_STABILITY_TIME_MS: 0,
+      STABILITY_POLLS_REQUIRED: 1,
+      MAX_POLL_TIME_MS: 100,
+    })
+    const { initTaskToastManager, _resetTaskToastManagerForTesting } = require("../../features/task-toast-manager/manager")
+    _resetTaskToastManagerForTesting()
+    initTaskToastManager({
+      tui: { showToast: mock(() => Promise.resolve()) },
+    })
+  })
+
+  afterEach(() => {
+    const { __resetTimingConfig } = require("./timing")
+    __resetTimingConfig()
+    const { _resetTaskToastManagerForTesting } = require("../../features/task-toast-manager/manager")
+    _resetTaskToastManagerForTesting()
+    _resetForTesting()
+  })
+
+  test("#given a sync task whose session was created and handed back #when the child later idles #then todo-continuation does not re-awaken it and the child was aborted", async () => {
+    //#given
+    const abortMock = mock(async () => ({ data: true }))
+    const mockCtx = { sessionID: "parent-session", callID: "call-123", metadata: () => {} }
+    const mockExecutorCtx = {
+      client: {
+        session: {
+          create: async () => ({ data: { id: CHILD_SESSION_ID } }),
+          abort: abortMock,
+        },
+      },
+      directory: "/tmp",
+      onSyncSessionCreated: null,
+    }
+    const args = {
+      prompt: "test prompt",
+      description: "test task",
+      category: "test",
+      load_skills: [],
+      run_in_background: false,
+      command: null,
+    }
+    await executeSyncTask(args as never, mockCtx as never, mockExecutorCtx as never, {
+      sessionID: "parent-session",
+    } as never, "test-agent", undefined, undefined, undefined, undefined, createDeps() as never)
+
+    //#when
+    const store = createSessionStateStore()
+    await handleSessionIdle({
+      ctx: createEnforcerContext() as never,
+      sessionID: CHILD_SESSION_ID,
+      sessionStateStore: store,
+      backgroundManager: { getTasksByParentSession: () => [] } as never,
+    })
+    const countdownArmed = store.getState(CHILD_SESSION_ID).countdownStartedAt !== undefined
+    store.cancelCountdown(CHILD_SESSION_ID)
+
+    //#then
+    expect(abortMock).toHaveBeenCalledWith({ path: { id: CHILD_SESSION_ID } })
+    expect(countdownArmed).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -1,3 +1,4 @@
+import { handedBackSyncSessions } from "../../features/claude-code-session-state"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
 import type { FallbackEntry } from "../../shared/model-requirements"
@@ -153,12 +154,16 @@ export async function executeSyncTask(
   } finally {
     if (syncSessionID) {
       cleanupSyncSessionSideEffects(syncSessionID, executorCtx)
+      handedBackSyncSessions.add(syncSessionID)
 
       // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
       // When a sync subagent finishes, its session may still exist and have incomplete
       // todos; without an explicit abort, the continuation hook sees session.idle and
       // injects a continuation prompt, causing the subagent to resume after the parent
       // has already moved on. This creates a race where two agents work concurrently.
+      // Aborting an already-idle session emits no error event (opencode re-publishes
+      // session.idle), so handedBackSyncSessions is the signal the enforcer keys on;
+      // the abort still cancels the child's opencode-side background jobs.
       if (typeof client.session.abort === "function") {
         void client.session.abort({ path: { id: syncSessionID } }).catch((error: unknown) => {
           log(`[task] Failed to abort completed sync session:`, error)

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -1,6 +1,7 @@
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
 import type { FallbackEntry } from "../../shared/model-requirements"
+import { log } from "../../shared/logger"
 import { formatDetailedError } from "./error-formatting"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import { reserveSyncSubagentSpawn } from "./sync-spawn-reservation"
@@ -152,6 +153,17 @@ export async function executeSyncTask(
   } finally {
     if (syncSessionID) {
       cleanupSyncSessionSideEffects(syncSessionID, executorCtx)
+
+      // Prevent todo-continuation-enforcer from re-awakening a completed sync subagent.
+      // When a sync subagent finishes, its session may still exist and have incomplete
+      // todos; without an explicit abort, the continuation hook sees session.idle and
+      // injects a continuation prompt, causing the subagent to resume after the parent
+      // has already moved on. This creates a race where two agents work concurrently.
+      if (typeof client.session.abort === "function") {
+        void client.session.abort({ path: { id: syncSessionID } }).catch((error: unknown) => {
+          log(`[task] Failed to abort completed sync session:`, error)
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Stops `todo-continuation-enforcer` from re-awakening a synchronous subagent after its result was handed back to the parent, which let two agents edit the same codebase concurrently.

Builds on #5113 by @Ruifeng-Zhang (cherry-picked with authorship preserved) and completes it:

- #5113 aborts the child session in the executors' `finally`. That alone cannot gate the enforcer: at the pinned opencode version (v1.15.13), `session.abort` on an **already-idle** session only cancels background jobs and re-publishes `session.idle` — it emits no `session.error`/`MessageAbortedError` (`packages/opencode/src/session/run-state.ts` `cancel`: no busy runner → `status.set(idle)`; `status.ts` `set`: idle → publish `Event.Idle`). Since a sync child is always idle by the time the `finally` runs (`waitForCompletion` returned), neither `wasCancelled` nor aborted-message detection ever engages — and the extra `session.idle` hands the enforcer one more trigger.
- This PR adds the signal the enforcer can actually key on: `handedBackSyncSessions` in `claude-code-session-state` (same module-level pattern as `syncSubagentSessions`).
  - Marked in `executeSync` (scoped to `createdSessionForExecution`) and `executeSyncTask`'s `finally`.
  - Checked in `handleSessionIdle` (idle path) and `injectContinuation` (countdown fire path — closes the in-flight-countdown race), mirroring the existing `wasCancelled` double-gate.
  - Cleared on `session.deleted` and when a later sync run re-activates the session (`session_id` reuse keeps continuation for live children).
  - The cherry-picked abort is kept: it still cancels the child's opencode-side background jobs at handoff.

## Evidence

- RED at base (`.ulw/evidence/i5112-red.txt`): 3 fail / 1 pass — enforcer reaches countdown for a handed-back child via both `executeSync` and `executeSyncTask`; abort never called.
- GREEN (`.ulw/evidence/i5112-green.txt`): regression tests 4/4; combined touched dirs (`call-omo-agent`, `delegate-task`, `todo-continuation-enforcer`, `claude-code-session-state`) 657 pass / 0 fail.
- QA (`.ulw/evidence/i5112-qa.txt`): adapted sweep repro driving the REAL `executeSync` handoff then the REAL `handleSessionIdle` — NOT-REPRODUCED (3/3: live sync child still gets continuation; handed-back child does not; `wasCancelled` control holds).

## Tests

- `sync-executor-reawaken-guard.test.ts`: handed-back child not re-awakened; abort issued for created sessions (pins #5113); reused session (`isNew=false`) neither aborted nor exempted.
- `sync-task-reawaken-guard.test.ts`: delegate-task child aborted + not re-awakened after handoff.

Closes #5112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `todo-continuation-enforcer` from re-awakening sync subagents after their result is handed back, preventing parent/child from editing concurrently. Adds a simple gate and aborts the child to stop background jobs.

- **Bug Fixes**
  - Track handed-back sync subagents via `handedBackSyncSessions` in `claude-code-session-state`.
  - In `call-omo-agent/executeSync` and `delegate-task/executeSyncTask`: clear the mark on start; on completion, mark and call `session.abort()` (guarded by `typeof ...abort === "function"`) to cancel background work.
  - In `todo-continuation-enforcer`: skip continuation for marked sessions in `handleSessionIdle` and `injectContinuation`; clear the mark on `session.deleted` and when a new sync run registers/reactivates the session.
  - Tests added: `sync-executor-reawaken-guard.test.ts` and `sync-task-reawaken-guard.test.ts` cover created/reused session flows and abort behavior.

<sup>Written for commit 850415a797e405c95b72f29e750e6bb21d690938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

