### PR TITLE
fix(team-mode): verify live delivery before idle-ack; requeue unconfirmed messages

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/team-mailbox/pending-delivery-recovery.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-mailbox/pending-delivery-recovery.ts
@@ -1,0 +1,91 @@
+import type { TeamModeConfig } from "../../../config/schema/team-mode"
+import { isRecord } from "../../../shared/record-type-guard"
+import { log } from "../../../shared/logger"
+import { releaseDeliveryReservation, reserveMessageForDelivery } from "./reservation"
+
+type SessionMessagesClient = {
+  session?: {
+    messages?: (input: { path: { id: string } }) => Promise<unknown>
+  }
+}
+
+function getMessagesData(response: unknown): unknown[] {
+  if (isRecord(response) && Array.isArray(response.data)) {
+    return response.data
+  }
+  return Array.isArray(response) ? response : []
+}
+
+function valueContainsMessageId(value: unknown, messageId: string): boolean {
+  if (typeof value === "string") {
+    return value.includes(messageId)
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => valueContainsMessageId(entry, messageId))
+  }
+  if (isRecord(value)) {
+    return Object.values(value).some((entry) => valueContainsMessageId(entry, messageId))
+  }
+  return false
+}
+
+/**
+ * Returns the subset of messageIds whose live-delivery envelope is present in the
+ * recipient session's message history. A live/poll-injected peer message embeds
+ * its messageId in the injected `<peer_message messageId="...">` envelope, so a
+ * message that genuinely reached the recipient's context is detectable here.
+ *
+ * Messages NOT returned were marked "pending" (the wake/dispatch was accepted) but
+ * never actually entered context - acking those would silently lose them.
+ *
+ * On any error (or when the client cannot read messages) returns an empty set,
+ * which is the loss-safe answer: callers requeue rather than ack.
+ */
+export async function findDeliveredMessageIds(
+  client: SessionMessagesClient,
+  sessionID: string,
+  messageIds: readonly string[],
+): Promise<Set<string>> {
+  const delivered = new Set<string>()
+  if (messageIds.length === 0 || typeof client.session?.messages !== "function") {
+    return delivered
+  }
+
+  try {
+    const response = await client.session.messages({ path: { id: sessionID } })
+    const messages = getMessagesData(response)
+    for (const messageId of messageIds) {
+      if (messages.some((message) => valueContainsMessageId(message, messageId))) {
+        delivered.add(messageId)
+      }
+    }
+  } catch (error) {
+    log("[team-mailbox] failed to read session history for pending-delivery verification", {
+      sessionID,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return delivered
+}
+
+/**
+ * Returns reserved (`.delivering-<id>.json`) pending messages to the inbox as
+ * normal unread (`<id>.json`) files so the next poll-injection / wake-hint can
+ * re-deliver them. Used when a pending live delivery is found to have never
+ * reached the recipient's context.
+ */
+export async function requeuePendingLiveDeliveries(
+  teamRunId: string,
+  memberName: string,
+  messageIds: readonly string[],
+  config: TeamModeConfig,
+): Promise<void> {
+  for (const messageId of messageIds) {
+    const reservation = await reserveMessageForDelivery(teamRunId, memberName, messageId, config)
+    if (reservation === null) {
+      continue
+    }
+    await releaseDeliveryReservation(reservation)
+  }
+}

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
+import { clearTeamSessionRegistry } from "../../features/team-mode/team-session-registry"
+import { getInboxDir, resolveBaseDir } from "../../features/team-mode/team-registry/paths"
+import { loadRuntimeState, saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import type { RuntimeState } from "../../features/team-mode/types"
+import { createTeamIdleWakeHint } from "./team-idle-wake-hint"
+
+const temporaryDirectories: string[] = []
+
+function createConfig(baseDir: string): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+}
+
+function createRuntimeState(teamRunId: string, pendingInjectedMessageIds: string[]): RuntimeState {
+  return {
+    version: 1,
+    teamRunId,
+    teamName: "team-alpha",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "worker",
+        sessionId: "member-session",
+        agentType: "general-purpose",
+        status: "idle",
+        pendingInjectedMessageIds,
+      },
+    ],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
+
+async function seedReservedPendingMessage(config: TeamModeConfig, messageId: string): Promise<string> {
+  const teamRunId = randomUUID()
+  await mkdir(path.join(config.base_dir ?? "", "runtime", teamRunId), { recursive: true })
+  await saveRuntimeState(createRuntimeState(teamRunId, [messageId]), config)
+  await sendMessage({
+    version: 1,
+    messageId,
+    from: "lead",
+    to: "worker",
+    kind: "message",
+    body: "in-flight live delivery",
+    timestamp: 100,
+  }, teamRunId, config, {
+    isLead: true,
+    activeMembers: ["worker"],
+    reservedRecipients: new Set(["worker"]),
+  })
+  return teamRunId
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function driveIdle(config: TeamModeConfig, withMessagesApi: boolean): Promise<void> {
+  const session: Record<string, unknown> = {}
+  if (withMessagesApi) {
+    session.messages = async () => ({ data: [] })
+  }
+  const handler = createTeamIdleWakeHint({
+    directory: "/tmp/project",
+    client: { session },
+  } as never, config)
+  await handler({
+    event: {
+      type: "session.idle",
+      properties: { sessionID: "member-session" },
+    },
+  })
+}
+
+afterEach(async () => {
+  clearTeamSessionRegistry()
+  await Promise.all(temporaryDirectories.splice(0).map(async (directoryPath) => {
+    await rm(directoryPath, { recursive: true, force: true })
+  }))
+})
+
+describe("issue #5101 - pending live delivery must not be silently lost on idle-ack", () => {
+  test("#given a reserved (.delivering-) message pending injection that never reached the recipient #when the recipient idles #then the message stays recoverable by poll-injection", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "wake-hint-delivering-loss-"))
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const messageId = randomUUID()
+    const teamRunId = await seedReservedPendingMessage(config, messageId)
+
+    // when
+    await driveIdle(config, true)
+
+    // then
+    const unreadMessages = await listUnreadMessages(teamRunId, "worker", config)
+    expect(unreadMessages.map((message) => message.messageId)).toContain(messageId)
+    const processedPath = path.join(getInboxDir(resolveBaseDir(config), teamRunId, "worker"), "processed", `${messageId}.json`)
+    expect(await fileExists(processedPath)).toBe(false)
+    const runtimeState = await loadRuntimeState(teamRunId, config)
+    expect(runtimeState.members[0]?.pendingInjectedMessageIds).toEqual([])
+  })
+
+  test("#given the client cannot read session history #when the recipient idles #then the prior ack-all behavior is preserved (loss-safe fallback unavailable)", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "wake-hint-delivering-ackall-"))
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const messageId = randomUUID()
+    const teamRunId = await seedReservedPendingMessage(config, messageId)
+
+    // when
+    await driveIdle(config, false)
+
+    // then
+    const processedPath = path.join(getInboxDir(resolveBaseDir(config), teamRunId, "worker"), "processed", `${messageId}.json`)
+    expect(await fileExists(processedPath)).toBe(true)
+    expect(await listUnreadMessages(teamRunId, "worker", config)).toEqual([])
+  })
+})

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="bun-types" />
+
+// Regression test for the team-mailbox pending live-delivery data-loss bug:
+// the idle-wake-hint handler used to ack every pendingInjectedMessageId purely
+// because the session went idle, with no check that the message actually reached
+// the recipient's context. A wake accepted-but-not-processed was silently moved
+// to processed/ and lost. The fix verifies session.messages history and requeues
+// unconfirmed messages back to the inbox instead.
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { sendMessage } from "../../features/team-mode/team-mailbox/send"
+import { saveRuntimeState } from "../../features/team-mode/team-state-store/store"
+import type { RuntimeState } from "../../features/team-mode/types"
+import { getInboxDir, resolveBaseDir } from "../../features/team-mode/team-registry/paths"
+import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-async-gate"
+import { createTeamIdleWakeHint } from "./team-idle-wake-hint"
+
+const tmpDirs: string[] = []
+
+afterEach(async () => {
+  releaseAllPromptAsyncReservationsForTesting()
+  await Promise.all(tmpDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })))
+})
+
+async function makeBaseDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "pending-verify-"))
+  tmpDirs.push(dir)
+  return dir
+}
+
+function makeConfig(baseDir: string): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: baseDir, enabled: true })
+}
+
+function runtimeWithPending(teamRunId: string, messageId: string): RuntimeState {
+  return {
+    version: 1,
+    teamRunId,
+    teamName: "team-alpha",
+    specSource: "project",
+    createdAt: 1,
+    status: "active",
+    leadSessionId: "lead-session",
+    members: [
+      {
+        name: "worker",
+        sessionId: "member-session",
+        agentType: "general-purpose",
+        status: "idle",
+        pendingInjectedMessageIds: [messageId],
+      },
+    ],
+    shutdownRequests: [],
+    bounds: {
+      maxMembers: 8,
+      maxParallelMembers: 4,
+      maxMessagesPerRun: 10000,
+      maxWallClockMinutes: 120,
+      maxMemberTurns: 500,
+    },
+  }
+}
+
+async function seedPendingReserved(
+  teamRunId: string,
+  config: TeamModeConfig,
+  messageId: string,
+  body: string,
+): Promise<void> {
+  await sendMessage(
+    { version: 1, messageId, from: "lead", to: "worker", kind: "message", body, timestamp: 100 },
+    teamRunId,
+    config,
+    { isLead: true, activeMembers: ["worker"], reservedRecipients: new Set(["worker"]) },
+  )
+}
+
+const idleStatus = () => async () => ({ data: { "member-session": { type: "idle" } } })
+const noopPromptAsync = async () => ({})
+
+describe("team idle-wake-hint pending live-delivery verification", () => {
+  test("unconfirmed pending message (absent from session history) is requeued to inbox, not acked/lost", async () => {
+    const baseDir = await makeBaseDir()
+    const config = makeConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState(runtimeWithPending(teamRunId, messageId), config)
+    await seedPendingReserved(teamRunId, config, messageId, "ROUND 2 CRITIQUE")
+
+    const handler = createTeamIdleWakeHint(
+      {
+        directory: "/tmp/project",
+        client: {
+          session: {
+            promptAsync: noopPromptAsync,
+            status: idleStatus(),
+            messages: async () => ({ data: [] }), // recipient never saw the message
+          },
+        },
+      },
+      config,
+      { idleSettleMs: 0 },
+    )
+
+    await handler({ event: { type: "session.idle", properties: { sessionID: "member-session" } } })
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inbox = await readdir(inboxDir)
+    const processed = await readdir(path.join(inboxDir, "processed")).catch(() => [] as string[])
+
+    // requeued as a normal unread file (recoverable by poll-inject), NOT lost to processed/
+    expect(inbox.includes(`${messageId}.json`)).toBe(true)
+    expect(inbox.includes(`.delivering-${messageId}.json`)).toBe(false)
+    expect(processed.includes(`${messageId}.json`)).toBe(false)
+  })
+
+  test("confirmed pending message (envelope present in session history) is acked to processed/", async () => {
+    const baseDir = await makeBaseDir()
+    const config = makeConfig(baseDir)
+    const teamRunId = randomUUID()
+    const messageId = randomUUID()
+    await mkdir(path.join(baseDir, "runtime", teamRunId), { recursive: true })
+    await saveRuntimeState(runtimeWithPending(teamRunId, messageId), config)
+    await seedPendingReserved(teamRunId, config, messageId, "ROUND 2 CRITIQUE")
+
+    const handler = createTeamIdleWakeHint(
+      {
+        directory: "/tmp/project",
+        client: {
+          session: {
+            promptAsync: noopPromptAsync,
+            status: idleStatus(),
+            messages: async () => ({
+              data: [
+                {
+                  role: "user",
+                  parts: [
+                    {
+                      type: "text",
+                      text: `<peer_message messageId="${messageId}" from="lead">ROUND 2 CRITIQUE</peer_message>`,
+                    },
+                  ],
+                },
+              ],
+            }),
+          },
+        },
+      },
+      config,
+      { idleSettleMs: 0 },
+    )
+
+    await handler({ event: { type: "session.idle", properties: { sessionID: "member-session" } } })
+
+    const inboxDir = getInboxDir(resolveBaseDir(config), teamRunId, "worker")
+    const inbox = await readdir(inboxDir)
+    const processed = await readdir(path.join(inboxDir, "processed")).catch(() => [] as string[])
+
+    expect(processed.includes(`${messageId}.json`)).toBe(true)
+    expect(inbox.includes(`${messageId}.json`)).toBe(false)
+    expect(inbox.includes(`.delivering-${messageId}.json`)).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.ts
@@ -7,6 +7,7 @@ import {
 import { ackMessages } from "../../features/team-mode/team-mailbox/ack"
 import { listUnreadMessages } from "../../features/team-mode/team-mailbox/inbox"
 import { loadRuntimeState, transitionRuntimeState } from "../../features/team-mode/team-state-store/store"
+import { findDeliveredMessageIds, requeuePendingLiveDeliveries } from "../../features/team-mode/team-mailbox/pending-delivery-recovery"
 import { resolveSessionEventID } from "../../shared/event-session-id"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { log } from "../../shared/logger"
@@ -30,6 +31,7 @@ type TeamIdleWakeHintContext = {
     session: {
       promptAsync?: (input: PromptAsyncInput) => Promise<unknown>
       status?: () => Promise<unknown>
+      messages?: (input: { path: { id: string } }) => Promise<unknown>
     }
   }
 }
@@ -134,13 +136,24 @@ export function createTeamIdleWakeHint(ctx: TeamIdleWakeHintContext, config: Tea
           config,
         )
         if (claimedMessageIds.length > 0) {
-          await ackMessages(runtimeState.teamRunId, memberEntry.name, claimedMessageIds, config)
+          const deliveredMessageIds = typeof ctx.client.session.messages === "function"
+            ? await findDeliveredMessageIds(ctx.client, sessionID, claimedMessageIds)
+            : new Set(claimedMessageIds)
+          const ackedMessageIds = claimedMessageIds.filter((messageId) => deliveredMessageIds.has(messageId))
+          const requeuedMessageIds = claimedMessageIds.filter((messageId) => !deliveredMessageIds.has(messageId))
+          if (ackedMessageIds.length > 0) {
+            await ackMessages(runtimeState.teamRunId, memberEntry.name, ackedMessageIds, config)
+          }
+          if (requeuedMessageIds.length > 0) {
+            await requeuePendingLiveDeliveries(runtimeState.teamRunId, memberEntry.name, requeuedMessageIds, config)
+          }
           log("team idle handled pending live delivery ack", {
             event: "team-mode-idle-pending-ack",
             teamRunId: runtimeState.teamRunId,
             memberName: memberEntry.name,
             sessionID,
-            ackedCount: claimedMessageIds.length,
+            ackedCount: ackedMessageIds.length,
+            requeuedCount: requeuedMessageIds.length,
           })
         }
       }

--- a/packages/omo-opencode/src/plugin/build-team-idle-wake-hint-client.ts
+++ b/packages/omo-opencode/src/plugin/build-team-idle-wake-hint-client.ts
@@ -3,11 +3,13 @@ import type { PluginInput } from "@opencode-ai/plugin"
 type SdkSession = PluginInput["client"]["session"]
 type SdkPromptAsync = SdkSession["promptAsync"]
 type SdkStatus = SdkSession["status"]
+type SdkMessages = SdkSession["messages"]
 
 export type TeamIdleWakeHintNarrowClient = {
   session: {
     promptAsync?: SdkPromptAsync
     status?: SdkStatus
+    messages?: SdkMessages
   }
 }
 
@@ -19,7 +21,10 @@ export function buildTeamIdleWakeHintClient(client: PluginInput["client"]): Team
   const status = typeof session.status === "function"
     ? session.status.bind(session) as SdkStatus
     : undefined
+  const messages = typeof session.messages === "function"
+    ? session.messages.bind(session) as SdkMessages
+    : undefined
   return {
-    session: { promptAsync, status },
+    session: { promptAsync, status, messages },
   }
 }


### PR DESCRIPTION
## Summary

Stops team-mode peer messages from being silently lost when the recipient goes idle before a live-delivery wake was durably processed.

Builds on #5022 by @sjawhar (cherry-picked with authorship preserved) and completes it mechanically:

- **Mechanism (verified at HEAD):** `listUnreadMessages` ignores dot-prefixed files (`inbox.ts` `isInboxMessageFile`), so a `.delivering-<id>.json` reservation is invisible to poll-injection; the idle wake-hint acked `pendingInjectedMessageIds` purely because the session went idle, and `ackMessages` renames the reservation into `processed/` — after that, even `reclaimStaleReservations` cannot recover it. Net result: accepted-but-never-injected messages vanished.
- **Fix (from #5022):** before acking on idle, verify each pending id actually reached `session.messages` (the injected `<peer_message messageId="...">` envelope is detectable — same history-scan pattern the codebase already uses in `reservation-reconciliation.ts`). Confirmed → ack; unconfirmed → requeue to the inbox via the reservation helpers so the next poll/wake re-delivers. When the client cannot read history, the prior ack-all behavior is preserved (loss-safe additive change).
- **Top-ups (mechanical, per the PR review):**
  - Rebased across the `src/` → `packages/omo-opencode/src/` move (the two added files land at the new paths; modified files integrate with the current `claimPendingMessageAcks` flow).
  - Verified the diff contains no em/en dashes (AGENTS.md convention).
  - Added an end-to-end regression at the wake-hint surface: an undelivered reserved message stays recoverable by `listUnreadMessages` after the idle pass (this exact test fails at base with the message consumed into `processed/`), plus an ack-all fallback pin.

## Evidence

- RED at base (`.ulw/evidence/i5101-red.txt`): undelivered reserved message → `listUnreadMessages` returns `[]` after idle (silently lost).
- GREEN (`.ulw/evidence/i5101-green.txt`): new regression + PR's `team-idle-wake-hint-pending-delivery-verify.test.ts` 4/4; `team-mailbox/` + `team-session-events/` + wake-hint client suites 59 pass / 0 fail.
- QA (`.ulw/evidence/i5101-qa.txt`): real `createTeamIdleWakeHint` driven against an isolated team base_dir — NOT-REPRODUCED 3/3 (reservation window invariant holds; undelivered → requeued and recoverable; delivered-in-history → acked exactly once).

Closes #5101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents team-mode message loss when a member idles before live delivery is processed. On idle, we now verify the delivery reached session history before acking; unconfirmed reservations are requeued to the inbox, with ack-all preserved when `session.messages` is unavailable.

- **Bug Fixes**
  - Verify each pending message against `session.messages`; ack confirmed, requeue the rest.
  - Added `findDeliveredMessageIds` and `requeuePendingLiveDeliveries`.
  - Pass `session.messages` through the idle wake-hint client; fall back to ack-all when absent.
  - Added end-to-end tests for requeueing undelivered reservations, acking confirmed deliveries, and the ack-all fallback.

<sup>Written for commit b6383cffc431c6b6a6824cd1c6cd988b87cc01a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

