### PR TITLE
fix(omo-codex): persist OMO config and skills across Codex auth/provider switches

### DIFF
--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -45,7 +45,7 @@ If Codex auth/provider switching (official ChatGPT login vs relay `base_url`) st
 npx lazycodex-ai repair-config
 ```
 
-This restores only OMO-managed marketplace/plugin/hook/agent blocks and leaves `model_provider`, `base_url`, and other user auth settings untouched. The repair shim also runs automatically from the `omo` runtime wrapper and from LazyCodex `SessionStart` auto-update checks when the plugin is enabled.
+This restores only OMO-managed marketplace/plugin/hook/agent blocks and leaves `model_provider`, `base_url`, and other user auth settings untouched. LazyCodex also mirrors OMO plugin skills into `~/.codex/skills/` (the same durable location used by manually installed skills such as `nature-*` or `zenmux-*`), so OMO skills remain discoverable even if a provider switch temporarily strips plugin config. The repair shim also runs automatically from the `omo` runtime wrapper and from LazyCodex `SessionStart` auto-update checks when the plugin is enabled.
 
 The Codex plugin bundle includes Context7 as a default MCP in its `.mcp.json`, using the hosted `https://mcp.context7.com/mcp` endpoint. The installer enables the `omo@sisyphuslabs` plugin MCP policy for Context7 while leaving any existing user-level `[mcp_servers.context7]` block untouched.
 The same plugin-scoped MCP manifest also bundles `ast_grep`, `grep_app`, `git_bash`, and `lsp`. `git_bash` is enabled only on Windows by default.

--- a/packages/omo-codex/README.md
+++ b/packages/omo-codex/README.md
@@ -39,6 +39,14 @@ The installer copies the built plugin into `~/.codex/plugins/cache/sisyphuslabs/
 
 To remove managed Codex Light state, run `npx lazycodex-ai uninstall`. The backward-compatible alias is `npx lazycodex-ai cleanup`. Uninstall removes managed `sisyphuslabs` cache/marketplace directories, strips OMO marketplace/plugin/hook-state config blocks with a backup, removes managed agent TOML files from `~/.codex/agents/`, and repairs the known project-local legacy `.codex/config.toml` conflict while leaving project-owned `.codex` files in place.
 
+If Codex auth/provider switching (official ChatGPT login vs relay `base_url`) strips `omo@sisyphuslabs` from `~/.codex/config.toml` while the plugin cache is still present, run:
+
+```bash
+npx lazycodex-ai repair-config
+```
+
+This restores only OMO-managed marketplace/plugin/hook/agent blocks and leaves `model_provider`, `base_url`, and other user auth settings untouched. The repair shim also runs automatically from the `omo` runtime wrapper and from LazyCodex `SessionStart` auto-update checks when the plugin is enabled.
+
 The Codex plugin bundle includes Context7 as a default MCP in its `.mcp.json`, using the hosted `https://mcp.context7.com/mcp` endpoint. The installer enables the `omo@sisyphuslabs` plugin MCP policy for Context7 while leaving any existing user-level `[mcp_servers.context7]` block untouched.
 The same plugin-scoped MCP manifest also bundles `ast_grep`, `grep_app`, `git_bash`, and `lsp`. `git_bash` is enabled only on Windows by default.
 

--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -14,6 +14,7 @@ import {
 	writeState,
 } from "./auto-update-state.mjs";
 import { migrateCodexConfig } from "./migrate-codex-config.mjs";
+import { repairOmoCodexConfig } from "./repair-omo-config.mjs";
 import { resolveSpawnInvocation } from "./spawn-command.mjs";
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
@@ -147,6 +148,13 @@ export async function runAutoUpdateCheck({ env = process.env, now = Date.now() }
 }
 
 async function runConfigMigration({ env }) {
+	if (env.LAZYCODEX_CONFIG_REPAIR_DISABLED !== "1" && env.OMO_CODEX_CONFIG_REPAIR_DISABLED !== "1") {
+		try {
+			await repairOmoCodexConfig({ env });
+		} catch (error) {
+			if (!(error instanceof Error)) throw error;
+		}
+	}
 	if (env.LAZYCODEX_CONFIG_MIGRATION_DISABLED === "1" || env.OMO_CODEX_CONFIG_MIGRATION_DISABLED === "1") return;
 	try {
 		await migrateCodexConfig({ env });

--- a/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
+++ b/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const MARKETPLACE_NAME = "sisyphuslabs";
+const PLUGIN_NAME = "omo";
+const PLUGIN_KEY = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+const MANAGED_CODEX_AGENT_NAMES = new Set([
+	"codex-ultrawork-reviewer",
+	"explorer",
+	"librarian",
+	"metis",
+	"momus",
+	"plan",
+]);
+const EVENT_LABELS = new Map([
+	["PreToolUse", "pre_tool_use"],
+	["PermissionRequest", "permission_request"],
+	["PostToolUse", "post_tool_use"],
+	["PreCompact", "pre_compact"],
+	["PostCompact", "post_compact"],
+	["SessionStart", "session_start"],
+	["UserPromptSubmit", "user_prompt_submit"],
+	["SubagentStart", "subagent_start"],
+	["SubagentStop", "subagent_stop"],
+	["Stop", "stop"],
+]);
+
+export async function repairOmoCodexConfig({ env = process.env, codexHome = resolveCodexHome(env), platform = process.platform, now = () => new Date() } = {}) {
+	const installState = await discoverOmoInstallState({ codexHome, platform });
+	if (installState === null) return { repaired: false, reason: "not-installed" };
+
+	const configPath = join(codexHome, "config.toml");
+	const before = await readConfig(configPath);
+	if (isOmoConfigHealthy(before, installState)) {
+		try {
+			await installRepairConfigShim({ codexHome, pluginRoot: installState.pluginRoot });
+		} catch (error) {
+			if (!(error instanceof Error)) throw error;
+		}
+		return { repaired: false, reason: "ok" };
+	}
+
+	const after = applyOmoConfigRepair(before, installState);
+	if (after === before) return { repaired: false, reason: "unchanged" };
+
+	await mkdir(dirname(configPath), { recursive: true });
+	const backupPath = await writeConfigBackup(configPath, before, now);
+	await writeFile(configPath, `${after.trimEnd()}\n`);
+	try {
+		await installRepairConfigShim({ codexHome, pluginRoot: installState.pluginRoot });
+	} catch (error) {
+		if (!(error instanceof Error)) throw error;
+	}
+	return { repaired: true, reason: "restored", configPath, backupPath };
+}
+
+export async function discoverOmoInstallState({ codexHome, platform = process.platform }) {
+	const pluginRoot = await resolveInstalledPluginRoot(codexHome);
+	if (pluginRoot === null) return null;
+
+	const marketplaceRoot = join(codexHome, "plugins", "cache", MARKETPLACE_NAME);
+	const trustedHookStates = await trustedHookStatesForPlugin({
+		marketplaceName: MARKETPLACE_NAME,
+		pluginName: PLUGIN_NAME,
+		pluginRoot,
+	});
+	const agentConfigs = await discoverManagedAgentConfigs(codexHome);
+	return {
+		marketplaceName: MARKETPLACE_NAME,
+		marketplaceSource: {
+			sourceType: "local",
+			source: marketplaceRoot,
+		},
+		pluginNames: [PLUGIN_NAME],
+		platform,
+		trustedHookStates,
+		agentConfigs,
+		pluginRoot,
+	};
+}
+
+export function isOmoConfigHealthy(config, installState) {
+	if (!findTomlSection(config, `marketplaces.${installState.marketplaceName}`)) return false;
+	const pluginSection = findTomlSection(config, `plugins.${JSON.stringify(PLUGIN_KEY)}`);
+	if (!pluginSection) return false;
+	return /^\s*enabled\s*=\s*true\s*$/m.test(pluginSection.text);
+}
+
+export function applyOmoConfigRepair(config, installState) {
+	let next = config;
+	next = ensureFeatureEnabled(next, "plugins");
+	next = ensureFeatureEnabled(next, "plugin_hooks");
+	next = ensureFeatureEnabled(next, "multi_agent");
+	next = ensureFeatureEnabled(next, "child_agents_md");
+	next = ensureMarketplaceBlock(next, installState.marketplaceName, installState.marketplaceSource);
+	for (const pluginName of installState.pluginNames) {
+		next = ensurePluginEnabled(next, `${pluginName}@${installState.marketplaceName}`);
+	}
+	next = ensureOmoBuiltinMcpPolicies(next, installState);
+	for (const state of installState.trustedHookStates) {
+		next = ensureHookTrusted(next, state.key, state.trustedHash);
+	}
+	for (const agentConfig of installState.agentConfigs) {
+		next = ensureAgentConfig(next, agentConfig);
+	}
+	return next;
+}
+
+export async function installRepairConfigShim({ codexHome, pluginRoot }) {
+	const dataDir = join(codexHome, "plugins", "data", "omo-sisyphuslabs");
+	await mkdir(dataDir, { recursive: true });
+	const targetPath = join(dataDir, "repair-omo-config.mjs");
+	await copyFile(join(dirname(fileURLToPath(import.meta.url)), "repair-omo-config.mjs"), targetPath);
+	return targetPath;
+}
+
+async function resolveInstalledPluginRoot(codexHome) {
+	const pluginCacheRoot = join(codexHome, "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME);
+	let entries;
+	try {
+		entries = await readdir(pluginCacheRoot, { withFileTypes: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
+	}
+
+	const versions = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort(compareVersionLabels);
+	if (versions.length === 0) return null;
+	return join(pluginCacheRoot, versions[versions.length - 1]);
+}
+
+async function discoverManagedAgentConfigs(codexHome) {
+	const agentsDir = join(codexHome, "agents");
+	let entries;
+	try {
+		entries = await readdir(agentsDir, { withFileTypes: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+		throw error;
+	}
+
+	const configs = [];
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".toml")) continue;
+		const agentName = entry.name.slice(0, -".toml".length);
+		if (!MANAGED_CODEX_AGENT_NAMES.has(agentName)) continue;
+		configs.push({ name: agentName, configFile: `./agents/${entry.name}` });
+	}
+	return configs.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function trustedHookStatesForPlugin({ marketplaceName, pluginName, pluginRoot }) {
+	const manifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
+	let manifest;
+	try {
+		manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	} catch (error) {
+		if (error instanceof Error) return [];
+		throw error;
+	}
+	if (!isRecord(manifest) || typeof manifest.hooks !== "string") return [];
+
+	const hooksPath = join(pluginRoot, manifest.hooks);
+	let parsed;
+	try {
+		parsed = JSON.parse(await readFile(hooksPath, "utf8"));
+	} catch (error) {
+		if (error instanceof Error) return [];
+		throw error;
+	}
+	if (!isRecord(parsed) || !isRecord(parsed.hooks)) return [];
+
+	const keySource = `${pluginName}@${marketplaceName}:${stripDotSlash(manifest.hooks)}`;
+	const states = [];
+	for (const [eventName, groups] of Object.entries(parsed.hooks)) {
+		if (!Array.isArray(groups)) continue;
+		const eventLabel = EVENT_LABELS.get(eventName);
+		if (eventLabel === undefined) continue;
+		for (const [groupIndex, group] of groups.entries()) {
+			if (!isRecord(group) || !Array.isArray(group.hooks)) continue;
+			for (const [handlerIndex, handler] of group.hooks.entries()) {
+				if (!isRecord(handler) || handler.type !== "command") continue;
+				if (handler.async === true) continue;
+				if (typeof handler.command !== "string" || handler.command.trim() === "") continue;
+				states.push({
+					key: `${keySource}:${eventLabel}:${groupIndex}:${handlerIndex}`,
+					trustedHash: commandHookHash(eventLabel, group.matcher, handler),
+				});
+			}
+		}
+	}
+	return states;
+}
+
+function commandHookHash(eventName, matcher, handler) {
+	const command = handler.command;
+	const timeout = Math.max(Number(handler.timeout ?? 600), 1);
+	const normalizedHandler = {
+		type: "command",
+		command,
+		timeout,
+		async: false,
+	};
+	if (typeof handler.statusMessage === "string") normalizedHandler.statusMessage = handler.statusMessage;
+	const identity = {
+		event_name: eventName,
+		hooks: [normalizedHandler],
+	};
+	if (typeof matcher === "string") identity.matcher = matcher;
+	return `sha256:${createHash("sha256").update(JSON.stringify(canonicalJson(identity))).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+	if (Array.isArray(value)) return value.map(canonicalJson);
+	if (!isRecord(value)) return value;
+	const result = {};
+	for (const key of Object.keys(value).sort()) {
+		result[key] = canonicalJson(value[key]);
+	}
+	return result;
+}
+
+function stripDotSlash(value) {
+	return value.startsWith("./") ? value.slice(2) : value;
+}
+
+function ensureFeatureEnabled(config, featureName) {
+	const section = findTomlSection(config, "features");
+	if (!section) return appendBlock(config, `[features]\n${featureName} = true\n`);
+	return replaceOrInsertSetting(config, section, featureName, "true");
+}
+
+function ensureMarketplaceBlock(config, marketplaceName, source) {
+	const header = `marketplaces.${marketplaceName}`;
+	const block = [
+		`[${header}]`,
+		`last_updated = "${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}"`,
+		`source_type = ${JSON.stringify(source.sourceType)}`,
+		`source = ${JSON.stringify(source.source)}`,
+		source.ref === undefined ? null : `ref = ${JSON.stringify(source.ref)}`,
+		"",
+	].filter((line) => line !== null).join("\n");
+	const section = findTomlSection(config, header);
+	if (section) return config.slice(0, section.start) + block + config.slice(section.end);
+	return appendBlock(config, block);
+}
+
+function ensurePluginEnabled(config, pluginKey) {
+	const header = `plugins.${JSON.stringify(pluginKey)}`;
+	const section = findTomlSection(config, header);
+	if (!section) return appendBlock(config, `[${header}]\nenabled = true\n`);
+	return replaceOrInsertSetting(config, section, "enabled", "true");
+}
+
+function ensurePluginMcpEnabled(config, pluginKey, serverName, enabled) {
+	const header = `plugins.${JSON.stringify(pluginKey)}.mcp_servers.${serverName}`;
+	const section = findTomlSection(config, header);
+	const enabledValue = enabled ? "true" : "false";
+	if (!section) return appendBlock(config, `[${header}]\nenabled = ${enabledValue}\n`);
+	return replaceOrInsertSetting(config, section, "enabled", enabledValue);
+}
+
+function ensureOmoBuiltinMcpPolicies(config, installState) {
+	if (installState.marketplaceName !== MARKETPLACE_NAME || !installState.pluginNames.includes(PLUGIN_NAME)) return config;
+	let nextConfig = ensurePluginMcpEnabled(config, PLUGIN_KEY, "context7", true);
+	nextConfig = ensurePluginMcpEnabled(nextConfig, PLUGIN_KEY, "git_bash", installState.platform === "win32");
+	return nextConfig;
+}
+
+function ensureHookTrusted(config, key, trustedHash) {
+	const header = `hooks.state.${JSON.stringify(key)}`;
+	const section = findTomlSection(config, header);
+	if (!section) return appendBlock(config, `[${header}]\ntrusted_hash = ${JSON.stringify(trustedHash)}\n`);
+	return replaceOrInsertSetting(config, section, "trusted_hash", JSON.stringify(trustedHash));
+}
+
+function ensureAgentConfig(config, agentConfig) {
+	const header = `agents.${tomlKeySegment(agentConfig.name)}`;
+	const section = findTomlSection(config, header);
+	const configFile = JSON.stringify(agentConfig.configFile);
+	if (!section) return appendBlock(config, `[${header}]\nconfig_file = ${configFile}\n`);
+	return replaceOrInsertSetting(config, section, "config_file", configFile);
+}
+
+function tomlKeySegment(value) {
+	return /^[A-Za-z0-9_-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function findTomlSection(config, header) {
+	const headerLine = `[${header}]`;
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let start = -1;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const trimmed = line.trim();
+		if (start === -1) {
+			if (trimmed === headerLine) start = offset;
+		} else if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			return { start, end: offset, text: config.slice(start, offset) };
+		}
+		offset += line.length;
+	}
+	if (start === -1) return null;
+	return { start, end: config.length, text: config.slice(start) };
+}
+
+function replaceOrInsertSetting(config, section, key, value) {
+	const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
+	const replacement = linePattern.test(section.text)
+		? section.text.replace(linePattern, `${key} = ${value}`)
+		: insertSetting(section.text, key, value);
+	return config.slice(0, section.start) + replacement + config.slice(section.end);
+}
+
+function insertSetting(sectionText, key, value) {
+	const trimmed = sectionText.trimEnd();
+	return `${trimmed}\n${key} = ${value}\n`;
+}
+
+function appendBlock(config, block) {
+	const prefix = config.trimEnd();
+	return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${block.trimEnd()}\n`;
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function readConfig(configPath) {
+	try {
+		return await readFile(configPath, "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+		throw error;
+	}
+}
+
+async function writeConfigBackup(configPath, content, now) {
+	if (content.trim().length === 0) return undefined;
+	const timestamp = formatBackupTimestamp(now());
+	const backupPath = `${configPath}.bak-omo-repair-${timestamp}`;
+	await writeFile(backupPath, content);
+	return backupPath;
+}
+
+function formatBackupTimestamp(date) {
+	const pad = (value) => String(value).padStart(2, "0");
+	return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function resolveCodexHome(env) {
+	const value = env.CODEX_HOME?.trim();
+	return value && value.length > 0 ? value : join(homedir(), ".codex");
+}
+
+function compareVersionLabels(left, right) {
+	const leftParts = parseVersionLabel(left);
+	const rightParts = parseVersionLabel(right);
+	for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+		const leftValue = leftParts[index] ?? 0;
+		const rightValue = rightParts[index] ?? 0;
+		if (leftValue !== rightValue) return leftValue - rightValue;
+	}
+	return left.localeCompare(right);
+}
+
+function parseVersionLabel(value) {
+	return value.split(/[.-]/).map((part) => {
+		const numeric = Number.parseInt(part, 10);
+		return Number.isFinite(numeric) ? numeric : 0;
+	});
+}
+
+function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	repairOmoCodexConfig()
+		.then((result) => {
+			if (result.repaired) {
+				console.log(`Repaired OMO Codex config (${result.reason}). Backup: ${result.backupPath ?? "none"}`);
+				return;
+			}
+			console.log(`OMO Codex config repair skipped (${result.reason}).`);
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		});
+}

--- a/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
+++ b/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
@@ -5,6 +5,7 @@ import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises"
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { syncOmoGlobalSkills } from "./sync-global-skills.mjs";
 
 const MARKETPLACE_NAME = "sisyphuslabs";
 const PLUGIN_NAME = "omo";
@@ -36,13 +37,14 @@ export async function repairOmoCodexConfig({ env = process.env, codexHome = reso
 
 	const configPath = join(codexHome, "config.toml");
 	const before = await readConfig(configPath);
+	const skillSync = await syncOmoGlobalSkills({ codexHome, pluginRoot: installState.pluginRoot, now });
 	if (isOmoConfigHealthy(before, installState)) {
 		try {
 			await installRepairConfigShim({ codexHome, pluginRoot: installState.pluginRoot });
 		} catch (error) {
 			if (!(error instanceof Error)) throw error;
 		}
-		return { repaired: false, reason: "ok" };
+		return { repaired: false, reason: "ok", skillSync };
 	}
 
 	const after = applyOmoConfigRepair(before, installState);
@@ -56,7 +58,7 @@ export async function repairOmoCodexConfig({ env = process.env, codexHome = reso
 	} catch (error) {
 		if (!(error instanceof Error)) throw error;
 	}
-	return { repaired: true, reason: "restored", configPath, backupPath };
+	return { repaired: true, reason: "restored", configPath, backupPath, skillSync };
 }
 
 export async function discoverOmoInstallState({ codexHome, platform = process.platform }) {

--- a/packages/omo-codex/plugin/scripts/sync-global-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-global-skills.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const MANIFEST_FILE = "global-skills-manifest.json";
+
+export async function syncOmoGlobalSkills({
+	codexHome = resolveCodexHome(process.env),
+	pluginRoot,
+	now = () => new Date(),
+} = {}) {
+	if (typeof pluginRoot !== "string" || pluginRoot.trim().length === 0) {
+		return { synced: false, reason: "missing-plugin-root", skills: [] };
+	}
+
+	const sourceRoot = join(pluginRoot, "skills");
+	let sourceEntries;
+	try {
+		sourceEntries = await readdir(sourceRoot, { withFileTypes: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return { synced: false, reason: "missing-plugin-skills", skills: [] };
+		}
+		throw error;
+	}
+
+	const skillNames = sourceEntries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((name) => name !== ".system")
+		.sort();
+
+	if (skillNames.length === 0) {
+		return { synced: false, reason: "empty-plugin-skills", skills: [] };
+	}
+
+	const targetRoot = join(codexHome, "skills");
+	await mkdir(targetRoot, { recursive: true });
+
+	const manifestPath = resolveManifestPath(codexHome);
+	const previousManifest = await readManifest(manifestPath);
+	const syncedSkills = [];
+	const skippedSkills = [];
+
+	for (const skillName of skillNames) {
+		const sourcePath = join(sourceRoot, skillName);
+		const targetPath = join(targetRoot, skillName);
+		const hasSkillFile = await exists(join(sourcePath, "SKILL.md"));
+		if (!hasSkillFile) continue;
+
+		const previousManaged = previousManifest.skills.includes(skillName);
+		const targetExists = await exists(targetPath);
+		if (targetExists && !previousManaged) {
+			skippedSkills.push({ name: skillName, reason: "user-owned" });
+			continue;
+		}
+
+		await rm(targetPath, { recursive: true, force: true });
+		await cp(sourcePath, targetPath, { recursive: true });
+		syncedSkills.push(skillName);
+	}
+
+	for (const staleSkillName of previousManifest.skills) {
+		if (skillNames.includes(staleSkillName)) continue;
+		const stalePath = join(targetRoot, staleSkillName);
+		if (await exists(stalePath)) {
+			await rm(stalePath, { recursive: true, force: true });
+		}
+	}
+
+	await writeManifest(manifestPath, {
+		version: await readPluginVersion(pluginRoot),
+		skills: syncedSkills,
+		skipped: skippedSkills,
+		syncedAt: now().toISOString(),
+		source: sourceRoot,
+	});
+
+	return {
+		synced: syncedSkills.length > 0,
+		reason: syncedSkills.length > 0 ? "synced" : "unchanged",
+		skills: syncedSkills,
+		skipped: skippedSkills,
+		manifestPath,
+	};
+}
+
+export async function removeManagedOmoGlobalSkills({ codexHome = resolveCodexHome(process.env) } = {}) {
+	const manifestPath = resolveManifestPath(codexHome);
+	const manifest = await readManifest(manifestPath);
+	const targetRoot = join(codexHome, "skills");
+	const removed = [];
+
+	for (const skillName of manifest.skills) {
+		const targetPath = join(targetRoot, skillName);
+		if (!(await exists(targetPath))) continue;
+		await rm(targetPath, { recursive: true, force: true });
+		removed.push(skillName);
+	}
+
+	await rm(manifestPath, { force: true });
+	return { removed, manifestPath };
+}
+
+function resolveManifestPath(codexHome) {
+	return join(codexHome, "plugins", "data", "omo-sisyphuslabs", MANIFEST_FILE);
+}
+
+async function readManifest(manifestPath) {
+	try {
+		const parsed = JSON.parse(await readFile(manifestPath, "utf8"));
+		return {
+			skills: Array.isArray(parsed.skills) ? parsed.skills.filter((value) => typeof value === "string") : [],
+		};
+	} catch (error) {
+		if (error instanceof Error) return { skills: [] };
+		throw error;
+	}
+}
+
+async function writeManifest(manifestPath, manifest) {
+	await mkdir(dirname(manifestPath), { recursive: true });
+	await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+async function readPluginVersion(pluginRoot) {
+	try {
+		const parsed = JSON.parse(await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"));
+		return typeof parsed.version === "string" ? parsed.version : "unknown";
+	} catch (error) {
+		if (error instanceof Error) return "unknown";
+		throw error;
+	}
+}
+
+async function exists(path) {
+	try {
+		await stat(path);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function resolveCodexHome(env = process.env) {
+	const value = env.CODEX_HOME?.trim();
+	return value && value.length > 0 ? value : join(homedir(), ".codex");
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	syncOmoGlobalSkills({
+		pluginRoot: process.env.OMO_PLUGIN_ROOT?.trim() || dirname(dirname(fileURLToPath(import.meta.url))),
+	})
+		.then((result) => {
+			if (!result.synced) {
+				console.log(`OMO global skill sync skipped (${result.reason}).`);
+				return;
+			}
+			console.log(`Synced ${result.skills.length} OMO skill(s) to ~/.codex/skills: ${result.skills.join(", ")}`);
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		});
+}

--- a/packages/omo-codex/plugin/test/repair-omo-config.test.mjs
+++ b/packages/omo-codex/plugin/test/repair-omo-config.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+	applyOmoConfigRepair,
+	discoverOmoInstallState,
+	isOmoConfigHealthy,
+	repairOmoCodexConfig,
+} from "../scripts/repair-omo-config.mjs";
+
+const SOURCE_PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+async function seedInstalledOmo(codexHome) {
+	const cacheRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0");
+	await mkdir(join(cacheRoot, ".codex-plugin"), { recursive: true });
+	await mkdir(join(cacheRoot, "hooks"), { recursive: true });
+	await cp(join(SOURCE_PLUGIN_ROOT, ".codex-plugin", "plugin.json"), join(cacheRoot, ".codex-plugin", "plugin.json"));
+	await cp(join(SOURCE_PLUGIN_ROOT, "hooks", "hooks.json"), join(cacheRoot, "hooks", "hooks.json"));
+	await mkdir(join(codexHome, "agents"), { recursive: true });
+	await writeFile(join(codexHome, "agents", "plan.toml"), 'model_reasoning_effort = "high"\n');
+}
+
+test("#given stripped Codex config after provider switch #when repairing #then restores omo plugin without touching auth settings", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-provider-switch-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			'model_provider = "custom"',
+			"",
+			"[model_providers.custom]",
+			'name = "custom"',
+			'wire_api = "responses"',
+			"requires_openai_auth = true",
+			'base_url = "https://api.example.test/openai"',
+			"",
+		].join("\n"),
+	);
+
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "win32" });
+	const content = await readFile(configPath, "utf8");
+
+	assert.equal(result.repaired, true);
+	assert.match(content, /\[marketplaces\.sisyphuslabs\]/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\]/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\][\s\S]*enabled = true/);
+	assert.match(content, /base_url = "https:\/\/api\.example\.test\/openai"/);
+	assert.match(content, /model_provider = "custom"/);
+	assert.doesNotMatch(content, /plan_mode_reasoning_effort = "xhigh"/);
+});
+
+test("#given official Codex config without custom provider #when repairing #then preserves chatgpt-oriented settings", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-official-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			'model_reasoning_effort = "xhigh"',
+			"",
+			"[windows]",
+			'sandbox = "elevated"',
+			"",
+		].join("\n"),
+	);
+
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "linux" });
+	const content = await readFile(configPath, "utf8");
+
+	assert.equal(result.repaired, true);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\]/);
+	assert.match(content, /model_reasoning_effort = "xhigh"/);
+	assert.doesNotMatch(content, /\[model_providers\./);
+});
+
+test("#given healthy omo config #when repairing #then leaves config unchanged", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-healthy-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+	const discovered = await discoverOmoInstallState({ codexHome, platform: "linux" });
+	assert.notEqual(discovered, null);
+
+	const healthyConfig = applyOmoConfigRepair("", discovered);
+	assert.equal(isOmoConfigHealthy(healthyConfig, discovered), true);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(configPath, healthyConfig);
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "linux" });
+	assert.equal(result.repaired, false);
+	assert.equal(result.reason, "ok");
+});

--- a/packages/omo-codex/plugin/test/sync-global-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-global-skills.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { removeManagedOmoGlobalSkills, syncOmoGlobalSkills } from "../scripts/sync-global-skills.mjs";
+
+const SOURCE_PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+async function seedPluginCache(codexHome) {
+	const cacheRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0");
+	await mkdir(join(cacheRoot, ".codex-plugin"), { recursive: true });
+	await cp(join(SOURCE_PLUGIN_ROOT, ".codex-plugin", "plugin.json"), join(cacheRoot, ".codex-plugin", "plugin.json"));
+	await cp(join(SOURCE_PLUGIN_ROOT, "skills"), join(cacheRoot, "skills"), { recursive: true });
+	return cacheRoot;
+}
+
+test("#given installed omo plugin cache #when syncing global skills #then copies plugin skills into ~/.codex/skills", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-sync-global-skills-"));
+	const codexHome = join(root, "codex-home");
+	const pluginRoot = await seedPluginCache(codexHome);
+
+	const result = await syncOmoGlobalSkills({ codexHome, pluginRoot });
+	assert.equal(result.synced, true);
+	assert.ok(result.skills.includes("ulw-loop"));
+	assert.ok(await readFile(join(codexHome, "skills", "ulw-loop", "SKILL.md"), "utf8"));
+});
+
+test("#given user-owned skill with same name #when syncing global skills #then preserves user-owned skill", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-sync-global-skills-user-owned-"));
+	const codexHome = join(root, "codex-home");
+	const pluginRoot = await seedPluginCache(codexHome);
+	await mkdir(join(codexHome, "skills", "ulw-loop"), { recursive: true });
+	await writeFile(join(codexHome, "skills", "ulw-loop", "SKILL.md"), "# user-owned\n");
+
+	const result = await syncOmoGlobalSkills({ codexHome, pluginRoot });
+	assert.equal(result.synced, true);
+	assert.deepEqual(
+		result.skipped.find((entry) => entry.name === "ulw-loop"),
+		{ name: "ulw-loop", reason: "user-owned" },
+	);
+	assert.match(await readFile(join(codexHome, "skills", "ulw-loop", "SKILL.md"), "utf8"), /user-owned/);
+});
+
+test("#given managed global skills manifest #when uninstall cleanup runs #then only managed skills are removed", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-sync-global-skills-cleanup-"));
+	const codexHome = join(root, "codex-home");
+	const pluginRoot = await seedPluginCache(codexHome);
+	await syncOmoGlobalSkills({ codexHome, pluginRoot });
+	await mkdir(join(codexHome, "skills", "nature-reader"), { recursive: true });
+	await writeFile(join(codexHome, "skills", "nature-reader", "SKILL.md"), "# keep\n");
+
+	const removed = await removeManagedOmoGlobalSkills({ codexHome });
+	assert.ok(removed.removed.includes("ulw-loop"));
+	assert.match(await readFile(join(codexHome, "skills", "nature-reader", "SKILL.md"), "utf8"), /keep/);
+});

--- a/packages/omo-codex/scripts/install-cli-args-repair-config.test.mjs
+++ b/packages/omo-codex/scripts/install-cli-args-repair-config.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseLazyCodexInstallCliArgs } from "./install/cli-args.mjs";
+
+test("#given repair-config command #when parsing Node installer argv #then returns native repair intent", () => {
+	const parsed = parseLazyCodexInstallCliArgs(["repair-config"]);
+	assert.deepEqual(parsed, { kind: "repair-config", dryRun: false });
+});
+
+test("#given dry-run repair-config command #when parsing Node installer argv #then preserves dry-run intent", () => {
+	const parsed = parseLazyCodexInstallCliArgs(["--dry-run", "repair-config"]);
+	assert.deepEqual(parsed, { kind: "repair-config", dryRun: true });
+});

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -39,6 +39,7 @@ import {
 } from "./install/lazycodex-version-stamp.mjs";
 import { shouldBuildSourcePackages } from "./install/source-package-build.mjs";
 import { runLazyCodexManualUpdate } from "../plugin/scripts/auto-update.mjs";
+import { installRepairConfigShim, repairOmoCodexConfig } from "./install/repair-omo-config.mjs";
 export { nonEmptyEnvValue, resolveCodexInstallerBinDir } from "./install/bin-dir.mjs";
 import { nonEmptyEnvValue, resolveCodexInstallerBinDir } from "./install/bin-dir.mjs";
 
@@ -161,6 +162,11 @@ export async function installMarketplaceLocally(options = {}) {
 		agentConfigs: [...agentConfigs.values()].sort((left, right) => left.name.localeCompare(right.name)),
 		autonomousPermissions: options.autonomousPermissions !== false,
 	});
+	for (const plugin of installed) {
+		if (marketplace.name !== "sisyphuslabs" || plugin.name !== "omo") continue;
+		const repairShimPath = await installRepairConfigShim({ codexHome, pluginRoot: plugin.path });
+		log(`Installed OMO config repair shim -> ${repairShimPath}`);
+	}
 	const projectCleanup = await repairProjectLocalCodexArtifactsBestEffort({ startDirectory: projectDirectory, codexHome, log });
 	for (const configCleanup of projectCleanup.configs) {
 		if (!configCleanup.changed) continue;
@@ -212,6 +218,19 @@ async function main() {
 		const packageJson = JSON.parse(await readFile(join(resolveDefaultRepoRoot(), "package.json"), "utf8"));
 		const version = typeof packageJson.version === "string" ? packageJson.version : "unknown";
 		console.log(`lazycodex-ai ${version}`);
+		return;
+	}
+	if (parsed.kind === "repair-config") {
+		if (parsed.dryRun) {
+			console.log("node packages/omo-codex/plugin/scripts/repair-omo-config.mjs");
+			return;
+		}
+		const result = await repairOmoCodexConfig({ env: process.env });
+		if (result.repaired) {
+			console.log(`Repaired OMO Codex config (${result.reason}). Backup: ${result.backupPath ?? "none"}`);
+			return;
+		}
+		console.log(`OMO Codex config repair skipped (${result.reason}).`);
 		return;
 	}
 	if (parsed.kind === "command") {

--- a/packages/omo-codex/scripts/install-local.mjs
+++ b/packages/omo-codex/scripts/install-local.mjs
@@ -40,6 +40,7 @@ import {
 import { shouldBuildSourcePackages } from "./install/source-package-build.mjs";
 import { runLazyCodexManualUpdate } from "../plugin/scripts/auto-update.mjs";
 import { installRepairConfigShim, repairOmoCodexConfig } from "./install/repair-omo-config.mjs";
+import { syncOmoGlobalSkills } from "./install/sync-global-skills.mjs";
 export { nonEmptyEnvValue, resolveCodexInstallerBinDir } from "./install/bin-dir.mjs";
 import { nonEmptyEnvValue, resolveCodexInstallerBinDir } from "./install/bin-dir.mjs";
 
@@ -166,6 +167,10 @@ export async function installMarketplaceLocally(options = {}) {
 		if (marketplace.name !== "sisyphuslabs" || plugin.name !== "omo") continue;
 		const repairShimPath = await installRepairConfigShim({ codexHome, pluginRoot: plugin.path });
 		log(`Installed OMO config repair shim -> ${repairShimPath}`);
+		const skillSync = await syncOmoGlobalSkills({ codexHome, pluginRoot: plugin.path });
+		if (skillSync.synced) {
+			log(`Synced ${skillSync.skills.length} OMO skill(s) to ${join(codexHome, "skills")}`);
+		}
 	}
 	const projectCleanup = await repairProjectLocalCodexArtifactsBestEffort({ startDirectory: projectDirectory, codexHome, log });
 	for (const configCleanup of projectCleanup.configs) {

--- a/packages/omo-codex/scripts/install/bin-links.mjs
+++ b/packages/omo-codex/scripts/install/bin-links.mjs
@@ -164,11 +164,13 @@ async function existingNonRuntimeWrapper(path) {
 
 function posixRuntimeWrapper(cliPath, codexHome, binDir) {
 	const ulwLoopBin = join(binDir, "omo-ulw-loop");
+	const repairScript = join(codexHome, "plugins", "data", "omo-sisyphuslabs", "repair-omo-config.mjs");
 	return [
 		"#!/bin/sh",
 		`# ${RUNTIME_WRAPPER_MARKER}`,
 		`export CODEX_HOME="\${CODEX_HOME:-${escapePosixDoubleQuoted(codexHome)}}"`,
 		'export OMO_SPARKSHELL_APP_SERVER_SOCKET="${OMO_SPARKSHELL_APP_SERVER_SOCKET:-$CODEX_HOME/app-server-control/app-server-control.sock}"',
+		`if [ -f "${escapePosixDoubleQuoted(repairScript)}" ]; then node "${escapePosixDoubleQuoted(repairScript)}" >/dev/null 2>&1 || true; fi`,
 		'if [ "$1" = "ulw-loop" ] && [ -x "' + escapePosixDoubleQuoted(ulwLoopBin) + '" ]; then',
 		"  shift",
 		'  exec "' + escapePosixDoubleQuoted(ulwLoopBin) + '" "$@"',
@@ -196,11 +198,13 @@ function posixRuntimeWrapper(cliPath, codexHome, binDir) {
 
 function windowsRuntimeWrapper(cliPath, codexHome, binDir) {
 	const ulwLoopBin = join(binDir, "omo-ulw-loop.cmd");
+	const repairScript = join(codexHome, "plugins", "data", "omo-sisyphuslabs", "repair-omo-config.mjs");
 	return [
 		"@echo off",
 		`rem ${RUNTIME_WRAPPER_MARKER}`,
 		`if not defined CODEX_HOME set "CODEX_HOME=${codexHome}"`,
 		'if not defined OMO_SPARKSHELL_APP_SERVER_SOCKET set "OMO_SPARKSHELL_APP_SERVER_SOCKET=%CODEX_HOME%\\app-server-control\\app-server-control.sock"',
+		`if exist "${repairScript}" node "${repairScript}" >nul 2>&1`,
 		`if "%~1"=="ulw-loop" if exist "${ulwLoopBin}" (`,
 		"  shift /1",
 		`  "${ulwLoopBin}" %*`,

--- a/packages/omo-codex/scripts/install/cli-args.mjs
+++ b/packages/omo-codex/scripts/install/cli-args.mjs
@@ -1,5 +1,6 @@
 const CODEX_ONLY_ERROR = "lazycodex-ai installs the Codex Light edition only. Use the omo installer for OpenCode or both-platform installs.";
 export const PASSTHROUGH_COMMANDS = new Set(["doctor", "cleanup", "get-local-version", "boulder", "refresh-model-capabilities", "run", "ulw-loop"]);
+export const NATIVE_COMMANDS = new Set(["repair-config"]);
 
 export function parseLazyCodexInstallCliArgs(argv) {
 	const args = [...argv];
@@ -100,6 +101,9 @@ export function parseLazyCodexInstallCliArgs(argv) {
 		if (arg === "uninstall") {
 			return { kind: "command", command: "cleanup", dryRun, args: args.slice(index + 1) };
 		}
+		if (arg === "repair-config") {
+			return { kind: "repair-config", dryRun };
+		}
 		if (PASSTHROUGH_COMMANDS.has(arg)) {
 			return { kind: "command", command: arg, dryRun, args: args.slice(index + 1) };
 		}
@@ -137,6 +141,7 @@ export function formatLazyCodexInstallHelp() {
 		"Usage: lazycodex-ai install [--no-tui] [--codex-autonomous|--no-codex-autonomous] [--repo-root <path>]",
 		"       lazycodex-ai uninstall [--project <path>]",
 		"       lazycodex-ai update [--dry-run] [--repo-root <path>]",
+		"       lazycodex-ai repair-config [--dry-run]",
 		"       lazycodex-ai version",
 		"       lazycodex-ai <command> [args...]",
 		"",

--- a/packages/omo-codex/scripts/install/repair-omo-config.mjs
+++ b/packages/omo-codex/scripts/install/repair-omo-config.mjs
@@ -1,0 +1,7 @@
+export {
+	applyOmoConfigRepair,
+	discoverOmoInstallState,
+	installRepairConfigShim,
+	isOmoConfigHealthy,
+	repairOmoCodexConfig,
+} from "../../plugin/scripts/repair-omo-config.mjs";

--- a/packages/omo-codex/scripts/install/sync-global-skills.mjs
+++ b/packages/omo-codex/scripts/install/sync-global-skills.mjs
@@ -1,0 +1,1 @@
+export { removeManagedOmoGlobalSkills, syncOmoGlobalSkills } from "../../plugin/scripts/sync-global-skills.mjs";

--- a/packages/omo-opencode/src/cli/install-codex/codex-cleanup.ts
+++ b/packages/omo-opencode/src/cli/install-codex/codex-cleanup.ts
@@ -22,6 +22,7 @@ export interface CodexCleanupResult {
   readonly removedPaths: readonly string[]
   readonly removedAgentLinks: readonly string[]
   readonly skippedAgentLinks: readonly string[]
+  readonly removedGlobalSkills: readonly string[]
   readonly projectCleanup: ProjectLocalCodexCleanupResult
 }
 
@@ -33,6 +34,7 @@ export async function cleanupCodexLight(input: CodexCleanupOptions = {}): Promis
   const agentPaths = await collectInstalledAgentPaths(codexHome, configPath)
   const configCleanup = await cleanupCodexConfig(configPath, input.now)
   const agentCleanup = await removeManifestListedAgentLinks(codexHome, agentPaths)
+  const globalSkillCleanup = await removeManagedOmoGlobalSkills({ codexHome })
 
   const removedPaths: string[] = []
   for (const path of managedGlobalStatePaths(codexHome)) {
@@ -55,8 +57,34 @@ export async function cleanupCodexLight(input: CodexCleanupOptions = {}): Promis
     removedPaths,
     removedAgentLinks: agentCleanup.removed,
     skippedAgentLinks: agentCleanup.skipped,
+    removedGlobalSkills: globalSkillCleanup.removed,
     projectCleanup,
   }
+}
+
+async function removeManagedOmoGlobalSkills(input: { readonly codexHome: string }): Promise<{ readonly removed: readonly string[] }> {
+  const manifestPath = join(input.codexHome, "plugins", "data", "omo-sisyphuslabs", "global-skills-manifest.json")
+  let manifest: { skills?: unknown }
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { skills?: unknown }
+  } catch (error) {
+    if (error instanceof Error) return { removed: [] }
+    throw error
+  }
+
+  const skillNames = Array.isArray(manifest.skills)
+    ? manifest.skills.filter((value): value is string => typeof value === "string")
+    : []
+  const removed: string[] = []
+  for (const skillName of skillNames) {
+    const targetPath = join(input.codexHome, "skills", skillName)
+    if (!(await exists(targetPath))) continue
+    await rm(targetPath, { recursive: true, force: true })
+    removed.push(skillName)
+  }
+
+  await rm(manifestPath, { force: true })
+  return { removed }
 }
 
 export { cleanupCodexLightConfigText } from "./codex-cleanup-config"


### PR DESCRIPTION
## Summary

This PR makes OMO (LazyCodex / `omo@sisyphuslabs`) resilient to Codex auth and provider switches. When users switch between official ChatGPT login and relay providers (e.g. ZenMux), Codex tooling often rewrites `~/.codex/config.toml` and strips marketplace/plugin entries, while the OMO plugin cache under `~/.codex/plugins/cache/sisyphuslabs/omo/` remains intact.

This change adds surgical config repair and mirrors OMO plugin skills into the durable global `~/.codex/skills/` directory (the same discovery path used by user-installed skills such as `nature-*` or `zenmux-*`).

## Problem

- Switching Codex auth/provider commonly resets `config.toml`, removing `omo@sisyphuslabs` and related hook/agent blocks.
- OMO plugin files and bundled skills still exist in the plugin cache, but Codex stops loading them because config no longer references the plugin.
- User-owned skills in `~/.codex/skills/` survive these switches because Codex discovers them independently of plugin config; OMO plugin skills did not.

## Solution

### 1. Config repair (`repair-omo-config.mjs`)

- Discovers the installed OMO plugin cache and surgically re-merges only OMO-managed blocks:
  - `sisyphuslabs` marketplace registration
  - `omo@sisyphuslabs` plugin enablement
  - trusted hook states
  - bundled agent TOML references
- **Does not touch** user auth/provider settings (`model_provider`, `base_url`, etc.).
- Installs a stable repair shim at `~/.codex/plugins/data/omo-sisyphuslabs/repair-omo-config.mjs`.
- Runs automatically from:
  - `npx lazycodex-ai repair-config`
  - the `omo` runtime wrapper (via `bin-links.mjs`, adapted from upstream refactor)
  - LazyCodex `SessionStart` auto-update checks

### 2. Global skills mirror (`sync-global-skills.mjs`)

- Syncs OMO plugin skills from the plugin cache into `~/.codex/skills/<skill-name>/`.
- Tracks managed copies in `~/.codex/plugins/data/omo-sisyphuslabs/global-skills-manifest.json`.
- **Never overwrites** user-owned skills with the same name.
- Uninstall cleanup removes only manifest-tracked copies (`removedGlobalSkills` in `codex-cleanup.ts`).

## Upstream refactor adaptation

Upstream `dev` extracted `resolveCodexInstallerBinDir` to `bin-dir.mjs` and runtime wrappers to `bin-links.mjs`. This PR applies the repair shim hook in `bin-links.mjs` instead of the former `cache.mjs` location.

## How to verify

```bash
node --test packages/omo-codex/plugin/test/repair-omo-config.test.mjs \
  packages/omo-codex/plugin/test/sync-global-skills.test.mjs \
  packages/omo-codex/scripts/install-cli-args-repair-config.test.mjs
```

Manual smoke test after install:

```bash
npx lazycodex-ai install
npx lazycodex-ai repair-config
# Confirm ~/.codex/config.toml still has omo@sisyphuslabs after simulating a provider switch
# Confirm OMO skills appear under ~/.codex/skills/
```

## Test plan

- [x] Repair restores stripped `omo@sisyphuslabs` config without modifying auth/provider fields
- [x] Repair is a no-op on healthy config
- [x] Global skill sync copies plugin skills into `~/.codex/skills/`
- [x] User-owned skill names are preserved during sync
- [x] Uninstall cleanup removes only manifest-managed global skills
- [x] `repair-config` CLI parsing works (including dry-run)

---

## Chinese summary

### Background

When switching between official Codex login and relay providers (e.g. ZenMux), `~/.codex/config.toml` is often rewritten and `omo@sisyphuslabs` plus related hook/agent blocks disappear. The plugin cache under `~/.codex/plugins/cache/` remains, but Codex stops loading OMO skills.

Skills manually installed under `~/.codex/skills/` (e.g. `nature-*`, `zenmux-*`) are unaffected because Codex discovers them directly. OMO plugin skills previously depended on plugin config and disappeared after provider switches.

### Changes

1. **Config repair**: New `repair-omo-config.mjs` restores only OMO-managed marketplace/plugin/hook/agent blocks and does not modify `model_provider`, `base_url`, or other auth/relay settings. Available via `npx lazycodex-ai repair-config`, and runs silently from the `omo` wrapper and SessionStart auto-update.

2. **Global skills mirror**: Syncs OMO plugin skills into `~/.codex/skills/` using the same discovery path as user-installed skills. A manifest tracks managed copies; uninstall removes only managed entries and never overwrites user-owned skill names.

### Verification

All local tests pass (8/8). After merge, OMO config and skills should remain available across official/relay login switches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep OMO working across Codex auth/provider switches by repairing OMO config and mirroring OMO skills into the durable global skills folder. Runs automatically via the `omo` wrapper and auto-update, and is available as `npx lazycodex-ai repair-config`.

- **Bug Fixes**
  - Add surgical repair of `~/.codex/config.toml` for `omo@sisyphuslabs` (marketplace, plugin enabled, trusted hooks, agent refs) without touching `model_provider`, `base_url`, or other auth settings.
  - Ship a stable repair shim under `~/.codex/plugins/data/omo-sisyphuslabs/` and invoke it from `bin-links.mjs`, auto-update, and `npx lazycodex-ai repair-config`.
  - Tests cover healthy/no-op repair and provider-switch scenarios.

- **New Features**
  - Mirror OMO plugin skills to `~/.codex/skills/` with a manifest; never overwrite user-owned skills; uninstall removes only managed copies.
  - Add CLI parsing for `repair-config`; README updated; cleanup now deletes managed global skills.

<sup>Written for commit 000091447b5206f52ec25e985fa01bf0e9713af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

