### PR TITLE
fix(background-agent): break infinite deadlock in parent wake noReply admission deferral

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-history-deferral.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-history-deferral.test.ts
@@ -409,4 +409,228 @@ describe("ParentWakeNotifier — assistant history deferral", () => {
       releaseAllPromptAsyncReservationsForTesting()
     }
   })
+
+  test("#given completed assistant turn followed by synthetic internal user message with noReply admitted #when deferral has timed out #then escape fires and stops deferring", async () => {
+    // This test covers the deadlock where:
+    // 1. Agent finished normally (no pending tools)
+    // 2. Background tasks completed -> admit-only noReply notification was sent
+    // 3. latestAssistantTurnBlocksInternalPrompt returns true because
+    //    there's an unanswered synthetic user message with no assistant after it
+    // 4. Without the fix, this loops forever because there's no tool block to trigger stale-tool escape
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "user", time: { created: 80_000 } },
+              parts: [{ type: "text", text: "start work" }],
+            },
+            {
+              info: { role: "assistant", finish: "stop", time: { created: 85_000 } },
+              parts: [{ type: "text", text: "I delegated to background agents" }],
+            },
+            {
+              // This is the admit-only noReply notification (synthetic/internal user message)
+              info: { role: "user", time: { created: 92_000 } },
+              parts: [{ type: "text", text: "<system-reminder>\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-noreply-deadlock": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-noreply-deadlock",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-noreply-deadlock")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    // Simulate: deferral started 6s ago (past the 5s toolCallDeferMaxMs)
+    pendingWake.toolCallDeferralStartedAt = 94_000
+    // Simulate: noReply admission was already recorded
+    pendingWake.noReplyAdmittedAt = 95_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-noreply-deadlock", pendingWake)
+
+      // then: the new escape fires — no longer defers infinitely
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: true })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given completed assistant turn followed by synthetic internal user message WITHOUT noReply admitted #when deferral has timed out #then escape does NOT fire", async () => {
+    // Negative test: without noReplyAdmittedAt the escape should NOT fire.
+    // This ensures we only break the deadlock for the specific admit-only scenario.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "user", time: { created: 80_000 } },
+              parts: [{ type: "text", text: "start work" }],
+            },
+            {
+              info: { role: "assistant", finish: "stop", time: { created: 85_000 } },
+              parts: [{ type: "text", text: "I delegated to background agents" }],
+            },
+            {
+              info: { role: "user", time: { created: 92_000 } },
+              parts: [{ type: "text", text: "<system-reminder>\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-noreply-no-admit": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-noreply-no-admit",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-noreply-no-admit")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    // Deferral timed out but NO noReplyAdmittedAt set
+    pendingWake.toolCallDeferralStartedAt = 94_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-noreply-no-admit", pendingWake)
+
+      // then: should still defer (escape does NOT fire without noReplyAdmittedAt)
+      expect(decision).toEqual({ defer: true, skipPromptGateToolStateCheck: false })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given assistant turn with active tool block and noReply admitted #when deferral has timed out #then stale-tool escape fires instead of noReply escape", async () => {
+    // When there IS a tool block, the existing stale-tool escape should handle it,
+    // not the new noReply admission escape.
+    const originalDateNow = Date.now
+    Date.now = () => 100_000
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "user", time: { created: 80_000 } },
+              parts: [{ type: "text", text: "start work" }],
+            },
+            {
+              info: { role: "assistant", finish: "tool-calls", time: { created: 85_000 } },
+              parts: [{ type: "tool", state: { status: "complete" } }],
+            },
+            {
+              info: { role: "user", time: { created: 92_000 } },
+              parts: [{ type: "text", text: "<system-reminder>\n[ALL BACKGROUND TASKS COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->" }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-tool-block-with-admit": { type: "idle" } } }),
+        promptAsync: async () => {
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-tool-block-with-admit",
+      "task complete",
+      { agent: "sisyphus" },
+      true,
+    )
+    const pendingWake = notifier.getPendingParentWakes().get("parent-tool-block-with-admit")
+    expect(pendingWake).toBeDefined()
+    if (!pendingWake) {
+      throw new Error("Missing pending parent wake")
+    }
+    pendingWake.toolCallDeferralStartedAt = 94_000
+    pendingWake.noReplyAdmittedAt = 95_000
+
+    try {
+      // when
+      const decision = await notifier["shouldDeferParentWakeForSessionHistory"]("parent-tool-block-with-admit", pendingWake)
+
+      // then: the stale-tool escape fires (latestAssistantTurnHasToolBlock is true),
+      // not the noReply admission escape
+      expect(decision).toEqual({ defer: false, skipPromptGateToolStateCheck: true })
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
@@ -141,6 +141,15 @@ export function getParentWakeSessionHistoryDeferralDecision(input: {
     log("[background-agent] Retrying parent wake after stale tool-call deferral:", { sessionID: input.sessionID })
     return { defer: false, skipPromptGateToolStateCheck: true }
   }
+  if (
+    now - input.wake.toolCallDeferralStartedAt >= input.toolCallDeferMaxMs
+    && !latestAssistantTurnHasToolBlock(messages)
+    && input.wake.noReplyAdmittedAt !== undefined
+  ) {
+    delete input.wake.toolCallDeferralStartedAt
+    log("[background-agent] Retrying parent wake after retained no-reply admission deferral timeout:", { sessionID: input.sessionID })
+    return { defer: false, skipPromptGateToolStateCheck: true }
+  }
   log("[background-agent] Deferred parent wake because latest assistant turn blocks internal prompts:", {
     sessionID: input.sessionID,
   })


### PR DESCRIPTION
## Summary

Fixes the infinite deadlock where background task completion notifications never wake the parent agent. After an admit-only (`noReply: true`) wake is dispatched, `latestAssistantTurnBlocksInternalPrompt()` sees the resulting synthetic user message with no assistant response and permanently blocks further wake dispatches.

## Root Cause

1. Flush runner sends admit-only notification when parent has recent activity
2. The synthetic user message refreshes `recordParentSessionActivity()` (no filter for internal messages at `manager.ts:1584`)
3. Once `noReplyAdmittedAt` is set, `deferReplyWakeWhileUnsafe` perpetually reschedules
4. After activity window expires, `latestAssistantTurnBlocksInternalPrompt()` returns `true` (unanswered synthetic message)
5. The stale-tool escape requires `latestAssistantTurnHasToolBlock` which is `false` for normally-completed agent turns
6. Result: permanent infinite reschedule loop — the wake never dispatches with `noReply: false`

## Fix

Added a timeout-based escape hatch in `getParentWakeSessionHistoryDeferralDecision` that fires when:
- `toolCallDeferralStartedAt` has exceeded `toolCallDeferMaxMs` (5s)
- There is no tool block (`!latestAssistantTurnHasToolBlock`)
- The wake was previously admitted as noReply (`noReplyAdmittedAt !== undefined`)

Returns `{ defer: false, skipPromptGateToolStateCheck: true }` to bypass both the flush runner deferral and the prompt-async-gate tool state check (which would also be fooled by the same synthetic message).

Recovery time: ~10s (5s activity window + 5s deferral timeout) instead of infinite deadlock.

## Files Changed (2 files, +233 LOC)

- `packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts` — escape hatch logic
- `packages/omo-opencode/src/features/background-agent/parent-wake-history-deferral.test.ts` — 3 regression tests

## Testing

Three regression tests added:
- **Positive**: completed assistant + synthetic user msg + `noReplyAdmittedAt` + timeout → escape fires
- **Negative**: same scenario WITHOUT `noReplyAdmittedAt` → still defers (no false positives)
- **Negative**: tool block present → existing stale-tool escape handles it (no interference)

Verified locally: built the package, pointed OpenCode config to local build, main agent launched background agents and resumed automatically after completion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock that blocked parent wakes after admit-only (`noReply: true`) notifications by adding a timeout escape in the deferral logic. Parent agents now recover in ~10s instead of looping forever.

- Bug Fixes
  - Add timeout escape in `getParentWakeSessionHistoryDeferralDecision` when deferral exceeds `toolCallDeferMaxMs`, there’s no tool block, and `noReplyAdmittedAt` is set; returns `{ defer: false, skipPromptGateToolStateCheck: true }`.
  - Add 3 regression tests: escape fires on the admit-only case; stays deferred without `noReplyAdmittedAt`; tool-block path continues to use the stale-tool escape.

<sup>Written for commit 34c16193a2fc8e5138954aea9d886501f18635ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

