### PR TITLE
fix: bypass promptAsync gate for error messages in runtime-fallback

### DIFF
--- a/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
@@ -399,4 +399,48 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
     // then
     expect(blocks).toBe(true)
   })
+
+  test("#given assistant message with info.error #when checking prompt safety #then internal prompts are not blocked (error is terminal)", () => {
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          time: { created: 2000 },
+          error: { name: "UnknownError", message: "rate-limited" },
+        },
+      },
+    ]
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+    expect(blocks).toBe(false)
+  })
+
+  test("#given assistant message with error part #when checking prompt safety #then internal prompts are not blocked (error is terminal)", () => {
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          time: { created: 2000 },
+        },
+        parts: [{ type: "error", text: "All accounts rate-limited" }],
+      },
+    ]
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+    expect(blocks).toBe(false)
+  })
+
+  test("#given assistant message with info.error and unknown finish #when checking prompt safety #then error check takes priority over unknown-finish block", () => {
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "unknown",
+          time: { created: 2000 },
+          error: { name: "ProviderRateLimitError" },
+        },
+        parts: [],
+      },
+    ]
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+    expect(blocks).toBe(false)
+  })
 })

--- a/packages/utils/src/prompt-async-gate/pending-tool-turn.ts
+++ b/packages/utils/src/prompt-async-gate/pending-tool-turn.ts
@@ -75,11 +75,14 @@ export function latestAssistantTurnBlocksInternalPrompt(messages: unknown[]): bo
       if (finish === "tool-calls") {
         return !isRecord(message) || !Array.isArray(message.parts) || messageHasUnresolvedTool(message)
       }
+      if (messageHasTerminalError(message)) {
+        return false
+      }
       if (
         (finish === undefined || finish === "unknown")
         && !messageHasSubstantiveAssistantOutput(message)
       ) {
-        return !(messageCompleted(message) && messageHasTerminalError(message))
+        return true
       }
       if (messageCompleted(message)) {
         return false

--- a/packages/utils/src/prompt-async-gate/prompt-message-state.ts
+++ b/packages/utils/src/prompt-async-gate/prompt-message-state.ts
@@ -57,7 +57,13 @@ export function messageHasTerminalError(message: unknown): boolean {
   if (isRecord(info) && info.error !== undefined && info.error !== null) {
     return true
   }
-  return message.error !== undefined && message.error !== null
+  if (message.error !== undefined && message.error !== null) {
+    return true
+  }
+  return (
+    Array.isArray(message.parts) &&
+    (message.parts as unknown[]).some((part) => isRecord(part) && part.type === "error")
+  )
 }
 
 function toInternalInitiatorTextPartLike(part: unknown): InternalInitiatorTextPartLike {


### PR DESCRIPTION
## Summary

The `promptAsync` gate (`latestAssistantTurnBlocksInternalPrompt`) blocks runtime-fallback retries when the latest assistant message is an error (e.g. rate-limit/quota exceeded), because it treats error messages as "still active" — they have `finish: undefined` and no substantive output.

## Problem

When a provider returns an error, the runtime-fallback hook correctly detects it and prepares a fallback model. But when it calls `promptAsync` to dispatch the retry, the gate sees the error-bearing assistant message and blocks it:

```
[runtime-fallback] Auto-retrying with fallback model (session.error) {"model":"fallback-model"}
[prompt-async-gate] promptAsync skipped because latest assistant is still active
[runtime-fallback] Auto-retry skipped by promptAsync gate (session.error) {"status":"active"}
```

The error message has:
- `finish: undefined` (no completion marker from provider)
- `parts: []` (no substantive output)
- `info.error` set (error object — but the gate never checks this)

The gate falls through to the `(finish === undefined || finish === "unknown") && !messageHasSubstantiveAssistantOutput(message)` check → returns `true` (blocking).

## Fix

3 files changed:

1. **`prompt-message-state.ts`** — Extend the existing `messageHasTerminalError()` helper (it already checked `info.error` and `message.error`) to also detect error-type parts by scanning `parts[]` for `{ type: "error" }`
2. **`pending-tool-turn.ts`** — Add `if (messageHasTerminalError(message)) return false` before the unknown-finish block, so error messages are treated as terminal (non-blocking)
3. **`pending-tool-turn.test.ts`** — Add 3 test cases covering `info.error`, error parts, and combined error+unknown-finish

## Testing

**Unit tests** — `bun test packages/omo-opencode/src/shared/prompt-async-gate/` → **28/28 pass** (3 new + 25 existing, including the `prompt-async-route-audit.test.ts` meta-audit that guards the architectural invariant "no raw `session.promptAsync` outside the gate").

**Live verification** — Patched the bundled output in a live environment (oMo v4.8.1, OpenCode TUI). Debug logging confirmed the fix:

| Event | `hasErr` | Gate Result |
|---|---|---|
| `session.error` | `false` (message not yet updated) | blocked (expected — no error in message yet) |
| `message.updated` | `true` (`info.error: [object Object]`) | **gate opened → dispatched** ✅ |

After the gate opened, the fallback model responded successfully with `finish: "stop"`.

## Related Issues

- #1420 — runtime-fallback not triggering
- #2393 — rate limit handling
- #3519 — promptAsync gate blocking retries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass the `promptAsync` gate for assistant error messages so runtime-fallback auto-retries proceed after provider failures (rate limits, quota). Error turns are treated as terminal, not active.

- **Bug Fixes**
  - Extended `messageHasTerminalError()` in `prompt-message-state.ts` to detect `info.error`, `message.error`, and `{ type: "error" }` parts.
  - In `latestAssistantTurnBlocksInternalPrompt`, added an early error check to bypass the gate before the unknown-finish block.
  - Added tests in `packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts` for `info.error`, error parts, and error with `finish: "unknown"`.

<sup>Written for commit 397881e2958e77cbe7f2973c88d3cd3e17f223b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

