### PR TITLE
fix(postinstall): refresh OpenCode plugin cache instead of leaving it cold

### DIFF
--- a/bin/opencode-cache.js
+++ b/bin/opencode-cache.js
@@ -1,0 +1,153 @@
+// bin/opencode-cache.js
+// Refreshes OpenCode's plugin cache after a global install so it stays "hot".
+// Deleting alone (PR #4640) leaves the cache cold; OpenCode's cold-cache
+// install path can then deadlock under Bun, hanging at "loading plugin" (#5050).
+
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/;
+
+const INSTALL_TIMEOUT_MS = 180_000;
+
+/**
+ * Install commands tried in order. `--ignore-scripts` is mandatory: it keeps
+ * the nested install from re-running this package's own postinstall
+ * (no recursion) and mirrors how OpenCode itself installs plugin specs
+ * (Arborist is invoked with `ignoreScripts: true`).
+ */
+const INSTALL_COMMANDS = [
+  { command: "bun", args: ["install", "--ignore-scripts"] },
+  { command: "npm", args: ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--loglevel=error"] },
+];
+
+/**
+ * @param {string} requested Version part of a cache spec dir name (after "@").
+ * @returns {boolean} true when it pins an exact semver, false for dist-tags/ranges.
+ */
+export function isExactVersion(requested) {
+  return EXACT_SEMVER_PATTERN.test(requested);
+}
+
+/**
+ * Default dependency installer: runs the first available package manager in
+ * the spec directory. Returns false on spawn failure, non-zero exit, or
+ * timeout so callers can fall back to removing the directory.
+ *
+ * @param {{ directory: string }} input
+ * @returns {boolean}
+ */
+export function runDependencyInstall({ directory }) {
+  for (const { command, args } of INSTALL_COMMANDS) {
+    const result = spawnSync(command, args, {
+      cwd: directory,
+      stdio: "ignore",
+      timeout: INSTALL_TIMEOUT_MS,
+      shell: process.platform === "win32",
+    });
+    if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOENT") {
+      continue;
+    }
+    return !result.error && result.status === 0;
+  }
+  return false;
+}
+
+/**
+ * Refresh every OpenCode plugin cache spec dir (both `<cacheDir>/<name>@...` and
+ * `<cacheDir>/packages/<name>@...` layouts): delete the stale copy, rebuild it
+ * with a manifest pinning the right version (exact specs keep their pin;
+ * dist-tags/ranges pin the just-installed version), and reinstall deps. On
+ * failure the dir is removed, degrading to the old cold-cache behaviour.
+ *
+ * @param {object} input
+ * @param {string} input.cacheDir OpenCode cache root (e.g. ~/.cache/opencode).
+ * @param {string[]} input.packageNames Plugin package names to refresh.
+ * @param {string | null} input.installedVersion Version that was just installed.
+ * @param {(input: { directory: string }) => boolean} [input.installDependencies]
+ * @returns {{ refreshed: string[], removed: string[] }} Spec dir paths by outcome.
+ */
+export function refreshOpenCodePluginCache({
+  cacheDir,
+  packageNames,
+  installedVersion,
+  installDependencies = runDependencyInstall,
+}) {
+  /** @type {{ refreshed: string[], removed: string[] }} */
+  const summary = { refreshed: [], removed: [] };
+  const parentDirs = [cacheDir, join(cacheDir, "packages")];
+
+  for (const parentDir of parentDirs) {
+    let entries;
+    try {
+      entries = readdirSync(parentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const packageName = packageNames.find((name) => entry.name.startsWith(`${name}@`));
+      if (!packageName) continue;
+
+      const specPath = join(parentDir, entry.name);
+      const requested = entry.name.slice(packageName.length + 1);
+      const version = isExactVersion(requested) ? requested : installedVersion;
+
+      // A copy we cannot delete is the pre-#4640 stale-cache situation;
+      // leave it for OpenCode rather than corrupting it half-way.
+      if (!removeDirectory(specPath)) continue;
+
+      if (!version) {
+        summary.removed.push(specPath);
+        continue;
+      }
+
+      if (repopulateSpecDir({ specPath, packageName, version, installDependencies })) {
+        summary.refreshed.push(specPath);
+      } else {
+        // Best effort: worst case OpenCode finds a cold cache and reinstalls.
+        removeDirectory(specPath);
+        summary.removed.push(specPath);
+      }
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * @param {string} path
+ * @returns {boolean} true when the directory no longer exists.
+ */
+function removeDirectory(path) {
+  try {
+    rmSync(path, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {object} input
+ * @param {string} input.specPath
+ * @param {string} input.packageName
+ * @param {string} input.version
+ * @param {(input: { directory: string }) => boolean} input.installDependencies
+ * @returns {boolean} true when the spec dir contains a loadable package copy.
+ */
+function repopulateSpecDir({ specPath, packageName, version, installDependencies }) {
+  try {
+    mkdirSync(specPath, { recursive: true });
+    const manifest = { dependencies: { [packageName]: version } };
+    writeFileSync(join(specPath, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+    if (!installDependencies({ directory: specPath })) {
+      return false;
+    }
+    return existsSync(join(specPath, "node_modules", packageName, "package.json"));
+  } catch {
+    return false;
+  }
+}

--- a/bin/opencode-cache.test.ts
+++ b/bin/opencode-cache.test.ts
@@ -1,0 +1,186 @@
+// bin/opencode-cache.test.ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isExactVersion, refreshOpenCodePluginCache } from "./opencode-cache.js";
+
+const PACKAGE_NAMES = ["oh-my-opencode", "oh-my-openagent"];
+
+let cacheDir: string;
+
+function makeSpecDir(parent: string, name: string): string {
+  const specPath = join(parent, name);
+  mkdirSync(join(specPath, "node_modules"), { recursive: true });
+  writeFileSync(join(specPath, "package.json"), JSON.stringify({ dependencies: {} }));
+  return specPath;
+}
+
+function stubInstall(options: { succeed: boolean }): (input: { directory: string }) => boolean {
+  return ({ directory }) => {
+    if (!options.succeed) return false;
+    const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+    const [name] = Object.keys(manifest.dependencies);
+    const version = manifest.dependencies[name];
+    const packageDir = join(directory, "node_modules", name);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(join(packageDir, "package.json"), JSON.stringify({ name, version }));
+    return true;
+  };
+}
+
+beforeEach(() => {
+  cacheDir = mkdtempSync(join(tmpdir(), "omo-opencode-cache-"));
+});
+
+afterEach(() => {
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+describe("isExactVersion", () => {
+  test("accepts exact semver pins including prereleases", () => {
+    // #given exact version strings
+    // #when / #then they are recognised as exact pins
+    expect(isExactVersion("4.8.1")).toBe(true);
+    expect(isExactVersion("4.8.1-beta.1")).toBe(true);
+  });
+
+  test("rejects dist-tags and ranges", () => {
+    // #given non-exact specs as they appear in cache dir names
+    // #when / #then they are not treated as exact pins
+    expect(isExactVersion("latest")).toBe(false);
+    expect(isExactVersion("next")).toBe(false);
+    expect(isExactVersion("^4.8.0")).toBe(false);
+    expect(isExactVersion("4")).toBe(false);
+  });
+});
+
+describe("refreshOpenCodePluginCache", () => {
+  test("repopulates a dist-tag spec dir pinned to the installed version", () => {
+    // #given a cached oh-my-openagent@latest spec dir in the packages layout
+    const packagesDir = join(cacheDir, "packages");
+    const specPath = makeSpecDir(packagesDir, "oh-my-openagent@latest");
+
+    // #when refreshing after installing 4.9.0
+    const summary = refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then the spec dir is rebuilt with a manifest pinning 4.9.0
+    expect(summary.refreshed).toEqual([specPath]);
+    expect(summary.removed).toEqual([]);
+    const manifest = JSON.parse(readFileSync(join(specPath, "package.json"), "utf8"));
+    expect(manifest.dependencies["oh-my-openagent"]).toBe("4.9.0");
+    expect(existsSync(join(specPath, "node_modules", "oh-my-openagent", "package.json"))).toBe(true);
+  });
+
+  test("keeps the pin of an exact-version spec dir", () => {
+    // #given a cached spec dir pinned to an older exact version
+    const packagesDir = join(cacheDir, "packages");
+    const specPath = makeSpecDir(packagesDir, "oh-my-openagent@4.5.0");
+
+    // #when refreshing after installing 4.9.0
+    refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then the manifest still pins the exact version the user requested
+    const manifest = JSON.parse(readFileSync(join(specPath, "package.json"), "utf8"));
+    expect(manifest.dependencies["oh-my-openagent"]).toBe("4.5.0");
+  });
+
+  test("refreshes the legacy cache layout next to the packages layout", () => {
+    // #given spec dirs in both supported cache layouts
+    const legacyPath = makeSpecDir(cacheDir, "oh-my-opencode@latest");
+    const packagedPath = makeSpecDir(join(cacheDir, "packages"), "oh-my-opencode@latest");
+
+    // #when refreshing
+    const summary = refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then both layouts are repopulated
+    expect(summary.refreshed.sort()).toEqual([legacyPath, packagedPath].sort());
+  });
+
+  test("removes the spec dir entirely when dependency install fails", () => {
+    // #given a cached spec dir and an installer that fails
+    const specPath = makeSpecDir(join(cacheDir, "packages"), "oh-my-openagent@latest");
+
+    // #when refreshing
+    const summary = refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: false }),
+    });
+
+    // #then the dir is gone so OpenCode sees a clean cold cache, not a broken tree
+    expect(summary.refreshed).toEqual([]);
+    expect(summary.removed).toEqual([specPath]);
+    expect(existsSync(specPath)).toBe(false);
+  });
+
+  test("removes the spec dir when the installed version is unknown", () => {
+    // #given a dist-tag spec dir but no version information
+    const specPath = makeSpecDir(join(cacheDir, "packages"), "oh-my-openagent@latest");
+
+    // #when refreshing without an installed version
+    const summary = refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: null,
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then the previous delete-only behaviour applies
+    expect(summary.removed).toEqual([specPath]);
+    expect(existsSync(specPath)).toBe(false);
+  });
+
+  test("leaves unrelated cached plugins untouched", () => {
+    // #given another plugin's spec dir in the cache
+    const otherPath = makeSpecDir(join(cacheDir, "packages"), "opencode-pty@latest");
+    const sentinel = join(otherPath, "node_modules", "sentinel");
+    mkdirSync(sentinel, { recursive: true });
+
+    // #when refreshing oh-my plugin caches
+    const summary = refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then the unrelated plugin cache is untouched
+    expect(summary.refreshed).toEqual([]);
+    expect(summary.removed).toEqual([]);
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  test("is a no-op when the cache root does not exist", () => {
+    // #given a cache root that was never created
+    const missing = join(cacheDir, "does-not-exist");
+
+    // #when refreshing
+    const summary = refreshOpenCodePluginCache({
+      cacheDir: missing,
+      packageNames: PACKAGE_NAMES,
+      installedVersion: "4.9.0",
+      installDependencies: stubInstall({ succeed: true }),
+    });
+
+    // #then nothing is reported and nothing is created
+    expect(summary).toEqual({ refreshed: [], removed: [] });
+    expect(existsSync(missing)).toBe(false);
+  });
+});

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,7 +1,7 @@
 // postinstall.mjs
 // Runs after npm install to verify platform binary is available
 
-import { readFileSync, readdirSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +10,7 @@ import {
   getBinaryPath,
   resolvePlatformPackageBaseName,
 } from "./bin/platform.js";
+import { refreshOpenCodePluginCache } from "./bin/opencode-cache.js";
 import { detectPlatformBinaryMismatch } from "./bin/version-mismatch.js";
 
 const require = createRequire(import.meta.url);
@@ -103,21 +104,20 @@ function getMainPackageVersion() {
   return packageJson?.version ?? null;
 }
 
-function invalidateOpenCodePluginCache() {
+// Refresh (not just delete) the OpenCode plugin cache. Deleting alone leaves
+// the cache cold, and OpenCode's cold-cache plugin install can deadlock under
+// Bun, hanging OpenCode at startup (issue #5050). Best-effort: postinstall
+// must never fail the package install.
+function refreshPluginCache() {
   const cacheDir = join(process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache"), "opencode");
-  const parentDirs = [cacheDir, join(cacheDir, "packages")];
-  const prefixes = OPENCODE_PLUGIN_PACKAGES.map((packageName) => `${packageName}@`);
-
-  for (const parentDir of parentDirs) {
-    try {
-      for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
-        if (entry.isDirectory() && prefixes.some((prefix) => entry.name.startsWith(prefix))) {
-          rmSync(join(parentDir, entry.name), { recursive: true, force: true });
-        }
-      }
-    } catch {
-      // Cache invalidation is best-effort; postinstall should not fail package installs.
-    }
+  try {
+    return refreshOpenCodePluginCache({
+      cacheDir,
+      packageNames: OPENCODE_PLUGIN_PACKAGES,
+      installedVersion: getMainPackageVersion(),
+    });
+  } catch {
+    return { refreshed: [], removed: [] };
   }
 }
 
@@ -136,7 +136,11 @@ function main() {
   const libcFamily = getLibcFamily();
   const packageBaseName = getPackageBaseName();
 
-  invalidateOpenCodePluginCache();
+  const cacheRefresh = refreshPluginCache();
+  for (const specPath of cacheRefresh.removed) {
+    console.warn(`oh-my-opencode: could not refresh OpenCode plugin cache at ${specPath}`);
+    console.warn(`  OpenCode will reinstall the plugin on next startup.`);
+  }
 
   // Check opencode version requirement
   const versionCheck = checkOpenCodeVersion();


### PR DESCRIPTION
## Summary

- Fixes the infinite "loading plugin" hang on OpenCode startup after installing/updating this package (#5050).
- `postinstall` now refreshes (repopulates) OpenCode's plugin cache instead of only deleting it.

## Changes

- Added `bin/opencode-cache.js`: `refreshOpenCodePluginCache()` removes each cached
  `oh-my-opencode@*` / `oh-my-openagent@*` spec dir (both cache layouts, same as before)
  and immediately rebuilds it: writes a manifest pinning the version OpenCode should load
  (exact specs keep their pin, dist-tags and ranges pin the just-installed version) and
  reinstalls dependencies with `--ignore-scripts` (bun first, npm fallback, 180s timeout).
  If repopulation fails, the dir is removed entirely, degrading to the previous
  delete-only behaviour, never worse.
- Added `bin/opencode-cache.test.ts`: 9 tests (given/when/then) covering both cache
  layouts, exact-pin preservation, install failure fallback, unknown version fallback,
  unrelated plugins untouched, and missing cache root.
- Updated `postinstall.mjs` to call the refresh and warn when a spec dir could not be
  repopulated.

Why: PR #4640 made postinstall delete the cached plugin dirs so OpenCode picks up the
new version after a global install. That leaves the cache cold, and OpenCode's
cold-cache install path (Arborist `reify()` running under Bun, no timeout,
see anomalyco/opencode#31463) can deadlock silently, hanging OpenCode at
"loading plugin" forever. Keeping the cache hot sidesteps the deadlock-prone path
entirely while preserving the update-propagation behaviour #4640 introduced.

## Testing

```bash
bun run typecheck   # passes
bun run build       # passes
bun test            # failing set identical to clean dev baseline; new tests 9/9
bun run test:codex  # passes
```

End-to-end reproduction on Linux (WSL2), OpenCode 1.16.2:

1. Ran the published 4.8.1 postinstall: cache dirs wiped.
2. Started OpenCode: hung forever at `loading plugin oh-my-openagent@4.8.1`
   (killed by timeout after 75s, empty spec dir left behind by Arborist).
3. Ran this branch's postinstall: spec dir repopulated (manifest + node_modules) in seconds.
4. Started OpenCode: plugin loads normally, OMO agents respond.

## Related Issues

Closes #5050
Related: #4640, #5072, anomalyco/opencode#31463

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the OpenCode plugin cache during postinstall so plugins load from a hot cache and avoid the infinite “loading plugin” hang. Fixes #5050.

- **Bug Fixes**
  - Rebuilds `oh-my-opencode@*` and `oh-my-openagent@*` spec dirs in both cache layouts, keeping exact pins and pinning dist-tags/ranges to the just-installed version.
  - Installs deps with `--ignore-scripts` (tries Bun, then npm; 180s timeout). On failure, deletes the dir and logs a warning so OpenCode reinstalls.
  - Updates `postinstall.mjs` to run the refresher; adds tests for both layouts, pin handling, failures/no-op, and unrelated plugins.

<sup>Written for commit 6b96ccfb7b245c77298a4cb2e2741f444acdfe2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

