### PR TITLE
fix: remove incorrect markServerRunningInProcess short-circuit

### DIFF
--- a/packages/omo-opencode/src/create-managers.test.ts
+++ b/packages/omo-opencode/src/create-managers.test.ts
@@ -14,7 +14,6 @@ type CleanupRegistration = {
 
 type CleanupSessionTeamRunsFn = typeof import("./features/team-mode/team-runtime/session-cleanup").cleanupSessionTeamRuns
 
-const markServerRunningInProcess = mock(() => {})
 let backgroundManagerOptions: {
   onSubagentSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
 } | null = null
@@ -76,7 +75,6 @@ function createDeps(): NonNullable<Parameters<typeof createManagers>[0]["deps"]>
     registerManagerForCleanupFn: registerManagerForCleanup,
     cleanupSessionTeamRunsFn: cleanupSessionTeamRunsMock as CleanupSessionTeamRunsFn,
     createConfigHandlerFn: createConfigHandler,
-    markServerRunningInProcessFn: markServerRunningInProcess,
   }
 }
 
@@ -133,7 +131,6 @@ describe("createManagers", () => {
 
   beforeEach(() => {
     dispatchOpenClawEvent = spyOn(openclawRuntimeDispatch, "dispatchOpenClawEvent")
-    markServerRunningInProcess.mockClear()
     dispatchOpenClawEvent.mockReset()
     backgroundManagerOptions = null
     trackedPaneBySession.clear()
@@ -145,22 +142,7 @@ describe("createManagers", () => {
     dispatchOpenClawEvent.mockRestore()
   })
 
-  it("#given tmux integration is disabled #when managers are created #then it does not mark the tmux server as running", () => {
-    const args = {
-      ctx: createContext("/tmp"),
-      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
-      tmuxConfig: createTmuxConfig(false),
-      modelCacheState: createModelCacheState(),
-      backgroundNotificationHookEnabled: false,
-      deps: createDeps(),
-    }
-
-    createManagers(args)
-
-    expect(markServerRunningInProcess).not.toHaveBeenCalled()
-  })
-
-  it("#given tmux integration is enabled #when managers are created #then it marks the tmux server as running", () => {
+  it("#given tmux integration is enabled #when managers are created #then TmuxSessionManager is constructed (server readiness is now deferred to isServerRunning health check)", () => {
     const args = {
       ctx: createContext("/tmp"),
       pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
@@ -172,29 +154,40 @@ describe("createManagers", () => {
 
     createManagers(args)
 
-    expect(markServerRunningInProcess).toHaveBeenCalledTimes(1)
+    // markServerRunningInProcess was removed.  The server readiness check
+    // is now delegated to isServerRunning() which performs a real HTTP
+    // health check.  TmuxSessionManager still initializes, but spawns
+    // will only proceed if the health check passes (real HTTP server).
+    expect(MockTmuxSessionManager).toHaveBeenCalledTimes(1)
   })
 
-  it("#given tmux is enabled but ctx.serverUrl is undefined #when managers are created #then it does NOT mark the server as running (issue #3894)", () => {
-    // Vanilla `opencode` (no `opencode serve` / `opencode web`) leaves
-    // ctx.serverUrl undefined. Marking the server as in-process running
-    // would short-circuit isServerRunning() in createTeamLayout, letting
-    // it spawn tmux panes whose `opencode attach` then fails because no
-    // server is actually listening on the fallback port.
+  it("#given tmux is enabled #when managers are created #then the in-process mark is never set (server readiness verified by HTTP health check)", () => {
+    // Regardless of tmux config or ctx.serverUrl, we no longer
+    // markServerRunningInProcess.  The isServerRunning() function
+    // performs a real HTTP health check before each spawn.
+    // This prevents false positives when `opencode` runs in default
+    // TUI mode (internal RPC, no HTTP listener).
+
     const ctx = createContext("/tmp")
     const ctxWithoutServerUrl = { ...ctx, serverUrl: undefined as unknown as URL }
-    const args = {
-      ctx: ctxWithoutServerUrl,
-      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
-      tmuxConfig: createTmuxConfig(true),
-      modelCacheState: createModelCacheState(),
-      backgroundNotificationHookEnabled: false,
-      deps: createDeps(),
+
+    for (const ctxVariant of [ctx, ctxWithoutServerUrl]) {
+      for (const enabled of [true, false]) {
+        const args = {
+          ctx: ctxVariant,
+          pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+          tmuxConfig: createTmuxConfig(enabled),
+          modelCacheState: createModelCacheState(),
+          backgroundNotificationHookEnabled: false,
+          deps: createDeps(),
+        }
+
+        createManagers(args)
+      }
     }
 
-    createManagers(args)
-
-    expect(markServerRunningInProcess).not.toHaveBeenCalled()
+    // markServerRunningInProcess is never called — the logic was removed.
+    // Server availability is verified lazily by isServerRunning().
   })
 
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {

--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -14,7 +14,6 @@ import * as openclawRuntimeDispatch from "./openclaw/runtime-dispatch"
 import { registerManagerForCleanup } from "./features/background-agent/process-cleanup"
 import { createConfigHandler } from "./plugin-handlers"
 import { log } from "./shared"
-import { markServerRunningInProcess } from "./shared/tmux/tmux-utils/server-health"
 import type { ModelFallbackControllerAccessor } from "./hooks/model-fallback"
 
 type CreateManagersDeps = {
@@ -25,7 +24,6 @@ type CreateManagersDeps = {
   registerManagerForCleanupFn: typeof registerManagerForCleanup
   cleanupSessionTeamRunsFn: typeof cleanupSessionTeamRuns
   createConfigHandlerFn: typeof createConfigHandler
-  markServerRunningInProcessFn: typeof markServerRunningInProcess
 }
 
 const defaultCreateManagersDeps: CreateManagersDeps = {
@@ -36,7 +34,6 @@ const defaultCreateManagersDeps: CreateManagersDeps = {
   registerManagerForCleanupFn: registerManagerForCleanup,
   cleanupSessionTeamRunsFn: cleanupSessionTeamRuns,
   createConfigHandlerFn: createConfigHandler,
-  markServerRunningInProcessFn: markServerRunningInProcess,
 }
 
 export type Managers = {
@@ -59,17 +56,17 @@ export function createManagers(args: {
   const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled, runtimeSkillSourceUrl } = args
   const deps = { ...defaultCreateManagersDeps, ...args.deps }
 
-  // Only mark the server as in-process when the SDK actually exposes a
-  // serverUrl. `tmuxConfig.enabled` alone is not proof of a running server —
-  // a vanilla `opencode` session (no `opencode serve`/`opencode web`) leaves
-  // `ctx.serverUrl` undefined, and marking it running would make
-  // `isServerRunning` short-circuit to true. That bypasses the guard in
-  // `createTeamLayout` and lets it spawn tmux panes whose `opencode attach`
-  // command then fails because nothing is actually listening on the
-  // fallback port (issue #3894).
-  if (tmuxConfig.enabled && ctx.serverUrl) {
-    deps.markServerRunningInProcessFn()
-  }
+  // The in-process server mark was removed because ctx.serverUrl is always
+  // truthy (OpenCode's plugin getter falls back to http://localhost:4096
+  // even when Server.listen() was never called).  Marking it running
+  // short-circuited isServerRunning() and let tmux panes spawn with
+  // `opencode attach` commands that failed because no HTTP listener existed.
+  //
+  // Now isServerRunning() always performs a real HTTP health check against
+  // the resolved URL.  In default TUI mode (no --port flag) there is no
+  // HTTP listener → health check fails → spawn is skipped.
+  // When using --port 4096 or `omo run`, the HTTP server is listening →
+  // health check succeeds → tmux panes work correctly.
   const tmuxSessionManager = new deps.TmuxSessionManagerClass(ctx, tmuxConfig, undefined, {
     // Team-mode members get their tmux panes from team-layout-tmux, which
     // owns the lifecycle via runtimeState.tmuxLayout. Telling the subagent


### PR DESCRIPTION
## Problem

OpenCode's plugin getter for `ctx.serverUrl` always returns a truthy URL:

```ts
// opencode/packages/opencode/src/plugin/index.ts
get serverUrl(): URL {
    return Server.url ?? new URL("http://localhost:4096")
}
```

Even when `Server.listen()` was never called (default TUI mode without `--port`), the fallback `http://localhost:4096` is still a truthy `URL` object.
The guard in `createManagers`:

```ts
if (tmuxConfig.enabled && ctx.serverUrl) {
    deps.markServerRunningInProcessFn()
}
```

...thus **always evaluated to true**, short-circuiting `isServerRunning()` even when no HTTP listener existed.

This caused tmux sub-agent panes to spawn with `opencode attach` commands that failed -- nothing was listening on port 4096.

## Fix

Remove the `markServerRunningInProcess()` call entirely. `isServerRunning()` now performs a real HTTP health check (`GET /global/health`) before each tmux spawn.

- `opencode --port 4096` or `omo run`: real HTTP server -> health check passes -> tmux panes work
- `opencode` (default TUI, no `--port`): no HTTP listener -> health check fails -> spawn gracefully skipped

## Changes

- `create-managers.ts`: removed `markServerRunningInProcess` import, deps entry, and call site
- `create-managers.test.ts`: updated tests to reflect new behavior

## Related

- Fixes #5158
- OpenCode feature request: anomalyco/opencode#31821 — add `ensureServer()` to PluginInput so plugins can ensure an HTTP server is running without requiring users to pass `--port`