### PR TITLE
feat: call ctx.ensureServer() on init when tmux is enabled

### DIFF
--- a/packages/omo-opencode/src/create-managers.test.ts
+++ b/packages/omo-opencode/src/create-managers.test.ts
@@ -197,6 +197,45 @@ describe("createManagers", () => {
     expect(markServerRunningInProcess).not.toHaveBeenCalled()
   })
 
+  it("#given tmux is enabled and ctx.ensureServer is available #when managers are created #then ensureServer is called (fire-and-forget)", async () => {
+    // ctx.ensureServer() is an upcoming OpenCode plugin API (anomalyco/opencode#31821).
+    // When OpenCode merges it, OMO will call it as a fire-and-forget side effect
+    // during init to ensure an HTTP server is listening before tmux panes spawn.
+    const ensureServerMock = mock(() => Promise.resolve())
+    const ctx = createContext("/tmp")
+    const ctxWithEnsureServer = { ...ctx, ensureServer: ensureServerMock }
+    const args = {
+      ctx: ctxWithEnsureServer,
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(true),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+
+    createManagers(args)
+
+    // Fire-and-forget: ensureServer is called but not awaited
+    expect(ensureServerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given tmux is enabled but ctx.ensureServer is not available #when managers are created #then no error is thrown (backward compatible)", () => {
+    // Before OpenCode merges ensureServer, ctx won't have the method.
+    // This test verifies OMO works without it (backward compatible).
+    const ctx = createContext("/tmp")
+    const args = {
+      ctx,
+      pluginConfig: OhMyOpenCodeConfigSchema.parse({}),
+      tmuxConfig: createTmuxConfig(true),
+      modelCacheState: createModelCacheState(),
+      backgroundNotificationHookEnabled: false,
+      deps: createDeps(),
+    }
+
+    // Should not throw
+    createManagers(args)
+  })
+
   it("#given openclaw is enabled #when the background session-created callback runs #then it dispatches openclaw with the tracked pane id", async () => {
     const args = {
       ctx: createContext("/tmp/project"),

--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -59,6 +59,33 @@ export function createManagers(args: {
   const { ctx, pluginConfig, tmuxConfig, modelCacheState, backgroundNotificationHookEnabled, runtimeSkillSourceUrl } = args
   const deps = { ...defaultCreateManagersDeps, ...args.deps }
 
+  // Ensure a real HTTP server is running when tmux visualization is enabled.
+  // In default `opencode` TUI mode (no --port), no HTTP listener exists, so
+  // sub-agent panes cannot spawn `opencode attach` commands.
+  //
+  // ctx.ensureServer() is an upcoming OpenCode plugin API (anomalyco/opencode#31821).
+  // When available, it starts an HTTP server if one isn't already listening,
+  // so tmux panes work out of the box without requiring users to pass --port.
+  //
+  // The runtime check via (ctx as any) is intentional: the API is in review
+  // and not yet published in the @opencode-ai/plugin type definitions.
+  if (tmuxConfig.enabled) {
+    const ensureServer = (ctx as Record<string, unknown>).ensureServer
+    if (typeof ensureServer === "function") {
+      void (ensureServer as () => Promise<unknown>).call(ctx).then(() => {
+        log("[create-managers] ensureServer succeeded — HTTP server is now listening")
+      }).catch((error: unknown) => {
+        log("[create-managers] ensureServer failed", {
+          error: error instanceof Error ? error.message : String(error),
+        })
+        console.warn(
+          "[omo] Unable to start HTTP server for tmux visualization.\n" +
+          "      Sub-agent panes may not work. Start opencode with --port 4096.",
+        )
+      })
+    }
+  }
+
   // Only mark the server as in-process when the SDK actually exposes a
   // serverUrl. `tmuxConfig.enabled` alone is not proof of a running server —
   // a vanilla `opencode` session (no `opencode serve`/`opencode web`) leaves


### PR DESCRIPTION
## Summary

When OpenCode merges `ensureServer()` into PluginInput (anomalyco/opencode#31821), OMO should call it during initialization to ensure an HTTP server is listening before tmux sub-agent panes are spawned.

This PR adds the call site now, as a **fire-and-forget** side effect, so it works the moment OpenCode ships the API — no additional OMO changes needed.

## How it works

```ts
// create-managers.ts
if (tmuxConfig.enabled) {
    const ensureServer = (ctx as any).ensureServer
    if (typeof ensureServer === "function") {
        void ensureServer.call(ctx).then(/* success */).catch(/* warn */)
    }
}
```

- **`ensureServer` available** (OpenCode merged the API): starts HTTP server, tmux panes work out of the box
- **`ensureServer` not available** (current OpenCode): fire-and-forget check fails silently, zero impact

The `(ctx as any)` runtime check is intentional — the type isn't in `@opencode-ai/plugin` yet. Once OpenCode publishes it, we'll update to use the typed API.

## Why fire-and-forget

`createManagers()` is synchronous and used in the plugin init pipeline. Making it async would change the signature and cascade through many callers. Fire-and-forget works because:

1. `ensureServer()` returns quickly if the server is already running
2. If the server needs to start, it's ready within milliseconds — well before the first sub-agent spawn
3. If it fails, we log a warning and let `isServerRunning()` handle it later

## Changes

- `create-managers.ts`: added fire-and-forget `ensureServer()` call when tmux is enabled
- `create-managers.test.ts`: added two test cases — one verifies `ensureServer` is called, one verifies backward compatibility

## Related

- Depends on #5159 (removes the `markServerRunningInProcess` short-circuit)
- Relates to #5158 (resolveServerUrl fallback URL detection)
- Relates to #5162 (sub-agent pane auth env vars)
- Upstream: anomalyco/opencode#31821 — Feature Request: add `ensureServer()` to PluginInput