### PR TITLE
test(omo-codex): make lsp prebuild npm fixture Windows-safe

### DIFF
--- a/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs
+++ b/packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -19,9 +19,14 @@ async function makeFixture() {
 	await mkdir(fakeBin, { recursive: true });
 	const npmLog = join(root, "npm.log");
 	await writeFile(
-		join(fakeBin, "npm"),
-		`#!/usr/bin/env node\nconst { appendFileSync } = require("node:fs");\nappendFileSync(${JSON.stringify(npmLog)}, process.argv.slice(2).join(" ") + "\\n");\n`,
+		join(fakeBin, "npm.js"),
+		`const { appendFileSync } = require("node:fs");\nappendFileSync(${JSON.stringify(npmLog)}, process.argv.slice(2).join(" ") + "\\n");\n`,
 	);
+	await writeFile(
+		join(fakeBin, "npm"),
+		`#!/usr/bin/env node\nrequire("./npm.js");\n`,
+	);
+	await writeFile(join(fakeBin, "npm.cmd"), `@echo off\r\nnode "%~dp0\\npm.js" %*\r\n`);
 	await chmod(join(fakeBin, "npm"), 0o755);
 	return { root, npmLog, script: join(root, "packages", "omo-codex", "plugin", "components", "lsp", "scripts", "build-lsp-tools.mjs"), fakeBin };
 }
@@ -29,7 +34,7 @@ async function makeFixture() {
 function runScript(script, fakeBin, args = []) {
 	return spawnSync(process.execPath, [script, ...args], {
 		encoding: "utf8",
-		env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+		env: { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}` },
 	});
 }
 


### PR DESCRIPTION
## Summary
- Refs #5149 by preserving Windows test coverage for the LSP prebuild path after the installed-cache runtime fix landed.
- Make the `build-lsp-tools.test.mjs` fake npm fixture work on Windows by adding an `npm.cmd` shim next to the POSIX `npm` script.
- Use Node's platform `path.delimiter` when prepending the fake bin directory to `PATH`, so the fixture does not hard-code the POSIX `:` separator.
- Keep the change test-only and scoped to the existing LSP prebuild test fixture.

## Context
This is a follow-up to #5149 and the upstream runtime fix in `238ed70610ecf750ad7bdcb5f1e2af7b881531ad`.

That commit covers the installed-cache runtime resolver itself, including `lsp-tools-mcp` and `lsp-daemon`. After that landed on `dev`, the new `lsp-prebuild-layouts.test.mjs` passes on Windows, but the older `components/lsp/scripts/build-lsp-tools.test.mjs` still fails on Windows because its test fixture only creates a POSIX `npm` executable and hard-codes `:` as the `PATH` separator.

This PR keeps the Windows test environment aligned with the runtime behavior already expected by the project: npm subprocesses should be invocable through Windows `.cmd` shims when tests exercise npm-related paths.

## Why This Remains Useful After #5149
- #5149's runtime behavior has already been fixed upstream.
- This PR does not reopen, replace, or close that runtime issue.
- It preserves the Windows regression coverage around the LSP prebuild path by making the older test fixture executable on Windows too.
- The fix is intentionally smaller than #5048: one test file, no runtime code changes.

## Verification
- `node --test packages/omo-codex/plugin/components/lsp/scripts/build-lsp-tools.test.mjs`
- `node --test packages/omo-codex/plugin/test/lsp-prebuild-layouts.test.mjs`
