### PR TITLE
fix(background-agent): wake parent when subagent session transport disconnects

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/error-classifier.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/error-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test"
 import {
   isRecord,
   isAbortedSessionError,
+  isTransportDisconnectError,
   getErrorText,
   extractErrorName,
   extractErrorMessage,
@@ -104,6 +105,50 @@ describe("isAbortedSessionError", () => {
 
     test("returns false for object without message", () => {
       expect(isAbortedSessionError({ code: "ABORTED" })).toBe(false)
+    })
+  })
+})
+
+describe("isTransportDisconnectError", () => {
+  describe("#given SDK transport-teardown errors", () => {
+    test("returns true for the this._client TypeError", () => {
+      expect(isTransportDisconnectError(new TypeError("undefined is not an object (evaluating 'this._client')"))).toBe(true)
+    })
+
+    test("returns true for a Not connected error", () => {
+      expect(isTransportDisconnectError(new Error("Not connected"))).toBe(true)
+    })
+
+    test("returns true for a connection closed message object", () => {
+      expect(isTransportDisconnectError({ message: "The connection closed unexpectedly" })).toBe(true)
+    })
+  })
+
+  describe("#given transient or unrelated errors", () => {
+    test("returns false for a transient 500", () => {
+      expect(isTransportDisconnectError({ message: "Network timeout", status: 500 })).toBe(false)
+    })
+
+    test("returns false for a generic error", () => {
+      expect(isTransportDisconnectError(new Error("Something went wrong"))).toBe(false)
+    })
+
+    test("returns false for an aborted error", () => {
+      expect(isTransportDisconnectError(new Error("Session aborted"))).toBe(false)
+    })
+  })
+
+  describe("#given invalid inputs", () => {
+    test("returns false for null", () => {
+      expect(isTransportDisconnectError(null)).toBe(false)
+    })
+
+    test("returns false for undefined", () => {
+      expect(isTransportDisconnectError(undefined)).toBe(false)
+    })
+
+    test("returns false for empty string", () => {
+      expect(isTransportDisconnectError("")).toBe(false)
     })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/error-classifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/error-classifier.ts
@@ -7,6 +7,21 @@ export function isAbortedSessionError(error: unknown): boolean {
   return message.toLowerCase().includes("aborted")
 }
 
+const TRANSPORT_DISCONNECT_MARKERS = [
+  "_client",
+  "not connected",
+  "connection closed",
+  "connection is closed",
+]
+
+// Matches SDK transport-teardown errors (e.g. `this._client` undefined, "Not
+// connected") which are unrecoverable, unlike transient 4xx/5xx/timeouts. #5104
+export function isTransportDisconnectError(error: unknown): boolean {
+  const text = getErrorText(error).toLowerCase()
+  if (!text) return false
+  return TRANSPORT_DISCONNECT_MARKERS.some((marker) => text.includes(marker))
+}
+
 export function getErrorText(error: unknown): string {
   if (!error) return ""
   if (typeof error === "string") return error

--- a/packages/omo-opencode/src/features/background-agent/session-activity.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-activity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, mock, test } from "bun:test"
+
+import type { OpencodeClient } from "./opencode-client"
+import { getSessionActivityFromClient } from "./session-activity"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+
+describe("getSessionActivityFromClient", () => {
+  test("returns activity when the session reports a recent update", async () => {
+    // given
+    const updated = Date.now() - 5_000
+    const get = mock(async () => ({ data: { id: "ses-1", time: { updated } } }))
+    const client = unsafeTestValue<OpencodeClient>({ session: { get } })
+
+    // when
+    const result = await getSessionActivityFromClient(client, "ses-1")
+
+    // then
+    expect(result).toEqual({ type: "activity", activity: new Date(updated) })
+  })
+
+  test("treats a thrown transport-disconnect error as a missing session", async () => {
+    // given
+    const get = mock(async () => {
+      throw new TypeError("undefined is not an object (evaluating 'this._client')")
+    })
+    const client = unsafeTestValue<OpencodeClient>({ session: { get } })
+
+    // when
+    const result = await getSessionActivityFromClient(client, "ses-1")
+
+    // then
+    expect(result).toEqual({ type: "missing" })
+  })
+
+  test("treats a transport-disconnect error response as a missing session", async () => {
+    // given
+    const get = mock(async () => ({ error: { message: "Not connected" }, data: undefined }))
+    const client = unsafeTestValue<OpencodeClient>({ session: { get } })
+
+    // when
+    const result = await getSessionActivityFromClient(client, "ses-1")
+
+    // then
+    expect(result).toEqual({ type: "missing" })
+  })
+
+  test("keeps a transient lookup error as unavailable", async () => {
+    // given
+    const get = mock(async () => {
+      throw new Error("Network timeout")
+    })
+    const client = unsafeTestValue<OpencodeClient>({ session: { get } })
+
+    // when
+    const result = await getSessionActivityFromClient(client, "ses-1")
+
+    // then
+    expect(result).toEqual({ type: "unavailable" })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/session-activity.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-activity.ts
@@ -1,4 +1,5 @@
 import { isRecord, log } from "../../shared"
+import { isTransportDisconnectError } from "./error-classifier"
 import type { OpencodeClient } from "./opencode-client"
 
 export type SessionActivityLookup =
@@ -39,6 +40,10 @@ export async function getSessionActivityFromClient(
       ...(directory ? { query: { directory } } : {}),
     })
     if (isRecord(response) && response.error !== undefined && response.error !== null) {
+      if (isTransportDisconnectError(response.error)) {
+        log("[background-agent] Session transport disconnected while reading activity:", { sessionID, error: response.error })
+        return { type: "missing" }
+      }
       log("[background-agent] Failed to read session activity:", { sessionID, error: response.error })
       return { type: "unavailable" }
     }
@@ -46,6 +51,10 @@ export async function getSessionActivityFromClient(
     const sessionInfo = isRecord(response) && "data" in response ? response.data : response
     return sessionActivityLookupFromInfo(sessionInfo)
   } catch (error) {
+    if (isTransportDisconnectError(error)) {
+      log("[background-agent] Session transport disconnected while reading activity:", { sessionID, error: error instanceof Error ? error.message : error })
+      return { type: "missing" }
+    }
     if (error instanceof Error) {
       log("[background-agent] Failed to read session activity:", { sessionID, error: error.message })
       return { type: "unavailable" }

--- a/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
@@ -40,4 +40,35 @@ describe("verifySessionExists", () => {
 
     expect(result).toBe("unknown")
   })
+
+  test("classifies a thrown transport-disconnect error as missing", async () => {
+    const get = mock(async () => {
+      throw new TypeError("undefined is not an object (evaluating 'this._client')")
+    })
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        get,
+      },
+    })
+
+    const result = await checkSessionExistence(client, "session-123")
+
+    expect(result).toBe("missing")
+  })
+
+  test("classifies a transport-disconnect error response as missing", async () => {
+    const get = mock(async () => ({
+      error: { message: "Not connected" },
+      data: undefined,
+    }))
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        get,
+      },
+    })
+
+    const result = await checkSessionExistence(client, "session-123")
+
+    expect(result).toBe("missing")
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/session-existence.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.ts
@@ -1,3 +1,4 @@
+import { isTransportDisconnectError } from "./error-classifier"
 import type { OpencodeClient } from "./opencode-client"
 
 export const MIN_SESSION_GONE_POLLS = 3
@@ -48,11 +49,13 @@ export async function checkSessionExistence(
     })
 
     if (response.error !== undefined && response.error !== null) {
+      if (isTransportDisconnectError(response.error)) return "missing"
       return isSessionNotFoundError(response.error) ? "missing" : "unknown"
     }
 
     return response.data != null ? "exists" : "missing"
   } catch (error) {
+    if (isTransportDisconnectError(error)) return "missing"
     return isSessionNotFoundError(error) ? "missing" : "unknown"
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/task-poller-session-activity.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller-session-activity.test.ts
@@ -129,6 +129,42 @@ describe("checkAndInterruptStaleTasks persisted session activity", () => {
     expect(mockNotify).toHaveBeenCalledWith(task)
   })
 
+  test("finalizes a stale task and wakes the parent when the session transport is gone", async () => {
+    //#given - the status registry still reports the child as busy, but its SDK transport is gone
+    spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)
+    const staleActivity = new Date(Date.now() - 45 * 60 * 1000)
+    const transportError = new TypeError("undefined is not an object (evaluating 'this._client')")
+    const disconnectedClient = unsafeTestValue<Parameters<typeof checkAndInterruptStaleTasks>[0]["client"]>({
+      session: {
+        abort: mock(() => Promise.reject(transportError)),
+        get: mock(() => Promise.reject(transportError)),
+      },
+    })
+    const task = createRunningTask({
+      startedAt: staleActivity,
+      progress: {
+        toolCalls: 2,
+        lastUpdate: staleActivity,
+      },
+    })
+
+    //#when - both the activity probe and the abort fail because the transport is disconnected
+    await checkAndInterruptStaleTasks({
+      tasks: [task],
+      client: disconnectedClient,
+      directory: "/project/root",
+      config: { staleTimeoutMs: 180_000 },
+      concurrencyManager: mockConcurrencyManager,
+      notifyParentSession: mockNotify,
+      sessionStatuses: { "ses-1": { type: "busy" } },
+    })
+
+    //#then - the task is finalized instead of stranded as running, so the parent is notified
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toContain("Stale timeout")
+    expect(mockNotify).toHaveBeenCalledWith(task)
+  })
+
   test("keeps a busy task running when persisted session activity lookup is unavailable", async () => {
     //#given - the child session is active, but session.get returned an error response during confirmation
     spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)

--- a/packages/omo-opencode/src/features/background-agent/task-poller.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller.ts
@@ -116,6 +116,7 @@ export type SessionStatusMap = Record<string, { type: string }>
 async function interruptStaleTask(args: {
   task: BackgroundTask
   client: OpencodeClient
+  directory?: string
   concurrencyManager: ConcurrencyManager
   notifyParentSession: (task: BackgroundTask) => Promise<void>
   onTaskInterrupted: (task: BackgroundTask) => void
@@ -129,6 +130,7 @@ async function interruptStaleTask(args: {
   const {
     task,
     client,
+    directory,
     concurrencyManager,
     notifyParentSession,
     onTaskInterrupted,
@@ -142,12 +144,23 @@ async function interruptStaleTask(args: {
 
   const aborted = await abortWithTimeout(client, sessionID)
   if (!aborted) {
-    log("[background-agent] Task stale interruption skipped because session abort failed:", {
+    // A dead SDK transport can never abort, so backing off forever strands the
+    // task as "running" and the parent waits indefinitely (#5104). Finalize only
+    // once the session is confirmed gone; a live session keeps the retry path.
+    const existence = await checkSessionExistence(client, sessionID, directory)
+    if (existence !== "missing") {
+      log("[background-agent] Task stale interruption skipped because session abort failed:", {
+        taskId: task.id,
+        sessionID,
+        reason,
+      })
+      return
+    }
+    log("[background-agent] Session unreachable during stale interruption; finalizing without a clean abort:", {
       taskId: task.id,
       sessionID,
       reason,
     })
-    return
   }
 
   if (task.status !== "running" || task.sessionId !== sessionID) return
@@ -251,6 +264,7 @@ export async function checkAndInterruptStaleTasks(args: {
         interruptStaleTask({
           task,
           client,
+          directory,
           concurrencyManager,
           notifyParentSession,
           onTaskInterrupted,


### PR DESCRIPTION
## Summary
- Classify OpenCode SDK transport-disconnect errors (`this._client` undefined / "Not connected") as "session gone" instead of transient, so a background subagent whose transport was torn down is finalized and the parent session is woken instead of waiting forever. `Refs #5104`.
- Transient 4xx/5xx/timeout failures are intentionally unchanged and keep the conservative retry/defer behavior.
- Adds a regression test that fails without the runtime change, plus unit coverage for the new classification.

## Context
A background subagent child session can close while the SDK client's outer object survives but its inner transport (`this._client`) is released. After that, `session.status()` still works (the status registry can keep reporting the session), but `session.get()` and `session.abort()` throw `undefined is not an object (evaluating 'this._client')` / "Not connected".

The poll loop treated those throws as transient: `getSessionActivityFromClient` returned `unavailable` and `checkSessionExistence` returned `unknown`, so `checkAndInterruptStaleTasks` skipped the stale interruption on every 3s poll. Even when interruption was reached, `abortWithTimeout` could not succeed against the dead transport, so the task was never finalized. The parent session stayed on "waiting for background agents to complete" with no stop button, and the log filled with `Failed to read session activity` (the reporter saw ~91 entries per session in #5104).

## What changed
- `error-classifier.ts`: new `isTransportDisconnectError()` matching only transport-teardown signatures (`_client`, "not connected", "connection closed"), never generic 4xx/5xx/timeouts.
- `session-existence.ts`: a transport-disconnect now classifies as `missing` (unreachable) instead of `unknown`.
- `session-activity.ts`: a transport-disconnect now classifies as `missing` instead of `unavailable`.
- `task-poller.ts` (`interruptStaleTask`): when the abort cannot succeed because the transport is gone, confirm the session is missing and finalize the task instead of backing off forever. A still-existing session keeps the safe retry path.

## Why This Is Standalone
- This is not a duplicate of #5089. That issue is the parent-wake admission/notification path after a normal completion, and it is already covered by separate PRs (#5114 merged, #5148 and #5038 open). This PR does not touch parent-wake admission. It fixes the upstream classification that prevents a stale task from ever being finalized once the transport dies.
- It is intentionally scoped to the case in #5104: the status registry still reports the session, but its transport is gone. The separate "`session.status()` itself throws" path is deliberately left untouched, because the existing `manager.polling.session-status-unavailable` test pins that as intentionally conservative.
- The affected surface is easy to miss on a healthy connection: it only triggers when the SDK transport is torn down underneath a live client, which is why a deterministic unit/integration repro is the most reliable evidence here.

## Verification
- `bun test packages/omo-opencode/src/features/background-agent/` -> 683 pass, 0 fail
- Regression proof: reverting only the runtime change (keeping the tests) makes `finalizes a stale task and wakes the parent when the session transport is gone` fail with `Expected: "cancelled" Received: "running"`.
- `bun run typecheck` -> exit 0


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where background subagents got stuck when the SDK transport disconnected. These errors are now treated as a gone session, so stale tasks are finalized and the parent session wakes. Refs #5104.

- **Bug Fixes**
  - Classify SDK transport-teardown errors (`_client` undefined, “Not connected”, “connection closed”) as session gone, not transient.
  - Mark session activity/existence lookups as `missing` on transport disconnect.
  - Finalize stale tasks when abort fails and the session is unreachable, then notify the parent.
  - Keep transient 4xx/5xx/timeouts unchanged (retry/defer), and add tests covering the new classification and regression.

<sup>Written for commit 0ba774b720f97059a1512b861e8be0042d02e451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

