### PR TITLE
fix(background-agent): look through noReply tails in prompt gate to prevent wake deadlock

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-assistant-blocking.test.ts
@@ -2,6 +2,10 @@
 
 import { describe, expect, test } from "bun:test"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../hooks/shared/prompt-async-gate"
+import {
+  OMO_INTERNAL_INITIATOR_MARKER,
+  OMO_INTERNAL_NOREPLY_MARKER,
+} from "../../shared/internal-initiator-marker"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { ParentWakeNotifier } from "./parent-wake-notifier"
 
@@ -244,6 +248,76 @@ describe("ParentWakeNotifier — assistant turn blocking", () => {
       expect(notifier.getPendingParentWakes().has("parent-completed-unknown")).toBe(true)
     } finally {
       Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a completed assistant followed by stacked noReply notification tails #when flushing a shouldReply wake #then it dispatches immediately instead of deadlocking", async () => {
+    // given
+    const noReplyTailText = `task done\n${OMO_INTERNAL_INITIATOR_MARKER}\n${OMO_INTERNAL_NOREPLY_MARKER}`
+    const promptAsyncCalls: PromptAsyncCall[] = []
+    const client = unsafeTestValue<ParentWakeClient>({
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                finish: "stop",
+                time: { created: 1_000, completed: 2_000 },
+              },
+              parts: [{ type: "text", text: "fired the background tasks" }],
+            },
+            {
+              info: { role: "user", time: { created: 3_000 } },
+              parts: [{ type: "text", text: noReplyTailText, synthetic: true }],
+            },
+            {
+              info: { role: "user", time: { created: 4_000 } },
+              parts: [{ type: "text", text: noReplyTailText, synthetic: true }],
+            },
+          ],
+        }),
+        status: async () => ({ data: { "parent-noreply-tail": { type: "idle" } } }),
+        promptAsync: async (call: PromptAsyncCall) => {
+          promptAsyncCalls.push(call)
+          return { data: {} }
+        },
+      },
+    })
+    const notifier = new ParentWakeNotifier(
+      {
+        client,
+        directory: "/tmp/test-omo",
+        enqueueNotificationForParent: async (_sessionID, operation) => {
+          await operation()
+        },
+      },
+      {
+        pendingRetryMs: 1_000,
+        acceptedMessageSkewMs: 5_000,
+        toolCallDeferMaxMs: 5_000,
+        failureRequeueWindowMs: 5_000,
+        userMessageInProgressWindowMs: 2_000,
+      },
+    )
+    notifier.queuePendingParentWake(
+      "parent-noreply-tail",
+      "[ALL BACKGROUND TASKS COMPLETE]",
+      { agent: "sisyphus" },
+      true,
+    )
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-noreply-tail")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBeFalsy()
+      expect(notifier.getPendingParentWakes().has("parent-noreply-tail")).toBe(false)
+    } finally {
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -2,6 +2,7 @@ import {
   createInternalAgentTextPart,
   isAmbiguousPostDispatchPromptFailure,
   log,
+  withInternalNoReplyMarker,
 } from "../../shared"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
 import type { PromptDispatchClient } from "../../shared/prompt-async-gate/types"
@@ -48,7 +49,11 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         body: {
           noReply: input.forceNoReply === true || !input.latestWake.shouldReply,
           ...input.latestWake.promptContext,
-          parts: [createInternalAgentTextPart(notificationContent)],
+          parts: [
+            input.forceNoReply === true || !input.latestWake.shouldReply
+              ? withInternalNoReplyMarker(createInternalAgentTextPart(notificationContent))
+              : createInternalAgentTextPart(notificationContent),
+          ],
         },
         query: { directory: input.directory },
       },

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/recovery.ts
@@ -5,7 +5,10 @@ import {
 import {
   getCompactionAgentConfigCheckpoint,
 } from "../../shared/compaction-agent-config-checkpoint"
-import { createInternalAgentContinuationTextPart } from "../../shared/internal-initiator-marker"
+import {
+  createInternalAgentContinuationTextPart,
+  withInternalNoReplyMarker,
+} from "../../shared/internal-initiator-marker"
 import { log } from "../../shared/logger"
 import { isAmbiguousPostDispatchPromptFailure } from "../../shared/prompt-failure-classifier"
 import { setSessionModel } from "../../shared/session-model-state"
@@ -96,7 +99,7 @@ export function createRecoveryLogic(
             agent: launchAgent ?? expectedPromptConfig.agent,
             ...(model ? { model } : {}),
             ...(tools ? { tools } : {}),
-            parts: [createInternalAgentContinuationTextPart(AGENT_RECOVERY_PROMPT)],
+            parts: [withInternalNoReplyMarker(createInternalAgentContinuationTextPart(AGENT_RECOVERY_PROMPT))],
           },
           query: { directory: ctx.directory },
         },

--- a/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
+++ b/packages/omo-opencode/src/shared/internal-initiator-marker.test.ts
@@ -1,14 +1,20 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import {
   createInternalAgentContinuationTextPart,
   createInternalAgentTextPart,
   hasInternalInitiatorMarker,
+  hasInternalNoReplyMarker,
   isRealUserMessage,
   isRealUserTextPart,
   isSyntheticOrInternalOnlyTextParts,
   isSyntheticOrInternalUserMessage,
+  isTerminalNoReplyUserMessage,
   OMO_INTERNAL_INITIATOR_MARKER,
+  OMO_INTERNAL_NOREPLY_MARKER,
   stripInternalInitiatorMarkers,
+  withInternalNoReplyMarker,
 } from "./internal-initiator-marker"
 
 describe("internal-initiator-marker", () => {
@@ -209,6 +215,87 @@ describe("internal-initiator-marker", () => {
       // then
       expect(result).toBe(false)
       expect(isSyntheticOrInternalUserMessage(message)).toBe(true)
+    })
+  })
+
+  describe("noReply marker", () => {
+    test("#given a text part wrapped with the noReply marker #when inspecting it #then it carries both markers and is still synthetic", () => {
+      // given
+      const part = withInternalNoReplyMarker(createInternalAgentTextPart("task done"))
+
+      // then
+      expect(hasInternalInitiatorMarker(part.text)).toBe(true)
+      expect(hasInternalNoReplyMarker(part.text)).toBe(true)
+      expect(part.text).toContain(OMO_INTERNAL_NOREPLY_MARKER)
+    })
+
+    test("#given a continuation part wrapped with the noReply marker #when inspecting it #then synthetic and metadata are preserved", () => {
+      // given
+      const part = withInternalNoReplyMarker(createInternalAgentContinuationTextPart("recover"))
+
+      // then
+      expect(part.synthetic).toBe(true)
+      expect(part.metadata).toEqual({ compaction_continue: true })
+      expect(hasInternalNoReplyMarker(part.text)).toBe(true)
+    })
+
+    test("#given a part already carrying the noReply marker #when wrapping again #then it is not duplicated", () => {
+      // given
+      const once = withInternalNoReplyMarker(createInternalAgentTextPart("task done"))
+
+      // when
+      const twice = withInternalNoReplyMarker(once)
+
+      // then
+      expect(twice.text).toBe(once.text)
+      expect(twice.text.match(/OMO_INTERNAL_NOREPLY/g)).toHaveLength(1)
+    })
+
+    test("#given a noReply-tagged user message #when classifying #then it is a terminal noReply message", () => {
+      // given
+      const message = {
+        info: { role: "user" },
+        parts: [withInternalNoReplyMarker(createInternalAgentTextPart("task done"))],
+      }
+
+      // then
+      expect(isTerminalNoReplyUserMessage(message)).toBe(true)
+      expect(isSyntheticOrInternalUserMessage(message)).toBe(true)
+    })
+
+    test("#given an ordinary internal user message without the noReply marker #when classifying #then it is not terminal", () => {
+      // given
+      const message = {
+        info: { role: "user" },
+        parts: [createInternalAgentTextPart("continue")],
+      }
+
+      // then
+      expect(isTerminalNoReplyUserMessage(message)).toBe(false)
+    })
+
+    test("#given an assistant message carrying the noReply marker #when classifying #then it is not a terminal noReply user message", () => {
+      // given
+      const message = {
+        info: { role: "assistant" },
+        parts: [withInternalNoReplyMarker(createInternalAgentTextPart("noise"))],
+      }
+
+      // then
+      expect(isTerminalNoReplyUserMessage(message)).toBe(false)
+    })
+
+    test("#given noReply-marked text #when stripping internal markers #then both markers are removed", () => {
+      // given
+      const part = withInternalNoReplyMarker(createInternalAgentTextPart("hello world"))
+
+      // when
+      const stripped = stripInternalInitiatorMarkers(part.text)
+
+      // then
+      expect(stripped).toBe("hello world")
+      expect(hasInternalInitiatorMarker(stripped)).toBe(false)
+      expect(hasInternalNoReplyMarker(stripped)).toBe(false)
     })
   })
 })

--- a/packages/omo-opencode/src/shared/internal-initiator-marker.ts
+++ b/packages/omo-opencode/src/shared/internal-initiator-marker.ts
@@ -1,7 +1,11 @@
 export const OMO_INTERNAL_INITIATOR_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
 
+export const OMO_INTERNAL_NOREPLY_MARKER = "<!-- OMO_INTERNAL_NOREPLY -->"
+
 const INTERNAL_INITIATOR_MARKER_DETECT_PATTERN = /<!--\s*OMO_INTERNAL_INITIATOR\s*-->/
+const INTERNAL_NOREPLY_MARKER_DETECT_PATTERN = /<!--\s*OMO_INTERNAL_NOREPLY\s*-->/
 const INTERNAL_INITIATOR_MARKER_PATTERN = /\n*<!--\s*OMO_INTERNAL_INITIATOR\s*-->\s*/g
+const INTERNAL_NOREPLY_MARKER_PATTERN = /\n*<!--\s*OMO_INTERNAL_NOREPLY\s*-->\s*/g
 
 export type InternalInitiatorTextPartLike = {
   type?: string
@@ -17,6 +21,10 @@ export type InternalInitiatorMessageLike = {
 
 export function hasInternalInitiatorMarker(text: string): boolean {
   return INTERNAL_INITIATOR_MARKER_DETECT_PATTERN.test(text)
+}
+
+export function hasInternalNoReplyMarker(text: string): boolean {
+  return INTERNAL_NOREPLY_MARKER_DETECT_PATTERN.test(text)
 }
 
 export function isTextPartLike(
@@ -54,6 +62,21 @@ export function isSyntheticOrInternalUserMessage(
   return role === "user" && isSyntheticOrInternalOnlyTextParts(message.parts)
 }
 
+function isNoReplyTextPart(part: InternalInitiatorTextPartLike): boolean {
+  return isTextPartLike(part) && hasInternalNoReplyMarker(part.text)
+}
+
+export function isTerminalNoReplyUserMessage(
+  message: InternalInitiatorMessageLike
+): boolean {
+  const role = message.info?.role ?? message.role
+  if (role !== "user") {
+    return false
+  }
+  const textParts = (message.parts ?? []).filter(isTextPartLike)
+  return textParts.some(isNoReplyTextPart)
+}
+
 export function isRealUserMessage(
   message: InternalInitiatorMessageLike
 ): boolean {
@@ -62,7 +85,10 @@ export function isRealUserMessage(
 }
 
 export function stripInternalInitiatorMarkers(text: string): string {
-  return text.replace(INTERNAL_INITIATOR_MARKER_PATTERN, "").trimEnd()
+  return text
+    .replace(INTERNAL_INITIATOR_MARKER_PATTERN, "")
+    .replace(INTERNAL_NOREPLY_MARKER_PATTERN, "")
+    .trimEnd()
 }
 
 export function createInternalAgentTextPart(text: string): {
@@ -87,4 +113,13 @@ export function createInternalAgentContinuationTextPart(text: string): {
     synthetic: true,
     metadata: { compaction_continue: true },
   }
+}
+
+export function withInternalNoReplyMarker<T extends { type: "text"; text: string }>(
+  part: T
+): T {
+  if (hasInternalNoReplyMarker(part.text)) {
+    return part
+  }
+  return { ...part, text: `${part.text}\n${OMO_INTERNAL_NOREPLY_MARKER}` }
 }

--- a/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.test.ts
@@ -1,5 +1,14 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
+import {
+  OMO_INTERNAL_INITIATOR_MARKER,
+  OMO_INTERNAL_NOREPLY_MARKER,
+} from "../internal-initiator-marker"
 import { latestAssistantTurnBlocksInternalPrompt } from "./pending-tool-turn"
+
+const NOREPLY_TAIL_TEXT = `notification\n${OMO_INTERNAL_INITIATOR_MARKER}\n${OMO_INTERNAL_NOREPLY_MARKER}`
+const REPLY_EXPECTING_TAIL_TEXT = `continue\n${OMO_INTERNAL_INITIATOR_MARKER}`
 
 describe("latestAssistantTurnBlocksInternalPrompt", () => {
   test("#given completed assistant question tool has no real user answer #when checking prompt safety #then internal prompts stay blocked", () => {
@@ -282,5 +291,112 @@ describe("latestAssistantTurnBlocksInternalPrompt", () => {
 
     // then
     expect(blocks).toBe(false)
+  })
+
+  test("#given a completed assistant is followed by a noReply notification tail #when checking prompt safety #then internal prompts are not blocked", () => {
+    // given
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "stop",
+          time: { created: 1000, completed: 2000 },
+        },
+        parts: [{ type: "text", text: "done with the work" }],
+      },
+      {
+        info: {
+          role: "user",
+          time: { created: 3000 },
+        },
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+      },
+    ]
+
+    // when
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+
+    // then
+    expect(blocks).toBe(false)
+  })
+
+  test("#given a completed assistant is followed by several stacked noReply notification tails #when checking prompt safety #then internal prompts are not blocked", () => {
+    // given
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "stop",
+          time: { created: 1000, completed: 2000 },
+        },
+        parts: [{ type: "text", text: "fired the background tasks" }],
+      },
+      {
+        info: { role: "user", time: { created: 3000 } },
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+      },
+      {
+        info: { role: "user", time: { created: 4000 } },
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+      },
+    ]
+
+    // when
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+
+    // then
+    expect(blocks).toBe(false)
+  })
+
+  test("#given a reply-expecting internal tail sits behind a noReply tail #when checking prompt safety #then internal prompts stay blocked", () => {
+    // given
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "stop",
+          time: { created: 1000, completed: 2000 },
+        },
+        parts: [{ type: "text", text: "working" }],
+      },
+      {
+        info: { role: "user", time: { created: 3000 } },
+        parts: [{ type: "text", text: REPLY_EXPECTING_TAIL_TEXT, synthetic: true }],
+      },
+      {
+        info: { role: "user", time: { created: 4000 } },
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+      },
+    ]
+
+    // when
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+
+    // then
+    expect(blocks).toBe(true)
+  })
+
+  test("#given an actively waiting assistant sits behind a noReply tail #when checking prompt safety #then internal prompts stay blocked", () => {
+    // given
+    const messages = [
+      {
+        info: {
+          role: "assistant",
+          finish: "tool-calls",
+          time: { created: 1000 },
+        },
+        parts: [{ type: "tool", tool: "bash", state: { status: "running" } }],
+      },
+      {
+        info: { role: "user", time: { created: 3000 } },
+        parts: [{ type: "text", text: NOREPLY_TAIL_TEXT, synthetic: true }],
+      },
+    ]
+
+    // when
+    const blocks = latestAssistantTurnBlocksInternalPrompt(messages)
+
+    // then
+    expect(blocks).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/pending-tool-turn.ts
@@ -7,6 +7,7 @@ import {
   messageHasUnresolvedTool,
   messageHasWaitingTool,
   messageIsSyntheticOrInternalUser,
+  messageIsTerminalNoReplyUser,
   messageRole,
 } from "./prompt-message-state"
 import { isRecord } from "../record-type-guard"
@@ -95,6 +96,9 @@ export function latestAssistantTurnBlocksInternalPrompt(messages: unknown[]): bo
     }
     if (role === "user") {
       if (messageIsSyntheticOrInternalUser(message)) {
+        if (messageIsTerminalNoReplyUser(message)) {
+          continue
+        }
         if (!sawAssistantAfterLatestUser) {
           return true
         }

--- a/packages/omo-opencode/src/shared/prompt-async-gate/prompt-message-state.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/prompt-message-state.ts
@@ -1,5 +1,6 @@
 import {
   isSyntheticOrInternalUserMessage,
+  isTerminalNoReplyUserMessage,
   type InternalInitiatorMessageLike,
   type InternalInitiatorTextPartLike,
 } from "../internal-initiator-marker"
@@ -88,6 +89,11 @@ function toInternalInitiatorMessageLike(message: unknown): InternalInitiatorMess
 export function messageIsSyntheticOrInternalUser(message: unknown): boolean {
   const initiatorMessage = toInternalInitiatorMessageLike(message)
   return initiatorMessage !== undefined && isSyntheticOrInternalUserMessage(initiatorMessage)
+}
+
+export function messageIsTerminalNoReplyUser(message: unknown): boolean {
+  const initiatorMessage = toInternalInitiatorMessageLike(message)
+  return initiatorMessage !== undefined && isTerminalNoReplyUserMessage(initiatorMessage)
 }
 
 const QUESTION_TOOL_NAMES = new Set(["question", "ask_user_question", "askuserquestion"])


### PR DESCRIPTION
## Problem

A `noReply: true` injection adds a synthetic user message to session history that **never receives an assistant reply** (it's terminal/fire-and-forget context). The shared gate function `latestAssistantTurnBlocksInternalPrompt` treated *every* synthetic user tail as a reply-expecting pending prompt that a forthcoming assistant message would clear. Because a noReply tail never gets that reply, it blocked the gate forever — deadlocking parent-wake notifications behind stacked noReply notification tails.

Critically, both gate layers — the wake-deferral check (`shouldDeferParentWakeForSessionHistory`) and the prompt gate (`dispatchAfterSessionIdle` → `sessionLatestAssistantBlocksInternalPrompt`) — call the **same** function, so the fix must live there. (A fix at only one layer just relocates the deadlock to the other.)

## Fix

- Tag noReply injections with a distinct text marker (`OMO_INTERNAL_NOREPLY_MARKER`) at the two injection sites.
- The shared gate function now **looks through** terminal noReply tails to the real assistant turn behind them, while still blocking on genuine reply-expecting internal tails (anti-stacking preserved) and on a genuinely active assistant turn behind the tail.
- Text marker chosen over metadata because text is the only field proven to round-trip through `session.messages()`.

This fixes both gate layers at once with no parent-wake control-flow changes.

## Tests

13 new tests across 3 files:
- marker round-trip / idempotent wrap / strip-both-markers / terminal detection
- gate looks through a single and stacked noReply tails (not blocked)
- reply-expecting tail behind a noReply tail still blocks (anti-stacking)
- active assistant (pending tool) behind a noReply tail still blocks
- end-to-end: completed assistant + stacked noReply tails → `shouldReply` wake dispatches immediately instead of deadlocking

All touched suites pass (39/39 in the 3 files; full prompt-async-gate + compaction suites green); `tsgo` typecheck clean. The 3 pre-existing parent-wake tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wake deadlock by making the prompt gate look past terminal `noReply` synthetic user tails. Parent wake notifications now send immediately after background completion instead of getting stuck behind stacked `noReply` tails.

- **Bug Fixes**
  - Tag `noReply: true` injections with `OMO_INTERNAL_NOREPLY_MARKER` (text marker that round-trips).
  - Update shared gate `latestAssistantTurnBlocksInternalPrompt` to skip terminal `noReply` user messages, while still blocking on reply-expecting internal tails and active assistant turns.
  - Apply tagging at both injection sites: parent-wake prompt dispatch (`sendParentWakePrompt`) and compaction recovery (via `withInternalNoReplyMarker`).
  - Add helpers and detection: `withInternalNoReplyMarker`, `hasInternalNoReplyMarker`, `isTerminalNoReplyUserMessage`, and strip logic; tests cover marker round-trip, gate behavior, and end-to-end wake dispatch.

<sup>Written for commit 1f6d0e4bba3201fb491d19eac65885cd04820525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

