### PR TITLE
fix: eliminate duplicate background task completion notifications

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -57,13 +57,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry: false,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake flush without admit-only dispatch (parent session activity still fresh):", {
         sessionID,
       })
       return
@@ -75,11 +70,9 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake flush without admit-only dispatch (tool state suggests deferral):", {
+        sessionID,
       })
       return
     }
@@ -94,13 +87,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake flush without admit-only dispatch (user message just arrived):", {
         sessionID,
       })
       return


### PR DESCRIPTION
## Bug

When a background task completes, the `<system-reminder>` notification is dispatched **twice** to the parent session, producing duplicate visible notifications.

## Root Cause

In `flushPendingParentWake`, three code paths call `sendParentWakePrompt` with `forceNoReply: true` and `retainPendingWake: true`:

1. `hasRecentParentSessionActivity` — admits notification when parent was recently active
2. `toolWaitDecision.defer` — admits when tool state suggests deferral
3. `isUserMessageInProgress` — admits when user message just arrived

Each of these injects the full `<system-reminder>` notification text into session history as an "admit-only" dispatch (no reply). Later, when the session becomes idle, the retained wake is re-dispatched with a reply, injecting the **same** notification text again. Result: duplicate visible notifications.

## Fix

Replace the `await this.sendParentWakePrompt(...)` calls in the 3 admit-only paths with `this.schedulePendingParentWakeFlush(sessionID)`. This defers the notification without injecting anything into session history. When the session becomes idle, the scheduled flush fires a single full dispatch — no duplicate.

The `deferReplyWakeWhileUnsafe` safety checks before each path are preserved unchanged.

## Before/After

**Before:** Background task completes → admit-only dispatch injects `<system-reminder>` → session idle → reply dispatch injects same `<system-reminder>` → **duplicate notification visible**.

**After:** Background task completes → flush is deferred without injection → session idle → single reply dispatch injects `<system-reminder>` → **one notification visible**.

## Files Changed

- `packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts` — 3 call sites replaced, 7 insertions, 19 deletions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate background task completion notifications by deferring the parent wake flush instead of injecting admit-only prompts. Parent sessions now see a single `<system-reminder>` when idle.

- **Bug Fixes**
  - In `packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts`, replaced `sendParentWakePrompt(..., forceNoReply: true, retainPendingWake: true)` with `schedulePendingParentWakeFlush(sessionID)` in three paths (recent activity, tool deferral, user message in progress).
  - Kept `deferReplyWakeWhileUnsafe` safety checks unchanged.
  - Idle-time flush now sends one full wake dispatch without intermediate history injection; logs updated to reflect deferral.

<sup>Written for commit 770cd0ed5505575152176e291972d66ba253f11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

