### PR TITLE
fix: eliminate duplicate background task completion notifications

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -57,13 +57,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry: false,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because parent session activity is still fresh:", {
         sessionID,
       })
       return
@@ -75,11 +70,9 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because tool wait deferred:", {
+        sessionID,
       })
       return
     }
@@ -94,13 +87,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because user message just arrived:", {
         sessionID,
       })
       return


### PR DESCRIPTION
## Bug

Background tasks send **two notifications** on completion: one "admit-only" (noReply) dispatch while the parent session is still active, followed by a second reply-producing dispatch once the parent becomes idle. The admit-only dispatch was never intended to produce visible output — it was just liveness insurance — but it still injected a duplicate notification into the parent session.

## Root Cause

In `flushPendingParentWake`, three code paths sent a `sendParentWakePrompt` with `forceNoReply: true` and `retainPendingWake: latestWake.shouldReply`:

1. **Recent parent activity detected** — admits the wake as noReply while parent session activity is still fresh.
2. **Tool wait deferral** — admits the wake as noReply while tools are still running in parent session history.
3. **User message in progress** — admits the wake as noReply to avoid racing with the user's own prompt.

Each of these "admit-only" dispatches retained the wake for re-dispatch. When the parent session later became idle, `schedulePendingParentWakeFlush` would fire again and send a **second** (reply-producing) dispatch for the same wake — resulting in a duplicate notification.

## Fix

Replace all three `sendParentWakePrompt(..., { forceNoReply: true, retainPendingWake: ... })` calls with `this.schedulePendingParentWakeFlush(sessionID)`. Instead of admitting the wake as a silent noReply dispatch that will be re-dispatched later, **simply defer the flush**. The wake stays in the pending queue until the parent session is safe, at which point it is dispatched once with a proper reply.

All `deferReplyWakeWhileUnsafe` checks are preserved — failure wakes and already-admitted reply-required wakes continue to be deferred until the parent session is safe.

Log messages updated from "Recorded admit-only" to "Deferred parent wake (no admit-only)" to reflect the behavioral change.

## Files Changed

- `packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop duplicate background task completion notifications by removing admit-only dispatches. Wakes are now deferred and dispatched once when the parent session is safe.

- **Bug Fixes**
  - Replaced admit-only `sendParentWakePrompt(..., forceNoReply: true)` with `schedulePendingParentWakeFlush(sessionID)` for: recent parent activity, tool wait deferral, and user message in progress. The wake is now sent once with a reply when safe.
  - Preserved `deferReplyWakeWhileUnsafe` logic so failure and reply-required wakes still wait.
  - Updated logs to “Deferred parent wake (no admit-only)” to reflect the new behavior.

<sup>Written for commit 24d3fd709ea53c33b27f6c7af45d74d59341d4ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

