### PR TITLE
fix: eliminate duplicate background task completion notifications

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-turn-event.test.ts
@@ -231,8 +231,7 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 
@@ -267,8 +266,7 @@ describe("BackgroundManager parent wake active turn events", () => {
     await flushPendingParentWakeForTest(manager, "parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -57,13 +57,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry: false,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because parent session activity is still fresh:", {
         sessionID,
       })
       return
@@ -75,11 +70,9 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { ...toolWaitDecision, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because tool wait deferred:", {
+        sessionID,
       })
       return
     }
@@ -94,13 +87,8 @@ export class ParentWakeFlushRunner {
       if (this.deferReplyWakeWhileUnsafe(sessionID, latestWake)) {
         return
       }
-      await this.sendParentWakePrompt(sessionID, latestWake, {
-        emptyAssistantTurnRetry,
-        toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
-        forceNoReply: true,
-        retainPendingWake: latestWake.shouldReply,
-      })
-      log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
+      this.schedulePendingParentWakeFlush(sessionID)
+      log("[background-agent] Deferred parent wake (no admit-only) because user message just arrived:", {
         sessionID,
       })
       return

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-non-error-retry.test.ts
@@ -161,8 +161,7 @@ describe("ParentWakeNotifier non-Error retry recovery", () => {
       await notifier.flushPendingParentWake(sessionID)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has(sessionID)).toBe(true)
     } finally {
       notifier.shutdown()

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-user-message-race.test.ts
@@ -98,8 +98,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-boundary")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-boundary")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -261,8 +260,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-stale-idle")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(notifier.getPendingParentWakes().has("parent-stale-idle")).toBe(true)
 
     notifier.shutdown()
@@ -299,8 +297,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
     await notifier.flushPendingParentWake("parent-1")
 
     // then
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+    expect(promptAsyncCalls).toHaveLength(0)
     expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
 
     notifier.shutdown()
@@ -524,8 +521,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-repaired-tail")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-repaired-tail")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -576,8 +572,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-tools")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-internal-tail-tools")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -620,8 +615,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-internal-tail-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-internal-tail-user-race")).toBe(true)
     } finally {
       Date.now = originalDateNow
@@ -667,8 +661,7 @@ describe("ParentWakeNotifier — user message race guard (issue #4120)", () => {
       await notifier.flushPendingParentWake("parent-mixed-user-race")
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(notifier.getPendingParentWakes().has("parent-mixed-user-race")).toBe(true)
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-completion-cleanup.test.ts
@@ -508,8 +508,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush()
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow
@@ -554,8 +553,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush()
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow
@@ -606,10 +604,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
-      expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
     })
 
@@ -657,10 +652,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       await waitForDeferredWake(promptAsyncCalls)
 
       // then
-      expect(promptAsyncCalls).toHaveLength(1)
-      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
-      const notificationPayload = JSON.stringify(promptAsyncCalls[0]?.body.parts)
-      expect(notificationPayload).toContain("ALL BACKGROUND TASKS COMPLETE")
+      expect(promptAsyncCalls).toHaveLength(0)
       expect(getPendingParentWakes(manager).get("parent-1")?.shouldReply).toBe(true)
     })
 
@@ -699,8 +691,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
         await waitForCoalescedFlush()
 
         // then
-        expect(promptAsyncCalls).toHaveLength(1)
-        expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+        expect(promptAsyncCalls).toHaveLength(0)
         expect(getPendingParentWakes(manager).has("parent-1")).toBe(true)
       } finally {
         Date.now = originalDateNow


### PR DESCRIPTION
## Problem

When a background task completes, the `<system-reminder>` notification is dispatched **twice** to the parent session, resulting in duplicate visible notifications.

## Root Cause

In `parent-wake-flush-runner.ts`, the `flushPendingParentWake` method has 3 code paths that call `sendParentWakePrompt` with `forceNoReply: true` and `retainPendingWake: true` (the "admit-only" pattern):

1. `hasRecentParentSessionActivity` — parent session was recently active
2. `toolWaitDecision.defer` — tool state suggests deferral  
3. `isUserMessageInProgress` — user message just arrived

Each admit-only dispatch injects the full `<system-reminder>` notification text into session history without waking the session. Later, when the retained wake is re-dispatched as a reply, the **same notification content is injected again**, producing duplicates.

## Fix

Replace the 3 `sendParentWakePrompt(forceNoReply: true, retainPendingWake: true)` calls with `schedulePendingParentWakeFlush(sessionID)`. This defers the flush without injecting anything into history. When the session becomes idle, a single full dispatch delivers the notification once.

All existing safety checks (`deferReplyWakeWhileUnsafe`) are preserved.

## Before / After

**Before:** Background task completion → two identical `<system-reminder>` blocks in conversation  
**After:** Background task completion → one `<system-reminder>` block, session wakes correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate background task completion notifications by deferring the parent wake flush instead of admit-only dispatches. Users now see a single `<system-reminder>`, and the session wakes once.

- **Bug Fixes**
  - Replaced admit-only `sendParentWakePrompt(...forceNoReply: true, retainPendingWake: true)` in three cases (recent parent activity, deferred tool wait, in-progress user message) with `schedulePendingParentWakeFlush(sessionID)`; updated tests to expect 0 `promptAsyncCalls`, remove `noReply` checks, and revert normal-dispatch assertions (incl. `session.messages` rejection).
  - Preserves `deferReplyWakeWhileUnsafe`; no history injection; a single flush runs when idle.

<sup>Written for commit c302b876be118f26ec94c12c5001e9aeae15fdb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Fixes #5177