### PR TITLE
fix(lsp-tools-mcp): start kotlin-lsp over stdio

### DIFF
--- a/packages/lsp-tools-mcp/src/lsp/server-definitions.ts
+++ b/packages/lsp-tools-mcp/src/lsp/server-definitions.ts
@@ -140,7 +140,7 @@ export const BUILTIN_SERVERS: Record<string, Omit<LspServerConfig, "id">> = {
 		command: ["haskell-language-server-wrapper", "--lsp"],
 		extensions: [".hs", ".lhs"],
 	},
-	"kotlin-ls": { command: ["kotlin-lsp"], extensions: [".kt", ".kts"] },
+	"kotlin-ls": { command: ["kotlin-lsp", "--stdio"], extensions: [".kt", ".kts"] },
 	julials: {
 		command: ["julia", "--startup-file=no", "--history-file=no", "-e", "using LanguageServer; runserver()"],
 		extensions: [".jl"],

--- a/packages/lsp-tools-mcp/test/server-definitions.test.ts
+++ b/packages/lsp-tools-mcp/test/server-definitions.test.ts
@@ -70,4 +70,14 @@ describe("BUILTIN_SERVERS", () => {
 		expect(hint).toContain("roslyn-language-server");
 		expect(hint).toContain("dotnet tool install");
 	});
+
+	it("#given kotlin-ls #when looking it up #then starts kotlin-lsp over stdio", () => {
+		// given
+		const kotlin = BUILTIN_SERVERS["kotlin-ls"];
+
+		// when / then
+		expect(kotlin).toBeDefined();
+		expect(kotlin?.command).toEqual(["kotlin-lsp", "--stdio"]);
+		expect(kotlin?.extensions).toEqual([".kt", ".kts"]);
+	});
 });


### PR DESCRIPTION
## Summary

- Fixes the built-in Kotlin LSP server (`kotlin-ls`) definition to start `kotlin-lsp` with the `--stdio` flag.
- Adds regression coverage for the `kotlin-ls` command arguments and `.kt`/`.kts` extension mapping.

## Changes

- Modified the Kotlin LSP server definition to call `kotlin-lsp --stdio`.
- Added a regression test in `server-definitions.test.ts` for the Kotlin command arguments and extension mapping.

## Testing

```bash
npm --prefix packages/lsp-tools-mcp test -- server-definitions.test.ts
npm --prefix packages/lsp-tools-mcp test
npm --prefix packages/lsp-tools-mcp run check
bun run typecheck
bun run build
```

### Manual QA Details

- Verified direct `lsp-tools-mcp` MCP `symbols` call on a temporary `Gender.kt` file returned `Gender`, `MALE`, and `FEMALE`.
- Verified the `lsp-daemon` proxy path reported `kotlin-ls` as installed and returned the same Kotlin symbols.
- Tested locally with OpenCode using a plugin override.

## Related Issues

N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the built-in `kotlin-ls` in `lsp-tools-mcp` to start `kotlin-lsp` with `--stdio`, restoring proper stdio-based LSP communication. Adds regression tests for the command arguments and the `.kt`/`.kts` extension mapping.

<sup>Written for commit 53461514892805f9ad57e39c1c37fe8a1197ef17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

