### PR TITLE
fix: cross-platform launcher and POSIX wrapper tests for Windows CI

### DIFF
--- a/packages/omo-opencode/src/cli/install-codex/codex-cache-bins.ts
+++ b/packages/omo-opencode/src/cli/install-codex/codex-cache-bins.ts
@@ -174,16 +174,19 @@ async function existingNonRuntimeWrapper(path: string): Promise<boolean> {
 }
 
 function posixRuntimeWrapper(cliPath: string, codexHome: string, binDir: string, nodeCliPath: string): string {
-  const ulwLoopBin = join(binDir, "omo-ulw-loop")
-  const nodeCli = escapePosixDoubleQuoted(nodeCliPath)
+  const ulwLoopBin = toPosixPath(join(binDir, "omo-ulw-loop"))
+  const nodeCli = escapePosixDoubleQuoted(toPosixPath(nodeCliPath))
+  const escapedCliPath = escapePosixDoubleQuoted(toPosixPath(cliPath))
+  const escapedCodexHome = escapePosixDoubleQuoted(toPosixPath(codexHome))
+  const escapedUlwLoopBin = escapePosixDoubleQuoted(ulwLoopBin)
   return [
     "#!/bin/sh",
     `# ${RUNTIME_WRAPPER_MARKER}`,
-    `export CODEX_HOME="\${CODEX_HOME:-${escapePosixDoubleQuoted(codexHome)}}"`,
+    `export CODEX_HOME="\${CODEX_HOME:-${escapedCodexHome}}"`,
     'export OMO_SPARKSHELL_APP_SERVER_SOCKET="${OMO_SPARKSHELL_APP_SERVER_SOCKET:-$CODEX_HOME/app-server-control/app-server-control.sock}"',
-    'if [ "$1" = "ulw-loop" ] && [ -x "' + escapePosixDoubleQuoted(ulwLoopBin) + '" ]; then',
+    'if [ "$1" = "ulw-loop" ] && [ -x "' + escapedUlwLoopBin + '" ]; then',
     "  shift",
-    '  exec "' + escapePosixDoubleQuoted(ulwLoopBin) + '" "$@"',
+    '  exec "' + escapedUlwLoopBin + '" "$@"',
     "fi",
     `if [ "\${OMO_RUNTIME:-}" = "node" ] && [ -f "${nodeCli}" ]; then`,
     `  exec node "${nodeCli}" "$@"`,
@@ -207,7 +210,7 @@ function posixRuntimeWrapper(cliPath: string, codexHome: string, binDir: string,
     `  echo "omo: bun runtime not found (checked PATH, ~/.bun/bin, /opt/homebrew/bin, /usr/local/bin) and the node fallback CLI is missing at ${nodeCli}; install bun from https://bun.sh, or reinstall omo and force the fallback with OMO_RUNTIME=node" >&2`,
     "  exit 127",
     "fi",
-    `exec "$BUN_BINARY" "${escapePosixDoubleQuoted(cliPath)}" "$@"`,
+    `exec "$BUN_BINARY" "${escapedCliPath}" "$@"`,
     "",
   ].join("\n")
 }
@@ -241,6 +244,10 @@ function windowsRuntimeWrapper(cliPath: string, codexHome: string, binDir: strin
     `"%BUN_BINARY%" "${cliPath}" %*`,
     "",
   ].join("\r\n")
+}
+
+function toPosixPath(p: string): string {
+  return p.replaceAll("\\", "/")
 }
 
 function escapePosixDoubleQuoted(value: string): string {

--- a/script/build-binaries-launcher.test.ts
+++ b/script/build-binaries-launcher.test.ts
@@ -42,6 +42,23 @@ function runLauncher(fixture: LauncherFixture, env: Record<string, string>, args
   });
 }
 
+async function writeFakeBun(
+  dir: string,
+  name: string,
+  posixScript: string,
+  winCmd: string,
+): Promise<string> {
+  if (process.platform === "win32") {
+    const path = join(dir, `${name}.cmd`);
+    await writeFile(path, `@echo off\r\n${winCmd}\r\n`);
+    return path;
+  }
+  const path = join(dir, name);
+  await writeFile(path, `#!/bin/sh\n${posixScript}\n`);
+  await chmod(path, 0o755);
+  return path;
+}
+
 describe("platform launcher runtime fallback (lazycodex#47)", () => {
   it("#given bun missing entirely #when launching #then falls back to the node CLI", async () => {
     const fixture = await createLauncherFixture({ withNodeCli: true });
@@ -53,8 +70,21 @@ describe("platform launcher runtime fallback (lazycodex#47)", () => {
     expect(result.stderr).toContain("node CLI");
   });
 
-  it("#given bun dies with SIGILL (unsupported CPU) #when launching #then explains the CPU limitation and falls back", async () => {
+  it("#given bun dies with SIGILL (unsupported CPU) #when launching #then falls back to node CLI", async () => {
     const fixture = await createLauncherFixture({ withNodeCli: true });
+
+    if (process.platform === "win32") {
+      // given: Windows cannot propagate SIGILL through spawnSync; exercise the error fallback path
+      const result = runLauncher(fixture, { BUN_BINARY: join(fixture.root, "nonexistent-bun.exe") });
+
+      // then: fallback to node CLI still works
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("OMO_NODE_OK --help");
+      expect(result.stderr).toContain("node CLI");
+      return;
+    }
+
+    // given: POSIX — simulate SIGILL with kill
     const sigillBun = join(fixture.root, "sigill-bun.sh");
     await writeFile(sigillBun, "#!/bin/sh\nkill -ILL $$\n");
     await chmod(sigillBun, 0o755);
@@ -68,9 +98,12 @@ describe("platform launcher runtime fallback (lazycodex#47)", () => {
 
   it("#given a working bun #when launching #then bun stays the preferred runtime", async () => {
     const fixture = await createLauncherFixture({ withNodeCli: true });
-    const fakeBun = join(fixture.root, "fake-bun.sh");
-    await writeFile(fakeBun, '#!/bin/sh\necho "BUN_OK $2"\n');
-    await chmod(fakeBun, 0o755);
+    const fakeBun = await writeFakeBun(
+      fixture.root,
+      "fake-bun",
+      'echo "BUN_OK $2"',
+      "echo BUN_OK %2",
+    );
 
     const result = runLauncher(fixture, { BUN_BINARY: fakeBun });
 
@@ -81,9 +114,12 @@ describe("platform launcher runtime fallback (lazycodex#47)", () => {
 
   it("#given OMO_RUNTIME=node #when launching #then skips bun even when it works", async () => {
     const fixture = await createLauncherFixture({ withNodeCli: true });
-    const fakeBun = join(fixture.root, "fake-bun.sh");
-    await writeFile(fakeBun, '#!/bin/sh\necho "BUN_OK"\n');
-    await chmod(fakeBun, 0o755);
+    const fakeBun = await writeFakeBun(
+      fixture.root,
+      "fake-bun",
+      'echo "BUN_OK"',
+      "echo BUN_OK",
+    );
 
     const result = runLauncher(fixture, { BUN_BINARY: fakeBun, OMO_RUNTIME: "node" });
 

--- a/script/build-binaries-launcher.test.ts
+++ b/script/build-binaries-launcher.test.ts
@@ -14,11 +14,19 @@ type LauncherFixture = {
   readonly root: string;
 };
 
-async function createLauncherFixture({ withNodeCli }: { readonly withNodeCli: boolean }): Promise<LauncherFixture> {
+async function createLauncherFixture(
+  { withNodeCli, bunOutput }: {
+    readonly withNodeCli: boolean;
+    readonly bunOutput?: string;
+  },
+): Promise<LauncherFixture> {
   const root = await mkdtemp(join(tmpdir(), "launcher-fixture-"));
   const wrapperPackageRoot = join(root, "pkg");
   await mkdir(join(wrapperPackageRoot, "dist", "cli"), { recursive: true });
-  await writeFile(join(wrapperPackageRoot, "dist", "cli", "index.js"), 'console.log("BUN_CLI_RAN");\n');
+  await writeFile(
+    join(wrapperPackageRoot, "dist", "cli", "index.js"),
+    bunOutput ? `console.log(${JSON.stringify(bunOutput)})\n` : 'console.log("BUN_CLI_RAN");\n',
+  );
   if (withNodeCli) {
     await mkdir(join(wrapperPackageRoot, "dist", "cli-node"), { recursive: true });
     await writeFile(
@@ -97,13 +105,23 @@ describe("platform launcher runtime fallback (lazycodex#47)", () => {
   });
 
   it("#given a working bun #when launching #then bun stays the preferred runtime", async () => {
-    const fixture = await createLauncherFixture({ withNodeCli: true });
-    const fakeBun = await writeFakeBun(
-      fixture.root,
-      "fake-bun",
-      'echo "BUN_OK $2"',
-      "echo BUN_OK %2",
-    );
+    if (process.platform === "win32") {
+      // given: Windows spawnSync without shell:true cannot run .sh or .cmd as a bun stand-in;
+      // use node (process.execPath) as the fake bun binary, which the launcher invokes as
+      // spawnSync(node, [cliPath, ...args]) — effectively running the CLI with node instead of bun
+      const fixture = await createLauncherFixture({ withNodeCli: true, bunOutput: "BUN_OK" });
+
+      const result = runLauncher(fixture, { BUN_BINARY: process.execPath });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("BUN_OK");
+      expect(result.stdout).not.toContain("OMO_NODE_OK");
+      return;
+    }
+
+    // given: POSIX — use a shell script fake bun
+    const fixture = await createLauncherFixture({ withNodeCli: true, bunOutput: "BUN_OK" });
+    const fakeBun = await writeFakeBun(fixture.root, "fake-bun", 'echo "BUN_OK $2"', "echo BUN_OK %2");
 
     const result = runLauncher(fixture, { BUN_BINARY: fakeBun });
 


### PR DESCRIPTION
## Problem

`test (windows-latest)` has been failing on every CI run on `dev`. Three tests consistently fail on Windows while passing on Ubuntu and macOS.

## Root Causes

| # | Test | Root Cause |
|---|------|-----------|
| 1 | `build-binaries-launcher.test.ts:66` — SIGILL fallback | Fake bun executables are `.sh` scripts that Windows `spawnSync` cannot execute (`EFTYPE` error). Asserts `stderr.contains("cpu")` which only applies on POSIX where `SIGILL` propagates. |
| 2 | `build-binaries-launcher.test.ts:78` — working bun | Same `.sh` scripts cannot execute on Windows. Launcher falls back to node CLI instead of running the fake bun. |
| 3 | `codex-cache-bins.test.ts:30` — POSIX wrapper paths | `posixRuntimeWrapper()` uses `join()` (backslash on Windows) then `escapePosixDoubleQuoted()` doubles each `\`. Test regex `[\\/]` only matches a single separator, not `\\\\`. |

## Changes

### `script/build-binaries-launcher.test.ts`
- Added `writeFakeBun()` helper that creates `.cmd` on Windows, `.sh` on POSIX
- SIGILL test: on Windows, exercises the error fallback path (SIGILL cannot propagate through Windows `spawnSync`)
- Working-bun and `OMO_RUNTIME=node` tests: use `writeFakeBun()` for cross-platform fake executables

### `packages/omo-opencode/src/cli/install-codex/codex-cache-bins.ts`
- Added `toPosixPath()` helper: `p.replaceAll("\\", "/")`
- Applied to all paths in `posixRuntimeWrapper()` before `escapePosixDoubleQuoted()` — semantically correct since the function generates POSIX shell scripts that must use forward slashes regardless of host platform

## Verification

- `bun test script/build-binaries-launcher.test.ts` — 5 pass
- `bun test packages/omo-opencode/src/cli/install-codex/codex-cache-bins.test.ts` — 3 pass
- `bun test packages/omo-opencode/src/cli/install-codex/` — 136 pass (full install-codex suite)
- `bun run typecheck` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Windows CI by making launcher tests cross-platform and generating correct POSIX paths in the runtime wrapper. Unblocks `windows-latest` by aligning behavior with macOS/Linux.

- **Bug Fixes**
  - Launcher tests: add `writeFakeBun()`; for the “working bun” test on Windows use `process.execPath` as the fake bun; on POSIX use a shell script; keep `writeFakeBun()` for the `OMO_RUNTIME=node` case.
  - SIGILL test: on Windows, assert node fallback when `bun` can’t launch; POSIX still simulates SIGILL.
  - `posixRuntimeWrapper()`: add `toPosixPath()` and apply before `escapePosixDoubleQuoted()`, producing valid POSIX script paths and fixing regex mismatches.

<sup>Written for commit 44da8f4f4b9cb2b5f1bd77c06e8909a5b64c51fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

