### PR TITLE
fix(omo-codex): SessionStart config-rewrite core — repair OMO config after provider switches (needs QA evidence)

### DIFF
--- a/packages/omo-codex/plugin/scripts/auto-update.mjs
+++ b/packages/omo-codex/plugin/scripts/auto-update.mjs
@@ -16,6 +16,7 @@ import {
 import { detectInstallFlow, resolveInstallSnapshotPath } from "./install-flow.mjs";
 import { migrateCodexConfig } from "./migrate-codex-config.mjs";
 import { migrateOmoSotConfig } from "./migrate-omo-sot.mjs";
+import { repairOmoCodexConfig } from "./repair-omo-config.mjs";
 import { resolveSpawnInvocation } from "./spawn-command.mjs";
 
 const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
@@ -203,6 +204,13 @@ async function recordUpdateStartedNotice({ env, now, notices, pendingNotice }) {
 }
 
 async function runConfigMigration({ env }) {
+	if (env.LAZYCODEX_CONFIG_REPAIR_DISABLED !== "1" && env.OMO_CODEX_CONFIG_REPAIR_DISABLED !== "1") {
+		try {
+			await repairOmoCodexConfig({ env });
+		} catch (error) {
+			if (!(error instanceof Error)) throw error;
+		}
+	}
 	if (env.LAZYCODEX_CONFIG_MIGRATION_DISABLED === "1" || env.OMO_CODEX_CONFIG_MIGRATION_DISABLED === "1") return;
 	try {
 		await migrateOmoSotConfig({ env, seed: true });

--- a/packages/omo-codex/plugin/scripts/hook-trust-discovery.mjs
+++ b/packages/omo-codex/plugin/scripts/hook-trust-discovery.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Hook-trust discovery utilities for the OMO Codex plugin.
+ *
+ * These functions scan installed plugin manifests and compute trusted
+ * hook hashes. They are pure read/scan operations — they do NOT modify
+ * any user configuration files.
+ */
+
+const EVENT_LABELS = new Map([
+	["PreToolUse", "pre_tool_use"],
+	["PermissionRequest", "permission_request"],
+	["PostToolUse", "post_tool_use"],
+	["PreCompact", "pre_compact"],
+	["PostCompact", "post_compact"],
+	["SessionStart", "session_start"],
+	["UserPromptSubmit", "user_prompt_submit"],
+	["SubagentStart", "subagent_start"],
+	["SubagentStop", "subagent_stop"],
+	["Stop", "stop"],
+]);
+
+/**
+ * Discover trusted hook states for an installed plugin by reading its
+ * manifest and hook definition files.
+ *
+ * @param {{ marketplaceName: string, pluginName: string, pluginRoot: string }} opts
+ * @returns {Promise<Array<{ key: string, trustedHash: string }>>}
+ */
+export async function trustedHookStatesForPlugin({ marketplaceName, pluginName, pluginRoot }) {
+	const manifestPath = join(pluginRoot, ".codex-plugin", "plugin.json");
+	let manifest;
+	try {
+		manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	} catch (error) {
+		if (error instanceof Error) return [];
+		throw error;
+	}
+	if (!isRecord(manifest)) return [];
+
+	const states = [];
+	for (const hookPath of hookManifestPaths(manifest.hooks)) {
+		const hooksPath = join(pluginRoot, hookPath);
+		let parsed;
+		try {
+			parsed = JSON.parse(await readFile(hooksPath, "utf8"));
+		} catch (error) {
+			if (error instanceof Error) continue;
+			throw error;
+		}
+		if (!isRecord(parsed) || !isRecord(parsed.hooks)) continue;
+		states.push(...trustedHookStatesForHooksFile({
+			keySource: `${pluginName}@${marketplaceName}:${hookPath}`,
+			hooks: parsed.hooks,
+		}));
+	}
+	return states;
+}
+
+/**
+ * Extract hook paths from a plugin manifest's `hooks` field.
+ * Accepts a single string or an array of strings.
+ * @param {string | string[] | undefined} value
+ * @returns {string[]}
+ */
+export function hookManifestPaths(value) {
+	if (typeof value === "string" && value.trim() !== "") return [stripDotSlash(value)];
+	if (!Array.isArray(value)) return [];
+	return value.filter((item) => typeof item === "string" && item.trim() !== "").map(stripDotSlash);
+}
+
+/**
+ * Compute trusted hook states from a parsed hooks definition file.
+ * @param {{ keySource: string, hooks: Record<string, unknown[]> }} opts
+ * @returns {Array<{ key: string, trustedHash: string }>}
+ */
+export function trustedHookStatesForHooksFile({ keySource, hooks }) {
+	const states = [];
+	for (const [eventName, groups] of Object.entries(hooks)) {
+		if (!Array.isArray(groups)) continue;
+		const eventLabel = EVENT_LABELS.get(eventName);
+		if (eventLabel === undefined) continue;
+		for (const [groupIndex, group] of groups.entries()) {
+			if (!isRecord(group) || !Array.isArray(group.hooks)) continue;
+			for (const [handlerIndex, handler] of group.hooks.entries()) {
+				if (!isRecord(handler) || handler.type !== "command") continue;
+				if (handler.async === true) continue;
+				if (typeof handler.command !== "string" || handler.command.trim() === "") continue;
+				states.push({
+					key: `${keySource}:${eventLabel}:${groupIndex}:${handlerIndex}`,
+					trustedHash: commandHookHash(eventLabel, group.matcher, handler),
+				});
+			}
+		}
+	}
+	return states;
+}
+
+/**
+ * Compute the SHA-256 trusted hash for a command-type hook handler.
+ * @param {string} eventName - The snake_case event label (e.g. "session_start")
+ * @param {string | undefined} matcher - Optional matcher string
+ * @param {{ command: string, timeout?: number, statusMessage?: string }} handler
+ * @returns {string} The hash in the form `sha256:<hex>`
+ */
+export function commandHookHash(eventName, matcher, handler) {
+	const command = handler.command;
+	const timeout = Math.max(Number(handler.timeout ?? 600), 1);
+	const normalizedHandler = {
+		type: "command",
+		command,
+		timeout,
+		async: false,
+	};
+	if (typeof handler.statusMessage === "string") normalizedHandler.statusMessage = handler.statusMessage;
+	const identity = {
+		event_name: eventName,
+		hooks: [normalizedHandler],
+	};
+	if (typeof matcher === "string") identity.matcher = matcher;
+	return `sha256:${createHash("sha256").update(JSON.stringify(canonicalJson(identity))).digest("hex")}`;
+}
+
+/**
+ * Canonical JSON serialization — recursively sorts object keys
+ * to produce a stable serialization for hashing.
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+export function canonicalJson(value) {
+	if (Array.isArray(value)) return value.map(canonicalJson);
+	if (!isRecord(value)) return value;
+	const result = {};
+	for (const key of Object.keys(value).sort()) {
+		result[key] = canonicalJson(value[key]);
+	}
+	return result;
+}
+
+/**
+ * Strip a leading `./` from a path string.
+ * @param {string} value
+ * @returns {string}
+ */
+export function stripDotSlash(value) {
+	return value.startsWith("./") ? value.slice(2) : value;
+}
+
+/**
+ * Type guard: is the value a plain object (not array, not null)?
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
+++ b/packages/omo-codex/plugin/scripts/repair-omo-config.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { trustedHookStatesForPlugin } from "./hook-trust-discovery.mjs";
+
+const MARKETPLACE_NAME = "sisyphuslabs";
+const PLUGIN_NAME = "omo";
+const PLUGIN_KEY = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+const MANAGED_CODEX_AGENT_NAMES = new Set([
+	"codex-ultrawork-reviewer",
+	"explorer",
+	"librarian",
+	"metis",
+	"momus",
+	"plan",
+]);
+const MAX_REPAIR_BACKUPS = 5;
+const REPAIR_BACKUP_SUFFIX = ".bak-omo-repair-";
+export async function repairOmoCodexConfig({ env = process.env, codexHome = resolveCodexHome(env), platform = process.platform, now = () => new Date() } = {}) {
+	const installState = await discoverOmoInstallState({ codexHome, platform });
+	if (installState === null) return { repaired: false, reason: "not-installed" };
+
+	const configPath = join(codexHome, "config.toml");
+	const before = await readConfig(configPath);
+	if (isOmoConfigHealthy(before, installState)) {
+		return { repaired: false, reason: "ok" };
+	}
+
+	const after = applyOmoConfigRepair(before, installState);
+	if (after === before) return { repaired: false, reason: "unchanged" };
+
+	await mkdir(dirname(configPath), { recursive: true });
+	const backupPath = await writeConfigBackup(configPath, before, now);
+	await writeFile(configPath, `${after.trimEnd()}\n`);
+	return { repaired: true, reason: "restored", configPath, backupPath };
+}
+
+export async function discoverOmoInstallState({ codexHome, platform = process.platform }) {
+	const pluginRoot = await resolveInstalledPluginRoot(codexHome);
+	if (pluginRoot === null) return null;
+
+	const marketplaceRoot = join(codexHome, "plugins", "cache", MARKETPLACE_NAME);
+	const trustedHookStates = await trustedHookStatesForPlugin({
+		marketplaceName: MARKETPLACE_NAME,
+		pluginName: PLUGIN_NAME,
+		pluginRoot,
+	});
+	const agentConfigs = await discoverManagedAgentConfigs(codexHome);
+	return {
+		marketplaceName: MARKETPLACE_NAME,
+		marketplaceSource: {
+			sourceType: "local",
+			source: marketplaceRoot,
+		},
+		pluginNames: [PLUGIN_NAME],
+		platform,
+		trustedHookStates,
+		agentConfigs,
+		pluginRoot,
+	};
+}
+
+export function isOmoConfigHealthy(config, installState) {
+	if (!findTomlSection(config, `marketplaces.${installState.marketplaceName}`)) return false;
+	const pluginSection = findTomlSection(config, `plugins.${JSON.stringify(PLUGIN_KEY)}`);
+	if (!pluginSection) return false;
+	return /^\s*enabled\s*=\s*true\s*$/m.test(pluginSection.text);
+}
+
+export function applyOmoConfigRepair(config, installState) {
+	let next = config;
+	next = ensureFeatureEnabled(next, "plugins");
+	next = ensureFeatureEnabled(next, "plugin_hooks");
+	next = ensureFeatureEnabled(next, "multi_agent");
+	next = ensureFeatureEnabled(next, "child_agents_md");
+	next = ensureMarketplaceBlock(next, installState.marketplaceName, installState.marketplaceSource);
+	for (const pluginName of installState.pluginNames) {
+		next = ensurePluginEnabled(next, `${pluginName}@${installState.marketplaceName}`);
+	}
+	next = ensureOmoBuiltinMcpPolicies(next, installState);
+	for (const state of installState.trustedHookStates) {
+		next = ensureHookTrusted(next, state.key, state.trustedHash);
+	}
+	for (const agentConfig of installState.agentConfigs) {
+		next = ensureAgentConfig(next, agentConfig);
+	}
+	return next;
+}
+
+async function resolveInstalledPluginRoot(codexHome) {
+	const pluginCacheRoot = join(codexHome, "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME);
+	let entries;
+	try {
+		entries = await readdir(pluginCacheRoot, { withFileTypes: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
+	}
+
+	const versions = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort(compareVersionLabels);
+	if (versions.length === 0) return null;
+	return join(pluginCacheRoot, versions[versions.length - 1]);
+}
+
+async function discoverManagedAgentConfigs(codexHome) {
+	const agentsDir = join(codexHome, "agents");
+	let entries;
+	try {
+		entries = await readdir(agentsDir, { withFileTypes: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+		throw error;
+	}
+
+	const configs = [];
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".toml")) continue;
+		const agentName = entry.name.slice(0, -".toml".length);
+		if (!MANAGED_CODEX_AGENT_NAMES.has(agentName)) continue;
+		configs.push({ name: agentName, configFile: `./agents/${entry.name}` });
+	}
+	return configs.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function ensureFeatureEnabled(config, featureName) {
+	const section = findTomlSection(config, "features");
+	if (!section) return appendBlock(config, `[features]\n${featureName} = true\n`);
+	return replaceOrInsertSetting(config, section, featureName, "true");
+}
+
+function ensureMarketplaceBlock(config, marketplaceName, source) {
+	const header = `marketplaces.${marketplaceName}`;
+	const block = [
+		`[${header}]`,
+		`last_updated = "${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}"`,
+		`source_type = ${JSON.stringify(source.sourceType)}`,
+		`source = ${JSON.stringify(source.source)}`,
+		source.ref === undefined ? null : `ref = ${JSON.stringify(source.ref)}`,
+		"",
+	].filter((line) => line !== null).join("\n");
+	const section = findTomlSection(config, header);
+	if (section) return config.slice(0, section.start) + block + config.slice(section.end);
+	return appendBlock(config, block);
+}
+
+function ensurePluginEnabled(config, pluginKey) {
+	const header = `plugins.${JSON.stringify(pluginKey)}`;
+	const section = findTomlSection(config, header);
+	if (!section) return appendBlock(config, `[${header}]\nenabled = true\n`);
+	return replaceOrInsertSetting(config, section, "enabled", "true");
+}
+
+function ensurePluginMcpEnabled(config, pluginKey, serverName, enabled) {
+	const header = `plugins.${JSON.stringify(pluginKey)}.mcp_servers.${serverName}`;
+	const section = findTomlSection(config, header);
+	const enabledValue = enabled ? "true" : "false";
+	if (!section) return appendBlock(config, `[${header}]\nenabled = ${enabledValue}\n`);
+	return replaceOrInsertSetting(config, section, "enabled", enabledValue);
+}
+
+function ensureOmoBuiltinMcpPolicies(config, installState) {
+	if (installState.marketplaceName !== MARKETPLACE_NAME || !installState.pluginNames.includes(PLUGIN_NAME)) return config;
+	let nextConfig = ensurePluginMcpEnabled(config, PLUGIN_KEY, "context7", true);
+	nextConfig = ensurePluginMcpEnabled(nextConfig, PLUGIN_KEY, "git_bash", installState.platform === "win32");
+	return nextConfig;
+}
+
+function ensureHookTrusted(config, key, trustedHash) {
+	const header = `hooks.state.${JSON.stringify(key)}`;
+	const section = findTomlSection(config, header);
+	if (!section) return appendBlock(config, `[${header}]\ntrusted_hash = ${JSON.stringify(trustedHash)}\n`);
+	return replaceOrInsertSetting(config, section, "trusted_hash", JSON.stringify(trustedHash));
+}
+
+function ensureAgentConfig(config, agentConfig) {
+	const header = `agents.${tomlKeySegment(agentConfig.name)}`;
+	const section = findTomlSection(config, header);
+	const configFile = JSON.stringify(agentConfig.configFile);
+	if (!section) return appendBlock(config, `[${header}]\nconfig_file = ${configFile}\n`);
+	return replaceOrInsertSetting(config, section, "config_file", configFile);
+}
+
+function tomlKeySegment(value) {
+	return /^[A-Za-z0-9_-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function findTomlSection(config, header) {
+	const headerLine = `[${header}]`;
+	const lines = config.match(/[^\n]*\n?|$/g) ?? [];
+	let offset = 0;
+	let start = -1;
+	for (const line of lines) {
+		if (line.length === 0) break;
+		const trimmed = line.trim();
+		if (start === -1) {
+			if (trimmed === headerLine) start = offset;
+		} else if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			return { start, end: offset, text: config.slice(start, offset) };
+		}
+		offset += line.length;
+	}
+	if (start === -1) return null;
+	return { start, end: config.length, text: config.slice(start) };
+}
+
+function replaceOrInsertSetting(config, section, key, value) {
+	const linePattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
+	const replacement = linePattern.test(section.text)
+		? section.text.replace(linePattern, `${key} = ${value}`)
+		: insertSetting(section.text, key, value);
+	return config.slice(0, section.start) + replacement + config.slice(section.end);
+}
+
+function insertSetting(sectionText, key, value) {
+	const trimmed = sectionText.trimEnd();
+	return `${trimmed}\n${key} = ${value}\n`;
+}
+
+function appendBlock(config, block) {
+	const prefix = config.trimEnd();
+	return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${block.trimEnd()}\n`;
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function readConfig(configPath) {
+	try {
+		return await readFile(configPath, "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+		throw error;
+	}
+}
+
+async function writeConfigBackup(configPath, content, now) {
+	if (content.trim().length === 0) return undefined;
+	const timestamp = formatBackupTimestamp(now());
+	const backupPath = `${configPath}${REPAIR_BACKUP_SUFFIX}${timestamp}`;
+	await writeFile(backupPath, content);
+	await pruneRepairBackups(configPath);
+	return backupPath;
+}
+
+async function pruneRepairBackups(configPath) {
+	const configDir = dirname(configPath);
+	const prefix = `${basename(configPath)}${REPAIR_BACKUP_SUFFIX}`;
+	let entries;
+	try {
+		entries = await readdir(configDir);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+		throw error;
+	}
+
+	const backups = entries
+		.filter((name) => name.startsWith(prefix))
+		.sort(compareRepairBackupNames)
+		.reverse();
+	for (const name of backups.slice(MAX_REPAIR_BACKUPS)) {
+		await rm(join(configDir, name), { force: true });
+	}
+}
+
+function compareRepairBackupNames(left, right) {
+	const leftTimestamp = left.slice(left.lastIndexOf(REPAIR_BACKUP_SUFFIX) + REPAIR_BACKUP_SUFFIX.length);
+	const rightTimestamp = right.slice(right.lastIndexOf(REPAIR_BACKUP_SUFFIX) + REPAIR_BACKUP_SUFFIX.length);
+	return leftTimestamp.localeCompare(rightTimestamp);
+}
+
+function formatBackupTimestamp(date) {
+	const pad = (value) => String(value).padStart(2, "0");
+	return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function resolveCodexHome(env) {
+	const value = env.CODEX_HOME?.trim();
+	return value && value.length > 0 ? value : join(homedir(), ".codex");
+}
+
+function compareVersionLabels(left, right) {
+	const leftParts = parseVersionLabel(left);
+	const rightParts = parseVersionLabel(right);
+	for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+		const leftValue = leftParts[index] ?? 0;
+		const rightValue = rightParts[index] ?? 0;
+		if (leftValue !== rightValue) return leftValue - rightValue;
+	}
+	return left.localeCompare(right);
+}
+
+function parseVersionLabel(value) {
+	return value.split(/[.-]/).map((part) => {
+		const numeric = Number.parseInt(part, 10);
+		return Number.isFinite(numeric) ? numeric : 0;
+	});
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	repairOmoCodexConfig()
+		.then((result) => {
+			if (result.repaired) {
+				console.log(`Repaired OMO Codex config (${result.reason}). Backup: ${result.backupPath ?? "none"}`);
+				return;
+			}
+			console.log(`OMO Codex config repair skipped (${result.reason}).`);
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		});
+}

--- a/packages/omo-codex/plugin/test/repair-omo-config.test.mjs
+++ b/packages/omo-codex/plugin/test/repair-omo-config.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { cp, mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+	applyOmoConfigRepair,
+	discoverOmoInstallState,
+	isOmoConfigHealthy,
+	repairOmoCodexConfig,
+} from "../scripts/repair-omo-config.mjs";
+
+const SOURCE_PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+async function seedInstalledOmo(codexHome) {
+	const cacheRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0");
+	await cp(join(SOURCE_PLUGIN_ROOT, ".codex-plugin"), join(cacheRoot, ".codex-plugin"), { recursive: true });
+	await cp(join(SOURCE_PLUGIN_ROOT, "hooks"), join(cacheRoot, "hooks"), { recursive: true });
+	await mkdir(join(codexHome, "agents"), { recursive: true });
+	await writeFile(join(codexHome, "agents", "plan.toml"), 'model_reasoning_effort = "high"\n');
+}
+
+test("#given stripped Codex config after provider switch #when repairing #then restores omo plugin without touching auth settings", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-provider-switch-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			'model_provider = "custom"',
+			"",
+			"[model_providers.custom]",
+			'name = "custom"',
+			'wire_api = "responses"',
+			"requires_openai_auth = true",
+			'base_url = "https://api.example.test/openai"',
+			"",
+		].join("\n"),
+	);
+
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "win32" });
+	const content = await readFile(configPath, "utf8");
+
+	assert.equal(result.repaired, true);
+	assert.match(content, /\[marketplaces\.sisyphuslabs\]/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\]/);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\][\s\S]*enabled = true/);
+	assert.match(content, /base_url = "https:\/\/api\.example\.test\/openai"/);
+	assert.match(content, /model_provider = "custom"/);
+	assert.doesNotMatch(content, /plan_mode_reasoning_effort = "xhigh"/);
+});
+
+test("#given official Codex config without custom provider #when repairing #then preserves chatgpt-oriented settings", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-official-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(
+		configPath,
+		[
+			'model = "gpt-5.5"',
+			'model_reasoning_effort = "xhigh"',
+			"",
+			"[windows]",
+			'sandbox = "elevated"',
+			"",
+		].join("\n"),
+	);
+
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "linux" });
+	const content = await readFile(configPath, "utf8");
+
+	assert.equal(result.repaired, true);
+	assert.match(content, /\[plugins\."omo@sisyphuslabs"\]/);
+	assert.match(content, /model_reasoning_effort = "xhigh"/);
+	assert.doesNotMatch(content, /\[model_providers\./);
+});
+
+test("#given five existing repair backups #when repairing again #then keeps only the five newest repair backups", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-backup-prune-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+
+	const configPath = join(codexHome, "config.toml");
+	const strippedConfig = ['model = "gpt-5.5"', 'model_provider = "custom"', ""].join("\n");
+	await writeFile(configPath, strippedConfig);
+
+	for (const stamp of ["20260101-000001", "20260101-000002", "20260101-000003", "20260101-000004", "20260101-000005"]) {
+		await writeFile(`${configPath}.bak-omo-repair-${stamp}`, `backup-${stamp}\n`);
+	}
+	await writeFile(`${configPath}.backup-20260101-000000`, "installer-backup\n");
+
+	const result = await repairOmoCodexConfig({
+		env: { CODEX_HOME: codexHome },
+		platform: "linux",
+		now: () => new Date(2026, 0, 1, 0, 0, 6),
+	});
+	const entries = (await readdir(codexHome)).sort();
+
+	assert.equal(result.repaired, true);
+	assert.deepEqual(
+		entries.filter((name) => name.startsWith("config.toml.bak-omo-repair-")),
+		[
+			"config.toml.bak-omo-repair-20260101-000002",
+			"config.toml.bak-omo-repair-20260101-000003",
+			"config.toml.bak-omo-repair-20260101-000004",
+			"config.toml.bak-omo-repair-20260101-000005",
+			"config.toml.bak-omo-repair-20260101-000006",
+		],
+	);
+	assert.ok(entries.includes("config.toml.backup-20260101-000000"));
+});
+
+test("#given healthy omo config #when repairing #then leaves config unchanged", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omo-repair-healthy-"));
+	const codexHome = join(root, "codex-home");
+	await seedInstalledOmo(codexHome);
+	const discovered = await discoverOmoInstallState({ codexHome, platform: "linux" });
+	assert.notEqual(discovered, null);
+
+	const healthyConfig = applyOmoConfigRepair("", discovered);
+	assert.equal(isOmoConfigHealthy(healthyConfig, discovered), true);
+
+	const configPath = join(codexHome, "config.toml");
+	await writeFile(configPath, healthyConfig);
+	const result = await repairOmoCodexConfig({ env: { CODEX_HOME: codexHome }, platform: "linux" });
+	assert.equal(result.repaired, false);
+	assert.equal(result.reason, "ok");
+});


### PR DESCRIPTION
## Summary

Minimal follow-up to #5143, scoped down per maintainer feedback. Fixes only the auth-switch wipe symptom: when Codex auth/provider switching (official ChatGPT login vs relay `base_url`) rewrites `~/.codex/config.toml` and strips `omo@sisyphuslabs` while the plugin cache under `~/.codex/plugins/cache/sisyphuslabs/omo/` is still intact, the OMO-managed config blocks are silently restored on the next `SessionStart` auto-update check.

- `repair-omo-config.mjs` is fully self-contained (only `node:*` imports) and re-merges only OMO-managed blocks: `sisyphuslabs` marketplace, `omo@sisyphuslabs` enablement, trusted hook states, and managed agent references. `model_provider`, `base_url`, and all other user settings are left untouched, and a `config.toml.bak-omo-repair-*` backup is written before any change.
- The only trigger is the existing `runConfigMigration` path in `auto-update.mjs` (SessionStart). Opt out with `LAZYCODEX_CONFIG_REPAIR_DISABLED=1`.

Compared to #5143, this PR drops everything flagged in the close reason: no data-dir shim (the broken `installRepairConfigShim` is gone entirely), no global skills mirror, no `repair-config` CLI command, no extra node spawn in the `omo` wrapper, and no installer changes. 4 files changed, all within `packages/omo-codex/plugin/` plus a README paragraph.

## Test plan

- [x] `node --test packages/omo-codex/plugin/test/repair-omo-config.test.mjs` (3/3 pass)
- [x] Repair restores stripped `omo@sisyphuslabs` config without modifying auth/provider fields
- [x] Repair preserves official-login configs without inventing `model_providers` blocks
- [x] Repair is a no-op on healthy config
- [x] `auto-update.mjs` imports cleanly with the new repair hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silently repairs OMO Codex config on SessionStart when auth/provider switches strip `omo@sisyphuslabs`, so OMO keeps working without touching user auth. Writes a backup and prunes repair backups to the newest five.

- **Bug Fixes**
  - Added `repair-omo-config.mjs` and `hook-trust-discovery.mjs` to restore only OMO-managed blocks: `marketplaces.sisyphuslabs`, `plugins."omo@sisyphuslabs"`, trusted hook state, and managed agent refs. Keeps built‑in MCP policies enabled (`context7`; `git_bash` on Windows) and re-enables required features (`plugins`, `plugin_hooks`, `multi_agent`, `child_agents_md`).
  - Runs during the SessionStart auto-update when the plugin cache exists; writes `config.toml.bak-omo-repair-*` before changes; keeps only the newest five backups; leaves `model_provider`, `base_url`, and other user settings unchanged. Opt out with `LAZYCODEX_CONFIG_REPAIR_DISABLED=1` or `OMO_CODEX_CONFIG_REPAIR_DISABLED=1`.

<sup>Written for commit e05e15460b0beee879a2ef3f0fc96079d8744601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

