### PR TITLE
fix(background-agent): schedule re-flush for reply-required wake after activity window

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -66,6 +66,9 @@ export class ParentWakeFlushRunner {
       log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
         sessionID,
       })
+      if (latestWake.shouldReply) {
+        this.schedulePendingParentWakeFlush(sessionID)
+      }
       return
     }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-noreply-liveness.test.ts
@@ -639,9 +639,12 @@ describe("BackgroundManager parent wake recent-activity admission liveness", () 
       expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
       expect(parentWakeNotifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      // regression: the reply-required wake must be scheduled for re-flush
+      expect(parentWakeNotifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
 
       // when: activity goes stale and the gate hold expires
       now = 110_000
+      parentWakeNotifier.clearPendingParentWakeTimer("parent-1")
       releaseParentWakeHold("parent-1")
       await flushPendingParentWake.call(manager, "parent-1")
 


### PR DESCRIPTION
## Summary

- Fix background agent wake deadlock: orchestrator agent never responds after task completes
- When `hasRecentParentSessionActivity()` fires and wake `shouldReply`, schedule a re-flush instead of leaving the retained wake stranded forever
- Targeted 3-line fix in `parent-wake-flush-runner.ts` — no behavioral change outside the activity-window path

## Changes

- **`packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts`** (+3 lines)
  - After forceNoReply admission in the `hasRecentParentSessionActivity()` block, call `this.schedulePendingParentWakeFlush(sessionID)` if `latestWake.shouldReply`
  - The retained wake previously stayed in the pending queue with no retry scheduled; now it retries after the activity window expires

## Testing

```bash
bun test packages/omo-opencode/src/features/background-agent/parent-wake-*.test.ts
```

Result: **78/78 pass, 0 fail** across 15 files.

Key coverage:

- parent-wake-activity-window.test.ts — verifies wake is admitted without forking a reply when parent has recent activity ✅
- parent-wake-noreply-liveness.test.ts — "recent-activity admission liveness" test verifies parent resumes after activity goes stale ✅
- All existing liveness, dedupe, deferral, and regression tests unaffected ✅

## Related Issues

Closes #5189 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Schedules a re-flush for reply-required parent wakes retained during recent session activity, preventing stuck pending wakes and restoring orchestrator replies after the activity window. Closes #5189.

- **Bug Fixes**
  - When hasRecentParentSessionActivity() is true and a wake shouldReply, call schedulePendingParentWakeFlush(sessionID) so the retained wake retries after the activity window instead of remaining pending.
  - Assert the timer is armed in the recent-activity admission liveness test to catch regressions.

<sup>Written for commit c97528736c5e3f288d2b340ef9426ccf26d655aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



