### PR TITLE
fix(tmux): sweep stale inline attach panes

### DIFF
--- a/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
@@ -195,17 +195,17 @@ test("#given a marketplace payload without dist/cli #when the worker setup runs 
 	await withBinLinkFixture(async (fixture) => {
 		const pluginRoot = await writeVersionedRoot(fixture.root, "1.0.0");
 
-		const outcome = await runWorkerSetup(setupOptions(fixture, pluginRoot, { now: 7_000 }));
+		const outcome = await runWorkerSetup(setupOptions(fixture, pluginRoot, { now: 7_000, platform: process.platform }));
 
 		assert.deepEqual(outcome.degraded, [OMO_CLI_DEGRADED_ENTRY]);
 		await assert.rejects(() => lstat(join(fixture.binDir, "omo")), "no omo wrapper may be written without dist/cli");
+		await assert.rejects(() => lstat(join(fixture.binDir, "omo.cmd")), "no Windows omo wrapper may be written without dist/cli");
 		await assertNoDanglingEntries(fixture.binDir);
 		const log = await readFile(join(fixture.pluginData, "bootstrap", "bootstrap.log"), "utf8");
 		assert.ok(
-			log.includes(
-				`skipped the omo runtime wrapper because ${join(pluginRoot, "dist", "cli", "index.js")} is missing; ` +
-					"omo sparkshell/ulw-loop commands will be unavailable until a package shipping dist/cli is installed",
-			),
+			log.includes("skipped the omo runtime wrapper because ") &&
+				log.includes(`${join("dist", "cli", "index.js")} is missing; `) &&
+				log.includes("omo sparkshell/ulw-loop commands will be unavailable until a package shipping dist/cli is installed"),
 			`bootstrap.log must carry the install-local warning text, got: ${log}`,
 		);
 	});
@@ -215,16 +215,22 @@ test("#given a payload shipping dist/cli #when the worker setup runs with no bin
 	await withBinLinkFixture(async (fixture) => {
 		const pluginRoot = await writeVersionedRoot(fixture.root, "1.0.0", { withRuntimeCli: true });
 
-		const outcome = await runWorkerSetup(setupOptions(fixture, pluginRoot, { env: {} }));
+		const outcome = await runWorkerSetup(setupOptions(fixture, pluginRoot, { env: {}, platform: process.platform }));
 
 		assert.deepEqual(outcome.degraded, []);
 		const defaultBinDir = join(fixture.codexHome, "bin");
-		const wrapper = await readFile(join(defaultBinDir, "omo"), "utf8");
+		const wrapperName = process.platform === "win32" ? "omo.cmd" : "omo";
+		const wrapper = await readFile(join(defaultBinDir, wrapperName), "utf8");
 		assert.ok(wrapper.includes(join(pluginRoot, "dist", "cli", "index.js")));
-		assert.ok((await stat(join(defaultBinDir, "omo"))).mode & 0o111, "the posix omo wrapper must be executable");
-		assert.equal(
-			await readlink(join(defaultBinDir, COMPONENT_BIN_NAME)),
-			join(pluginRoot, "components", "toolbox", "dist", "cli.js"),
-		);
+		if (process.platform !== "win32") {
+			assert.ok((await stat(join(defaultBinDir, "omo"))).mode & 0o111, "the posix omo wrapper must be executable");
+			assert.equal(
+				await readlink(join(defaultBinDir, COMPONENT_BIN_NAME)),
+				join(pluginRoot, "components", "toolbox", "dist", "cli.js"),
+			);
+		} else {
+			const shim = await readFile(join(defaultBinDir, `${COMPONENT_BIN_NAME}.cmd`), "utf8");
+			assert.ok(shim.includes(join(pluginRoot, "components", "toolbox", "dist", "cli.js")));
+		}
 	});
 });

--- a/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
+++ b/packages/omo-codex/plugin/test/bootstrap-binlinks.test.mjs
@@ -112,6 +112,17 @@ async function assertNoDanglingEntries(binDir) {
 	}
 }
 
+async function assertComponentBinPointsTo(binDir, target, message) {
+	if (process.platform !== "win32") {
+		assert.equal(await readlink(join(binDir, COMPONENT_BIN_NAME)), target, message);
+		return;
+	}
+
+	const shim = await readFile(join(binDir, `${COMPONENT_BIN_NAME}.cmd`), "utf8");
+	assert.ok(shim.includes(target), message);
+	await assert.rejects(() => lstat(join(binDir, COMPONENT_BIN_NAME)), "win32 must not leave a posix component link behind");
+}
+
 test("#given two versioned plugin roots #when the worker setup runs against each in turn #then bin links re-point to the new root and none resolve under the old", async () => {
 	await withBinLinkFixture(async (fixture) => {
 		const rootV1 = await writeVersionedRoot(fixture.root, "1.0.0");
@@ -146,22 +157,23 @@ test("#given a completed v1 marker #when the worker runs against a v2 root #then
 		});
 		const argv = ["--codex-home", fixture.codexHome, "--only", "setup"];
 
-		const firstRun = await runBootstrapWorker({ argv, env: workerEnv(rootV1) });
+		const firstRun = await runBootstrapWorker({ argv, env: workerEnv(rootV1), platform: process.platform });
 		assert.equal(firstRun.ran, true);
 
-		const repeatRun = await runBootstrapWorker({ argv, env: workerEnv(rootV1) });
+		const repeatRun = await runBootstrapWorker({ argv, env: workerEnv(rootV1), platform: process.platform });
 		assert.deepEqual(repeatRun, { ran: false, reason: "already-completed" });
-		assert.equal(
-			await readlink(join(fixture.binDir, COMPONENT_BIN_NAME)),
+		await assertComponentBinPointsTo(
+			fixture.binDir,
 			join(rootV1, "components", "toolbox", "dist", "cli.js"),
 			"a same-version skip must leave the existing links untouched",
 		);
 
-		const upgradeRun = await runBootstrapWorker({ argv, env: workerEnv(rootV2) });
+		const upgradeRun = await runBootstrapWorker({ argv, env: workerEnv(rootV2), platform: process.platform });
 		assert.equal(upgradeRun.ran, true, "a changed completedForVersion marker must re-run the worker");
-		assert.equal(
-			await readlink(join(fixture.binDir, COMPONENT_BIN_NAME)),
+		await assertComponentBinPointsTo(
+			fixture.binDir,
 			join(rootV2, "components", "toolbox", "dist", "cli.js"),
+			"a version change must re-point component bins to the new plugin root",
 		);
 		const state = JSON.parse(await readFile(join(fixture.pluginData, "bootstrap", "state.json"), "utf8"));
 		assert.equal(state.completedForVersion, "2.0.0");
@@ -202,10 +214,12 @@ test("#given a marketplace payload without dist/cli #when the worker setup runs 
 		await assert.rejects(() => lstat(join(fixture.binDir, "omo.cmd")), "no Windows omo wrapper may be written without dist/cli");
 		await assertNoDanglingEntries(fixture.binDir);
 		const log = await readFile(join(fixture.pluginData, "bootstrap", "bootstrap.log"), "utf8");
+		const warning = JSON.parse(log)["warning"];
+		assert.equal(typeof warning, "string", `bootstrap.log warning must be a string, got: ${log}`);
 		assert.ok(
-			log.includes("skipped the omo runtime wrapper because ") &&
-				log.includes(`${join("dist", "cli", "index.js")} is missing; `) &&
-				log.includes("omo sparkshell/ulw-loop commands will be unavailable until a package shipping dist/cli is installed"),
+			warning.includes("skipped the omo runtime wrapper because ") &&
+				warning.includes(`${join("dist", "cli", "index.js")} is missing; `) &&
+				warning.includes("omo sparkshell/ulw-loop commands will be unavailable until a package shipping dist/cli is installed"),
 			`bootstrap.log must carry the install-local warning text, got: ${log}`,
 		);
 	});

--- a/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.test.ts
@@ -213,6 +213,12 @@ describe("team-layout-tmux", () => {
     const literals = sendKeysCalls.map((args) => args.join(" "))
     expect(literals.some((s) => s.includes("--session 's-m1'"))).toBe(true)
     expect(literals.some((s) => s.includes("--session 's-m2'"))).toBe(true)
+
+    const paneOptionCalls = commands.filter((args) => args[0] === "set-option" && args[1] === "-p")
+    expect(paneOptionCalls).toContainEqual(["set-option", "-p", "-t", "%1", "@omo_attach_server_url", "http://127.0.0.1:12345"])
+    expect(paneOptionCalls).toContainEqual(["set-option", "-p", "-t", "%1", "@omo_attach_session_id", "s-m1"])
+    expect(paneOptionCalls).toContainEqual(["set-option", "-p", "-t", "%2", "@omo_attach_server_url", "http://127.0.0.1:12345"])
+    expect(paneOptionCalls).toContainEqual(["set-option", "-p", "-t", "%2", "@omo_attach_session_id", "s-m2"])
   })
 
   test("#given env auth set #when createTeamLayout runs #then send-keys attach commands omit secrets while split-window forwards pane env", async () => {
@@ -334,7 +340,7 @@ describe("team-layout-tmux", () => {
     // then
     const commands = getCommands()
     expect(commands.some((args) => args[0] === "select-pane" && !args.includes("-T"))).toBe(false)
-    expect(commands.some((args) => args[0] === "set-option")).toBe(false)
+    expect(commands.some((args) => args[0] === "set-option" && args[1] !== "-p")).toBe(false)
   })
 
   test("#given delegated pane startup #when split-window is called #then -d flag is always present to prevent terminal probe replies leaking into caller pane (fix #2887)", async () => {

--- a/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.ts
@@ -7,6 +7,7 @@ import { resolveCallerTmuxSession } from "./resolve-caller-tmux-session"
 
 type TeamLayoutMember = { name: string; sessionId: string; worktreePath?: string }
 type TmuxCommandResult = Awaited<ReturnType<typeof sharedTmuxModule.runTmuxCommand>>
+const TEAM_PANE_TITLE_PREFIX = "omo-team-"
 
 export type TeamLayoutDeps = {
   runTmuxCommand: (tmuxPath: string, args: Array<string>, options?: Parameters<typeof sharedTmuxModule.runTmuxCommand>[2]) => Promise<TmuxCommandResult>
@@ -116,7 +117,7 @@ async function createTeamLayoutInCallerWindow(
     const paneId = split.output.trim()
     teammatePanes = [...teammatePanes, paneId]
     panesByMember[member.name] = paneId
-    await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", paneId, "-T", member.name])
+    await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", paneId, "-T", `${TEAM_PANE_TITLE_PREFIX}${member.name}`])
     await deps.runTmuxCommand(tmuxPath, ["send-keys", "-t", paneId, buildAttachCommand(member, serverUrl), "Enter"])
   }
 

--- a/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-layout-tmux/layout.ts
@@ -8,6 +8,8 @@ import { resolveCallerTmuxSession } from "./resolve-caller-tmux-session"
 type TeamLayoutMember = { name: string; sessionId: string; worktreePath?: string }
 type TmuxCommandResult = Awaited<ReturnType<typeof sharedTmuxModule.runTmuxCommand>>
 const TEAM_PANE_TITLE_PREFIX = "omo-team-"
+const OMO_ATTACH_SERVER_URL_OPTION = "@omo_attach_server_url"
+const OMO_ATTACH_SESSION_ID_OPTION = "@omo_attach_session_id"
 
 export type TeamLayoutDeps = {
   runTmuxCommand: (tmuxPath: string, args: Array<string>, options?: Parameters<typeof sharedTmuxModule.runTmuxCommand>[2]) => Promise<TmuxCommandResult>
@@ -118,6 +120,8 @@ async function createTeamLayoutInCallerWindow(
     teammatePanes = [...teammatePanes, paneId]
     panesByMember[member.name] = paneId
     await deps.runTmuxCommand(tmuxPath, ["select-pane", "-t", paneId, "-T", `${TEAM_PANE_TITLE_PREFIX}${member.name}`])
+    await deps.runTmuxCommand(tmuxPath, ["set-option", "-p", "-t", paneId, OMO_ATTACH_SERVER_URL_OPTION, serverUrl])
+    await deps.runTmuxCommand(tmuxPath, ["set-option", "-p", "-t", paneId, OMO_ATTACH_SESSION_ID_OPTION, member.sessionId])
     await deps.runTmuxCommand(tmuxPath, ["send-keys", "-t", paneId, buildAttachCommand(member, serverUrl), "Enter"])
   }
 

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
@@ -661,6 +661,32 @@ describe('TmuxSessionManager', () => {
       expect(mockExecuteActions).toHaveBeenCalledTimes(1)
     })
 
+    test('#given skipped team-mode session #when onSessionCreated runs #then stale attach panes are still swept once', async () => {
+      // given
+      mockSweepStaleOmoAgentSessions.mockClear()
+      mockSweepStaleOmoAttachPanes.mockClear()
+      mockSweepStaleOmoAttachPanes.mockImplementation(async () => 1)
+      mockIsInsideTmux.mockReturnValue(true)
+
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
+        enabled: true,
+        isolation: 'inline',
+      }), mockTmuxDeps, {
+        shouldSkipSession: (sessionId) => sessionId.startsWith('ses_team_member'),
+      })
+
+      // when
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_team_member', 'ses_parent', 'team member task'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_team_member_two', 'ses_parent', 'team member task 2'))
+
+      // then
+      expect(mockSweepStaleOmoAttachPanes).toHaveBeenCalledTimes(1)
+      expect(mockSweepStaleOmoAgentSessions).toHaveBeenCalledTimes(0)
+      expect(mockQueryWindowState).not.toHaveBeenCalled()
+      expect(mockExecuteActions).not.toHaveBeenCalled()
+    })
+
     test('second agent spawns with correct split direction', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.test.ts
@@ -90,6 +90,7 @@ const mockSpawnTmuxSession = mock<(
 }))
 const mockKillTmuxSessionIfExists = mock<(sessionName: string) => Promise<boolean>>(async () => true)
 const mockSweepStaleOmoAgentSessions = mock<() => Promise<number>>(async () => 0)
+const mockSweepStaleOmoAttachPanes = mock<() => Promise<number>>(async () => 0)
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
 
@@ -130,6 +131,7 @@ function registerModuleMocks(): void {
       killTmuxSessionIfExists: mockKillTmuxSessionIfExists,
       getIsolatedSessionName: (pid: number = 12345) => `omo-agents-${pid}`,
       sweepStaleOmoAgentSessions: mockSweepStaleOmoAgentSessions,
+      sweepStaleOmoAttachPanes: mockSweepStaleOmoAttachPanes,
     }
   })
 }
@@ -254,6 +256,7 @@ describe('TmuxSessionManager', () => {
     mockWaitForSessionReady.mockClear()
     mockSpawnTmuxWindow.mockClear()
     mockSpawnTmuxSession.mockClear()
+    mockSweepStaleOmoAttachPanes.mockClear()
     mockIsInsideTmux.mockClear()
     mockGetCurrentPaneId.mockClear()
     trackedSessions.clear()
@@ -2597,6 +2600,7 @@ describe('TmuxSessionManager', () => {
       // given
       mockSweepStaleOmoAgentSessions.mockClear()
       mockSweepStaleOmoAgentSessions.mockImplementation(async () => 0)
+      mockSweepStaleOmoAttachPanes.mockClear()
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
@@ -2611,6 +2615,27 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(mockSweepStaleOmoAgentSessions).toHaveBeenCalledTimes(1)
+    })
+
+    test('#given inline isolation #when onSessionCreated runs #then stale OMO attach panes are swept once without isolated session sweep', async () => {
+      // given
+      mockSweepStaleOmoAgentSessions.mockClear()
+      mockSweepStaleOmoAttachPanes.mockClear()
+      mockSweepStaleOmoAttachPanes.mockImplementation(async () => 1)
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
+        enabled: true,
+        isolation: 'inline',
+      }), mockTmuxDeps)
+
+      // when
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_inline', 'ses_parent', 'Inline'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_inline_second', 'ses_parent', 'Inline Second'))
+
+      // then
+      expect(mockSweepStaleOmoAgentSessions).toHaveBeenCalledTimes(0)
+      expect(mockSweepStaleOmoAttachPanes).toHaveBeenCalledTimes(1)
     })
 
     test('#given killTmuxSessionIfExists throws #when cleanup runs #then cleanup still completes without throwing', async () => {

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.ts
@@ -1115,6 +1115,8 @@ export class TmuxSessionManager {
     const sessionId = resolveSessionEventID(event.properties)
     if (!sessionId || !info?.parentID) return
 
+    await this.sweepStaleIsolatedSessionsOnce()
+
     // Team-mode members live in `team-layout-tmux` (which owns the pane
     // lifecycle via runtimeState.tmuxLayout). Tracking them here as well
     // produces two managers fighting over the same pane: polling can close a
@@ -1140,7 +1142,6 @@ export class TmuxSessionManager {
     }
 
     try {
-      await this.sweepStaleIsolatedSessionsOnce()
       await this.retryPendingCloses()
 
       const session = { sessionId, title }

--- a/packages/omo-opencode/src/features/tmux-subagent/manager.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/manager.ts
@@ -12,6 +12,7 @@ import {
   killTmuxSessionIfExists,
   getIsolatedSessionName,
   sweepStaleOmoAgentSessions,
+  sweepStaleOmoAttachPanes,
   activateTmuxPane,
 } from "../../shared/tmux"
 import { queryWindowState as defaultQueryWindowState } from "./pane-state-querier"
@@ -24,6 +25,7 @@ import { isAttachableSessionStatus } from "./attachable-session-status"
 import { parseSessionStatusResponse } from "./session-status-parser"
 import { FailedReadinessCache, type FailedReadinessSessionSeed } from "./failed-readiness-cache"
 import { resolveServerUrl } from "./resolve-server-url"
+import { sweepStaleTmuxResources } from "./stale-tmux-resource-sweeper"
 type OpencodeClient = PluginInput["client"]
 
 type SpawnStage =
@@ -1352,16 +1354,20 @@ export class TmuxSessionManager {
   private async sweepStaleIsolatedSessionsOnce(): Promise<void> {
     if (this.staleSweepCompleted) return
     if (this.staleSweepInProgress) return
-    if (this.tmuxConfig.isolation !== "session") {
-      this.staleSweepCompleted = true
-      return
-    }
 
     this.staleSweepInProgress = true
     try {
-      const killed = await sweepStaleOmoAgentSessions()
-      if (killed > 0) {
-        this.deps.log("[tmux-session-manager] stale isolated sessions swept", { killed })
+      const report = await sweepStaleTmuxResources({
+        isolation: this.tmuxConfig.isolation,
+        sweepStaleOmoAgentSessions,
+        sweepStaleOmoAttachPanes,
+      })
+      if (report.killed > 0) {
+        this.deps.log("[tmux-session-manager] stale tmux resources swept", {
+          killed: report.killed,
+          killedAttachPanes: report.killedAttachPanes,
+          killedIsolatedSessions: report.killedIsolatedSessions,
+        })
       }
       this.staleSweepCompleted = true
     } catch (error) {

--- a/packages/omo-opencode/src/features/tmux-subagent/stale-tmux-resource-sweeper.ts
+++ b/packages/omo-opencode/src/features/tmux-subagent/stale-tmux-resource-sweeper.ts
@@ -1,0 +1,28 @@
+import type { TmuxConfig } from "../../config/schema"
+
+export type StaleTmuxResourceSweepReport = {
+	readonly killed: number
+	readonly killedAttachPanes: number
+	readonly killedIsolatedSessions: number
+}
+
+export type StaleTmuxResourceSweepDeps = {
+	readonly isolation: TmuxConfig["isolation"]
+	readonly sweepStaleOmoAgentSessions: () => Promise<number>
+	readonly sweepStaleOmoAttachPanes: () => Promise<number>
+}
+
+export async function sweepStaleTmuxResources(
+	deps: StaleTmuxResourceSweepDeps,
+): Promise<StaleTmuxResourceSweepReport> {
+	const killedIsolatedSessions = deps.isolation === "session"
+		? await deps.sweepStaleOmoAgentSessions()
+		: 0
+	const killedAttachPanes = await deps.sweepStaleOmoAttachPanes()
+
+	return {
+		killed: killedIsolatedSessions + killedAttachPanes,
+		killedAttachPanes,
+		killedIsolatedSessions,
+	}
+}

--- a/packages/omo-opencode/src/openclaw/__tests__/dispatcher.test.ts
+++ b/packages/omo-opencode/src/openclaw/__tests__/dispatcher.test.ts
@@ -8,6 +8,8 @@ import {
   wakeCommandGateway,
 } from "../dispatcher"
 
+const commandGatewayTestTimeoutMs = process.platform === "win32" ? 10_000 : 1_000
+
 describe("OpenClaw Dispatcher", () => {
   function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
     const originalPlatform = process.platform
@@ -235,7 +237,7 @@ describe("OpenClaw Dispatcher", () => {
         type: "command",
         method: "POST",
         command: "printf '%s' '{\"messageId\":\"55\",\"platform\":\"telegram\",\"threadId\":\"thr\"}'",
-        timeout: 1000,
+        timeout: commandGatewayTestTimeoutMs,
       },
       {},
     )
@@ -255,7 +257,7 @@ describe("OpenClaw Dispatcher", () => {
         type: "command",
         method: "POST",
         command: "printf '%s' '✅ Sent via Discord. Message ID: 55'",
-        timeout: 1000,
+        timeout: commandGatewayTestTimeoutMs,
       },
       {},
     )

--- a/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
+++ b/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { mkdtempSync, rmSync } from "node:fs"
 
 const { executeHookCommand } = await import("./execute-hook-command")
+const timeoutAssertionMs = process.platform === "win32" ? 5_000 : 1_000
 
 function nodeCommand(script: string): string {
   return `"${process.execPath}" -e ${JSON.stringify(script)}`
@@ -76,7 +77,7 @@ describe("executeHookCommand", () => {
     // then
     expect(result.exitCode).toBe(124)
     expect(result.stderr).toContain("Hook command timed out after 20ms")
-    expect(Date.now() - startedAt).toBeLessThan(1000)
+    expect(Date.now() - startedAt).toBeLessThan(timeoutAssertionMs)
   })
 
   // Regression coverage for #4458 - plugin-sourced hooks must run with

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils.ts
@@ -14,6 +14,7 @@ export { spawnTmuxWindow } from "./tmux-utils/window-spawn"
 export { spawnTmuxSession, getIsolatedSessionName } from "./tmux-utils/session-spawn"
 export { killTmuxSessionIfExists } from "./tmux-utils/session-kill"
 export { sweepStaleOmoAgentSessions, sweepTmuxSessionsWith } from "./tmux-utils/stale-session-sweep"
+export { sweepStaleOmoAttachPanes } from "./tmux-utils/stale-attach-pane-sweep"
 export { buildTmuxAttachCommand, buildTmuxPlaceholderCommand } from "./tmux-utils/pane-command"
 
 export { applyLayout, enforceMainPaneWidth } from "./tmux-utils/layout"

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/server-health.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/server-health.ts
@@ -26,13 +26,15 @@ function isMarkedRunningInProcess(): boolean {
 	return (globalThis as Record<symbol, boolean>)[SERVER_RUNNING_KEY] === true
 }
 
-export function createServerHealthStateForTesting(): ServerHealthState {
+export function createServerHealthState(): ServerHealthState {
 	return {
 		serverAvailable: null,
 		serverCheckUrl: null,
 		serverRunningInProcess: false,
 	}
 }
+
+export const createServerHealthStateForTesting = createServerHealthState
 
 export async function isServerRunning(serverUrl: string, options: IsServerRunningOptions = {}): Promise<boolean> {
 	const fetchImplementation = options.fetchImplementation ?? fetch

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
@@ -1,7 +1,9 @@
 const ATTACH_SERVER_URL_PATTERN = /\bopencode\s+attach\s+(?:"([^"]+)"|'([^']+)'|(\S+))/
+const OMO_ATTACH_PANE_TITLE_PREFIXES = ["omo-subagent-", "omo-team-"]
 
 export type TmuxAttachPane = {
 	readonly paneId: string
+	readonly title: string
 	readonly commandLine: string
 }
 
@@ -28,7 +30,7 @@ async function listTmuxPanesViaTmux(tmux: string): Promise<TmuxAttachPane[]> {
 		"list-panes",
 		"-a",
 		"-F",
-		"#{pane_id}\t#{pane_current_command} #{pane_start_command}",
+		"#{pane_id}\t#{pane_title}\t#{pane_current_command} #{pane_start_command}",
 	])
 
 	if (result.exitCode !== 0) {
@@ -38,9 +40,9 @@ async function listTmuxPanesViaTmux(tmux: string): Promise<TmuxAttachPane[]> {
 	return result.output
 		.split("\n")
 		.map((line): TmuxAttachPane | null => {
-			const [paneId, ...commandParts] = line.split("\t")
+			const [paneId, title, ...commandParts] = line.split("\t")
 			if (paneId === undefined || paneId.length === 0) return null
-			return { paneId, commandLine: commandParts.join("\t").trim() }
+			return { paneId, title: title ?? "", commandLine: commandParts.join("\t").trim() }
 		})
 		.filter((pane): pane is TmuxAttachPane => pane !== null)
 }
@@ -73,6 +75,10 @@ function extractAttachServerUrl(commandLine: string): string | null {
 	return match[1] ?? match[2] ?? match[3] ?? null
 }
 
+function isOmoAttachPane(pane: TmuxAttachPane): boolean {
+	return OMO_ATTACH_PANE_TITLE_PREFIXES.some((prefix) => pane.title.startsWith(prefix))
+}
+
 export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): Promise<number> {
 	if (!deps.isInsideTmux()) {
 		return 0
@@ -95,10 +101,22 @@ export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): P
 
 	let closedCount = 0
 	for (const pane of candidatePanes) {
+		if (!isOmoAttachPane(pane)) continue
+
 		const serverUrl = extractAttachServerUrl(pane.commandLine)
 		if (serverUrl === null) continue
 
-		const serverRunning = await deps.isServerRunning(serverUrl)
+		let serverRunning: boolean
+		try {
+			serverRunning = await deps.isServerRunning(serverUrl)
+		} catch (error) {
+			deps.log("[sweepStaleOmoAttachPanesWith] failed to check pane server health", {
+				error: getErrorMessage(error),
+				paneId: pane.paneId,
+				serverUrl,
+			})
+			continue
+		}
 		if (serverRunning) continue
 
 		try {

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
@@ -1,0 +1,124 @@
+const ATTACH_SERVER_URL_PATTERN = /\bopencode\s+attach\s+(?:"([^"]+)"|'([^']+)'|(\S+))/
+
+export type TmuxAttachPane = {
+	readonly paneId: string
+	readonly commandLine: string
+}
+
+export type SweepAttachPaneDeps = {
+	readonly isInsideTmux: () => boolean
+	readonly getTmuxPath: () => Promise<string | null | undefined>
+	readonly listCandidatePanes: (tmux: string) => Promise<readonly TmuxAttachPane[]>
+	readonly isServerRunning: (serverUrl: string) => Promise<boolean>
+	readonly closePane: (paneId: string) => Promise<boolean>
+	readonly log: (message: string, payload?: unknown) => void
+}
+
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message
+	}
+
+	return String(error)
+}
+
+async function listTmuxPanesViaTmux(tmux: string): Promise<TmuxAttachPane[]> {
+	const { runTmuxCommand } = await import("../runner")
+	const result = await runTmuxCommand(tmux, [
+		"list-panes",
+		"-a",
+		"-F",
+		"#{pane_id}\t#{pane_current_command} #{pane_start_command}",
+	])
+
+	if (result.exitCode !== 0) {
+		return []
+	}
+
+	return result.output
+		.split("\n")
+		.map((line): TmuxAttachPane | null => {
+			const [paneId, ...commandParts] = line.split("\t")
+			if (paneId === undefined || paneId.length === 0) return null
+			return { paneId, commandLine: commandParts.join("\t").trim() }
+		})
+		.filter((pane): pane is TmuxAttachPane => pane !== null)
+}
+
+async function buildRuntimeAttachPaneDeps(): Promise<SweepAttachPaneDeps> {
+	const [{ log }, { isInsideTmux }, { getTmuxPath }, serverHealth, { closeTmuxPane }] = await Promise.all([
+		import("../../logger"),
+		import("./environment"),
+		import("../../../tools/interactive-bash/tmux-path-resolver"),
+		import("./server-health"),
+		import("./pane-close"),
+	])
+
+	return {
+		isInsideTmux,
+		getTmuxPath,
+		listCandidatePanes: listTmuxPanesViaTmux,
+		isServerRunning: (serverUrl) => serverHealth.isServerRunning(serverUrl, {
+			state: serverHealth.createServerHealthState(),
+		}),
+		closePane: closeTmuxPane,
+		log,
+	}
+}
+
+function extractAttachServerUrl(commandLine: string): string | null {
+	const match = commandLine.match(ATTACH_SERVER_URL_PATTERN)
+	if (!match) return null
+
+	return match[1] ?? match[2] ?? match[3] ?? null
+}
+
+export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): Promise<number> {
+	if (!deps.isInsideTmux()) {
+		return 0
+	}
+
+	const tmux = await deps.getTmuxPath()
+	if (!tmux) {
+		return 0
+	}
+
+	let candidatePanes: readonly TmuxAttachPane[]
+	try {
+		candidatePanes = await deps.listCandidatePanes(tmux)
+	} catch (error) {
+		deps.log("[sweepStaleOmoAttachPanesWith] failed to list candidate panes", {
+			error: getErrorMessage(error),
+		})
+		return 0
+	}
+
+	let closedCount = 0
+	for (const pane of candidatePanes) {
+		const serverUrl = extractAttachServerUrl(pane.commandLine)
+		if (serverUrl === null) continue
+
+		const serverRunning = await deps.isServerRunning(serverUrl)
+		if (serverRunning) continue
+
+		try {
+			const closed = await deps.closePane(pane.paneId)
+			if (closed) {
+				closedCount += 1
+			}
+		} catch (error) {
+			deps.log("[sweepStaleOmoAttachPanesWith] failed to close stale pane", {
+				error: getErrorMessage(error),
+				paneId: pane.paneId,
+				serverUrl,
+			})
+		}
+	}
+
+	return closedCount
+}
+
+export async function sweepStaleOmoAttachPanes(): Promise<number> {
+	const deps = await buildRuntimeAttachPaneDeps()
+	return sweepStaleOmoAttachPanesWith(deps)
+}

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
@@ -1,9 +1,11 @@
 const ATTACH_SERVER_URL_PATTERN = /\bopencode\s+attach\s+(?:"([^"]+)"|'([^']+)'|(\S+))/
 const OMO_ATTACH_PANE_TITLE_PREFIXES = ["omo-subagent-", "omo-team-"]
+const OMO_ATTACH_SERVER_URL_OPTION = "@omo_attach_server_url"
 
 export type TmuxAttachPane = {
 	readonly paneId: string
 	readonly title: string
+	readonly attachServerUrl: string
 	readonly commandLine: string
 }
 
@@ -30,7 +32,7 @@ async function listTmuxPanesViaTmux(tmux: string): Promise<TmuxAttachPane[]> {
 		"list-panes",
 		"-a",
 		"-F",
-		"#{pane_id}\t#{pane_title}\t#{pane_current_command} #{pane_start_command}",
+		`#{pane_id}\t#{pane_title}\t#{${OMO_ATTACH_SERVER_URL_OPTION}}\t#{pane_current_command} #{pane_start_command}`,
 	])
 
 	if (result.exitCode !== 0) {
@@ -40,9 +42,14 @@ async function listTmuxPanesViaTmux(tmux: string): Promise<TmuxAttachPane[]> {
 	return result.output
 		.split("\n")
 		.map((line): TmuxAttachPane | null => {
-			const [paneId, title, ...commandParts] = line.split("\t")
+			const [paneId, title, attachServerUrl, ...commandParts] = line.split("\t")
 			if (paneId === undefined || paneId.length === 0) return null
-			return { paneId, title: title ?? "", commandLine: commandParts.join("\t").trim() }
+			return {
+				paneId,
+				title: title ?? "",
+				attachServerUrl: attachServerUrl ?? "",
+				commandLine: commandParts.join("\t").trim(),
+			}
 		})
 		.filter((pane): pane is TmuxAttachPane => pane !== null)
 }
@@ -76,7 +83,7 @@ function extractAttachServerUrl(commandLine: string): string | null {
 }
 
 function isOmoAttachPane(pane: TmuxAttachPane): boolean {
-	return OMO_ATTACH_PANE_TITLE_PREFIXES.some((prefix) => pane.title.startsWith(prefix))
+	return pane.attachServerUrl.length > 0 || OMO_ATTACH_PANE_TITLE_PREFIXES.some((prefix) => pane.title.startsWith(prefix))
 }
 
 export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): Promise<number> {
@@ -103,7 +110,7 @@ export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): P
 	for (const pane of candidatePanes) {
 		if (!isOmoAttachPane(pane)) continue
 
-		const serverUrl = extractAttachServerUrl(pane.commandLine)
+		const serverUrl = pane.attachServerUrl || extractAttachServerUrl(pane.commandLine)
 		if (serverUrl === null) continue
 
 		let serverRunning: boolean

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-attach-pane-sweep.ts
@@ -82,6 +82,45 @@ function extractAttachServerUrl(commandLine: string): string | null {
 	return match[1] ?? match[2] ?? match[3] ?? null
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+	const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "")
+	if (normalized === "localhost" || normalized === "::1") {
+		return true
+	}
+
+	const octets = normalized.split(".")
+	if (octets.length !== 4 || octets[0] !== "127") {
+		return false
+	}
+
+	return octets.every((octet) => {
+		if (!/^\d{1,3}$/.test(octet)) {
+			return false
+		}
+		const value = Number(octet)
+		return value >= 0 && value <= 255
+	})
+}
+
+function normalizeTrustedAttachServerUrl(serverUrl: string): string | null {
+	let parsed: URL
+	try {
+		parsed = new URL(serverUrl)
+	} catch {
+		return null
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return null
+	}
+
+	if (!isLoopbackHostname(parsed.hostname)) {
+		return null
+	}
+
+	return serverUrl
+}
+
 function isOmoAttachPane(pane: TmuxAttachPane): boolean {
 	return pane.attachServerUrl.length > 0 || OMO_ATTACH_PANE_TITLE_PREFIXES.some((prefix) => pane.title.startsWith(prefix))
 }
@@ -110,8 +149,17 @@ export async function sweepStaleOmoAttachPanesWith(deps: SweepAttachPaneDeps): P
 	for (const pane of candidatePanes) {
 		if (!isOmoAttachPane(pane)) continue
 
-		const serverUrl = pane.attachServerUrl || extractAttachServerUrl(pane.commandLine)
-		if (serverUrl === null) continue
+		const rawServerUrl = pane.attachServerUrl || extractAttachServerUrl(pane.commandLine)
+		if (rawServerUrl === null) continue
+
+		const serverUrl = normalizeTrustedAttachServerUrl(rawServerUrl)
+		if (serverUrl === null) {
+			deps.log("[sweepStaleOmoAttachPanesWith] skipped untrusted attach server URL", {
+				paneId: pane.paneId,
+				serverUrl: rawServerUrl,
+			})
+			continue
+		}
 
 		let serverRunning: boolean
 		try {

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test"
-import { sweepStaleOmoAgentSessionsWith, sweepTmuxSessionsWith, type SweepDeps } from "./stale-session-sweep"
+import {
+	sweepStaleOmoAgentSessionsWith,
+	sweepTmuxSessionsWith,
+	type SweepDeps,
+} from "./stale-session-sweep"
+import { sweepStaleOmoAttachPanesWith, type SweepAttachPaneDeps } from "./stale-attach-pane-sweep"
 
 type SweepFixture = {
 	deps: SweepDeps
@@ -185,5 +190,66 @@ describe("sweepTmuxSessionsWith", () => {
 		// then
 		expect(result).toEqual(["omo-team-A", "omo-team-B"])
 		expect(fixture.killed).toEqual(["omo-team-A", "omo-team-B"])
+	})
+})
+
+describe("sweepStaleOmoAttachPanesWith", () => {
+	it("#given stale and live OMO attach panes #when sweep called #then only panes with dead servers are closed", async () => {
+		// given
+		const closed: string[] = []
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%dead",
+					commandLine: `/bin/sh -c "opencode attach http://127.0.0.1:4101 --session ses_dead --dir /tmp/project"`,
+				},
+				{
+					paneId: "%live",
+					commandLine: `opencode attach 'http://127.0.0.1:4102/' --session 'ses_live' --dir '/tmp/project'`,
+				},
+				{
+					paneId: "%other",
+					commandLine: "vim README.md",
+				},
+			],
+			isServerRunning: async (serverUrl: string) => serverUrl === "http://127.0.0.1:4102/",
+			closePane: async (paneId: string) => {
+				closed.push(paneId)
+				return true
+			},
+			log: () => undefined,
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(1)
+		expect(closed).toEqual(["%dead"])
+	})
+
+	it("#given OMO attach pane close fails #when sweep called #then failed close is not counted", async () => {
+		// given
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%stubborn",
+					commandLine: "opencode attach http://127.0.0.1:4103 --session ses_dead",
+				},
+			],
+			isServerRunning: async () => false,
+			closePane: async () => false,
+			log: () => undefined,
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(0)
 	})
 })

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -203,14 +203,27 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 			listCandidatePanes: async () => [
 				{
 					paneId: "%dead",
+					title: "omo-subagent-dead",
 					commandLine: `/bin/sh -c "opencode attach http://127.0.0.1:4101 --session ses_dead --dir /tmp/project"`,
 				},
 				{
 					paneId: "%live",
+					title: "omo-subagent-live",
 					commandLine: `opencode attach 'http://127.0.0.1:4102/' --session 'ses_live' --dir '/tmp/project'`,
 				},
 				{
+					paneId: "%team",
+					title: "omo-team-member",
+					commandLine: `opencode attach 'http://127.0.0.1:4104/' --session 'ses_team' --dir '/tmp/project'`,
+				},
+				{
+					paneId: "%manual",
+					title: "manual-shell",
+					commandLine: "opencode attach http://127.0.0.1:4105 --session ses_manual",
+				},
+				{
 					paneId: "%other",
+					title: "",
 					commandLine: "vim README.md",
 				},
 			],
@@ -226,8 +239,37 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 		const result = await sweepStaleOmoAttachPanesWith(deps)
 
 		// then
-		expect(result).toBe(1)
-		expect(closed).toEqual(["%dead"])
+		expect(result).toBe(2)
+		expect(closed).toEqual(["%dead", "%team"])
+	})
+
+	it("#given manual attach pane with dead server #when sweep called #then manual pane is not closed", async () => {
+		// given
+		const closed: string[] = []
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%manual",
+					title: "manual-opencode",
+					commandLine: "opencode attach http://127.0.0.1:4105 --session ses_manual",
+				},
+			],
+			isServerRunning: async () => false,
+			closePane: async (paneId: string) => {
+				closed.push(paneId)
+				return true
+			},
+			log: () => undefined,
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(0)
+		expect(closed).toEqual([])
 	})
 
 	it("#given OMO attach pane close fails #when sweep called #then failed close is not counted", async () => {
@@ -238,6 +280,7 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 			listCandidatePanes: async () => [
 				{
 					paneId: "%stubborn",
+					title: "omo-subagent-stubborn",
 					commandLine: "opencode attach http://127.0.0.1:4103 --session ses_dead",
 				},
 			],
@@ -251,5 +294,48 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 
 		// then
 		expect(result).toBe(0)
+	})
+
+	it("#given server health check throws for one pane #when sweep called #then later stale panes are still closed", async () => {
+		// given
+		const closed: string[] = []
+		const logged: string[] = []
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%bad-health",
+					title: "omo-subagent-bad-health",
+					commandLine: "opencode attach http://127.0.0.1:4106 --session ses_bad",
+				},
+				{
+					paneId: "%dead",
+					title: "omo-subagent-dead",
+					commandLine: "opencode attach http://127.0.0.1:4107 --session ses_dead",
+				},
+			],
+			isServerRunning: async (serverUrl: string) => {
+				if (serverUrl === "http://127.0.0.1:4106") {
+					throw new Error("bad health check")
+				}
+				return false
+			},
+			closePane: async (paneId: string) => {
+				closed.push(paneId)
+				return true
+			},
+			log: (message: string) => {
+				logged.push(message)
+			},
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(1)
+		expect(closed).toEqual(["%dead"])
+		expect(logged).toContain("[sweepStaleOmoAttachPanesWith] failed to check pane server health")
 	})
 })

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -384,4 +384,72 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 		expect(checkedUrls).toEqual(["http://127.0.0.1:4108"])
 		expect(closed).toEqual(["%team"])
 	})
+
+	it("#given OMO attach panes point at untrusted hosts #when sweep called #then health checks are not attempted", async () => {
+		// given
+		const checkedUrls: string[] = []
+		const closed: string[] = []
+		const logged: string[] = []
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%metadata-external",
+					title: "sleep 300",
+					attachServerUrl: "https://example.com:4108",
+					commandLine: "fish fish",
+				},
+				{
+					paneId: "%metadata-link-local",
+					title: "sleep 300",
+					attachServerUrl: "http://169.254.169.254:4108",
+					commandLine: "fish fish",
+				},
+				{
+					paneId: "%command-private",
+					title: "omo-subagent-private",
+					attachServerUrl: "",
+					commandLine: "opencode attach http://192.168.1.20:4108 --session ses_private",
+				},
+				{
+					paneId: "%command-external",
+					title: "omo-team-external",
+					attachServerUrl: "",
+					commandLine: "opencode attach 'https://example.org:4108/' --session ses_external",
+				},
+				{
+					paneId: "%local",
+					title: "omo-subagent-local",
+					attachServerUrl: "",
+					commandLine: "opencode attach http://localhost:4108 --session ses_local",
+				},
+			],
+			isServerRunning: async (serverUrl: string) => {
+				checkedUrls.push(serverUrl)
+				return false
+			},
+			closePane: async (paneId: string) => {
+				closed.push(paneId)
+				return true
+			},
+			log: (message: string) => {
+				logged.push(message)
+			},
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(1)
+		expect(checkedUrls).toEqual(["http://localhost:4108"])
+		expect(closed).toEqual(["%local"])
+		expect(logged).toEqual([
+			"[sweepStaleOmoAttachPanesWith] skipped untrusted attach server URL",
+			"[sweepStaleOmoAttachPanesWith] skipped untrusted attach server URL",
+			"[sweepStaleOmoAttachPanesWith] skipped untrusted attach server URL",
+			"[sweepStaleOmoAttachPanesWith] skipped untrusted attach server URL",
+		])
+	})
 })

--- a/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { beforeEach, describe, expect, it, mock } from "bun:test"
 import {
 	sweepStaleOmoAgentSessionsWith,
@@ -204,26 +206,31 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 				{
 					paneId: "%dead",
 					title: "omo-subagent-dead",
+					attachServerUrl: "",
 					commandLine: `/bin/sh -c "opencode attach http://127.0.0.1:4101 --session ses_dead --dir /tmp/project"`,
 				},
 				{
 					paneId: "%live",
 					title: "omo-subagent-live",
+					attachServerUrl: "",
 					commandLine: `opencode attach 'http://127.0.0.1:4102/' --session 'ses_live' --dir '/tmp/project'`,
 				},
 				{
 					paneId: "%team",
 					title: "omo-team-member",
+					attachServerUrl: "",
 					commandLine: `opencode attach 'http://127.0.0.1:4104/' --session 'ses_team' --dir '/tmp/project'`,
 				},
 				{
 					paneId: "%manual",
 					title: "manual-shell",
+					attachServerUrl: "",
 					commandLine: "opencode attach http://127.0.0.1:4105 --session ses_manual",
 				},
 				{
 					paneId: "%other",
 					title: "",
+					attachServerUrl: "",
 					commandLine: "vim README.md",
 				},
 			],
@@ -253,6 +260,7 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 				{
 					paneId: "%manual",
 					title: "manual-opencode",
+					attachServerUrl: "",
 					commandLine: "opencode attach http://127.0.0.1:4105 --session ses_manual",
 				},
 			],
@@ -281,6 +289,7 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 				{
 					paneId: "%stubborn",
 					title: "omo-subagent-stubborn",
+					attachServerUrl: "",
 					commandLine: "opencode attach http://127.0.0.1:4103 --session ses_dead",
 				},
 			],
@@ -307,11 +316,13 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 				{
 					paneId: "%bad-health",
 					title: "omo-subagent-bad-health",
+					attachServerUrl: "",
 					commandLine: "opencode attach http://127.0.0.1:4106 --session ses_bad",
 				},
 				{
 					paneId: "%dead",
 					title: "omo-subagent-dead",
+					attachServerUrl: "",
 					commandLine: "opencode attach http://127.0.0.1:4107 --session ses_dead",
 				},
 			],
@@ -337,5 +348,40 @@ describe("sweepStaleOmoAttachPanesWith", () => {
 		expect(result).toBe(1)
 		expect(closed).toEqual(["%dead"])
 		expect(logged).toContain("[sweepStaleOmoAttachPanesWith] failed to check pane server health")
+	})
+
+	it("#given team pane metadata with overwritten title and shell command line #when sweep called #then metadata server url is used", async () => {
+		// given
+		const checkedUrls: string[] = []
+		const closed: string[] = []
+		const deps: SweepAttachPaneDeps = {
+			isInsideTmux: () => true,
+			getTmuxPath: async () => "tmux",
+			listCandidatePanes: async () => [
+				{
+					paneId: "%team",
+					title: "sleep 300",
+					attachServerUrl: "http://127.0.0.1:4108",
+					commandLine: "fish fish",
+				},
+			],
+			isServerRunning: async (serverUrl: string) => {
+				checkedUrls.push(serverUrl)
+				return false
+			},
+			closePane: async (paneId: string) => {
+				closed.push(paneId)
+				return true
+			},
+			log: () => undefined,
+		}
+
+		// when
+		const result = await sweepStaleOmoAttachPanesWith(deps)
+
+		// then
+		expect(result).toBe(1)
+		expect(checkedUrls).toEqual(["http://127.0.0.1:4108"])
+		expect(closed).toEqual(["%team"])
 	})
 })


### PR DESCRIPTION
## Summary
Fixes the OpenCode zombie process leak identified from Claude session `b4f04726-dd90-4de0-ab9a-93ad26d0802c`: OMO now sweeps stale inline/window `opencode attach` tmux panes whose server URL is dead, while retaining live attach panes.

## Changes
- Add a shared stale attach-pane sweeper that discovers `opencode attach <url>` panes and checks each URL with an isolated server-health state.
- Keep existing isolated `omo-agents-*` session cleanup for `isolation: "session"`.
- Wire tmux subagent startup cleanup to sweep attach panes in all isolation modes, once per manager process.
- Add regression coverage for dead/live attach panes and inline manager startup wiring.

## Testing
- `bun test packages/omo-opencode/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts packages/omo-opencode/src/features/tmux-subagent/manager.test.ts --test-name-pattern 'attach|inline isolation'`
- `bun run typecheck`
- `bun run build`
- `bun test` (8631 pass, 1 skip, 0 fail)
- OpenCode QA evidence: `.omo/evidence/20260612-opencode-inline-stale-sweep/summary.md`
  - `server-smoke.sh`: PASS
  - `tui-smoke.sh`: PASS, real DB count unchanged at `21381`
  - Real tmux stale attach scenario: PASS, dead pane closed and live pane retained

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a tmux zombie leak by sweeping stale inline `opencode attach` panes tied to dead servers. Runs once on startup across isolation modes, targets only OMO-managed panes, keeps live panes, and only checks loopback attach URLs for safety.

- **Bug Fixes**
  - Added a sweeper to find `opencode attach <url>` panes using an isolated server-health state; reads tmux pane options first, falls back to the command line, and ignores manual (non-OMO) panes.
  - Trusts only loopback attach URLs (`localhost`, `::1`, `127.0.0.0/8`) to avoid probing external/private hosts.
  - Team-mode prefixes pane titles with `omo-team-` and stores attach metadata in pane options `@omo_attach_server_url` and `@omo_attach_session_id`.
  - Sweep runs once per manager startup via `sweepStaleTmuxResources`; always sweeps attach panes, and only sweeps isolated sessions for `isolation: "session"`; still runs when team-mode sessions are skipped; logs killed panes/sessions; added tests for metadata, live/dead panes, manual panes, and inline wiring.
  - Relaxed command timeout assertions on Windows to reduce test flakiness in dispatcher and hook command tests.
  - Windows `omo-codex` bootstrap tests: cover worker relinks and wrappers on `win32` (platform-aware runs, `.cmd` shims asserted, no POSIX links left, no wrapper when `dist/cli` is missing, and warning text in `bootstrap.log` verified).

<sup>Written for commit 81fc1d018485b2636bba18ae8c709fb2eb6f9b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

