### PR TITLE
fix(agents-md): deduplicate AGENTS.md injection across hephaestus and directory hooks

### DIFF
--- a/packages/agents-md-core/src/injector.ts
+++ b/packages/agents-md-core/src/injector.ts
@@ -24,6 +24,8 @@ export async function processFilePathForAgentsInjection(input: {
   readonly filePath: string;
   readonly sessionID: string;
   readonly output: AgentsMdContextOutput;
+  /** External dedup set: directories already injected by other hooks (e.g. hephaestus-agents-md-injector). */
+  readonly alreadyInjected?: ReadonlySet<string>;
 }): Promise<void> {
   if (typeof input.output.output !== "string") return;
 
@@ -48,6 +50,7 @@ export async function processFilePathForAgentsInjection(input: {
   for (const agentsPath of agentsPaths) {
     const agentsDir = dirname(agentsPath);
     if (cache.has(agentsDir)) continue;
+    if (input.alreadyInjected?.has(agentsDir)) continue;
 
     const content = await fsPromises.readFile(agentsPath, "utf-8").catch(() => null);
     if (content === null) continue;

--- a/packages/omo-opencode/src/hooks/directory-agents-injector/hook.ts
+++ b/packages/omo-opencode/src/hooks/directory-agents-injector/hook.ts
@@ -1,6 +1,7 @@
 import { createAgentsMdCache } from "@oh-my-opencode/rules-engine";
 import type { PluginInput } from "@opencode-ai/plugin";
 
+import { getAgentsMdInjectionRegistry } from "../../shared/agents-md-injection-registry";
 import { createDynamicTruncator } from "../../shared/dynamic-truncator";
 import { resolveSessionEventID } from "../../shared/event-session-id";
 import { processFilePathForAgentsInjection } from "./injector";
@@ -47,6 +48,7 @@ export function createDirectoryAgentsInjectorHook(
     const toolName = input.tool.toLowerCase();
 
     if (toolName === "read") {
+      const registry = getAgentsMdInjectionRegistry()
       await processFilePathForAgentsInjection({
         rootDirectory: ctx.directory,
         truncator,
@@ -56,6 +58,7 @@ export function createDirectoryAgentsInjectorHook(
         filePath: output.title,
         sessionID: input.sessionID,
         output,
+        alreadyInjected: registry.getSessionDirs(input.sessionID),
       });
       return;
     }
@@ -68,6 +71,7 @@ export function createDirectoryAgentsInjectorHook(
         sessionCaches.delete(sessionID);
         clearInjectedPaths(sessionID);
         agentsMdCache.clear();
+        getAgentsMdInjectionRegistry().clearSession(sessionID);
       }
     }
 
@@ -77,6 +81,7 @@ export function createDirectoryAgentsInjectorHook(
         sessionCaches.delete(sessionID);
         clearInjectedPaths(sessionID);
         agentsMdCache.clear();
+        getAgentsMdInjectionRegistry().clearSession(sessionID);
       }
     }
   };

--- a/packages/omo-opencode/src/hooks/hephaestus-agents-md-injector/hook.ts
+++ b/packages/omo-opencode/src/hooks/hephaestus-agents-md-injector/hook.ts
@@ -1,8 +1,10 @@
 import { promises as fsPromises } from "node:fs"
+import { dirname } from "node:path"
 import { createAgentsMdCache, findAgentsMdUp } from "@oh-my-opencode/rules-engine"
 import type { AgentsMdCache } from "@oh-my-opencode/rules-engine"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { formatAgentsMdContextBlock } from "@oh-my-opencode/agents-md-core"
+import { getAgentsMdInjectionRegistry } from "../../shared/agents-md-injection-registry"
 import { createDynamicTruncator } from "../../shared/dynamic-truncator"
 import type { ContextLimitModelCacheState } from "../../shared/context-limit-resolver"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
@@ -90,11 +92,17 @@ export function createHephaestusAgentsMdInjectorHook(
 
     textPart.text = `${contextBlocks.join("")}\n\n---\n\n${textPart.text ?? ""}`
     injectedSessions.add(input.sessionID)
+
+    const registry = getAgentsMdInjectionRegistry()
+    for (const agentsPath of agentsPaths) {
+      registry.mark(input.sessionID, dirname(agentsPath))
+    }
   }
 
   function clearSession(sessionID: string): void {
     injectedSessions.delete(sessionID)
     agentsMdCache.clear()
+    getAgentsMdInjectionRegistry().clearSession(sessionID)
   }
 
   async function eventHandler({ event }: EventInput): Promise<void> {

--- a/packages/omo-opencode/src/shared/agents-md-injection-registry.ts
+++ b/packages/omo-opencode/src/shared/agents-md-injection-registry.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared deduplication registry for AGENTS.md injection paths.
+ *
+ * Both {@link hephaestus-agents-md-injector} and {@link directory-agents-injector}
+ * independently inject AGENTS.md content into session context. This singleton
+ * ensures the same AGENTS.md directory is only injected once per session cycle,
+ * preventing duplicate context blocks in the conversation transcript.
+ *
+ * Lifecycle: cleared per-session on compaction (so the instruction is re-supplied
+ * after context truncation) and on session deletion.
+ */
+
+const injectedDirectories = new Map<string, Set<string>>()
+
+export interface AgentsMdInjectionRegistry {
+  /** Returns the set of directories already injected for this session, or undefined. */
+  getSessionDirs(sessionID: string): Set<string> | undefined
+  /** Marks a directory as injected for this session. */
+  mark(sessionID: string, directory: string): void
+  /** Clears all tracked directories for this session. */
+  clearSession(sessionID: string): void
+}
+
+export function getAgentsMdInjectionRegistry(): AgentsMdInjectionRegistry {
+  return {
+    getSessionDirs(sessionID: string): Set<string> | undefined {
+      return injectedDirectories.get(sessionID)
+    },
+
+    mark(sessionID: string, directory: string): void {
+      const dirs = injectedDirectories.get(sessionID)
+      if (dirs) {
+        dirs.add(directory)
+      } else {
+        injectedDirectories.set(sessionID, new Set([directory]))
+      }
+    },
+
+    clearSession(sessionID: string): void {
+      injectedDirectories.delete(sessionID)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Fix AGENTS.md content appearing multiple times in session transcripts due to independent injection caches
- Add shared injection registry so hephaestus and directory-agents injectors coordinate deduplication
- 4 files changed, +59 lines

## Changes

- **new: shared/agents-md-injection-registry.ts** — singleton Map tracking injected AGENTS.md dirs per session
- **agents-md-core/injector.ts** — accepts optional alreadyInjected set for external dedup (+2 lines)
- **hephaestus-agents-md-injector/hook.ts** — marks each injected path in shared registry
- **directory-agents-injector/hook.ts** — passes registry state as alreadyInjected; clears on session events

## Testing

```bash
bun test packages/omo-opencode/src/hooks/directory-agents-injector/injector.test.ts          packages/agents-md-core/src/injector.test.ts          packages/omo-opencode/src/hooks/hephaestus-agents-md-injector/index.test.ts
```
14/14 pass. Regression: 78/78 pass on parent-wake suite.

## Related Issues

Closes #5163

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates AGENTS.md injection across Hephaestus and Directory hooks so each directory is injected once per session. Fixes #5163 and removes duplicate context blocks after reads or compaction.

- **Bug Fixes**
  - Added a shared injection registry to track injected directories per session.
  - `@oh-my-opencode/agents-md-core`: injector now accepts `alreadyInjected` to skip known dirs.
  - `hephaestus-agents-md-injector`: records injected dirs in the registry; clears on session reset.
  - `directory-agents-injector`: uses registry for dedup; clears on `session.compacted` and `session.deleted`.

<sup>Written for commit 7b721252961edddbdf69acc2792d2373118db977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

