### PR TITLE
fix: apply migrateAgentConfig in sisyphus-junior factory to rescue tools→permission

### DIFF
--- a/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
@@ -16,6 +16,7 @@ import { isGlmModel, isGpt5_5Model, isGptModel, isGeminiModel, isKimiK2Model, bu
 import type { AgentOverrideConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
+  migrateAgentConfig,
   type PermissionValue,
 } from "../../shared/permission-compat"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
@@ -93,21 +94,24 @@ export function createSisyphusJuniorAgentWithOverrides(
   systemDefaultModel?: string,
   useTaskSystem = false
 ): AgentConfig {
-  if (override?.disable) {
-    override = undefined
-  }
+  // tools→permission migration: AgentPermissionSchema strips MCP tool keys,
+  // but z.record tools survive. migrateAgentConfig rescues them — same as mergeAgentConfig.
+  const migrated = override
+    ? (migrateAgentConfig(override as Record<string, unknown>) as typeof override)
+    : undefined
+  const ov = migrated?.disable ? undefined : migrated
 
-  const overrideModel = (override as { model?: string } | undefined)?.model
+  const overrideModel = (ov as { model?: string } | undefined)?.model
   const model = overrideModel ?? systemDefaultModel ?? SISYPHUS_JUNIOR_DEFAULTS.model
-  const temperature = override?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
+  const temperature = ov?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
 
-  const promptAppend = override?.prompt_append
+  const promptAppend = ov?.prompt_append
   const prompt = buildSisyphusJuniorPrompt(model, useTaskSystem, promptAppend)
   const blockedTools = isGptModel(model) ? GPT_BLOCKED_TOOLS : BLOCKED_TOOLS
 
   const baseRestrictions = createAgentToolRestrictions(blockedTools)
 
-  const userPermission = (override?.permission ?? {}) as Record<string, PermissionValue>
+  const userPermission = (ov?.permission ?? {}) as Record<string, PermissionValue>
   const basePermission = baseRestrictions.permission
   const merged: Record<string, PermissionValue> = { ...userPermission }
   for (const tool of blockedTools) {
@@ -121,19 +125,19 @@ export function createSisyphusJuniorAgentWithOverrides(
   }
 
   const base: AgentConfig = {
-    description: override?.description ??
+    description: ov?.description ??
       "Focused task executor. Same discipline, no delegation. (Sisyphus-Junior - OhMyOpenCode)",
     mode: MODE,
     model,
     temperature,
     maxTokens: 64000,
     prompt,
-    color: override?.color ?? "#20B2AA",
+    color: ov?.color ?? "#20B2AA",
     permission,
   }
 
-  if (override?.top_p !== undefined) {
-    base.top_p = override.top_p
+  if (ov?.top_p !== undefined) {
+    base.top_p = ov.top_p
   }
 
   if (isGptModel(model)) {

--- a/packages/omo-opencode/src/config/schema/internal/permission.ts
+++ b/packages/omo-opencode/src/config/schema/internal/permission.ts
@@ -15,6 +15,6 @@ export const AgentPermissionSchema = z.object({
   task: PermissionValueSchema.optional(),
   doom_loop: PermissionValueSchema.optional(),
   external_directory: PermissionValueSchema.optional(),
-})
+}).catchall(PermissionValueSchema)
 
 export type AgentPermission = z.infer<typeof AgentPermissionSchema>


### PR DESCRIPTION
Closes #5193

## Bug Report

### Summary

`createSisyphusJuniorAgentWithOverrides` does not apply `tools` or `permission` overrides from the oh-my-opencode config. This means sisyphus-junior cannot be restricted from calling specific MCP tools (e.g., `report_completion`, `update_progress`).

### Root Cause (two-part failure)

**1. `AgentPermissionSchema` strips MCP tool keys**

`internal/permission.ts` defines a strict `z.object()` that only recognizes `edit`, `bash`, `webfetch`, `task`, `doom_loop`, `external_directory`. Any MCP tool permission keys (e.g., `mcp-report_completion`) are stripped during `OhMyOpenCodeConfigSchema.safeParse()`.

**2. sisyphus-junior factory does not call `migrateAgentConfig`**

Other agents (metis, momus, oracle, etc.) go through `applyOverrides()` -> `mergeAgentConfig()` -> `migrateAgentConfig()`, which converts the surviving `tools` field (validated by permissive `z.record()`) back into `permission` entries. This rescues the permission after Zod strips the direct `permission` keys.

`sisyphus-junior` is explicitly skipped in `collectPendingBuiltinAgents` (line 59: `if (agentName === "sisyphus-junior") continue`) and instead registered via `createSisyphusJuniorAgentWithOverrides` in `agent-config-assembly.ts:131`. This factory:
- Never reads `override?.tools` at all
- Reads `override?.permission` directly (already stripped of MCP tool keys by Zod)

### Impact

| Override field | Other agents | sisyphus-junior |
|---|---|---|
| `tools` | Survives `z.record()`, migrated to permission | Ignored by factory |
| `permission` (MCP keys) | Stripped by schema, but rescued by tools->migration | Stripped, never rescued |

Any tool restriction set via the oh-my-opencode config's `agents.sisyphus-junior` section is silently dropped.

### Fix

Call `migrateAgentConfig()` at the top of `createSisyphusJuniorAgentWithOverrides` to convert `tools` -> `permission` before reading the override — same pattern used by `mergeAgentConfig` for other agents.

### Files Involved

- `packages/omo-opencode/src/agents/sisyphus-junior/agent.ts` -- `createSisyphusJuniorAgentWithOverrides`
- `packages/omo-opencode/src/shared/permission-compat.ts` -- `migrateAgentConfig`
- `packages/omo-opencode/src/config/schema/internal/permission.ts` -- `AgentPermissionSchema`