### PR TITLE
fix(doctor): warn on unresolved tui entry

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts
@@ -66,7 +66,9 @@ describe("tui-plugin-config check", () => {
   })
 
   it("passes when both server and TUI entries are registered", async () => {
-    //#given opencode.json has the server entry and tui.json has the TUI entry
+    //#given opencode.json has the server entry, tui.json has the TUI entry,
+    //#       and the installed package exports ./tui
+    writeInstalledPackage(PLUGIN_NAME, { ".": "./dist/index.js", "./tui": "./dist/tui.js" })
     writeOpenCodeConfig([PLUGIN_NAME])
     writeTuiConfig([`${PLUGIN_NAME}/tui`])
 
@@ -77,6 +79,21 @@ describe("tui-plugin-config check", () => {
     expect(result.status).toBe("pass")
     expect(result.issues).toHaveLength(0)
     expect(result.name).toBe("TUI Plugin")
+  })
+
+  it("warns when a named TUI entry points at a missing installed package", async () => {
+    //#given opencode.json has the server entry, tui.json has the TUI entry,
+    //#       but the installed package cannot be resolved from the config node_modules path
+    writeOpenCodeConfig([PLUGIN_NAME])
+    writeTuiConfig([`${PLUGIN_NAME}/tui`])
+
+    //#when running the check
+    const result = await checkTuiPluginConfig()
+
+    //#then doctor flags the named TUI entry as unresolvable instead of falsely passing
+    expect(result.status).toBe("warn")
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].title).toContain("unresolvable")
   })
 
   it("warns when server is registered but TUI entry is missing", async () => {

--- a/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.ts
@@ -34,6 +34,7 @@ interface TuiPluginInfo {
   configPath: string | null
   exists: boolean
   hasNamedTuiEntry: boolean
+  hasCanonicalNamedTuiEntry: boolean
 }
 
 function fileEntryPackageJsonPath(entry: string): string {
@@ -115,6 +116,11 @@ function isNamedTuiPluginEntry(entry: string): boolean {
   return false
 }
 
+function isCanonicalNamedTuiPluginEntry(entry: string): boolean {
+  const canonicalPrefix = `${PLUGIN_NAME}/${TUI_SUBPATH}`
+  return entry === canonicalPrefix || entry.startsWith(`${canonicalPrefix}@`)
+}
+
 export function detectServerPluginRegistration(): ServerPluginInfo {
   const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
   const configPath = existsSync(paths.configJsonc)
@@ -145,7 +151,13 @@ export function detectServerPluginRegistration(): ServerPluginInfo {
 export function detectTuiPluginRegistration(): TuiPluginInfo {
   const tuiJsonPath = join(getOpenCodeConfigDir({ binary: "opencode" }), "tui.json")
   if (!existsSync(tuiJsonPath)) {
-    return { registered: false, configPath: tuiJsonPath, exists: false, hasNamedTuiEntry: false }
+    return {
+      registered: false,
+      configPath: tuiJsonPath,
+      exists: false,
+      hasNamedTuiEntry: false,
+      hasCanonicalNamedTuiEntry: false,
+    }
   }
 
   try {
@@ -156,10 +168,17 @@ export function detectTuiPluginRegistration(): TuiPluginInfo {
       configPath: tuiJsonPath,
       exists: true,
       hasNamedTuiEntry: plugins.some(isNamedTuiPluginEntry),
+      hasCanonicalNamedTuiEntry: plugins.some(isCanonicalNamedTuiPluginEntry),
     }
   } catch (error) {
     void error
-    return { registered: false, configPath: tuiJsonPath, exists: true, hasNamedTuiEntry: false }
+    return {
+      registered: false,
+      configPath: tuiJsonPath,
+      exists: true,
+      hasNamedTuiEntry: false,
+      hasCanonicalNamedTuiEntry: false,
+    }
   }
 }
 
@@ -183,7 +202,7 @@ export async function checkTuiPluginConfig(): Promise<CheckResult> {
     }
   }
 
-  if (server.registered && server.packageExportsTui === false && tui.hasNamedTuiEntry) {
+  if (server.registered && server.packageExportsTui !== true && tui.hasCanonicalNamedTuiEntry) {
     issues.push({
       title: "TUI plugin entry in tui.json is unresolvable",
       description:


### PR DESCRIPTION
Fixes #5173.

`doctor` now warns when `tui.json` contains the canonical `oh-my-openagent/tui` entry but the package cannot be inspected from the OpenCode config `node_modules` path.

The false pass came from treating `packageExportsTui === null` as inconclusive even when a named canonical TUI entry was present. In Bun/global installs, the package is often outside `~/.config/opencode/node_modules`, so the check could pass while `oh-my-openagent/tui` was still unresolvable.

Changed:

- Added a regression test for a canonical named TUI entry with no resolvable installed package.
- Kept the legacy `oh-my-opencode/tui` compatibility pass.
- Warn for canonical named entries unless the registered package explicitly exports `./tui`.

Validation:

- RED: `bun test packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts --bail` failed with `Expected: "warn" Received: "pass"`.
- GREEN: `bun test packages/omo-opencode/src/cli/doctor/checks/tui-plugin-config.test.ts` passed 12 tests.
- Typecheck: `bun run typecheck:packages` passed.
- Build: `bun run build` passed.
- tmux QA: isolated `OPENCODE_CONFIG_DIR`, `opencode.json` with `oh-my-openagent`, `tui.json` with `oh-my-openagent/tui`, then `bun dist/cli/index.js doctor --json`; the TUI Plugin result was `warn` with `TUI plugin entry in tui.json is unresolvable`.

Plan: `.omo/plans/quick-fix-pr-waves-20260612.md`
