### PR TITLE
fix(model-core): recognize fable mythos context windows

### DIFF
--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -73,6 +73,28 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(1_000_000)
   })
 
+  it("returns GA 1M for Anthropic claude-fable-5 without explicit 1M mode", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-fable-5", {
+      anthropicContext1MEnabled: false,
+    })
+
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("returns GA 1M for Anthropic claude-mythos-5 without explicit 1M mode", () => {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-mythos-5", {
+      anthropicContext1MEnabled: false,
+    })
+
+    expect(actualLimit).toBe(1_000_000)
+  })
+
   it("returns GA 1M for Antigravity Claude models served by google", () => {
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -26,6 +26,7 @@ function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState):
 
 function hasGA1MContext(modelID: string): boolean {
   return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7|8)(?:-high)?$/.test(modelID)
+    || /^claude-(fable|mythos)-5$/.test(modelID)
 }
 
 export function resolveActualContextLimit(


### PR DESCRIPTION
Fixes #5188.

`resolveActualContextLimit()` now treats `claude-fable-5` and `claude-mythos-5` as Anthropic GA 1M-context models.

The resolver already handled Claude Opus/Sonnet 4.6+ GA models without requiring `ANTHROPIC_1M_CONTEXT`. Fable 5 and Mythos 5 missed that matcher, fell back to the 200k Anthropic default, and could trigger compaction too early.

Changed:

- Added regression coverage for `claude-fable-5` and `claude-mythos-5`.
- Extended the GA 1M matcher only to those two model families.
- Kept non-GA Anthropic models on the 200k default.

Validation:

- RED: `bun test packages/model-core/src/context-limit-resolver.test.ts --bail` failed with `Expected: 1000000 Received: 200000` for `claude-fable-5`.
- GREEN: `bun test packages/model-core/src/context-limit-resolver.test.ts` passed 11 tests.
- Typecheck: `./node_modules/.bin/tsgo --noEmit -p packages/model-core/tsconfig.json` passed.
- tmux QA: a real Bun import of `resolveActualContextLimit` printed `1000000` for both `claude-fable-5` and `claude-mythos-5`.
- Regression: `claude-haiku-4-5` still returns `200000`.

Plan: `.omo/plans/quick-fix-pr-waves-20260612.md`
