### PR TITLE
fix: respect user approval gates in todo-continuation-enforcer

### DIFF
--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-4.ts
@@ -58,6 +58,7 @@ function buildTodoDisciplineSection(useTaskSystem: boolean): string {
 2. **Before each step**: \`task_update(status="in_progress")\` (ONE at a time)
 3. **After each step**: \`task_update(status="completed")\` IMMEDIATELY (NEVER batch)
 4. **Scope changes**: Update tasks BEFORE proceeding
+5. **Waiting for user input/approval**: Mark the task \`blocked\`. Set back to \`in_progress\` when you resume.
 
 **NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
   }
@@ -78,6 +79,7 @@ function buildTodoDisciplineSection(useTaskSystem: boolean): string {
 2. **Before each step**: Mark \`in_progress\` (ONE at a time)
 3. **After each step**: Mark \`completed\` IMMEDIATELY (NEVER batch)
 4. **Scope changes**: Update todos BEFORE proceeding
+5. **Waiting for user input/approval**: Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 **NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
 }

--- a/packages/omo-opencode/src/agents/hephaestus/gpt-5-5.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt-5-5.ts
@@ -14,10 +14,10 @@ import {
 
 function buildTaskSystemGuide(useTaskSystem: boolean): string {
   if (useTaskSystem) {
-    return `Create tasks for any non-trivial work (2+ steps, uncertain scope, multiple items). Call \`task_create\` with atomic steps before starting. Mark exactly one item \`in_progress\` at a time via \`task_update\`. Mark items \`completed\` immediately when done; never batch. Update the task list when scope shifts.`
+    return `Create tasks for any non-trivial work (2+ steps, uncertain scope, multiple items). Call \`task_create\` with atomic steps before starting. Mark exactly one item \`in_progress\` at a time via \`task_update\`. Mark items \`completed\` immediately when done; never batch. Update the task list when scope shifts. When waiting for user input or approval, mark the current task \`blocked\`; set it back to \`in_progress\` when you resume.`
   }
 
-  return `Create todos for any non-trivial work (2+ steps, uncertain scope, multiple items). Call \`todowrite\` with atomic steps before starting. Mark exactly one item \`in_progress\` at a time. Mark items \`completed\` immediately when done; never batch. Update the todo list when scope shifts.`
+  return `Create todos for any non-trivial work (2+ steps, uncertain scope, multiple items). Call \`todowrite\` with atomic steps before starting. Mark exactly one item \`in_progress\` at a time. Mark items \`completed\` immediately when done; never batch. Update the todo list when scope shifts. When waiting for user input or approval, mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume.`
 }
 
 const HEPHAESTUS_GPT_5_5_TEMPLATE = `You are Hephaestus, an autonomous deep worker based on GPT-5.5. You and the user share one workspace. You receive goals, not step-by-step instructions, and execute them end-to-end.

--- a/packages/omo-opencode/src/agents/hephaestus/gpt.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/gpt.ts
@@ -38,6 +38,7 @@ function buildTodoDisciplineSection(useTaskSystem: boolean): string {
 2. **Before each step**: \`task_update(status="in_progress")\` (ONE at a time)
 3. **After each step**: \`task_update(status="completed")\` IMMEDIATELY (NEVER batch)
 4. **Scope changes**: Update tasks BEFORE proceeding
+5. **Waiting for user input/approval**: Mark the task \`blocked\`. Set back to \`in_progress\` when you resume.
 
 **NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
   }
@@ -58,6 +59,7 @@ function buildTodoDisciplineSection(useTaskSystem: boolean): string {
 2. **Before each step**: Mark \`in_progress\` (ONE at a time)
 3. **After each step**: Mark \`completed\` IMMEDIATELY (NEVER batch)
 4. **Scope changes**: Update todos BEFORE proceeding
+5. **Waiting for user input/approval**: Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 **NO TODOS ON MULTI-STEP WORK = INCOMPLETE WORK.**`;
 }

--- a/packages/omo-opencode/src/agents/sisyphus-junior/default.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/default.ts
@@ -58,6 +58,7 @@ TASK OBSESSION (NON-NEGOTIABLE):
 - task_update(status="in_progress") before starting (ONE at a time)
 - task_update(status="completed") IMMEDIATELY after each step
 - NEVER batch completions
+- Waiting for user input/approval -> mark the current task \`blocked\`; set it back to \`in_progress\` when you resume
 
 No tasks on multi-step work = INCOMPLETE WORK.
 </Task_Discipline>`
@@ -69,6 +70,7 @@ TODO OBSESSION (NON-NEGOTIABLE):
 - Mark in_progress before starting (ONE at a time)
 - Mark completed IMMEDIATELY after each step
 - NEVER batch completions
+- Waiting for user input/approval -> mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume
 
 No todos on multi-step work = INCOMPLETE WORK.
 </Todo_Discipline>`

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gemini.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gemini.ts
@@ -176,7 +176,9 @@ function buildGeminiTaskDisciplineSection(useTaskSystem: boolean): string {
 - **2+ steps** - task_create FIRST, atomic breakdown. DO THIS BEFORE ANY IMPLEMENTATION.
 - **Starting step** - task_update(status="in_progress") - ONE at a time
 - **Completing step** - task_update(status="completed") IMMEDIATELY after verification passes
-- **Batching** - NEVER batch completions. Mark EACH task individually.
+- **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current task \`blocked\`; set it back to \`in_progress\` when you resume.
+- **Individual updates** - Mark EACH task individually.
 
 No tasks on multi-step work = INCOMPLETE WORK. The user tracks your progress through tasks.`
   }
@@ -188,7 +190,9 @@ No tasks on multi-step work = INCOMPLETE WORK. The user tracks your progress thr
 - **2+ steps** - todowrite FIRST, atomic breakdown. DO THIS BEFORE ANY IMPLEMENTATION.
 - **Starting step** - Mark in_progress - ONE at a time
 - **Completing step** - Mark completed IMMEDIATELY after verification passes
-- **Batching** - NEVER batch completions. Mark EACH todo individually.
+- **Batching** - NEVER batch completions.
+- **Waiting for user input/approval** - Mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume.
+- **Individual updates** - Mark EACH todo individually.
 
 No todos on multi-step work = INCOMPLETE WORK. The user tracks your progress through todos.`
 }

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-4.ts
@@ -146,6 +146,7 @@ function buildGpt54TaskDisciplineSection(useTaskSystem: boolean): string {
 - **Starting step** - task_update(status="in_progress") - ONE at a time
 - **Completing step** - task_update(status="completed") IMMEDIATELY
 - **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current task \`blocked\`; set it back to \`in_progress\` when you resume
 
 No tasks on multi-step work = INCOMPLETE WORK.`;
   }
@@ -156,6 +157,7 @@ No tasks on multi-step work = INCOMPLETE WORK.`;
 - **Starting step** - Mark in_progress - ONE at a time
 - **Completing step** - Mark completed IMMEDIATELY
 - **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume
 
 No todos on multi-step work = INCOMPLETE WORK.`;
 }

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-5.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt-5-5.ts
@@ -14,7 +14,8 @@ Workflow:
 1. Call \`task_create\` with atomic steps at the start of work the category asked for.
 2. Before each step, call \`task_update(status="in_progress")\`. One step in progress at a time.
 3. After each step, call \`task_update(status="completed")\` immediately. Never batch completions.
-4. If scope changes, update the task list before proceeding.`
+4. If scope changes, update the task list before proceeding.
+5. When waiting for user input, approval, or a human decision, mark the current task \`blocked\`. Set it back to \`in_progress\` when you resume.`
   }
 
   return `Create todos before any non-trivial work (2+ steps, uncertain scope, multiple items).
@@ -23,7 +24,8 @@ Workflow:
 1. Call \`todowrite\` with atomic steps at the start of work the category asked for.
 2. Before each step, mark the item \`in_progress\`. One step in progress at a time.
 3. After each step, mark it \`completed\` immediately. Never batch completions.
-4. If scope changes, update the todo list before proceeding.`
+4. If scope changes, update the todo list before proceeding.
+5. When waiting for user input, approval, or a human decision, mark the current todo \`blocked\`. Set it back to \`in_progress\` when you resume.`
 }
 
 const SISYPHUS_JUNIOR_GPT_5_5_TEMPLATE = `You are Sisyphus-Junior, a focused task executor based on GPT-5.5. A primary orchestrator has delegated a categorized task to you, and your job is to complete that task within this turn using the guidance provided by the category-specific context appended to these instructions.

--- a/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/gpt.ts
@@ -142,6 +142,7 @@ function buildGptTaskDisciplineSection(useTaskSystem: boolean): string {
 - **Starting step** - task_update(status="in_progress") - ONE at a time
 - **Completing step** - task_update(status="completed") IMMEDIATELY
 - **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current task \`blocked\`; set it back to \`in_progress\` when you resume
 
 No tasks on multi-step work = INCOMPLETE WORK.`
   }
@@ -152,6 +153,7 @@ No tasks on multi-step work = INCOMPLETE WORK.`
 - **Starting step** - Mark in_progress - ONE at a time
 - **Completing step** - Mark completed IMMEDIATELY
 - **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume
 
 No todos on multi-step work = INCOMPLETE WORK.`
 }

--- a/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/kimi-k2-6.ts
@@ -224,7 +224,8 @@ Skip tasks for V1 trivial fixes and single-step requests.
 - **2+ steps in V2/V3** - task_create FIRST, atomic breakdown
 - **Starting step** - task_update(status="in_progress") - ONE at a time
 - **Completing step** - task_update(status="completed") IMMEDIATELY
-- **Batching** - NEVER batch completions`;
+- **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current task \`blocked\`; set it back to \`in_progress\` when you resume`;
   }
 
   return `## Todo Discipline (NON-NEGOTIABLE)
@@ -235,5 +236,6 @@ Skip todos for V1 trivial fixes and single-step requests.
 - **2+ steps in V2/V3** - todowrite FIRST, atomic breakdown
 - **Starting step** - Mark in_progress - ONE at a time
 - **Completing step** - Mark completed IMMEDIATELY
-- **Batching** - NEVER batch completions`;
+- **Batching** - NEVER batch completions
+- **Waiting for user input/approval** - Mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume`;
 }

--- a/packages/omo-opencode/src/agents/sisyphus/claude-opus-4-7.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/claude-opus-4-7.ts
@@ -335,6 +335,7 @@ STOP searching the moment ANY of these holds: you can name the files you will ch
 1. 2+ steps → create todo list IMMEDIATELY, in detail. NO announcements.
 2. Mark current todo \`in_progress\` BEFORE starting.
 3. Mark \`completed\` AS SOON AS done. NEVER batch.
+4. Waiting for user input/approval? Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 ${categorySkillsGuide}
 

--- a/packages/omo-opencode/src/agents/sisyphus/default.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/default.ts
@@ -46,6 +46,7 @@ export function buildTaskManagementSection(useTaskSystem: boolean): string {
 2. **Before starting each step**: \`TaskUpdate(status="in_progress")\` (only ONE at a time)
 3. **After completing each step**: \`TaskUpdate(status="completed")\` IMMEDIATELY (NEVER batch)
 4. **If scope changes**: Update tasks before proceeding
+5. **Waiting for user input/approval**: Mark the task \`blocked\`. Set back to \`in_progress\` when you resume.
 
 ### Why This Is Non-Negotiable
 
@@ -100,6 +101,7 @@ Should I proceed with [recommendation], or would you prefer differently?
 2. **Before starting each step**: Mark \`in_progress\` (only ONE at a time)
 3. **After completing each step**: Mark \`completed\` IMMEDIATELY (NEVER batch)
 4. **If scope changes**: Update todos before proceeding
+5. **Waiting for user input/approval**: Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 ### Why This Is Non-Negotiable
 

--- a/packages/omo-opencode/src/agents/sisyphus/gpt-5-4.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/gpt-5-4.ts
@@ -56,6 +56,7 @@ Workflow:
 2. Before each step: \`TaskUpdate(status="in_progress")\` - one at a time.
 3. After each step: \`TaskUpdate(status="completed")\` immediately. Never batch.
 4. Scope change: update tasks before proceeding.
+5. Waiting for user input/approval? Mark the task \`blocked\`. Set back to \`in_progress\` when you resume.
 
 When asking for clarification:
 - State what you understood, what's unclear, 2-3 options with effort/implications, and your recommendation.
@@ -72,6 +73,7 @@ Workflow:
 2. Before each step: mark \`in_progress\` - one at a time.
 3. After each step: mark \`completed\` immediately. Never batch.
 4. Scope change: update todos before proceeding.
+5. Waiting for user input/approval? Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 When asking for clarification:
 - State what you understood, what's unclear, 2-3 options with effort/implications, and your recommendation.

--- a/packages/omo-opencode/src/agents/sisyphus/gpt-5-5.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/gpt-5-5.ts
@@ -27,6 +27,7 @@ Workflow:
 2. Before each step, call \`task_update(status="in_progress")\`. One step in progress at a time.
 3. After each step, call \`task_update(status="completed")\` immediately. Never batch completions.
 4. If scope changes, update the task list before proceeding.
+5. When waiting for user input, approval, or a human decision, mark the current task \`blocked\`. Set it back to \`in_progress\` when you resume.
 
 Your task creations are tracked by the harness; the system will nudge you if you go idle with open tasks.`
   }
@@ -38,6 +39,7 @@ Workflow:
 2. Before each step, mark the item \`in_progress\`. One step in progress at a time.
 3. After each step, mark it \`completed\` immediately. Never batch completions.
 4. If scope changes, update the todo list before proceeding.
+5. When waiting for user input, approval, or a human decision, mark the current todo \`blocked\`. Set it back to \`in_progress\` when you resume.
 
 Your todo creations are tracked by the harness; the system will nudge you if you go idle with open items.`
 }

--- a/packages/omo-opencode/src/agents/sisyphus/kimi-k2-6.ts
+++ b/packages/omo-opencode/src/agents/sisyphus/kimi-k2-6.ts
@@ -61,6 +61,7 @@ Workflow when tasks exist:
 2. Before each step: \`TaskUpdate(status="in_progress")\` - one at a time.
 3. After each step: \`TaskUpdate(status="completed")\` immediately. Never batch.
 4. Scope change: update tasks before proceeding.
+5. Waiting for user input/approval? Mark the task \`blocked\`. Set back to \`in_progress\` when you resume.
 
 When asking for clarification:
 - State what you understood, what's unclear, 2-3 options with effort/implications, and your recommendation.
@@ -76,6 +77,7 @@ Workflow when todos exist:
 2. Before each step: mark \`in_progress\` - one at a time.
 3. After each step: mark \`completed\` immediately. Never batch.
 4. Scope change: update todos before proceeding.
+5. Waiting for user input/approval? Mark the todo \`blocked\`. Set back to \`in_progress\` when you resume.
 
 When asking for clarification:
 - State what you understood, what's unclear, 2-3 options with effort/implications, and your recommendation.

--- a/packages/omo-opencode/src/features/claude-tasks/types.test.ts
+++ b/packages/omo-opencode/src/features/claude-tasks/types.test.ts
@@ -4,7 +4,7 @@ import { TaskSchema, TaskStatusSchema, type Task, type TaskStatus } from "./type
 describe("TaskStatusSchema", () => {
   test("accepts valid status values", () => {
     //#given
-    const validStatuses: TaskStatus[] = ["pending", "in_progress", "completed", "deleted"]
+    const validStatuses: TaskStatus[] = ["pending", "in_progress", "completed", "deleted", "blocked"]
 
     //#when
     const results = validStatuses.map((status) => TaskStatusSchema.safeParse(status))

--- a/packages/omo-opencode/src/features/claude-tasks/types.ts
+++ b/packages/omo-opencode/src/features/claude-tasks/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const TaskStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted"])
+export const TaskStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted", "blocked"])
 export type TaskStatus = z.infer<typeof TaskStatusSchema>
 
 export const TaskSchema = z

--- a/packages/omo-opencode/src/hooks/atlas/system-reminder-templates.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/system-reminder-templates.test.ts
@@ -51,16 +51,17 @@ describe("BOULDER_CONTINUATION_PROMPT", () => {
       expect(firstRule).toContain("IMMEDIATELY")
     })
 
-    it("checkbox-marking guidance appears BEFORE Proceed without asking for permission", () => {
+    it("approval-gate stop guidance appears before conditional proceed guidance", () => {
       const rulesSection = requireContinuationRulesSection()
 
-      const checkboxMarkingMatch = rulesSection.match(/- \[x\]/i)
-      const proceedMatch = rulesSection.match(/Proceed without asking for permission/)
+      const stopMatch = rulesSection.match(/waiting for user input/i)
+      const proceedMatch = rulesSection.match(/Otherwise, proceed without asking for permission/)
 
-      const checkboxPosition = requireMatchIndex(checkboxMarkingMatch, "checkbox marking")
-      const proceedPosition = requireMatchIndex(proceedMatch, "proceed guidance")
+      const stopPosition = requireMatchIndex(stopMatch, "approval-gate stop guidance")
+      const proceedPosition = requireMatchIndex(proceedMatch, "conditional proceed guidance")
 
-      expect(checkboxPosition).toBeLessThan(proceedPosition)
+      expect(stopPosition).toBeLessThan(proceedPosition)
+      expect(rulesSection).toContain("Do not proceed past approval gates")
     })
   })
 })

--- a/packages/omo-opencode/src/hooks/atlas/system-reminder-templates.ts
+++ b/packages/omo-opencode/src/hooks/atlas/system-reminder-templates.ts
@@ -28,9 +28,10 @@ You have an active work plan with incomplete tasks. Continue working.
 
 RULES:
 - **FIRST**: Read the plan file NOW. If the last completed task is still unchecked, mark it \`- [x]\` IMMEDIATELY before anything else
-- Proceed without asking for permission
+- If you are currently waiting for user input, approval, or a human decision, STOP. Do not proceed past approval gates. Wait for the user's response.
+- Otherwise, proceed without asking for permission
 - Use the notepad at .omo/notepads/{PLAN_NAME}/ to record learnings
-- Do not stop until all tasks are complete
+- Otherwise, do not stop until all tasks are complete
 - If a task is blocked by missing external input, unavailable credentials, access limits, or a decision only the user can make, you MUST edit the plan file in this turn and change that task's checkbox from \`- [ ]\` to \`- [~]\` before moving on
 - A text-only explanation of a blocker is NOT progress. The \`- [~]\` checkbox edit is mandatory and must happen via a real file-editing tool call`
 

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/constants.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/constants.ts
@@ -8,9 +8,9 @@ export const CONTINUATION_PROMPT = `${createSystemDirective(SystemDirectiveTypes
 
 Incomplete tasks remain in your todo list. Continue working on the next pending task.
 
-- Proceed without asking for permission
-- Mark each task complete when finished
-- Do not stop until all tasks are done
+- If you are currently waiting for user input, approval, or a human decision, STOP. Do not proceed past approval gates. Wait for the user's response.
+- Otherwise, proceed with the next pending task without asking for permission.
+- Mark each task complete when finished.
 - If you believe all work is already complete, the system is questioning your completion claim. Critically re-examine each todo item from a skeptical perspective, verify the work was actually done correctly, and update the todo list accordingly.`
 
 export const COUNTDOWN_SECONDS = 2

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -7,10 +7,23 @@ import { releaseAllPromptAsyncReservationsForTesting } from "../shared/prompt-as
 import { createTodoContinuationEnforcer } from "."
 import {
   CONTINUATION_COOLDOWN_MS,
+  CONTINUATION_PROMPT,
   FAILURE_RESET_WINDOW_MS,
   MAX_CONSECUTIVE_FAILURES,
   MAX_STAGNATION_COUNT,
 } from "./constants"
+
+describe("CONTINUATION_PROMPT", () => {
+  test("checks approval gates before telling the agent to continue", () => {
+    const stopIndex = CONTINUATION_PROMPT.indexOf("waiting for user input")
+    const proceedIndex = CONTINUATION_PROMPT.indexOf("Otherwise, proceed")
+
+    expect(stopIndex).toBeGreaterThanOrEqual(0)
+    expect(CONTINUATION_PROMPT).toContain("Do not proceed past approval gates")
+    expect(proceedIndex).toBeGreaterThan(stopIndex)
+    expect(CONTINUATION_PROMPT).not.toContain("Do not stop until all tasks are done")
+  })
+})
 
 type TimerCallback = (...args: unknown[]) => void
 type FakeTimerID = number & ReturnType<typeof setTimeout> & ReturnType<typeof setInterval>

--- a/packages/omo-opencode/src/hooks/todo-description-override/description.ts
+++ b/packages/omo-opencode/src/hooks/todo-description-override/description.ts
@@ -5,7 +5,7 @@ export const TODOWRITE_DESCRIPTION = `Use this tool to create and manage a struc
 The upstream OpenCode \`todowrite\` schema expects each todo item to include:
 
 - \`content\`: string
-- \`status\`: string, one of \`pending\`, \`in_progress\`, \`completed\`, \`cancelled\`
+- \`status\`: string, one of \`pending\`, \`in_progress\`, \`completed\`, \`cancelled\`, \`blocked\`
 - \`priority\`: string, one of \`high\`, \`medium\`, \`low\`
 
 \`priority\` is a string field. Never send numeric priorities such as \`0\`, \`1\`, \`2\`, or labels such as \`P0\`, \`P1\`, \`P2\`.
@@ -34,5 +34,6 @@ Each todo MUST be a single atomic action completable in 1-3 tool calls. If it ne
 
 ## Task Management
 - One in_progress at a time. Complete it before starting the next.
+- When waiting for user input, approval, or a human decision, mark the current todo \`blocked\`; set it back to \`in_progress\` when you resume.
 - Mark completed immediately after finishing each item.
 - Skip this tool for single trivial tasks (one-step, obvious action).`

--- a/packages/omo-opencode/src/tools/task/task-update.test.ts
+++ b/packages/omo-opencode/src/tools/task/task-update.test.ts
@@ -123,6 +123,33 @@ describe("task_update tool", () => {
       expect(result.task.status).toBe("in_progress")
     })
 
+    test("updates task status to blocked when waiting for user input", async () => {
+      //#given
+      const taskId = "T-test-blocked"
+      const taskPath = join(TEST_DIR, `${taskId}.json`)
+      const initialTask: TaskObject = {
+        id: taskId,
+        subject: "Await user approval",
+        description: "Waiting for review gate",
+        status: "in_progress",
+        blocks: [],
+        blockedBy: [],
+        threadID: TEST_SESSION_ID,
+      }
+      await Bun.write(taskPath, JSON.stringify(initialTask))
+
+      //#when
+      const args = {
+        id: taskId,
+        status: "blocked" as const,
+      }
+      const resultStr = await tool.execute(args, TEST_CONTEXT)
+      const result = JSON.parse(resultStr)
+
+      //#then
+      expect(result.task.status).toBe("blocked")
+    })
+
     test("additively appends to blocks array without replacing", async () => {
       //#given
       const taskId = "T-test-126"

--- a/packages/omo-opencode/src/tools/task/task-update.ts
+++ b/packages/omo-opencode/src/tools/task/task-update.ts
@@ -38,7 +38,7 @@ Properly managed dependencies enable maximum parallel execution.`,
       subject: tool.schema.string().optional().describe("Task subject"),
       description: tool.schema.string().optional().describe("Task description"),
       status: tool.schema
-        .enum(["pending", "in_progress", "completed", "deleted"])
+        .enum(["pending", "in_progress", "completed", "deleted", "blocked"])
         .optional()
         .describe("Task status"),
       activeForm: tool.schema

--- a/packages/omo-opencode/src/tools/task/todo-sync.test.ts
+++ b/packages/omo-opencode/src/tools/task/todo-sync.test.ts
@@ -73,6 +73,25 @@ describe("syncTaskToTodo", () => {
     expect(result?.status).toBe("completed");
   });
 
+  it("converts blocked task to blocked todo", () => {
+    // given
+    const task: Task = {
+      id: "T-blocked",
+      subject: "Await user approval",
+      description: "Waiting for review gate",
+      status: "blocked",
+      blocks: [],
+      blockedBy: [],
+    };
+
+    // when
+    const result = syncTaskToTodo(task);
+
+    // then
+    expect(result?.status).toBe("blocked");
+    expect(result?.content).toBe("Await user approval");
+  });
+
   it("returns null for deleted task", () => {
     // given
     const task: Task = {

--- a/packages/omo-opencode/src/tools/task/todo-sync.ts
+++ b/packages/omo-opencode/src/tools/task/todo-sync.ts
@@ -5,7 +5,7 @@ import type { Task } from "../../features/claude-tasks/types.ts";
 export interface TodoInfo {
   id?: string;
   content: string;
-  status: "pending" | "in_progress" | "completed" | "cancelled";
+  status: "pending" | "in_progress" | "completed" | "cancelled" | "blocked";
   priority?: "low" | "medium" | "high";
 }
 
@@ -24,6 +24,8 @@ function mapTaskStatusToTodoStatus(
       return "in_progress";
     case "completed":
       return "completed";
+    case "blocked":
+      return "blocked";
     case "deleted":
       return null;
     default:

--- a/packages/omo-opencode/src/tools/task/types.test.ts
+++ b/packages/omo-opencode/src/tools/task/types.test.ts
@@ -12,7 +12,7 @@ import {
 describe("TaskStatusSchema", () => {
   test("accepts valid status values", () => {
     //#given
-    const validStatuses = ["pending", "in_progress", "completed", "deleted"]
+    const validStatuses = ["pending", "in_progress", "completed", "deleted", "blocked"]
 
     //#when
     const results = validStatuses.map((status) => TaskStatusSchema.safeParse(status))

--- a/packages/omo-opencode/src/tools/task/types.ts
+++ b/packages/omo-opencode/src/tools/task/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const TaskStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted"])
+export const TaskStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted", "blocked"])
 export type TaskStatus = z.infer<typeof TaskStatusSchema>
 
 export const TaskObjectSchema = z


### PR DESCRIPTION
## Problem

The `todo-continuation-enforcer` bypasses user approval gates used by skills like [Superpowers brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md). When the agent pauses at an approval gate (design review, spec review, user confirmation), the todo remains `in_progress`, and the enforcer injects a continuation nudge that the agent interprets as approval.

Related: [obra/superpowers#1734](https://github.com/obra/superpowers/pull/1734) — a prior attempt to fix this in the Superpowers repo was correctly rejected by the maintainer: the fix belongs in OMO, not in upstream skills.

## Root Cause

Two issues combine:

1. **`hasUnansweredQuestion()`** only detects tool-based questions (`question`, `ask_user_question`). Skills like Superpowers brainstorming use natural language at approval gates ("Does this look right?", "Please review the spec..."), which goes undetected. The enforcer sees incomplete todos and fires.

2. **`CONTINUATION_PROMPT`** contained two instructions that actively override approval gates:
   - `"Proceed without asking for permission"`
   - `"Do not stop until all tasks are done"`
   
   Even if the agent hesitates, these instructions push it past the gate.

## Fix

**Change 1: Soften `CONTINUATION_PROMPT`** (`constants.ts`)

Replace the gate-overriding instructions with an explicit approval-gate check:
- "If you are currently waiting for user input, approval, or a human decision, STOP. Do not proceed past approval gates. Wait for the user's response."
- "Otherwise, proceed with the next pending task without asking for permission."

This is the reactive fix — even if the enforcer fires, the agent checks whether it's actually at a gate before proceeding.

**Change 2: Add `blocked` status rule to agent system prompts**

All model-specific Sisyphus, Sisyphus-Junior, and Hephaestus prompt files now instruct agents:

> When waiting for user input, approval, or a human decision, mark the current todo as `blocked`. Set it back to `in_progress` when you resume.

`getIncompleteCount()` already filters `blocked` todos (see `todo.ts`), so the enforcer will not fire while a gate is held. This is the preventive fix.

## Why this approach (not regex)

An earlier iteration proposed detecting natural-language questions via regex patterns. This was rejected because:
- Fragile across languages (Chinese, Japanese, Korean, etc.)
- Maintenance burden for every new question phrasing
- False positives/negatives

The `blocked` status approach is language-independent, deterministic, and requires no pattern matching.

## Files Changed

| File | Change |
|---|---|
| `src/hooks/todo-continuation-enforcer/constants.ts` | Soften CONTINUATION_PROMPT |
| `src/agents/sisyphus/gpt-5-5.ts` | Add blocked-status rule to task guide |
| `src/agents/sisyphus/gpt-5-4.ts` | Same |
| `src/agents/sisyphus/default.ts` | Same |
| `src/agents/sisyphus/kimi-k2-6.ts` | Same |
| `src/agents/sisyphus/claude-opus-4-7.ts` | Same |
| `src/agents/sisyphus-junior/gpt-5-5.ts` | Same |
| `src/agents/hephaestus/gpt-5-5.ts` | Same |

## Testing

- Verified `getIncompleteCount()` in `todo.ts` already filters `blocked` status — no code change needed there.
- No existing tests reference the old `CONTINUATION_PROMPT` text.
- Remaining model files (sisyphus-junior gpt-5-4/gpt/kimi/default/gemini, hephaestus gpt-5-4/gpt) have the same pattern and should receive the same rule in a follow-up.

## Notes

- Agent compliance with the `blocked` rule is not guaranteed (LLM instruction-following). The `CONTINUATION_PROMPT` softening serves as defense-in-depth for cases where the agent forgets to mark `blocked`.
- The `blocked` status semantics align naturally: a todo waiting for external input IS blocked by an external dependency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `todo-continuation-enforcer` and Atlas boulder reminders from bypassing user approval gates. Adds a `blocked` status and prompt rules so agents stop at gates and only continue after approval.

- **Bug Fixes**
  - Continuation prompts: In `todo-continuation-enforcer` and Atlas boulder reminders, check for approval gates first; only “proceed” otherwise. Removed unconditional continue language; tests assert stop guidance appears before proceed.
  - Agent prompts: All Sisyphus, Sisyphus‑Junior, and Hephaestus templates (GPT‑5‑4/5‑5, Gemini, Kimi, Claude, defaults) now mark the current item `blocked` while waiting and back to `in_progress` on resume. `getIncompleteCount()` ignores `blocked`, so the enforcer won’t fire at gates.
  - Schemas and tools: Added `blocked` to task/todo status types (incl. `features/claude-tasks`), the `task_update` tool, and `todo-sync` (blocked tasks -> blocked todos). Updated `todowrite` docs and added tests.

<sup>Written for commit 9d2102d20b09352d2b867ec7195e725b015ffb8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

