### PR TITLE
fix(omo-codex): accept direct ulw-plan approvals

### DIFF
--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/SKILL.md
@@ -22,7 +22,7 @@ This skill is intentionally compact. The full planning workflow lives in `refere
 - **Plan mode is sticky.** While this skill is active, "do X" / "fix X" / "build X" means "plan X". You NEVER start implementation — not for small, obvious, or urgent work. Execution begins only when the user explicitly says start (e.g. `$start-work`).
 - **Explore before asking.** Most "questions" are discoverable facts. Ground yourself in the repo with read-only tools and parallel research subagents FIRST; ask the user ONLY what neither exploration nor their stated intent can resolve.
 - **Surface, then ask.** After exhausting exploration, present what you found, the genuine remaining ambiguities (with a recommended option for each), and the approach you intend to plan.
-- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis until the user approves the approach.
+- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis until the user approves the approach. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief.
 - **After the plan is written, stop and ask.** Present the summary, then ask ONE question: start work now, or run a high-accuracy Momus review first? Never skip the question, never pick either path yourself.
 - **Planner scope only.** Write only `.omo/plans/<slug>.md` and `.omo/drafts/*.md`. Never edit source.
 

--- a/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ultrawork/skills/ulw-plan/references/full-workflow.md
@@ -65,7 +65,7 @@ When exploration is exhausted and the genuine unknowns are answered, do NOT auto
 - the remaining ambiguities, each with the option you recommend,
 - the approach you intend to plan.
 
-Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. If the user amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
+Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief. If the user says `change the scope first` or otherwise amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
 
 Narrow `$start-work` bootstrap exception: if `$start-work` invoked this skill because there was no active Boulder work and no selectable plan, the user's `start work` request counts as approval to generate the plan and begin execution. Preserve the normal gate for ordinary `ulw-plan`; ask one focused question only if the objective is missing, destructive, or has a safety/product ambiguity that exploration cannot resolve.
 

--- a/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
+++ b/packages/omo-codex/plugin/skills/ulw-plan/SKILL.md
@@ -22,7 +22,7 @@ This skill is intentionally compact. The full planning workflow lives in `refere
 - **Plan mode is sticky.** While this skill is active, "do X" / "fix X" / "build X" means "plan X". You NEVER start implementation — not for small, obvious, or urgent work. Execution begins only when the user explicitly says start (e.g. `$start-work`).
 - **Explore before asking.** Most "questions" are discoverable facts. Ground yourself in the repo with read-only tools and parallel research subagents FIRST; ask the user ONLY what neither exploration nor their stated intent can resolve.
 - **Surface, then ask.** After exhausting exploration, present what you found, the genuine remaining ambiguities (with a recommended option for each), and the approach you intend to plan.
-- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis until the user approves the approach.
+- **Wait for the user's explicit okay before generating the plan.** Never auto-transition from interview to plan generation. No plan file, no Metis gap-analysis until the user approves the approach. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief.
 - **After the plan is written, stop and ask.** Present the summary, then ask ONE question: start work now, or run a high-accuracy Momus review first? Never skip the question, never pick either path yourself.
 - **Planner scope only.** Write only `.omo/plans/<slug>.md` and `.omo/drafts/*.md`. Never edit source.
 

--- a/packages/omo-codex/plugin/skills/ulw-plan/references/full-workflow.md
+++ b/packages/omo-codex/plugin/skills/ulw-plan/references/full-workflow.md
@@ -65,7 +65,7 @@ When exploration is exhausted and the genuine unknowns are answered, do NOT auto
 - the remaining ambiguities, each with the option you recommend,
 - the approach you intend to plan.
 
-Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. If the user amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
+Then **wait for the user's explicit okay** before generating the plan. No Metis, no plan file, no execution until the user approves. Direct replies such as `yes`, `approve`, `proceed`, `write the plan`, or `create the plan` count as approval only when they answer the approval brief. If the user says `change the scope first` or otherwise amends scope, fold it in and re-present the brief. This gate replaces any automatic interview-to-plan transition.
 
 Narrow `$start-work` bootstrap exception: if `$start-work` invoked this skill because there was no active Boulder work and no selectable plan, the user's `start work` request counts as approval to generate the plan and begin execution. Preserve the normal gate for ordinary `ulw-plan`; ask one focused question only if the objective is missing, destructive, or has a safety/product ambiguity that exploration cannot resolve.
 

--- a/packages/omo-codex/plugin/test/ulw-plan-skill.test.mjs
+++ b/packages/omo-codex/plugin/test/ulw-plan-skill.test.mjs
@@ -30,6 +30,23 @@ test("#given ulw-plan skill #when the planning gate is inspected #then it explor
 	assert.doesNotMatch(skill, /Proceeding to plan generation/);
 });
 
+test("#given ulw-plan workflow #when the approval brief is answered directly #then common approval replies enter planning and scope changes stay gated", async () => {
+	// given
+	const skill = await readFile(skillPath, "utf8");
+	const workflow = await readFile(workflowPath, "utf8");
+	const approvalGate = `${skill}\n${workflow}`.toLowerCase();
+	const directApprovalReplies = ["yes", "approve", "proceed", "write the plan", "create the plan"];
+
+	// then
+	assert.deepEqual(
+		directApprovalReplies.filter((reply) => !approvalGate.includes(reply)),
+		[],
+	);
+	assert.match(workflow, /only when they answer the approval brief/i);
+	assert.match(workflow, /change the scope first/i);
+	assert.match(workflow, /fold it in and re-present the brief/i);
+});
+
 test("#given ulw-plan skill #when the execution gate is inspected #then plan mode is sticky, execution needs an explicit start, and the high-accuracy ask is mandatory", async () => {
 	// given
 	const skill = await readFile(skillPath, "utf8");


### PR DESCRIPTION
Reroutes https://github.com/code-yeongyu/lazycodex/pull/51 into `code-yeongyu/oh-my-openagent`, where the Codex implementation lives under `packages/omo-codex`.

I opened the first PR against `code-yeongyu/lazycodex`. The maintainer note on that PR says LazyCodex changes land through this repo, not the generated marketplace repo, so this applies the same fix here.

The fix tightens the `ulw-plan` approval gate wording:

- Direct replies like `yes`, `approve`, `proceed`, `write the plan`, and `create the plan` count as approval when they answer the approval brief.
- Scope-changing replies such as `change the scope first` stay gated. The planner must fold the change into the brief and ask again.
- Both aggregate and `components/ultrawork` copies of the skill text carry the same contract.
- The skill test now pins those approval and scope-change phrases so future syncs do not drop them.

Validation:

- RED: `/mnt/c/Users/Han/.omo/evidence/task-reroute-approval-red.txt`
- GREEN: `/mnt/c/Users/Han/.omo/evidence/task-reroute-approval-green.txt`
- Focused/full ulw-plan test: `/mnt/c/Users/Han/.omo/evidence/task-reroute-ulw-plan-skill-test.txt`
- Full plugin tests: `/mnt/c/Users/Han/.omo/evidence/task-reroute-plugin-npm-test-3.txt` (180 pass)
- Diff check: `/mnt/c/Users/Han/.omo/evidence/task-reroute-diff-check-final.txt`
- Isolated Codex tmux QA: `/mnt/c/Users/Han/.omo/evidence/task-reroute-codex-real-clean-2.tmux.txt`

The Codex QA installed the local build into a throwaway `CODEX_HOME`, confirmed `omo@sisyphuslabs` was installed and enabled, saw `SessionStart` and `UserPromptSubmit` hooks fire through `codex exec`, verified the approval strings in the installed plugin cache, and confirmed the real `~/.codex/config.toml` hash did not change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts direct approvals for `ulw-plan` (e.g., “yes”, “approve”, “proceed”, “write the plan”, “create the plan”) so planning can start without extra back-and-forth, while keeping scope changes gated.
Updates both copies of the skill text and adds a test to lock this behavior.

- **Bug Fixes**
  - Count common direct replies as approval only when they answer the approval brief.
  - Keep scope-changing replies (e.g., “change the scope first”) gated until folded into the brief and re-asked.
  - Sync wording in `components/ultrawork` and the aggregate `skills` copy; add a test to pin phrases and prevent regressions.

<sup>Written for commit 0b1677baff521cf842bf9e16cf69f350ba5e7043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

