### PR TITLE
fix(agents): honor sisyphus junior tools overrides

### DIFF
--- a/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
@@ -16,6 +16,7 @@ import { isGlmModel, isGpt5_5Model, isGptModel, isGeminiModel, isKimiK2Model, bu
 import type { AgentOverrideConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
+  migrateAgentConfig,
   type PermissionValue,
 } from "../../shared/permission-compat"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
@@ -93,21 +94,21 @@ export function createSisyphusJuniorAgentWithOverrides(
   systemDefaultModel?: string,
   useTaskSystem = false
 ): AgentConfig {
-  if (override?.disable) {
-    override = undefined
-  }
+  const activeOverride = override?.disable
+    ? undefined
+    : migrateAgentConfig(override as Record<string, unknown>) as AgentOverrideConfig
 
-  const overrideModel = (override as { model?: string } | undefined)?.model
+  const overrideModel = activeOverride?.model
   const model = overrideModel ?? systemDefaultModel ?? SISYPHUS_JUNIOR_DEFAULTS.model
-  const temperature = override?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
+  const temperature = activeOverride?.temperature ?? SISYPHUS_JUNIOR_DEFAULTS.temperature
 
-  const promptAppend = override?.prompt_append
+  const promptAppend = activeOverride?.prompt_append
   const prompt = buildSisyphusJuniorPrompt(model, useTaskSystem, promptAppend)
   const blockedTools = isGptModel(model) ? GPT_BLOCKED_TOOLS : BLOCKED_TOOLS
 
   const baseRestrictions = createAgentToolRestrictions(blockedTools)
 
-  const userPermission = (override?.permission ?? {}) as Record<string, PermissionValue>
+  const userPermission = (activeOverride?.permission ?? {}) as Record<string, PermissionValue>
   const basePermission = baseRestrictions.permission
   const merged: Record<string, PermissionValue> = { ...userPermission }
   for (const tool of blockedTools) {
@@ -121,19 +122,19 @@ export function createSisyphusJuniorAgentWithOverrides(
   }
 
   const base: AgentConfig = {
-    description: override?.description ??
+    description: activeOverride?.description ??
       "Focused task executor. Same discipline, no delegation. (Sisyphus-Junior - OhMyOpenCode)",
     mode: MODE,
     model,
     temperature,
     maxTokens: 64000,
     prompt,
-    color: override?.color ?? "#20B2AA",
+    color: activeOverride?.color ?? "#20B2AA",
     permission,
   }
 
-  if (override?.top_p !== undefined) {
-    base.top_p = override.top_p
+  if (activeOverride?.top_p !== undefined) {
+    base.top_p = activeOverride.top_p
   }
 
   if (isGptModel(model)) {

--- a/packages/omo-opencode/src/agents/sisyphus-junior/tools-override.test.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/tools-override.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { createSisyphusJuniorAgentWithOverrides } from "./index"
+
+describe("createSisyphusJuniorAgentWithOverrides tools override", () => {
+  test("#given tools override denies grep #when agent is created #then permission denies grep", () => {
+    // given
+    const override = {
+      tools: {
+        grep: false,
+      },
+    }
+
+    // when
+    const result = createSisyphusJuniorAgentWithOverrides(override)
+
+    // then
+    expect(result.permission?.grep).toBe("deny")
+  })
+
+  test("#given GPT tools override allows task #when agent is created #then hard safety denies task and apply_patch", () => {
+    // given
+    const override = {
+      tools: {
+        task: true,
+      },
+    }
+
+    // when
+    const result = createSisyphusJuniorAgentWithOverrides(override, "openai/gpt-5.5")
+
+    // then
+    expect(result.permission?.task).toBe("deny")
+    expect(result.permission?.apply_patch).toBe("deny")
+  })
+})


### PR DESCRIPTION
Refs #5193.

This fixes the `agents.sisyphus-junior.tools` path. It does not change direct `permission` schema handling for arbitrary MCP keys; that is a separate config-schema decision from the same issue report.

`createSisyphusJuniorAgentWithOverrides()` now runs the override through the existing `migrateAgentConfig()` helper before reading `permission`. That matches the path used by the other built-in agents: boolean `tools` entries become `permission` entries before the agent-specific safety rules are applied.

Changed:

- `tools: { grep: false }` now produces `permission.grep = "deny"` for Sisyphus-Junior.
- The hard safety denials still win: GPT-backed Sisyphus-Junior keeps `task = "deny"` and `apply_patch = "deny"` even if `tools.task = true`.
- Added a focused regression test outside the existing oversized `index.test.ts` file.

Validation:

- RED: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-red.txt`
- GREEN: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-green.txt`
- Agent suite: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-agent-suite.txt`
- Config/agent slice: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-config-slice.txt`
- Typecheck: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-typecheck.txt`
- Diff check: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools-diff-check.txt`
- tmux QA: `/mnt/c/Users/Han/.omo/evidence/task-5-sj-tools.tmux.txt`

Manual QA result: tmux ran the real agent factory import. The transcript shows `{"grep":"deny","task":"deny","call_omo_agent":"allow"}` for the tools-deny case and `{"task":"deny","apply_patch":"deny","call_omo_agent":"allow"}` for the GPT hard-safety case, followed by cleanup receipts.

Plan: `.omo/plans/quick-fix-pr-waves-20260612.md`
