### PR TITLE
fix(delegate): apply category tool restrictions

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-category-tools.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-category-tools.test.ts
@@ -1,0 +1,68 @@
+import { expect, mock, test } from "bun:test"
+
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import type { FallbackEntry } from "../../shared/model-requirements"
+import type { ConcurrencyManager } from "./concurrency"
+import type { OpencodeClient, QueueItem } from "./constants"
+import { tryFallbackRetry } from "./fallback-retry-handler"
+import type { BackgroundTask } from "./types"
+
+test("preserves category tools in fallback retry input", async () => {
+  const fallbackChain: FallbackEntry[] = [
+    { model: "fallback-model", providers: ["provider-a"], variant: undefined },
+  ]
+  const task: BackgroundTask = {
+    id: "task-category-tools",
+    description: "category tools",
+    prompt: "check tools",
+    agent: "sisyphus-junior",
+    status: "error",
+    parentSessionId: "ses_parent",
+    parentMessageId: "msg_parent",
+    fallbackChain,
+    attemptCount: 0,
+    concurrencyKey: "provider-a/original-model",
+    model: { providerID: "provider-a", modelID: "original-model" },
+    sessionPermission: [
+      { permission: "grep", action: "deny", pattern: "*" },
+      { permission: "question", action: "deny", pattern: "*" },
+    ],
+    categoryTools: { grep: false },
+  }
+  const queuesByKey = new Map<string, QueueItem[]>()
+  const processKey = mock(() => {})
+
+  await tryFallbackRetry({
+    task,
+    errorInfo: { name: "OverloadedError", message: "model overloaded" },
+    source: "polling",
+    concurrencyManager: unsafeTestValue<ConcurrencyManager>({
+      release: mock(() => {}),
+      getConcurrencyKey: mock((key: string) => key),
+    }),
+    client: unsafeTestValue<OpencodeClient>({
+      session: { abort: mock(async () => ({})) },
+    }),
+    idleDeferralTimers: new Map(),
+    queuesByKey,
+    processKey,
+    deps: {
+      shouldRetryError: mock(() => true),
+      hasMoreFallbacks: mock((chain: FallbackEntry[], attempt: number) => attempt < chain.length),
+      getNextFallback: mock((chain: FallbackEntry[], attempt: number) => chain[attempt]),
+      readProviderModelsCache: mock(() => null),
+      readConnectedProvidersCache: mock(() => null),
+      selectFallbackProvider: mock((providers: string[]) => providers[0]),
+      transformModelForProvider: mock((_provider: string, model: string) => model),
+    },
+  })
+
+  const key = `${task.model?.providerID}/${task.model?.modelID}`
+  const retryInput = queuesByKey.get(key)?.[0]?.input
+  expect(retryInput?.categoryTools).toEqual({ grep: false })
+  expect(retryInput?.sessionPermission).toEqual([
+    { permission: "grep", action: "deny", pattern: "*" },
+    { permission: "question", action: "deny", pattern: "*" },
+  ])
+  expect(processKey).toHaveBeenCalledWith(key)
+})

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-category-tools.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-category-tools.test.ts
@@ -9,7 +9,7 @@ import type { BackgroundTask } from "./types"
 
 test("preserves category tools in fallback retry input", async () => {
   const fallbackChain: FallbackEntry[] = [
-    { model: "fallback-model", providers: ["provider-a"], variant: undefined },
+    { model: "gpt-5.4-mini", providers: ["openai"], variant: undefined },
   ]
   const task: BackgroundTask = {
     id: "task-category-tools",
@@ -27,7 +27,7 @@ test("preserves category tools in fallback retry input", async () => {
       { permission: "grep", action: "deny", pattern: "*" },
       { permission: "question", action: "deny", pattern: "*" },
     ],
-    categoryTools: { grep: false },
+    categoryTools: { grep: false, apply_patch: true },
   }
   const queuesByKey = new Map<string, QueueItem[]>()
   const processKey = mock(() => {})
@@ -59,10 +59,11 @@ test("preserves category tools in fallback retry input", async () => {
 
   const key = `${task.model?.providerID}/${task.model?.modelID}`
   const retryInput = queuesByKey.get(key)?.[0]?.input
-  expect(retryInput?.categoryTools).toEqual({ grep: false })
-  expect(retryInput?.sessionPermission).toEqual([
+  expect(retryInput?.categoryTools).toEqual({ grep: false, apply_patch: true })
+  expect(retryInput?.sessionPermission).toEqual(expect.arrayContaining([
     { permission: "grep", action: "deny", pattern: "*" },
+    { permission: "apply_patch", action: "deny", pattern: "*" },
     { permission: "question", action: "deny", pattern: "*" },
-  ])
+  ]))
   expect(processKey).toHaveBeenCalledWith(key)
 })

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -218,6 +218,7 @@ export async function tryFallbackRetry(args: {
     fallbackChain: task.fallbackChain,
     skillContent: task.skillContent,
     sessionPermission: task.sessionPermission,
+    categoryTools: task.categoryTools,
     category: task.category,
     isUnstableAgent: task.isUnstableAgent,
     onSessionCreated: task.onSessionCreated,

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -3,6 +3,8 @@ import type { FallbackEntry } from "../../shared/model-requirements"
 import type { ConcurrencyManager } from "./concurrency"
 import type { OpencodeClient, QueueItem } from "./constants"
 import { log, readConnectedProvidersCache, readProviderModelsCache } from "../../shared"
+import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
 import {
   shouldRetryError,
   getNextFallback,
@@ -217,7 +219,10 @@ export async function tryFallbackRetry(args: {
     model: nextModel,
     fallbackChain: task.fallbackChain,
     skillContent: task.skillContent,
-    sessionPermission: task.sessionPermission,
+    sessionPermission: buildDelegateSessionPermission(
+      task.categoryTools,
+      getAgentToolRestrictions(task.agent, { model: nextModel.modelID }),
+    ),
     categoryTools: task.categoryTools,
     category: task.category,
     isUnstableAgent: task.isUnstableAgent,

--- a/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
@@ -145,7 +145,8 @@ describe("BackgroundManager session permission", () => {
       agent: "sisyphus-junior",
       parentSessionId: "ses_parent",
       parentMessageId: "msg_parent",
-      categoryTools: { grep: false, glob: true },
+      model: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      categoryTools: { grep: false, glob: true, apply_patch: true },
     })
     await new Promise(resolve => setTimeout(resolve, 50))
     manager.shutdown()
@@ -156,6 +157,7 @@ describe("BackgroundManager session permission", () => {
       tools: {
         grep: false,
         glob: true,
+        apply_patch: false,
         question: false,
         task: false,
       },

--- a/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
@@ -121,4 +121,44 @@ describe("BackgroundManager session permission", () => {
       ],
     })
   })
+
+  test("applies category tools to child prompt body", async () => {
+    // given
+    const promptCalls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async () => ({ data: { id: "ses_child" } }),
+        promptAsync: async (input: Record<string, unknown>) => {
+          promptCalls.push(input)
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+
+    // when
+    await manager.launch({
+      description: "Test task",
+      prompt: "Do something",
+      agent: "sisyphus-junior",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      categoryTools: { grep: false, glob: true },
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.body).toMatchObject({
+      tools: {
+        grep: false,
+        glob: true,
+        question: false,
+        task: false,
+      },
+    })
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -25,6 +25,7 @@ import {
   clearDelegatedChildSessionBootstrap,
   registerDelegatedChildSessionBootstrap,
 } from "../../shared/delegated-child-session-bootstrap"
+import { mergeDelegatePromptTools } from "../../shared/delegate-tool-overrides"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import {
   hasMoreFallbacks,
@@ -599,6 +600,7 @@ export class BackgroundManager {
         fallbackChain: input.fallbackChain,
         skillContent: input.skillContent,
         sessionPermission: input.sessionPermission,
+        categoryTools: input.categoryTools,
         attemptCount: 0,
         category: input.category,
         onSessionCreated: input.onSessionCreated,
@@ -879,14 +881,17 @@ The fallback retry session is now created and can be inspected directly.
       applySessionPromptParams(sessionID, input.model)
     }
 
-    const launchTools = {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(input.agent, {
+    const launchTools = mergeDelegatePromptTools({
+      defaults: {
+        task: false,
+        call_omo_agent: true,
+        question: false,
+      },
+      configuredTools: input.categoryTools,
+      hardRestrictions: getAgentToolRestrictions(input.agent, {
         includeTeamToolDenylist: input.teamRunId === undefined,
       }),
-    }
+    })
     setSessionTools(sessionID, launchTools)
 
     log("[background-agent] Launching task:", { taskId: task.id, sessionID, agent: input.agent })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -888,9 +888,7 @@ The fallback retry session is now created and can be inspected directly.
         question: false,
       },
       configuredTools: input.categoryTools,
-      hardRestrictions: getAgentToolRestrictions(input.agent, {
-        includeTeamToolDenylist: input.teamRunId === undefined,
-      }),
+      hardRestrictions: getAgentToolRestrictions(input.agent, { includeTeamToolDenylist: input.teamRunId === undefined, model: input.model?.modelID }),
     })
     setSessionTools(sessionID, launchTools)
 
@@ -1369,9 +1367,7 @@ The fallback retry session is now created and can be inspected directly.
               task: false,
               call_omo_agent: true,
               question: false,
-              ...getAgentToolRestrictions(existingTask.agent, {
-                includeTeamToolDenylist: existingTask.teamRunId === undefined,
-              }),
+              ...getAgentToolRestrictions(existingTask.agent, { includeTeamToolDenylist: existingTask.teamRunId === undefined, model: existingTask.model?.modelID }),
             }
             setSessionTools(existingTask.sessionId!, tools)
             return tools

--- a/packages/omo-opencode/src/features/background-agent/spawner.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.ts
@@ -111,6 +111,7 @@ export async function startTask(
     system: input.skillContent,
     model: input.model,
     prompt: input.prompt,
+    categoryTools: input.categoryTools,
     includeTeamToolDenylist: input.teamRunId === undefined,
   })
   setSessionTools(sessionID, promptBody.tools)

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
@@ -1,4 +1,5 @@
 import { createInternalAgentTextPart, getAgentToolRestrictions } from "../../../shared"
+import { mergeDelegatePromptTools } from "../../../shared/delegate-tool-overrides"
 import type { LaunchInput } from "../types"
 
 type PromptModel = LaunchInput["model"]
@@ -11,6 +12,7 @@ type TaskPromptBodyOptions =
       readonly system: LaunchInput["skillContent"]
       readonly prompt: string
       readonly includeTeamToolDenylist: boolean
+      readonly categoryTools?: Record<string, boolean>
     }
   | {
       readonly kind: "resume"
@@ -49,14 +51,17 @@ export function buildTaskPromptBody(options: TaskPromptBodyOptions): TaskPromptB
     ...(promptModel ? { model: promptModel } : {}),
     ...(promptVariant ? { variant: promptVariant } : {}),
     ...(options.kind === "launch" ? { system: options.system } : {}),
-    tools: {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(options.agent, {
+    tools: mergeDelegatePromptTools({
+      defaults: {
+        task: false,
+        call_omo_agent: true,
+        question: false,
+      },
+      configuredTools: options.kind === "launch" ? options.categoryTools : undefined,
+      hardRestrictions: getAgentToolRestrictions(options.agent, {
         includeTeamToolDenylist: options.includeTeamToolDenylist,
       }),
-    },
+    }),
     parts: [createInternalAgentTextPart(options.prompt)],
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
@@ -60,6 +60,7 @@ export function buildTaskPromptBody(options: TaskPromptBodyOptions): TaskPromptB
       configuredTools: options.kind === "launch" ? options.categoryTools : undefined,
       hardRestrictions: getAgentToolRestrictions(options.agent, {
         includeTeamToolDenylist: options.includeTeamToolDenylist,
+        model: options.model?.modelID,
       }),
     }),
     parts: [createInternalAgentTextPart(options.prompt)],

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
@@ -18,6 +18,7 @@ export function buildTaskRecord(input: LaunchInput, id: string, queuedAt: Date):
     fallbackChain: input.fallbackChain,
     skillContent: input.skillContent,
     sessionPermission: input.sessionPermission,
+    categoryTools: input.categoryTools,
     category: input.category,
     isUnstableAgent: input.isUnstableAgent,
     onSessionCreated: input.onSessionCreated,

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -75,6 +75,7 @@ export interface BackgroundTask {
   parentTools?: Record<string, boolean>
   skillContent?: string
   sessionPermission?: SessionPermissionRule[]
+  categoryTools?: Record<string, boolean>
   /** Marks if the task was launched from an unstable agent/category */
   isUnstableAgent?: boolean
   /** Category used for this task (e.g., 'quick', 'visual-engineering') */
@@ -120,6 +121,7 @@ export interface LaunchInput {
   skillContent?: string
   category?: string
   sessionPermission?: SessionPermissionRule[]
+  categoryTools?: Record<string, boolean>
   onSessionCreated?: (sessionId: string) => void | Promise<void>
 }
 

--- a/packages/omo-opencode/src/shared/agent-tool-restrictions.ts
+++ b/packages/omo-opencode/src/shared/agent-tool-restrictions.ts
@@ -1,4 +1,5 @@
 import { stripInvisibleAgentCharacters } from "./agent-display-names"
+import { isGptModel } from "@oh-my-opencode/model-core"
 
 /**
  * Agent tool restrictions for session.prompt calls.
@@ -61,17 +62,23 @@ const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
 
 type AgentToolRestrictionsOptions = {
   includeTeamToolDenylist?: boolean
+  model?: string
 }
 
 export function getAgentToolRestrictions(agentName: string, options: AgentToolRestrictionsOptions = {}): Record<string, boolean> {
   const stripped = stripInvisibleAgentCharacters(agentName)
+  const normalizedAgent = stripped.toLowerCase()
   const agentRestrictions = AGENT_RESTRICTIONS[stripped]
-    ?? Object.entries(AGENT_RESTRICTIONS).find(([key]) => key.toLowerCase() === stripped.toLowerCase())?.[1]
+    ?? Object.entries(AGENT_RESTRICTIONS).find(([key]) => key.toLowerCase() === normalizedAgent)?.[1]
     ?? {}
+  const modelRestrictions: Record<string, boolean> = normalizedAgent === "sisyphus-junior" && options.model && isGptModel(options.model)
+    ? { apply_patch: false }
+    : {}
 
   return {
     ...(options.includeTeamToolDenylist === false ? {} : TEAM_TOOL_DENYLIST),
     ...agentRestrictions,
+    ...modelRestrictions,
   }
 }
 

--- a/packages/omo-opencode/src/shared/delegate-tool-overrides.test.ts
+++ b/packages/omo-opencode/src/shared/delegate-tool-overrides.test.ts
@@ -42,3 +42,24 @@ test("buildDelegateSessionPermission keeps hard tool denies above category allow
     { permission: "team_create", action: "allow", pattern: "*" },
   )
 })
+
+test("buildDelegateSessionPermission keeps GPT Sisyphus-Junior apply_patch denied above category allows", () => {
+  //#given
+  const configuredTools = {
+    apply_patch: true,
+  }
+
+  //#when
+  const rules = buildDelegateSessionPermission(
+    configuredTools,
+    getAgentToolRestrictions("sisyphus-junior", { model: "openai/gpt-5.4-mini" }),
+  )
+
+  //#then
+  expect(rules).toContainEqual(
+    { permission: "apply_patch", action: "deny", pattern: "*" },
+  )
+  expect(rules).not.toContainEqual(
+    { permission: "apply_patch", action: "allow", pattern: "*" },
+  )
+})

--- a/packages/omo-opencode/src/shared/delegate-tool-overrides.test.ts
+++ b/packages/omo-opencode/src/shared/delegate-tool-overrides.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+
+import { getAgentToolRestrictions } from "./agent-tool-restrictions"
+import { buildDelegateSessionPermission } from "./delegate-tool-overrides"
+
+test("buildDelegateSessionPermission keeps hard tool denies above category allows", () => {
+  //#given
+  const configuredTools = {
+    grep: false,
+    glob: true,
+    question: true,
+    task: true,
+    team_create: true,
+  }
+
+  //#when
+  const rules = buildDelegateSessionPermission(
+    configuredTools,
+    getAgentToolRestrictions("sisyphus-junior"),
+  )
+
+  //#then
+  expect(rules).toContainEqual(
+    { permission: "grep", action: "deny", pattern: "*" },
+  )
+  expect(rules).toContainEqual(
+    { permission: "glob", action: "allow", pattern: "*" },
+  )
+  expect(rules).toContainEqual(
+    { permission: "question", action: "deny", pattern: "*" },
+  )
+  expect(rules).toContainEqual(
+    { permission: "task", action: "deny", pattern: "*" },
+  )
+  expect(rules).toContainEqual(
+    { permission: "team_create", action: "deny", pattern: "*" },
+  )
+  expect(rules).not.toContainEqual(
+    { permission: "task", action: "allow", pattern: "*" },
+  )
+  expect(rules).not.toContainEqual(
+    { permission: "team_create", action: "allow", pattern: "*" },
+  )
+})

--- a/packages/omo-opencode/src/shared/delegate-tool-overrides.ts
+++ b/packages/omo-opencode/src/shared/delegate-tool-overrides.ts
@@ -18,9 +18,14 @@ export function mergeDelegatePromptTools(input: {
 
 export function buildDelegateSessionPermission(
   configuredTools?: DelegateToolOverrides,
+  hardRestrictions?: Record<string, boolean>,
 ): SessionPermissionRule[] {
-  const permission = configuredTools ? migrateToolsToPermission(configuredTools) : {}
-  permission.question = "deny"
+  const promptTools = mergeDelegatePromptTools({
+    defaults: {},
+    configuredTools,
+    hardRestrictions,
+  })
+  const permission = migrateToolsToPermission(promptTools)
 
   const rules: SessionPermissionRule[] = []
   for (const [toolName, action] of Object.entries(permission)) {

--- a/packages/omo-opencode/src/shared/delegate-tool-overrides.ts
+++ b/packages/omo-opencode/src/shared/delegate-tool-overrides.ts
@@ -1,0 +1,32 @@
+import { migrateToolsToPermission } from "./permission-compat"
+import type { SessionPermissionRule } from "./question-denied-session-permission"
+
+export type DelegateToolOverrides = Record<string, boolean>
+
+export function mergeDelegatePromptTools(input: {
+  readonly defaults: Record<string, boolean>
+  readonly configuredTools?: DelegateToolOverrides
+  readonly hardRestrictions?: Record<string, boolean>
+}): Record<string, boolean> {
+  return {
+    ...input.defaults,
+    ...(input.configuredTools ?? {}),
+    question: false,
+    ...(input.hardRestrictions ?? {}),
+  }
+}
+
+export function buildDelegateSessionPermission(
+  configuredTools?: DelegateToolOverrides,
+): SessionPermissionRule[] {
+  const permission = configuredTools ? migrateToolsToPermission(configuredTools) : {}
+  permission.question = "deny"
+
+  const rules: SessionPermissionRule[] = []
+  for (const [toolName, action] of Object.entries(permission)) {
+    if (action === "allow" || action === "deny") {
+      rules.push({ permission: toolName, action, pattern: "*" })
+    }
+  }
+  return rules
+}

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -289,18 +289,19 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       { manager },
       { sessionID: "ses_parent", messageID: "msg_category_tools" },
       "sisyphus-junior",
+      { providerID: "openai", modelID: "gpt-5.4-mini" },
       undefined,
       undefined,
-      undefined,
-      { grep: false, glob: true },
+      { grep: false, glob: true, apply_patch: true },
     )
 
     //#then
     expectFn(launchCalls).toHaveLength(1)
-    expectFn(launchCalls[0].categoryTools).toEqual({ grep: false, glob: true })
+    expectFn(launchCalls[0].categoryTools).toEqual({ grep: false, glob: true, apply_patch: true })
     expectFn(launchCalls[0].sessionPermission).toEqual(expectFn.arrayContaining([
       { permission: "grep", action: "deny", pattern: "*" },
       { permission: "glob", action: "allow", pattern: "*" },
+      { permission: "apply_patch", action: "deny", pattern: "*" },
       { permission: "question", action: "deny", pattern: "*" },
       { permission: "task", action: "deny", pattern: "*" },
     ]))

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -252,6 +252,57 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     ])
   })
 
+  testFn("passes category tool permissions and prompt tools when launching delegate task", async () => {
+    //#given - category tool overrides should reach the background child session
+    const launchCalls: Array<{ sessionPermission: unknown; categoryTools: unknown }> = []
+    const manager = {
+      launch: async (input: { sessionPermission: unknown; categoryTools: unknown }) => {
+        launchCalls.push(input)
+        return {
+          id: "bg_category_tools",
+          sessionId: "ses_category_tools_123",
+          description: "Category tools session",
+          agent: "sisyphus-junior",
+          status: "running",
+        }
+      },
+      getTask: () => ({ sessionId: "ses_category_tools_123" }),
+    }
+
+    //#when
+    await executeBackgroundTask(
+      {
+        description: "Category tools session",
+        prompt: "check",
+        category: "visual-engineering",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_category_tools",
+        metadata: async () => {},
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_category_tools" },
+      "sisyphus-junior",
+      undefined,
+      undefined,
+      undefined,
+      { grep: false, glob: true },
+    )
+
+    //#then
+    expectFn(launchCalls).toHaveLength(1)
+    expectFn(launchCalls[0].categoryTools).toEqual({ grep: false, glob: true })
+    expectFn(launchCalls[0].sessionPermission).toEqual([
+      { permission: "grep", action: "deny", pattern: "*" },
+      { permission: "glob", action: "allow", pattern: "*" },
+      { permission: "question", action: "deny", pattern: "*" },
+    ])
+  })
+
   testFn("strips leading zwsp from agent name before launching background task", async () => {
     //#given - display-sorted agent names should be normalized before manager launch
     const launchCalls: unknown[] = []

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.test.ts
@@ -247,9 +247,11 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
 
     //#then
     expectFn(launchCalls).toHaveLength(1)
-    expectFn(launchCalls[0].sessionPermission).toEqual([
+    expectFn(launchCalls[0].sessionPermission).toEqual(expectFn.arrayContaining([
       { permission: "question", action: "deny", pattern: "*" },
-    ])
+      { permission: "task", action: "deny", pattern: "*" },
+      { permission: "call_omo_agent", action: "deny", pattern: "*" },
+    ]))
   })
 
   testFn("passes category tool permissions and prompt tools when launching delegate task", async () => {
@@ -296,11 +298,12 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     //#then
     expectFn(launchCalls).toHaveLength(1)
     expectFn(launchCalls[0].categoryTools).toEqual({ grep: false, glob: true })
-    expectFn(launchCalls[0].sessionPermission).toEqual([
+    expectFn(launchCalls[0].sessionPermission).toEqual(expectFn.arrayContaining([
       { permission: "grep", action: "deny", pattern: "*" },
       { permission: "glob", action: "allow", pattern: "*" },
       { permission: "question", action: "deny", pattern: "*" },
-    ])
+      { permission: "task", action: "deny", pattern: "*" },
+    ]))
   })
 
   testFn("strips leading zwsp from agent name before launching background task", async () => {

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -132,7 +132,7 @@ export async function executeBackgroundTask(
       categoryTools,
       sessionPermission: buildDelegateSessionPermission(
         categoryTools,
-        getAgentToolRestrictions(normalizedAgent),
+        getAgentToolRestrictions(normalizedAgent, { model: categoryModel?.modelID }),
       ),
     })
 

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -8,6 +8,7 @@ import { formatDetailedError } from "./error-formatting"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
+import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
 import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 import { resolveMetadataModel } from "./resolve-metadata-model"
@@ -129,7 +130,10 @@ export async function executeBackgroundTask(
       skillContent: systemContent,
       category: args.category,
       categoryTools,
-      sessionPermission: buildDelegateSessionPermission(categoryTools),
+      sessionPermission: buildDelegateSessionPermission(
+        categoryTools,
+        getAgentToolRestrictions(normalizedAgent),
+      ),
     })
 
     // OpenCode TUI's `Task` tool UI calculates toolcalls by looking up

--- a/packages/omo-opencode/src/tools/delegate-task/background-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-task.ts
@@ -7,7 +7,7 @@ import { publishToolMetadata } from "../../features/tool-metadata-store"
 import { formatDetailedError } from "./error-formatting"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
-import { QUESTION_DENIED_SESSION_PERMISSION } from "../../shared/question-denied-session-permission"
+import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
 import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 import { resolveMetadataModel } from "./resolve-metadata-model"
@@ -106,6 +106,7 @@ export async function executeBackgroundTask(
   categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
   fallbackChain?: FallbackEntry[],
+  categoryTools?: Record<string, boolean>,
 ): Promise<string> {
   const { manager } = executorCtx
 
@@ -127,7 +128,8 @@ export async function executeBackgroundTask(
       skills: args.load_skills.length > 0 ? args.load_skills : undefined,
       skillContent: systemContent,
       category: args.category,
-      sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+      categoryTools,
+      sessionPermission: buildDelegateSessionPermission(categoryTools),
     })
 
     // OpenCode TUI's `Task` tool UI calculates toolcalls by looking up

--- a/packages/omo-opencode/src/tools/delegate-task/category-resolver.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/category-resolver.test.ts
@@ -62,6 +62,32 @@ describe("resolveCategoryExecution", () => {
 		expect(result.agentToUse).toBeDefined()
 	})
 
+	test("returns category tools for delegate session restrictions", async () => {
+		//#given
+		const args = {
+			category: "quick",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			quick: {
+				tools: { grep: false, glob: true },
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.categoryTools).toEqual({ grep: false, glob: true })
+	})
+
 	test("returns 'unknown category' error for truly unknown categories", async () => {
 		//#given
 		const args = {

--- a/packages/omo-opencode/src/tools/delegate-task/category-resolver.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/category-resolver.ts
@@ -47,6 +47,7 @@ function resolveCategoryPromptAppendForModel(
 export interface CategoryResolutionResult {
   agentToUse: string
   categoryModel: DelegatedModelConfig | undefined
+  categoryTools?: Record<string, boolean>
   categoryPromptAppend: string | undefined
   maxPromptTokens?: number
   modelInfo: ModelFallbackInfo | undefined
@@ -261,6 +262,7 @@ Available categories: ${categoryNames.join(", ")}`)
   return {
     agentToUse: SISYPHUS_JUNIOR_AGENT,
     categoryModel,
+    categoryTools: resolved.config.tools,
     categoryPromptAppend,
     maxPromptTokens: resolved.config.max_prompt_tokens,
     modelInfo,

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
@@ -157,7 +157,7 @@ export async function executeSyncContinuation(
       task: allowTask,
       call_omo_agent: true,
       question: false,
-      ...(resumeAgent ? getAgentToolRestrictions(resumeAgent) : {}),
+      ...(resumeAgent ? getAgentToolRestrictions(resumeAgent, { model: resumeModel?.modelID }) : {}),
     }
     setSessionTools(continuationID, tools)
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
@@ -135,8 +135,8 @@ bunDescribe("sendSyncPrompt", () => {
         load_skills: [],
       },
       systemContent: undefined,
-      categoryModel: undefined,
-      categoryTools: { grep: false, glob: true },
+      categoryModel: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      categoryTools: { grep: false, glob: true, apply_patch: true },
       toastManager: null,
       taskId: undefined,
     }
@@ -147,6 +147,7 @@ bunDescribe("sendSyncPrompt", () => {
     //#then
     bunExpect(promptArgs.body.tools.grep).toBe(false)
     bunExpect(promptArgs.body.tools.glob).toBe(true)
+    bunExpect(promptArgs.body.tools.apply_patch).toBe(false)
     bunExpect(promptArgs.body.tools.question).toBe(false)
     bunExpect(promptArgs.body.tools.task).toBe(false)
   })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.test.ts
@@ -107,6 +107,50 @@ bunDescribe("sendSyncPrompt", () => {
     bunExpect(promptArgs.body.tools.question).toBe(false)
   })
 
+  bunTest("applies category tool overrides to the prompt tools", async () => {
+    //#given
+    const { sendSyncPrompt } = require("./sync-prompt-sender")
+
+    let promptArgs!: PromptArgs
+    const promptAsync = bunMock(async (input: PromptArgs) => {
+      promptArgs = input
+      return { data: {} }
+    })
+
+    const mockClient = {
+      session: {
+        prompt: promptAsync,
+        promptAsync,
+      },
+    }
+
+    const input = {
+      sessionID: "test-session",
+      agentToUse: "sisyphus-junior",
+      args: {
+        description: "test task",
+        prompt: "test prompt",
+        category: "visual-engineering",
+        run_in_background: false,
+        load_skills: [],
+      },
+      systemContent: undefined,
+      categoryModel: undefined,
+      categoryTools: { grep: false, glob: true },
+      toastManager: null,
+      taskId: undefined,
+    }
+
+    //#when
+    await sendSyncPrompt(mockClient, input)
+
+    //#then
+    bunExpect(promptArgs.body.tools.grep).toBe(false)
+    bunExpect(promptArgs.body.tools.glob).toBe(true)
+    bunExpect(promptArgs.body.tools.question).toBe(false)
+    bunExpect(promptArgs.body.tools.task).toBe(false)
+  })
+
   bunTest("applies agent tool restrictions for explore agent", async () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
@@ -53,6 +53,7 @@ function isUnexpectedEofError(error: unknown): boolean {
 export function buildSyncPromptTools(
   agentToUse: string,
   categoryTools?: Record<string, boolean>,
+  model?: string,
 ): Record<string, boolean> {
   return mergeDelegatePromptTools({
     defaults: {
@@ -61,7 +62,7 @@ export function buildSyncPromptTools(
       question: false,
     },
     configuredTools: categoryTools,
-    hardRestrictions: getAgentToolRestrictions(agentToUse),
+    hardRestrictions: getAgentToolRestrictions(agentToUse, { model }),
   })
 }
 
@@ -83,7 +84,7 @@ export async function sendSyncPrompt(
 ): Promise<string | null> {
   const tddEnabled = input.sisyphusAgentConfig?.tdd
   const effectivePrompt = buildTaskPrompt(input.args.prompt, input.agentToUse, tddEnabled)
-  const tools = buildSyncPromptTools(input.agentToUse, input.categoryTools)
+  const tools = buildSyncPromptTools(input.agentToUse, input.categoryTools, input.categoryModel?.modelID)
   setSessionTools(input.sessionID, tools)
 
   applySessionPromptParams(input.sessionID, input.categoryModel)

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,5 +1,6 @@
 import type { SisyphusAgentConfig } from "../../config/schema"
 import { stripInvisibleAgentCharacters } from "../../shared/agent-display-names"
+import { mergeDelegatePromptTools } from "../../shared/delegate-tool-overrides"
 import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import {
@@ -49,13 +50,19 @@ function isUnexpectedEofError(error: unknown): boolean {
   return lowered.includes("unexpected eof") || lowered.includes("json parse error")
 }
 
-export function buildSyncPromptTools(agentToUse: string): Record<string, boolean> {
-  return {
-    task: isPlanFamily(agentToUse),
-    call_omo_agent: true,
-    question: false,
-    ...getAgentToolRestrictions(agentToUse),
-  }
+export function buildSyncPromptTools(
+  agentToUse: string,
+  categoryTools?: Record<string, boolean>,
+): Record<string, boolean> {
+  return mergeDelegatePromptTools({
+    defaults: {
+      task: isPlanFamily(agentToUse),
+      call_omo_agent: true,
+      question: false,
+    },
+    configuredTools: categoryTools,
+    hardRestrictions: getAgentToolRestrictions(agentToUse),
+  })
 }
 
 export async function sendSyncPrompt(
@@ -66,6 +73,7 @@ export async function sendSyncPrompt(
     args: DelegateTaskArgs
     systemContent: string | undefined
     categoryModel: DelegatedModelConfig | undefined
+    categoryTools?: Record<string, boolean>
     directory: string
     toastManager: { removeTask: (id: string) => void } | null | undefined
     taskId: string | undefined
@@ -75,7 +83,7 @@ export async function sendSyncPrompt(
 ): Promise<string | null> {
   const tddEnabled = input.sisyphusAgentConfig?.tdd
   const effectivePrompt = buildTaskPrompt(input.args.prompt, input.agentToUse, tddEnabled)
-  const tools = buildSyncPromptTools(input.agentToUse)
+  const tools = buildSyncPromptTools(input.agentToUse, input.categoryTools)
   setSessionTools(input.sessionID, tools)
 
   applySessionPromptParams(input.sessionID, input.categoryModel)

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
@@ -57,7 +57,8 @@ describe("createSyncSession", () => {
       agentToUse: "sisyphus-junior",
       description: "test task",
       defaultDirectory: "/fallback",
-      categoryTools: { grep: false, glob: true },
+      categoryModel: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      categoryTools: { grep: false, glob: true, apply_patch: true },
     })
 
     // then
@@ -68,6 +69,7 @@ describe("createSyncSession", () => {
       permission: expect.arrayContaining([
         { permission: "grep", action: "deny", pattern: "*" },
         { permission: "glob", action: "allow", pattern: "*" },
+        { permission: "apply_patch", action: "deny", pattern: "*" },
         { permission: "question", action: "deny", pattern: "*" },
         { permission: "task", action: "deny", pattern: "*" },
       ]),

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
@@ -27,12 +27,14 @@ describe("createSyncSession", () => {
     // then
     expect(result).toEqual({ ok: true, sessionID: "ses_child", parentDirectory: "/parent" })
     expect(createCalls).toHaveLength(1)
-    expect(createCalls[0]?.body).toEqual({
+    expect(createCalls[0]?.body).toMatchObject({
       parentID: "ses_parent",
       title: "test task (@explore subagent)",
-      permission: [
+      permission: expect.arrayContaining([
         { permission: "question", action: "deny", pattern: "*" },
-      ],
+        { permission: "task", action: "deny", pattern: "*" },
+        { permission: "call_omo_agent", action: "deny", pattern: "*" },
+      ]),
     })
   })
 
@@ -60,14 +62,15 @@ describe("createSyncSession", () => {
 
     // then
     expect(result.ok).toBe(true)
-    expect(createCalls[0]?.body).toEqual({
+    expect(createCalls[0]?.body).toMatchObject({
       parentID: "ses_parent",
       title: "test task (@sisyphus-junior subagent)",
-      permission: [
+      permission: expect.arrayContaining([
         { permission: "grep", action: "deny", pattern: "*" },
         { permission: "glob", action: "allow", pattern: "*" },
         { permission: "question", action: "deny", pattern: "*" },
-      ],
+        { permission: "task", action: "deny", pattern: "*" },
+      ]),
     })
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.test.ts
@@ -35,4 +35,39 @@ describe("createSyncSession", () => {
       ],
     })
   })
+
+  test("creates child session with category tool permission rules", async () => {
+    // given
+    const createCalls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child" } }
+        },
+      },
+    }
+
+    // when
+    const result = await createSyncSession(client as never, {
+      parentSessionID: "ses_parent",
+      agentToUse: "sisyphus-junior",
+      description: "test task",
+      defaultDirectory: "/fallback",
+      categoryTools: { grep: false, glob: true },
+    })
+
+    // then
+    expect(result.ok).toBe(true)
+    expect(createCalls[0]?.body).toEqual({
+      parentID: "ses_parent",
+      title: "test task (@sisyphus-junior subagent)",
+      permission: [
+        { permission: "grep", action: "deny", pattern: "*" },
+        { permission: "glob", action: "allow", pattern: "*" },
+        { permission: "question", action: "deny", pattern: "*" },
+      ],
+    })
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
@@ -25,7 +25,7 @@ export async function createSyncSession(
       title: `${input.description} (@${input.agentToUse} subagent)`,
       permission: buildDelegateSessionPermission(
         input.categoryTools,
-        getAgentToolRestrictions(input.agentToUse),
+        getAgentToolRestrictions(input.agentToUse, { model: input.categoryModel?.modelID }),
       ),
       ...(input.categoryModel
         ? {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
@@ -1,6 +1,7 @@
 import type { OpencodeClient } from "./types"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
+import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
 
 export async function createSyncSession(
   client: OpencodeClient,
@@ -22,7 +23,10 @@ export async function createSyncSession(
     body: {
       parentID: input.parentSessionID,
       title: `${input.description} (@${input.agentToUse} subagent)`,
-      permission: buildDelegateSessionPermission(input.categoryTools),
+      permission: buildDelegateSessionPermission(
+        input.categoryTools,
+        getAgentToolRestrictions(input.agentToUse),
+      ),
       ...(input.categoryModel
         ? {
             model: {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-creator.ts
@@ -1,6 +1,6 @@
 import type { OpencodeClient } from "./types"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
-import { QUESTION_DENIED_SESSION_PERMISSION } from "../../shared/question-denied-session-permission"
+import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
 
 export async function createSyncSession(
   client: OpencodeClient,
@@ -10,6 +10,7 @@ export async function createSyncSession(
     description: string
     defaultDirectory: string
     categoryModel?: DelegatedModelConfig
+    categoryTools?: Record<string, boolean>
   }
 ): Promise<{ ok: true; sessionID: string; parentDirectory: string } | { ok: false; error: string }> {
   const parentSession = client.session.get
@@ -21,7 +22,7 @@ export async function createSyncSession(
     body: {
       parentID: input.parentSessionID,
       title: `${input.description} (@${input.agentToUse} subagent)`,
-      permission: QUESTION_DENIED_SESSION_PERMISSION,
+      permission: buildDelegateSessionPermission(input.categoryTools),
       ...(input.categoryModel
         ? {
             model: {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -18,6 +18,7 @@ export async function registerSyncSessionSideEffects(input: {
   readonly agentToUse: string
   readonly fallbackChain: import("../../shared/model-requirements").FallbackEntry[] | undefined
   readonly systemContent: string | undefined
+  readonly categoryTools?: Record<string, boolean>
 }): Promise<void> {
   subagentSessions.add(input.sessionID)
   syncSubagentSessions.add(input.sessionID)
@@ -29,7 +30,7 @@ export async function registerSyncSessionSideEffects(input: {
     fallbackChain: input.fallbackChain,
     category: input.args.category,
     system: input.systemContent,
-    tools: buildSyncPromptTools(input.agentToUse),
+    tools: buildSyncPromptTools(input.agentToUse, input.categoryTools),
     modelFallbackControllerAccessor: input.executorCtx.modelFallbackControllerAccessor,
   })
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-lifecycle.ts
@@ -8,7 +8,7 @@ import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import { buildTaskPrompt } from "./prompt-builder"
 import { buildSyncPromptTools } from "./sync-prompt-sender"
-import type { DelegateTaskArgs } from "./types"
+import type { DelegatedModelConfig, DelegateTaskArgs } from "./types"
 
 export async function registerSyncSessionSideEffects(input: {
   readonly args: DelegateTaskArgs
@@ -18,6 +18,7 @@ export async function registerSyncSessionSideEffects(input: {
   readonly agentToUse: string
   readonly fallbackChain: import("../../shared/model-requirements").FallbackEntry[] | undefined
   readonly systemContent: string | undefined
+  readonly categoryModel: DelegatedModelConfig | undefined
   readonly categoryTools?: Record<string, boolean>
 }): Promise<void> {
   subagentSessions.add(input.sessionID)
@@ -30,7 +31,7 @@ export async function registerSyncSessionSideEffects(input: {
     fallbackChain: input.fallbackChain,
     category: input.args.category,
     system: input.systemContent,
-    tools: buildSyncPromptTools(input.agentToUse, input.categoryTools),
+    tools: buildSyncPromptTools(input.agentToUse, input.categoryTools, input.categoryModel?.modelID),
     modelFallbackControllerAccessor: input.executorCtx.modelFallbackControllerAccessor,
   })
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
@@ -27,6 +27,7 @@ type SyncTaskRunnerInput = {
   readonly systemContent: string | undefined
   readonly toastManager: TaskToastManager | undefined
   readonly modelInfo: ModelFallbackInfo | undefined
+  readonly categoryTools?: Record<string, boolean>
   readonly registerSyncSession: (newSessionID: string) => Promise<void>
   readonly publishSyncMetadata: (
     currentSessionID: string,
@@ -74,6 +75,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
     systemContent,
     toastManager,
     modelInfo,
+    categoryTools,
     registerSyncSession,
     publishSyncMetadata,
     cleanupRetrySession,
@@ -104,6 +106,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
       taskId,
       sisyphusAgentConfig,
       categoryModel: effectiveCategoryModel,
+      categoryTools,
     })
     if (promptError) {
       const promptResult = await retrySyncPromptWithFallbacks({
@@ -122,6 +125,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
             taskId,
             sisyphusAgentConfig,
             categoryModel: fallbackModel,
+            categoryTools,
           })
         },
       })
@@ -175,6 +179,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
         description: args.description,
         defaultDirectory: directory,
         categoryModel: nextFallbackModel,
+        categoryTools,
       })
       if (!retrySessionResult.ok) {
         return retrySessionResult.error

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task-runner.ts
@@ -28,7 +28,7 @@ type SyncTaskRunnerInput = {
   readonly toastManager: TaskToastManager | undefined
   readonly modelInfo: ModelFallbackInfo | undefined
   readonly categoryTools?: Record<string, boolean>
-  readonly registerSyncSession: (newSessionID: string) => Promise<void>
+  readonly registerSyncSession: (newSessionID: string, currentModel: DelegatedModelConfig | undefined) => Promise<void>
   readonly publishSyncMetadata: (
     currentSessionID: string,
     currentModel: DelegatedModelConfig | undefined,
@@ -188,7 +188,7 @@ export async function runSyncTaskLoop(input: SyncTaskRunnerInput): Promise<strin
       activeSessionID = retrySessionResult.sessionID
       setSyncSessionID(activeSessionID)
       effectiveCategoryModel = nextFallbackModel
-      await registerSyncSession(activeSessionID)
+      await registerSyncSession(activeSessionID, effectiveCategoryModel)
       addRetryTaskToast({
         args,
         agentToUse,

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -12,6 +12,10 @@ import { runSyncTaskLoop } from "./sync-task-runner"
 import { cleanupSyncSessionSideEffects, registerSyncSessionSideEffects } from "./sync-session-lifecycle"
 import type { DelegatedModelConfig, DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 
+function isSyncTaskDeps(value: SyncTaskDeps | Record<string, boolean>): value is SyncTaskDeps {
+  return typeof value.sendSyncPrompt === "function"
+}
+
 export async function executeSyncTask(
   args: DelegateTaskArgs,
   ctx: ToolContextWithMetadata,
@@ -22,8 +26,12 @@ export async function executeSyncTask(
   systemContent: string | undefined,
   modelInfo?: ModelFallbackInfo,
   fallbackChain?: FallbackEntry[],
-  deps: SyncTaskDeps = syncTaskDeps
+  depsOrCategoryTools: SyncTaskDeps | Record<string, boolean> = syncTaskDeps,
+  categoryToolsForDeps?: Record<string, boolean>,
 ): Promise<string> {
+  const hasDeps = isSyncTaskDeps(depsOrCategoryTools)
+  const deps = hasDeps ? depsOrCategoryTools : syncTaskDeps
+  const categoryTools = hasDeps ? categoryToolsForDeps : depsOrCategoryTools
   const { client, directory, syncPollTimeoutMs } = executorCtx
   const toastManager = getTaskToastManager()
   let taskId: string | undefined
@@ -43,6 +51,7 @@ export async function executeSyncTask(
       description: args.description,
       defaultDirectory: directory,
       categoryModel,
+      categoryTools,
     })
 
     if (!createSessionResult.ok) {
@@ -64,6 +73,7 @@ export async function executeSyncTask(
         agentToUse,
         fallbackChain,
         systemContent,
+        categoryTools,
       })
     }
 
@@ -131,6 +141,7 @@ export async function executeSyncTask(
         systemContent,
         toastManager: toastManager ?? undefined,
         modelInfo,
+        categoryTools,
         registerSyncSession,
         publishSyncMetadata,
         cleanupRetrySession,

--- a/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-task.ts
@@ -63,7 +63,10 @@ export async function executeSyncTask(
     spawnReservation?.commit()
     syncSessionID = sessionID
 
-    const registerSyncSession = async (newSessionID: string): Promise<void> => {
+    const registerSyncSession = async (
+      newSessionID: string,
+      currentModel: DelegatedModelConfig | undefined,
+    ): Promise<void> => {
       syncSessionID = newSessionID
       await registerSyncSessionSideEffects({
         args,
@@ -73,6 +76,7 @@ export async function executeSyncTask(
         agentToUse,
         fallbackChain,
         systemContent,
+        categoryModel: currentModel,
         categoryTools,
       })
     }
@@ -93,7 +97,7 @@ export async function executeSyncTask(
       })
     }
 
-    await registerSyncSession(sessionID)
+    await registerSyncSession(sessionID, categoryModel)
 
     taskId = `sync_${sessionID.slice(0, 8)}`
     const startTime = new Date()

--- a/packages/omo-opencode/src/tools/delegate-task/tools.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.ts
@@ -125,6 +125,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       let isUnstableAgent = false
       let fallbackChain: import("../../shared/model-requirements").FallbackEntry[] | undefined
       let maxPromptTokens: number | undefined
+      let categoryTools: Record<string, boolean> | undefined
 
       if (delegateTaskArgs.category) {
         const resolution = await resolveCategoryExecution(delegateTaskArgs, options, inheritedModel, systemDefaultModel)
@@ -139,6 +140,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         isUnstableAgent = resolution.isUnstableAgent
         fallbackChain = resolution.fallbackChain
         maxPromptTokens = resolution.maxPromptTokens
+        categoryTools = resolution.categoryTools
 
         const isRunInBackgroundExplicitlyFalse = isExplicitSyncRun(delegateTaskArgs.run_in_background)
 
@@ -164,7 +166,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
             availableSkills,
             nativeSkillInfos: nativeSkillEntries,
           })
-          return executeUnstableAgentTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
+          return executeUnstableAgentTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel, categoryTools)
         }
       } else {
         const resolution = await resolveSubagentExecution(delegateTaskArgs, options, parentContext.agent, categoryExamples)
@@ -189,10 +191,10 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       })
 
       if (runInBackground) {
-        return executeBackgroundTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, fallbackChain)
+        return executeBackgroundTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, fallbackChain, categoryTools)
       }
 
-      return executeSyncTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, modelInfo, fallbackChain)
+      return executeSyncTask(delegateTaskArgs, ctx, options, parentContext, agentToUse, categoryModel, systemContent, modelInfo, fallbackChain, categoryTools)
     },
   })
 }

--- a/packages/omo-opencode/src/tools/delegate-task/unstable-agent-permission.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/unstable-agent-permission.test.ts
@@ -68,8 +68,9 @@ describe("executeUnstableAgentTask session permission", () => {
 
     // then
     expect(launchCalls).toHaveLength(1)
-    expect(launchCalls[0]?.sessionPermission).toEqual([
+    expect(launchCalls[0]?.sessionPermission).toEqual(expect.arrayContaining([
       { permission: "question", action: "deny", pattern: "*" },
-    ])
+      { permission: "task", action: "deny", pattern: "*" },
+    ]))
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/unstable-agent-permission.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/unstable-agent-permission.test.ts
@@ -61,9 +61,10 @@ describe("executeUnstableAgentTask session permission", () => {
       executorContext,
       parentContext,
       "sisyphus-junior",
+      { providerID: "openai", modelID: "gpt-5.4-mini" },
       undefined,
-      undefined,
-      "test-model",
+      "openai/gpt-5.4-mini",
+      { apply_patch: true },
     )
 
     // then
@@ -71,6 +72,7 @@ describe("executeUnstableAgentTask session permission", () => {
     expect(launchCalls[0]?.sessionPermission).toEqual(expect.arrayContaining([
       { permission: "question", action: "deny", pattern: "*" },
       { permission: "task", action: "deny", pattern: "*" },
+      { permission: "apply_patch", action: "deny", pattern: "*" },
     ]))
   })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
@@ -8,7 +8,7 @@ import { formatDuration } from "./time-formatter"
 import { formatDetailedError } from "./error-formatting"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { normalizeSDKResponse } from "../../shared"
-import { QUESTION_DENIED_SESSION_PERMISSION } from "../../shared/question-denied-session-permission"
+import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
 import { resolveMetadataModel } from "./resolve-metadata-model"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 
@@ -20,7 +20,8 @@ export async function executeUnstableAgentTask(
   agentToUse: string,
   categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
-  actualModel: string | undefined
+  actualModel: string | undefined,
+  categoryTools?: Record<string, boolean>,
 ): Promise<string> {
   const { manager, client, syncPollTimeoutMs, sisyphusAgentConfig } = executorCtx
   let cleanupReason: string | undefined
@@ -42,7 +43,8 @@ export async function executeUnstableAgentTask(
       skills: args.load_skills.length > 0 ? args.load_skills : undefined,
       skillContent: systemContent,
       category: args.category,
-      sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+      categoryTools,
+      sessionPermission: buildDelegateSessionPermission(categoryTools),
     })
     launchedTaskID = task.id
 

--- a/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
@@ -47,7 +47,7 @@ export async function executeUnstableAgentTask(
       categoryTools,
       sessionPermission: buildDelegateSessionPermission(
         categoryTools,
-        getAgentToolRestrictions(agentToUse),
+        getAgentToolRestrictions(agentToUse, { model: categoryModel?.modelID ?? actualModel }),
       ),
     })
     launchedTaskID = task.id

--- a/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/unstable-agent-task.ts
@@ -9,6 +9,7 @@ import { formatDetailedError } from "./error-formatting"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { normalizeSDKResponse } from "../../shared"
 import { buildDelegateSessionPermission } from "../../shared/delegate-tool-overrides"
+import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
 import { resolveMetadataModel } from "./resolve-metadata-model"
 import { buildTaskMetadataBlock } from "../../features/tool-metadata-store/task-metadata-contract"
 
@@ -44,7 +45,10 @@ export async function executeUnstableAgentTask(
       skillContent: systemContent,
       category: args.category,
       categoryTools,
-      sessionPermission: buildDelegateSessionPermission(categoryTools),
+      sessionPermission: buildDelegateSessionPermission(
+        categoryTools,
+        getAgentToolRestrictions(agentToUse),
+      ),
     })
     launchedTaskID = task.id
 


### PR DESCRIPTION
## Summary
Refs #5182.

`task(category=...)` now carries `categories.<name>.tools` into the child session:

- category resolution returns the configured tool map
- sync and background launches add matching session permission rules
- prompt tool masks get the same category tool overrides
- fallback retries keep the category tool map
- agent hard denies still win when a category tries to allow a blocked tool
- GPT Sisyphus-Junior model denies still win when a category tries to allow `apply_patch`

Agent-level `agents.sisyphus-junior.tools` is covered separately in #5199.

## Verification
- RED: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-red.txt`
- Hard-deny RED: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-hard-deny-red.txt`
- Model-deny RED: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-apply-patch-red.txt`
- GREEN: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-apply-patch-suite-final.txt`
- Typecheck: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-apply-patch-typecheck-final.txt`
- Diff check: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-apply-patch-diff-check-final.txt`
- OpenCode QA, category `apply_patch` denied in the child session: `/mnt/c/Users/Han/.omo/evidence/task-6-opencode-real-category-apply-patch-deny-final.txt`
- Push: `/mnt/c/Users/Han/.omo/evidence/task-6-category-tools-apply-patch-push.txt`

Plan: `.omo/plans/quick-fix-pr-waves-20260612.md`
