### PR TITLE
chore: Ignore workspace and backup directories globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ plans/
 !.claude/skills
 !.claude/commands
 !.claude/settings.json
+
+.omg/
+*-backup/


### PR DESCRIPTION
### Description
This PR introduces preventative `.gitignore` rules to keep the repository clean from agent workspace residue and accidental backup commits.

### Changes
- Adds `.omg/` to ignore local OhMyOpenAgent state/intent tracking directories.
- Adds `*-backup/` to globally ignore backup directories (such as `lsp-tools-mcp-backup/`). This prevents indiscriminate `git add .` operations from accidentally staging massive directories of untracked files into the version history.