### PR TITLE
feat(background-agent): persist background tasks across OpenCode restarts

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6168,6 +6168,10 @@
           "minimum": 10,
           "maximum": 9007199254740991
         },
+        "persistence": {
+          "description": "Persist background task snapshots to <project>/.omo/background-tasks for restart recovery (default: true)",
+          "type": "boolean"
+        },
         "circuitBreaker": {
           "type": "object",
           "properties": {

--- a/packages/omo-opencode/src/config/schema/background-task.test.ts
+++ b/packages/omo-opencode/src/config/schema/background-task.test.ts
@@ -72,4 +72,36 @@ describe("BackgroundTaskConfigSchema", () => {
       })
     })
   })
+
+  describe("persistence", () => {
+    describe("#given valid persistence (false)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = BackgroundTaskConfigSchema.parse({ persistence: false })
+
+        expect(result.persistence).toBe(false)
+      })
+    })
+
+    describe("#given persistence not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = BackgroundTaskConfigSchema.parse({})
+
+        expect(result.persistence).toBeUndefined()
+      })
+    })
+
+    describe('#given persistence is non-boolean ("x")', () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+
+        try {
+          BackgroundTaskConfigSchema.parse({ persistence: "x" })
+        } catch (error) {
+          thrownError = error
+        }
+
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+  })
 })

--- a/packages/omo-opencode/src/config/schema/background-task.ts
+++ b/packages/omo-opencode/src/config/schema/background-task.ts
@@ -24,6 +24,8 @@ export const BackgroundTaskConfigSchema = z.object({
   syncPollTimeoutMs: z.number().min(60000).optional(),
   /** Maximum tool calls per subagent task before circuit breaker triggers (default: 200, minimum: 10). Prevents runaway loops from burning unlimited tokens. */
   maxToolCalls: z.number().int().min(10).optional(),
+  /** Persist background task snapshots to <project>/.omo/background-tasks for restart recovery (default: true) */
+  persistence: z.boolean().optional().describe("Persist background task snapshots to <project>/.omo/background-tasks for restart recovery (default: true)"),
   circuitBreaker: CircuitBreakerConfigSchema.optional(),
 })
 

--- a/packages/omo-opencode/src/create-managers.ts
+++ b/packages/omo-opencode/src/create-managers.ts
@@ -166,6 +166,13 @@ export function createManagers(args: {
     modelFallbackControllerAccessor,
   })
 
+  // Reconcile persisted background-task snapshots from a previous process so
+  // background_output can reach them after an OpenCode restart. Fire-and-forget:
+  // construction must stay synchronous and a failure must not block init.
+  void backgroundManager.restorePersistedTasks().catch((error) => {
+    log("[create-managers] restorePersistedTasks failed:", error)
+  })
+
   deps.initTaskToastManagerFn(ctx.client)
 
   const skillMcpManager = new deps.SkillMcpManagerClass()

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -63,9 +63,10 @@ export async function tryFallbackRetry(args: {
     failedError?: string
     nextModel: string
   }) => void
+  persistTask?: (task: BackgroundTask) => void
   deps?: Partial<FallbackRetryHandlerDeps>
 }): Promise<boolean> {
-  const { task, errorInfo, source, concurrencyManager, client, idleDeferralTimers, queuesByKey, processKey, onRetrying } = args
+  const { task, errorInfo, source, concurrencyManager, client, idleDeferralTimers, queuesByKey, processKey, onRetrying, persistTask } = args
   const deps = { ...defaultFallbackRetryHandlerDeps, ...args.deps }
   const fallbackChain = task.fallbackChain
   const canRetry =
@@ -223,6 +224,9 @@ export async function tryFallbackRetry(args: {
     onSessionCreated: task.onSessionCreated,
   }
 
+  // Persist the re-queued pending task (sessionId cleared by startAttempt) before
+  // the abort await so a crash during abort cannot lose the pending state (F4).
+  persistTask?.(task)
   if (previousSessionID) {
     await abortWithTimeout(client, previousSessionID).catch(() => {})
   }

--- a/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
-import type { PersistedTaskSnapshot } from "./task-persistence"
+import { createTaskPersistenceStore, type PersistedTaskSnapshot, type TaskPersistenceStore } from "./task-persistence"
 import { BackgroundManager } from "./manager"
 import { clearBackgroundTaskRegistryForTesting, getRegisteredBackgroundTask } from "./task-registry"
 import type { BackgroundTask, BackgroundTaskStatus } from "./types"
@@ -16,8 +16,14 @@ function cast<T>(value: unknown): T {
 type ManagerInternals = {
   tasks: Map<string, BackgroundTask>
   tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
+  tryFallbackRetry: (
+    task: BackgroundTask,
+    errorInfo: { name?: string; message?: string; statusCode?: number },
+    source: string,
+  ) => Promise<boolean>
   scheduleTaskRemoval: (taskId: string) => void
   removeTask: (task: BackgroundTask) => void
+  checkAndInterruptStaleTasks: (statuses?: Record<string, { type: string }>) => Promise<void>
 }
 
 function internals(manager: BackgroundManager): ManagerInternals {
@@ -60,16 +66,51 @@ function createManager(args: {
   directory: string
   client: unknown
   persistence?: boolean
+  persistenceStore?: TaskPersistenceStore
 }): BackgroundManager {
   const manager = new BackgroundManager({
     pluginContext: cast<PluginInput>({ client: args.client, directory: args.directory }),
     config: args.persistence === undefined ? undefined : { persistence: args.persistence },
+    persistenceStore: args.persistenceStore,
     // Disabled so notifyParentSession takes the no-op branch yet still funnels
     // terminal tasks into scheduleTaskRemoval (where the snapshot is persisted).
     enableParentSessionNotifications: false,
   })
   createdManagers.push(manager)
   return manager
+}
+
+type PersistRecord = { status: BackgroundTaskStatus; sessionId: string | undefined }
+
+// A TaskPersistenceStore double that records the status/sessionId of every
+// persist call (preserving order against external markers like "abort") while
+// delegating to a real disk store so on-disk assertions still hold.
+function createRecordingStore(
+  directory: string,
+  events: string[],
+  records: PersistRecord[],
+): TaskPersistenceStore {
+  const real = createTaskPersistenceStore({ directory })
+  return {
+    persist(task) {
+      events.push(`persist:${task.status}`)
+      records.push({ status: task.status, sessionId: task.sessionId })
+      real.persist(task)
+    },
+    persistSnapshot(snapshot) {
+      real.persistSnapshot(snapshot)
+    },
+    delete(taskId) {
+      events.push("delete")
+      real.delete(taskId)
+    },
+    listSnapshots() {
+      return real.listSnapshots()
+    },
+    gcOlderThan(maxAgeMs, now) {
+      real.gcOlderThan(maxAgeMs, now)
+    },
+  }
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
@@ -128,6 +169,161 @@ describe("BackgroundManager snapshot persistence", () => {
       const snapshot = readSnapshot(directory, task.id)
       expect(snapshot.status).toBe("running")
       expect(snapshot.sessionId).toBe("ses_launch")
+    })
+  })
+
+  describe("#given a task is launched but its session has not yet bound (F2)", () => {
+    test("#when launch returns #then a pending snapshot is persisted without a sessionId", async () => {
+      // given a client whose session.create never resolves, so the task is
+      // persisted while still pending and never reaches the running/bound state.
+      const neverResolves = new Promise<never>(() => {})
+      const client = {
+        session: {
+          get: async () => ({ data: { directory: tmpdir() } }),
+          create: () => neverResolves,
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          abort: async () => ({ data: {} }),
+        },
+      }
+      const manager = createManager({ directory, client })
+
+      // when
+      const launched = await manager.launch({
+        description: "queued persist test",
+        prompt: "do work",
+        agent: "general",
+        parentSessionId: "ses_parent",
+        parentMessageId: "msg_parent",
+      })
+      await waitFor(() => existsSync(snapshotPathFor(directory, launched.id)))
+
+      // then
+      expect(existsSync(snapshotPathFor(directory, launched.id))).toBe(true)
+      const snapshot = readSnapshot(directory, launched.id)
+      expect(snapshot.status).toBe("pending")
+      expect(snapshot.sessionId).toBeUndefined()
+    })
+  })
+
+  describe("#given a running task with a recording persistence store (F3)", () => {
+    test("#when it completes #then the terminal snapshot is persisted before the session-abort side effect", async () => {
+      // given a recording store and a client whose abort records its ordering
+      const events: string[] = []
+      const records: PersistRecord[] = []
+      const store = createRecordingStore(directory, events, records)
+      const client = {
+        session: {
+          get: async () => ({ data: { directory: tmpdir() } }),
+          create: async () => ({ data: { id: "ses_order" } }),
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          abort: async () => {
+            events.push("abort")
+            return { data: {} }
+          },
+        },
+      }
+      const manager = createManager({ directory, client, persistenceStore: store })
+      const task = await launchAndAwaitRunning(manager, directory)
+
+      // when
+      await internals(manager).tryCompleteTask(task, "test")
+
+      // then the completed status must be persisted before the abort await runs
+      const completedIndex = events.indexOf("persist:completed")
+      const abortIndex = events.indexOf("abort")
+      expect(completedIndex).toBeGreaterThanOrEqual(0)
+      expect(abortIndex).toBeGreaterThanOrEqual(0)
+      expect(completedIndex).toBeLessThan(abortIndex)
+    })
+  })
+
+  describe("#given a running task that hits a retryable error (F4)", () => {
+    test("#when a fallback retry is scheduled #then the pending snapshot is persisted before the session-abort await resolves", async () => {
+      // given a recording store and a client whose abort resolves only after a delay
+      const events: string[] = []
+      const records: PersistRecord[] = []
+      const store = createRecordingStore(directory, events, records)
+      const client = {
+        session: {
+          get: async () => ({ data: { directory: tmpdir() } }),
+          create: async () => ({ data: { id: "ses_retry" } }),
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          abort: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50))
+            events.push("abort-resolved")
+            return { data: {} }
+          },
+        },
+      }
+      const manager = createManager({ directory, client, persistenceStore: store })
+      const task = await launchAndAwaitRunning(manager, directory)
+      task.model = { providerID: "provider-a", modelID: "original-model" }
+      task.fallbackChain = [
+        { model: "fallback-model-1", providers: ["provider-b"], variant: undefined },
+      ]
+      task.attemptCount = 0
+      const recordsBefore = records.length
+      const eventsBefore = events.length
+
+      // when
+      const retried = await internals(manager).tryFallbackRetry(
+        task,
+        { message: "model overloaded" },
+        "test",
+      )
+
+      // then a pending snapshot with no sessionId is persisted
+      expect(retried).toBe(true)
+      const pendingPersist = records
+        .slice(recordsBefore)
+        .find((record) => record.status === "pending")
+      expect(pendingPersist).toBeDefined()
+      expect(pendingPersist?.sessionId).toBeUndefined()
+
+      // and that persist landed before the abort await resolved
+      const tail = events.slice(eventsBefore)
+      const pendingIndex = tail.indexOf("persist:pending")
+      const abortIndex = tail.indexOf("abort-resolved")
+      expect(pendingIndex).toBeGreaterThanOrEqual(0)
+      expect(abortIndex).toBeGreaterThanOrEqual(0)
+      expect(pendingIndex).toBeLessThan(abortIndex)
+    })
+  })
+
+  describe("#given a stale running task with a recording persistence store (F3)", () => {
+    test("#when checkAndInterruptStaleTasks cancels it #then the cancelled status is persisted", async () => {
+      // given a recording store and a running task far past the staleness timeout
+      const events: string[] = []
+      const records: PersistRecord[] = []
+      const store = createRecordingStore(directory, events, records)
+      const manager = createManager({
+        directory,
+        client: createFakeClient("ses_stale"),
+        persistenceStore: store,
+      })
+      const task = await launchAndAwaitRunning(manager, directory)
+      task.startedAt = new Date(0)
+      task.progress = undefined
+      // Stub the parent-notification path so the cancellation can only be
+      // persisted by the poller's onTaskInterrupted callback, not by the
+      // incidental scheduleTaskRemoval persist inside notifyParentSession.
+      cast<{ notifyParentSession: (task: BackgroundTask) => Promise<void> }>(
+        manager,
+      ).notifyParentSession = async () => {}
+      const recordsBefore = records.length
+
+      // when the stale sweep runs with no live session status registry
+      await internals(manager).checkAndInterruptStaleTasks(undefined)
+
+      // then the cancellation was persisted via onTaskInterrupted
+      const cancelledPersist = records
+        .slice(recordsBefore)
+        .find((record) => record.status === "cancelled")
+      expect(cancelledPersist).toBeDefined()
+      expect(task.status).toBe("cancelled")
     })
   })
 
@@ -499,6 +695,32 @@ describe("BackgroundManager.restorePersistedTasks", () => {
         }
       }
       expect(retrievable).toBe(100)
+    })
+  })
+
+  describe("#given a pending no-session snapshot owned by a dead process (F2)", () => {
+    test("#when manager B restores #then getTask resolves an error task 'session lost across restart'", async () => {
+      // given a pending snapshot that never bound a session, owned by a dead process
+      const id = "bg_f2_no_session"
+      writeSnapshotToDisk(
+        directory,
+        makeSnapshot({
+          id,
+          status: "pending",
+          sessionId: undefined,
+          parentSessionId: "ses_parent",
+        }),
+      )
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const manager = createManager({ directory, client: createFakeClient("ses_f2") })
+      await manager.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then the recovered terminal error task is reachable via getTask
+      const restored = manager.getTask(id)
+      expect(restored?.status).toBe("error")
+      expect(restored?.error).toContain("session lost across restart")
     })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
@@ -1,0 +1,277 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
+import type { PersistedTaskSnapshot } from "./task-persistence"
+import { BackgroundManager } from "./manager"
+import { clearBackgroundTaskRegistryForTesting } from "./task-registry"
+import type { BackgroundTask, BackgroundTaskStatus } from "./types"
+
+function cast<T>(value: unknown): T {
+  return value as T
+}
+
+type ManagerInternals = {
+  tasks: Map<string, BackgroundTask>
+  tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
+  scheduleTaskRemoval: (taskId: string) => void
+  removeTask: (task: BackgroundTask) => void
+}
+
+function internals(manager: BackgroundManager): ManagerInternals {
+  return cast<ManagerInternals>(manager)
+}
+
+function tasksDirFor(directory: string): string {
+  return join(directory, ".omo", "background-tasks")
+}
+
+function snapshotPathFor(directory: string, taskId: string): string {
+  return join(tasksDirFor(directory), `${taskId}.json`)
+}
+
+function readSnapshot(directory: string, taskId: string): PersistedTaskSnapshot {
+  return JSON.parse(readFileSync(snapshotPathFor(directory, taskId), "utf-8")) as PersistedTaskSnapshot
+}
+
+function createFakeClient(sessionId: string, options?: { promptRejection?: unknown }) {
+  return {
+    session: {
+      get: async () => ({ data: { directory: tmpdir() } }),
+      create: async () => ({ data: { id: sessionId } }),
+      prompt: async () => {
+        if (options?.promptRejection) throw options.promptRejection
+        return { data: {} }
+      },
+      promptAsync: async () => {
+        if (options?.promptRejection) throw options.promptRejection
+        return { data: {} }
+      },
+      abort: async () => ({ data: {} }),
+    },
+  }
+}
+
+const createdManagers: BackgroundManager[] = []
+
+function createManager(args: {
+  directory: string
+  client: unknown
+  persistence?: boolean
+}): BackgroundManager {
+  const manager = new BackgroundManager({
+    pluginContext: cast<PluginInput>({ client: args.client, directory: args.directory }),
+    config: args.persistence === undefined ? undefined : { persistence: args.persistence },
+    // Disabled so notifyParentSession takes the no-op branch yet still funnels
+    // terminal tasks into scheduleTaskRemoval (where the snapshot is persisted).
+    enableParentSessionNotifications: false,
+  })
+  createdManagers.push(manager)
+  return manager
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt >= timeoutMs) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
+async function launchAndAwaitRunning(
+  manager: BackgroundManager,
+  directory: string,
+): Promise<BackgroundTask> {
+  const launched = await manager.launch({
+    description: "persist test",
+    prompt: "do work",
+    agent: "general",
+    parentSessionId: "ses_parent",
+    parentMessageId: "msg_parent",
+  })
+  await waitFor(() => existsSync(snapshotPathFor(directory, launched.id)))
+  const tracked = internals(manager).tasks.get(launched.id)
+  await waitFor(() => internals(manager).tasks.get(launched.id)?.status === "running")
+  return tracked ?? launched
+}
+
+let directory: string
+
+beforeEach(() => {
+  clearBackgroundTaskRegistryForTesting()
+  releaseAllPromptAsyncReservationsForTesting()
+  directory = mkdtempSync(join(tmpdir(), "omo-bg-persist-"))
+})
+
+afterEach(() => {
+  for (const manager of createdManagers.splice(0)) {
+    manager.shutdown()
+  }
+  clearBackgroundTaskRegistryForTesting()
+  releaseAllPromptAsyncReservationsForTesting()
+  rmSync(directory, { recursive: true, force: true })
+})
+
+describe("BackgroundManager snapshot persistence", () => {
+  describe("#given a task is launched", () => {
+    test("#when it starts running #then a running snapshot file is written with sessionId", async () => {
+      // given
+      const manager = createManager({ directory, client: createFakeClient("ses_launch") })
+
+      // when
+      const task = await launchAndAwaitRunning(manager, directory)
+
+      // then
+      expect(existsSync(snapshotPathFor(directory, task.id))).toBe(true)
+      const snapshot = readSnapshot(directory, task.id)
+      expect(snapshot.status).toBe("running")
+      expect(snapshot.sessionId).toBe("ses_launch")
+    })
+  })
+
+  describe("#given a running task", () => {
+    test("#when it completes #then the snapshot status is completed", async () => {
+      // given
+      const manager = createManager({ directory, client: createFakeClient("ses_complete") })
+      const task = await launchAndAwaitRunning(manager, directory)
+
+      // when
+      await internals(manager).tryCompleteTask(task, "test")
+
+      // then
+      const snapshot = readSnapshot(directory, task.id)
+      expect(snapshot.status).toBe("completed")
+    })
+
+    test("#when it is cancelled via cancelTask #then the snapshot status is cancelled", async () => {
+      // given
+      const manager = createManager({ directory, client: createFakeClient("ses_cancel") })
+      const task = await launchAndAwaitRunning(manager, directory)
+
+      // when
+      const cancelled = await manager.cancelTask(task.id)
+
+      // then
+      expect(cancelled).toBe(true)
+      const snapshot = readSnapshot(directory, task.id)
+      expect(snapshot.status).toBe("cancelled")
+    })
+  })
+
+  describe("#given a completed task", () => {
+    test("#when it is resumed #then the snapshot status returns to running", async () => {
+      // given
+      const manager = createManager({ directory, client: createFakeClient("ses_resume") })
+      const completed: BackgroundTask = {
+        id: "bg_resume",
+        sessionId: "ses_resume",
+        parentSessionId: "ses_parent",
+        parentMessageId: "msg_parent",
+        description: "resume test",
+        prompt: "say hi",
+        agent: "general",
+        status: "completed",
+        startedAt: new Date(),
+        completedAt: new Date(),
+        concurrencyGroup: "general",
+      }
+      internals(manager).tasks.set(completed.id, completed)
+
+      // when
+      await manager.resume({
+        sessionId: "ses_resume",
+        prompt: "continue",
+        parentSessionId: "ses_parent",
+        parentMessageId: "msg_parent_2",
+      })
+
+      // then
+      const snapshot = readSnapshot(directory, completed.id)
+      expect(snapshot.status).toBe("running")
+    })
+  })
+
+  describe("#given a terminal task funneled through scheduleTaskRemoval", () => {
+    // The error and interrupt terminal states require heavy async scaffolding to
+    // reach through real lifecycle entry points, so the terminal funnel
+    // (scheduleTaskRemoval) is asserted directly: every terminal status that
+    // passes through it must be persisted.
+    const terminalStatuses: BackgroundTaskStatus[] = [
+      "completed",
+      "error",
+      "cancelled",
+      "interrupt",
+    ]
+    for (const status of terminalStatuses) {
+      test(`#when status is ${status} #then the snapshot reflects ${status}`, () => {
+        // given
+        const manager = createManager({ directory, client: createFakeClient("ses_term") })
+        const task: BackgroundTask = {
+          id: `bg_term_${status}`,
+          sessionId: `ses_term_${status}`,
+          parentSessionId: "ses_parent",
+          parentMessageId: "msg_parent",
+          description: "terminal test",
+          prompt: "do work",
+          agent: "general",
+          status,
+          startedAt: new Date(),
+          completedAt: new Date(),
+        }
+        internals(manager).tasks.set(task.id, task)
+
+        // when
+        internals(manager).scheduleTaskRemoval(task.id)
+
+        // then
+        const snapshot = readSnapshot(directory, task.id)
+        expect(snapshot.status).toBe(status)
+      })
+    }
+  })
+
+  describe("#given a persisted snapshot", () => {
+    test("#when the task is removed #then the snapshot file is deleted", async () => {
+      // given
+      const manager = createManager({ directory, client: createFakeClient("ses_remove") })
+      const task = await launchAndAwaitRunning(manager, directory)
+      expect(existsSync(snapshotPathFor(directory, task.id))).toBe(true)
+
+      // when
+      internals(manager).removeTask(task)
+
+      // then
+      expect(existsSync(snapshotPathFor(directory, task.id))).toBe(false)
+    })
+  })
+
+  describe("#given persistence is disabled via config", () => {
+    test("#when a task is launched and completed #then no snapshot directory is created", async () => {
+      // given
+      const manager = createManager({
+        directory,
+        client: createFakeClient("ses_disabled"),
+        persistence: false,
+      })
+
+      // when
+      const launched = await manager.launch({
+        description: "disabled test",
+        prompt: "do work",
+        agent: "general",
+        parentSessionId: "ses_parent",
+        parentMessageId: "msg_parent",
+      })
+      await waitFor(() => internals(manager).tasks.get(launched.id)?.status === "running")
+      const task = internals(manager).tasks.get(launched.id)
+      if (task) {
+        await internals(manager).tryCompleteTask(task, "test")
+      }
+
+      // then
+      expect(existsSync(tasksDirFor(directory))).toBe(false)
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
@@ -6,7 +6,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import { releaseAllPromptAsyncReservationsForTesting } from "../../shared/prompt-async-gate"
 import type { PersistedTaskSnapshot } from "./task-persistence"
 import { BackgroundManager } from "./manager"
-import { clearBackgroundTaskRegistryForTesting } from "./task-registry"
+import { clearBackgroundTaskRegistryForTesting, getRegisteredBackgroundTask } from "./task-registry"
 import type { BackgroundTask, BackgroundTaskStatus } from "./types"
 
 function cast<T>(value: unknown): T {
@@ -272,6 +272,233 @@ describe("BackgroundManager snapshot persistence", () => {
 
       // then
       expect(existsSync(tasksDirFor(directory))).toBe(false)
+    })
+  })
+})
+
+function deadOwner(): PersistedTaskSnapshot["owner"] {
+  // 999999999 is beyond Linux pid_max, so process.kill(pid, 0) reports ESRCH.
+  return { pid: 999999999, startedAt: new Date().toISOString() }
+}
+
+function makeSnapshot(
+  overrides: Partial<PersistedTaskSnapshot> & { id: string },
+): PersistedTaskSnapshot {
+  return {
+    schema_version: 1,
+    description: "restore test",
+    agent: "general",
+    status: "completed",
+    owner: deadOwner(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function writeSnapshotToDisk(dir: string, snapshot: PersistedTaskSnapshot): void {
+  mkdirSync(tasksDirFor(dir), { recursive: true })
+  writeFileSync(
+    snapshotPathFor(dir, snapshot.id),
+    `${JSON.stringify(snapshot, null, 2)}\n`,
+    "utf-8",
+  )
+}
+
+function createReconcileClient(options: {
+  sessionSurvives: boolean
+}) {
+  return {
+    session: {
+      get: async () =>
+        options.sessionSurvives
+          ? { data: { id: "ses_orphan" } }
+          : { error: { name: "NotFoundError", data: {} } },
+      messages: async () => ({ data: [] }),
+      create: async () => ({ data: { id: "ses_orphan" } }),
+      prompt: async () => ({ data: {} }),
+      promptAsync: async () => ({ data: {} }),
+      abort: async () => ({ data: {} }),
+    },
+  }
+}
+
+describe("BackgroundManager.restorePersistedTasks", () => {
+  describe("#given a terminal snapshot owned by a dead process (S1)", () => {
+    test("#when manager B restores #then getTask and the registry resolve the completed task", async () => {
+      // given
+      const managerA = createManager({ directory, client: createFakeClient("ses_s1") })
+      const task = await launchAndAwaitRunning(managerA, directory)
+      await internals(managerA).tryCompleteTask(task, "test")
+      expect(readSnapshot(directory, task.id).status).toBe("completed")
+
+      // simulate a restart: the snapshot is now owned by a dead process and the
+      // in-memory registry is wiped.
+      const snapshot = readSnapshot(directory, task.id)
+      writeSnapshotToDisk(directory, { ...snapshot, owner: deadOwner() })
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const managerB = createManager({ directory, client: createFakeClient("ses_s1") })
+      await managerB.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then
+      const restored = managerB.getTask(task.id)
+      expect(restored?.status).toBe("completed")
+      expect(getRegisteredBackgroundTask(task.id)).toBeDefined()
+    })
+  })
+
+  describe("#given a snapshot owned by a live process (S2)", () => {
+    test("#when manager B restores #then nothing is restored and the file is byte-identical", async () => {
+      // given
+      const id = "bg_s2"
+      writeSnapshotToDisk(
+        directory,
+        makeSnapshot({
+          id,
+          sessionId: "ses_s2",
+          status: "completed",
+          owner: { pid: process.pid, startedAt: new Date().toISOString() },
+        }),
+      )
+      clearBackgroundTaskRegistryForTesting()
+      const before = readFileSync(snapshotPathFor(directory, id), "utf-8")
+
+      // when (real default isPidAlive sees process.pid as alive)
+      const manager = createManager({ directory, client: createFakeClient("ses_s2") })
+      await manager.restorePersistedTasks()
+
+      // then
+      expect(manager.getTask(id)).toBeUndefined()
+      const after = readFileSync(snapshotPathFor(directory, id), "utf-8")
+      expect(after).toBe(before)
+    })
+  })
+
+  describe("#given an orphaned running snapshot whose session is lost (S3)", () => {
+    test("#when manager B restores #then the task and snapshot become error 'session lost across restart'", async () => {
+      // given
+      const id = "bg_s3"
+      writeSnapshotToDisk(
+        directory,
+        makeSnapshot({
+          id,
+          sessionId: "ses_orphan",
+          parentSessionId: "ses_parent",
+          status: "running",
+        }),
+      )
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const manager = createManager({
+        directory,
+        client: createReconcileClient({ sessionSurvives: false }),
+      })
+      await manager.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then
+      const restored = manager.getTask(id)
+      expect(restored?.status).toBe("error")
+      expect(restored?.error).toBe("session lost across restart")
+      const snapshot = readSnapshot(directory, id)
+      expect(snapshot.status).toBe("error")
+      expect(snapshot.error).toBe("session lost across restart")
+    })
+
+    test("#when the session survived #then the task becomes interrupt with session_read guidance", async () => {
+      // given
+      const id = "bg_s3_interrupt"
+      writeSnapshotToDisk(
+        directory,
+        makeSnapshot({
+          id,
+          sessionId: "ses_orphan",
+          parentSessionId: "ses_parent",
+          status: "running",
+        }),
+      )
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const manager = createManager({
+        directory,
+        client: createReconcileClient({ sessionSurvives: true }),
+      })
+      await manager.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then
+      const restored = manager.getTask(id)
+      expect(restored?.status).toBe("interrupt")
+      expect(restored?.result).toContain("session_read")
+      expect(readSnapshot(directory, id).status).toBe("interrupt")
+    })
+  })
+
+  describe("#given persistence is disabled", () => {
+    test("#when restorePersistedTasks runs #then it resolves and no directory is created", async () => {
+      // given
+      const manager = createManager({
+        directory,
+        client: createFakeClient("ses_off"),
+        persistence: false,
+      })
+
+      // when
+      await manager.restorePersistedTasks()
+
+      // then
+      expect(existsSync(tasksDirFor(directory))).toBe(false)
+    })
+  })
+
+  describe("#given a corrupt snapshot alongside a good one", () => {
+    test("#when manager B restores #then it does not throw and the good snapshot is restored", async () => {
+      // given
+      mkdirSync(tasksDirFor(directory), { recursive: true })
+      writeFileSync(snapshotPathFor(directory, "bg_corrupt"), "{ not valid json", "utf-8")
+      writeSnapshotToDisk(
+        directory,
+        makeSnapshot({ id: "bg_good", sessionId: "ses_good", status: "completed" }),
+      )
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const manager = createManager({ directory, client: createFakeClient("ses_good") })
+      await manager.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then
+      expect(manager.getTask("bg_good")?.status).toBe("completed")
+      expect(manager.getTask("bg_corrupt")).toBeUndefined()
+    })
+  })
+
+  describe("#given more terminal snapshots than the archive cap", () => {
+    test("#when 105 are restored #then exactly the 100-entry cap is retrievable without crashing", async () => {
+      // given
+      const ids: string[] = []
+      for (let index = 0; index < 105; index++) {
+        const id = `bg_bulk_${String(index).padStart(3, "0")}`
+        ids.push(id)
+        writeSnapshotToDisk(
+          directory,
+          makeSnapshot({ id, sessionId: `ses_${id}`, status: "completed" }),
+        )
+      }
+      clearBackgroundTaskRegistryForTesting()
+
+      // when
+      const manager = createManager({ directory, client: createFakeClient("ses_bulk") })
+      await manager.restorePersistedTasks({ isPidAlive: () => false })
+
+      // then
+      let retrievable = 0
+      for (const id of ids) {
+        if (manager.getTask(id)) {
+          retrievable++
+        }
+      }
+      expect(retrievable).toBe(100)
     })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -106,6 +106,7 @@ import {
 } from "./subagent-spawn-limits"
 import { TaskHistory } from "./task-history"
 import { checkAndInterruptStaleTasks, pruneStaleTasksAndNotifications, type SessionStatusMap } from "./task-poller"
+import { createTaskPersistenceStore, type TaskPersistenceStore } from "./task-persistence"
 import {
   archiveBackgroundTask,
   forgetBackgroundTask,
@@ -278,6 +279,7 @@ export class BackgroundManager {
   private loggedSessionStatusUnavailable = false
   readonly taskHistory = new TaskHistory()
   private cachedCircuitBreakerSettings?: CircuitBreakerSettings
+  private persistenceStore?: TaskPersistenceStore
 
   constructor(config: BackgroundManagerConfig) {
     const { pluginContext, ...options } = config
@@ -299,6 +301,10 @@ export class BackgroundManager {
     this.enableParentSessionNotifications = options?.enableParentSessionNotifications ?? true
     this.modelFallbackControllerAccessor = options?.modelFallbackControllerAccessor
     this.logger = options?.log ?? log
+    const persistenceEnabled = options?.config?.persistence ?? true
+    this.persistenceStore = persistenceEnabled
+      ? createTaskPersistenceStore({ directory: this.directory })
+      : undefined
     this.parentWakeNotifier = new ParentWakeNotifier(
       {
         client: this.client,
@@ -424,10 +430,15 @@ export class BackgroundManager {
     this.tasksByParentSession.set(task.parentSessionId, taskIDs)
   }
 
+  private persistTask(task: BackgroundTask): void {
+    if (task.sessionId) this.persistenceStore?.persist(task)
+  }
+
   private removeTask(task: BackgroundTask): void {
     this.archiveCompletedTask(task)
     archiveBackgroundTask(task)
     this.tasks.delete(task.id)
+    this.persistenceStore?.delete(task.id)
     this.removeTaskFromParentIndex(task.id, task.parentSessionId)
   }
 
@@ -823,6 +834,7 @@ export class BackgroundManager {
     }
     task.concurrencyKey = concurrencyKey
     task.concurrencyGroup = concurrencyKey
+    this.persistTask(task)
 
     if (task.retryNotification) {
       const attemptNumber = boundAttempt.attemptNumber
@@ -1232,6 +1244,7 @@ The fallback retry session is now created and can be inspected directly.
     }
 
     this.addTask(task)
+    this.persistTask(task)
     subagentSessions.add(input.sessionId)
     this.startPolling()
     this.taskHistory.record(input.parentSessionId, { id: task.id, sessionID: input.sessionId, agent: input.agent || "task", description: input.description, status: "running", startedAt: task.startedAt })
@@ -1303,6 +1316,7 @@ The fallback retry session is now created and can be inspected directly.
     }
 
     this.startPolling()
+    this.persistTask(existingTask)
     if (existingTask.sessionId) {
       subagentSessions.add(existingTask.sessionId)
     }
@@ -2260,6 +2274,8 @@ The task was re-queued on a fallback model after a retryable failure.
   }
 
   private scheduleTaskRemoval(taskId: string, rescheduleCount = 0): void {
+    const taskToPersist = this.tasks.get(taskId)
+    if (taskToPersist) this.persistTask(taskToPersist)
     const existingTimer = this.completionTimers.get(taskId)
     if (existingTimer) {
       clearTimeout(existingTimer)
@@ -2735,6 +2751,7 @@ The task was re-queued on a fallback model after a retryable failure.
       notifications: this.notifications,
       taskTtlMs: this.config?.taskTtlMs,
       sessionStatuses: allStatuses,
+      onTaskRemoved: (taskId) => this.persistenceStore?.delete(taskId),
       onTaskPruned: (taskId, task, errorMessage) => {
         const wasPending = task.status === "pending"
         log("[background-agent] Pruning stale task:", { taskId, status: task.status, age: Math.round(((wasPending ? task.queuedAt?.getTime() : task.startedAt?.getTime()) ? (Date.now() - (wasPending ? task.queuedAt!.getTime() : task.startedAt!.getTime())) : 0) / 1000) + "s" })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -106,7 +106,7 @@ import {
 } from "./subagent-spawn-limits"
 import { TaskHistory } from "./task-history"
 import { checkAndInterruptStaleTasks, pruneStaleTasksAndNotifications, type SessionStatusMap } from "./task-poller"
-import { createTaskPersistenceStore, type TaskPersistenceStore } from "./task-persistence"
+import { createTaskPersistenceStore, recoverPersistedTasks, type TaskPersistenceStore } from "./task-persistence"
 import {
   archiveBackgroundTask,
   forgetBackgroundTask,
@@ -465,6 +465,7 @@ export class BackgroundManager {
       model: task.model,
       error: task.error,
       category: task.category,
+      result: task.result,
     }
 
     this.completedTaskArchive.set(task.id, archivedTask)
@@ -475,6 +476,38 @@ export class BackgroundManager {
     const oldestTaskID = this.completedTaskArchive.keys().next().value
     if (typeof oldestTaskID === "string") {
       this.completedTaskArchive.delete(oldestTaskID)
+    }
+  }
+
+  /**
+   * Reconcile persisted task snapshots after an OpenCode restart and surface the
+   * recovered tasks through the same read paths `background_output` already uses
+   * (`completedTaskArchive` + the cross-instance registry). Recovered tasks are
+   * never re-added to `this.tasks`: no polling, notifications, parent-wake, or
+   * prompts are triggered for them. Fire-and-forget safe: the whole body is
+   * wrapped so a failure can never propagate to plugin init.
+   */
+  async restorePersistedTasks(options?: { isPidAlive?: (pid: number) => boolean }): Promise<void> {
+    if (!this.persistenceStore) {
+      return
+    }
+
+    try {
+      const recovered = await recoverPersistedTasks({
+        store: this.persistenceStore,
+        client: this.client,
+        isPidAlive: options?.isPidAlive,
+        logger: this.logger,
+      })
+
+      for (const { task } of recovered) {
+        this.archiveCompletedTask(task)
+        archiveBackgroundTask(task)
+      }
+    } catch (error) {
+      this.logger("[background-agent] restorePersistedTasks failed:", {
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
   }
 

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -238,6 +238,8 @@ export interface BackgroundManagerConfig {
   enableParentSessionNotifications?: boolean
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   log?: typeof log
+  /** Test seam: override the persistence store (e.g. a recording double). Falls back to the disk store. */
+  persistenceStore?: TaskPersistenceStore
 }
 
 export class BackgroundManager {
@@ -302,9 +304,8 @@ export class BackgroundManager {
     this.modelFallbackControllerAccessor = options?.modelFallbackControllerAccessor
     this.logger = options?.log ?? log
     const persistenceEnabled = options?.config?.persistence ?? true
-    this.persistenceStore = persistenceEnabled
-      ? createTaskPersistenceStore({ directory: this.directory })
-      : undefined
+    this.persistenceStore = options?.persistenceStore
+      ?? (persistenceEnabled ? createTaskPersistenceStore({ directory: this.directory }) : undefined)
     this.parentWakeNotifier = new ParentWakeNotifier(
       {
         client: this.client,
@@ -431,7 +432,7 @@ export class BackgroundManager {
   }
 
   private persistTask(task: BackgroundTask): void {
-    if (task.sessionId) this.persistenceStore?.persist(task)
+    this.persistenceStore?.persist(task)
   }
 
   private removeTask(task: BackgroundTask): void {
@@ -443,9 +444,9 @@ export class BackgroundManager {
   }
 
   private archiveCompletedTask(task: BackgroundTask): void {
-    if (!task.sessionId) {
-      return
-    }
+    // Terminal tasks are archived even without a sessionId: recovery surfaces
+    // session-lost tasks here (e.g. a pending-no-session snapshot reconciled to
+    // error), and getTask must be able to resolve them after a restart (F2).
     if (task.status === "running" || task.status === "pending") {
       return
     }
@@ -496,6 +497,7 @@ export class BackgroundManager {
       const recovered = await recoverPersistedTasks({
         store: this.persistenceStore,
         client: this.client,
+        directory: this.directory,
         isPidAlive: options?.isPidAlive,
         logger: this.logger,
       })
@@ -650,6 +652,9 @@ export class BackgroundManager {
       const firstAttempt = startAttempt(task, input.model)
 
       this.addTask(task)
+      // Persist the queued pending task immediately so a crash before the
+      // session binds still leaves a recoverable on-disk snapshot (F2).
+      this.persistTask(task)
       this.taskHistory.record(input.parentSessionId, { id: task.id, agent: input.agent, description: input.description, status: "pending", category: input.category })
 
       // Track for batched notifications immediately (pending state)
@@ -742,6 +747,9 @@ export class BackgroundManager {
             item.task.error = error instanceof Error ? error.message : String(error)
             item.task.completedAt = new Date()
           }
+          // Persist the terminal status before any await so a crash leaves an
+          // accurate on-disk snapshot, not a stale "running" (F3).
+          this.persistTask(item.task)
 
           if (item.task.concurrencyKey) {
             this.concurrencyManager.release(item.task.concurrencyKey)
@@ -1037,6 +1045,7 @@ The fallback retry session is now created and can be inspected directly.
           existingTask.error = terminalError
           existingTask.completedAt = new Date()
         }
+        this.persistTask(existingTask)
         if (existingTask.rootSessionId) {
           this.unregisterRootDescendant(existingTask.rootSessionId)
         }
@@ -1465,6 +1474,7 @@ The fallback retry session is now created and can be inspected directly.
       const errorMessage = errorInfo.message ?? (error instanceof Error ? error.message : String(error))
       existingTask.error = errorMessage
       existingTask.completedAt = new Date()
+      this.persistTask(existingTask)
       if (existingTask.rootSessionId) {
         this.unregisterRootDescendant(existingTask.rootSessionId)
       }
@@ -1963,6 +1973,7 @@ The fallback retry session is now created and can be inspected directly.
       task.error = errorMessage
       task.completedAt = new Date()
     }
+    this.persistTask(task)
 
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
@@ -2078,6 +2089,7 @@ The fallback retry session is now created and can be inspected directly.
       task.error = errorMsg
       task.completedAt = new Date()
     }
+    this.persistTask(task)
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
@@ -2139,6 +2151,7 @@ The fallback retry session is now created and can be inspected directly.
       idleDeferralTimers: this.idleDeferralTimers,
       queuesByKey: this.queuesByKey,
       processKey: (key: string) => this.processKey(key),
+      persistTask: (task) => this.persistTask(task),
       onRetrying: ({ task, source }) => {
         const currentAttempt = getCurrentAttempt(task)
         const previousAttempt = getPreviousAttempt(task, currentAttempt?.attemptId)
@@ -2158,6 +2171,9 @@ The task was re-queued on a fallback model after a retryable failure.
       },
     })
     const retried = await result
+    // Persist the re-queued pending task (sessionId cleared by the retry) right
+    // after scheduling so a crash before the new attempt starts is recoverable (F4).
+    if (retried) this.persistTask(task)
     if (retried && retryingNotification) {
       const parentPromptContext = await this.resolveParentWakePromptContext(task)
       this.queuePendingParentWake(
@@ -2395,6 +2411,7 @@ The task was re-queued on a fallback model after a retryable failure.
         task.error = reason
       }
     }
+    this.persistTask(task)
     if (wasRunning && task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }
@@ -2513,6 +2530,8 @@ The task was re-queued on a fallback model after a retryable failure.
       task.status = "completed"
       task.completedAt = new Date()
     }
+    // Persist the terminal status before the abort/notification awaits below (F3).
+    this.persistTask(task)
     this.taskHistory.record(task.parentSessionId, { id: task.id, sessionID: task.sessionId, agent: task.agent, description: task.description, status: "completed", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
 
     if (task.rootSessionId) {
@@ -2791,6 +2810,7 @@ The task was re-queued on a fallback model after a retryable failure.
         task.status = "error"
         task.error = errorMessage
         task.completedAt = new Date()
+        this.persistTask(task)
         if (!wasPending && task.rootSessionId) {
           this.unregisterRootDescendant(task.rootSessionId)
         }
@@ -2847,6 +2867,10 @@ The task was re-queued on a fallback model after a retryable failure.
       concurrencyManager: this.concurrencyManager,
       notifyParentSession: (task) => this.enqueueNotificationForParent(task.parentSessionId, () => this.notifyParentSession(task)),
       sessionStatuses: allStatuses,
+      onTaskInterrupted: (task) => {
+        this.persistTask(task)
+        removeTaskToastTracking(task.id)
+      },
     })
   }
 
@@ -2862,6 +2886,7 @@ The task was re-queued on a fallback model after a retryable failure.
       task.error = errorMessage
       task.completedAt = new Date()
     }
+    this.persistTask(task)
     if (task.rootSessionId) {
       this.unregisterRootDescendant(task.rootSessionId)
     }

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/index.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/index.ts
@@ -1,0 +1,17 @@
+export {
+	isPidAlive,
+	stampOwner,
+} from "./owner-fencing";
+export {
+	type PersistedModelConfig,
+	type PersistedTaskSnapshot,
+	parseSnapshotFile,
+	type SnapshotOwner,
+	snapshotToTask,
+	taskToSnapshot,
+} from "./snapshot-schema";
+export {
+	type CreateTaskPersistenceStoreOptions,
+	createTaskPersistenceStore,
+	type TaskPersistenceStore,
+} from "./snapshot-store";

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/index.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/index.ts
@@ -3,6 +3,12 @@ export {
 	stampOwner,
 } from "./owner-fencing";
 export {
+	type RecoveredTask,
+	type RecoverPersistedTasksOptions,
+	type RecoveryClient,
+	recoverPersistedTasks,
+} from "./recovery";
+export {
 	type PersistedModelConfig,
 	type PersistedTaskSnapshot,
 	parseSnapshotFile,

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { isPidAlive, stampOwner } from "./owner-fencing";
+
+class ErrnoError extends Error {
+	code?: string;
+	constructor(message: string, code?: string) {
+		super(message);
+		this.code = code;
+	}
+}
+
+describe("owner-fencing", () => {
+	describe("#stampOwner", () => {
+		test("should return stamp with current pid and startedAt ISO string", () => {
+			// given
+			// when
+			const stamp = stampOwner();
+
+			// then
+			expect(stamp.pid).toBe(process.pid);
+			expect(typeof stamp.startedAt).toBe("string");
+			expect(() => new Date(stamp.startedAt).toISOString()).not.toThrow();
+		});
+	});
+
+	describe("#isPidAlive", () => {
+		test("should return true for current process pid with real default", () => {
+			// given
+			const pid = process.pid;
+
+			// when
+			const alive = isPidAlive(pid);
+
+			// then
+			expect(alive).toBe(true);
+		});
+
+		test("should return false for non-positive or non-integer pids", () => {
+			// given
+			const invalidPids = [0, -1, -100, 1.5, NaN, Infinity, -Infinity];
+
+			for (const pid of invalidPids) {
+				// when
+				const alive = isPidAlive(pid);
+
+				// then
+				expect(alive).toBe(false);
+			}
+		});
+
+		test("should return false when injected kill throws ESRCH", () => {
+			// given
+			const pid = 99999;
+			const mockKill = () => {
+				throw new ErrnoError("No such process", "ESRCH");
+			};
+
+			// when
+			const alive = isPidAlive(pid, { kill: mockKill });
+
+			// then
+			expect(alive).toBe(false);
+		});
+
+		test("should return true when injected kill throws EPERM", () => {
+			// given
+			const pid = 99999;
+			const mockKill = () => {
+				throw new ErrnoError("Operation not permitted", "EPERM");
+			};
+
+			// when
+			const alive = isPidAlive(pid, { kill: mockKill });
+
+			// then
+			expect(alive).toBe(true);
+		});
+
+		test("should return false when injected kill throws any other error", () => {
+			// given
+			const pid = 99999;
+			const mockKill = () => {
+				throw new Error("Some other error");
+			};
+
+			// when
+			const alive = isPidAlive(pid, { kill: mockKill });
+
+			// then
+			expect(alive).toBe(false);
+		});
+
+		test("should return true when injected kill does not throw", () => {
+			// given
+			const pid = 99999;
+			const mockKill = () => {
+				// no-op
+			};
+
+			// when
+			const alive = isPidAlive(pid, { kill: mockKill });
+
+			// then
+			expect(alive).toBe(true);
+		});
+	});
+});

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.ts
@@ -1,0 +1,62 @@
+interface ErrnoException extends Error {
+	code?: string;
+}
+
+function isErrnoException(error: unknown): error is ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+/**
+ * Stamps the current process owner information.
+ *
+ * @returns An object containing the current process PID and the start timestamp in ISO format.
+ */
+export function stampOwner(): { pid: number; startedAt: string } {
+	return {
+		pid: process.pid,
+		startedAt: new Date().toISOString(),
+	};
+}
+
+/**
+ * Checks if a process with the given PID is currently alive.
+ *
+ * @param pid - The process ID to check. Must be a positive integer.
+ * @param deps - Optional dependencies for dependency injection.
+ * @param deps.kill - A function to send a signal to a process. Defaults to process.kill.
+ * @returns True if the process is alive or if we cannot determine (e.g., due to permission errors), false otherwise.
+ *
+ * @remarks
+ * **Limitations:**
+ * 1. **PID Recycling:** PID recycling is not fully detectable. If a process dies and its PID is reassigned
+ *    to a new process before this check, it will incorrectly report the process as alive. This is an accepted
+ *    limitation of PID-based fencing.
+ * 2. **Windows Semantics:** On Windows, `process.kill(pid, 0)` semantics differ from POSIX systems. Specifically,
+ *    sending signal 0 is not supported in the same way and may throw or behave differently.
+ *    Using dependency injection (`deps.kill`) keeps the policy unit-testable and cross-platform.
+ */
+export function isPidAlive(
+	pid: number,
+	deps?: { kill?: (pid: number, signal: number) => unknown },
+): boolean {
+	if (pid <= 0 || !Number.isInteger(pid)) {
+		return false;
+	}
+
+	const killFn = deps?.kill ?? process.kill;
+
+	try {
+		killFn(pid, 0);
+		return true;
+	} catch (error) {
+		if (isErrnoException(error)) {
+			if (error.code === "ESRCH") {
+				return false;
+			}
+			if (error.code === "EPERM") {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/owner-fencing.ts
@@ -30,7 +30,11 @@ export function stampOwner(): { pid: number; startedAt: string } {
  * **Limitations:**
  * 1. **PID Recycling:** PID recycling is not fully detectable. If a process dies and its PID is reassigned
  *    to a new process before this check, it will incorrectly report the process as alive. This is an accepted
- *    limitation of PID-based fencing.
+ *    limitation of PID-based fencing. The owning snapshot records `owner.startedAt` precisely so a future
+ *    refinement can compare the recorded start time against the live process start time and reject a recycled
+ *    pid; today fencing is pid-liveness only and does not yet consult `owner.startedAt`. The direction is
+ *    deliberately conservative: a falsely-"alive" owner only causes recovery to skip adoption, never to corrupt
+ *    or steal a task another process may legitimately own.
  * 2. **Windows Semantics:** On Windows, `process.kill(pid, 0)` semantics differ from POSIX systems. Specifically,
  *    sending signal 0 is not supported in the same way and may throw or behave differently.
  *    Using dependency injection (`deps.kill`) keeps the policy unit-testable and cross-platform.

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type RecoveryClient, recoverPersistedTasks } from "./recovery";
+import type { PersistedTaskSnapshot } from "./snapshot-schema";
+import {
+	createTaskPersistenceStore,
+	type TaskPersistenceStore,
+} from "./snapshot-store";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let baseDir: string;
+let store: TaskPersistenceStore;
+
+beforeEach(() => {
+	baseDir = mkdtempSync(join(tmpdir(), "omo-recovery-"));
+	store = createTaskPersistenceStore({ directory: baseDir, logger: () => {} });
+});
+
+afterEach(() => {
+	rmSync(baseDir, { recursive: true, force: true });
+});
+
+function tasksDir(): string {
+	return join(baseDir, ".omo", "background-tasks");
+}
+
+function snapshotPath(id: string): string {
+	return join(tasksDir(), `${id}.json`);
+}
+
+function makeSnapshot(
+	overrides: Partial<PersistedTaskSnapshot> & { id: string },
+): PersistedTaskSnapshot {
+	return {
+		schema_version: 1,
+		description: "a persisted task",
+		agent: "explore",
+		status: "running",
+		owner: { pid: 4242424, startedAt: new Date().toISOString() },
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+function createRecordingClient(
+	getImpl: (args: { path: { id: string } }) => Promise<unknown>,
+): { client: RecoveryClient; calls: string[] } {
+	const calls: string[] = [];
+	const client: RecoveryClient = {
+		session: {
+			get: async (args) => {
+				calls.push("session.get");
+				return getImpl(args);
+			},
+			messages: async () => {
+				calls.push("session.messages");
+				return [];
+			},
+		},
+	};
+	return { client, calls };
+}
+
+const okGet = async (args: { path: { id: string } }) => ({
+	data: { id: args.path.id },
+});
+
+describe("recoverPersistedTasks", () => {
+	test("#given live-owner snapshot #when recovering #then skips and leaves file untouched", async () => {
+		// given a snapshot whose owner pid is reported alive
+		const snapshot = makeSnapshot({ id: "live-task", status: "running" });
+		store.persistSnapshot(snapshot);
+		const before = readFileSync(snapshotPath("live-task"), "utf-8");
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner reported alive
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => true,
+		});
+
+		// then no task is recovered, no client call, and the file is byte-identical
+		expect(recovered).toHaveLength(0);
+		expect(calls).toHaveLength(0);
+		expect(readFileSync(snapshotPath("live-task"), "utf-8")).toBe(before);
+	});
+
+	test("#given dead-owner terminal snapshot #when recovering #then restores without ever calling the client", async () => {
+		// given a completed snapshot owned by a dead process
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "done-task",
+				status: "completed",
+				sessionId: "ses_done",
+			}),
+		);
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner reported dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the task is restored as terminal, the client is never touched, file retained
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("terminal");
+		expect(recovered[0]?.task.status).toBe("completed");
+		expect(recovered[0]?.task.id).toBe("done-task");
+		expect(calls).toHaveLength(0);
+		expect(existsSync(snapshotPath("done-task"))).toBe(true);
+	});
+
+	test("#given dead-owner non-terminal with session.get throwing #when recovering #then reconciles to error and rewrites file", async () => {
+		// given a running snapshot whose session lookup throws
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "throw-task",
+				status: "running",
+				sessionId: "ses_gone",
+			}),
+		);
+		const { client } = createRecordingClient(async () => {
+			throw new Error("network down");
+		});
+
+		// when recovery runs with the owner dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the task is reconciled to error and the on-disk file is rewritten
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("reconciled-error");
+		expect(recovered[0]?.task.status).toBe("error");
+		expect(recovered[0]?.task.error).toBe("session lost across restart");
+
+		const rewritten = JSON.parse(
+			readFileSync(snapshotPath("throw-task"), "utf-8"),
+		) as PersistedTaskSnapshot;
+		expect(rewritten.status).toBe("error");
+		expect(rewritten.error).toBe("session lost across restart");
+		expect(rewritten.owner.pid).toBe(process.pid);
+		expect(rewritten.owner.pid).not.toBe(4242424);
+	});
+
+	test("#given dead-owner non-terminal with surviving session #when recovering #then reconciles to interrupt with guidance and rewrites file", async () => {
+		// given a running snapshot whose session still exists
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "alive-task",
+				status: "running",
+				sessionId: "ses_alive",
+			}),
+		);
+		const { client } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the task is reconciled to interrupt with guidance text and the file is rewritten
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("reconciled-interrupt");
+		expect(recovered[0]?.task.status).toBe("interrupt");
+		const result = recovered[0]?.task.result ?? "";
+		expect(result).toContain("Task interrupted by OpenCode restart");
+		expect(result).toContain("ses_alive");
+		expect(result).toContain('session_read(session_id="ses_alive")');
+		expect(result).toContain(
+			'task(task_id="ses_alive", run_in_background=false)',
+		);
+
+		const rewritten = JSON.parse(
+			readFileSync(snapshotPath("alive-task"), "utf-8"),
+		) as PersistedTaskSnapshot;
+		expect(rewritten.status).toBe("interrupt");
+		expect(rewritten.owner.pid).toBe(process.pid);
+	});
+
+	test("#given dead-owner non-terminal without sessionId #when recovering #then reconciles to error", async () => {
+		// given a running snapshot that never recorded a sessionId
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "no-session",
+				status: "pending",
+				sessionId: undefined,
+			}),
+		);
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the task is reconciled to error without consulting the client
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("reconciled-error");
+		expect(recovered[0]?.task.error).toBe("session lost across restart");
+		expect(calls).toHaveLength(0);
+	});
+
+	test("#given a corrupt file alongside good snapshots #when recovering #then the good ones still recover", async () => {
+		// given one valid terminal snapshot and one unparseable file in the same dir
+		store.persistSnapshot(
+			makeSnapshot({ id: "good-task", status: "completed" }),
+		);
+		writeFileSync(snapshotPath("corrupt-task"), "{ not json at all", "utf-8");
+		const { client } = createRecordingClient(okGet);
+
+		// when recovery runs
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the good snapshot is still recovered
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.task.id).toBe("good-task");
+	});
+
+	test("#given a stale snapshot older than gc window #when recovering #then it is garbage-collected from disk", async () => {
+		// given one stale snapshot (8 days old) and one fresh terminal snapshot
+		const stale = new Date(Date.now() - 8 * DAY_MS).toISOString();
+		store.persistSnapshot(
+			makeSnapshot({ id: "stale-task", status: "completed", updatedAt: stale }),
+		);
+		store.persistSnapshot(
+			makeSnapshot({ id: "fresh-task", status: "completed" }),
+		);
+		const { client } = createRecordingClient(okGet);
+
+		// when recovery runs with the default 7-day gc window
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the stale file is gone and only the fresh one is recovered
+		expect(existsSync(snapshotPath("stale-task"))).toBe(false);
+		expect(existsSync(snapshotPath("fresh-task"))).toBe(true);
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.task.id).toBe("fresh-task");
+	});
+
+	test("#given every recovery scenario #when run against a recording client #then only session.get is ever called", async () => {
+		// given snapshots covering terminal, no-session, throw, and surviving-session paths
+		store.persistSnapshot(
+			makeSnapshot({ id: "inv-terminal", status: "completed" }),
+		);
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "inv-no-session",
+				status: "running",
+				sessionId: undefined,
+			}),
+		);
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "inv-alive",
+				status: "running",
+				sessionId: "ses_inv",
+			}),
+		);
+		let first = true;
+		const { client, calls } = createRecordingClient(async (args) => {
+			if (first) {
+				first = false;
+				throw new Error("boom");
+			}
+			return okGet(args);
+		});
+
+		// when recovery runs over all of them
+		await recoverPersistedTasks({ store, client, isPidAlive: () => false });
+
+		// then recovery never reached beyond session.get (no prompt/messages/command)
+		const allowed = new Set(["session.get"]);
+		for (const call of calls) {
+			expect(allowed.has(call)).toBe(true);
+		}
+	});
+});

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.test.ts
@@ -301,4 +301,148 @@ describe("recoverPersistedTasks", () => {
 			expect(allowed.has(call)).toBe(true);
 		}
 	});
+
+	test("#given stale live-owner snapshot #when recovering #then gc fencing keeps it on disk and recovery skips it", async () => {
+		// given a stale snapshot (8 days old) whose owner is reported alive
+		const stale = new Date(Date.now() - 8 * DAY_MS).toISOString();
+		store.persistSnapshot(
+			makeSnapshot({ id: "stale-live", status: "running", updatedAt: stale }),
+		);
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner reported alive
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => true,
+		});
+
+		// then gc did not delete the live sibling's snapshot and recovery skipped it
+		expect(existsSync(snapshotPath("stale-live"))).toBe(true);
+		expect(recovered).toHaveLength(0);
+		expect(calls).toHaveLength(0);
+	});
+
+	test("#given a directory option #when reconciling a non-terminal snapshot #then session.get is scoped by query.directory", async () => {
+		// given a running snapshot whose owner is dead
+		store.persistSnapshot(
+			makeSnapshot({ id: "dir-task", status: "running", sessionId: "ses_dir" }),
+		);
+		const seenArgs: Array<{
+			path: { id: string };
+			query?: { directory: string };
+		}> = [];
+		const client: RecoveryClient = {
+			session: {
+				get: async (args) => {
+					seenArgs.push(args);
+					return { data: { id: args.path.id, directory: "/proj" } };
+				},
+				messages: async () => [],
+			},
+		};
+
+		// when recovery runs with a directory option
+		await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+			directory: "/proj",
+		});
+
+		// then session.get received the directory in its query (matches session-existence.ts)
+		expect(seenArgs).toHaveLength(1);
+		expect(seenArgs[0]?.path).toEqual({ id: "ses_dir" });
+		expect(seenArgs[0]?.query).toEqual({ directory: "/proj" });
+	});
+
+	test("#given a response whose directory mismatches the option #when recovering #then reconciles to session-lost error", async () => {
+		// given a running snapshot whose session resolves to a different directory
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "mismatch-task",
+				status: "running",
+				sessionId: "ses_x",
+			}),
+		);
+		const client: RecoveryClient = {
+			session: {
+				get: async (args) => ({
+					data: { id: args.path.id, directory: "/other-project" },
+				}),
+				messages: async () => [],
+			},
+		};
+
+		// when recovery runs scoped to a different directory
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+			directory: "/my-project",
+		});
+
+		// then the cross-directory session is treated as lost across restart
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("reconciled-error");
+		expect(recovered[0]?.task.status).toBe("error");
+		expect(recovered[0]?.task.error).toBe("session lost across restart");
+	});
+
+	test("#given dead-owner terminal interrupt snapshot with sessionId #when recovering #then the restored task carries session_read guidance", async () => {
+		// given a terminal interrupt snapshot (already reconciled on a prior restart),
+		// whose guidance text was never written to disk (no snapshot.result field)
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "second-restart-interrupt",
+				status: "interrupt",
+				sessionId: "ses_survivor",
+			}),
+		);
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the terminal interrupt is restored with guidance reconstructed from sessionId
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("terminal");
+		expect(recovered[0]?.task.status).toBe("interrupt");
+		const result = recovered[0]?.task.result ?? "";
+		expect(result).toContain('session_read(session_id="ses_survivor")');
+		expect(calls).toHaveLength(0);
+	});
+
+	test("#given dead-owner terminal interrupt snapshot carrying an error #when recovering #then no restart guidance is reconstructed", async () => {
+		// given an ordinary persisted interrupt (e.g. a prompt failure) that already
+		// recorded an error - NOT a restart-recovery reconcile
+		store.persistSnapshot(
+			makeSnapshot({
+				id: "prompt-failure-interrupt",
+				status: "interrupt",
+				sessionId: "ses_prompt_failure",
+				error: "agent not found",
+			}),
+		);
+		const { client, calls } = createRecordingClient(okGet);
+
+		// when recovery runs with the owner dead
+		const recovered = await recoverPersistedTasks({
+			store,
+			client,
+			isPidAlive: () => false,
+		});
+
+		// then the interrupt is restored as-is without restart-recovery guidance
+		expect(recovered).toHaveLength(1);
+		expect(recovered[0]?.kind).toBe("terminal");
+		expect(recovered[0]?.task.status).toBe("interrupt");
+		expect(recovered[0]?.task.error).toBe("agent not found");
+		expect(recovered[0]?.task.result).toBeUndefined();
+		expect(calls).toHaveLength(0);
+	});
 });

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.ts
@@ -10,7 +10,10 @@ import type { TaskPersistenceStore } from "./snapshot-store";
  */
 export type RecoveryClient = {
 	session: {
-		get(args: { path: { id: string } }): Promise<unknown>;
+		get(args: {
+			path: { id: string };
+			query?: { directory: string };
+		}): Promise<unknown>;
 		messages(args: { path: { id: string } }): Promise<unknown>;
 	};
 };
@@ -23,6 +26,7 @@ export type RecoveredTask = {
 export interface RecoverPersistedTasksOptions {
 	store: TaskPersistenceStore;
 	client: RecoveryClient;
+	directory?: string;
 	isPidAlive?: (pid: number) => boolean;
 	now?: Date;
 	logger?: (message: string, data?: unknown) => void;
@@ -51,6 +55,25 @@ function isErrorResponse(response: unknown): boolean {
 	);
 }
 
+/**
+ * True when a `session.get` response exposes a `data.directory` that does not
+ * match the directory recovery is scoped to. The OpenCode SDK returns the
+ * owning project directory on `response.data.directory` (see manager parent
+ * session lookup); a mismatch means a same-ID session belongs to another
+ * project and must not reconcile this task to "interrupt".
+ */
+function isDirectoryMismatch(
+	response: unknown,
+	directory: string | undefined,
+): boolean {
+	if (!directory) return false;
+	if (!isRecord(response)) return false;
+	const data = response.data;
+	if (!isRecord(data)) return false;
+	const responseDirectory = data.directory;
+	if (typeof responseDirectory !== "string") return false;
+	return responseDirectory !== directory;
+}
 function interruptGuidance(sessionId: string): string {
 	return (
 		`Task interrupted by OpenCode restart. The subagent session ${sessionId} ` +
@@ -78,6 +101,7 @@ function reconciledSnapshot(
 interface ReconcileDeps {
 	store: TaskPersistenceStore;
 	client: RecoveryClient;
+	directory?: string;
 	isPidAlive: (pid: number) => boolean;
 	now: Date;
 	logger: (message: string, data?: unknown) => void;
@@ -95,7 +119,21 @@ async function recoverSnapshot(
 
 	// Terminal tasks are restored as-is without ever consulting the client.
 	if (TERMINAL_STATUSES.has(snapshot.status)) {
-		return { task: snapshotToTask(snapshot), kind: "terminal" };
+		const task = snapshotToTask(snapshot);
+		// The interrupt guidance text lives only in memory (the snapshot schema has
+		// no result field), so a terminal interrupt restored on a later restart would
+		// otherwise lose it. Reconstruct it from the surviving sessionId (F8). Gated
+		// on !task.error so ordinary persisted interrupts (e.g. prompt failures that
+		// recorded an error) are never mislabeled as restart-recovered.
+		if (
+			task.status === "interrupt" &&
+			task.sessionId &&
+			!task.result &&
+			!task.error
+		) {
+			task.result = interruptGuidance(task.sessionId);
+		}
+		return { task, kind: "terminal" };
 	}
 
 	const sessionId = snapshot.sessionId;
@@ -112,8 +150,13 @@ async function recoverSnapshot(
 
 	let sessionSurvived = false;
 	try {
-		const response = await deps.client.session.get({ path: { id: sessionId } });
-		sessionSurvived = !isErrorResponse(response);
+		const response = await deps.client.session.get({
+			path: { id: sessionId },
+			...(deps.directory ? { query: { directory: deps.directory } } : {}),
+		});
+		sessionSurvived =
+			!isErrorResponse(response) &&
+			!isDirectoryMismatch(response, deps.directory);
 	} catch (error) {
 		deps.logger("task-recovery: session.get threw during reconcile", {
 			id: snapshot.id,
@@ -149,6 +192,12 @@ async function recoverSnapshot(
  * non-terminal survivors against the OpenCode session API, and returns the
  * recovered tasks for the manager to apply. Never rejects on a single bad
  * snapshot: each is wrapped in its own try/catch and logged.
+ *
+ * Owner fencing is pid-liveness only: `owner.startedAt` is persisted to enable a
+ * future start-time comparison but is not yet consulted. A recycled pid that
+ * happens to be alive is treated as a live owner, so recovery conservatively
+ * skips adoption rather than risk corrupting a task another process may own.
+ * See {@link isPidAlive} for the underlying accepted limitation.
  */
 export async function recoverPersistedTasks(
 	options: RecoverPersistedTasksOptions,
@@ -160,9 +209,14 @@ export async function recoverPersistedTasks(
 		isPidAlive: options.isPidAlive ?? ((pid) => defaultIsPidAlive(pid)),
 		now: options.now ?? new Date(),
 		logger,
+		directory: options.directory,
 	};
 
-	deps.store.gcOlderThan(options.gcMaxAgeMs ?? DEFAULT_GC_MAX_AGE_MS);
+	deps.store.gcOlderThan(
+		options.gcMaxAgeMs ?? DEFAULT_GC_MAX_AGE_MS,
+		deps.now,
+		deps.isPidAlive,
+	);
 
 	const recovered: RecoveredTask[] = [];
 	for (const snapshot of deps.store.listSnapshots()) {

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/recovery.ts
@@ -1,0 +1,182 @@
+import type { BackgroundTask, BackgroundTaskStatus } from "../types";
+import { isPidAlive as defaultIsPidAlive, stampOwner } from "./owner-fencing";
+import { type PersistedTaskSnapshot, snapshotToTask } from "./snapshot-schema";
+import type { TaskPersistenceStore } from "./snapshot-store";
+
+/**
+ * Minimal structural view of the OpenCode SDK client that recovery needs. Only
+ * `session.get` is ever invoked; `messages` is declared to mirror the SDK shape
+ * but recovery must never call it (nor any prompt/command route).
+ */
+export type RecoveryClient = {
+	session: {
+		get(args: { path: { id: string } }): Promise<unknown>;
+		messages(args: { path: { id: string } }): Promise<unknown>;
+	};
+};
+
+export type RecoveredTask = {
+	task: BackgroundTask;
+	kind: "terminal" | "reconciled-error" | "reconciled-interrupt";
+};
+
+export interface RecoverPersistedTasksOptions {
+	store: TaskPersistenceStore;
+	client: RecoveryClient;
+	isPidAlive?: (pid: number) => boolean;
+	now?: Date;
+	logger?: (message: string, data?: unknown) => void;
+	gcMaxAgeMs?: number;
+}
+
+const DEFAULT_GC_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const SESSION_LOST_ERROR = "session lost across restart";
+const TERMINAL_STATUSES: ReadonlySet<BackgroundTaskStatus> = new Set([
+	"completed",
+	"error",
+	"cancelled",
+	"interrupt",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/** True when a `session.get` response carries a non-null `error` field. */
+function isErrorResponse(response: unknown): boolean {
+	return (
+		isRecord(response) &&
+		response.error !== undefined &&
+		response.error !== null
+	);
+}
+
+function interruptGuidance(sessionId: string): string {
+	return (
+		`Task interrupted by OpenCode restart. The subagent session ${sessionId} ` +
+		`survived with its full transcript. Inspect output with ` +
+		`session_read(session_id="${sessionId}") or continue with ` +
+		`task(task_id="${sessionId}", run_in_background=false).`
+	);
+}
+
+function reconciledSnapshot(
+	snapshot: PersistedTaskSnapshot,
+	status: BackgroundTaskStatus,
+	now: Date,
+	error: string | undefined,
+): PersistedTaskSnapshot {
+	return {
+		...snapshot,
+		status,
+		error,
+		owner: stampOwner(),
+		updatedAt: now.toISOString(),
+	};
+}
+
+interface ReconcileDeps {
+	store: TaskPersistenceStore;
+	client: RecoveryClient;
+	isPidAlive: (pid: number) => boolean;
+	now: Date;
+	logger: (message: string, data?: unknown) => void;
+}
+
+async function recoverSnapshot(
+	snapshot: PersistedTaskSnapshot,
+	deps: ReconcileDeps,
+): Promise<RecoveredTask | undefined> {
+	// A live owner means another OpenCode instance still owns this task: skip
+	// entirely and leave the file untouched.
+	if (deps.isPidAlive(snapshot.owner.pid)) {
+		return undefined;
+	}
+
+	// Terminal tasks are restored as-is without ever consulting the client.
+	if (TERMINAL_STATUSES.has(snapshot.status)) {
+		return { task: snapshotToTask(snapshot), kind: "terminal" };
+	}
+
+	const sessionId = snapshot.sessionId;
+	if (!sessionId) {
+		const updated = reconciledSnapshot(
+			snapshot,
+			"error",
+			deps.now,
+			SESSION_LOST_ERROR,
+		);
+		deps.store.persistSnapshot(updated);
+		return { task: snapshotToTask(updated), kind: "reconciled-error" };
+	}
+
+	let sessionSurvived = false;
+	try {
+		const response = await deps.client.session.get({ path: { id: sessionId } });
+		sessionSurvived = !isErrorResponse(response);
+	} catch (error) {
+		deps.logger("task-recovery: session.get threw during reconcile", {
+			id: snapshot.id,
+			error: String(error),
+		});
+	}
+
+	if (!sessionSurvived) {
+		const updated = reconciledSnapshot(
+			snapshot,
+			"error",
+			deps.now,
+			SESSION_LOST_ERROR,
+		);
+		deps.store.persistSnapshot(updated);
+		return { task: snapshotToTask(updated), kind: "reconciled-error" };
+	}
+
+	const updated = reconciledSnapshot(
+		snapshot,
+		"interrupt",
+		deps.now,
+		undefined,
+	);
+	deps.store.persistSnapshot(updated);
+	const task = snapshotToTask(updated);
+	task.result = interruptGuidance(sessionId);
+	return { task, kind: "reconciled-interrupt" };
+}
+
+/**
+ * Reads persisted task snapshots, fences by owner liveness, reconciles the
+ * non-terminal survivors against the OpenCode session API, and returns the
+ * recovered tasks for the manager to apply. Never rejects on a single bad
+ * snapshot: each is wrapped in its own try/catch and logged.
+ */
+export async function recoverPersistedTasks(
+	options: RecoverPersistedTasksOptions,
+): Promise<RecoveredTask[]> {
+	const logger = options.logger ?? (() => {});
+	const deps: ReconcileDeps = {
+		store: options.store,
+		client: options.client,
+		isPidAlive: options.isPidAlive ?? ((pid) => defaultIsPidAlive(pid)),
+		now: options.now ?? new Date(),
+		logger,
+	};
+
+	deps.store.gcOlderThan(options.gcMaxAgeMs ?? DEFAULT_GC_MAX_AGE_MS);
+
+	const recovered: RecoveredTask[] = [];
+	for (const snapshot of deps.store.listSnapshots()) {
+		try {
+			const result = await recoverSnapshot(snapshot, deps);
+			if (result) {
+				recovered.push(result);
+			}
+		} catch (error) {
+			logger("task-recovery: failed to recover snapshot", {
+				id: snapshot.id,
+				error: String(error),
+			});
+		}
+	}
+	return recovered;
+}

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-schema.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-schema.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "bun:test"
+import type { BackgroundTask } from "../types"
+import {
+  type PersistedTaskSnapshot,
+  parseSnapshotFile,
+  snapshotToTask,
+  taskToSnapshot,
+} from "./snapshot-schema"
+
+const OWNER = { pid: 4242, startedAt: "2026-06-12T10:00:00.000Z" }
+
+function buildTask(): BackgroundTask {
+  return {
+    id: "task-abc",
+    sessionId: "ses_child",
+    rootSessionId: "ses_root",
+    parentSessionId: "ses_parent",
+    parentMessageId: "msg_parent",
+    teamRunId: "team-run-1",
+    description: "do a thing",
+    prompt: "SECRET-LAUNCH-PROMPT-should-never-touch-disk",
+    agent: "sisyphus-junior",
+    spawnDepth: 2,
+    status: "running",
+    queuedAt: new Date("2026-06-12T09:58:00.000Z"),
+    startedAt: new Date("2026-06-12T09:59:00.000Z"),
+    completedAt: new Date("2026-06-12T10:01:00.000Z"),
+    error: "boom",
+    concurrencyKey: "anthropic/claude-opus-4-8",
+    concurrencyGroup: "anthropic/claude-opus-4-8",
+    category: "unspecified-high",
+    model: {
+      providerID: "anthropic",
+      modelID: "claude-opus-4-8",
+      variant: "thinking",
+      reasoningEffort: "high",
+    },
+  }
+}
+
+describe("taskToSnapshot", () => {
+  it("maps all persisted fields and converts Dates to ISO strings", () => {
+    // #given a fully populated background task
+    const task = buildTask()
+
+    // #when converting it to a snapshot
+    const snapshot = taskToSnapshot(task, OWNER)
+
+    // #then scalar identity fields are carried over
+    expect(snapshot.schema_version).toBe(1)
+    expect(snapshot.id).toBe("task-abc")
+    expect(snapshot.sessionId).toBe("ses_child")
+    expect(snapshot.rootSessionId).toBe("ses_root")
+    expect(snapshot.parentSessionId).toBe("ses_parent")
+    expect(snapshot.parentMessageId).toBe("msg_parent")
+    expect(snapshot.teamRunId).toBe("team-run-1")
+    expect(snapshot.description).toBe("do a thing")
+    expect(snapshot.agent).toBe("sisyphus-junior")
+    expect(snapshot.spawnDepth).toBe(2)
+    expect(snapshot.status).toBe("running")
+    expect(snapshot.error).toBe("boom")
+    expect(snapshot.concurrencyKey).toBe("anthropic/claude-opus-4-8")
+    expect(snapshot.concurrencyGroup).toBe("anthropic/claude-opus-4-8")
+    expect(snapshot.category).toBe("unspecified-high")
+
+    // #then dates are serialized as ISO strings
+    expect(snapshot.queuedAt).toBe("2026-06-12T09:58:00.000Z")
+    expect(snapshot.startedAt).toBe("2026-06-12T09:59:00.000Z")
+    expect(snapshot.completedAt).toBe("2026-06-12T10:01:00.000Z")
+    expect(typeof snapshot.updatedAt).toBe("string")
+    expect(Number.isNaN(Date.parse(snapshot.updatedAt))).toBe(false)
+
+    // #then only the model subset is persisted
+    expect(snapshot.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-8",
+      variant: "thinking",
+    })
+
+    // #then owner identity is captured
+    expect(snapshot.owner).toEqual(OWNER)
+  })
+
+  it("omits optional fields that are absent on the task", () => {
+    // #given a minimal task
+    const task: BackgroundTask = {
+      id: "task-min",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      description: "minimal",
+      prompt: "another secret",
+      agent: "sisyphus-junior",
+      status: "pending",
+    }
+
+    // #when converting it
+    const snapshot = taskToSnapshot(task, OWNER)
+
+    // #then optional fields are undefined, not present
+    expect(snapshot.sessionId).toBeUndefined()
+    expect(snapshot.model).toBeUndefined()
+    expect(snapshot.queuedAt).toBeUndefined()
+    expect(snapshot.startedAt).toBeUndefined()
+    expect(snapshot.completedAt).toBeUndefined()
+    expect(snapshot.category).toBeUndefined()
+  })
+})
+
+describe("snapshot serialization", () => {
+  it("never writes the launch prompt to disk", () => {
+    // #given a task with a sensitive prompt
+    const task = buildTask()
+
+    // #when serializing the snapshot to JSON
+    const json = JSON.stringify(taskToSnapshot(task, OWNER))
+
+    // #then the prompt text is absent from the serialized payload
+    expect(json).not.toContain("SECRET-LAUNCH-PROMPT-should-never-touch-disk")
+    expect(json).not.toContain("prompt")
+  })
+})
+
+describe("roundtrip taskToSnapshot -> snapshotToTask", () => {
+  it("preserves all listed fields and reconstructs Dates", () => {
+    // #given a task converted to a snapshot
+    const task = buildTask()
+    const snapshot = taskToSnapshot(task, OWNER)
+
+    // #when reconstructing the task from the snapshot
+    const restored = snapshotToTask(snapshot)
+
+    // #then identity and scalar fields match
+    expect(restored.id).toBe(task.id)
+    expect(restored.sessionId).toBe(task.sessionId)
+    expect(restored.rootSessionId).toBe(task.rootSessionId)
+    expect(restored.parentSessionId).toBe(task.parentSessionId)
+    expect(restored.parentMessageId).toBe(task.parentMessageId)
+    expect(restored.teamRunId).toBe(task.teamRunId)
+    expect(restored.description).toBe(task.description)
+    expect(restored.agent).toBe(task.agent)
+    expect(restored.spawnDepth).toBe(task.spawnDepth)
+    expect(restored.status).toBe(task.status)
+    expect(restored.error).toBe(task.error)
+    expect(restored.concurrencyKey).toBe(task.concurrencyKey)
+    expect(restored.concurrencyGroup).toBe(task.concurrencyGroup)
+    expect(restored.category).toBe(task.category)
+
+    // #then dates are reconstructed as Date instances with identical values
+    expect(restored.queuedAt).toBeInstanceOf(Date)
+    expect(restored.queuedAt?.toISOString()).toBe("2026-06-12T09:58:00.000Z")
+    expect(restored.startedAt?.toISOString()).toBe("2026-06-12T09:59:00.000Z")
+    expect(restored.completedAt?.toISOString()).toBe("2026-06-12T10:01:00.000Z")
+
+    // #then model subset is restored
+    expect(restored.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-8",
+      variant: "thinking",
+    })
+  })
+
+  it("sets prompt to the placeholder since it is not persisted", () => {
+    // #given a roundtripped task
+    const restored = snapshotToTask(taskToSnapshot(buildTask(), OWNER))
+
+    // #then the prompt is the explicit placeholder
+    expect(restored.prompt).toBe("[not persisted across restart]")
+  })
+
+  it("falls back to empty strings for required parent fields when absent", () => {
+    // #given a snapshot with no parent identifiers
+    const snapshot: PersistedTaskSnapshot = {
+      schema_version: 1,
+      id: "task-noparent",
+      description: "orphan",
+      agent: "sisyphus-junior",
+      status: "pending",
+      owner: OWNER,
+      updatedAt: "2026-06-12T10:00:00.000Z",
+    }
+
+    // #when reconstructing the task
+    const restored = snapshotToTask(snapshot)
+
+    // #then required string fields are present and empty
+    expect(restored.parentSessionId).toBe("")
+    expect(restored.parentMessageId).toBe("")
+  })
+})
+
+describe("parseSnapshotFile", () => {
+  it("parses a valid serialized snapshot", () => {
+    // #given a serialized valid snapshot
+    const content = JSON.stringify(taskToSnapshot(buildTask(), OWNER))
+
+    // #when parsing it
+    const parsed = parseSnapshotFile(content)
+
+    // #then it returns the snapshot
+    expect(parsed?.id).toBe("task-abc")
+    expect(parsed?.schema_version).toBe(1)
+    expect(parsed?.owner.pid).toBe(4242)
+  })
+
+  it("returns undefined on garbage JSON", () => {
+    // #given non-JSON content
+    // #when parsing it
+    // #then it returns undefined without throwing
+    expect(parseSnapshotFile("{not valid json")).toBeUndefined()
+    expect(parseSnapshotFile("")).toBeUndefined()
+  })
+
+  it("returns undefined on a wrong schema version", () => {
+    // #given a snapshot with the wrong schema version
+    const content = JSON.stringify({
+      schema_version: 2,
+      id: "task-abc",
+      description: "x",
+      agent: "a",
+      status: "pending",
+      owner: OWNER,
+      updatedAt: "2026-06-12T10:00:00.000Z",
+    })
+
+    // #when parsing it
+    // #then it returns undefined
+    expect(parseSnapshotFile(content)).toBeUndefined()
+  })
+
+  it("returns undefined when id is missing or not a string", () => {
+    // #given snapshots with a bad id
+    const missingId = JSON.stringify({
+      schema_version: 1,
+      description: "x",
+      agent: "a",
+      status: "pending",
+      owner: OWNER,
+      updatedAt: "2026-06-12T10:00:00.000Z",
+    })
+    const numericId = JSON.stringify({
+      schema_version: 1,
+      id: 123,
+      description: "x",
+      agent: "a",
+      status: "pending",
+      owner: OWNER,
+      updatedAt: "2026-06-12T10:00:00.000Z",
+    })
+
+    // #when parsing them
+    // #then both return undefined
+    expect(parseSnapshotFile(missingId)).toBeUndefined()
+    expect(parseSnapshotFile(numericId)).toBeUndefined()
+  })
+
+  it("returns undefined when owner is missing", () => {
+    // #given a snapshot without an owner
+    const content = JSON.stringify({
+      schema_version: 1,
+      id: "task-abc",
+      description: "x",
+      agent: "a",
+      status: "pending",
+      updatedAt: "2026-06-12T10:00:00.000Z",
+    })
+
+    // #when parsing it
+    // #then it returns undefined
+    expect(parseSnapshotFile(content)).toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-schema.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-schema.ts
@@ -1,0 +1,157 @@
+import type { BackgroundTask, BackgroundTaskStatus } from "../types"
+
+/**
+ * Identity of the process that owns a persisted task. Used by the store layer
+ * to fence stale snapshots written by a previous (now-dead) process.
+ */
+export interface SnapshotOwner {
+  pid: number
+  /** ISO 8601 timestamp of when the owning process started. */
+  startedAt: string
+}
+
+/** Subset of model configuration that is safe and useful to persist. */
+export interface PersistedModelConfig {
+  providerID: string
+  modelID: string
+  variant?: string
+}
+
+/**
+ * On-disk representation of a {@link BackgroundTask}. The launch `prompt` is
+ * intentionally absent: it must never be written to disk (registry precedent
+ * redacts prompts). Dates are stored as ISO 8601 strings.
+ */
+export interface PersistedTaskSnapshot {
+  schema_version: 1
+  id: string
+  sessionId?: string
+  rootSessionId?: string
+  parentSessionId?: string
+  parentMessageId?: string
+  description: string
+  agent: string
+  category?: string
+  model?: PersistedModelConfig
+  status: BackgroundTaskStatus
+  queuedAt?: string
+  startedAt?: string
+  completedAt?: string
+  error?: string
+  concurrencyGroup?: string
+  concurrencyKey?: string
+  teamRunId?: string
+  spawnDepth?: number
+  owner: SnapshotOwner
+  updatedAt: string
+}
+
+const PROMPT_PLACEHOLDER = "[not persisted across restart]"
+
+function toISO(date: Date | undefined): string | undefined {
+  return date ? date.toISOString() : undefined
+}
+
+function fromISO(value: string | undefined): Date | undefined {
+  if (!value) return undefined
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed
+}
+
+/** Convert a live {@link BackgroundTask} into its persisted snapshot form. */
+export function taskToSnapshot(
+  task: BackgroundTask,
+  owner: SnapshotOwner,
+): PersistedTaskSnapshot {
+  return {
+    schema_version: 1,
+    id: task.id,
+    sessionId: task.sessionId,
+    rootSessionId: task.rootSessionId,
+    parentSessionId: task.parentSessionId,
+    parentMessageId: task.parentMessageId,
+    description: task.description,
+    agent: task.agent,
+    category: task.category,
+    model: task.model
+      ? {
+          providerID: task.model.providerID,
+          modelID: task.model.modelID,
+          variant: task.model.variant,
+        }
+      : undefined,
+    status: task.status,
+    queuedAt: toISO(task.queuedAt),
+    startedAt: toISO(task.startedAt),
+    completedAt: toISO(task.completedAt),
+    error: task.error,
+    concurrencyGroup: task.concurrencyGroup,
+    concurrencyKey: task.concurrencyKey,
+    teamRunId: task.teamRunId,
+    spawnDepth: task.spawnDepth,
+    owner,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Reconstruct a {@link BackgroundTask} from a persisted snapshot. The `prompt`
+ * is set to a placeholder because it was never written to disk; required
+ * parent identifiers fall back to empty strings when absent.
+ */
+export function snapshotToTask(snapshot: PersistedTaskSnapshot): BackgroundTask {
+  return {
+    id: snapshot.id,
+    sessionId: snapshot.sessionId,
+    rootSessionId: snapshot.rootSessionId,
+    parentSessionId: snapshot.parentSessionId ?? "",
+    parentMessageId: snapshot.parentMessageId ?? "",
+    teamRunId: snapshot.teamRunId,
+    description: snapshot.description,
+    prompt: PROMPT_PLACEHOLDER,
+    agent: snapshot.agent,
+    spawnDepth: snapshot.spawnDepth,
+    status: snapshot.status,
+    queuedAt: fromISO(snapshot.queuedAt),
+    startedAt: fromISO(snapshot.startedAt),
+    completedAt: fromISO(snapshot.completedAt),
+    error: snapshot.error,
+    concurrencyKey: snapshot.concurrencyKey,
+    concurrencyGroup: snapshot.concurrencyGroup,
+    category: snapshot.category,
+    model: snapshot.model
+      ? {
+          providerID: snapshot.model.providerID,
+          modelID: snapshot.model.modelID,
+          variant: snapshot.model.variant,
+        }
+      : undefined,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+/**
+ * Parse the contents of a snapshot file. Returns `undefined` (never throws) on
+ * invalid JSON, an unsupported `schema_version`, a missing/non-string `id`, or
+ * a missing `owner`.
+ */
+export function parseSnapshotFile(
+  content: string,
+): PersistedTaskSnapshot | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    return undefined
+  }
+
+  if (!isRecord(parsed)) return undefined
+  if (parsed.schema_version !== 1) return undefined
+  if (typeof parsed.id !== "string" || parsed.id.length === 0) return undefined
+  if (!isRecord(parsed.owner)) return undefined
+
+  return parsed as unknown as PersistedTaskSnapshot
+}

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { BackgroundTask } from "../types"
@@ -163,20 +163,54 @@ describe("createTaskPersistenceStore listSnapshots", () => {
 })
 
 describe("createTaskPersistenceStore gcOlderThan", () => {
-  it("deletes only entries whose updatedAt is older than the cutoff", () => {
-    // #given one stale and one fresh snapshot
+  it("deletes stale entries whose owner is dead", () => {
+    // #given one stale and one fresh snapshot, both owned by a dead process
     const directory = makeTempDir()
     const store = createTaskPersistenceStore({ directory })
     const now = new Date("2026-06-12T12:00:00.000Z")
     store.persistSnapshot(buildSnapshot("task-stale", "2026-06-12T09:00:00.000Z"))
     store.persistSnapshot(buildSnapshot("task-fresh", "2026-06-12T11:59:00.000Z"))
 
-    // #when running gc with a one-hour max age
-    store.gcOlderThan(60 * 60 * 1000, now)
+    // #when running gc with a one-hour max age and the owner reported dead
+    store.gcOlderThan(60 * 60 * 1000, now, () => false)
 
-    // #then only the stale entry is removed
+    // #then only the stale dead-owner entry is removed
     const remaining = store.listSnapshots().map((snapshot) => snapshot.id)
     expect(remaining).toEqual(["task-fresh"])
+  })
+
+  it("keeps a stale snapshot whose owner is still alive", () => {
+    // #given a stale snapshot whose owner pid is reported alive
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+    const now = new Date("2026-06-12T12:00:00.000Z")
+    store.persistSnapshot(buildSnapshot("task-stale", "2026-06-12T09:00:00.000Z"))
+
+    // #when running gc with a one-hour max age and the owner reported alive
+    store.gcOlderThan(60 * 60 * 1000, now, () => true)
+
+    // #then the live sibling's snapshot survives regardless of age
+    const remaining = store.listSnapshots().map((snapshot) => snapshot.id)
+    expect(remaining).toEqual(["task-stale"])
+  })
+
+  it("deletes an unparseable file older than maxAge by mtime regardless of owner liveness", () => {
+    // #given a fresh valid snapshot and an old unparseable file
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+    store.persistSnapshot(buildSnapshot("task-keep", "2026-06-12T11:59:00.000Z"))
+    const garbage = join(tasksDir(directory), "garbage.json")
+    writeFileSync(garbage, "{ not valid json", "utf-8")
+    const oldTime = new Date("2020-01-01T00:00:00.000Z")
+    utimesSync(garbage, oldTime, oldTime)
+    const now = new Date("2026-06-12T12:00:00.000Z")
+
+    // #when running gc with the owner reported alive (cannot fence unparseable files)
+    store.gcOlderThan(60 * 60 * 1000, now, () => true)
+
+    // #then the old unparseable file is deleted and the fresh snapshot is kept
+    expect(existsSync(garbage)).toBe(false)
+    expect(store.listSnapshots().map((snapshot) => snapshot.id)).toEqual(["task-keep"])
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackgroundTask } from "../types"
+import { type PersistedTaskSnapshot, parseSnapshotFile } from "./snapshot-schema"
+import { createTaskPersistenceStore } from "./snapshot-store"
+
+const BOULDER_GITIGNORE_CONTENT = ["*", "!/rules/", "!/rules/**", ""].join("\n")
+
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "snapshot-store-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+function tasksDir(directory: string): string {
+  return join(directory, ".omo", "background-tasks")
+}
+
+function buildTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: "task-1",
+    parentSessionId: "ses_parent",
+    parentMessageId: "msg_parent",
+    description: "do a thing",
+    prompt: "secret-prompt",
+    agent: "sisyphus-junior",
+    status: "running",
+    ...overrides,
+  }
+}
+
+function buildSnapshot(id: string, updatedAt: string): PersistedTaskSnapshot {
+  return {
+    schema_version: 1,
+    id,
+    description: "snap",
+    agent: "sisyphus-junior",
+    status: "completed",
+    owner: { pid: process.pid, startedAt: "2026-06-12T10:00:00.000Z" },
+    updatedAt,
+  }
+}
+
+function makeRecordingLogger(): {
+  logger: (message: string, data?: unknown) => void
+  entries: string[]
+} {
+  const entries: string[] = []
+  return {
+    entries,
+    logger: (message: string) => {
+      entries.push(message)
+    },
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("createTaskPersistenceStore persist", () => {
+  it("writes a per-task json file with valid JSON, owning pid, and status", () => {
+    // #given a store rooted at a fresh temp directory
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+
+    // #when persisting a running task
+    store.persist(buildTask({ id: "task-persist", status: "running" }))
+
+    // #then the per-task file exists and parses to a valid snapshot
+    const filePath = join(tasksDir(directory), "task-persist.json")
+    expect(existsSync(filePath)).toBe(true)
+    const snapshot = parseSnapshotFile(readFileSync(filePath, "utf-8"))
+    expect(snapshot?.id).toBe("task-persist")
+    expect(snapshot?.status).toBe("running")
+    expect(snapshot?.owner.pid).toBe(process.pid)
+  })
+
+  it("creates .omo/.gitignore with the boulder precedent content on a fresh dir", () => {
+    // #given a fresh temp directory with no .omo
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+
+    // #when persisting a task (which provisions .omo)
+    store.persist(buildTask())
+
+    // #then a .gitignore is created mirroring the boulder precedent
+    const gitignorePath = join(directory, ".omo", ".gitignore")
+    expect(existsSync(gitignorePath)).toBe(true)
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(BOULDER_GITIGNORE_CONTENT)
+  })
+
+  it("leaves a pre-existing .omo/.gitignore untouched", () => {
+    // #given a directory whose .omo already exists with custom gitignore content
+    const directory = makeTempDir()
+    const omoDir = join(directory, ".omo")
+    mkdirSync(omoDir, { recursive: true })
+    const gitignorePath = join(omoDir, ".gitignore")
+    writeFileSync(gitignorePath, "custom-content\n", "utf-8")
+    const store = createTaskPersistenceStore({ directory })
+
+    // #when persisting a task
+    store.persist(buildTask())
+
+    // #then the existing gitignore is preserved
+    expect(readFileSync(gitignorePath, "utf-8")).toBe("custom-content\n")
+  })
+})
+
+describe("createTaskPersistenceStore delete", () => {
+  it("removes the file and is idempotent when already missing", () => {
+    // #given a persisted task
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+    store.persist(buildTask({ id: "task-del" }))
+    const filePath = join(tasksDir(directory), "task-del.json")
+    expect(existsSync(filePath)).toBe(true)
+
+    // #when deleting it twice
+    store.delete("task-del")
+    store.delete("task-del")
+
+    // #then the file is gone and no error is thrown
+    expect(existsSync(filePath)).toBe(false)
+  })
+})
+
+describe("createTaskPersistenceStore listSnapshots", () => {
+  it("returns persisted entries and skips a hand-written garbage file while logging it", () => {
+    // #given two persisted tasks and one garbage json file
+    const directory = makeTempDir()
+    const { logger, entries } = makeRecordingLogger()
+    const store = createTaskPersistenceStore({ directory, logger })
+    store.persist(buildTask({ id: "task-a" }))
+    store.persist(buildTask({ id: "task-b" }))
+    writeFileSync(join(tasksDir(directory), "garbage.json"), "{not valid json", "utf-8")
+
+    // #when listing snapshots
+    const snapshots = store.listSnapshots()
+
+    // #then both valid entries are returned and the garbage entry was logged
+    const ids = snapshots.map((snapshot) => snapshot.id).sort()
+    expect(ids).toEqual(["task-a", "task-b"])
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it("returns an empty array when the directory does not exist", () => {
+    // #given a store over a directory that was never provisioned
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+
+    // #when listing snapshots
+    // #then it returns an empty array
+    expect(store.listSnapshots()).toEqual([])
+  })
+})
+
+describe("createTaskPersistenceStore gcOlderThan", () => {
+  it("deletes only entries whose updatedAt is older than the cutoff", () => {
+    // #given one stale and one fresh snapshot
+    const directory = makeTempDir()
+    const store = createTaskPersistenceStore({ directory })
+    const now = new Date("2026-06-12T12:00:00.000Z")
+    store.persistSnapshot(buildSnapshot("task-stale", "2026-06-12T09:00:00.000Z"))
+    store.persistSnapshot(buildSnapshot("task-fresh", "2026-06-12T11:59:00.000Z"))
+
+    // #when running gc with a one-hour max age
+    store.gcOlderThan(60 * 60 * 1000, now)
+
+    // #then only the stale entry is removed
+    const remaining = store.listSnapshots().map((snapshot) => snapshot.id)
+    expect(remaining).toEqual(["task-fresh"])
+  })
+})
+
+describe("createTaskPersistenceStore resilience", () => {
+  it("does not throw when the target directory is actually a file path", () => {
+    // #given a store whose directory points at a regular file
+    const parent = makeTempDir()
+    const filePath = join(parent, "not-a-dir")
+    writeFileSync(filePath, "i am a file", "utf-8")
+    const { logger, entries } = makeRecordingLogger()
+    const store = createTaskPersistenceStore({ directory: filePath, logger })
+
+    // #when persisting into the unwritable location
+    // #then no error escapes and the failure is logged
+    expect(() => store.persist(buildTask())).not.toThrow()
+    expect(entries.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { log as defaultLog } from "../../../shared/logger";
 import { writeFileAtomically } from "../../../shared/write-file-atomically";
 import type { BackgroundTask } from "../types";
-import { stampOwner } from "./owner-fencing";
+import { isPidAlive as defaultIsPidAlive, stampOwner } from "./owner-fencing";
 import {
 	type PersistedTaskSnapshot,
 	parseSnapshotFile,
@@ -47,7 +47,11 @@ export interface TaskPersistenceStore {
 	persistSnapshot(snapshot: PersistedTaskSnapshot): void;
 	delete(taskId: string): void;
 	listSnapshots(): PersistedTaskSnapshot[];
-	gcOlderThan(maxAgeMs: number, now?: Date): void;
+	gcOlderThan(
+		maxAgeMs: number,
+		now?: Date,
+		isPidAlive?: (pid: number) => boolean,
+	): void;
 }
 
 export function createTaskPersistenceStore(
@@ -152,7 +156,11 @@ export function createTaskPersistenceStore(
 			return snapshots;
 		},
 
-		gcOlderThan(maxAgeMs: number, now: Date = new Date()): void {
+		gcOlderThan(
+			maxAgeMs: number,
+			now: Date = new Date(),
+			isPidAlive: (pid: number) => boolean = defaultIsPidAlive,
+		): void {
 			try {
 				if (!existsSync(tasksDir)) {
 					return;
@@ -164,6 +172,12 @@ export function createTaskPersistenceStore(
 					try {
 						const snapshot = readSnapshot(filePath);
 						if (snapshot) {
+							// Owner-aware fencing: a live owner means another OpenCode
+							// instance still owns this task. Never delete a live sibling's
+							// snapshot, regardless of how stale its updatedAt looks.
+							if (isPidAlive(snapshot.owner.pid)) {
+								continue;
+							}
 							const updatedAt = Date.parse(snapshot.updatedAt);
 							if (!Number.isNaN(updatedAt) && updatedAt < cutoff) {
 								unlinkSync(filePath);

--- a/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-persistence/snapshot-store.ts
@@ -1,0 +1,190 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { log as defaultLog } from "../../../shared/logger";
+import { writeFileAtomically } from "../../../shared/write-file-atomically";
+import type { BackgroundTask } from "../types";
+import { stampOwner } from "./owner-fencing";
+import {
+	type PersistedTaskSnapshot,
+	parseSnapshotFile,
+	taskToSnapshot,
+} from "./snapshot-schema";
+
+const OMO_DIR = ".omo";
+const BACKGROUND_TASKS_DIR = "background-tasks";
+
+/**
+ * Mirrors the boulder-state precedent (`packages/boulder-state/src/storage/write-state.ts`):
+ * ignore everything inside `.omo` while keeping the tracked `rules/` tree.
+ */
+const GITIGNORE_CONTENT = ["*", "!/rules/", "!/rules/**", ""].join("\n");
+
+type Logger = (message: string, data?: unknown) => void;
+
+export interface CreateTaskPersistenceStoreOptions {
+	directory: string;
+	logger?: Logger;
+}
+
+/**
+ * Persists background-task snapshots as one atomic JSON file per task under
+ * `<directory>/.omo/background-tasks/{taskId}.json`. Per-task files plus atomic
+ * rename avoid the multi-instance write race that the previous single shared
+ * JSON file suffered (commit 24a7f333a). Every public method swallows and logs
+ * its own failures so persistence is never able to crash the manager.
+ */
+export interface TaskPersistenceStore {
+	persist(task: BackgroundTask): void;
+	persistSnapshot(snapshot: PersistedTaskSnapshot): void;
+	delete(taskId: string): void;
+	listSnapshots(): PersistedTaskSnapshot[];
+	gcOlderThan(maxAgeMs: number, now?: Date): void;
+}
+
+export function createTaskPersistenceStore(
+	options: CreateTaskPersistenceStoreOptions,
+): TaskPersistenceStore {
+	const logger = options.logger ?? defaultLog;
+	const omoDir = join(options.directory, OMO_DIR);
+	const tasksDir = join(omoDir, BACKGROUND_TASKS_DIR);
+
+	function ensureDir(): void {
+		const omoExisted = existsSync(omoDir);
+		mkdirSync(tasksDir, { recursive: true });
+		if (!omoExisted) {
+			writeFileSync(join(omoDir, ".gitignore"), GITIGNORE_CONTENT, "utf-8");
+		}
+	}
+
+	function filePathFor(taskId: string): string {
+		return join(tasksDir, `${taskId}.json`);
+	}
+
+	function writeSnapshot(snapshot: PersistedTaskSnapshot): void {
+		ensureDir();
+		writeFileAtomically(
+			filePathFor(snapshot.id),
+			`${JSON.stringify(snapshot, null, 2)}\n`,
+		);
+	}
+
+	function readSnapshot(filePath: string): PersistedTaskSnapshot | undefined {
+		const content = readFileSync(filePath, "utf-8");
+		return parseSnapshotFile(content);
+	}
+
+	return {
+		persist(task: BackgroundTask): void {
+			try {
+				writeSnapshot(taskToSnapshot(task, stampOwner()));
+			} catch (error) {
+				logger("task-persistence: persist failed", {
+					taskId: task.id,
+					error: String(error),
+				});
+			}
+		},
+
+		persistSnapshot(snapshot: PersistedTaskSnapshot): void {
+			try {
+				writeSnapshot(snapshot);
+			} catch (error) {
+				logger("task-persistence: persistSnapshot failed", {
+					taskId: snapshot.id,
+					error: String(error),
+				});
+			}
+		},
+
+		delete(taskId: string): void {
+			try {
+				const filePath = filePathFor(taskId);
+				if (existsSync(filePath)) {
+					unlinkSync(filePath);
+				}
+			} catch (error) {
+				logger("task-persistence: delete failed", {
+					taskId,
+					error: String(error),
+				});
+			}
+		},
+
+		listSnapshots(): PersistedTaskSnapshot[] {
+			const snapshots: PersistedTaskSnapshot[] = [];
+			try {
+				if (!existsSync(tasksDir)) {
+					return snapshots;
+				}
+				for (const entry of readdirSync(tasksDir)) {
+					if (!entry.endsWith(".json")) continue;
+					const filePath = join(tasksDir, entry);
+					try {
+						const snapshot = readSnapshot(filePath);
+						if (snapshot) {
+							snapshots.push(snapshot);
+						} else {
+							logger("task-persistence: skipping unparseable snapshot", {
+								filePath,
+							});
+						}
+					} catch (error) {
+						logger("task-persistence: failed to read snapshot", {
+							filePath,
+							error: String(error),
+						});
+					}
+				}
+			} catch (error) {
+				logger("task-persistence: listSnapshots failed", {
+					error: String(error),
+				});
+			}
+			return snapshots;
+		},
+
+		gcOlderThan(maxAgeMs: number, now: Date = new Date()): void {
+			try {
+				if (!existsSync(tasksDir)) {
+					return;
+				}
+				const cutoff = now.getTime() - maxAgeMs;
+				for (const entry of readdirSync(tasksDir)) {
+					if (!entry.endsWith(".json")) continue;
+					const filePath = join(tasksDir, entry);
+					try {
+						const snapshot = readSnapshot(filePath);
+						if (snapshot) {
+							const updatedAt = Date.parse(snapshot.updatedAt);
+							if (!Number.isNaN(updatedAt) && updatedAt < cutoff) {
+								unlinkSync(filePath);
+							}
+							continue;
+						}
+						if (statSync(filePath).mtimeMs < cutoff) {
+							unlinkSync(filePath);
+						}
+					} catch (error) {
+						logger("task-persistence: gc entry failed", {
+							filePath,
+							error: String(error),
+						});
+					}
+				}
+			} catch (error) {
+				logger("task-persistence: gcOlderThan failed", {
+					error: String(error),
+				});
+			}
+		},
+	};
+}

--- a/packages/omo-opencode/src/features/background-agent/task-poller.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller.ts
@@ -33,6 +33,7 @@ export function pruneStaleTasksAndNotifications(args: {
   tasks: Map<string, BackgroundTask>
   notifications: Map<string, BackgroundTask[]>
   onTaskPruned: (taskId: string, task: BackgroundTask, errorMessage: string) => void
+  onTaskRemoved?: (taskId: string) => void
   taskTtlMs?: number
   sessionStatuses?: SessionStatusMap
 }): void {
@@ -58,6 +59,7 @@ export function pruneStaleTasksAndNotifications(args: {
       if (age <= TERMINAL_TASK_TTL_MS) continue
 
       removeTaskToastTracking(taskId)
+      args.onTaskRemoved?.(taskId)
       tasks.delete(taskId)
       continue
     }

--- a/packages/omo-opencode/src/features/background-agent/task-registry.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-registry.ts
@@ -106,7 +106,7 @@ export function archiveBackgroundTask(task: BackgroundTask): void {
   const registry = getRegistry()
   registry.activeTasks.delete(task.id)
   registry.completedTasks.delete(task.id)
-  if (!task.sessionId || !TERMINAL_TASK_STATUSES.has(task.status)) {
+  if (!TERMINAL_TASK_STATUSES.has(task.status)) {
     return
   }
   registry.completedTasks.set(task.id, cloneRegisteredTask(task))

--- a/packages/omo-opencode/src/tools/background-task/task-status-format.test.ts
+++ b/packages/omo-opencode/src/tools/background-task/task-status-format.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
+import type { BackgroundTask } from "../../features/background-agent"
+import type { BackgroundOutputClient, BackgroundOutputManager } from "./clients"
+import { createBackgroundOutput } from "./create-background-output"
+import { formatTaskStatus } from "./task-status-format"
+
+function createTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: "task-1",
+    sessionId: "ses-1",
+    parentSessionId: "main-1",
+    parentMessageId: "msg-1",
+    description: "background task",
+    prompt: "do work",
+    agent: "test-agent",
+    status: "running",
+    ...overrides,
+  }
+}
+
+const mockContext = {
+  sessionID: "test-session",
+  messageID: "test-message",
+  agent: "test-agent",
+  abort: new AbortController().signal,
+  metadata: () => {},
+} as unknown as ToolContext
+
+function createMockClient(): BackgroundOutputClient {
+  return {
+    session: {
+      messages: async () => ({ data: [] }),
+    },
+  }
+}
+
+describe("formatTaskStatus recovered tasks", () => {
+  test("surfaces task.error for an error task lost across restart", () => {
+    // #given
+    const task = createTask({
+      status: "error",
+      error: "session lost across restart",
+    })
+
+    // #when
+    const output = formatTaskStatus(task)
+
+    // #then
+    expect(output).toContain("session lost across restart")
+  })
+
+  test("surfaces task.result recovery guidance for an interrupted task", () => {
+    // #given
+    const guidance =
+      'Task interrupted by OpenCode restart. Inspect output with session_read(session_id="ses-1") or continue with task(task_id="ses-1", run_in_background=false).'
+    const task = createTask({
+      status: "interrupt",
+      result: guidance,
+    })
+
+    // #when
+    const output = formatTaskStatus(task)
+
+    // #then
+    expect(output).toContain('session_read(session_id="ses-1")')
+    expect(output).toContain('task(task_id="ses-1"')
+  })
+})
+
+describe("background_output recovered tasks", () => {
+  test("surfaces error text for a registry-recovered error task", async () => {
+    // #given
+    const task = createTask({
+      id: "bg_recovered_error",
+      status: "error",
+      error: "session lost across restart",
+    })
+    const manager: BackgroundOutputManager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+    }
+    const tool = createBackgroundOutput(manager, createMockClient())
+
+    // #when
+    const output = await tool.execute({ task_id: task.id }, mockContext)
+
+    // #then
+    expect(output).toContain("session lost across restart")
+  })
+
+  test("surfaces recovery guidance for a registry-recovered interrupted task", async () => {
+    // #given
+    const guidance =
+      'Task interrupted by OpenCode restart. Inspect output with session_read(session_id="ses-1") or continue with task(task_id="ses-1", run_in_background=false).'
+    const task = createTask({
+      id: "bg_recovered_interrupt",
+      status: "interrupt",
+      result: guidance,
+    })
+    const manager: BackgroundOutputManager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+    }
+    const tool = createBackgroundOutput(manager, createMockClient())
+
+    // #when
+    const output = await tool.execute({ task_id: task.id }, mockContext)
+
+    // #then
+    expect(output).toContain('session_read(session_id="ses-1")')
+  })
+})

--- a/packages/omo-opencode/src/tools/background-task/task-status-format.ts
+++ b/packages/omo-opencode/src/tools/background-task/task-status-format.ts
@@ -51,6 +51,26 @@ ${truncated}
 > **Interrupted**: The task was interrupted by a prompt error. The session may contain partial results.`
    }
 
+  let errorSection = ""
+  if (task.error) {
+    errorSection = `
+
+## Error
+
+\`\`\`
+${truncateText(task.error, 500)}
+\`\`\``
+  }
+
+  let recoverySection = ""
+  if (task.result && (task.status === "interrupt" || task.status === "error")) {
+    recoverySection = `
+
+## Recovery
+
+${truncateText(task.result, 500)}`
+  }
+
   const durationLabel = task.status === "pending" ? "Queued for" : "Duration"
 
   return `# Task Status
@@ -63,7 +83,7 @@ ${truncated}
 | Status | **${task.status}** |
 | ${durationLabel} | ${duration} |
 | Session ID | \`${task.sessionId}\` |${progressSection}
-${statusNote}
+${statusNote}${errorSection}${recoverySection}
 ## Original Prompt
 
 \`\`\`


### PR DESCRIPTION
## Problem

Background task bookkeeping (`BackgroundManager.tasks`, `completedTaskArchive`, the `globalThis` registry) lives entirely in process memory. When OpenCode restarts, every `bg_...` → `ses_...` mapping evaporates: `background_output(task_id="bg_...")` returns "Task not found", completion notifications never fire, and `task(task_id=..., run_in_background=true)` resumes fail — even though the subagent sessions themselves survive in SQLite.

A previous file-backed implementation (single shared `.opencode/background-tasks.json`) was removed in 24a7f333a because multiple OpenCode instances sharing a project directory overwrote each other's state. This PR re-introduces persistence with a design that structurally eliminates that race.

## Design

- **Per-task snapshot files** at `<project>/.omo/background-tasks/{taskId}.json` — no shared file to fight over. Atomic writes (`writeFileAtomically`), tolerant parsing, no prompt text persisted.
- **PID owner fencing** — each snapshot records `owner: {pid, startedAt}`. Recovery only adopts snapshots whose owner process is dead; live siblings are never touched. GC is owner-aware too (a live owner's snapshot survives regardless of age).
- **Eager lifecycle persistence** — snapshots are written at enqueue (pending, pre-session), session binding, resume, and synchronously after every terminal mutation (complete / cancel / interrupt / error / stale-timeout / fallback retry) *before* any await, so a crash window cannot strand a `running` snapshot.
- **Recovery at plugin init** (`restorePersistedTasks`, fire-and-forget from `createManagers`): orphaned terminal snapshots are loaded into the completed-task archive + registry so `background_output` works post-restart with zero tool changes. Orphaned non-terminal snapshots are reconciled against `session.get` (scoped by project directory): session gone → `error("session lost across restart")`; session alive → `interrupt` with guidance pointing at `session_read(...)` / `task(task_id="ses_...")`. Recovery **never injects prompts** (prompt-async-gate audit stays green) and never starts pollers or notifications for recovered tasks.
- **Config**: `background_task.persistence` (default `true`); `false` → zero filesystem footprint.

## Known limitation

PID-reuse fencing is liveness-only today; `owner.startedAt` is recorded so a future refinement can compare process start times. The failure direction is conservative: a falsely-"alive" owner only skips adoption, never corrupts another instance's task.

## Testing

- TDD throughout; ~90 new tests (schema / fencing / store / recovery / manager lifecycle / restart-simulation integration / `background_output` rendering), full `background-agent` + `tools/background-task` + `config` + prompt-async-route-audit suites: **901 pass / 0 fail**, `bun run typecheck` clean, `bun run build` green.
- Source-level e2e with a genuinely dead spawned process exercising real PID fencing.
- **Real-harness QA** (isolated XDG sandbox, real opencode): a live session spawned a background task → snapshot appeared; the opencode process was SIGKILL'd mid-flight; a fresh opencode on the same project reconciled the orphan to `interrupt` 17 ms after plugin init, and `background_output` in a third process returned the recovered task with guidance. Real `~/.local/share/opencode/opencode.db` untouched (isolation proven). Evidence recorded under `.omo/evidence/20260612-background-task-persistence/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist background tasks to disk so they survive OpenCode restarts, with safe recovery that keeps `background_output` working across processes. Uses per-task snapshots with owner fencing to avoid cross-instance corruption.

- **New Features**
  - Per-task snapshot files at `<project>/.omo/background-tasks/{taskId}.json` with atomic writes and no prompt text.
  - PID owner fencing in each snapshot; only adopt tasks from dead owners, and never delete a live owner’s snapshots.
  - Eager persistence at enqueue, session bind/resume, and synchronously before every terminal change (complete/cancel/interrupt/error/stale-timeout/fallback-retry).
  - Automatic recovery on plugin init: terminal tasks are restored to the archive/registry so `background_output(task_id)` works after restart; non-terminal tasks are reconciled against surviving sessions without starting pollers or notifications.
  - Config: `background_task.persistence` (default `true`); set to `false` to disable all filesystem writes.

- **Bug Fixes**
  - Recovered terminal tasks without `sessionId` now appear in the archive/registry, enabling lookups after restart.
  - Recovery scopes `session.get` by project directory and treats mismatches as “session lost,” preventing cross-project adoption.
  - `background_output` now includes Error and Recovery sections for clearer post-restart guidance.

<sup>Written for commit 03f3fd0b7f2c4b3738e07a59e4903c585878abe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

