### PR TITLE
fix(background-agent): subagent reliability - parent-wake delivery guarantees, zombie-task elimination, message-delivery honesty

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/constants.ts
+++ b/packages/omo-opencode/src/features/background-agent/constants.ts
@@ -15,6 +15,10 @@ export const MIN_IDLE_TIME_MS = 5000
 export const POLLING_INTERVAL_MS = 3000
 export const TASK_CLEANUP_DELAY_MS = 10 * 60 * 1000
 export const TMUX_CALLBACK_DELAY_MS = 200
+/** Number of transient session.error events (session still alive) within the window before a task is failed */
+export const SESSION_ERROR_TRANSIENT_THRESHOLD = 3
+/** Rolling window for counting transient session.error events; resets the counter once exceeded */
+export const SESSION_ERROR_WINDOW_MS = 10 * 60 * 1000
 
 export type ProcessCleanupEvent = NodeJS.Signals | "beforeExit" | "exit"
 

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.message-stability.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.message-stability.test.ts
@@ -8,25 +8,38 @@ import { MIN_RUNTIME_BEFORE_STALE_MS, MIN_STABILITY_TIME_MS } from "./constants"
 import type { BackgroundTask } from "./types"
 
 type SessionStatus = { type: string }
+type SessionPart = { type: string; text?: string }
 type SessionMessage = {
-  info?: { role?: string; finish?: unknown; time?: { completed?: unknown } }
-  parts?: Array<{ type: string; text?: string }>
+  info?: { role?: string; finish?: unknown; id?: string }
+  parts?: SessionPart[]
 }
+type Todo = { content: string; status: string; priority: string; id?: string }
 type ManagerOverrides = {
   status?: (() => Promise<{ data: Record<string, SessionStatus> }>) | undefined
   messages: () => SessionMessage[]
+  todos?: () => Todo[]
   abort?: () => Promise<object>
 }
 
 const RUNNING_FOR_MS = MIN_RUNTIME_BEFORE_STALE_MS + 5_000
 const STABLE_FOR_MS = MIN_STABILITY_TIME_MS + 1_000
 
-function finishedAssistant(text: string): SessionMessage {
-  return { info: { role: "assistant", finish: "end_turn" }, parts: [{ type: "text", text }] }
+// Message ids are compared lexically (assistant must come AFTER the user), so use
+// zero-padded ids that sort correctly.
+function userMessage(id: string, text: string): SessionMessage {
+  return { info: { role: "user", id }, parts: [{ type: "text", text }] }
 }
 
-function unfinishedAssistant(text: string): SessionMessage {
-  return { info: { role: "assistant" }, parts: [{ type: "text", text }] }
+function assistantMessage(id: string, finish: unknown, parts: SessionPart[]): SessionMessage {
+  return { info: { role: "assistant", id, finish }, parts }
+}
+
+// A normal completed turn: user prompt followed by a finished assistant reply with text.
+function completedTurn(): SessionMessage[] {
+  return [
+    userMessage("msg-0001", "do the thing"),
+    assistantMessage("msg-0002", "stop", [{ type: "text", text: "done" }]),
+  ]
 }
 
 function createRunningTask(sessionId: string): BackgroundTask {
@@ -45,27 +58,30 @@ function createRunningTask(sessionId: string): BackgroundTask {
 }
 
 function createManager(overrides: ManagerOverrides): BackgroundManager {
-  let abortCount = 0
   const session = {
     ...(overrides.status === undefined ? {} : { status: overrides.status }),
     get: async () => ({ data: { id: "session" } }),
     prompt: async () => ({}),
     promptAsync: async () => ({}),
-    abort: overrides.abort ?? (async () => { abortCount += 1; return {} }),
-    todo: async () => ({ data: [] }),
+    abort: overrides.abort ?? (async () => ({})),
+    todo: async () => ({ data: overrides.todos ? overrides.todos() : [] }),
     messages: async () => ({ data: overrides.messages() }),
   }
   const client = { session }
-  const manager = new BackgroundManager({
+  return new BackgroundManager({
     pluginContext: { client, directory: tmpdir() } as PluginInput,
     enableParentSessionNotifications: false,
   })
-  ;(manager as unknown as { _abortCount: () => number })._abortCount = () => abortCount
-  return manager
 }
 
 function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
   ;(manager as unknown as { tasks: Map<string, BackgroundTask> }).tasks.set(task.id, task)
+}
+
+// Pre-seed the stability window so a single poll observes a stable, aged message count.
+function seedStable(task: BackgroundTask, count: number): void {
+  task.lastMsgCount = count
+  task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
 }
 
 async function poll(manager: BackgroundManager): Promise<void> {
@@ -73,15 +89,11 @@ async function poll(manager: BackgroundManager): Promise<void> {
 }
 
 describe("BackgroundManager pollRunningTasks message-stability completion fallback", () => {
-  test("#given status is unavailable and the last assistant message is finished and stable for 10s #when polled #then the task completes", async () => {
+  test("#given status is unavailable and the last assistant turn is terminally finished and stable for 10s #when polled #then the task completes", async () => {
     // given
-    const manager = createManager({
-      status: undefined,
-      messages: () => [finishedAssistant("done")],
-    })
+    const manager = createManager({ status: undefined, messages: () => completedTurn() })
     const task = createRunningTask("ses-stable-finished")
-    task.lastMsgCount = 1
-    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    seedStable(task, 2)
     injectTask(manager, task)
 
     // when
@@ -98,7 +110,10 @@ describe("BackgroundManager pollRunningTasks message-stability completion fallba
     let count = 1
     const manager = createManager({
       status: async () => ({ data: { "ses-busy-growing": { type: "busy" } } }),
-      messages: () => Array.from({ length: count }, (_, index) => finishedAssistant(`chunk-${index}`)),
+      messages: () =>
+        Array.from({ length: count }, (_, index) =>
+          assistantMessage(`msg-${String(index).padStart(4, "0")}`, "stop", [{ type: "text", text: `chunk-${index}` }]),
+        ),
     })
     const task = createRunningTask("ses-busy-growing")
     injectTask(manager, task)
@@ -118,15 +133,17 @@ describe("BackgroundManager pollRunningTasks message-stability completion fallba
     expect(task.completedAt).toBeUndefined()
   })
 
-  test("#given the last assistant message is unfinished but the count is stable for 10s #when polled #then the task does NOT complete", async () => {
+  test("#given the last assistant message has no finish reason but the count is stable #when polled #then the task does NOT complete", async () => {
     // given
     const manager = createManager({
       status: undefined,
-      messages: () => [unfinishedAssistant("still generating")],
+      messages: () => [
+        userMessage("msg-0001", "go"),
+        assistantMessage("msg-0002", undefined, [{ type: "text", text: "still generating" }]),
+      ],
     })
     const task = createRunningTask("ses-unfinished")
-    task.lastMsgCount = 1
-    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    seedStable(task, 2)
     injectTask(manager, task)
 
     // when
@@ -138,16 +155,99 @@ describe("BackgroundManager pollRunningTasks message-stability completion fallba
     expect(task.completedAt).toBeUndefined()
   })
 
-  test("#given a finished stable message but the task has only been running briefly #when polled #then the runtime throttle prevents completion", async () => {
+  test("#given the last assistant message finished with reason tool-calls #when polled #then the task does NOT complete (mid tool-loop)", async () => {
     // given
     const manager = createManager({
       status: undefined,
-      messages: () => [finishedAssistant("done")],
+      messages: () => [
+        userMessage("msg-0001", "go"),
+        assistantMessage("msg-0002", "tool-calls", [{ type: "tool", text: "" }]),
+      ],
     })
+    const task = createRunningTask("ses-tool-calls")
+    seedStable(task, 2)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given the last assistant message finished with reason unknown #when polled #then the task does NOT complete", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => [
+        userMessage("msg-0001", "go"),
+        assistantMessage("msg-0002", "unknown", [{ type: "text", text: "partial" }]),
+      ],
+    })
+    const task = createRunningTask("ses-unknown-finish")
+    seedStable(task, 2)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given an old finished assistant turn followed by a newer user message #when polled #then the task does NOT complete (turn superseded by new prompt)", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => [
+        userMessage("msg-0001", "first"),
+        assistantMessage("msg-0002", "stop", [{ type: "text", text: "old answer" }]),
+        userMessage("msg-0003", "follow-up just arrived"),
+      ],
+    })
+    const task = createRunningTask("ses-superseded")
+    seedStable(task, 3)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given a finished stable turn but incomplete todos #when polled #then the task does NOT complete (idle-path todo gate)", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => completedTurn(),
+      todos: () => [{ content: "still pending", status: "pending", priority: "high", id: "t1" }],
+    })
+    const task = createRunningTask("ses-incomplete-todos")
+    seedStable(task, 2)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given a finished stable turn but the task has only been running briefly #when polled #then the runtime throttle prevents completion", async () => {
+    // given
+    const manager = createManager({ status: undefined, messages: () => completedTurn() })
     const task = createRunningTask("ses-too-young")
     task.startedAt = new Date()
-    task.lastMsgCount = 1
-    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    seedStable(task, 2)
     injectTask(manager, task)
 
     // when

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.message-stability.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.message-stability.test.ts
@@ -1,0 +1,161 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { BackgroundManager } from "./manager"
+import { MIN_RUNTIME_BEFORE_STALE_MS, MIN_STABILITY_TIME_MS } from "./constants"
+import type { BackgroundTask } from "./types"
+
+type SessionStatus = { type: string }
+type SessionMessage = {
+  info?: { role?: string; finish?: unknown; time?: { completed?: unknown } }
+  parts?: Array<{ type: string; text?: string }>
+}
+type ManagerOverrides = {
+  status?: (() => Promise<{ data: Record<string, SessionStatus> }>) | undefined
+  messages: () => SessionMessage[]
+  abort?: () => Promise<object>
+}
+
+const RUNNING_FOR_MS = MIN_RUNTIME_BEFORE_STALE_MS + 5_000
+const STABLE_FOR_MS = MIN_STABILITY_TIME_MS + 1_000
+
+function finishedAssistant(text: string): SessionMessage {
+  return { info: { role: "assistant", finish: "end_turn" }, parts: [{ type: "text", text }] }
+}
+
+function unfinishedAssistant(text: string): SessionMessage {
+  return { info: { role: "assistant" }, parts: [{ type: "text", text }] }
+}
+
+function createRunningTask(sessionId: string): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test prompt",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(Date.now() - RUNNING_FOR_MS),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+function createManager(overrides: ManagerOverrides): BackgroundManager {
+  let abortCount = 0
+  const session = {
+    ...(overrides.status === undefined ? {} : { status: overrides.status }),
+    get: async () => ({ data: { id: "session" } }),
+    prompt: async () => ({}),
+    promptAsync: async () => ({}),
+    abort: overrides.abort ?? (async () => { abortCount += 1; return {} }),
+    todo: async () => ({ data: [] }),
+    messages: async () => ({ data: overrides.messages() }),
+  }
+  const client = { session }
+  const manager = new BackgroundManager({
+    pluginContext: { client, directory: tmpdir() } as PluginInput,
+    enableParentSessionNotifications: false,
+  })
+  ;(manager as unknown as { _abortCount: () => number })._abortCount = () => abortCount
+  return manager
+}
+
+function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
+  ;(manager as unknown as { tasks: Map<string, BackgroundTask> }).tasks.set(task.id, task)
+}
+
+async function poll(manager: BackgroundManager): Promise<void> {
+  await (manager as unknown as { pollRunningTasks: () => Promise<void> }).pollRunningTasks()
+}
+
+describe("BackgroundManager pollRunningTasks message-stability completion fallback", () => {
+  test("#given status is unavailable and the last assistant message is finished and stable for 10s #when polled #then the task completes", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => [finishedAssistant("done")],
+    })
+    const task = createRunningTask("ses-stable-finished")
+    task.lastMsgCount = 1
+    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("completed")
+    expect(task.completedAt).toBeDefined()
+  })
+
+  test("#given the session status stays busy but messages keep growing #when polled repeatedly #then the task never completes", async () => {
+    // given
+    let count = 1
+    const manager = createManager({
+      status: async () => ({ data: { "ses-busy-growing": { type: "busy" } } }),
+      messages: () => Array.from({ length: count }, (_, index) => finishedAssistant(`chunk-${index}`)),
+    })
+    const task = createRunningTask("ses-busy-growing")
+    injectTask(manager, task)
+
+    // when: each poll observes a larger message count, which resets the stability window
+    await poll(manager)
+    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    count = 2
+    await poll(manager)
+    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    count = 3
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given the last assistant message is unfinished but the count is stable for 10s #when polled #then the task does NOT complete", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => [unfinishedAssistant("still generating")],
+    })
+    const task = createRunningTask("ses-unfinished")
+    task.lastMsgCount = 1
+    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+
+  test("#given a finished stable message but the task has only been running briefly #when polled #then the runtime throttle prevents completion", async () => {
+    // given
+    const manager = createManager({
+      status: undefined,
+      messages: () => [finishedAssistant("done")],
+    })
+    const task = createRunningTask("ses-too-young")
+    task.startedAt = new Date()
+    task.lastMsgCount = 1
+    task.lastMessageCountChangedAt = new Date(Date.now() - STABLE_FOR_MS)
+    injectTask(manager, task)
+
+    // when
+    await poll(manager)
+    await manager.shutdown()
+
+    // then
+    expect(task.status).toBe("running")
+    expect(task.completedAt).toBeUndefined()
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -805,6 +805,69 @@ describe("BackgroundManager prompt rejection fallback routing", () => {
   })
 })
 
+describe("BackgroundManager.resume undelivered notification", () => {
+  test("notifies the parent and reverts the task when a resume prompt cannot be delivered", async () => {
+    //#given - client exposes no promptAsync so the resume dispatch resolves as unavailable
+    const client = {
+      session: {
+        messages: async () => [],
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+    const task: BackgroundTask = {
+      id: "bg_resume_undelivered",
+      sessionId: "ses_resume_undelivered",
+      parentSessionId: "parent-session",
+      parentMessageId: "parent-message",
+      description: "undelivered resume test",
+      prompt: "say hi",
+      agent: "sisyphus-junior",
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+      concurrencyGroup: "anthropic/claude-haiku-4-5",
+    }
+    getTaskMap(manager).set(task.id, task)
+    const queuePendingParentWake = mock(() => {})
+    ;(cast<{
+      queuePendingParentWake: (
+        sessionId: string,
+        notification: string,
+        promptContext: Record<string, unknown>,
+        shouldReply: boolean,
+        delayMs?: number,
+      ) => void
+    }>(manager)).queuePendingParentWake = queuePendingParentWake
+
+    //#when
+    await manager.resume({
+      sessionId: "ses_resume_undelivered",
+      prompt: "continue",
+      parentSessionId: "parent-session",
+      parentMessageId: "parent-message-2",
+    })
+    await waitUntil(() => queuePendingParentWake.mock.calls.length > 0, 1_000)
+
+    //#then
+    const storedTask = getTaskMap(manager).get(task.id)
+    expect(storedTask?.status).toBe("completed")
+    expect(queuePendingParentWake).toHaveBeenCalledTimes(1)
+    const wakeCall = cast<Array<[string, string, Record<string, unknown>, boolean]>>(
+      queuePendingParentWake.mock.calls,
+    )[0]
+    if (!wakeCall) {
+      throw new Error("Expected an undelivered-resume parent wake call")
+    }
+    const [sessionID, notification] = wakeCall
+    expect(sessionID).toBe("parent-session")
+    expect(notification).toContain("NOT delivered")
+    expect(notification).toContain("bg_resume_undelivered")
+    expect(notification).toContain("task_id")
+  })
+})
+
 describe("BackgroundManager retry observability", () => {
   test("queues a parent-visible retry notification when fallback retry is scheduled", async () => {
     //#given

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -860,11 +860,12 @@ describe("BackgroundManager.resume undelivered notification", () => {
     if (!wakeCall) {
       throw new Error("Expected an undelivered-resume parent wake call")
     }
-    const [sessionID, notification] = wakeCall
+    const [sessionID, notification, , shouldReply] = wakeCall
     expect(sessionID).toBe("parent-session")
     expect(notification).toContain("NOT delivered")
     expect(notification).toContain("bg_resume_undelivered")
     expect(notification).toContain("task_id")
+    expect(shouldReply).toBe(true)
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../claude-code-session-state"
 import { _resetTaskToastManagerForTesting, initTaskToastManager } from "../task-toast-manager/manager"
 import type { ConcurrencyManager } from "./concurrency"
-import { MIN_IDLE_TIME_MS } from "./constants"
+import { MIN_IDLE_TIME_MS, SESSION_ERROR_TRANSIENT_THRESHOLD, SESSION_ERROR_WINDOW_MS } from "./constants"
 import { BackgroundManager } from "./manager"
 import { _resetForTesting as resetProcessCleanupState } from "./process-cleanup"
 import { clearBackgroundTaskRegistryForTesting } from "./task-registry"
@@ -8383,6 +8383,258 @@ describe("BackgroundManager attempt lifecycle bindings", () => {
       sessionId: "session-attempt-2",
     })
     expect(abortCalls).toEqual([])
+
+    manager.shutdown()
+  })
+})
+
+describe("BackgroundManager session.error bookkeeping (G1)", () => {
+  const spyVerify = (manager: BackgroundManager, alive: boolean): ReturnType<typeof spyOn> => {
+    const spy = spyOn(
+      cast<{ verifySessionExists: (sessionID: string) => Promise<boolean> }>(manager),
+      "verifySessionExists",
+    )
+    spy.mockImplementation(async () => alive)
+    return spy
+  }
+
+  const fireSessionError = (manager: BackgroundManager, sessionID: string, message: string): void => {
+    manager.handleEvent({
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: { name: "UnknownError", message },
+      },
+    })
+  }
+
+  test("fails task after repeated session.error events while the session stays alive", async () => {
+    //#given
+    const manager = createBackgroundManager()
+    stubNotifyParentSession(manager)
+    const verifySpy = spyVerify(manager, true)
+    const concurrencyManager = getConcurrencyManager(manager)
+    const concurrencyKey = "anthropic/claude-opus-4.7"
+    await concurrencyManager.acquire(concurrencyKey)
+    const errorText = "Expected 'function.name' to be a string"
+    const task = createMockTask({
+      id: "task-g1-fail",
+      sessionId: "ses-g1-fail",
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-g1",
+      description: "task hit by repeated provider errors",
+      agent: "explore",
+      status: "running",
+      concurrencyKey,
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    //#when - first two errors keep the task running (below threshold)
+    fireSessionError(manager, task.sessionId!, errorText)
+    await flushBackgroundNotifications()
+    expect(task.status).toBe("running")
+    expect(task.sessionErrorCount).toBe(1)
+
+    fireSessionError(manager, task.sessionId!, errorText)
+    await flushBackgroundNotifications()
+    expect(task.status).toBe("running")
+    expect(task.sessionErrorCount).toBe(2)
+
+    //#when - the threshold-th error finalizes the task
+    fireSessionError(manager, task.sessionId!, errorText)
+    await flushBackgroundNotifications()
+
+    //#then
+    expect(task.sessionErrorCount).toBe(SESSION_ERROR_TRANSIENT_THRESHOLD)
+    expect(task.status).toBe("error")
+    expect(task.error).toContain(errorText)
+    expect(task.completedAt).toBeInstanceOf(Date)
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
+    expect(getCompletionTimers(manager).has(task.id)).toBe(true)
+    expect(manager.getPendingNotifications("parent-session").some((t) => t.id === task.id)).toBe(true)
+
+    verifySpy.mockRestore()
+    manager.shutdown()
+  })
+
+  test("resets the session.error counter when progress is observed between errors", async () => {
+    //#given
+    const manager = createBackgroundManager()
+    stubNotifyParentSession(manager)
+    const verifySpy = spyVerify(manager, true)
+    const sessionID = "ses-g1-progress"
+    const task = createMockTask({
+      id: "task-g1-progress",
+      sessionId: sessionID,
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-g1-progress",
+      description: "task that recovers progress between errors",
+      agent: "explore",
+      status: "running",
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    //#when - two errors accumulate, then progress arrives, then one more error
+    fireSessionError(manager, sessionID, "boom one")
+    await flushBackgroundNotifications()
+    fireSessionError(manager, sessionID, "boom two")
+    await flushBackgroundNotifications()
+    expect(task.sessionErrorCount).toBe(2)
+
+    manager.handleEvent({
+      type: "message.part.updated",
+      properties: { sessionID, type: "text" },
+    })
+    expect(task.sessionErrorCount).toBe(0)
+
+    fireSessionError(manager, sessionID, "boom three")
+    await flushBackgroundNotifications()
+
+    //#then - counter restarted from the progress reset, task still running
+    expect(task.status).toBe("running")
+    expect(task.sessionErrorCount).toBe(1)
+
+    verifySpy.mockRestore()
+    manager.shutdown()
+  })
+
+  test("resets the session.error window when the previous error is older than the window", async () => {
+    //#given
+    const manager = createBackgroundManager()
+    stubNotifyParentSession(manager)
+    const verifySpy = spyVerify(manager, true)
+    const sessionID = "ses-g1-window"
+    const task = createMockTask({
+      id: "task-g1-window",
+      sessionId: sessionID,
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-g1-window",
+      description: "task with a stale error window",
+      agent: "explore",
+      status: "running",
+    })
+    task.sessionErrorCount = 2
+    task.lastSessionErrorAt = new Date(Date.now() - (SESSION_ERROR_WINDOW_MS + 60_000))
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    fireSessionError(manager, sessionID, "fresh error after a long gap")
+    await flushBackgroundNotifications()
+
+    //#then - stale window discarded, counter restarts at 1, task still running
+    expect(task.status).toBe("running")
+    expect(task.sessionErrorCount).toBe(1)
+
+    verifySpy.mockRestore()
+    manager.shutdown()
+  })
+})
+
+describe("BackgroundManager orphaned launch session cleanup (G2)", () => {
+  test("aborts the spawned session when a launch prompt fails and no task owns it", async () => {
+    //#given
+    const abortCalls: string[] = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: tmpdir() } }),
+        create: async () => ({ data: { id: "ses_orphan_launch" } }),
+        promptAsync: async () => {
+          throw new Error("orphaned launch failure")
+        },
+        abort: async (args: { path: { id: string } }) => {
+          abortCalls.push(args.path.id)
+          return {}
+        },
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+    ;(cast<{
+      reserveSubagentSpawn: () => Promise<{
+        spawnContext: { rootSessionID: string; parentDepth: number; childDepth: number }
+        descendantCount: number
+        commit: () => number
+        rollback: () => void
+      }>
+    }>(manager)).reserveSubagentSpawn = async () => ({
+      spawnContext: { rootSessionID: "parent-session", parentDepth: 0, childDepth: 1 },
+      descendantCount: 1,
+      commit: () => 1,
+      rollback: () => {},
+    })
+    // No task can be resolved for the failing session (orphaned by definition of this branch)
+    ;(cast<{ resolveTaskAttemptBySession: () => undefined }>(manager)).resolveTaskAttemptBySession = () => undefined
+
+    //#when
+    await manager.launch({
+      description: "orphaned launch",
+      prompt: "say hi",
+      agent: "sisyphus-junior",
+      parentSessionId: "parent-session",
+      parentMessageId: "parent-message",
+    })
+    await flushBackgroundNotifications()
+
+    //#then
+    expect(abortCalls).toContain("ses_orphan_launch")
+
+    manager.shutdown()
+  })
+})
+
+describe("BackgroundManager resume error finalization (G4)", () => {
+  test("finalizes the current attempt when a resume prompt fails without a fallback", async () => {
+    //#given
+    const client = {
+      session: {
+        promptAsync: async () => {
+          throw new Error("resume prompt blew up")
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ pluginContext: createPluginInput(client) })
+    stubNotifyParentSession(manager)
+    const task: BackgroundTask = {
+      id: "bg_resume_g4",
+      sessionId: "ses_resume_g4",
+      parentSessionId: "parent-session",
+      parentMessageId: "parent-message",
+      description: "resume finalize test",
+      prompt: "say hi",
+      agent: "sisyphus-junior",
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+      concurrencyGroup: "sisyphus-junior",
+      attempts: [
+        {
+          attemptId: "att_g4",
+          attemptNumber: 1,
+          sessionId: "ses_resume_g4",
+          status: "running",
+          startedAt: new Date(),
+        },
+      ],
+      currentAttemptID: "att_g4",
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    await manager.resume({
+      sessionId: "ses_resume_g4",
+      prompt: "continue",
+      parentSessionId: "parent-session",
+      parentMessageId: "parent-message-2",
+    })
+    await flushBackgroundNotifications()
+
+    //#then
+    const storedTask = getTaskMap(manager).get(task.id)
+    expect(storedTask?.status).toBe("interrupt")
+    expect(storedTask?.attempts?.[0]?.status).toBe("interrupt")
+    expect(storedTask?.attempts?.[0]?.status).not.toBe("running")
+    expect(storedTask?.error).toContain("resume prompt blew up")
 
     manager.shutdown()
   })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -126,17 +126,41 @@ import type {
 
 type OpencodeClient = PluginInput["client"]
 
-function isCompletionMarker(value: unknown): boolean {
-  if (typeof value === "boolean") return value
-  return value !== undefined && value !== null
+// Finish reasons that do NOT mean the assistant turn is done (mid tool-loop / unknown).
+// Mirrored from tools/delegate-task/sync-session-poller.ts.
+const NON_TERMINAL_FINISH_REASONS = new Set(["tool-calls", "unknown"])
+const PENDING_TOOL_PART_TYPES = new Set(["tool", "tool_use", "tool-call"])
+
+type StabilityMessage = {
+  info?: { role?: string; finish?: unknown; id?: string }
+  parts?: Array<{ type?: string }>
 }
 
-function isAssistantMessageFinished(info: { finish?: unknown; finished?: unknown; completed?: unknown; time?: { completed?: unknown } } | undefined): boolean {
-  if (!info) return false
-  return isCompletionMarker(info.finish)
-    || isCompletionMarker(info.finished)
-    || isCompletionMarker(info.completed)
-    || isCompletionMarker(info.time?.completed)
+/**
+ * Terminal-completion check mirrored from
+ * tools/delegate-task/sync-session-poller.ts `isSessionComplete`. A session turn is
+ * complete only when the latest assistant message has a terminal finish reason, has
+ * no pending tool-call parts, and comes strictly AFTER the latest user message (so an
+ * old finished turn cannot complete a task that just received a new prompt/resume).
+ */
+function isSessionMessageComplete(messages: StabilityMessage[]): boolean {
+  let lastUser: StabilityMessage | undefined
+  let lastAssistant: StabilityMessage | undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (!lastAssistant && message.info?.role === "assistant") lastAssistant = message
+    if (!lastUser && message.info?.role === "user") lastUser = message
+    if (lastUser && lastAssistant) break
+  }
+
+  const finish = lastAssistant?.info?.finish
+  if (typeof finish !== "string" || finish.length === 0) return false
+  if (NON_TERMINAL_FINISH_REASONS.has(finish)) return false
+  if (lastAssistant?.parts?.some((part) => typeof part.type === "string" && PENDING_TOOL_PART_TYPES.has(part.type))) return false
+  const userId = lastUser?.info?.id
+  const assistantId = lastAssistant?.info?.id
+  if (!userId || !assistantId) return false
+  return userId < assistantId
 }
 
 type ResumeTaskSnapshot = {
@@ -584,14 +608,14 @@ Your message to this background task was NOT delivered (reason: ${reason}). The 
 </system-reminder>`
     void this.resolveParentWakePromptContext(task)
       .then((promptContext) => {
-        this.queuePendingParentWake(parentSessionId, notification, promptContext, false, PENDING_PARENT_WAKE_DEBOUNCE_MS)
+        this.queuePendingParentWake(parentSessionId, notification, promptContext, true, PENDING_PARENT_WAKE_DEBOUNCE_MS)
       })
       .catch((error) => {
         log("[background-agent] Failed to resolve prompt context for undelivered-resume notification:", {
           taskId: task.id,
           error: String(error),
         })
-        this.queuePendingParentWake(parentSessionId, notification, {}, false, PENDING_PARENT_WAKE_DEBOUNCE_MS)
+        this.queuePendingParentWake(parentSessionId, notification, {}, true, PENDING_PARENT_WAKE_DEBOUNCE_MS)
       })
   }
 
@@ -2988,10 +3012,10 @@ The task was re-queued on a fallback model after a retryable failure.
       return false
     }
 
-    let messages: Array<{ info?: { role?: string; finish?: unknown; finished?: unknown; completed?: unknown; time?: { completed?: unknown } } }>
+    let messages: StabilityMessage[]
     try {
       const response = await messagesInDirectory(this.client, { path: { id: sessionID } }, this.directory)
-      messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, { preferResponseOnMissingData: true })
+      messages = normalizeSDKResponse(response, [] as StabilityMessage[], { preferResponseOnMissingData: true })
     } catch (error) {
       log("[background-agent] Message-stability fallback failed to read messages:", { taskId: task.id, error })
       return false
@@ -3011,11 +3035,19 @@ The task was re-queued on a fallback model after a retryable failure.
       return false
     }
 
-    // Stable, but never complete a session that has not finished its turn.
-    const lastAssistant = [...messages].reverse().find((message) => message.info?.role === "assistant")
-    if (!lastAssistant || !isAssistantMessageFinished(lastAssistant.info)) {
+    // Stable, but never complete a session whose turn is not terminally finished.
+    // Rejects finish:"tool-calls"/"unknown", pending tool-call parts, and old finished
+    // turns superseded by a newer user/resume message.
+    if (!isSessionMessageComplete(messages)) {
       return false
     }
+
+    // Mirror the session.idle completion gates: require real output and no incomplete todos.
+    const hasValidOutput = await this.validateSessionHasOutput(sessionID)
+    if (!hasValidOutput) return false
+    if (task.status !== "running") return false
+    const hasIncompleteTodos = await this.checkSessionTodos(sessionID)
+    if (hasIncompleteTodos) return false
 
     // Re-check after async work to avoid racing with another completion path.
     if (task.status !== "running") return false

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -144,23 +144,22 @@ type StabilityMessage = {
  * old finished turn cannot complete a task that just received a new prompt/resume).
  */
 function isSessionMessageComplete(messages: StabilityMessage[]): boolean {
-  let lastUser: StabilityMessage | undefined
-  let lastAssistant: StabilityMessage | undefined
+  let lastUserIndex = -1
+  let lastAssistantIndex = -1
   for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]
-    if (!lastAssistant && message.info?.role === "assistant") lastAssistant = message
-    if (!lastUser && message.info?.role === "user") lastUser = message
-    if (lastUser && lastAssistant) break
+    const role = messages[i]?.info?.role
+    if (lastAssistantIndex === -1 && role === "assistant") lastAssistantIndex = i
+    if (lastUserIndex === -1 && role === "user") lastUserIndex = i
+    if (lastUserIndex !== -1 && lastAssistantIndex !== -1) break
   }
 
+  if (lastAssistantIndex === -1 || lastUserIndex === -1) return false
+  const lastAssistant = messages[lastAssistantIndex]
   const finish = lastAssistant?.info?.finish
   if (typeof finish !== "string" || finish.length === 0) return false
   if (NON_TERMINAL_FINISH_REASONS.has(finish)) return false
   if (lastAssistant?.parts?.some((part) => typeof part.type === "string" && PENDING_TOOL_PART_TYPES.has(part.type))) return false
-  const userId = lastUser?.info?.id
-  const assistantId = lastAssistant?.info?.id
-  if (!userId || !assistantId) return false
-  return userId < assistantId
+  return lastAssistantIndex > lastUserIndex
 }
 
 type ResumeTaskSnapshot = {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -551,6 +551,33 @@ export class BackgroundManager {
       this.scheduleTaskRemoval(task.id)
     }
     this.updateBackgroundTaskMarker(task.parentSessionId)
+    this.notifyResumePromptNotDelivered(task, skippedStatus)
+  }
+
+  private notifyResumePromptNotDelivered(task: BackgroundTask, reason: string): void {
+    const parentSessionId = task.parentSessionId
+    if (!parentSessionId) {
+      return
+    }
+    const revertedStatus = task.status
+    const notification = `<system-reminder>
+[BACKGROUND TASK MESSAGE NOT DELIVERED]
+**ID:** \`${task.id}\`
+**Description:** ${task.description}
+
+Your message to this background task was NOT delivered (reason: ${reason}). The task was reverted to "${revertedStatus}". Retry with task(task_id="${task.id}", prompt="...").
+</system-reminder>`
+    void this.resolveParentWakePromptContext(task)
+      .then((promptContext) => {
+        this.queuePendingParentWake(parentSessionId, notification, promptContext, false, PENDING_PARENT_WAKE_DEBOUNCE_MS)
+      })
+      .catch((error) => {
+        log("[background-agent] Failed to resolve prompt context for undelivered-resume notification:", {
+          taskId: task.id,
+          error: String(error),
+        })
+        this.queuePendingParentWake(parentSessionId, notification, {}, false, PENDING_PARENT_WAKE_DEBOUNCE_MS)
+      })
   }
 
   private removeTaskFromParentIndex(taskID: string, parentSessionID: string | undefined): void {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -56,6 +56,8 @@ import {
 } from "./compaction-aware-message-resolver"
 import { ConcurrencyManager } from "./concurrency"
 import {
+  MIN_RUNTIME_BEFORE_STALE_MS,
+  MIN_STABILITY_TIME_MS,
   POLLING_INTERVAL_MS,
   type QueueItem,
   SESSION_ERROR_TRANSIENT_THRESHOLD,
@@ -123,6 +125,19 @@ import type {
 } from "./types"
 
 type OpencodeClient = PluginInput["client"]
+
+function isCompletionMarker(value: unknown): boolean {
+  if (typeof value === "boolean") return value
+  return value !== undefined && value !== null
+}
+
+function isAssistantMessageFinished(info: { finish?: unknown; finished?: unknown; completed?: unknown; time?: { completed?: unknown } } | undefined): boolean {
+  if (!info) return false
+  return isCompletionMarker(info.finish)
+    || isCompletionMarker(info.finished)
+    || isCompletionMarker(info.completed)
+    || isCompletionMarker(info.time?.completed)
+}
 
 type ResumeTaskSnapshot = {
   status: BackgroundTask["status"]
@@ -2888,6 +2903,24 @@ The task was re-queued on a fallback model after a retryable failure.
     return verifySessionStillExists(this.client, sessionID, this.directory)
   }
 
+  /**
+   * Surface a first-prompt-watchdog give-up (no fallback chain configured) for a
+   * background task. Locates the task by session and fails it through the same
+   * machinery as a crash so the parent is notified. No-op when the session is not
+   * a background task (e.g. a main session), preserving the watchdog's silent
+   * give-up for non-task sessions.
+   */
+  async failWatchdogExhaustedTask(sessionID: string, info: { model?: string; agent?: string } = {}): Promise<void> {
+    const task = this.findBySession(sessionID)
+    if (!task) return
+    if (task.status !== "running") return
+    const modelLabel = info.model ? ` on model ${info.model}` : ""
+    log("[background-agent] First-prompt watchdog exhausted with no fallback, failing task:", { taskId: task.id, sessionID, model: info.model, agent: info.agent })
+    await this.failCrashedTask(
+      task,
+      `Subagent produced no progress${modelLabel} and the first-prompt watchdog exhausted its same-model retries with no fallback model configured.`,
+    )
+  }
   private async failCrashedTask(task: BackgroundTask, errorMessage: string): Promise<void> {
     if (task.currentAttemptID) {
       finalizeAttempt(task, task.currentAttemptID, "error", errorMessage)
@@ -2935,6 +2968,61 @@ The task was re-queued on a fallback model after a retryable failure.
       log("[background-agent] Error in notifyParentSession for crashed task:", { taskId: task.id, error: err })
     })
   }
+
+  /**
+   * Completion fallback for the polling path when SSE idle events are missed.
+   * When a running task's session status is unavailable or stuck-busy, the
+   * idle SSE event can be dropped and the task wedges until the stale timeout.
+   * This detects completion from message stability: if the message count has
+   * been unchanged for MIN_STABILITY_TIME_MS AND the last assistant message is
+   * finished, the task is completed. It can NEVER complete a session that is
+   * still generating, because a growing message count resets the stability
+   * window and an unfinished last assistant message blocks completion.
+   */
+  private async tryMessageStabilityCompletion(task: BackgroundTask, sessionID: string, source: string): Promise<boolean> {
+    if (task.status !== "running") return false
+
+    // Throttle: only consider the fallback once the task has been running a while.
+    const startedAt = task.startedAt?.getTime()
+    if (startedAt === undefined || Date.now() - startedAt < MIN_RUNTIME_BEFORE_STALE_MS) {
+      return false
+    }
+
+    let messages: Array<{ info?: { role?: string; finish?: unknown; finished?: unknown; completed?: unknown; time?: { completed?: unknown } } }>
+    try {
+      const response = await messagesInDirectory(this.client, { path: { id: sessionID } }, this.directory)
+      messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, { preferResponseOnMissingData: true })
+    } catch (error) {
+      log("[background-agent] Message-stability fallback failed to read messages:", { taskId: task.id, error })
+      return false
+    }
+
+    const count = messages.length
+    if (task.lastMsgCount !== count) {
+      task.lastMsgCount = count
+      task.lastMessageCountChangedAt = new Date()
+      return false
+    }
+    if (!task.lastMessageCountChangedAt) {
+      task.lastMessageCountChangedAt = new Date()
+      return false
+    }
+    if (Date.now() - task.lastMessageCountChangedAt.getTime() < MIN_STABILITY_TIME_MS) {
+      return false
+    }
+
+    // Stable, but never complete a session that has not finished its turn.
+    const lastAssistant = [...messages].reverse().find((message) => message.info?.role === "assistant")
+    if (!lastAssistant || !isAssistantMessageFinished(lastAssistant.info)) {
+      return false
+    }
+
+    // Re-check after async work to avoid racing with another completion path.
+    if (task.status !== "running") return false
+
+    return await this.tryCompleteTask(task, source)
+  }
+
 
   private async pollRunningTasks(): Promise<void> {
     if (this.pollingInFlight) return
@@ -2993,6 +3081,7 @@ The task was re-queued on a fallback model after a retryable failure.
               sessionStatus: sessionStatus.type,
               toolCalls: task.progress?.toolCalls ?? 0,
             })
+            await this.tryMessageStabilityCompletion(task, sessionID, "polling (message stability, status busy)")
             continue
           }
 
@@ -3010,6 +3099,7 @@ The task was re-queued on a fallback model after a retryable failure.
           }
 
           if (allStatuses === undefined) {
+            await this.tryMessageStabilityCompletion(task, sessionID, "polling (message stability, status unavailable)")
             continue
           }
 

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -58,6 +58,8 @@ import { ConcurrencyManager } from "./concurrency"
 import {
   POLLING_INTERVAL_MS,
   type QueueItem,
+  SESSION_ERROR_TRANSIENT_THRESHOLD,
+  SESSION_ERROR_WINDOW_MS,
   TASK_CLEANUP_DELAY_MS,
   TASK_TTL_MS,
 } from "./constants"
@@ -1011,6 +1013,11 @@ The fallback retry session is now created and can be inspected directly.
         this.enqueueNotificationForParent(existingTask.parentSessionId, () => this.notifyParentSession(existingTask)).catch(err => {
           log("[background-agent] Failed to notify on error:", err)
         })
+      } else {
+        // No task owns this session (orphaned by definition of this branch): abort it best-effort
+        log("[background-agent] No task resolved for failed launch prompt, aborting orphaned session:", { sessionID })
+        clearDelegatedChildSessionBootstrap(sessionID)
+        await this.abortSessionWithLogging(sessionID, "orphaned launch session cleanup")
       }
     })
 
@@ -1414,10 +1421,14 @@ The fallback retry session is now created and can be inspected directly.
         return
       }
 
-      existingTask.status = "interrupt"
       const errorMessage = errorInfo.message ?? (error instanceof Error ? error.message : String(error))
-      existingTask.error = errorMessage
-      existingTask.completedAt = new Date()
+      if (existingTask.currentAttemptID) {
+        finalizeAttempt(existingTask, existingTask.currentAttemptID, "interrupt", errorMessage)
+      } else {
+        existingTask.status = "interrupt"
+        existingTask.error = errorMessage
+        existingTask.completedAt = new Date()
+      }
       if (existingTask.rootSessionId) {
         this.unregisterRootDescendant(existingTask.rootSessionId)
       }
@@ -1673,6 +1684,10 @@ The fallback retry session is now created and can be inspected directly.
         }
       }
       task.progress.lastUpdate = partInfo?.activityTime ?? new Date()
+      if (task.sessionErrorCount) {
+        task.sessionErrorCount = 0
+        task.lastSessionErrorAt = undefined
+      }
 
       if (partInfo?.type === "tool" || partInfo?.tool) {
         const countedToolPartIDs = task.progress.countedToolPartIDs ?? new Set<string>()
@@ -2011,24 +2026,48 @@ The fallback retry session is now created and can be inspected directly.
       canRetry,
     })
 
+    let repeatedTransientError = false
     const sessionId = task.sessionId
     if (sessionId) {
       const sessionStillAlive = await this.verifySessionExists(sessionId)
       if (sessionStillAlive) {
-        this.logger("[background-agent] session.error received but session still alive, treating as transient:", {
+        const now = Date.now()
+        const lastSessionErrorAt = task.lastSessionErrorAt?.getTime()
+        if (lastSessionErrorAt !== undefined && now - lastSessionErrorAt > SESSION_ERROR_WINDOW_MS) {
+          task.sessionErrorCount = 0
+        }
+        task.sessionErrorCount = (task.sessionErrorCount ?? 0) + 1
+        task.lastSessionErrorAt = new Date(now)
+
+        if (task.sessionErrorCount < SESSION_ERROR_TRANSIENT_THRESHOLD) {
+          this.logger("[background-agent] session.error received but session still alive, treating as transient:", {
+            taskId: task.id,
+            sessionId,
+            sessionErrorCount: task.sessionErrorCount,
+            errorMessage: errorMsg?.slice(0, 200),
+          })
+          return
+        }
+
+        repeatedTransientError = true
+        this.logger("[background-agent] session.error repeated past transient threshold while session alive, failing task:", {
           taskId: task.id,
           sessionId,
+          sessionErrorCount: task.sessionErrorCount,
           errorMessage: errorMsg?.slice(0, 200),
         })
-        return
       }
     }
 
+    const failureError = repeatedTransientError
+      ? `Session repeatedly errored ${task.sessionErrorCount} times without recovering. Last error: ${errorMsg}`
+      : errorMsg
+
     if (task.currentAttemptID) {
-      finalizeAttempt(task, task.currentAttemptID, "error", errorMsg)
+      finalizeAttempt(task, task.currentAttemptID, "error", failureError)
     } else {
       task.status = "error"
-      task.error = errorMsg
+      task.error = failureError
       task.completedAt = new Date()
     }
     if (task.rootSessionId) {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -86,6 +86,7 @@ import type { PendingParentWake } from "./parent-wake-dedupe"
 import { registerManagerForCleanup, unregisterManagerForCleanup } from "./process-cleanup"
 import { removeTaskToastTracking } from "./remove-task-toast-tracking"
 import {
+  checkSessionExistence,
   MIN_SESSION_GONE_POLLS,
   verifySessionExists as verifySessionStillExists,
 } from "./session-existence"
@@ -228,6 +229,19 @@ export type OnSubagentSessionDeleted = (event: SubagentSessionDeletedEvent) => P
 const MAX_TASK_REMOVAL_RESCHEDULES = 6
 const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 100
 const PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS = 5_000
+/**
+ * Upper bound on how long a single parent-wake may stay deferred before it is
+ * force-dispatched as an admit-only noReply. Without this bound a parent kept
+ * continuously busy (ultrawork / todo-continuation loops re-prompting at every
+ * turn end) starves the wake forever (8267x deferral incident, upstream #5089).
+ */
+const PARENT_WAKE_MAX_DEFER_MS = 120_000
+/**
+ * Number of consecutive 5s failure-requeue windows (each refreshing with zero
+ * assistant/tool output after the wake) tolerated before a silently-dropped
+ * dispatched wake is requeued into the pending queue (~15s total).
+ */
+const PARENT_WAKE_MAX_WINDOW_REFRESHES = 3
 
 export interface BackgroundManagerConfig {
   pluginContext: PluginInput
@@ -306,6 +320,8 @@ export class BackgroundManager {
         client: this.client,
         directory: this.directory,
         enqueueNotificationForParent: this.enqueueNotificationForParent.bind(this),
+        checkParentSessionExistence: (sessionID: string) =>
+          checkSessionExistence(this.client, sessionID, this.directory),
       },
       {
         pendingRetryMs: PENDING_PARENT_WAKE_RETRY_MS,
@@ -314,6 +330,8 @@ export class BackgroundManager {
         failureRequeueWindowMs: PARENT_WAKE_FAILURE_REQUEUE_WINDOW_MS,
         userMessageInProgressWindowMs: PARENT_WAKE_USER_MESSAGE_IN_PROGRESS_WINDOW_MS,
         parentSessionActivityInProgressWindowMs: PARENT_WAKE_SESSION_ACTIVITY_IN_PROGRESS_WINDOW_MS,
+        maxDeferMs: PARENT_WAKE_MAX_DEFER_MS,
+        maxWindowRefreshes: PARENT_WAKE_MAX_WINDOW_REFRESHES,
       },
     )
     this.registerProcessCleanup()

--- a/packages/omo-opencode/src/features/background-agent/manager.watchdog-exhaustion.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.watchdog-exhaustion.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+function createRunningTask(sessionId: string): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test prompt",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+function createManager(): BackgroundManager {
+  const session = {
+    get: async () => ({ data: { id: "session" } }),
+    prompt: async () => ({}),
+    promptAsync: async () => ({}),
+    abort: async () => ({}),
+    todo: async () => ({ data: [] }),
+    messages: async () => ({ data: [] }),
+  }
+  return new BackgroundManager({
+    pluginContext: { client: { session }, directory: tmpdir() } as PluginInput,
+    enableParentSessionNotifications: false,
+  })
+}
+
+function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
+  ;(manager as unknown as { tasks: Map<string, BackgroundTask> }).tasks.set(task.id, task)
+}
+
+describe("BackgroundManager.failWatchdogExhaustedTask", () => {
+  test("#given a running background task session #when the watchdog exhausts with no fallback #then the task is failed and a parent notification is enqueued", async () => {
+    // given
+    const manager = createManager()
+    const task = createRunningTask("ses-watchdog-bg-task")
+    injectTask(manager, task)
+
+    // when
+    await manager.failWatchdogExhaustedTask("ses-watchdog-bg-task", {
+      model: "openai/gpt-5.4-mini",
+      agent: "sisyphus-junior",
+    })
+
+    // then
+    expect(task.status).toBe("error")
+    expect(task.error).toContain("watchdog")
+    expect(manager.getPendingNotifications("parent-session").map((pending) => pending.id)).toContain(task.id)
+
+    await manager.shutdown()
+  })
+
+  test("#given a session that is not a background task #when the watchdog exhausts #then it is a no-op and does not throw", async () => {
+    // given
+    const manager = createManager()
+    const task = createRunningTask("ses-watchdog-bg-task")
+    injectTask(manager, task)
+
+    // when
+    await manager.failWatchdogExhaustedTask("ses-not-a-task", { model: "openai/gpt-5.4-mini" })
+
+    // then
+    expect(task.status).toBe("running")
+    expect(manager.getPendingNotifications("parent-session")).toHaveLength(0)
+
+    await manager.shutdown()
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -15,6 +15,9 @@ export type PendingParentWake = {
   noReplyAdmittedAt?: number
   toolCallDeferralStartedAt?: number
   allowEmptyAssistantTurnRetry?: boolean
+  firstDeferredAt?: number
+  deferCount?: number
+  windowRefreshCount?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -38,9 +41,12 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     ...(wake.toolCallDeferralStartedAt !== undefined
       ? { toolCallDeferralStartedAt: wake.toolCallDeferralStartedAt }
       : {}),
-    ...(wake.allowEmptyAssistantTurnRetry !== undefined
-      ? { allowEmptyAssistantTurnRetry: wake.allowEmptyAssistantTurnRetry }
+...(wake.allowEmptyAssistantTurnRetry !== undefined
+? { allowEmptyAssistantTurnRetry: wake.allowEmptyAssistantTurnRetry }
       : {}),
+    ...(wake.firstDeferredAt !== undefined ? { firstDeferredAt: wake.firstDeferredAt } : {}),
+    ...(wake.deferCount !== undefined ? { deferCount: wake.deferCount } : {}),
+    ...(wake.windowRefreshCount !== undefined ? { windowRefreshCount: wake.windowRefreshCount } : {}),
   }
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -19,6 +19,7 @@ export type PendingParentWake = {
   deferCount?: number
   windowRefreshCount?: number
   forcedQueuedAt?: number
+  forceQueueToken?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -49,6 +50,7 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     ...(wake.deferCount !== undefined ? { deferCount: wake.deferCount } : {}),
     ...(wake.windowRefreshCount !== undefined ? { windowRefreshCount: wake.windowRefreshCount } : {}),
     ...(wake.forcedQueuedAt !== undefined ? { forcedQueuedAt: wake.forcedQueuedAt } : {}),
+    ...(wake.forceQueueToken !== undefined ? { forceQueueToken: wake.forceQueueToken } : {}),
   }
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-dedupe.ts
@@ -18,6 +18,7 @@ export type PendingParentWake = {
   firstDeferredAt?: number
   deferCount?: number
   windowRefreshCount?: number
+  forcedQueuedAt?: number
 }
 
 export function resolveParentWakePromptContext(promptContext: ParentWakePromptContext): ParentWakePromptContext {
@@ -47,6 +48,7 @@ export function cloneParentWake(wake: PendingParentWake): PendingParentWake {
     ...(wake.firstDeferredAt !== undefined ? { firstDeferredAt: wake.firstDeferredAt } : {}),
     ...(wake.deferCount !== undefined ? { deferCount: wake.deferCount } : {}),
     ...(wake.windowRefreshCount !== undefined ? { windowRefreshCount: wake.windowRefreshCount } : {}),
+    ...(wake.forcedQueuedAt !== undefined ? { forcedQueuedAt: wake.forcedQueuedAt } : {}),
   }
 }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ParentWakeNotifier } from "./parent-wake-notifier"
+import type { SessionExistenceStatus } from "./session-existence"
+import {
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "../../hooks/shared/prompt-async-gate"
+
+type PromptAsyncCall = {
+  path: { id: string }
+  body: {
+    noReply?: boolean
+    parts?: unknown[]
+  }
+  query?: {
+    directory: string
+  }
+}
+
+type SessionMessageStub = {
+  info?: {
+    role?: string
+    finish?: string
+    time?: { created?: number; completed?: number }
+    error?: { name?: string }
+  }
+  parts?: Array<{ type?: string; text?: string; synthetic?: boolean; state?: { status?: string } }>
+}
+
+const FINAL_WAKE = [
+  "<system-reminder>",
+  "[BACKGROUND TASK COMPLETED]",
+  "[ALL BACKGROUND TASKS COMPLETE]",
+  "",
+  "**Completed:**",
+  "- `task-a`: task A",
+  "",
+  'Use `background_output(task_id="<id>")` to retrieve each result.',
+  "</system-reminder>",
+].join("\n")
+
+// An assistant turn that is still busy (running tool) so history-based and
+// activity-based defers keep firing while the parent stays unsafe.
+const BLOCKED_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "tool-calls", time: { created: 99_500 } },
+    parts: [{ type: "tool", state: { status: "running" } }],
+  },
+]
+
+// A settled assistant turn whose only output predates the wake, so the parent
+// is "safe" but no assistant output exists after a dispatch.
+const SAFE_MESSAGES: SessionMessageStub[] = [
+  {
+    info: { role: "user", time: { created: 80_000 } },
+    parts: [{ type: "text", text: "start work" }],
+  },
+  {
+    info: { role: "assistant", finish: "stop", time: { created: 90_000 } },
+    parts: [{ type: "text", text: "delegated to background" }],
+  },
+]
+
+function createNotifier(args: {
+  sessionStatuses?: Record<string, { type: string }>
+  messagesProvider: () => SessionMessageStub[]
+  promptAsyncImpl?: (call: PromptAsyncCall) => Promise<unknown>
+  checkParentSessionExistence?: (sessionID: string) => Promise<SessionExistenceStatus>
+  maxDeferMs?: number
+  maxWindowRefreshes?: number
+  failureRequeueWindowMs?: number
+}): {
+  notifier: ParentWakeNotifier
+  promptAsyncCalls: PromptAsyncCall[]
+} {
+  const promptAsyncCalls: PromptAsyncCall[] = []
+  const client = {
+    session: {
+      messages: async () => ({ data: args.messagesProvider() }),
+      status: async () => ({ data: args.sessionStatuses ?? {} }),
+      promptAsync: async (call: PromptAsyncCall) => {
+        promptAsyncCalls.push(call)
+        return (await args.promptAsyncImpl?.(call)) ?? { data: {} }
+      },
+      abort: async () => ({ data: {} }),
+    },
+  } as unknown as ConstructorParameters<typeof ParentWakeNotifier>[0]["client"]
+
+  const notifier = new ParentWakeNotifier(
+    {
+      client,
+      directory: "/tmp/test-omo",
+      enqueueNotificationForParent: async (_sessionID, operation) => {
+        await operation()
+      },
+      ...(args.checkParentSessionExistence
+        ? { checkParentSessionExistence: args.checkParentSessionExistence }
+        : {}),
+    },
+    {
+      pendingRetryMs: 1_000,
+      acceptedMessageSkewMs: 5_000,
+      toolCallDeferMaxMs: 5_000,
+      failureRequeueWindowMs: args.failureRequeueWindowMs ?? 5_000,
+      userMessageInProgressWindowMs: 2_000,
+      ...(args.maxDeferMs !== undefined ? { maxDeferMs: args.maxDeferMs } : {}),
+      ...(args.maxWindowRefreshes !== undefined ? { maxWindowRefreshes: args.maxWindowRefreshes } : {}),
+    },
+  )
+
+  return { notifier, promptAsyncCalls }
+}
+
+function releaseParentWakeHold(sessionID: string): void {
+  releasePromptAsyncReservation(sessionID, "test:simulate-expired-parent-wake-hold", {
+    reservedBy: "background-agent-parent-wake",
+  })
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 5))
+  }
+  expect(predicate()).toBe(true)
+}
+
+afterEach(() => {
+  releaseAllPromptAsyncReservationsForTesting()
+})
+
+describe("BUG B1: unbounded parent-wake deferral starvation (upstream #5089)", () => {
+  test("#given a perpetually busy parent #when the wake is deferred past the max #then it is force-dispatched as a noReply admission", async () => {
+    // given: the parent session is continuously active (ultrawork / todo loop),
+    // so the active-session defer path reschedules at 1s forever.
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "busy" } },
+      messagesProvider: () => BLOCKED_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when: the first flush only defers because the parent is active
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.firstDeferredAt).toBe(100_000)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+
+      // when: the deferral budget is exceeded while the parent stays busy
+      now = 100_000 + 5_001
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the wake is force-dispatched as a noReply admission despite the
+      // parent still being active (content lands at the next turn boundary)
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(JSON.stringify(promptAsyncCalls[0]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+      // the reply-required wake is retained for a later reply-producing resume
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})
+
+describe("BUG B2: retained reply-wake never re-flushed (upstream #5189)", () => {
+  test("#given a reply-required wake admitted as noReply while the parent is busy #then a re-flush stays scheduled and the wake force-delivers even if the parent never goes safe", async () => {
+    // given: the parent keeps a tool turn running, so every flush defers the
+    // retained reply wake (recent-activity / history defers).
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => BLOCKED_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when: the wake is admitted as noReply and retained
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      // then: it is retained AND a re-flush timer is scheduled (never abandoned)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+
+      // when: the parent stays unsafe across another flush
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+      // then: still retained, still re-flush-scheduled, no duplicate admission
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+
+      // when: the parent NEVER goes safe but the deferral budget is exceeded
+      now = 100_000 + 5_001
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: B1 force-path re-delivers the retained completion as noReply
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(true)
+      expect(JSON.stringify(promptAsyncCalls[1]?.body.parts)).toContain("ALL BACKGROUND TASKS COMPLETE")
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a retained reply wake #when the parent finally goes safe #then it dispatches with a reply", async () => {
+    // given
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    let blocked = true
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => (blocked ? BLOCKED_MESSAGES : SAFE_MESSAGES),
+      maxDeferMs: 5_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when: admitted as noReply while busy, then the parent goes safe
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+
+      blocked = false
+      now = 110_000
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: a reply-producing resume fires exactly once and the wake clears
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})
+
+describe("BUG B3: dispatched-wake silent loss requeues after repeated empty windows", () => {
+  test("#given a dispatched wake with no assistant output #when the failure window refreshes maxWindowRefreshes times #then the wake is requeued into the pending queue", async () => {
+    // given: the parent is safe so the wake dispatches normally, but no
+    // assistant/tool output ever appears after the dispatch (silent drop).
+    const sessionStatuses: Record<string, { type: string }> = { "parent-1": { type: "idle" } }
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses,
+      messagesProvider: () => SAFE_MESSAGES,
+      failureRequeueWindowMs: 5,
+      maxWindowRefreshes: 3,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when: the wake dispatches and is tracked
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(true)
+      // keep the parent busy from now so any re-flush after requeue just defers
+      sessionStatuses["parent-1"] = { type: "busy" }
+
+      // then: after the failure window refreshes 3x (~15ms) with no output, the
+      // wake is requeued into the pending queue and the dispatched record cleared
+      await waitUntil(() => notifier.getPendingParentWakes().has("parent-1"), 600)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.notifications).toEqual([FINAL_WAKE])
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})
+
+describe("BUG B4: deleted parent session drops the wake instead of retrying forever", () => {
+  test("#given the parent session is missing #when a dispatch fails #then the wake is dropped with no reschedule", async () => {
+    // given: every dispatch throws and the parent session no longer exists
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      promptAsyncImpl: async () => {
+        throw new Error("session not found")
+      },
+      checkParentSessionExistence: async () => "missing",
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the dispatch was attempted, then the wake is dropped permanently
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(false)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given the parent existence is unknown #when a dispatch fails #then the wake is requeued and retried", async () => {
+    // given: dispatch throws but existence cannot be confirmed as missing
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      promptAsyncImpl: async () => {
+        throw new Error("transient network error")
+      },
+      checkParentSessionExistence: async () => "unknown",
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the wake stays pending and a retry flush is scheduled
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.notifications).toEqual([FINAL_WAKE])
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+    } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
@@ -434,3 +434,162 @@ describe("BUG B1 follow-up (Oracle): force-dispatch that QUEUES at the gate is n
     }
   })
 })
+
+describe("BUG B1 follow-up round-2 (Oracle): force-queued lifecycle is gate-truthful", () => {
+  const SECOND_WAKE = [
+    "<system-reminder>",
+    "[BACKGROUND TASK COMPLETED]",
+    "[ALL BACKGROUND TASKS COMPLETE]",
+    "",
+    "**Completed:**",
+    "- `task-z`: task Z",
+    "</system-reminder>",
+  ].join("\n")
+
+  function reserveForeignGate(sessionID: string, now: number): void {
+    setPromptReservation(sessionID, {
+      source: "some-other-live-turn",
+      dedupeKey: "foreign-reservation-key",
+      reservedAt: now,
+      token: Symbol("foreign"),
+      expiresAt: now + 60_000,
+    })
+  }
+
+  test("#given a force-queued wake (HOLE 1) #when assistant output appears after forcedQueuedAt but before gate delivery #then the wake is NOT falsely consumed", async () => {
+    // given
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    let outputAppeared = false
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () =>
+        outputAppeared
+          ? [
+              ...SAFE_MESSAGES,
+              {
+                info: { role: "assistant", finish: "stop", time: { created: 100_500 } },
+                parts: [{ type: "text", text: "unrelated parent work" }],
+              },
+            ]
+          : SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    reserveForeignGate("parent-1", now)
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const wake = notifier.getPendingParentWakes().get("parent-1")
+    if (!wake) throw new Error("missing wake")
+    wake.firstDeferredAt = now - 5_001
+
+    try {
+      await notifier.flushPendingParentWake("parent-1")
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeUndefined()
+
+      // when: unrelated assistant output appears AFTER forcedQueuedAt, while the
+      // queued entry is still sitting undelivered behind the reservation
+      outputAppeared = true
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the wake is NOT consumed/dropped (forcedQueuedAt is not an admission)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+      expect(promptAsyncCalls).toHaveLength(0)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a force-queued wake that the gate delivers (HOLE 2) #when no assistant output follows #then the retained reply wake resumes with a reply (no deadlock)", async () => {
+    // given
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    reserveForeignGate("parent-1", now)
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const wake = notifier.getPendingParentWakes().get("parent-1")
+    if (!wake) throw new Error("missing wake")
+    wake.firstDeferredAt = now - 5_001
+
+    try {
+      await notifier.flushPendingParentWake("parent-1")
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+
+      // when: the reservation clears and the gate delivers the queued noReply entry
+      deletePromptReservation("parent-1")
+      schedulePromptQueueDrain("parent-1", 0)
+      await waitUntil(() => promptAsyncCalls.length === 1, 600)
+
+      // then: real admission is recorded only now, and the force marker is cleared
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+
+      // when: no assistant output follows the deposit and the parent is safe
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the retained reply wake resumes with a reply instead of deadlocking
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given a force-queued wake (HOLE 3) #when a new notification merges in #then the force marker clears and the new content dispatches", async () => {
+    // given
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    reserveForeignGate("parent-1", now)
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const wake = notifier.getPendingParentWakes().get("parent-1")
+    if (!wake) throw new Error("missing wake")
+    wake.firstDeferredAt = now - 5_001
+
+    try {
+      await notifier.flushPendingParentWake("parent-1")
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+
+      // when: a genuinely new notification merges into the pending wake
+      notifier.queuePendingParentWake("parent-1", SECOND_WAKE, { agent: "sisyphus" }, true)
+
+      // then: the stale force-queued marker is cleared so new content is not blocked
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
+      expect(JSON.stringify(notifier.getPendingParentWakes().get("parent-1")?.notifications)).toContain("task-z")
+
+      // when: the stale gate entry drops (Oracle: residual old-entry delivery is
+      // tolerated) and the gate is free, the unblocked wake force-dispatches the
+      // new merged content. Clearing gate state simulates the old queued entry
+      // expiring/being superseded.
+      releaseAllPromptAsyncReservationsForTesting()
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the new content (task-z) reaches a dispatch — it was not blocked
+      expect(promptAsyncCalls.some((call) => JSON.stringify(call.body.parts).includes("task-z"))).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
@@ -5,6 +5,8 @@ import {
   releaseAllPromptAsyncReservationsForTesting,
   releasePromptAsyncReservation,
 } from "../../hooks/shared/prompt-async-gate"
+import { schedulePromptQueueDrain } from "../../shared/prompt-async-gate/queue"
+import { deletePromptReservation, setPromptReservation } from "../../shared/prompt-async-gate/reservations"
 
 type PromptAsyncCall = {
   path: { id: string }
@@ -346,6 +348,87 @@ describe("BUG B4: deleted parent session drops the wake instead of retrying fore
       expect(notifier.getPendingParentWakes().get("parent-1")?.notifications).toEqual([FINAL_WAKE])
       expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
     } finally {
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})
+
+describe("BUG B1 follow-up (Oracle): force-dispatch that QUEUES at the gate is not tracked as dispatched", () => {
+  test("#given an active reservation on the parent #when a wake exceeds max deferral and force-dispatch queues at the gate #then it is not tracked dispatched, starts no B3 window, and the gate delivers it exactly once", async () => {
+    // given: a foreign reservation holds the gate, so an enqueue force-dispatch
+    // returns "queued" (blocked) rather than "dispatched".
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    let delivered = false
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () =>
+        delivered
+          ? [
+              ...SAFE_MESSAGES,
+              {
+                info: { role: "assistant", finish: "stop", time: { created: 100_500 } },
+                parts: [{ type: "text", text: "acknowledged background completion" }],
+              },
+            ]
+          : SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    setPromptReservation("parent-1", {
+      source: "some-other-live-turn",
+      dedupeKey: "foreign-reservation-key",
+      reservedAt: now,
+      token: Symbol("foreign"),
+      expiresAt: now + 60_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const queuedWake = notifier.getPendingParentWakes().get("parent-1")
+    if (!queuedWake) throw new Error("missing wake")
+    queuedWake.firstDeferredAt = now - 5_001
+
+    try {
+      // when: the force dispatch runs but the gate queues it behind the reservation
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: nothing was actually dispatched to the parent yet…
+      expect(promptAsyncCalls).toHaveLength(0)
+      // …the wake is NOT tracked as dispatched (no premature B3 state)…
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getDispatchedParentWakeTimers().has("parent-1")).toBe(false)
+      // …and the pending wake is retained and marked force-queued
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeUndefined()
+
+      // when: another flush runs while still queued at the gate
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+      // then: no re-force, no second dispatch, still queued (no duplicate entry)
+      expect(promptAsyncCalls).toHaveLength(0)
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+
+      // when: the reservation clears and the gate drains the queued entry
+      deletePromptReservation("parent-1")
+      schedulePromptQueueDrain("parent-1", 0)
+      await waitUntil(() => promptAsyncCalls.length === 1, 600)
+
+      // then: the gate delivered the queued entry exactly once as a noReply admission
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+
+      // when: the parent shows output after the deposit and the wake re-flushes
+      delivered = true
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the wake is dropped exactly once, with no duplicate dispatch
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+      expect(notifier.getDispatchedParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
       notifier.shutdown()
       releaseAllPromptAsyncReservationsForTesting()
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
@@ -593,3 +593,115 @@ describe("BUG B1 follow-up round-2 (Oracle): force-queued lifecycle is gate-trut
     }
   })
 })
+
+describe("BUG B1 follow-up round-3 (Oracle): force-queue callbacks are identity-bound", () => {
+  const SECOND_WAKE = [
+    "<system-reminder>",
+    "[BACKGROUND TASK COMPLETED]",
+    "[ALL BACKGROUND TASKS COMPLETE]",
+    "",
+    "**Completed:**",
+    "- `task-z`: task Z",
+    "</system-reminder>",
+  ].join("\n")
+
+  function reserveForeignGate(sessionID: string, now: number): void {
+    setPromptReservation(sessionID, {
+      source: "some-other-live-turn",
+      dedupeKey: "foreign-reservation-key",
+      reservedAt: now,
+      token: Symbol("foreign"),
+      expiresAt: now + 60_000,
+    })
+  }
+
+  test("#given a force-queued wake (ITEM 1) #when a new notification rotates the token before the stale gate entry dispatches #then the stale onDispatched does NOT admit and the new content still dispatches", async () => {
+    // given: wake A is force-queued (token T1) behind a reservation
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    reserveForeignGate("parent-1", now)
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const wake = notifier.getPendingParentWakes().get("parent-1")
+    if (!wake) throw new Error("missing wake")
+    wake.firstDeferredAt = now - 5_001
+
+    try {
+      await notifier.flushPendingParentWake("parent-1")
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeDefined()
+      const tokenBeforeMerge = notifier.getPendingParentWakes().get("parent-1")?.forceQueueToken
+      expect(tokenBeforeMerge).toBeDefined()
+
+      // when: a new notification B merges, rotating (clearing) the token
+      notifier.queuePendingParentWake("parent-1", SECOND_WAKE, { agent: "sisyphus" }, true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forceQueueToken).toBeUndefined()
+
+      // when: the STALE entry A finally dispatches (its onDispatched carries T1)
+      deletePromptReservation("parent-1")
+      schedulePromptQueueDrain("parent-1", 0)
+      await waitUntil(() => promptAsyncCalls.length === 1, 600)
+
+      // then: the stale callback is a no-op — the A+B wake is NOT marked admitted
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeUndefined()
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(true)
+
+      // when: the gate is cleared and the unblocked wake force-dispatches the new content
+      releaseAllPromptAsyncReservationsForTesting()
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the new content (task-z) is dispatched
+      expect(promptAsyncCalls.some((call) => JSON.stringify(call.body.parts).includes("task-z"))).toBe(true)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+
+  test("#given an identical dispatch is already in flight (ITEM 2) #when the force dispatch coalesces (queued without a real entry) #then forcedQueuedAt is NOT set", async () => {
+    // given: a first force dispatch actually dispatches and records a recent
+    // dispatch + a same-dedupe post-dispatch hold (no foreign reservation).
+    const originalDateNow = Date.now
+    const now = 100_000
+    Date.now = () => now
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses: { "parent-1": { type: "idle" } },
+      messagesProvider: () => SAFE_MESSAGES,
+      maxDeferMs: 5_000,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+    const wake = notifier.getPendingParentWakes().get("parent-1")
+    if (!wake) throw new Error("missing wake")
+    wake.firstDeferredAt = now - 5_001
+
+    try {
+      await notifier.flushPendingParentWake("parent-1")
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
+
+      // when: the budget is exhausted again and a second force dispatch fires
+      // while the identical dispatch is still in flight -> coalesced "queued"
+      const stillPending = notifier.getPendingParentWakes().get("parent-1")
+      if (!stillPending) throw new Error("missing retained wake")
+      stillPending.firstDeferredAt = now - 5_001
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: the coalesced queued result did NOT mark force-queued (which would
+      // never resolve), and no duplicate dispatch was issued
+      expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
+      expect(promptAsyncCalls).toHaveLength(1)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+      releaseAllPromptAsyncReservationsForTesting()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-delivery-bugs.test.ts
@@ -354,7 +354,7 @@ describe("BUG B4: deleted parent session drops the wake instead of retrying fore
   })
 })
 
-describe("BUG B1 follow-up (Oracle): force-dispatch that QUEUES at the gate is not tracked as dispatched", () => {
+describe("force-dispatch that QUEUES at the gate is not tracked as dispatched", () => {
   test("#given an active reservation on the parent #when a wake exceeds max deferral and force-dispatch queues at the gate #then it is not tracked dispatched, starts no B3 window, and the gate delivers it exactly once", async () => {
     // given: a foreign reservation holds the gate, so an enqueue force-dispatch
     // returns "queued" (blocked) rather than "dispatched".
@@ -435,7 +435,7 @@ describe("BUG B1 follow-up (Oracle): force-dispatch that QUEUES at the gate is n
   })
 })
 
-describe("BUG B1 follow-up round-2 (Oracle): force-queued lifecycle is gate-truthful", () => {
+describe("force-queued lifecycle is gate-truthful", () => {
   const SECOND_WAKE = [
     "<system-reminder>",
     "[BACKGROUND TASK COMPLETED]",
@@ -576,7 +576,7 @@ describe("BUG B1 follow-up round-2 (Oracle): force-queued lifecycle is gate-trut
       expect(notifier.getPendingParentWakes().get("parent-1")?.forcedQueuedAt).toBeUndefined()
       expect(JSON.stringify(notifier.getPendingParentWakes().get("parent-1")?.notifications)).toContain("task-z")
 
-      // when: the stale gate entry drops (Oracle: residual old-entry delivery is
+      // when: the stale gate entry drops (residual old-entry delivery is
       // tolerated) and the gate is free, the unblocked wake force-dispatches the
       // new merged content. Clearing gate state simulates the old queued entry
       // expiring/being superseded.
@@ -594,7 +594,7 @@ describe("BUG B1 follow-up round-2 (Oracle): force-queued lifecycle is gate-trut
   })
 })
 
-describe("BUG B1 follow-up round-3 (Oracle): force-queue callbacks are identity-bound", () => {
+describe("force-queue callbacks are identity-bound", () => {
   const SECOND_WAKE = [
     "<system-reminder>",
     "[BACKGROUND TASK COMPLETED]",

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -20,7 +20,7 @@ type ParentWakeFlushRunnerDeps = {
 export class ParentWakeFlushRunner {
   constructor(private readonly deps: ParentWakeFlushRunnerDeps) {}
 
-  // ITEM 1 (Oracle): monotonic token bound to each force-queue attempt so stale
+  // Monotonic token bound to each force-queue attempt so stale
   // gate callbacks (onDispatched / onExpiredOrFailed) only mutate the wake they
   // actually belong to.
   private forceQueueTokenSeq = 0
@@ -66,7 +66,7 @@ export class ParentWakeFlushRunner {
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
       return
     }
-    // BUG B1 follow-up (Oracle): while a forced wake is still queued at the gate
+    // While a forced wake is still queued at the gate
     // it is neither lost nor re-dispatched. Suppress all new dispatch paths and
     // just re-flush; it clears via consume-detection above (gate delivered it)
     // or via the onExpiredOrFailed re-arm (gate dropped it).
@@ -336,7 +336,7 @@ export class ParentWakeFlushRunner {
     }
   }
 
-  // BUG B1 follow-up (Oracle): a force-dispatch can be QUEUED at the gate rather
+  // A force-dispatch can be QUEUED at the gate rather
   // than dispatched. While queued, the wake stays pending and is neither tracked
   // as dispatched nor re-forced (forcedQueuedAt suppresses hasExceededMaxDeferral).
   private markForceQueued(sessionID: string, queuedAt: number, token: number): void {
@@ -358,16 +358,16 @@ export class ParentWakeFlushRunner {
     this.schedulePendingParentWakeFlush(sessionID)
   }
 
-  // BUG B1 follow-up (Oracle): the gate ACTUALLY dispatched the previously-queued
+  // The gate ACTUALLY dispatched the previously-queued
   // force entry — only now is the content in parent history. Record the real
   // noReply admission (mirrors markRetainedNoReplyAdmission) and clear the
   // force-queued marker so a reply-required wake proceeds through the normal
   // retained-reply lifecycle: consume-drop once the parent responds, or a
   // reply-producing resume once the parent is safe. This is what prevents the
-  // "delivered but no parent output" deadlock (HOLE 2).
+  // "delivered but no parent output" deadlock.
   private handleForceDispatched(sessionID: string, token: number): void {
     const wake = this.deps.pendingQueue.getWake(sessionID)
-    // ITEM 1 (Oracle): only honor this callback if the wake is STILL the one we
+    // Only honor this callback if the wake is STILL the one we
     // force-queued under this token. A newer notification merge rotates the token
     // (clearing it), so a stale entry's onDispatched can never admit content the
     // queued entry did not actually contain.

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -1,5 +1,6 @@
 import { log } from "../../shared"
 import { isSessionActive as isOpenCodeSessionActive, settleAfterSessionIdle } from "../../hooks/shared/session-idle-settle"
+import type { InternalPromptQueueBehavior } from "../../shared/prompt-async-gate/types"
 import { isFailureParentWake, isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
 import type { ParentWakePendingQueue } from "./parent-wake-pending-queue"
@@ -13,14 +14,28 @@ type ParentWakeFlushRunnerDeps = {
   readonly pendingQueue: ParentWakePendingQueue
   readonly dispatchedTracker: ParentWakeDispatchedTracker
   readonly sessionInspector: ParentWakeSessionInspector
+  readonly maxDeferMs: number
 }
 
 export class ParentWakeFlushRunner {
   constructor(private readonly deps: ParentWakeFlushRunnerDeps) {}
 
   async flushPendingParentWake(sessionID: string): Promise<void> {
-    if (!this.deps.pendingQueue.hasWake(sessionID)) {
+    const initialWake = this.deps.pendingQueue.getWake(sessionID)
+    if (!initialWake) {
       this.clearPendingParentWakeTimer(sessionID)
+      return
+    }
+
+    // BUG B1: bound deferral. A parent kept continuously busy (ultrawork /
+    // todo-continuation loops re-prompting at every turn end) would otherwise
+    // reschedule this flush at 1s intervals forever (8267x deferral incident,
+    // upstream #5089). Once the wake has been deferred past the max, force it
+    // through as an admit-only noReply so the content lands at the next turn
+    // boundary even while the parent stays busy.
+    if (this.hasExceededMaxDeferral(initialWake)) {
+      this.clearPendingParentWakeTimer(sessionID)
+      await this.forceDispatchAfterMaxDeferral(sessionID, initialWake)
       return
     }
 
@@ -30,6 +45,7 @@ export class ParentWakeFlushRunner {
       await settleAfterSessionIdle()
 
       if (await this.isSessionActive(sessionID)) {
+        this.recordDeferral(sessionID, initialWake)
         this.schedulePendingParentWakeFlush(sessionID)
         log("[background-agent] Deferred parent wake because parent session became active after idle settle:", {
           sessionID,
@@ -46,6 +62,7 @@ export class ParentWakeFlushRunner {
       return
     }
     if (sessionActive) {
+      this.recordDeferral(sessionID, latestWake)
       this.schedulePendingParentWakeFlush(sessionID)
       log("[background-agent] Deferred parent wake because parent session is active:", {
         sessionID,
@@ -63,6 +80,7 @@ export class ParentWakeFlushRunner {
         forceNoReply: true,
         retainPendingWake: latestWake.shouldReply,
       })
+      this.ensureRetainedReplyReflush(sessionID, latestWake)
       log("[background-agent] Recorded admit-only parent wake because parent session activity is still fresh:", {
         sessionID,
       })
@@ -81,6 +99,7 @@ export class ParentWakeFlushRunner {
         forceNoReply: true,
         retainPendingWake: latestWake.shouldReply,
       })
+      this.ensureRetainedReplyReflush(sessionID, latestWake)
       return
     }
 
@@ -100,6 +119,7 @@ export class ParentWakeFlushRunner {
         forceNoReply: true,
         retainPendingWake: latestWake.shouldReply,
       })
+      this.ensureRetainedReplyReflush(sessionID, latestWake)
       log("[background-agent] Recorded admit-only parent wake because user message just arrived:", {
         sessionID,
       })
@@ -129,11 +149,13 @@ export class ParentWakeFlushRunner {
   // parent remains unsafe.
   private deferReplyWakeWhileUnsafe(sessionID: string, latestWake: PendingParentWake): boolean {
     if (isFailureParentWake(latestWake)) {
+      this.recordDeferral(sessionID, latestWake)
       this.schedulePendingParentWakeFlush(sessionID)
       log("[background-agent] Deferred failure parent wake until parent session is safe:", { sessionID })
       return true
     }
     if (latestWake.shouldReply && latestWake.noReplyAdmittedAt !== undefined) {
+      this.recordDeferral(sessionID, latestWake)
       this.schedulePendingParentWakeFlush(sessionID)
       log("[background-agent] Deferred retained reply-required parent wake until parent session is safe:", { sessionID })
       return true
@@ -170,11 +192,14 @@ export class ParentWakeFlushRunner {
       readonly toolWaitDecision: ToolWaitDeferralDecision
       readonly forceNoReply?: boolean
       readonly retainPendingWake?: boolean
+      readonly queueBehavior?: InternalPromptQueueBehavior
     },
   ): Promise<void> {
     if (options.retainPendingWake !== true) {
       this.deps.pendingQueue.deleteWake(sessionID)
     }
+
+    const checkParentSessionExistence = this.deps.notifierDeps.checkParentSessionExistence
 
     await sendParentWakePrompt({
       client: this.deps.notifierDeps.client,
@@ -183,6 +208,15 @@ export class ParentWakeFlushRunner {
       latestWake,
       ...(options.forceNoReply !== undefined ? { forceNoReply: options.forceNoReply } : {}),
       ...(options.retainPendingWake !== undefined ? { retainPendingWake: options.retainPendingWake } : {}),
+      ...(options.queueBehavior !== undefined ? { queueBehavior: options.queueBehavior } : {}),
+      ...(checkParentSessionExistence
+        ? { checkSessionExists: (id: string) => checkParentSessionExistence(id) }
+        : {}),
+      dropWake: () => {
+        this.deps.pendingQueue.deleteWake(sessionID)
+        this.deps.pendingQueue.clearTimer(sessionID)
+        this.deps.dispatchedTracker.clearWake(sessionID)
+      },
       emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
       toolWaitDecision: options.toolWaitDecision,
       getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
@@ -215,5 +249,55 @@ export class ParentWakeFlushRunner {
 
   private requeueWake(sessionID: string, latestWake: PendingParentWake): void {
     this.deps.pendingQueue.requeueWake(sessionID, latestWake)
+  }
+
+  private recordDeferral(sessionID: string, wake: PendingParentWake): void {
+    wake.firstDeferredAt ??= Date.now()
+    wake.deferCount = (wake.deferCount ?? 0) + 1
+    if (wake.deferCount % 60 === 0) {
+      log("[background-agent] Parent wake deferred repeatedly without delivery:", {
+        sessionID,
+        deferCount: wake.deferCount,
+      })
+    }
+  }
+
+  private hasExceededMaxDeferral(wake: PendingParentWake): boolean {
+    return wake.firstDeferredAt !== undefined && Date.now() - wake.firstDeferredAt >= this.deps.maxDeferMs
+  }
+
+  // BUG B1 force path: deliver the long-deferred wake as an admit-only noReply.
+  // queueBehavior "enqueue" makes the gate queue the prompt at a live/reserved
+  // turn boundary instead of skipping it, so a perpetually busy parent still
+  // receives the content. Reset the deferral budget afterwards so a retained
+  // reply wake cannot re-force every second.
+  private async forceDispatchAfterMaxDeferral(sessionID: string, wake: PendingParentWake): Promise<void> {
+    log("[background-agent] Force-dispatching parent wake after max deferral", {
+      sessionID,
+      deferCount: wake.deferCount,
+      deferredForMs: wake.firstDeferredAt !== undefined ? Date.now() - wake.firstDeferredAt : undefined,
+    })
+    await this.sendParentWakePrompt(sessionID, wake, {
+      emptyAssistantTurnRetry: false,
+      toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
+      forceNoReply: true,
+      retainPendingWake: wake.shouldReply,
+      queueBehavior: "enqueue",
+    })
+    const stillPending = this.deps.pendingQueue.getWake(sessionID)
+    if (stillPending) {
+      delete stillPending.firstDeferredAt
+      stillPending.deferCount = 0
+      this.schedulePendingParentWakeFlush(sessionID)
+    }
+  }
+
+  // BUG B2: a retained reply-required wake must always have a re-flush pending
+  // so it eventually dispatches with a reply once the parent goes safe (and via
+  // the B1 force path if it never does). scheduleFlush is idempotent.
+  private ensureRetainedReplyReflush(sessionID: string, latestWake: PendingParentWake): void {
+    if (latestWake.shouldReply && this.deps.pendingQueue.hasWake(sessionID)) {
+      this.schedulePendingParentWakeFlush(sessionID)
+    }
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -20,6 +20,11 @@ type ParentWakeFlushRunnerDeps = {
 export class ParentWakeFlushRunner {
   constructor(private readonly deps: ParentWakeFlushRunnerDeps) {}
 
+  // ITEM 1 (Oracle): monotonic token bound to each force-queue attempt so stale
+  // gate callbacks (onDispatched / onExpiredOrFailed) only mutate the wake they
+  // actually belong to.
+  private forceQueueTokenSeq = 0
+
   async flushPendingParentWake(sessionID: string): Promise<void> {
     const initialWake = this.deps.pendingQueue.getWake(sessionID)
     if (!initialWake) {
@@ -296,16 +301,17 @@ export class ParentWakeFlushRunner {
       deferCount: wake.deferCount,
       deferredForMs: wake.firstDeferredAt !== undefined ? Date.now() - wake.firstDeferredAt : undefined,
     })
+    const forceQueueToken = ++this.forceQueueTokenSeq
     await this.sendParentWakePrompt(sessionID, wake, {
       emptyAssistantTurnRetry: false,
       toolWaitDecision: { defer: false, skipPromptGateToolStateCheck: true },
       forceNoReply: true,
       retainPendingWake: wake.shouldReply,
       queueBehavior: "enqueue",
-      markForceQueued: (queuedAt) => this.markForceQueued(sessionID, queuedAt),
-      onForceQueueResolved: () => this.handleForceQueueResolved(sessionID),
+      markForceQueued: (queuedAt) => this.markForceQueued(sessionID, queuedAt, forceQueueToken),
+      onForceQueueResolved: () => this.handleForceQueueResolved(sessionID, forceQueueToken),
       forceQueueTtlMs: this.deps.maxDeferMs,
-      onForceDispatched: () => this.handleForceDispatched(sessionID),
+      onForceDispatched: () => this.handleForceDispatched(sessionID, forceQueueToken),
     })
     const stillPending = this.deps.pendingQueue.getWake(sessionID)
     if (stillPending) {
@@ -333,19 +339,21 @@ export class ParentWakeFlushRunner {
   // BUG B1 follow-up (Oracle): a force-dispatch can be QUEUED at the gate rather
   // than dispatched. While queued, the wake stays pending and is neither tracked
   // as dispatched nor re-forced (forcedQueuedAt suppresses hasExceededMaxDeferral).
-  private markForceQueued(sessionID: string, queuedAt: number): void {
+  private markForceQueued(sessionID: string, queuedAt: number, token: number): void {
     const wake = this.deps.pendingQueue.getWake(sessionID)
     if (wake) {
       wake.forcedQueuedAt = queuedAt
+      wake.forceQueueToken = token
     }
   }
 
   // The gate dropped/expired/failed the queued force entry: clear the marker and
   // re-flush so the force path can re-arm (firstDeferredAt is still in the past).
-  private handleForceQueueResolved(sessionID: string): void {
+  private handleForceQueueResolved(sessionID: string, token: number): void {
     const wake = this.deps.pendingQueue.getWake(sessionID)
-    if (wake) {
+    if (wake && wake.forceQueueToken === token) {
       delete wake.forcedQueuedAt
+      delete wake.forceQueueToken
     }
     this.schedulePendingParentWakeFlush(sessionID)
   }
@@ -357,13 +365,18 @@ export class ParentWakeFlushRunner {
   // retained-reply lifecycle: consume-drop once the parent responds, or a
   // reply-producing resume once the parent is safe. This is what prevents the
   // "delivered but no parent output" deadlock (HOLE 2).
-  private handleForceDispatched(sessionID: string): void {
+  private handleForceDispatched(sessionID: string, token: number): void {
     const wake = this.deps.pendingQueue.getWake(sessionID)
-    if (wake) {
+    // ITEM 1 (Oracle): only honor this callback if the wake is STILL the one we
+    // force-queued under this token. A newer notification merge rotates the token
+    // (clearing it), so a stale entry's onDispatched can never admit content the
+    // queued entry did not actually contain.
+    if (wake && wake.forceQueueToken === token) {
       // The deferral is over: the content actually reached parent history. Clear
       // the force-queued marker and the B1 deferral budget, and record the real
       // noReply admission so the wake follows the standard retained-reply path.
       delete wake.forcedQueuedAt
+      delete wake.forceQueueToken
       delete wake.firstDeferredAt
       wake.deferCount = 0
       if (wake.shouldReply) {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -180,7 +180,7 @@ export class ParentWakeFlushRunner {
   // the live turn consumed the deposit — re-dispatching it would inject a
   // duplicate notification and fork a concurrent assistant chain.
   private async dropAdmittedWakeConsumedByParent(sessionID: string, latestWake: PendingParentWake): Promise<boolean> {
-    if (latestWake.noReplyAdmittedAt === undefined && latestWake.forcedQueuedAt === undefined) {
+    if (latestWake.noReplyAdmittedAt === undefined) {
       return false
     }
     if (!(await this.deps.sessionInspector.hasAssistantOutputAfterAdmittedWake(sessionID, latestWake))) {
@@ -204,6 +204,7 @@ export class ParentWakeFlushRunner {
       readonly markForceQueued?: (queuedAt: number) => void
       readonly onForceQueueResolved?: () => void
       readonly forceQueueTtlMs?: number
+      readonly onForceDispatched?: () => void
     },
   ): Promise<void> {
     if (options.retainPendingWake !== true) {
@@ -231,6 +232,7 @@ export class ParentWakeFlushRunner {
       ...(options.markForceQueued !== undefined ? { markForceQueued: options.markForceQueued } : {}),
       ...(options.onForceQueueResolved !== undefined ? { onForceQueueResolved: options.onForceQueueResolved } : {}),
       ...(options.forceQueueTtlMs !== undefined ? { forceQueueTtlMs: options.forceQueueTtlMs } : {}),
+      ...(options.onForceDispatched !== undefined ? { onForceDispatched: options.onForceDispatched } : {}),
       emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
       toolWaitDecision: options.toolWaitDecision,
       getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
@@ -303,6 +305,7 @@ export class ParentWakeFlushRunner {
       markForceQueued: (queuedAt) => this.markForceQueued(sessionID, queuedAt),
       onForceQueueResolved: () => this.handleForceQueueResolved(sessionID),
       forceQueueTtlMs: this.deps.maxDeferMs,
+      onForceDispatched: () => this.handleForceDispatched(sessionID),
     })
     const stillPending = this.deps.pendingQueue.getWake(sessionID)
     if (stillPending) {
@@ -343,6 +346,29 @@ export class ParentWakeFlushRunner {
     const wake = this.deps.pendingQueue.getWake(sessionID)
     if (wake) {
       delete wake.forcedQueuedAt
+    }
+    this.schedulePendingParentWakeFlush(sessionID)
+  }
+
+  // BUG B1 follow-up (Oracle): the gate ACTUALLY dispatched the previously-queued
+  // force entry — only now is the content in parent history. Record the real
+  // noReply admission (mirrors markRetainedNoReplyAdmission) and clear the
+  // force-queued marker so a reply-required wake proceeds through the normal
+  // retained-reply lifecycle: consume-drop once the parent responds, or a
+  // reply-producing resume once the parent is safe. This is what prevents the
+  // "delivered but no parent output" deadlock (HOLE 2).
+  private handleForceDispatched(sessionID: string): void {
+    const wake = this.deps.pendingQueue.getWake(sessionID)
+    if (wake) {
+      // The deferral is over: the content actually reached parent history. Clear
+      // the force-queued marker and the B1 deferral budget, and record the real
+      // noReply admission so the wake follows the standard retained-reply path.
+      delete wake.forcedQueuedAt
+      delete wake.firstDeferredAt
+      wake.deferCount = 0
+      if (wake.shouldReply) {
+        wake.noReplyAdmittedAt = Date.now()
+      }
     }
     this.schedulePendingParentWakeFlush(sessionID)
   }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -61,6 +61,14 @@ export class ParentWakeFlushRunner {
     if (await this.dropAdmittedWakeConsumedByParent(sessionID, latestWake)) {
       return
     }
+    // BUG B1 follow-up (Oracle): while a forced wake is still queued at the gate
+    // it is neither lost nor re-dispatched. Suppress all new dispatch paths and
+    // just re-flush; it clears via consume-detection above (gate delivered it)
+    // or via the onExpiredOrFailed re-arm (gate dropped it).
+    if (latestWake.forcedQueuedAt !== undefined) {
+      this.schedulePendingParentWakeFlush(sessionID)
+      return
+    }
     if (sessionActive) {
       this.recordDeferral(sessionID, latestWake)
       this.schedulePendingParentWakeFlush(sessionID)
@@ -172,7 +180,7 @@ export class ParentWakeFlushRunner {
   // the live turn consumed the deposit — re-dispatching it would inject a
   // duplicate notification and fork a concurrent assistant chain.
   private async dropAdmittedWakeConsumedByParent(sessionID: string, latestWake: PendingParentWake): Promise<boolean> {
-    if (latestWake.noReplyAdmittedAt === undefined) {
+    if (latestWake.noReplyAdmittedAt === undefined && latestWake.forcedQueuedAt === undefined) {
       return false
     }
     if (!(await this.deps.sessionInspector.hasAssistantOutputAfterAdmittedWake(sessionID, latestWake))) {
@@ -193,6 +201,9 @@ export class ParentWakeFlushRunner {
       readonly forceNoReply?: boolean
       readonly retainPendingWake?: boolean
       readonly queueBehavior?: InternalPromptQueueBehavior
+      readonly markForceQueued?: (queuedAt: number) => void
+      readonly onForceQueueResolved?: () => void
+      readonly forceQueueTtlMs?: number
     },
   ): Promise<void> {
     if (options.retainPendingWake !== true) {
@@ -217,6 +228,9 @@ export class ParentWakeFlushRunner {
         this.deps.pendingQueue.clearTimer(sessionID)
         this.deps.dispatchedTracker.clearWake(sessionID)
       },
+      ...(options.markForceQueued !== undefined ? { markForceQueued: options.markForceQueued } : {}),
+      ...(options.onForceQueueResolved !== undefined ? { onForceQueueResolved: options.onForceQueueResolved } : {}),
+      ...(options.forceQueueTtlMs !== undefined ? { forceQueueTtlMs: options.forceQueueTtlMs } : {}),
       emptyAssistantTurnRetry: options.emptyAssistantTurnRetry,
       toolWaitDecision: options.toolWaitDecision,
       getDispatchedWake: () => this.deps.dispatchedTracker.getWake(sessionID),
@@ -263,6 +277,9 @@ export class ParentWakeFlushRunner {
   }
 
   private hasExceededMaxDeferral(wake: PendingParentWake): boolean {
+    if (wake.forcedQueuedAt !== undefined) {
+      return false
+    }
     return wake.firstDeferredAt !== undefined && Date.now() - wake.firstDeferredAt >= this.deps.maxDeferMs
   }
 
@@ -283,11 +300,20 @@ export class ParentWakeFlushRunner {
       forceNoReply: true,
       retainPendingWake: wake.shouldReply,
       queueBehavior: "enqueue",
+      markForceQueued: (queuedAt) => this.markForceQueued(sessionID, queuedAt),
+      onForceQueueResolved: () => this.handleForceQueueResolved(sessionID),
+      forceQueueTtlMs: this.deps.maxDeferMs,
     })
     const stillPending = this.deps.pendingQueue.getWake(sessionID)
     if (stillPending) {
-      delete stillPending.firstDeferredAt
-      stillPending.deferCount = 0
+      // If the force attempt only QUEUED at the gate, leave the deferral budget
+      // intact (so an onExpiredOrFailed re-arm re-forces immediately) and let the
+      // forcedQueuedAt guard manage it. Otherwise it actually dispatched: reset the
+      // budget so a retained reply wake cannot re-force every second.
+      if (stillPending.forcedQueuedAt === undefined) {
+        delete stillPending.firstDeferredAt
+        stillPending.deferCount = 0
+      }
       this.schedulePendingParentWakeFlush(sessionID)
     }
   }
@@ -299,5 +325,25 @@ export class ParentWakeFlushRunner {
     if (latestWake.shouldReply && this.deps.pendingQueue.hasWake(sessionID)) {
       this.schedulePendingParentWakeFlush(sessionID)
     }
+  }
+
+  // BUG B1 follow-up (Oracle): a force-dispatch can be QUEUED at the gate rather
+  // than dispatched. While queued, the wake stays pending and is neither tracked
+  // as dispatched nor re-forced (forcedQueuedAt suppresses hasExceededMaxDeferral).
+  private markForceQueued(sessionID: string, queuedAt: number): void {
+    const wake = this.deps.pendingQueue.getWake(sessionID)
+    if (wake) {
+      wake.forcedQueuedAt = queuedAt
+    }
+  }
+
+  // The gate dropped/expired/failed the queued force entry: clear the marker and
+  // re-flush so the force path can re-arm (firstDeferredAt is still in the past).
+  private handleForceQueueResolved(sessionID: string): void {
+    const wake = this.deps.pendingQueue.getWake(sessionID)
+    if (wake) {
+      delete wake.forcedQueuedAt
+    }
+    this.schedulePendingParentWakeFlush(sessionID)
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-late-error-recovery.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-late-error-recovery.test.ts
@@ -64,6 +64,10 @@ function createNotifier(args: {
       acceptedMessageSkewMs: 100,
       toolCallDeferMaxMs: 5_000,
       failureRequeueWindowMs: 1,
+      // This suite exercises the late session.error requeue path, not the B3
+      // silent-drop window-refresh requeue; keep the refresh budget effectively
+      // unbounded so the 1ms window only re-arms (matching pre-B3 behavior).
+      maxWindowRefreshes: Number.MAX_SAFE_INTEGER,
       userMessageInProgressWindowMs: 0,
     },
   )

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier-types.ts
@@ -1,5 +1,6 @@
 import type { PromptDispatchClient, PromptMessagesQuery } from "../../shared/prompt-async-gate/types"
 import type { ParentWakePromptContext } from "./parent-wake-dedupe"
+import type { SessionExistenceStatus } from "./session-existence"
 
 type ParentWakePromptBody = ParentWakePromptContext & {
   readonly noReply?: boolean
@@ -29,6 +30,7 @@ export type ParentWakeNotifierDeps = {
     parentSessionID: string | undefined,
     operation: () => Promise<void>,
   ) => Promise<void>
+  readonly checkParentSessionExistence?: (sessionID: string) => Promise<SessionExistenceStatus>
 }
 
 export type ParentWakeNotifierOptions = {
@@ -45,4 +47,16 @@ export type ParentWakeNotifierOptions = {
    */
   readonly userMessageInProgressWindowMs: number
   readonly parentSessionActivityInProgressWindowMs?: number
+  /**
+   * Upper bound on cumulative deferral time for a single parent-wake before it
+   * is force-dispatched as an admit-only noReply. Bounds the unbounded-deferral
+   * starvation case (upstream #5089). Defaults to 120s when omitted.
+   */
+  readonly maxDeferMs?: number
+  /**
+   * Consecutive failure-requeue windows (no assistant/tool output after the
+   * wake) tolerated before a silently-dropped dispatched wake is requeued into
+   * the pending queue (upstream P1). Defaults to 3 when omitted.
+   */
+  readonly maxWindowRefreshes?: number
 }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-notifier.ts
@@ -15,6 +15,9 @@ import {
 
 export type { ParentWakePromptContext, PendingParentWake } from "./parent-wake-dedupe"
 
+const DEFAULT_PARENT_WAKE_MAX_DEFER_MS = 120_000
+const DEFAULT_PARENT_WAKE_MAX_WINDOW_REFRESHES = 3
+
 export class ParentWakeNotifier {
   private readonly pendingQueue: ParentWakePendingQueue
   private readonly dispatchedTracker: ParentWakeDispatchedTracker
@@ -37,6 +40,9 @@ export class ParentWakeNotifier {
           wake,
           dispatchedTracker: this.dispatchedTracker,
           sessionInspector: this.sessionInspector,
+          pendingQueue: this.pendingQueue,
+          scheduleFlush: (id) => this.flushRunner.schedulePendingParentWakeFlush(id),
+          maxWindowRefreshes: options.maxWindowRefreshes ?? DEFAULT_PARENT_WAKE_MAX_WINDOW_REFRESHES,
         }).catch((error: unknown) => {
           logParentWakeWindowRecoveryError(
             sessionID,
@@ -62,6 +68,7 @@ export class ParentWakeNotifier {
       pendingQueue: this.pendingQueue,
       dispatchedTracker: this.dispatchedTracker,
       sessionInspector: this.sessionInspector,
+      maxDeferMs: options.maxDeferMs ?? DEFAULT_PARENT_WAKE_MAX_DEFER_MS,
     })
   }
 

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -82,6 +82,8 @@ export class ParentWakePendingQueue {
       pendingWake.noReplyAdmittedAt ??= latestWake.noReplyAdmittedAt
       pendingWake.toolCallDeferralStartedAt ??= latestWake.toolCallDeferralStartedAt
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
+      pendingWake.firstDeferredAt ??= latestWake.firstDeferredAt
+      pendingWake.deferCount ??= latestWake.deferCount
       return
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -84,6 +84,7 @@ export class ParentWakePendingQueue {
       pendingWake.allowEmptyAssistantTurnRetry ||= latestWake.allowEmptyAssistantTurnRetry
       pendingWake.firstDeferredAt ??= latestWake.firstDeferredAt
       pendingWake.deferCount ??= latestWake.deferCount
+      pendingWake.forcedQueuedAt ??= latestWake.forcedQueuedAt
       return
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -59,6 +59,12 @@ export class ParentWakePendingQueue {
       pendingWake.shouldReply = pendingWake.shouldReply || shouldReply
       if (notificationsChanged) {
         delete pendingWake.noReplyAdmittedAt
+        // HOLE 3 (Oracle): a force-queued gate entry holds the OLD notification
+        // snapshot. New content must be free to dispatch, so clear the
+        // force-queued marker too. The stale gate entry may still deliver, but
+        // semantic-dedupe plus the superseding (now-merged) wake make any
+        // residual duplicate tolerable.
+        delete pendingWake.forcedQueuedAt
       }
       return
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -61,10 +61,13 @@ export class ParentWakePendingQueue {
         delete pendingWake.noReplyAdmittedAt
         // HOLE 3 (Oracle): a force-queued gate entry holds the OLD notification
         // snapshot. New content must be free to dispatch, so clear the
-        // force-queued marker too. The stale gate entry may still deliver, but
+        // force-queued marker AND rotate the force-queue token so any stale
+        // onDispatched/onExpiredOrFailed callback from the old entry no-ops
+        // (ITEM 1 identity binding). The stale gate entry may still deliver, but
         // semantic-dedupe plus the superseding (now-merged) wake make any
         // residual duplicate tolerable.
         delete pendingWake.forcedQueuedAt
+        delete pendingWake.forceQueueToken
       }
       return
     }
@@ -91,6 +94,7 @@ export class ParentWakePendingQueue {
       pendingWake.firstDeferredAt ??= latestWake.firstDeferredAt
       pendingWake.deferCount ??= latestWake.deferCount
       pendingWake.forcedQueuedAt ??= latestWake.forcedQueuedAt
+      pendingWake.forceQueueToken ??= latestWake.forceQueueToken
       return
     }
     this.pendingParentWakes.set(sessionID, cloneParentWake(latestWake))

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-pending-queue.ts
@@ -59,11 +59,11 @@ export class ParentWakePendingQueue {
       pendingWake.shouldReply = pendingWake.shouldReply || shouldReply
       if (notificationsChanged) {
         delete pendingWake.noReplyAdmittedAt
-        // HOLE 3 (Oracle): a force-queued gate entry holds the OLD notification
+        // A force-queued gate entry holds the OLD notification
         // snapshot. New content must be free to dispatch, so clear the
         // force-queued marker AND rotate the force-queue token so any stale
         // onDispatched/onExpiredOrFailed callback from the old entry no-ops
-        // (ITEM 1 identity binding). The stale gate entry may still deliver, but
+        // (token identity binding). The stale gate entry may still deliver, but
         // semantic-dedupe plus the superseding (now-merged) wake make any
         // residual duplicate tolerable.
         delete pendingWake.forcedQueuedAt

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -109,11 +109,24 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       // gate (blocked by an existing reservation) is NOT yet in parent history.
       // It must not be tracked as dispatched (that would start the B3 silent-loss
       // window on a wake that hasn't dispatched and let unrelated assistant output
-      // clear the tracker) nor recorded as a noReply admission. Mark it
-      // force-queued so the force path is suppressed until the gate delivers it
-      // (consume-detected via forcedQueuedAt) or drops it (onExpiredOrFailed).
-      input.markForceQueued(dispatchStartedAt)
-      log("[background-agent] Parent wake force-queued at promptAsync gate; awaiting gate delivery:", {
+      // clear the tracker) nor recorded as a noReply admission.
+      if (promptResult.queuedEntryCreated) {
+        // A real queue entry now carries our onDispatched/onExpiredOrFailed
+        // callbacks: mark force-queued so the force path is suppressed until the
+        // gate delivers it (then onDispatched admits) or drops it (onExpiredOrFailed).
+        input.markForceQueued(dispatchStartedAt)
+        log("[background-agent] Parent wake force-queued at promptAsync gate; awaiting gate delivery:", {
+          sessionID: input.sessionID,
+          queuedBy: promptResult.queuedBy,
+        })
+        return
+      }
+      // ITEM 2 (Oracle): a coalesced "queued" result has NO entry carrying our
+      // callbacks (semantic-dedupe / same-dedupe reservation). An equivalent
+      // dispatch is already in flight, so do NOT mark force-queued (that marker
+      // would never resolve). Leave the wake pending to retry normally; the
+      // recent-dispatch redundancy checks govern duplication.
+      log("[background-agent] Force parent wake coalesced with an in-flight identical dispatch; not marking force-queued:", {
         sessionID: input.sessionID,
         queuedBy: promptResult.queuedBy,
       })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -32,6 +32,7 @@ type ParentWakePromptDispatchInput = {
   readonly markForceQueued?: (queuedAt: number) => void
   readonly onForceQueueResolved?: () => void
   readonly forceQueueTtlMs?: number
+  readonly onForceDispatched?: () => void
 }
 
 export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput): Promise<void> {
@@ -55,6 +56,9 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         ? { onExpiredOrFailed: () => input.onForceQueueResolved?.() }
         : {}),
       ...(input.forceQueueTtlMs !== undefined ? { ttlMs: input.forceQueueTtlMs } : {}),
+      ...(input.onForceDispatched !== undefined
+        ? { onDispatched: () => input.onForceDispatched?.() }
+        : {}),
       input: {
         path: { id: input.sessionID },
         body: {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -29,6 +29,9 @@ type ParentWakePromptDispatchInput = {
   readonly queueBehavior?: InternalPromptQueueBehavior
   readonly checkSessionExists?: (sessionID: string) => Promise<SessionExistenceStatus>
   readonly dropWake?: () => void
+  readonly markForceQueued?: (queuedAt: number) => void
+  readonly onForceQueueResolved?: () => void
+  readonly forceQueueTtlMs?: number
 }
 
 export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput): Promise<void> {
@@ -48,6 +51,10 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       queueBehavior: input.queueBehavior ?? "defer",
       checkStatus: input.forceNoReply !== true,
       checkToolState: input.forceNoReply !== true && !input.toolWaitDecision.skipPromptGateToolStateCheck,
+      ...(input.onForceQueueResolved !== undefined
+        ? { onExpiredOrFailed: () => input.onForceQueueResolved?.() }
+        : {}),
+      ...(input.forceQueueTtlMs !== undefined ? { ttlMs: input.forceQueueTtlMs } : {}),
       input: {
         path: { id: input.sessionID },
         body: {
@@ -90,6 +97,21 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       input.scheduleFlush(2_000)
       log("[background-agent] Requeued parent wake flush reserved by promptAsync gate hold:", {
         sessionID: input.sessionID,
+      })
+      return
+    }
+    if (promptResult.status === "queued" && input.markForceQueued !== undefined) {
+      // BUG B1 follow-up (Oracle): a force-dispatch that merely QUEUED at the
+      // gate (blocked by an existing reservation) is NOT yet in parent history.
+      // It must not be tracked as dispatched (that would start the B3 silent-loss
+      // window on a wake that hasn't dispatched and let unrelated assistant output
+      // clear the tracker) nor recorded as a noReply admission. Mark it
+      // force-queued so the force path is suppressed until the gate delivers it
+      // (consume-detected via forcedQueuedAt) or drops it (onExpiredOrFailed).
+      input.markForceQueued(dispatchStartedAt)
+      log("[background-agent] Parent wake force-queued at promptAsync gate; awaiting gate delivery:", {
+        sessionID: input.sessionID,
+        queuedBy: promptResult.queuedBy,
       })
       return
     }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -5,11 +5,12 @@ import {
   withInternalNoReplyMarker,
 } from "../../shared"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
-import type { PromptDispatchClient } from "../../shared/prompt-async-gate/types"
+import type { InternalPromptQueueBehavior, PromptDispatchClient } from "../../shared/prompt-async-gate/types"
 import { getErrorText } from "./error-classifier"
 import { createEmptyAssistantTurnRetryDedupeKey } from "./parent-wake-history-state"
 import { cloneParentWake, isRedundantParentWake, type PendingParentWake } from "./parent-wake-dedupe"
 import type { ToolWaitDeferralDecision } from "./parent-wake-session-history"
+import type { SessionExistenceStatus } from "./session-existence"
 
 type ParentWakePromptDispatchInput = {
   readonly client: PromptDispatchClient
@@ -25,6 +26,9 @@ type ParentWakePromptDispatchInput = {
   readonly trackDispatchedWake: (wake: PendingParentWake, dispatchedAt: number) => void
   readonly requeueWake: (wake: PendingParentWake) => void
   readonly scheduleFlush: (delayMs?: number) => void
+  readonly queueBehavior?: InternalPromptQueueBehavior
+  readonly checkSessionExists?: (sessionID: string) => Promise<SessionExistenceStatus>
+  readonly dropWake?: () => void
 }
 
 export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput): Promise<void> {
@@ -41,7 +45,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         ? { dedupeKey: createEmptyAssistantTurnRetryDedupeKey(input.latestWake) }
         : {}),
       settleMs: 0,
-      queueBehavior: "defer",
+      queueBehavior: input.queueBehavior ?? "defer",
       checkStatus: input.forceNoReply !== true,
       checkToolState: input.forceNoReply !== true && !input.toolWaitDecision.skipPromptGateToolStateCheck,
       input: {
@@ -104,6 +108,17 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
     input.trackDispatchedWake(createTrackedDispatchedWake(input.latestWake, input.forceNoReply), dispatchStartedAt)
   } catch (error) {
     const errorText = error instanceof Error ? `${error.name}: ${error.message}` : getErrorText(error) || String(error)
+    if (input.checkSessionExists !== undefined) {
+      const existence = await input.checkSessionExists(input.sessionID)
+      if (existence === "missing") {
+        input.dropWake?.()
+        log("[background-agent] Dropped parent wake because parent session no longer exists:", {
+          sessionID: input.sessionID,
+          error: errorText,
+        })
+        return
+      }
+    }
     input.requeueWake(input.latestWake)
     input.scheduleFlush()
     log("[background-agent] Failed to send deferred parent wake:", { sessionID: input.sessionID, error: errorText })

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -105,7 +105,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       return
     }
     if (promptResult.status === "queued" && input.markForceQueued !== undefined) {
-      // BUG B1 follow-up (Oracle): a force-dispatch that merely QUEUED at the
+      // A force-dispatch that merely QUEUED at the
       // gate (blocked by an existing reservation) is NOT yet in parent history.
       // It must not be tracked as dispatched (that would start the B3 silent-loss
       // window on a wake that hasn't dispatched and let unrelated assistant output
@@ -121,7 +121,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
         })
         return
       }
-      // ITEM 2 (Oracle): a coalesced "queued" result has NO entry carrying our
+      // A coalesced "queued" result has NO entry carrying our
       // callbacks (semantic-dedupe / same-dedupe reservation). An equivalent
       // dispatch is already in flight, so do NOT mark force-queued (that marker
       // would never resolve). Leave the wake pending to retry normally; the

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-prompt-dispatch.ts
@@ -1,6 +1,6 @@
 import {
   createInternalAgentTextPart,
-  isAmbiguousPostDispatchPromptFailure,
+  isVerifiableAmbiguousPromptFailure,
   log,
   withInternalNoReplyMarker,
 } from "../../shared"
@@ -63,7 +63,7 @@ export async function sendParentWakePrompt(input: ParentWakePromptDispatchInput)
       },
     })
     if (promptResult.status === "failed") {
-      if (isAmbiguousPostDispatchPromptFailure(promptResult)) {
+      if (isVerifiableAmbiguousPromptFailure(promptResult)) {
         const dispatchedWake = cloneParentWake(input.latestWake)
         dispatchedWake.dispatchedAt = dispatchStartedAt
         if (await input.hasRecordedPromptAfterDispatch(dispatchedWake)) {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
@@ -194,7 +194,7 @@ export function hasAssistantOutputAfterParentWakeAdmission(input: {
   readonly messages: readonly ParentWakeSessionMessage[] | undefined
   readonly wake: PendingParentWake
 }): boolean {
-  const admittedAt = input.wake.noReplyAdmittedAt ?? input.wake.forcedQueuedAt
+  const admittedAt = input.wake.noReplyAdmittedAt
   if (admittedAt === undefined || !input.messages) {
     return false
   }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-session-history.ts
@@ -194,7 +194,7 @@ export function hasAssistantOutputAfterParentWakeAdmission(input: {
   readonly messages: readonly ParentWakeSessionMessage[] | undefined
   readonly wake: PendingParentWake
 }): boolean {
-  const admittedAt = input.wake.noReplyAdmittedAt
+  const admittedAt = input.wake.noReplyAdmittedAt ?? input.wake.forcedQueuedAt
   if (admittedAt === undefined || !input.messages) {
     return false
   }

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-window-recovery.ts
@@ -1,6 +1,7 @@
 import { log } from "../../shared"
 import type { PendingParentWake } from "./parent-wake-dedupe"
 import type { ParentWakeDispatchedTracker } from "./parent-wake-dispatched-tracker"
+import type { ParentWakePendingQueue } from "./parent-wake-pending-queue"
 import type { ParentWakeSessionInspector } from "./parent-wake-session-inspector"
 
 type ParentWakeWindowRecoveryInput = {
@@ -8,6 +9,9 @@ type ParentWakeWindowRecoveryInput = {
   readonly wake: PendingParentWake
   readonly dispatchedTracker: ParentWakeDispatchedTracker
   readonly sessionInspector: ParentWakeSessionInspector
+  readonly pendingQueue: ParentWakePendingQueue
+  readonly scheduleFlush: (sessionID: string) => void
+  readonly maxWindowRefreshes: number
 }
 
 export async function handleDispatchedParentWakeWindowElapsed(
@@ -26,9 +30,28 @@ export async function handleDispatchedParentWakeWindowElapsed(
     return
   }
 
+  // BUG B3: OpenCode can accept a prompt and then silently drop it. The 5s
+  // failure window would otherwise refresh forever, leaving the wake stuck
+  // "dispatched" with no assistant/tool output ever arriving. After
+  // maxWindowRefreshes consecutive empty windows (~15s) requeue the dispatched
+  // wake into the pending queue so the normal flush flow re-delivers it.
+  const windowRefreshCount = (currentWake.windowRefreshCount ?? 0) + 1
+  if (windowRefreshCount >= input.maxWindowRefreshes) {
+    input.dispatchedTracker.clearWake(input.sessionID)
+    input.pendingQueue.requeueWake(input.sessionID, currentWake)
+    input.scheduleFlush(input.sessionID)
+    log("[background-agent] Requeued silently-dropped dispatched parent wake after repeated empty recovery windows:", {
+      sessionID: input.sessionID,
+      windowRefreshes: windowRefreshCount,
+    })
+    return
+  }
+
+  currentWake.windowRefreshCount = windowRefreshCount
   input.dispatchedTracker.refreshWakeTimer(input.sessionID)
   log("[background-agent] Kept dispatched parent wake awaiting late failure or assistant output:", {
     sessionID: input.sessionID,
+    windowRefreshes: windowRefreshCount,
   })
 }
 

--- a/packages/omo-opencode/src/features/background-agent/session-activity.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-activity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import type { OpencodeClient } from "./opencode-client"
+import { getSessionActivityFromClient } from "./session-activity"
+
+// A fake session API modeled after the generated OpenCode SDK: `get` is a real
+// method that reads `this._client`. If the method is detached from its receiver
+// (e.g. `const get = client.session.get; get(...)`), `this` becomes undefined
+// and reading `this._client` throws, exactly like production.
+class ThrowingIfDetachedSessionApi {
+  private readonly _client = { internal: true }
+
+  get(_input: { path: { id: string }; query?: { directory?: string } }): Promise<{ data: { time: { updated: number } } }> {
+    if (!this._client) {
+      throw new Error("undefined is not an object (evaluating 'this._client')")
+    }
+    return Promise.resolve({ data: { time: { updated: 1_700_000_000_000 } } })
+  }
+}
+
+function createClientWith(session: unknown): OpencodeClient {
+  return unsafeTestValue<OpencodeClient>({ session })
+}
+
+describe("getSessionActivityFromClient", () => {
+  test("returns activity when session.get is a method that depends on its receiver", async () => {
+    //#given - a client whose session.get throws unless called with its own `this`
+    const client = createClientWith(new ThrowingIfDetachedSessionApi())
+
+    //#when - resolving session activity through the client
+    const result = await getSessionActivityFromClient(client, "ses-1")
+
+    //#then - the method was invoked with `this` preserved and produced an activity timestamp
+    expect(result.type).toBe("activity")
+    if (result.type === "activity") {
+      expect(result.activity).toEqual(new Date(1_700_000_000_000))
+    }
+  })
+
+  test("forwards the directory query while preserving the receiver", async () => {
+    //#given - a method-based session api that captures its received arguments and `this`
+    const received: Array<{ path: { id: string }; query?: { directory?: string } }> = []
+    class CapturingSessionApi {
+      private readonly _client = {}
+      get(input: { path: { id: string }; query?: { directory?: string } }): Promise<{ data: Record<string, never> }> {
+        // Touch `this._client` so a detached call would throw before capturing.
+        void this._client
+        received.push(input)
+        return Promise.resolve({ data: {} })
+      }
+    }
+    const client = createClientWith(new CapturingSessionApi())
+
+    //#when - resolving activity with an explicit directory
+    await getSessionActivityFromClient(client, "ses-9", "/tmp/project")
+
+    //#then - the call landed with the right path and query, proving `this` survived
+    expect(received).toEqual([{ path: { id: "ses-9" }, query: { directory: "/tmp/project" } }])
+  })
+
+  test("returns missing when session.get is not a function", async () => {
+    //#given - a fake client (plain object) that omits session.get entirely
+    const client = createClientWith({})
+
+    //#when - resolving session activity
+    const result = await getSessionActivityFromClient(client, "ses-2")
+
+    //#then - the existence guard short-circuits to missing without throwing
+    expect(result.type).toBe("missing")
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/session-activity.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-activity.ts
@@ -30,11 +30,10 @@ export async function getSessionActivityFromClient(
   sessionID: string,
   directory?: string,
 ): Promise<SessionActivityLookup> {
-  const sessionGet = client.session.get
-  if (typeof sessionGet !== "function") return { type: "missing" }
+  if (typeof client.session.get !== "function") return { type: "missing" }
 
   try {
-    const response = await sessionGet({
+    const response = await client.session.get({
       path: { id: sessionID },
       ...(directory ? { query: { directory } } : {}),
     })

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -93,10 +93,12 @@ export interface BackgroundTask {
   /** ID of the currently active attempt */
   currentAttemptID?: string
 
-  /** Last message count for stability detection */
+  /** Last message count observed by the polling message-stability fallback */
   lastMsgCount?: number
   /** Number of consecutive polls with stable message count */
   stablePolls?: number
+  /** Timestamp when lastMsgCount last changed; drives the 10s message-stability completion fallback */
+  lastMessageCountChangedAt?: Date
   /** Number of consecutive polls where session was missing from status map */
   consecutiveMissedPolls?: number
   /** Number of transient session.error events seen while the session was still alive, within the rolling window */

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -99,6 +99,10 @@ export interface BackgroundTask {
   stablePolls?: number
   /** Number of consecutive polls where session was missing from status map */
   consecutiveMissedPolls?: number
+  /** Number of transient session.error events seen while the session was still alive, within the rolling window */
+  sessionErrorCount?: number
+  /** Timestamp of the most recent transient session.error event used to bound the rolling window */
+  lastSessionErrorAt?: Date
 }
 
 export interface LaunchInput {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -274,6 +274,31 @@ describe("first-prompt-watchdog", () => {
 
     watchdog.dispose()
   })
+
+  it("#given a subagent silent past the threshold with no fallback configured #when the watchdog fires #then it surfaces the exhaustion via onWatchdogExhausted", async () => {
+    // given
+    const sessionID = "session-no-fallback-exhausted"
+    subagentSessions.add(sessionID)
+    const deps = createDeps()
+    const exhausted: Array<{ sessionID: string; model?: string; agent?: string }> = []
+    deps.onWatchdogExhausted = (id, info) => {
+      exhausted.push({ sessionID: id, model: info.model, agent: info.agent })
+    }
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await wait(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+    expect(exhausted).toEqual([{ sessionID, model: PRIMARY_MODEL, agent: AGENT }])
+
+    watchdog.dispose()
+  })
 })
 
 interface RecordedWatchdogCalls {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -151,6 +151,7 @@ export function createFirstPromptWatchdog(
         model,
         agent: resolvedAgent,
       })
+      await deps.onWatchdogExhausted?.(sessionID, { model, agent: resolvedAgent })
       return
     }
 

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
@@ -56,6 +56,7 @@ export function createRuntimeFallbackHook(
     sessionFallbackTimeouts: new Map(),
     sessionStatusRetryKeys: new Map(),
     internallyAbortedSessions: new Set(),
+    onWatchdogExhausted: options?.onWatchdogExhausted,
   }
 
   const helpers = factories.createAutoRetryHelpers(deps)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
@@ -58,6 +58,13 @@ export interface RuntimeFallbackOptions {
   config?: RuntimeFallbackConfig
   pluginConfig?: OhMyOpenCodeConfig
   session_timeout_ms?: number
+  /**
+   * Invoked when the first-prompt watchdog gives up on a silent subagent because
+   * no fallback chain is configured. Lets the background manager surface the
+   * exhaustion (fail + notify) instead of leaving the task wedged. No-op for
+   * sessions that are not background tasks.
+   */
+  onWatchdogExhausted?: (sessionID: string, info: { model?: string; agent?: string }) => void | Promise<void>
 }
 
 export interface RuntimeFallbackHook {
@@ -85,4 +92,5 @@ export interface HookDeps {
    * loop (every cycle started over at attempt:1). See issue #4006.
    */
   internallyAbortedSessions: Set<string>
+  onWatchdogExhausted?: (sessionID: string, info: { model?: string; agent?: string }) => void | Promise<void>
 }

--- a/packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe-edge.test.ts
+++ b/packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe-edge.test.ts
@@ -91,7 +91,7 @@ describe("dispatchInternalPrompt semantic dedupe edge cases", () => {
         throw new Error("expected first dispatch to fail after attempt")
       }
       expect(first.dispatchAttempted).toBe(true)
-      expect(second).toEqual({ status: "queued", queuedBy: "test:reject-semantic:first", position: 0 })
+      expect(second).toEqual({ status: "queued", queuedBy: "test:reject-semantic:first", position: 0, queuedEntryCreated: false })
       expect(promptCalls).toEqual(["prompt"])
     } finally {
       Date.now = originalDateNow

--- a/packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe.test.ts
+++ b/packages/omo-opencode/src/hooks/shared/prompt-async-gate-semantic-dedupe.test.ts
@@ -61,7 +61,7 @@ describe("dispatchInternalPrompt semantic dedupe", () => {
 
       // then
       expect(first.status).toBe("dispatched")
-      expect(second).toEqual({ status: "queued", queuedBy: "test:semantic:first", position: 0 })
+      expect(second).toEqual({ status: "queued", queuedBy: "test:semantic:first", position: 0, queuedEntryCreated: false })
       expect(promptCalls).toEqual(["prompt"])
     } finally {
       Date.now = originalDateNow
@@ -114,7 +114,7 @@ describe("dispatchInternalPrompt semantic dedupe", () => {
 
       // then
       expect(first.status).toBe("dispatched")
-      expect(second).toEqual({ status: "queued", queuedBy: "test:semantic-order:first", position: 0 })
+      expect(second).toEqual({ status: "queued", queuedBy: "test:semantic-order:first", position: 0, queuedEntryCreated: false })
       expect(promptCalls).toEqual(["prompt"])
     } finally {
       Date.now = originalDateNow
@@ -355,6 +355,7 @@ describe("dispatchInternalPrompt semantic dedupe", () => {
         status: "queued",
         queuedBy: "test:semantic-continuation:first",
         position: 0,
+        queuedEntryCreated: false,
       })
       expect(promptCalls).toEqual(["prompt"])
     } finally {

--- a/packages/omo-opencode/src/hooks/shared/prompt-async-gate.test.ts
+++ b/packages/omo-opencode/src/hooks/shared/prompt-async-gate.test.ts
@@ -1088,7 +1088,7 @@ describe("dispatchInternalPrompt shared gate behavior", () => {
 
     // then
     expect(first.status).toBe("dispatched")
-    expect(second).toEqual({ status: "queued", queuedBy: "team-live-delivery", position: 1 })
+    expect(second).toEqual({ status: "queued", queuedBy: "team-live-delivery", position: 1, queuedEntryCreated: true })
     expect(promptCalls).toBe(1)
   })
 
@@ -1215,7 +1215,7 @@ describe("dispatchInternalPrompt shared gate behavior", () => {
     // then
     expect(first.status).toBe("failed")
     expect(first).toMatchObject({ dispatchAttempted: true })
-    expect(second).toEqual({ status: "queued", queuedBy: "test:reject:first", position: 0 })
+    expect(second).toEqual({ status: "queued", queuedBy: "test:reject:first", position: 0, queuedEntryCreated: false })
     expect(promptCalls).toBe(1)
   })
 
@@ -1263,7 +1263,7 @@ describe("dispatchInternalPrompt shared gate behavior", () => {
     // then
     expect(first.status).toBe("dispatched")
     expect(released).toBe(false)
-    expect(second).toEqual({ status: "queued", queuedBy: "model-fallbackx:message.updated", position: 1 })
+    expect(second).toEqual({ status: "queued", queuedBy: "model-fallbackx:message.updated", position: 1, queuedEntryCreated: true })
     expect(promptCalls).toBe(1)
   })
 

--- a/packages/omo-opencode/src/plugin/hooks/create-session-hooks.ts
+++ b/packages/omo-opencode/src/plugin/hooks/create-session-hooks.ts
@@ -215,6 +215,8 @@ export function createSessionHooks(args: {
         createRuntimeFallbackHook(ctx, {
           config: runtimeFallbackConfig,
           pluginConfig,
+          onWatchdogExhausted: (sessionID, info) =>
+            backgroundManager.failWatchdogExhaustedTask(sessionID, info),
         }))
     : null
 

--- a/packages/omo-opencode/src/shared/model-suggestion-retry.test.ts
+++ b/packages/omo-opencode/src/shared/model-suggestion-retry.test.ts
@@ -326,7 +326,7 @@ describe("promptWithModelSuggestionRetry", () => {
     })
 
     // then
-    expect(third).toEqual({ status: "queued", queuedBy: "model-suggestion-retry", position: 1 })
+    expect(third).toEqual({ status: "queued", queuedBy: "model-suggestion-retry", position: 1, queuedEntryCreated: true })
     expect(promptMock).toHaveBeenCalledTimes(1)
   })
 
@@ -427,7 +427,7 @@ describe("promptWithModelSuggestionRetry", () => {
     })
 
     // then
-    expect(second).toEqual({ status: "queued", queuedBy: "model-suggestion-retry", position: 1 })
+    expect(second).toEqual({ status: "queued", queuedBy: "model-suggestion-retry", position: 1, queuedEntryCreated: true })
     expect(promptMock).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/omo-opencode/src/shared/model-suggestion-retry.test.ts
+++ b/packages/omo-opencode/src/shared/model-suggestion-retry.test.ts
@@ -536,6 +536,26 @@ describe("promptWithModelSuggestionRetry", () => {
     // and should call promptAsync only once
     expect(promptMock).toHaveBeenCalledTimes(1)
   })
+
+  it("#given promptAsync fails with a dispatch timeout after dispatch was attempted #when the non-verifying caller classifies it #then it throws instead of silently assuming acceptance", async () => {
+    // given
+    const promptMock = mock().mockRejectedValueOnce(new Error("promptAsync timed out after 30000ms"))
+    const client = { session: { promptAsync: promptMock } }
+
+    // when
+    // then
+    await expect(
+      promptWithModelSuggestionRetry(unsafeTestValue(client), {
+        path: { id: "session-dispatch-timeout" },
+        body: {
+          parts: [{ type: "text", text: "hello" }],
+          model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+        },
+      })
+    ).rejects.toThrow("timed out")
+
+    expect(promptMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("promptSyncWithModelSuggestionRetry", () => {

--- a/packages/omo-opencode/src/shared/prompt-async-gate-queue-ttl.test.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate-queue-ttl.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  dispatchInternalPrompt,
+  releaseAllPromptAsyncReservationsForTesting,
+  releasePromptAsyncReservation,
+} from "./prompt-async-gate"
+import type { InternalPromptDispatchResult } from "./prompt-async-gate"
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt >= timeoutMs) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
+describe("prompt-async-gate queue TTL", () => {
+  afterEach(() => {
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
+  test("#given a queued prompt to a session that never goes idle #when the per-entry TTL elapses #then the entry expires and the onExpiredOrFailed channel reports it", async () => {
+    // given
+    let promptCalls = 0
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_ttl_busy: { type: "busy" } } }),
+        promptAsync: async () => {
+          promptCalls += 1
+        },
+      },
+    }
+    const settled: InternalPromptDispatchResult[] = []
+
+    // when
+    const result = await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: "ses_ttl_busy",
+      input: { path: { id: "ses_ttl_busy" }, body: { parts: [{ type: "text", text: "wedged" }] } },
+      source: "test:ttl-busy",
+      settleMs: 0,
+      queueRetryMs: 5,
+      ttlMs: 40,
+      onExpiredOrFailed: (settledResult) => {
+        settled.push(settledResult)
+      },
+    })
+    await waitUntil(() => settled.length > 0, 1_000)
+
+    // then
+    expect(result.status).toBe("queued")
+    expect(settled).toHaveLength(1)
+    expect(settled[0]?.status).toBe("expired")
+    if (settled[0]?.status === "expired") {
+      expect(settled[0].source).toBe("test:ttl-busy")
+      expect(settled[0].waitedMs).toBeGreaterThanOrEqual(40)
+    }
+    expect(promptCalls).toBe(0)
+  })
+
+  test("#given a stale queued prompt expired #when a fresh prompt targets the same idle session #then the gate dispatches it (queue blocker cleared)", async () => {
+    // given
+    let status = "busy"
+    let promptCalls = 0
+    const client = {
+      session: {
+        status: async () => ({ data: { ses_ttl_unblock: { type: status } } }),
+        promptAsync: async () => {
+          promptCalls += 1
+        },
+      },
+    }
+    const expired: InternalPromptDispatchResult[] = []
+
+    // when - first prompt wedges against a busy session and expires
+    await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: "ses_ttl_unblock",
+      input: { path: { id: "ses_ttl_unblock" }, body: { parts: [{ type: "text", text: "stale" }] } },
+      source: "test:ttl-unblock:stale",
+      settleMs: 0,
+      queueRetryMs: 5,
+      ttlMs: 40,
+      onExpiredOrFailed: (settledResult) => {
+        expired.push(settledResult)
+      },
+    })
+    await waitUntil(() => expired.length > 0, 1_000)
+
+    // session becomes idle, a brand new prompt should no longer be blocked
+    status = "idle"
+    let freshPromptSeen: (() => void) | undefined
+    const freshPromptDispatched = new Promise<void>((resolve) => {
+      freshPromptSeen = resolve
+    })
+    client.session.promptAsync = async () => {
+      promptCalls += 1
+      freshPromptSeen?.()
+    }
+    await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: "ses_ttl_unblock",
+      input: { path: { id: "ses_ttl_unblock" }, body: { parts: [{ type: "text", text: "fresh" }] } },
+      source: "test:ttl-unblock:fresh",
+      settleMs: 0,
+      queueRetryMs: 5,
+    })
+    await freshPromptDispatched
+
+    // then
+    expect(expired[0]?.status).toBe("expired")
+    expect(promptCalls).toBe(1)
+  })
+
+  test("#given a detached queued prompt whose dispatch fails #when the queue drains it #then the onExpiredOrFailed channel reports the failure", async () => {
+    // given
+    const client = {
+      session: {
+        promptAsync: async (input: { body: { parts: Array<{ text: string }> } }) => {
+          const text = input.body.parts[0]?.text
+          if (text === "second") {
+            throw new Error("promptAsync boom")
+          }
+        },
+      },
+    }
+    const settled: InternalPromptDispatchResult[] = []
+
+    // when - first holds a post-dispatch reservation, second queues behind it
+    const first = await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: "ses_queue_fail",
+      input: { path: { id: "ses_queue_fail" }, body: { parts: [{ type: "text", text: "first" }] } },
+      source: "test:queue-fail:first",
+      settleMs: 0,
+    })
+    const second = await dispatchInternalPrompt({
+      mode: "async",
+      client,
+      sessionID: "ses_queue_fail",
+      input: { path: { id: "ses_queue_fail" }, body: { parts: [{ type: "text", text: "second" }] } },
+      source: "test:queue-fail:second",
+      settleMs: 0,
+      queueRetryMs: 5,
+      onExpiredOrFailed: (settledResult) => {
+        settled.push(settledResult)
+      },
+    })
+    // releasing the first reservation triggers the detached drain of the second
+    releasePromptAsyncReservation("ses_queue_fail", "test:queue-fail:first", {
+      reservedBy: "test:queue-fail:first",
+    })
+    await waitUntil(() => settled.length > 0, 1_000)
+
+    // then
+    expect(first.status).toBe("dispatched")
+    expect(second.status).toBe("queued")
+    expect(settled).toHaveLength(1)
+    expect(settled[0]?.status).toBe("failed")
+  })
+})

--- a/packages/omo-opencode/src/shared/prompt-async-gate.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_PROMPT_ASYNC_POST_DISPATCH_HOLD_MS,
   DEFAULT_PROMPT_DISPATCH_TIMEOUT_MS,
   DEFAULT_PROMPT_QUEUE_RETRY_MS,
+  DEFAULT_PROMPT_QUEUE_TTL_MS,
   DEFAULT_PROMPT_SEMANTIC_DEDUPE_HOLD_MS,
   resetPromptGateTimingForTesting,
 } from "./prompt-async-gate/timing"
@@ -54,6 +55,7 @@ export {
   DEFAULT_PROMPT_DISPATCH_TIMEOUT_MS,
   DEFAULT_PROMPT_GATE_MESSAGES_FETCH_TIMEOUT_MS,
   DEFAULT_PROMPT_QUEUE_RETRY_MS,
+  DEFAULT_PROMPT_QUEUE_TTL_MS,
   DEFAULT_PROMPT_SEMANTIC_DEDUPE_HOLD_MS,
   _setPromptGateMessagesFetchTimeoutMsForTesting,
 } from "./prompt-async-gate/timing"
@@ -259,6 +261,9 @@ export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
       semanticDedupeHoldMs,
       dispatchTimeoutMs,
       queueRetryMs,
+      enqueuedAt: Date.now(),
+      ttlMs: args.ttlMs ?? DEFAULT_PROMPT_QUEUE_TTL_MS,
+      onExpiredOrFailed: args.onExpiredOrFailed,
       checkStatus: args.checkStatus !== false,
       checkToolState: args.checkToolState !== false,
       dispatch: async (_dispatchInput: unknown) => dispatchWithPathCompatibility(dispatch, input),

--- a/packages/omo-opencode/src/shared/prompt-async-gate.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate.ts
@@ -264,6 +264,7 @@ export async function dispatchInternalPrompt<TInput = PromptAsyncInput>(
       enqueuedAt: Date.now(),
       ttlMs: args.ttlMs ?? DEFAULT_PROMPT_QUEUE_TTL_MS,
       onExpiredOrFailed: args.onExpiredOrFailed,
+      onDispatched: args.onDispatched,
       checkStatus: args.checkStatus !== false,
       checkToolState: args.checkToolState !== false,
       dispatch: async (_dispatchInput: unknown) => dispatchWithPathCompatibility(dispatch, input),

--- a/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
@@ -46,6 +46,53 @@ function queuedResult(entry: QueuedInternalPrompt, position: number, queuedBy = 
   }
 }
 
+function expiredResult(entry: QueuedInternalPrompt, waitedMs: number): InternalPromptDispatchResult {
+  return {
+    status: "expired",
+    source: entry.source,
+    waitedMs,
+  }
+}
+
+function expireStaleEntries(
+  sessionID: string,
+  awaitedEntry?: QueuedInternalPrompt,
+): InternalPromptDispatchResult | undefined {
+  const queue = promptQueues.get(sessionID)
+  if (!queue || queue.length === 0) {
+    return undefined
+  }
+
+  const now = Date.now()
+  const inFlightID = promptQueueInFlight.get(sessionID)?.id
+  let awaitedExpired: InternalPromptDispatchResult | undefined
+  const survivors: QueuedInternalPrompt[] = []
+  for (const entry of queue) {
+    const ttlMs = entry.ttlMs
+    const waitedMs = now - entry.enqueuedAt
+    if (ttlMs === undefined || ttlMs <= 0 || waitedMs < ttlMs || entry.id === inFlightID) {
+      survivors.push(entry)
+      continue
+    }
+
+    const result = expiredResult(entry, waitedMs)
+    log("[prompt-async-gate] queued prompt expired past TTL", {
+      sessionID,
+      source: entry.source,
+      waitedMs,
+      ttlMs,
+    })
+    if (awaitedEntry?.id === entry.id) {
+      awaitedExpired = result
+    } else {
+      entry.onExpiredOrFailed?.(result)
+    }
+  }
+
+  setPromptQueue(sessionID, survivors)
+  return awaitedExpired
+}
+
 function clearPromptQueueTimer(sessionID: string): void {
   const timer = promptQueueTimers.get(sessionID)
   if (timer !== undefined) {
@@ -132,6 +179,15 @@ async function drainPromptQueue(sessionID: string, awaitedEntry?: QueuedInternal
   let awaitedResult: InternalPromptDispatchResult | undefined
   try {
     while (true) {
+      const expiredAwaited = expireStaleEntries(sessionID, awaitedEntry)
+      if (expiredAwaited) {
+        awaitedResult = expiredAwaited
+        const remainingAfterExpiry = promptQueues.get(sessionID)
+        if (remainingAfterExpiry && remainingAfterExpiry.length > 0) {
+          schedulePromptQueueDrain(sessionID, 0)
+        }
+        break
+      }
       const queue = promptQueues.get(sessionID)
       const entry = queue?.[0]
       if (!entry) {
@@ -174,6 +230,8 @@ async function drainPromptQueue(sessionID: string, awaitedEntry?: QueuedInternal
       removePromptQueueEntry(sessionID, entry)
       if (awaitedEntry?.id === entry.id) {
         awaitedResult = result
+      } else if (result.status === "failed") {
+        entry.onExpiredOrFailed?.(result)
       }
 
       const remainingQueue = promptQueues.get(sessionID)

--- a/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
@@ -232,6 +232,8 @@ async function drainPromptQueue(sessionID: string, awaitedEntry?: QueuedInternal
         awaitedResult = result
       } else if (result.status === "failed") {
         entry.onExpiredOrFailed?.(result)
+      } else if (result.status === "dispatched") {
+        entry.onDispatched?.(result)
       }
 
       const remainingQueue = promptQueues.get(sessionID)

--- a/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/queue.ts
@@ -38,11 +38,17 @@ function setPromptQueue(sessionID: string, queue: QueuedInternalPrompt[]): void 
   promptQueues.set(sessionID, queue)
 }
 
-function queuedResult(entry: QueuedInternalPrompt, position: number, queuedBy = entry.source): InternalPromptDispatchResult {
+function queuedResult(
+  entry: QueuedInternalPrompt,
+  position: number,
+  queuedBy = entry.source,
+  queuedEntryCreated = true,
+): InternalPromptDispatchResult {
   return {
     status: "queued",
     queuedBy,
     position,
+    queuedEntryCreated,
   }
 }
 
@@ -259,7 +265,7 @@ export async function enqueueInternalPrompt(entry: QueuedInternalPrompt): Promis
       source: entry.source,
       queuedBy: activeReservation.source,
     })
-    return queuedResult(entry, 0, activeReservation.source)
+    return queuedResult(entry, 0, activeReservation.source, false)
   }
 
   const queue = getPromptQueue(entry.sessionID)
@@ -273,7 +279,7 @@ export async function enqueueInternalPrompt(entry: QueuedInternalPrompt): Promis
         queuedBy: existing.source,
         position: existingIndex + 1,
       })
-      return queuedResult(existing, existingIndex + 1)
+      return queuedResult(existing, existingIndex + 1, existing.source, false)
     }
   }
 

--- a/packages/omo-opencode/src/shared/prompt-async-gate/semantic-dedupe.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/semantic-dedupe.ts
@@ -128,5 +128,5 @@ export function coalesceRecentSemanticPromptDispatch(args: {
     source: args.source,
     queuedBy: recentDispatch.source,
   })
-  return { status: "queued", queuedBy: recentDispatch.source, position: 0 }
+  return { status: "queued", queuedBy: recentDispatch.source, position: 0, queuedEntryCreated: false }
 }

--- a/packages/omo-opencode/src/shared/prompt-async-gate/timing.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/timing.ts
@@ -3,6 +3,7 @@ export const DEFAULT_PROMPT_SEMANTIC_DEDUPE_HOLD_MS = 15_000
 export const DEFAULT_PROMPT_DISPATCH_TIMEOUT_MS = 30_000
 export const DEFAULT_PROMPT_GATE_MESSAGES_FETCH_TIMEOUT_MS = 5_000
 export const DEFAULT_PROMPT_QUEUE_RETRY_MS = 250
+export const DEFAULT_PROMPT_QUEUE_TTL_MS = 5 * 60_000
 
 declare function setTimeout(callback: () => void, delay?: number): unknown
 declare function clearTimeout(timeout: unknown): void

--- a/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
@@ -49,6 +49,7 @@ type InternalPromptDispatchCommonArgs<TInput> = {
   readonly checkToolState?: boolean
   readonly ttlMs?: number
   readonly onExpiredOrFailed?: (result: InternalPromptDispatchResult) => void
+  readonly onDispatched?: (result: InternalPromptDispatchResult) => void
 }
 
 export type InternalPromptDispatchArgs<TInput = PromptAsyncInput> = InternalPromptDispatchCommonArgs<TInput> & (
@@ -106,4 +107,5 @@ export type QueuedInternalPrompt = {
   readonly enqueuedAt: number
   readonly ttlMs?: number
   readonly onExpiredOrFailed?: (result: InternalPromptDispatchResult) => void
+  readonly onDispatched?: (result: InternalPromptDispatchResult) => void
 }

--- a/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
@@ -47,6 +47,8 @@ type InternalPromptDispatchCommonArgs<TInput> = {
   readonly dispatchTimeoutMs?: number
   readonly checkStatus?: boolean
   readonly checkToolState?: boolean
+  readonly ttlMs?: number
+  readonly onExpiredOrFailed?: (result: InternalPromptDispatchResult) => void
 }
 
 export type InternalPromptDispatchArgs<TInput = PromptAsyncInput> = InternalPromptDispatchCommonArgs<TInput> & (
@@ -69,6 +71,7 @@ export type InternalPromptDispatchResult =
   | { readonly status: "reserved"; readonly reservedBy: string }
   | { readonly status: "unavailable" }
   | { readonly status: "failed"; readonly error: unknown; readonly dispatchAttempted: boolean }
+  | { readonly status: "expired"; readonly source: string; readonly waitedMs: number }
 
 export type PromptAsyncGateResult = InternalPromptDispatchResult
 
@@ -100,4 +103,7 @@ export type QueuedInternalPrompt = {
   readonly checkStatus: boolean
   readonly checkToolState: boolean
   readonly dispatch: (input: unknown) => Promise<unknown>
+  readonly enqueuedAt: number
+  readonly ttlMs?: number
+  readonly onExpiredOrFailed?: (result: InternalPromptDispatchResult) => void
 }

--- a/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
+++ b/packages/omo-opencode/src/shared/prompt-async-gate/types.ts
@@ -67,7 +67,7 @@ export type PromptAsyncReservation = {
 
 export type InternalPromptDispatchResult =
   | { readonly status: "dispatched"; readonly response: unknown }
-  | { readonly status: "queued"; readonly queuedBy: string; readonly position: number }
+  | { readonly status: "queued"; readonly queuedBy: string; readonly position: number; readonly queuedEntryCreated: boolean }
   | { readonly status: "active" }
   | { readonly status: "reserved"; readonly reservedBy: string }
   | { readonly status: "unavailable" }

--- a/packages/omo-opencode/src/shared/prompt-failure-classifier.test.ts
+++ b/packages/omo-opencode/src/shared/prompt-failure-classifier.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test"
 
 import {
-  isAmbiguousPostDispatchPromptFailure,
+isAmbiguousPostDispatchPromptFailure,
   isAmbiguousPromptDispatchFailure,
+  isVerifiableAmbiguousPromptFailure,
 } from "./prompt-failure-classifier"
 
 describe("prompt failure classifier", () => {
@@ -87,5 +88,65 @@ describe("prompt failure classifier", () => {
 
     // then
     expect(ambiguous).toBe(true)
+  })
+
+  test("#given a post-dispatch timeout failure #when a non-verifying caller classifies it #then it is NOT treated as accepted (timeout means not delivered)", () => {
+    // given
+    const result = {
+      status: "failed" as const,
+      dispatchAttempted: true,
+      error: new Error("promptAsync timed out after 30000ms"),
+    }
+
+    // when
+    const ambiguous = isAmbiguousPostDispatchPromptFailure(result)
+
+    // then
+    expect(ambiguous).toBe(false)
+  })
+
+  test("#given a post-dispatch timeout failure #when a verifying caller classifies it #then it stays ambiguous so the caller can verify acceptance", () => {
+    // given
+    const result = {
+      status: "failed" as const,
+      dispatchAttempted: true,
+      error: new Error("promptAsync timed out after 30000ms"),
+    }
+
+    // when
+    const ambiguous = isVerifiableAmbiguousPromptFailure(result)
+
+    // then
+    expect(ambiguous).toBe(true)
+  })
+
+  test("#given a non-timeout ambiguous failure after dispatch #when a verifying caller classifies it #then it is still ambiguous", () => {
+    // given
+    const result = {
+      status: "failed" as const,
+      dispatchAttempted: true,
+      error: new Error("JSON Parse error: Unexpected EOF"),
+    }
+
+    // when
+    const ambiguous = isVerifiableAmbiguousPromptFailure(result)
+
+    // then
+    expect(ambiguous).toBe(true)
+  })
+
+  test("#given a timeout ambiguous failure before dispatch #when a verifying caller classifies it #then it is not treated as ambiguous", () => {
+    // given
+    const result = {
+      status: "failed" as const,
+      dispatchAttempted: false,
+      error: new Error("promptAsync timed out after 30000ms"),
+    }
+
+    // when
+    const ambiguous = isVerifiableAmbiguousPromptFailure(result)
+
+    // then
+    expect(ambiguous).toBe(false)
   })
 })

--- a/packages/omo-opencode/src/shared/prompt-failure-classifier.ts
+++ b/packages/omo-opencode/src/shared/prompt-failure-classifier.ts
@@ -14,14 +14,32 @@ export function extractPromptFailureMessage(error: unknown): string {
   return String(error)
 }
 
-export function isAmbiguousPromptDispatchFailure(error: unknown): boolean {
+const VERIFICATION_INDEPENDENT_AMBIGUOUS_PATTERNS = [
+  "unexpected eof",
+  "json parse error",
+  "unexpected end of json input",
+] as const
+
+const VERIFICATION_DEPENDENT_AMBIGUOUS_PATTERNS = [
+  "timed out",
+] as const
+
+function promptFailureMessageMatches(error: unknown, patterns: readonly string[]): boolean {
   const message = extractPromptFailureMessage(error).toLowerCase()
-  return (
-    message.includes("unexpected eof")
-    || message.includes("json parse error")
-    || message.includes("unexpected end of json input")
-    || message.includes("timed out")
-  )
+  return patterns.some((pattern) => message.includes(pattern))
+}
+
+export function isAmbiguousPromptDispatchFailure(error: unknown): boolean {
+  return promptFailureMessageMatches(error, [
+    ...VERIFICATION_INDEPENDENT_AMBIGUOUS_PATTERNS,
+    ...VERIFICATION_DEPENDENT_AMBIGUOUS_PATTERNS,
+  ])
+}
+
+// Excludes timeouts: a dispatch timeout almost always means the prompt was NOT
+// accepted, so callers that cannot verify acceptance must treat it as a failure.
+export function isVerificationIndependentAmbiguousPromptDispatchFailure(error: unknown): boolean {
+  return promptFailureMessageMatches(error, VERIFICATION_INDEPENDENT_AMBIGUOUS_PATTERNS)
 }
 
 type PromptDispatchFailureResultLike = {
@@ -30,6 +48,17 @@ type PromptDispatchFailureResultLike = {
   dispatchAttempted?: boolean
 }
 
+// Default classification for callers WITHOUT post-dispatch verification: a
+// timeout is treated as a real failure, only genuinely indeterminate errors
+// (EOF / JSON parse) are considered possibly-accepted.
 export function isAmbiguousPostDispatchPromptFailure(result: PromptDispatchFailureResultLike): boolean {
+  return result.dispatchAttempted === true
+    && isVerificationIndependentAmbiguousPromptDispatchFailure(result.error)
+}
+
+// For callers that verify post-dispatch acceptance (e.g. parent-wake via
+// hasRecordedPromptAfterDispatch): timeouts remain ambiguous so the caller can
+// confirm delivery before retrying instead of risking a duplicate dispatch.
+export function isVerifiableAmbiguousPromptFailure(result: PromptDispatchFailureResultLike): boolean {
   return result.dispatchAttempted === true && isAmbiguousPromptDispatchFailure(result.error)
 }

--- a/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-continuation.test.ts
@@ -95,4 +95,46 @@ describe("executeBackgroundContinuation - subagent metadata", () => {
     expect(result).toContain("session_id: ses_resumed_456")
     expect(result).not.toContain("subagent:")
   })
+
+  test("states the message was dispatched asynchronously and a notification will follow if delivery fails", async () => {
+    //#given - mock manager.resume returning a running task (fire-and-forget dispatch)
+    const mockManager = {
+      resume: async () => ({
+        id: "bg_task_001",
+        description: "oracle consultation",
+        agent: "oracle",
+        status: "running",
+        sessionId: "ses_resumed_123",
+      }),
+    }
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-honesty",
+      metadata: mock(() => Promise.resolve()),
+    }
+    const mockExecutorCtx = {
+      manager: mockManager,
+    }
+    const parentContext = {
+      sessionID: "parent-session",
+      messageID: "msg-parent",
+      agent: "sisyphus",
+    }
+    const args = {
+      task_id: "ses_resumed_123",
+      prompt: "continue working",
+      description: "resume oracle",
+      load_skills: [],
+      run_in_background: true,
+    }
+
+    //#when - executeBackgroundContinuation completes
+    const { executeBackgroundContinuation } = require("./background-continuation")
+    const result = await executeBackgroundContinuation(args, mockCtx, mockExecutorCtx, parentContext)
+
+    //#then - output is honest that delivery is async and not yet confirmed
+    expect(result).toContain("dispatched asynchronously")
+    expect(result).toContain("delivery is not yet confirmed")
+    expect(result).toContain('task(task_id="bg_task_001")')
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/background-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/background-continuation.ts
@@ -65,6 +65,7 @@ Description: ${task.description}
 Agent: ${task.agent}
 Status: ${task.status}
 
+Your message was dispatched asynchronously to the background task; delivery is not yet confirmed. If it cannot be delivered, a <system-reminder> notification will follow and you can retry with task(task_id="${backgroundTaskId}").
 Agent continues with full previous context preserved.
 System notifies on completion. Use \`background_output\` with task_id="${backgroundTaskId}" to check.
 


### PR DESCRIPTION
## Problem

Three chronic reliability failures in the background subagent system, all observed in production logs:

1. **Completion callbacks missing/late** - a continuously busy parent (ultrawork / todo-continuation loops) starves the wake pipeline forever. Production evidence: one parent session had its completion wake deferred **8267 times at 1s intervals over 2h18m with zero deliveries**. Related: #5189, #5089.
2. **Weak interrupt/exception recovery** - tasks zombify: every session-activity read crashed (96x in one log) so stale-task interruption never ran; `session.error` while the session stays alive was treated as transient forever; watchdog exhaustion gave up silently. Related: #4528, #4570.
3. **Parent-to-subagent messages silently lost** - queued resume prompts had no TTL and could wedge task completion forever; skipped resumes reverted silently while the tool reported success; "timed out" dispatches were classified as possibly-delivered. Related: #4689.

## Fixes (9 commits, reviewed wave by wave)

### Wave A - zombie elimination
- `session-activity.ts` called a **detached** `client.session.get`, losing the SDK receiver (`this._client` crash) - every activity read failed, so the stale-task poller never interrupted zombies. One-line root fix + this-sensitive regression test.
- Repeated `session.error` while the session is alive now fails the task after 3 strikes in 10 minutes (progress resets the counter) and notifies the parent, instead of waiting for the 45-minute stale timeout.
- Launch errors with no resolvable task abort the orphaned session; resume errors finalize the attempt record.

### Wave B - parent-wake delivery guarantees
- **Bounded deferral**: wakes record `firstDeferredAt`/`deferCount`; past `PARENT_WAKE_MAX_DEFER_MS` (120s) the flush runner force-dispatches as an admit-only noReply via `dispatchInternalPrompt(queueBehavior: enqueue)` - content lands at the next turn boundary instead of never.
- Retained reply-wakes always reschedule a re-flush after noReply admission (#5189).
- Dispatched wakes with no assistant output for 3 failure windows (~15s) requeue instead of refreshing the window forever.
- Wake dispatch failures check parent session existence; missing parent drops the wake instead of retrying at 1s forever.
- Force-queued wakes are **gate-truthful**: a dispatch that merely queues at the gate is not tracked as dispatched; real admission happens only via the gate's new per-entry `onDispatched` callback; callbacks are identity-bound with a rotating `forceQueueToken` so stale entries can never admit superseded content; coalesced queued results (no real entry) never mark force-queued.

### Wave C - message-delivery honesty
- Prompt-async-gate queue entries gain a **TTL** (5 min, new `expired` result status + per-entry `onExpiredOrFailed`): an undeliverable queued resume no longer wedges task completion forever; the parent gets a reply-producing notification telling it the message was NOT delivered and how to retry.
- `restoreTaskAfterSkippedResume` now notifies the parent instead of reverting silently; the continuation tool output is honest about async dispatch.

### Wave D - completion detection fallback
- **Message-stability completion fallback** in the polling path: when the status API is unavailable or stuck busy, a task whose session shows a terminal assistant message (non-terminal finish reasons and pending tool parts rejected, latest-assistant-after-latest-user by array position) stable for 10s completes with the same output/todo gates as the idle path - instead of waiting 45-60 min for the stale timeout.
- First-prompt-watchdog same-model exhaustion on a background task now fails the task through the normal machinery (parent notified) via an `onWatchdogExhausted` seam.
- `"timed out"` dispatch failures are no longer classified as possibly-delivered except for the parent-wake caller that verifies acceptance via session history (`isVerifiableAmbiguousPromptFailure`).

## Validation

- TDD throughout: every fix landed with failing-first co-located tests (~60 new tests).
- Full suite: only pre-existing failures (verified against clean `origin/dev` in a separate worktree); wave-relevant dirs 0 failures; `prompt-async-route-audit` 10/10 (all dispatch through the gate); typecheck clean.
- 4 rounds of internal deep review until unconditional approval (rounds hardened: queued-vs-dispatched truthfulness, identity-bound callbacks, terminal-finish strictness, reply-producing failure notifications).
- **Real-harness QA** in an isolated XDG sandbox against real opencode (evidence: `.omo/evidence/20260612-subagent-reliability/`): the starvation scenario force-delivered after exactly 120s/120 deferrals (production: 8267 deferrals, zero deliveries), happy-path delegation unaffected, 0 session-activity read failures (production: 96), real opencode.db untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves background subagent reliability by guaranteeing parent‑wake delivery, preventing zombie tasks, and making message delivery/completion detection truthful. Busy-parent starvation is removed; undeliverable messages expire and notify the parent; stuck tasks now complete or fail promptly.

- **Bug Fixes**
  - Parent‑wake delivery guarantees: bounded deferral (120s) then force‑queued admit‑only via the gate with identity‑bound callbacks; requeue on silent drops; stop retrying when the parent session is gone.
  - Zombie elimination: fix `client.session.get` call binding; fail a task after 3 `session.error` events in 10 minutes unless progress occurs; abort orphaned sessions and finalize attempts on resume errors.
  - Timeout honesty: non‑verifying callers no longer treat “timed out” as possibly delivered; parent‑wake keeps verification via session history.

- **New Features**
  - Queue TTL in `prompt-async-gate`: expire queued prompts after 5 minutes and report via `onExpiredOrFailed`/`onDispatched`; queued results include `queuedEntryCreated`.
  - Completion fallback: polling‑based message‑stability completion with terminal‑message and gate checks when status is unavailable or stuck busy.
  - Watchdog and UX: expose `onWatchdogExhausted` to fail + notify background tasks; background‑continuation tool copy states async dispatch and that a failure notification will follow.

<sup>Written for commit 952720f498dff55208c67036b1252c7e4bb3dab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

