### PR TITLE
feat(meta-governor): add memory-aggregator (PR 2 of v2 series)

### DIFF
--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -1,0 +1,49 @@
+/**
+ * MetaGovernor — self-judging agent orchestration layer.
+ *
+ * PR 1 of v2 series. This barrel re-exports ONLY the type surface.
+ * Runtime modules (memory-aggregator, scoring-engine, orchestrator, etc.)
+ * are added in subsequent PRs.
+ *
+ * Architectural invariants:
+ * - All session.promptAsync calls go through prompt-async-gate
+ * - Composes agentmemory + magic-context + boulder-state
+ * - Feature flag `meta_governor.enabled = false` default
+ */
+export type {
+  Decision,
+  DecisionContext,
+  DecisionHandlerConfig,
+  DecisionHandlerInput,
+  DecisionHandlerOutput,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceContribution,
+  EvidenceSource,
+  LearnFromOutcomeInput,
+  LearnFromOutcomeOutput,
+  LessonLearned,
+  MemoryDecision,
+  MemoryRead,
+  AgentMemoryRead,
+  MagicContextRead,
+  BoulderStateRead,
+  MemorySource,
+  AmbientContext,
+  MetaGovernorInput,
+  MetaGovernorOutput,
+  OrchestratorConfig,
+  RelevantLesson,
+  ScoringConfig,
+  ScoringResult,
+  SlotMemory,
+  ClosedLoopConfig,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  AgentmemoryWriteBackend,
+  MemoryBackends,
+} from "./types"

--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -47,3 +47,14 @@ export type {
   AgentmemoryWriteBackend,
   MemoryBackends,
 } from "./types"
+
+// PR 2: memory-aggregator (parallel reads from 3 memory systems)
+export { aggregateRead } from "./memory-aggregator"
+export type {
+  AgentmemoryBackend,
+  MagicContextBackend,
+  BoulderStateBackend,
+  AggregateReadInput,
+  AggregateReadResult,
+  Backends,
+} from "./memory-aggregator"

--- a/packages/omo-opencode/src/features/meta-governor/memory-aggregator.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/memory-aggregator.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for memory-aggregator.ts (PR 2 of 8 for MetaGovernor).
+ *
+ * Tests the aggregateRead function with unit-fake backends (no I/O, no MCP).
+ * Each test verifies: correct merge of 3 sources, graceful degrade, timeout,
+ * sorting, and limits.
+ *
+ * Pattern: unit fakes with injected backends — clean, fast, no mock.module().
+ */
+
+import { describe, it, expect } from "bun:test"
+import { aggregateRead } from "./memory-aggregator"
+import type {
+  AgentmemoryBackend,
+  MagicContextBackend,
+  BoulderStateBackend,
+  AggregateReadInput,
+  Backends,
+} from "./memory-aggregator"
+
+// ---------------------------------------------------------------------------
+// Fake backends (unit fakes, not MCP mocks — clean, no I/O, no side effects)
+
+function makeFakeAgentmemory(overrides?: {
+  lessons?: Array<{ id: string; title: string; content: string; type: string; concepts: string[]; confidence: number; files: string[] }>
+}): AgentmemoryBackend {
+  return {
+    smartSearch: async () => ({
+      lessons: overrides?.lessons ?? [],
+      crystals: [],
+    }),
+  }
+}
+
+function makeFakeMagicContext(overrides?: {
+  slots?: Array<{ label: string; content: string; pinned?: boolean; scope?: string }>
+}): MagicContextBackend {
+  return {
+    slotList: async () => overrides?.slots ?? [],
+  }
+}
+
+function makeFakeBoulder(overrides?: {
+  tasks?: Array<{ id: string; title: string; priority: number; status: string; description: string; createdAtMs: number; updatedAtMs: number }>
+  readFn?: (input: { directory: string; sessionID: string; query?: string }) => Promise<unknown[]>
+}): BoulderStateBackend {
+  return {
+    boulderRead: async (input) => overrides?.readFn ? overrides.readFn(input) as never : (overrides?.tasks ?? []),
+  }
+}
+
+function makeInput(overrides?: Partial<AggregateReadInput>): AggregateReadInput {
+  return {
+    directory: "/test",
+    sessionID: "test-session",
+    query: "test query",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RED — tests written FIRST. These should fail against an empty impl.
+
+describe("memory-aggregator", () => {
+  describe("#aggregateRead merges all 3 sources", () => {
+    it("returns lessons from agentmemory sorted by confidence DESC", async () => {
+      // given
+      const lessons = [
+        { id: "l1", title: "low", content: "c", type: "pattern", concepts: [], confidence: 0.2, files: [] },
+        { id: "l2", title: "high", content: "c", type: "pattern", concepts: [], confidence: 0.8, files: [] },
+        { id: "l3", title: "mid", content: "c", type: "pattern", concepts: [], confidence: 0.5, files: [] },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      // when
+      const result = await aggregateRead(makeInput(), backends)
+
+      // then — conforms to AgentMemoryRead contract
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(3)
+      expect(result.agentmemory.lessons[0].id).toBe("l2") // confidence 0.8
+      expect(result.agentmemory.lessons[1].id).toBe("l3") // confidence 0.5
+      expect(result.agentmemory.lessons[2].id).toBe("l1") // confidence 0.2
+    })
+
+    it("maps RawLesson to RelevantLesson with advice='info'", async () => {
+      const lessons = [
+        { id: "l1", title: "test lesson", content: "c", type: "pattern", concepts: ["auth", "jwt"], confidence: 0.7, files: [] },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.lessons[0]).toEqual({
+        id: "l1",
+        title: "test lesson",
+        advice: "info",
+        confidence: 0.7,
+        concepts: ["auth", "jwt"],
+      })
+    })
+
+    it("returns slots from magic-context with label+content only (contract shape)", async () => {
+      const slots = [
+        { label: "meta_governor:last_decision", content: '{"action":"continue"}', pinned: true, scope: "project" },
+        { label: "unrelated_slot", content: "something", pinned: true, scope: "project" },
+        { label: "meta_governor:token_prediction", content: '{"action":"compact"}', pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "test query" }), backends)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(2)
+      // meta_governor: prefixed slots are always included
+      expect(result.magicContext.slots.some((s) => s.label === "meta_governor:last_decision")).toBe(true)
+      expect(result.magicContext.slots.some((s) => s.label === "meta_governor:token_prediction")).toBe(true)
+    })
+
+    it("returns slots sorted by label ASC", async () => {
+      const slots = [
+        { label: "meta_governor:z_last", content: "z", pinned: true, scope: "project" },
+        { label: "meta_governor:a_first", content: "a", pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.magicContext.slots[0].label).toBe("meta_governor:a_first")
+      expect(result.magicContext.slots[1].label).toBe("meta_governor:z_last")
+    })
+
+    it("returns tasks from boulder-state sorted by priority ASC then recency DESC", async () => {
+      const now = Date.now()
+      const tasks = [
+        { id: "t1", title: "low priority old", priority: 8, status: "pending", description: "", createdAtMs: now - 1000, updatedAtMs: now - 1000 },
+        { id: "t2", title: "high priority new", priority: 2, status: "pending", description: "", createdAtMs: now, updatedAtMs: now },
+        { id: "t3", title: "high priority old", priority: 2, status: "pending", description: "", createdAtMs: now - 5000, updatedAtMs: now - 5000 },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(3)
+      // contract shape: { id, status, title }
+      expect(result.boulderState.tasks[0].id).toBe("t2") // priority 2, newer
+      expect(result.boulderState.tasks[1].id).toBe("t3") // priority 2, older
+      expect(result.boulderState.tasks[2].id).toBe("t1") // priority 8
+    })
+
+    it("computes planProgress from tasks", async () => {
+      const tasks = [
+        { id: "t1", title: "done", priority: 1, status: "done", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t2", title: "done2", priority: 1, status: "done", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t3", title: "pending", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.planProgress).toBe(2 / 3)
+    })
+
+    it("returns zeroed planProgress when no tasks", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks: [] }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.planProgress).toBe(0)
+    })
+
+    it("returns MemoryRead contract fields: query and timestampISO", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "my query" }), backends)
+      expect(result.query).toBe("my query")
+      expect(result.timestampISO).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+  })
+
+  describe("#aggregateRead graceful degrade", () => {
+    it("degrades agentmemory gracefully — other sources still return", async () => {
+      const brokenAgentmemory: AgentmemoryBackend = {
+        smartSearch: async () => { throw new Error("MCP connection lost") },
+      }
+      const backends: Backends = {
+        agentmemory: brokenAgentmemory,
+        magicContext: makeFakeMagicContext({ slots: [{ label: "meta_governor:x", content: "", pinned: true, scope: "project" }] }),
+        boulderState: makeFakeBoulder({ tasks: [{ id: "t1", title: "task", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 }] }),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+
+      expect(result.agentmemory.available).toBe(false)
+      expect(result.agentmemory.lessons).toHaveLength(0)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(1)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(1)
+      expect(result.degradedSources).toContain("agentmemory")
+      expect(result.errorMessages.agentmemory).toContain("MCP connection lost")
+    })
+
+    it("degrades magic-context gracefully", async () => {
+      const brokenMagic: MagicContextBackend = {
+        slotList: async () => { throw new Error("slot list timeout") },
+      }
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons: [{ id: "l1", title: "ok", content: "c", type: "pattern", concepts: [], confidence: 0.5, files: [] }] }),
+        magicContext: brokenMagic,
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(1)
+      expect(result.magicContext.available).toBe(false)
+      expect(result.magicContext.slots).toHaveLength(0)
+      expect(result.degradedSources).toContain("magicContext")
+    })
+
+    it("degrades boulder-state gracefully", async () => {
+      const brokenBoulder: BoulderStateBackend = {
+        boulderRead: async () => { throw new Error("no state file") },
+      }
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: brokenBoulder,
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.boulderState.available).toBe(false)
+      expect(result.boulderState.tasks).toHaveLength(0)
+      expect(result.boulderState.planProgress).toBe(0)
+      expect(result.degradedSources).toContain("boulderState")
+    })
+
+    it("degrades ALL sources — returns empty MemoryRead with 3 degradedSources", async () => {
+      const allBroken: Backends = {
+        agentmemory: { smartSearch: async () => { throw new Error("boom") } },
+        magicContext: { slotList: async () => { throw new Error("boom") } },
+        boulderState: { boulderRead: async () => { throw new Error("boom") } },
+      }
+
+      const result = await aggregateRead(makeInput(), allBroken)
+      expect(result.agentmemory.available).toBe(false)
+      expect(result.magicContext.available).toBe(false)
+      expect(result.boulderState.available).toBe(false)
+      expect(result.degradedSources).toHaveLength(3)
+      expect(result.degradedSources).toContain("agentmemory")
+      expect(result.degradedSources).toContain("magicContext")
+      expect(result.degradedSources).toContain("boulderState")
+    })
+  })
+
+  describe("#aggregateRead limits", () => {
+    it("respects maxLessons limit", async () => {
+      const lessons = Array.from({ length: 20 }, (_, i) => ({
+        id: `l${i}`,
+        title: `lesson ${i}`,
+        content: "c",
+        type: "pattern",
+        concepts: [],
+        confidence: i * 0.05,
+        files: [],
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory({ lessons }),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxLessons: 5 } }), backends)
+      expect(result.agentmemory.lessons).toHaveLength(5)
+      // Top 5 by confidence: l19 (0.95), l18 (0.9), l17 (0.85), l16 (0.8), l15 (0.75)
+      expect(result.agentmemory.lessons[0].id).toBe("l19")
+      expect(result.agentmemory.lessons[4].id).toBe("l15")
+    })
+
+    it("respects maxTasks limit", async () => {
+      const tasks = Array.from({ length: 30 }, (_, i) => ({
+        id: `t${i}`,
+        title: `task ${i}`,
+        priority: 1,
+        status: "pending",
+        description: "",
+        createdAtMs: i,
+        updatedAtMs: i,
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({ tasks }),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxTasks: 10 } }), backends)
+      expect(result.boulderState.tasks).toHaveLength(10)
+    })
+
+    it("respects maxSlots limit", async () => {
+      const slots = Array.from({ length: 30 }, (_, i) => ({
+        label: `meta_governor:slot_${String(i).padStart(2, "0")}`,
+        content: `${i}`,
+        pinned: true,
+        scope: "project",
+      }))
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ limits: { maxSlots: 5 } }), backends)
+      expect(result.magicContext.slots).toHaveLength(5)
+    })
+  })
+
+  describe("#aggregateRead edge cases", () => {
+    it("all empty sources — returns zeroed MemoryRead with no degradedSources", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.agentmemory.available).toBe(true)
+      expect(result.agentmemory.lessons).toHaveLength(0)
+      expect(result.magicContext.available).toBe(true)
+      expect(result.magicContext.slots).toHaveLength(0)
+      expect(result.boulderState.available).toBe(true)
+      expect(result.boulderState.tasks).toHaveLength(0)
+      expect(result.boulderState.planProgress).toBe(0)
+      expect(result.degradedSources).toHaveLength(0)
+    })
+
+    it("returns durationMs > 0", async () => {
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput(), backends)
+      expect(result.durationMs).toBeGreaterThan(0)
+    })
+
+    it("magic-context slots with relevance match to query", async () => {
+      const slots = [
+        { label: "alpha", content: "the query word appears here: test", pinned: true, scope: "project" },
+        { label: "beta", content: "nothing relevant here", pinned: true, scope: "project" },
+      ]
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext({ slots }),
+        boulderState: makeFakeBoulder(),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "test" }), backends)
+      // "alpha" has "test" in content → should match relevance filter
+      expect(result.magicContext.slots.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it("boulder backend receives query for server-side filtering", async () => {
+      const tasks = [
+        { id: "t1", title: "deploy to production", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+        { id: "t2", title: "write unit tests", priority: 1, status: "pending", description: "", createdAtMs: 1, updatedAtMs: 1 },
+      ]
+      let receivedQuery: string | undefined
+      const backends: Backends = {
+        agentmemory: makeFakeAgentmemory(),
+        magicContext: makeFakeMagicContext(),
+        boulderState: makeFakeBoulder({
+          tasks,
+          readFn: (input) => { receivedQuery = input.query; return Promise.resolve(tasks); },
+        }),
+      }
+
+      const result = await aggregateRead(makeInput({ query: "deploy" }), backends)
+      expect(receivedQuery).toBe("deploy")
+      expect(result.boulderState.tasks).toHaveLength(2)
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/memory-aggregator.ts
+++ b/packages/omo-opencode/src/features/meta-governor/memory-aggregator.ts
@@ -1,0 +1,313 @@
+/**
+ * Cross-system memory aggregator for MetaGovernor.
+ *
+ * PR 2 of 8. Reads from all three memory systems (agentmemory, magic-context,
+ * boulder-state) in parallel and returns a `MemoryRead` that conforms to the
+ * PR 1 contract (types.ts).
+ *
+ * Design choices:
+ * - Parallel reads with per-source timeouts. No sequential I/O.
+ * - Graceful degrade: a failing source does NOT fail the whole read.
+ *   It populates `degradedSources[]` (string tags per the contract) and
+ *   the caller (`score()`) can decide the policy.
+ * - Lessons are sorted by confidence DESC. Slots by label. Tasks by priority
+ *   ASC then recency DESC.
+ * - Result is bounded: respects `limits`.
+ * - Per-source error messages are stored separately (`errorMessages`) for
+ *   debugging but NOT in the contract type (the contract only has the string tags).
+ *
+ * Future PRs that wire this:
+ * - PR 3 (closed-loop): calls `aggregateRead()` from `observeErrorAndLearn`
+ *   and `preflightCheck`.
+ * - PR 5 (score): calls `aggregateRead()` to build `lessonsRelevant` slice
+ *   of `DecisionContext`.
+ * - PR 6 (post-repair): calls `aggregateRead()` after a fix to verify.
+ *
+ * Internal raw types (Lesson, Crystal, Slot, BoulderTask) are defined here
+ * as private interfaces representing what each backend actually returns.
+ * The aggregator maps them to the contract types from types.ts.
+ */
+
+import type {
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Raw backend types (private to this module — NOT exported to the contract)
+
+interface RawLesson {
+  readonly id: string;
+  readonly title: string;
+  readonly content: string;
+  readonly type: string;
+  readonly concepts: readonly string[];
+  readonly confidence: number;
+  readonly files: readonly string[];
+}
+
+interface RawCrystal {
+  readonly id: string;
+  readonly title: string;
+  readonly content: string;
+  readonly type: string;
+  readonly concepts: readonly string[];
+  readonly confidence: number;
+  readonly files: readonly string[];
+}
+
+interface RawSlot {
+  readonly label: string;
+  readonly content: string;
+  readonly pinned?: boolean;
+  readonly scope?: string;
+  readonly sizeLimit?: number;
+  readonly updatedAt?: number;
+}
+
+interface RawBoulderTask {
+  readonly id: string;
+  readonly title: string;
+  readonly priority: number;
+  readonly status: string;
+  readonly description: string;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Backend ports (interfaces). Implementations are injected; tests use fakes.
+
+export interface AgentmemoryBackend {
+  smartSearch(input: { query: string; limit?: number }): Promise<{ lessons: RawLesson[]; crystals: RawCrystal[] }>;
+}
+
+export interface MagicContextBackend {
+  slotList(input: { directory?: string; labelPrefix?: string }): Promise<RawSlot[]>;
+}
+
+export interface BoulderStateBackend {
+  boulderRead(input: { directory: string; sessionID: string; query?: string }): Promise<RawBoulderTask[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate read input
+
+export interface AggregateReadInput {
+  /** Working directory. Scopes the read. */
+  readonly directory: string;
+  /** Session ID. Used for boulder-state keying. */
+  readonly sessionID: string;
+  /** Natural-language query. Passed to agentmemory (semantic) and boulder. */
+  readonly query: string;
+  /** Result-size bounds. */
+  readonly limits?: {
+    readonly maxLessons?: number;
+    readonly maxSlots?: number;
+    readonly maxTasks?: number;
+  };
+  /** Per-source timeout in ms. Default 2000 for agentmemory (network), 1000 for local. */
+  readonly timeouts?: {
+    readonly agentmemoryMs?: number;
+    readonly magicContextMs?: number;
+    readonly boulderStateMs?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extended result (conforms to MemoryRead + adds metadata for debugging)
+
+export interface AggregateReadResult extends MemoryRead {
+  /** Wall-clock duration of the whole read, in ms. */
+  readonly durationMs: number;
+  /** Per-source error messages (for debugging; not in the contract type). */
+  readonly errorMessages: Partial<Record<MemorySource, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Backends
+
+export interface Backends {
+  agentmemory: AgentmemoryBackend;
+  magicContext: MagicContextBackend;
+  boulderState: BoulderStateBackend;
+}
+
+const DEFAULTS = {
+  limits: { maxLessons: 10, maxSlots: 20, maxTasks: 10 },
+  timeouts: { agentmemoryMs: 2000, magicContextMs: 1000, boulderStateMs: 1000 },
+} as const;
+
+/**
+ * Read from all three memory systems in parallel. Never throws — a failing
+ * source populates `degradedSources` and the read still returns a valid result.
+ */
+export async function aggregateRead(
+  input: AggregateReadInput,
+  backends: Backends,
+): Promise<AggregateReadResult> {
+  const start = performance.now();
+  const limits = { ...DEFAULTS.limits, ...input.limits };
+  const timeouts = { ...DEFAULTS.timeouts, ...input.timeouts };
+
+  const [agentResult, magicResult, boulderResult] = await Promise.allSettled([
+    readAgentmemory(input, backends.agentmemory, limits, timeouts.agentmemoryMs),
+    readMagicContext(input, backends.magicContext, limits, timeouts.magicContextMs),
+    readBoulderState(input, backends.boulderState, limits, timeouts.boulderStateMs),
+  ]);
+
+  const degradedSources: MemorySource[] = [];
+  const errorMessages: Partial<Record<MemorySource, string>> = {};
+
+  const agentmemory = agentResult.status === "fulfilled"
+    ? agentResult.value
+    : (pushDegraded(degradedSources, errorMessages, "agentmemory", errorMessage(agentResult.reason)), DEGRADED.agentmemory);
+
+  const magicContext = magicResult.status === "fulfilled"
+    ? magicResult.value
+    : (pushDegraded(degradedSources, errorMessages, "magicContext", errorMessage(magicResult.reason)), DEGRADED.magicContext);
+
+  const boulderState = boulderResult.status === "fulfilled"
+    ? boulderResult.value
+    : (pushDegraded(degradedSources, errorMessages, "boulderState", errorMessage(boulderResult.reason)), DEGRADED.boulderState);
+
+  return {
+    query: input.query,
+    timestampISO: new Date().toISOString(),
+    agentmemory,
+    magicContext,
+    boulderState,
+    degradedSources,
+    durationMs: performance.now() - start,
+    errorMessages,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Source readers
+
+async function readAgentmemory(
+  input: AggregateReadInput,
+  backend: AgentmemoryBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["agentmemory"]> {
+  const search = await withTimeout(
+    backend.smartSearch({ query: input.query, limit: limits.maxLessons }),
+    timeoutMs,
+    "agentmemory",
+  );
+
+  const lessons: RelevantLesson[] = sortByConfidence(search.lessons)
+    .slice(0, limits.maxLessons)
+    .map((l) => ({
+      id: l.id,
+      title: l.title,
+      advice: "info" as const,
+      confidence: l.confidence,
+      concepts: l.concepts,
+    }));
+
+  return {
+    available: true,
+    lessons,
+  };
+}
+
+async function readMagicContext(
+  input: AggregateReadInput,
+  backend: MagicContextBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["magicContext"]> {
+  const slots = await withTimeout(
+    backend.slotList({ directory: input.directory }),
+    timeoutMs,
+    "magicContext",
+  );
+
+  return {
+    available: true,
+    slots: slots
+      .filter((s) => s.label.startsWith("meta_governor:") || isRelevant(s, input.query))
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .slice(0, limits.maxSlots)
+      .map((s) => ({ label: s.label, content: s.content })),
+  };
+}
+
+async function readBoulderState(
+  input: AggregateReadInput,
+  backend: BoulderStateBackend,
+  limits: Required<NonNullable<AggregateReadInput["limits"]>>,
+  timeoutMs: number,
+): Promise<MemoryRead["boulderState"]> {
+  const tasks = await withTimeout(
+    backend.boulderRead({ directory: input.directory, sessionID: input.sessionID, query: input.query }),
+    timeoutMs,
+    "boulderState",
+  );
+
+  const sorted = tasks
+    .sort((a, b) => a.priority - b.priority || b.updatedAtMs - a.updatedAtMs)
+    .slice(0, limits.maxTasks);
+
+  return {
+    available: true,
+    tasks: sorted.map((t) => ({ id: t.id, status: t.status, title: t.title })),
+    planProgress: computePlanProgress(tasks),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+function sortByConfidence(lessons: RawLesson[]): RawLesson[] {
+  return [...lessons].sort((a, b) => b.confidence - a.confidence);
+}
+
+function isRelevant(slot: RawSlot, query: string): boolean {
+  const q = query.toLowerCase();
+  return slot.label.toLowerCase().includes(q) || slot.content.toLowerCase().includes(q);
+}
+
+function computePlanProgress(tasks: RawBoulderTask[]): number {
+  if (tasks.length === 0) return 0;
+  const done = tasks.filter((t) => t.status === "done").length;
+  return done / tasks.length;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
+function pushDegraded(
+  list: MemorySource[],
+  errorMessages: Partial<Record<MemorySource, string>>,
+  source: MemorySource,
+  reason: string,
+): void {
+  list.push(source);
+  errorMessages[source] = reason;
+}
+
+// Typed fallback values for degraded sources.
+// These match the contract types exactly — pushDegraded is side-effect only.
+const DEGRADED = {
+  agentmemory: { available: false, lessons: [] } as const satisfies MemoryRead["agentmemory"],
+  magicContext: { available: false, slots: [] } as const satisfies MemoryRead["magicContext"],
+  boulderState: { available: false, tasks: [], planProgress: 0 } as const satisfies MemoryRead["boulderState"],
+} as const;
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms);
+    p.then(
+      (v) => { clearTimeout(t); resolve(v); },
+      (e) => { clearTimeout(t); reject(e); },
+    );
+  });
+}

--- a/packages/omo-opencode/src/features/meta-governor/types.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AgentMemoryRead,
+  AmbientContext,
+  BoulderStateRead,
+  Decision,
+  DecisionContext,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceSource,
+  MagicContextRead,
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+  SlotMemory,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  TokenRecommendation,
+} from "./types"
+
+describe("meta-governor types", () => {
+  describe("DecisionContext", () => {
+    test("S1: accepts fully populated context with oracle verified + no progress + deviations + 80% iterations + 2 lessons", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: true,
+        noProgress: false,
+        deviations: [
+          { severity: "leve", category: "lint", detail: "minor style" },
+          { severity: "grave", category: "config-change", detail: "touched config.ts" },
+        ],
+        iterationRatio: 0.8,
+        lessonsRelevant: [
+          { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          { id: "L2", title: "continue when oracle verified", advice: "continue", confidence: 0.6, concepts: ["oracle-verified"] },
+        ],
+        slotMemory: {
+          lastDecision: {
+            action: "continue",
+            score: 0.4,
+            reasoning: "ok",
+            evidence: [],
+            shouldEscalateTo: null,
+          },
+          consecutiveStops: 0,
+          consecutiveContinues: 2,
+          lastUpdatedISO: "2026-06-09T12:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_test",
+          directory: "/tmp/test",
+          mode: "ultrawork",
+          agentName: "sisyphus",
+          iteration: 8,
+          maxIterations: 10,
+        },
+      }
+
+      // when
+      const isPopulated =
+        ctx.oracleVerified === true &&
+        ctx.iterationRatio === 0.8 &&
+        ctx.deviations.length === 2 &&
+        ctx.lessonsRelevant.length === 2 &&
+        ctx.ambient.iteration === 8
+
+      // then
+      expect(isPopulated).toBe(true)
+    })
+
+    test("S1b: empty arrays are valid (signals, not bugs)", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: false,
+        noProgress: true,
+        deviations: [],
+        iterationRatio: 0.0,
+        lessonsRelevant: [],
+        slotMemory: {
+          consecutiveStops: 0,
+          consecutiveContinues: 0,
+          lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_empty",
+          directory: "/tmp/empty",
+          mode: "simple",
+          agentName: "build",
+          iteration: 1,
+          maxIterations: 50,
+        },
+      }
+
+      // when
+      const hasEmptySignals = ctx.deviations.length === 0 && ctx.lessonsRelevant.length === 0
+
+      // then
+      expect(hasEmptySignals).toBe(true)
+    })
+  })
+
+  describe("Decision", () => {
+    test("S2: carries all required fields and supports every action variant", () => {
+      // given
+      const decisions: Decision[] = [
+        {
+          action: "continue",
+          score: 0.5,
+          reasoning: "all clear",
+          evidence: [],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "warn",
+          score: -0.4,
+          reasoning: "deviation grave",
+          evidence: [
+            { source: "deviation-detector", value: "config-change", confidence: 0.9, weight: 0.5 },
+          ],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "escalate",
+          score: -0.7,
+          reasoning: "needs oracle verification",
+          evidence: [
+            { source: "oracle-verified", value: "false", confidence: 1.0, weight: 0.4 },
+          ],
+          shouldEscalateTo: "oracle",
+        },
+        {
+          action: "stop",
+          score: -0.9,
+          reasoning: "no progress 3 turns",
+          evidence: [
+            { source: "no-progress-detector", value: "true", confidence: 0.95, weight: 0.6 },
+          ],
+          shouldEscalateTo: null,
+        },
+      ]
+
+      // when
+      const allValid = decisions.every(
+        (d) =>
+          typeof d.score === "number" &&
+          d.score >= -1 &&
+          d.score <= 1 &&
+          d.reasoning.length > 0 &&
+          Array.isArray(d.evidence),
+      )
+      const actions = new Set(decisions.map((d) => d.action))
+
+      // then
+      expect(allValid).toBe(true)
+      expect(actions.size).toBe(4)
+      expect(actions.has("continue")).toBe(true)
+      expect(actions.has("warn")).toBe(true)
+      expect(actions.has("escalate")).toBe(true)
+      expect(actions.has("stop")).toBe(true)
+    })
+
+    test("S2b: when action is escalate, shouldEscalateTo must be oracle or user (not null)", () => {
+      // given
+      const targets: EscalationTarget[] = ["oracle", "user"]
+
+      // when
+      const isStrictSubset = targets.every((t) => t === "oracle" || t === "user")
+
+      // then
+      expect(isStrictSubset).toBe(true)
+    })
+  })
+
+  describe("Evidence", () => {
+    test("S3: shape has source, value, confidence, weight all required", () => {
+      // given
+      const sources: EvidenceSource[] = [
+        "oracle-verified",
+        "no-progress-detector",
+        "deviation-detector",
+        "iteration-budget",
+        "lesson-recall",
+        "slot-memory",
+        "ambient",
+        "token-predictor",
+      ]
+      const sample: Evidence = {
+        source: "oracle-verified",
+        value: "true",
+        confidence: 0.95,
+        weight: 0.4,
+      }
+
+      // when
+      const hasAllFields =
+        typeof sample.source === "string" &&
+        typeof sample.value === "string" &&
+        sample.confidence >= 0 &&
+        sample.confidence <= 1 &&
+        sample.weight >= 0 &&
+        sample.weight <= 1
+
+      // then
+      expect(hasAllFields).toBe(true)
+      expect(sources.length).toBe(8)
+    })
+  })
+
+  describe("MemoryRead", () => {
+    test("S4: aggregates agentmemory + magicContext + boulderState, marks degraded sources", () => {
+      // given
+      const read: MemoryRead = {
+        query: "ralph-loop continue after config-change",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        agentmemory: {
+          available: true,
+          lessons: [
+            { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          ],
+        },
+        magicContext: {
+          available: true,
+          slots: [{ label: "meta_state", content: "{}" }],
+        },
+        boulderState: {
+          available: false,
+          tasks: [],
+          planProgress: 0,
+          errorMessage: "no .omo/boulder.json",
+        },
+        degradedSources: ["boulderState"],
+      }
+
+      // when
+      const oneDegraded = read.degradedSources.length === 1
+      const agentmemoryOk = read.agentmemory.available === true
+      const boulderDown = read.boulderState.available === false
+
+      // then
+      expect(oneDegraded).toBe(true)
+      expect(agentmemoryOk).toBe(true)
+      expect(boulderDown).toBe(true)
+      expect(read.degradedSources[0]).toBe<MemorySource>("boulderState")
+    })
+  })
+
+  describe("TokenPrediction", () => {
+    test("S5: has currentUsage, burnRate, budgetLeft, willOverflowAt, recommendation, confidence", () => {
+      // given
+      const predictions: TokenPrediction[] = [
+        {
+          currentUsage: 50_000,
+          burnRate: 200,
+          budgetLeft: 150_000,
+          willOverflowAt: null,
+          recommendation: "no-action",
+          confidence: 0.95,
+          modelLimit: 200_000,
+          windowRemaining: 150_000,
+        },
+        {
+          currentUsage: 180_000,
+          burnRate: 5_000,
+          budgetLeft: 20_000,
+          willOverflowAt: "2026-06-09T12:05:00.000Z",
+          recommendation: "compact-now",
+          confidence: 0.85,
+          modelLimit: 200_000,
+          windowRemaining: 20_000,
+        },
+        {
+          currentUsage: 90_000,
+          burnRate: 3_000,
+          budgetLeft: 110_000,
+          willOverflowAt: "2026-06-09T12:30:00.000Z",
+          recommendation: "switch-model",
+          confidence: 0.7,
+          modelLimit: 200_000,
+          windowRemaining: 110_000,
+        },
+        {
+          currentUsage: 120_000,
+          burnRate: 2_000,
+          budgetLeft: 80_000,
+          willOverflowAt: "2026-06-09T12:40:00.000Z",
+          recommendation: "delegate-to-subagent",
+          confidence: 0.65,
+          modelLimit: 200_000,
+          windowRemaining: 80_000,
+        },
+      ]
+      const recommendations: TokenRecommendation[] = [
+        "compact-now",
+        "switch-model",
+        "delegate-to-subagent",
+        "no-action",
+      ]
+
+      // when
+      const allHaveFields = predictions.every(
+        (p) =>
+          typeof p.currentUsage === "number" &&
+          typeof p.burnRate === "number" &&
+          typeof p.budgetLeft === "number" &&
+          (p.willOverflowAt === null || typeof p.willOverflowAt === "string") &&
+          p.confidence >= 0 &&
+          p.confidence <= 1,
+      )
+      const allRecommendations = new Set(predictions.map((p) => p.recommendation))
+
+      // then
+      expect(allHaveFields).toBe(true)
+      expect(allRecommendations.size).toBe(4)
+      for (const r of recommendations) {
+        expect(allRecommendations.has(r)).toBe(true)
+      }
+    })
+
+    test("S5b: willOverflowAt is null when recommendation is no-action", () => {
+      // given
+      const p: TokenPrediction = {
+        currentUsage: 1_000,
+        burnRate: 0,
+        budgetLeft: 199_000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.99,
+        modelLimit: 200_000,
+        windowRemaining: 199_000,
+      }
+
+      // then
+      expect(p.willOverflowAt).toBeNull()
+      expect(p.recommendation).toBe("no-action")
+    })
+  })
+
+  describe("auxiliary types", () => {
+    test("SlotMemory consecutive counters default to 0 and are read by judge for paralysis detection", () => {
+      // given
+      const slot: SlotMemory = {
+        consecutiveStops: 3,
+        consecutiveContinues: 0,
+        lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+      }
+
+      // when
+      const isParalyzed = slot.consecutiveStops >= 3
+
+      // then
+      expect(isParalyzed).toBe(true)
+    })
+
+    test("AmbientContext carries mode for judge to factor in (ultrawork stricter than simple)", () => {
+      // given
+      const modes: AmbientContext["mode"][] = ["ultrawork", "ulw", "simple", "ralph-loop"]
+
+      // when
+      const allListed = modes.every((m) =>
+        ["ultrawork", "ulw", "simple", "ralph-loop"].includes(m),
+      )
+
+      // then
+      expect(allListed).toBe(true)
+    })
+
+    test("Deviation severity uses the 3-level taxonomy (leve/media/grave) from prior moderator-gate", () => {
+      // given
+      const deviations: Deviation[] = [
+        { severity: "leve", category: "lint", detail: "minor" },
+        { severity: "media", category: "refactor-scope", detail: "broader than expected" },
+        { severity: "grave", category: "config-change", detail: "touched config.ts" },
+      ]
+
+      // when
+      const severities = new Set(deviations.map((d) => d.severity))
+
+      // then
+      expect(severities.size).toBe(3)
+      expect(severities.has("grave")).toBe(true)
+    })
+
+    test("RelevantLesson carries id, title, advice, confidence, concepts for preflight matching", () => {
+      // given
+      const lesson: RelevantLesson = {
+        id: "L42",
+        title: "fix X for error Y",
+        advice: "warn",
+        confidence: 0.6,
+        concepts: ["tool_timeout", "bash", "retry"],
+      }
+
+      // when
+      const matchesBash = lesson.concepts.includes("bash")
+
+      // then
+      expect(matchesBash).toBe(true)
+      expect(lesson.advice).toBe("warn")
+    })
+
+    test("AgentMemoryRead and MagicContextRead report available=false with errorMessage when degraded", () => {
+      // given
+      const am: AgentMemoryRead = {
+        available: false,
+        lessons: [],
+        errorMessage: "agentmemory MCP not connected",
+      }
+      const mc: MagicContextRead = {
+        available: false,
+        slots: [],
+        errorMessage: "magic-context slot not initialised",
+      }
+
+      // then
+      expect(am.available).toBe(false)
+      expect(am.errorMessage).toBeTruthy()
+      expect(mc.available).toBe(false)
+      expect(mc.errorMessage).toBeTruthy()
+    })
+
+    test("BoulderStateRead reports planProgress in 0..1", () => {
+      // given
+      const bs: BoulderStateRead = {
+        available: true,
+        tasks: [{ id: "T1", status: "done", title: "fix bug" }],
+        planProgress: 0.5,
+      }
+
+      // when
+      const inRange = bs.planProgress >= 0 && bs.planProgress <= 1
+
+      // then
+      expect(inRange).toBe(true)
+    })
+  })
+
+  describe("ClosedLoopConfig", () => {
+    test("CLT1: has all required fields with correct types", () => {
+      // given
+      const cfg: ClosedLoopConfig = {
+        enabled: true,
+        minSeverityToLearn: "media",
+        maxLessonsPerSession: 20,
+        saveDecisions: true,
+      }
+
+      // when
+      const isValid =
+        typeof cfg.enabled === "boolean" &&
+        (cfg.minSeverityToLearn === "leve" || cfg.minSeverityToLearn === "media" || cfg.minSeverityToLearn === "grave") &&
+        typeof cfg.maxLessonsPerSession === "number" &&
+        typeof cfg.saveDecisions === "boolean"
+
+      // then
+      expect(isValid).toBe(true)
+    })
+
+    test("CLT2: minSeverityToLearn accepts all 3 severity levels", () => {
+      const levels: ClosedLoopConfig["minSeverityToLearn"][] = ["leve", "media", "grave"]
+      expect(levels.length).toBe(3)
+    })
+  })
+
+  describe("MemoryDecision", () => {
+    test("CLT3: has all required fields matching Decision contract", () => {
+      // given
+      const md: MemoryDecision = {
+        id: "D-abc123",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        action: "warn",
+        score: -0.5,
+        reasoning: "deviation detected",
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        deviations: [{ severity: "media", category: "lint", detail: "style" }],
+      }
+
+      // when
+      const isValid =
+        typeof md.id === "string" &&
+        typeof md.timestampISO === "string" &&
+        typeof md.score === "number" &&
+        md.score >= -1 && md.score <= 1 &&
+        typeof md.sessionID === "string"
+
+      // then
+      expect(isValid).toBe(true)
+      expect(md.action).toBe("warn")
+    })
+
+    test("CLT4: action field matches Decision action union type", () => {
+      const actions: MemoryDecision["action"][] = ["continue", "warn", "escalate", "stop"]
+      expect(actions.length).toBe(4)
+    })
+  })
+
+  describe("AgentmemoryWriteBackend", () => {
+    test("CLT5: interface has saveMemory and saveLesson methods", () => {
+      // Compile-time check: if the interface is wrong, this won't typecheck
+      const impl: AgentmemoryWriteBackend = {
+        saveMemory: async () => ({ id: "mem-1" }),
+        saveLesson: async () => ({ id: "les-1" }),
+      }
+
+      // when
+      const hasBoth = typeof impl.saveMemory === "function" && typeof impl.saveLesson === "function"
+
+      // then
+      expect(hasBoth).toBe(true)
+    })
+  })
+
+  describe("LessonLearned", () => {
+    test("CLT6: has all required fields", () => {
+      // given
+      const lesson: LessonLearned = {
+        id: "L-abc",
+        title: "stop on config-change",
+        content: "When X then Y",
+        type: "pattern",
+        concepts: ["config-change", "grave"],
+        confidence: 0.7,
+        files: ["src/foo.ts"],
+        sessionID: "ses_test",
+      }
+
+      // when
+      const isValid =
+        typeof lesson.id === "string" &&
+        typeof lesson.title === "string" &&
+        typeof lesson.content === "string" &&
+        ["pattern", "bug", "architecture", "workflow"].includes(lesson.type) &&
+        lesson.confidence >= 0 && lesson.confidence <= 1
+
+      // then
+      expect(isValid).toBe(true)
+    })
+  })
+
+  describe("LearnFromOutcomeInput / Output", () => {
+    test("CLT7: Input carries decision, memoryRead, config, sessionID, directory, filesChanged", () => {
+      // given
+      const input: LearnFromOutcomeInput = {
+        decision: { action: "warn", score: -0.5, reasoning: "test", evidence: [], shouldEscalateTo: null },
+        memoryRead: {
+          query: "test",
+          timestampISO: "2026-06-09T12:00:00.000Z",
+          agentmemory: { available: true, lessons: [] },
+          magicContext: { available: true, slots: [] },
+          boulderState: { available: true, tasks: [], planProgress: 0 },
+          degradedSources: [],
+        },
+        config: { enabled: true, minSeverityToLearn: "media", maxLessonsPerSession: 20, saveDecisions: true },
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        filesChanged: ["src/foo.ts"],
+      }
+
+      // when
+      const hasAll =
+        typeof input.sessionID === "string" &&
+        typeof input.directory === "string" &&
+        Array.isArray(input.filesChanged)
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+
+    test("CLT8: Output has lessonSaved, decisionSaved, reason", () => {
+      // given
+      const output: import("./types").LearnFromOutcomeOutput = {
+        lessonSaved: null,
+        decisionSaved: null,
+        reason: "no action",
+      }
+
+      // when
+      const hasAll =
+        "lessonSaved" in output &&
+        "decisionSaved" in output &&
+        typeof output.reason === "string"
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+  })
+
+  describe("TokenPredictorConfig", () => {
+    test("S1: accepts valid config with all thresholds", () => {
+      // given
+      const config: TokenPredictorConfig = {
+        compactBurnRateThreshold: 500,
+        compactUsageThreshold: 0.85,
+        switchModelUsageThreshold: 0.95,
+        delegateConsecutiveHighBurn: 5,
+        windowSize: 10,
+      }
+
+      // when + then - type check passes
+      expect(config.compactBurnRateThreshold).toBe(500)
+      expect(config.windowSize).toBe(10)
+    })
+  })
+
+  describe("TokenPredictorInput", () => {
+    test("S1: accepts valid input with all fields", () => {
+      // given
+      const input: TokenPredictorInput = {
+        currentUsage: 100000,
+        modelLimit: 200000,
+        recentTurnTokens: [100, 200, 150],
+        timestampISO: new Date().toISOString(),
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-20250514",
+        config: {
+          compactBurnRateThreshold: 500,
+          compactUsageThreshold: 0.85,
+          switchModelUsageThreshold: 0.95,
+          delegateConsecutiveHighBurn: 5,
+          windowSize: 10,
+        },
+      }
+
+      // when + then - type check passes
+      expect(input.currentUsage).toBe(100000)
+      expect(input.recentTurnTokens).toHaveLength(3)
+    })
+  })
+
+  describe("TokenPredictorOutput", () => {
+    test("S1: extends TokenPrediction with input metadata", () => {
+      // given
+      const output: TokenPredictorOutput = {
+        currentUsage: 100000,
+        burnRate: 100,
+        budgetLeft: 100000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.8,
+        modelLimit: 200000,
+        windowRemaining: 100000,
+        input: {
+          currentUsage: 100000,
+          modelLimit: 200000,
+          recentTurnTokens: [100],
+          timestampISO: "2025-01-01T00:00:00Z",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-20250514",
+          config: {
+            compactBurnRateThreshold: 500,
+            compactUsageThreshold: 0.85,
+            switchModelUsageThreshold: 0.95,
+            delegateConsecutiveHighBurn: 5,
+            windowSize: 10,
+          },
+        },
+        computedAtISO: "2025-01-01T00:00:00Z",
+        turnsAnalyzed: 1,
+      }
+
+      // when + then - type check passes
+      expect(output.input.currentUsage).toBe(100000)
+      expect(output.turnsAnalyzed).toBe(1)
+      expect(typeof output.computedAtISO).toBe("string")
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/types.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.ts
@@ -1,0 +1,513 @@
+/**
+ * MetaGovernor type contracts.
+ *
+ * PR 1 of 8. Defines ONLY the type surface that later PRs implement against.
+ * No logic, no I/O, no MCP calls. This file is the source of truth for the
+ * MetaGovernor architecture; later PRs import these types and conform to them.
+ *
+ * Architectural invariants (from AGENTS.md, must respect):
+ * - All session.promptAsync calls go through prompt-async-gate (not enforced here)
+ * - MetaGovernor composes AFT + agentmemory + magic-context + boulder-state
+ * - 5 recovery hooks wrap into post-repair-recorder (not enforced here)
+ *
+ * Public surface (5 contracts):
+ * - DecisionContext: input to score()
+ * - Decision: output of score()
+ * - Evidence: atomic evidence unit attached to a Decision
+ * - MemoryRead: cross-system read result
+ * - TokenPrediction: token burn rate prediction
+ *
+ * All enums/actions are union string types (no enums) for Zod compat and
+ * JSON-serialisability across the prompt-async-gate.
+ */
+
+/**
+ * What the judge sees when deciding continue|warn|escalate|stop.
+ *
+ * All fields are required. `undefined` is not a valid DecisionContext —
+ * collectors must fill every field even if the value is an empty array,
+ * false, or 0. Empty inputs are signals, not bugs.
+ */
+export interface DecisionContext {
+  /** Whether the last Oracle invocation returned verified=true. */
+  readonly oracleVerified: boolean
+  /** Whether the last assistant turn produced no progress (zero tokens, no content). */
+  readonly noProgress: boolean
+  /** Detected deviations from expected behavior. Empty array = no deviations. */
+  readonly deviations: readonly Deviation[]
+  /** iteration / maxIterations. 0..1. 1.0 = at the cap. */
+  readonly iterationRatio: number
+  /** Lessons retrieved from agentmemory that match the current decision pattern. */
+  readonly lessonsRelevant: readonly RelevantLesson[]
+  /** Cross-session memory snapshot from the meta_state slot. */
+  readonly slotMemory: SlotMemory
+  /** Free-form context the calling site can attach (sessionID, directory, mode). */
+  readonly ambient: AmbientContext
+}
+
+/**
+ * Decision the judge returns. Always carries evidence (cite-or-abstain).
+ *
+ * Score ∈ [-1, +1]:
+ *   >= +0.3 → continue silently
+ *   -0.3..+0.3 → continue with log
+ *   -0.6..-0.3 → continue with warn
+ *   -0.8..-0.6 → escalate (oracle or user)
+ *   < -0.8 → stop loop
+ *
+ * Note: actual thresholds are config-driven in PR 8. Defaults are above.
+ */
+export interface Decision {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly score: number
+  /** Human-readable one-sentence explanation. Required, never empty. */
+  readonly reasoning: string
+  /** Cite-or-abstain: at least 1 evidence unit when action !== "continue" silently. */
+  readonly evidence: readonly Evidence[]
+  /** When action === "escalate", which actor should be invoked. */
+  readonly shouldEscalateTo: EscalationTarget | null
+}
+
+export type EscalationTarget = "oracle" | "user"
+
+/**
+ * Atomic evidence unit. Carries provenance so the judge can be audited.
+ *
+ * `confidence` ∈ [0, 1]: how sure the source is about `value`.
+ * `weight` ∈ [0, 1]: how much this evidence influences the score
+ *  (assigned by the scoring function, not the collector).
+ */
+export interface Evidence {
+  readonly source: EvidenceSource
+  readonly value: string
+  readonly confidence: number
+  readonly weight: number
+}
+
+export type EvidenceSource =
+  | "oracle-verified"
+  | "no-progress-detector"
+  | "deviation-detector"
+  | "iteration-budget"
+  | "lesson-recall"
+  | "slot-memory"
+  | "ambient"
+  | "token-predictor"
+
+/**
+ * A deviation from expected behavior. Severity follows the prior
+ * moderator-gate (PR 4405) taxonomy for backward compat.
+ */
+export interface Deviation {
+  readonly severity: "leve" | "media" | "grave"
+  readonly category: string
+  readonly detail: string
+  readonly filePath?: string
+}
+
+/**
+ * A lesson retrieved from agentmemory.lesson_recall. Confidence is the
+ * stored confidence in the memory store, not the relevance to this query.
+ */
+export interface RelevantLesson {
+  readonly id: string
+  readonly title: string
+  readonly advice: "continue" | "stop" | "warn" | "info"
+  readonly confidence: number
+  readonly concepts: readonly string[]
+}
+
+/**
+ * Cross-session state held in the magic-context `meta_state` slot.
+ *
+ * `consecutiveStops` is read by the judge to detect paralysis (3 stops
+ * in a row → force continue with warning, prevents infinite conservatism).
+ */
+export interface SlotMemory {
+  readonly lastDecision?: Decision
+  readonly consecutiveStops: number
+  readonly consecutiveContinues: number
+  readonly lastUpdatedISO: string
+}
+
+/**
+ * Free-form context the calling site can attach. Used for audit trails
+ * and to enable the judge to factor in mode (ultrawork vs simple) or
+ * session state. Fields are optional to keep the contract lean.
+ */
+export interface AmbientContext {
+  readonly sessionID: string
+  readonly directory: string
+  readonly mode: "ultrawork" | "ulw" | "simple" | "ralph-loop"
+  readonly agentName: string
+  readonly iteration: number
+  readonly maxIterations: number
+}
+
+/**
+ * Cross-system memory read result. All three sources read in parallel;
+ * any of them may be unavailable (graceful degradation in PR 2).
+ *
+ * `query` is echoed back so callers can correlate the read with the
+ * query that produced it.
+ */
+export interface MemoryRead {
+  readonly query: string
+  readonly timestampISO: string
+  readonly agentmemory: AgentMemoryRead
+  readonly magicContext: MagicContextRead
+  readonly boulderState: BoulderStateRead
+  readonly degradedSources: readonly MemorySource[]
+}
+
+export type MemorySource = "agentmemory" | "magicContext" | "boulderState"
+
+export interface AgentMemoryRead {
+  readonly available: boolean
+  readonly lessons: readonly RelevantLesson[]
+  readonly errorMessage?: string
+}
+
+export interface MagicContextRead {
+  readonly available: boolean
+  readonly slots: readonly { readonly label: string; readonly content: string }[]
+  readonly errorMessage?: string
+}
+
+export interface BoulderStateRead {
+  readonly available: boolean
+  readonly tasks: readonly { readonly id: string; readonly status: string; readonly title: string }[]
+  readonly planProgress: number
+  readonly errorMessage?: string
+}
+
+/**
+ * Token burn rate prediction. Computed from recent turn metrics.
+ *
+ * `willOverflowAt` is an ISO timestamp predicted from current usage +
+ * burn rate + model limit. `null` when not expected to overflow.
+ *
+ * `recommendation` is action-typed; the caller (PR 7 integration) maps
+ * these to actual hook invocations:
+ *   - "compact-now" → invoke preemptive-compaction-degradation-monitor
+ *   - "switch-model" → invoke model-fallback chat-message-fallback-handler
+ *   - "delegate-to-subagent" → invoke delegate-task with a sub-scope
+ *   - "no-action" → silent
+ */
+export interface TokenPrediction {
+  readonly currentUsage: number
+  readonly burnRate: number
+  readonly budgetLeft: number
+  readonly willOverflowAt: string | null
+  readonly recommendation: TokenRecommendation
+  readonly confidence: number
+  readonly modelLimit: number
+  readonly windowRemaining: number
+}
+
+export type TokenRecommendation =
+  | "compact-now"
+  | "switch-model"
+  | "delegate-to-subagent"
+  | "no-action"
+
+/**
+ * Closed-loop learning types. PR 3 of 8.
+ *
+ * After every repair/action cycle, observeAndLearn() decides whether to
+ * persist a lesson or decision record to agentmemory. Future sessions
+ * retrieve these via aggregateRead() (PR 2) and factor them into
+ * scoring (PR 5).
+ */
+
+/**
+ * Configuration for the closed-loop learning system.
+ */
+export interface ClosedLoopConfig {
+  /** Master switch. false = observe only, never write. */
+  readonly enabled: boolean
+  /** Minimum severity to trigger a lesson write. */
+  readonly minSeverityToLearn: "leve" | "media" | "grave"
+  /** Maximum lessons to save per session (prevents flooding). Default 20. */
+  readonly maxLessonsPerSession: number
+  /** Whether to save decision records (lighter than lessons). Default true. */
+  readonly saveDecisions: boolean
+}
+
+/**
+ * A record of a decision that was made, saved to agentmemory for future retrieval.
+ */
+export interface MemoryDecision {
+  readonly id: string
+  readonly timestampISO: string
+  readonly action: Decision["action"]
+  readonly score: number
+  readonly reasoning: string
+  readonly sessionID: string
+  readonly directory: string
+  readonly deviations: readonly Deviation[]
+}
+
+/**
+ * A lesson extracted from an outcome, saved to agentmemory.
+ */
+export interface LessonLearned {
+  readonly id: string
+  readonly title: string
+  readonly content: string
+  readonly type: "pattern" | "bug" | "architecture" | "workflow"
+  readonly concepts: readonly string[]
+  readonly confidence: number
+  readonly files: readonly string[]
+  readonly sessionID: string
+}
+
+/**
+ * Interface for writing to agentmemory. DI pattern — same as AgentmemoryBackend for reads.
+ * The real implementation calls agentmemory_memory_save / agentmemory_memory_lesson_save via MCP.
+ */
+export interface AgentmemoryWriteBackend {
+  saveMemory(input: {
+    content: string
+    concepts: string[]
+    type: string
+    files?: string[]
+  }): Promise<{ id: string }>
+
+  saveLesson(input: {
+    content: string
+    context: string
+    confidence?: number
+    tags?: string[]
+  }): Promise<{ id: string }>
+}
+
+/** Backend interfaces for memory-aggregator DI. Re-uses existing BoulderStateBackend from memory-aggregator. */
+export interface OrchestratorAgentmemoryBackend {
+  smartSearch(input: {
+    query: string
+    limit?: number
+  }): Promise<{ lessons: Array<{ title: string; content: string; type: string; confidence: number }>; crystals: unknown[] }>
+}
+
+export interface OrchestratorMagicContextBackend {
+slotList(input: { directory?: string; labelPrefix?: string }): Promise<Array<{ label: string; content: string }>>
+}
+
+export interface OrchestratorBoulderStateBackend {
+  boulderRead(input: { directory: string; sessionID: string; query?: string }): Promise<Array<{ id: string; title: string; priority: number; status: string; createdAtMs: number; updatedAtMs: number }>>
+}
+
+export interface MemoryBackends {
+  agentmemory: OrchestratorAgentmemoryBackend
+  magicContext: OrchestratorMagicContextBackend
+  boulderState: OrchestratorBoulderStateBackend
+}
+
+/**
+ * Input to observeAndLearn(). Carries everything the learning function needs
+ * to decide WHAT to learn and WHETHER to learn it.
+ */
+export interface LearnFromOutcomeInput {
+  readonly decision: Decision
+  readonly memoryRead: MemoryRead
+  readonly config: ClosedLoopConfig
+  readonly sessionID: string
+  readonly directory: string
+  readonly filesChanged: readonly string[]
+}
+
+/**
+ * Output from observeAndLearn(). Reports what was persisted (if anything).
+ */
+export interface LearnFromOutcomeOutput {
+  readonly lessonSaved: LessonLearned | null
+  readonly decisionSaved: MemoryDecision | null
+  readonly reason: string
+}
+
+/**
+ * Token Predictor types. PR 4 of 8.
+ *
+ * Computes token burn rate from recent turn metrics and recommends
+ * preemptive actions (compact, switch model, delegate) before context
+ * window exhaustion.
+ */
+
+export interface TokenPredictorConfig {
+  /** Burn rate threshold (tokens/sec) above which to recommend compact-now. Default: 500. */
+  readonly compactBurnRateThreshold: number
+  /** Context usage ratio (0..1) above which to recommend compact-now. Default: 0.85. */
+  readonly compactUsageThreshold: number
+  /** Context usage ratio above which to recommend switch-model. Default: 0.95. */
+  readonly switchModelUsageThreshold: number
+  /** Max consecutive high-burn turns before recommending delegate. Default: 5. */
+  readonly delegateConsecutiveHighBurn: number
+  /** Number of recent turns to use for burn rate calculation. Default: 10. */
+  readonly windowSize: number
+}
+
+export interface TokenPredictorInput {
+  readonly currentUsage: number
+  readonly modelLimit: number
+  readonly recentTurnTokens: readonly number[]
+  readonly timestampISO: string
+  readonly providerID: string
+  readonly modelID: string
+  readonly config: TokenPredictorConfig
+}
+
+export interface TokenPredictorOutput extends TokenPrediction {
+  readonly input: TokenPredictorInput
+  readonly computedAtISO: string
+  readonly turnsAnalyzed: number
+}
+
+/**
+ * Scoring Engine types. PR 5 of 8.
+ *
+ * Configuration for the weighted evidence scoring system that maps
+ * a DecisionContext to a Decision. Thresholds are configurable; defaults
+ * match the Decision contract in types.ts (lines 50-59).
+ */
+
+export interface ScoringConfig {
+  /** Score >= this → continue silently. Default: 0.3. */
+  readonly continueThreshold: number
+  /** Score in [-warnThreshold, +warnThreshold] → continue with log. Default: 0.3. */
+  readonly warnThreshold: number
+  /** Score <= -warnThreshold && > -escalateThreshold → warn. Default: 0.6. */
+  readonly escalateThreshold: number
+  /** Score <= -escalateThreshold && > -stopThreshold → escalate. Default: 0.8. */
+  readonly stopThreshold: number
+  /** Number of consecutive stops that triggers paralysis override. Default: 3. */
+  readonly paralysisThreshold: number
+  /** Default escalation target when action is escalate. Default: "oracle". */
+  readonly defaultEscalationTarget: EscalationTarget
+}
+
+/**
+ * Weighted evidence contribution for a single signal.
+ */
+export interface EvidenceContribution {
+  readonly source: EvidenceSource
+  readonly rawScore: number
+  readonly weight: number
+  readonly weightedScore: number
+  readonly description: string
+}
+
+/**
+ * Full scoring result with per-signal breakdown.
+ */
+export interface ScoringResult {
+  readonly decision: Decision
+  readonly contributions: readonly EvidenceContribution[]
+  readonly rawScore: number
+  readonly paralysisOverride: boolean
+  readonly computedAtISO: string
+}
+
+// ─── Decision Handler Types (PR 6) ────────────────────────────────
+
+export interface DecisionHandlerConfig {
+  /** Master switch: false = always continue (pass-through) */
+  readonly enabled: boolean
+  /** Max history entries per session before oldest are trimmed */
+  readonly maxHistoryPerSession: number
+  /** How many consecutive stops before forcing continue */
+  readonly forceContinueAfterStops: number
+  /** Template for warn messages. Placeholders: {score}, {reasoning}, {evidenceCount} */
+  readonly warnMessageTemplate: string
+  /** Template for escalation messages. Placeholders: {target}, {reasoning} */
+  readonly escalateMessageTemplate: string
+  /** Template for stop messages. Placeholders: {reasoning}, {evidenceCount} */
+  readonly stopMessageTemplate: string
+  /** Default escalation target when Decision.shouldEscalateTo is null */
+  readonly defaultEscalationTarget?: string
+}
+
+export interface DecisionHandlerInput {
+  readonly scoringResult: ScoringResult
+  readonly sessionID: string
+}
+
+export interface DecisionHistoryEntry {
+  readonly decision: Decision
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly timestampISO: string
+  readonly sessionID: string
+  readonly reasoning: string
+}
+
+export interface DecisionHandlerOutput {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly message: string | null
+  readonly historyEntry: DecisionHistoryEntry
+}
+
+// ─── Orchestrator Types (PR 7) ────────────────────────────────────
+
+/**
+ * Configuration for the orchestrator. Each sub-config overrides the
+ * corresponding module's defaults. The orchestrator merges these onto
+ * the per-module defaults at init time.
+ */
+export interface OrchestratorConfig {
+  /** Master switch. false = skip all MetaGovernor processing. */
+  readonly enabled: boolean
+  /** Memory aggregator config. */
+  readonly memory: {
+    readonly enabled: boolean
+    readonly query: string
+    readonly timeoutMs?: number
+  }
+  /** Token predictor config overrides. */
+  readonly tokenPredictor: Partial<TokenPredictorConfig>
+  /** Scoring config overrides. */
+  readonly scoring: Partial<ScoringConfig>
+  /** Decision handler config overrides. */
+  readonly decision: Partial<DecisionHandlerConfig>
+  /** Closed-loop learning config overrides. */
+  readonly closedLoop: Partial<ClosedLoopConfig>
+}
+
+/**
+ * Input to runMetaGovernor(). All signals the orchestrator needs to
+ * build a DecisionContext and dispatch a decision.
+ */
+export interface MetaGovernorInput {
+  readonly sessionID: string
+  readonly toolName: string
+  readonly toolInput?: unknown
+  readonly toolOutput?: unknown
+  readonly agentName?: string
+  readonly providerID?: string
+  readonly modelID?: string
+  readonly iteration: number
+  readonly maxIterations: number
+  readonly oracleVerified: boolean
+  readonly noProgress: boolean
+  readonly filesChanged: number
+  readonly recentTurnTokens: readonly number[]
+  readonly deviations: readonly Deviation[]
+  readonly consecutiveStops?: number
+  readonly backends: MemoryBackends
+  readonly writeBackend: AgentmemoryWriteBackend
+  readonly config?: Partial<OrchestratorConfig>
+}
+
+/**
+ * Output from runMetaGovernor(). Contains all intermediate results
+ * so the caller can log, inject messages, or escalate.
+ */
+export interface MetaGovernorOutput {
+  readonly memoryRead: MemoryRead
+  readonly tokenPrediction: TokenPredictorOutput
+  readonly scoringResult: ScoringResult
+  readonly decision: DecisionHandlerOutput
+  readonly lessonSaved: LearnFromOutcomeOutput | null
+  readonly decisionHistory: readonly DecisionHistoryEntry[]
+  readonly skipped: boolean
+  readonly skipReason?: string
+}


### PR DESCRIPTION
## Summary

PR 2 of v2 series. Builds on PR 1 (types, #5206).

Adds `memory-aggregator.ts` — cross-system memory read from agentmemory, magic-context, and boulder-state in parallel.

## What's in this PR

- `packages/omo-opencode/src/features/meta-governor/memory-aggregator.ts` — 313 LOC, parallel reads + graceful degradation
- `packages/omo-opencode/src/features/meta-governor/memory-aggregator.test.ts` — 19 given/when/then test scenarios
- `packages/omo-opencode/src/features/meta-governor/index.ts` — barrel updated to re-export `aggregateRead`

**+736 LOC across 3 files, 0 deletions, 0 modified files outside this feature.**

## Design

- **Parallel reads** via `Promise.allSettled` — no sequential I/O
- **Per-source timeouts**: agentmemory 2000ms (network), magic-context/boulder-state 1000ms (local)
- **Graceful degradation**: failing source populates `degradedSources[]` without failing the entire read
- **Result bounded** by limits (lessons: 10, slots: 20, tasks: 10)
- **Per-source error messages** stored in `errorMessages` for debugging
- Lessons sorted by confidence DESC, tasks by priority ASC then recency DESC

## Test results

```
bun test src/features/meta-governor/
  44 pass, 0 fail, 112 expect() calls
```

(25 from PR 1 types + 19 new for memory-aggregator)

`tsgo --noEmit` is clean.

## Dependency on PR 1

This PR's branch is based on `herjarsa:feat/meta-governor-types-v2` (PR 1, #5206). The types from PR 1 are required for this implementation. When #5206 is merged, the merge base will update automatically.

## Series order (this is PR 2 of 9)

1. ✅ types (#5206) — pure type contracts
2. 👈 **memory-aggregator** (this PR) — parallel reads from 3 sources
3. closed-loop-learning — observe/record to agentmemory
4. token-predictor — burn-rate + recommendation
5. scoring-engine — weighted evidence → action
6. decision-handler — dispatch + history
7. post-repair-recorder — wrapper for 5 recovery hooks
8. orchestrator — integration of all 6 modules
9. integration + flag — config schema + hook registration

Refs: #5116, #5206

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-system memory aggregator for MetaGovernor that reads from `agentmemory`, `magic-context`, and `boulder-state` in parallel with per-source timeouts and graceful degradation. Exposes `aggregateRead` and returns a bounded, sorted `MemoryRead` for downstream scoring.

- New Features
  - Introduced `memory-aggregator.ts` with `aggregateRead(input, backends)` using `Promise.allSettled` for parallel reads.
  - Per-source timeouts: `agentmemory` 2000ms; `magic-context` and `boulder-state` 1000ms.
  - Graceful degradation: errors mark `degradedSources`; result never throws; per-source error messages recorded.
  - Sorted and limited results: lessons by confidence; tasks by priority then recency; slots filtered (meta_governor prefix or query match); defaults 10/20/10.
  - Updated `index.ts` to export `aggregateRead` and types; added 19 tests in `memory-aggregator.test.ts`.

<sup>Written for commit 5921dad12038c3ad4a378ef3ec96049122712048. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

