### PR TITLE
feat(meta-governor): add token predictor (PR 4 of v2 series)

### DIFF
--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -1,0 +1,49 @@
+/**
+ * MetaGovernor — self-judging agent orchestration layer.
+ *
+ * PR 1 of v2 series. This barrel re-exports ONLY the type surface.
+ * Runtime modules (memory-aggregator, scoring-engine, orchestrator, etc.)
+ * are added in subsequent PRs.
+ *
+ * Architectural invariants:
+ * - All session.promptAsync calls go through prompt-async-gate
+ * - Composes agentmemory + magic-context + boulder-state
+ * - Feature flag `meta_governor.enabled = false` default
+ */
+export type {
+  Decision,
+  DecisionContext,
+  DecisionHandlerConfig,
+  DecisionHandlerInput,
+  DecisionHandlerOutput,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceContribution,
+  EvidenceSource,
+  LearnFromOutcomeInput,
+  LearnFromOutcomeOutput,
+  LessonLearned,
+  MemoryDecision,
+  MemoryRead,
+  AgentMemoryRead,
+  MagicContextRead,
+  BoulderStateRead,
+  MemorySource,
+  AmbientContext,
+  MetaGovernorInput,
+  MetaGovernorOutput,
+  OrchestratorConfig,
+  RelevantLesson,
+  ScoringConfig,
+  ScoringResult,
+  SlotMemory,
+  ClosedLoopConfig,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  AgentmemoryWriteBackend,
+  MemoryBackends,
+} from "./types"

--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -47,3 +47,10 @@ export type {
   AgentmemoryWriteBackend,
   MemoryBackends,
 } from "./types"
+
+// PR 4: token-predictor (burn-rate + recommendation)
+export {
+  predict,
+  defaultTokenPredictorConfig,
+  calculateBurnRate,
+} from "./token-predictor"

--- a/packages/omo-opencode/src/features/meta-governor/token-predictor.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/token-predictor.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test"
+import type { TokenPredictorConfig, TokenPredictorInput } from "./types"
+import {
+  calculateBurnRate,
+  defaultTokenPredictorConfig,
+  predict,
+} from "./token-predictor"
+
+function makeInput(
+  overrides: Partial<TokenPredictorInput> = {}
+): TokenPredictorInput {
+  return {
+    currentUsage: 50_000,
+    modelLimit: 200_000,
+    recentTurnTokens: [100, 120, 80, 110, 90],
+    timestampISO: "2026-06-09T15:00:00Z",
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-20250514",
+    config: defaultTokenPredictorConfig(),
+    ...overrides,
+  }
+}
+
+// #given TokenPredictorConfig defaults
+describe("#given defaultTokenPredictorConfig", () => {
+  // #then returns sane defaults
+  it("returns sane defaults", () => {
+    const config = defaultTokenPredictorConfig()
+    expect(config.compactBurnRateThreshold).toBe(500)
+    expect(config.compactUsageThreshold).toBe(0.85)
+    expect(config.switchModelUsageThreshold).toBe(0.95)
+    expect(config.delegateConsecutiveHighBurn).toBe(5)
+    expect(config.windowSize).toBe(10)
+  })
+})
+
+// #given calculateBurnRate
+describe("#given calculateBurnRate", () => {
+  // #then returns 0 for empty array
+  it("returns 0 for empty array", () => {
+    expect(calculateBurnRate([])).toBe(0)
+  })
+
+  // #then returns average for single turn
+  it("returns average for single turn", () => {
+    expect(calculateBurnRate([1000])).toBe(1000)
+  })
+
+  // #then returns correct average for multiple turns
+  it("returns correct average for multiple turns", () => {
+    expect(calculateBurnRate([1000, 2000, 3000])).toBe(2000)
+  })
+
+  // #then handles fractional averages
+  it("handles fractional averages", () => {
+    expect(calculateBurnRate([100, 150])).toBe(125)
+  })
+})
+
+// #given predict with normal usage
+describe("#given predict with normal usage", () => {
+  // #then returns no-action recommendation
+  it("returns no-action recommendation", () => {
+    const result = predict(makeInput())
+    expect(result.recommendation).toBe("no-action")
+  })
+
+  // #then calculates correct burn rate
+  it("calculates correct burn rate", () => {
+    const result = predict(makeInput())
+    expect(result.burnRate).toBe(100)
+  })
+
+  // #then calculates correct budget left
+  it("calculates correct budget left", () => {
+    const result = predict(makeInput())
+    expect(result.budgetLeft).toBe(150_000)
+  })
+
+  // #then sets confidence based on window fill
+  it("sets confidence based on window fill", () => {
+    const result = predict(makeInput())
+    // 5 turns / 10 window = 0.5 → confidence = 0.3 + 0.5 * 0.65 = 0.625
+    expect(result.confidence).toBeCloseTo(0.625, 2)
+  })
+})
+
+// #given predict with high usage
+describe("#given predict with high usage", () => {
+  // #then recommends compact-now when above compact threshold
+  it("recommends compact-now when above compact threshold", () => {
+    const result = predict(
+      makeInput({ currentUsage: 175_000 }) // 87.5% > 85%
+    )
+    expect(result.recommendation).toBe("compact-now")
+  })
+
+  // #then recommends switch-model when above switch threshold
+  it("recommends switch-model when above switch threshold", () => {
+    const result = predict(
+      makeInput({ currentUsage: 192_000 }) // 96% > 95%
+    )
+    expect(result.recommendation).toBe("switch-model")
+  })
+})
+
+// #given predict with high burn rate
+describe("#given predict with high burn rate", () => {
+  // #then recommends compact-now when burn rate exceeds threshold
+  it("recommends compact-now when burn rate exceeds threshold", () => {
+    const result = predict(
+      makeInput({
+        recentTurnTokens: [600, 700, 800, 500, 2000],
+        // avg = 920, but the 2000 is high
+      })
+    )
+    // avg = (600+700+800+500+2000)/5 = 920 > 500
+    expect(result.recommendation).toBe("compact-now")
+    expect(result.burnRate).toBe(920)
+  })
+})
+
+// #given predict with consecutive high burn
+describe("#given predict with consecutive high burn", () => {
+  // #then recommends delegate after threshold consecutive turns
+  it("recommends delegate after threshold consecutive turns", () => {
+    const result = predict(
+      makeInput({
+        recentTurnTokens: [100, 200, 600, 600, 600, 600, 600],
+        // last 5 turns are all >= 500
+      })
+    )
+    expect(result.recommendation).toBe("delegate-to-subagent")
+  })
+
+  // #then does not delegate when consecutive count below threshold
+  it("does not delegate when consecutive count below threshold", () => {
+    const result = predict(
+      makeInput({
+        recentTurnTokens: [100, 600, 600, 600, 600, 100, 600],
+        // last 1 is high but not 5 consecutive
+      })
+    )
+    expect(result.recommendation).toBe("no-action")
+  })
+})
+
+// #given predict priority ordering
+describe("#given predict priority ordering", () => {
+  // #then switch-model takes priority over compact-now
+  it("switch-model takes priority over compact-now", () => {
+    const result = predict(
+      makeInput({
+        currentUsage: 192_000, // 96% > switch threshold
+        recentTurnTokens: [600, 700, 800, 500, 2000], // high burn too
+      })
+    )
+    expect(result.recommendation).toBe("switch-model")
+  })
+})
+
+// #given predict window limiting
+describe("#given predict window limiting", () => {
+  // #then uses at most windowSize turns
+  it("uses at most windowSize turns", () => {
+    const result = predict(
+      makeInput({
+        recentTurnTokens: [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 5000],
+        config: { ...defaultTokenPredictorConfig(), windowSize: 5 },
+      })
+    )
+    // Last 5 turns: [100, 100, 100, 100, 5000] → avg = 1080
+    expect(result.turnsAnalyzed).toBe(5)
+    expect(result.burnRate).toBe(1080)
+  })
+})
+
+// #given predict overflow prediction
+describe("#given predict overflow prediction", () => {
+  // #then returns null when not expected to overflow
+  it("returns null when not expected to overflow", () => {
+    // With empty turns, burn rate = 0, overflow is never predicted
+    const result = predict(makeInput({
+      recentTurnTokens: [],
+    }))
+    expect(result.willOverflowAt).toBeNull()
+  })
+
+  // #then returns ISO timestamp when overflow is imminent
+  it("returns ISO timestamp when overflow is imminent", () => {
+    const result = predict(
+      makeInput({ currentUsage: 199_000, modelLimit: 200_000 })
+    )
+    expect(result.willOverflowAt).not.toBeNull()
+  })
+})
+
+// #given predict with empty turns
+describe("#given predict with empty turns", () => {
+  // #then handles empty recentTurnTokens gracefully
+  it("handles empty recentTurnTokens gracefully", () => {
+    const result = predict(makeInput({ recentTurnTokens: [] }))
+    expect(result.burnRate).toBe(0)
+    expect(result.recommendation).toBe("no-action")
+    expect(result.turnsAnalyzed).toBe(0)
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/token-predictor.ts
+++ b/packages/omo-opencode/src/features/meta-governor/token-predictor.ts
@@ -1,0 +1,162 @@
+/**
+ * Token Predictor for MetaGovernor.
+ *
+ * PR 4 of 8. Computes token burn rate from recent turn metrics and recommends
+ * preemptive actions (compact, switch model, delegate) before context window
+ * exhaustion.
+ *
+ * Design:
+ * - Pure function with no I/O — takes input, returns prediction.
+ * - Configurable thresholds via TokenPredictorConfig.
+ * - Burn rate = avg tokens/turn over sliding window.
+ * - Overflow prediction: budgetLeft / burnRate = turns left.
+ * - Recommendations layered: compact-now > switch-model > delegate > no-action.
+ */
+
+import type {
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+} from "./types"
+
+/**
+ * Default configuration for the token predictor.
+ */
+export function defaultTokenPredictorConfig(): TokenPredictorConfig {
+  return {
+    compactBurnRateThreshold: 500,
+    compactUsageThreshold: 0.85,
+    switchModelUsageThreshold: 0.95,
+    delegateConsecutiveHighBurn: 5,
+    windowSize: 10,
+  }
+}
+
+/**
+ * Calculate burn rate (avg tokens/turn) from recent turn tokens.
+ * Returns 0 if no turns provided.
+ */
+export function calculateBurnRate(recentTurnTokens: readonly number[]): number {
+  if (recentTurnTokens.length === 0) return 0
+  const sum = recentTurnTokens.reduce((a, b) => a + b, 0)
+  return sum / recentTurnTokens.length
+}
+
+/**
+ * Count consecutive high-burn turns from the end of the window.
+ */
+function countConsecutiveHighBurn(
+  recentTurnTokens: readonly number[],
+  threshold: number
+): number {
+  let count = 0
+  for (let i = recentTurnTokens.length - 1; i >= 0; i--) {
+    if (recentTurnTokens[i] >= threshold) {
+      count++
+    } else {
+      break
+    }
+  }
+  return count
+}
+
+/**
+ * Determine when overflow will occur based on burn rate and budget.
+ * Returns ISO timestamp or null if no overflow expected.
+ */
+function predictOverflowTime(
+  currentUsage: number,
+  modelLimit: number,
+  burnRate: number,
+  timestampISO: string
+): string | null {
+  const budgetLeft = modelLimit - currentUsage
+  if (budgetLeft <= 0) return timestampISO
+  if (burnRate <= 0) return null
+
+  const turnsLeft = Math.floor(budgetLeft / burnRate)
+  if (turnsLeft <= 0) return timestampISO
+
+  // Estimate ~2 seconds per turn as baseline
+  const secondsLeft = turnsLeft * 2
+  const overflowDate = new Date(
+    new Date(timestampISO).getTime() + secondsLeft * 1000
+  )
+  return overflowDate.toISOString()
+}
+
+/**
+ * Core prediction function. Analyzes recent turn tokens and recommends
+ * an action to prevent context window exhaustion.
+ */
+export function predict(input: TokenPredictorInput): TokenPredictorOutput {
+  const { currentUsage, modelLimit, recentTurnTokens, timestampISO, config } =
+    input
+
+  // Use at most windowSize recent turns
+  const windowTokens = recentTurnTokens.slice(-config.windowSize)
+  const burnRate = calculateBurnRate(windowTokens)
+  const budgetLeft = modelLimit - currentUsage
+  const usageRatio = modelLimit > 0 ? currentUsage / modelLimit : 1
+
+  // Calculate confidence: more turns = higher confidence
+  const confidence = Math.min(0.95, 0.3 + (windowTokens.length / config.windowSize) * 0.65)
+
+  // Determine recommendation
+  let recommendation: TokenPredictorOutput["recommendation"] = "no-action"
+  let reason = "within normal parameters"
+
+  // Layer 1: Critical — context nearly full
+  if (usageRatio >= config.switchModelUsageThreshold) {
+    recommendation = "switch-model"
+    reason = `context usage ${(usageRatio * 100).toFixed(1)}% exceeds switch threshold ${(config.switchModelUsageThreshold * 100).toFixed(1)}%`
+  }
+
+  // Layer 2: High burn rate or usage above compact threshold
+  if (
+    usageRatio >= config.compactUsageThreshold ||
+    burnRate >= config.compactBurnRateThreshold
+  ) {
+    if (recommendation === "no-action") {
+      recommendation = "compact-now"
+      reason =
+        usageRatio >= config.compactUsageThreshold
+          ? `context usage ${(usageRatio * 100).toFixed(1)}% exceeds compact threshold ${(config.compactUsageThreshold * 100).toFixed(1)}%`
+          : `burn rate ${burnRate.toFixed(0)} tokens/turn exceeds threshold ${config.compactBurnRateThreshold}`
+    }
+  }
+
+  // Layer 3: Sustained high burn → delegate
+  const consecutiveHighBurn = countConsecutiveHighBurn(
+    windowTokens,
+    config.compactBurnRateThreshold
+  )
+  if (
+    consecutiveHighBurn >= config.delegateConsecutiveHighBurn &&
+    recommendation === "no-action"
+  ) {
+    recommendation = "delegate-to-subagent"
+    reason = `${consecutiveHighBurn} consecutive high-burn turns (threshold: ${config.delegateConsecutiveHighBurn})`
+  }
+
+  const willOverflowAt = predictOverflowTime(
+    currentUsage,
+    modelLimit,
+    burnRate,
+    timestampISO
+  )
+
+  return {
+    currentUsage,
+    burnRate,
+    budgetLeft,
+    willOverflowAt,
+    recommendation,
+    confidence,
+    modelLimit,
+    windowRemaining: Math.max(0, Math.floor(budgetLeft / Math.max(burnRate, 1))),
+    input: { ...input },
+    computedAtISO: timestampISO,
+    turnsAnalyzed: windowTokens.length,
+  }
+}

--- a/packages/omo-opencode/src/features/meta-governor/types.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AgentMemoryRead,
+  AmbientContext,
+  BoulderStateRead,
+  Decision,
+  DecisionContext,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceSource,
+  MagicContextRead,
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+  SlotMemory,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  TokenRecommendation,
+} from "./types"
+
+describe("meta-governor types", () => {
+  describe("DecisionContext", () => {
+    test("S1: accepts fully populated context with oracle verified + no progress + deviations + 80% iterations + 2 lessons", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: true,
+        noProgress: false,
+        deviations: [
+          { severity: "leve", category: "lint", detail: "minor style" },
+          { severity: "grave", category: "config-change", detail: "touched config.ts" },
+        ],
+        iterationRatio: 0.8,
+        lessonsRelevant: [
+          { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          { id: "L2", title: "continue when oracle verified", advice: "continue", confidence: 0.6, concepts: ["oracle-verified"] },
+        ],
+        slotMemory: {
+          lastDecision: {
+            action: "continue",
+            score: 0.4,
+            reasoning: "ok",
+            evidence: [],
+            shouldEscalateTo: null,
+          },
+          consecutiveStops: 0,
+          consecutiveContinues: 2,
+          lastUpdatedISO: "2026-06-09T12:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_test",
+          directory: "/tmp/test",
+          mode: "ultrawork",
+          agentName: "sisyphus",
+          iteration: 8,
+          maxIterations: 10,
+        },
+      }
+
+      // when
+      const isPopulated =
+        ctx.oracleVerified === true &&
+        ctx.iterationRatio === 0.8 &&
+        ctx.deviations.length === 2 &&
+        ctx.lessonsRelevant.length === 2 &&
+        ctx.ambient.iteration === 8
+
+      // then
+      expect(isPopulated).toBe(true)
+    })
+
+    test("S1b: empty arrays are valid (signals, not bugs)", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: false,
+        noProgress: true,
+        deviations: [],
+        iterationRatio: 0.0,
+        lessonsRelevant: [],
+        slotMemory: {
+          consecutiveStops: 0,
+          consecutiveContinues: 0,
+          lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_empty",
+          directory: "/tmp/empty",
+          mode: "simple",
+          agentName: "build",
+          iteration: 1,
+          maxIterations: 50,
+        },
+      }
+
+      // when
+      const hasEmptySignals = ctx.deviations.length === 0 && ctx.lessonsRelevant.length === 0
+
+      // then
+      expect(hasEmptySignals).toBe(true)
+    })
+  })
+
+  describe("Decision", () => {
+    test("S2: carries all required fields and supports every action variant", () => {
+      // given
+      const decisions: Decision[] = [
+        {
+          action: "continue",
+          score: 0.5,
+          reasoning: "all clear",
+          evidence: [],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "warn",
+          score: -0.4,
+          reasoning: "deviation grave",
+          evidence: [
+            { source: "deviation-detector", value: "config-change", confidence: 0.9, weight: 0.5 },
+          ],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "escalate",
+          score: -0.7,
+          reasoning: "needs oracle verification",
+          evidence: [
+            { source: "oracle-verified", value: "false", confidence: 1.0, weight: 0.4 },
+          ],
+          shouldEscalateTo: "oracle",
+        },
+        {
+          action: "stop",
+          score: -0.9,
+          reasoning: "no progress 3 turns",
+          evidence: [
+            { source: "no-progress-detector", value: "true", confidence: 0.95, weight: 0.6 },
+          ],
+          shouldEscalateTo: null,
+        },
+      ]
+
+      // when
+      const allValid = decisions.every(
+        (d) =>
+          typeof d.score === "number" &&
+          d.score >= -1 &&
+          d.score <= 1 &&
+          d.reasoning.length > 0 &&
+          Array.isArray(d.evidence),
+      )
+      const actions = new Set(decisions.map((d) => d.action))
+
+      // then
+      expect(allValid).toBe(true)
+      expect(actions.size).toBe(4)
+      expect(actions.has("continue")).toBe(true)
+      expect(actions.has("warn")).toBe(true)
+      expect(actions.has("escalate")).toBe(true)
+      expect(actions.has("stop")).toBe(true)
+    })
+
+    test("S2b: when action is escalate, shouldEscalateTo must be oracle or user (not null)", () => {
+      // given
+      const targets: EscalationTarget[] = ["oracle", "user"]
+
+      // when
+      const isStrictSubset = targets.every((t) => t === "oracle" || t === "user")
+
+      // then
+      expect(isStrictSubset).toBe(true)
+    })
+  })
+
+  describe("Evidence", () => {
+    test("S3: shape has source, value, confidence, weight all required", () => {
+      // given
+      const sources: EvidenceSource[] = [
+        "oracle-verified",
+        "no-progress-detector",
+        "deviation-detector",
+        "iteration-budget",
+        "lesson-recall",
+        "slot-memory",
+        "ambient",
+        "token-predictor",
+      ]
+      const sample: Evidence = {
+        source: "oracle-verified",
+        value: "true",
+        confidence: 0.95,
+        weight: 0.4,
+      }
+
+      // when
+      const hasAllFields =
+        typeof sample.source === "string" &&
+        typeof sample.value === "string" &&
+        sample.confidence >= 0 &&
+        sample.confidence <= 1 &&
+        sample.weight >= 0 &&
+        sample.weight <= 1
+
+      // then
+      expect(hasAllFields).toBe(true)
+      expect(sources.length).toBe(8)
+    })
+  })
+
+  describe("MemoryRead", () => {
+    test("S4: aggregates agentmemory + magicContext + boulderState, marks degraded sources", () => {
+      // given
+      const read: MemoryRead = {
+        query: "ralph-loop continue after config-change",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        agentmemory: {
+          available: true,
+          lessons: [
+            { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          ],
+        },
+        magicContext: {
+          available: true,
+          slots: [{ label: "meta_state", content: "{}" }],
+        },
+        boulderState: {
+          available: false,
+          tasks: [],
+          planProgress: 0,
+          errorMessage: "no .omo/boulder.json",
+        },
+        degradedSources: ["boulderState"],
+      }
+
+      // when
+      const oneDegraded = read.degradedSources.length === 1
+      const agentmemoryOk = read.agentmemory.available === true
+      const boulderDown = read.boulderState.available === false
+
+      // then
+      expect(oneDegraded).toBe(true)
+      expect(agentmemoryOk).toBe(true)
+      expect(boulderDown).toBe(true)
+      expect(read.degradedSources[0]).toBe<MemorySource>("boulderState")
+    })
+  })
+
+  describe("TokenPrediction", () => {
+    test("S5: has currentUsage, burnRate, budgetLeft, willOverflowAt, recommendation, confidence", () => {
+      // given
+      const predictions: TokenPrediction[] = [
+        {
+          currentUsage: 50_000,
+          burnRate: 200,
+          budgetLeft: 150_000,
+          willOverflowAt: null,
+          recommendation: "no-action",
+          confidence: 0.95,
+          modelLimit: 200_000,
+          windowRemaining: 150_000,
+        },
+        {
+          currentUsage: 180_000,
+          burnRate: 5_000,
+          budgetLeft: 20_000,
+          willOverflowAt: "2026-06-09T12:05:00.000Z",
+          recommendation: "compact-now",
+          confidence: 0.85,
+          modelLimit: 200_000,
+          windowRemaining: 20_000,
+        },
+        {
+          currentUsage: 90_000,
+          burnRate: 3_000,
+          budgetLeft: 110_000,
+          willOverflowAt: "2026-06-09T12:30:00.000Z",
+          recommendation: "switch-model",
+          confidence: 0.7,
+          modelLimit: 200_000,
+          windowRemaining: 110_000,
+        },
+        {
+          currentUsage: 120_000,
+          burnRate: 2_000,
+          budgetLeft: 80_000,
+          willOverflowAt: "2026-06-09T12:40:00.000Z",
+          recommendation: "delegate-to-subagent",
+          confidence: 0.65,
+          modelLimit: 200_000,
+          windowRemaining: 80_000,
+        },
+      ]
+      const recommendations: TokenRecommendation[] = [
+        "compact-now",
+        "switch-model",
+        "delegate-to-subagent",
+        "no-action",
+      ]
+
+      // when
+      const allHaveFields = predictions.every(
+        (p) =>
+          typeof p.currentUsage === "number" &&
+          typeof p.burnRate === "number" &&
+          typeof p.budgetLeft === "number" &&
+          (p.willOverflowAt === null || typeof p.willOverflowAt === "string") &&
+          p.confidence >= 0 &&
+          p.confidence <= 1,
+      )
+      const allRecommendations = new Set(predictions.map((p) => p.recommendation))
+
+      // then
+      expect(allHaveFields).toBe(true)
+      expect(allRecommendations.size).toBe(4)
+      for (const r of recommendations) {
+        expect(allRecommendations.has(r)).toBe(true)
+      }
+    })
+
+    test("S5b: willOverflowAt is null when recommendation is no-action", () => {
+      // given
+      const p: TokenPrediction = {
+        currentUsage: 1_000,
+        burnRate: 0,
+        budgetLeft: 199_000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.99,
+        modelLimit: 200_000,
+        windowRemaining: 199_000,
+      }
+
+      // then
+      expect(p.willOverflowAt).toBeNull()
+      expect(p.recommendation).toBe("no-action")
+    })
+  })
+
+  describe("auxiliary types", () => {
+    test("SlotMemory consecutive counters default to 0 and are read by judge for paralysis detection", () => {
+      // given
+      const slot: SlotMemory = {
+        consecutiveStops: 3,
+        consecutiveContinues: 0,
+        lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+      }
+
+      // when
+      const isParalyzed = slot.consecutiveStops >= 3
+
+      // then
+      expect(isParalyzed).toBe(true)
+    })
+
+    test("AmbientContext carries mode for judge to factor in (ultrawork stricter than simple)", () => {
+      // given
+      const modes: AmbientContext["mode"][] = ["ultrawork", "ulw", "simple", "ralph-loop"]
+
+      // when
+      const allListed = modes.every((m) =>
+        ["ultrawork", "ulw", "simple", "ralph-loop"].includes(m),
+      )
+
+      // then
+      expect(allListed).toBe(true)
+    })
+
+    test("Deviation severity uses the 3-level taxonomy (leve/media/grave) from prior moderator-gate", () => {
+      // given
+      const deviations: Deviation[] = [
+        { severity: "leve", category: "lint", detail: "minor" },
+        { severity: "media", category: "refactor-scope", detail: "broader than expected" },
+        { severity: "grave", category: "config-change", detail: "touched config.ts" },
+      ]
+
+      // when
+      const severities = new Set(deviations.map((d) => d.severity))
+
+      // then
+      expect(severities.size).toBe(3)
+      expect(severities.has("grave")).toBe(true)
+    })
+
+    test("RelevantLesson carries id, title, advice, confidence, concepts for preflight matching", () => {
+      // given
+      const lesson: RelevantLesson = {
+        id: "L42",
+        title: "fix X for error Y",
+        advice: "warn",
+        confidence: 0.6,
+        concepts: ["tool_timeout", "bash", "retry"],
+      }
+
+      // when
+      const matchesBash = lesson.concepts.includes("bash")
+
+      // then
+      expect(matchesBash).toBe(true)
+      expect(lesson.advice).toBe("warn")
+    })
+
+    test("AgentMemoryRead and MagicContextRead report available=false with errorMessage when degraded", () => {
+      // given
+      const am: AgentMemoryRead = {
+        available: false,
+        lessons: [],
+        errorMessage: "agentmemory MCP not connected",
+      }
+      const mc: MagicContextRead = {
+        available: false,
+        slots: [],
+        errorMessage: "magic-context slot not initialised",
+      }
+
+      // then
+      expect(am.available).toBe(false)
+      expect(am.errorMessage).toBeTruthy()
+      expect(mc.available).toBe(false)
+      expect(mc.errorMessage).toBeTruthy()
+    })
+
+    test("BoulderStateRead reports planProgress in 0..1", () => {
+      // given
+      const bs: BoulderStateRead = {
+        available: true,
+        tasks: [{ id: "T1", status: "done", title: "fix bug" }],
+        planProgress: 0.5,
+      }
+
+      // when
+      const inRange = bs.planProgress >= 0 && bs.planProgress <= 1
+
+      // then
+      expect(inRange).toBe(true)
+    })
+  })
+
+  describe("ClosedLoopConfig", () => {
+    test("CLT1: has all required fields with correct types", () => {
+      // given
+      const cfg: ClosedLoopConfig = {
+        enabled: true,
+        minSeverityToLearn: "media",
+        maxLessonsPerSession: 20,
+        saveDecisions: true,
+      }
+
+      // when
+      const isValid =
+        typeof cfg.enabled === "boolean" &&
+        (cfg.minSeverityToLearn === "leve" || cfg.minSeverityToLearn === "media" || cfg.minSeverityToLearn === "grave") &&
+        typeof cfg.maxLessonsPerSession === "number" &&
+        typeof cfg.saveDecisions === "boolean"
+
+      // then
+      expect(isValid).toBe(true)
+    })
+
+    test("CLT2: minSeverityToLearn accepts all 3 severity levels", () => {
+      const levels: ClosedLoopConfig["minSeverityToLearn"][] = ["leve", "media", "grave"]
+      expect(levels.length).toBe(3)
+    })
+  })
+
+  describe("MemoryDecision", () => {
+    test("CLT3: has all required fields matching Decision contract", () => {
+      // given
+      const md: MemoryDecision = {
+        id: "D-abc123",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        action: "warn",
+        score: -0.5,
+        reasoning: "deviation detected",
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        deviations: [{ severity: "media", category: "lint", detail: "style" }],
+      }
+
+      // when
+      const isValid =
+        typeof md.id === "string" &&
+        typeof md.timestampISO === "string" &&
+        typeof md.score === "number" &&
+        md.score >= -1 && md.score <= 1 &&
+        typeof md.sessionID === "string"
+
+      // then
+      expect(isValid).toBe(true)
+      expect(md.action).toBe("warn")
+    })
+
+    test("CLT4: action field matches Decision action union type", () => {
+      const actions: MemoryDecision["action"][] = ["continue", "warn", "escalate", "stop"]
+      expect(actions.length).toBe(4)
+    })
+  })
+
+  describe("AgentmemoryWriteBackend", () => {
+    test("CLT5: interface has saveMemory and saveLesson methods", () => {
+      // Compile-time check: if the interface is wrong, this won't typecheck
+      const impl: AgentmemoryWriteBackend = {
+        saveMemory: async () => ({ id: "mem-1" }),
+        saveLesson: async () => ({ id: "les-1" }),
+      }
+
+      // when
+      const hasBoth = typeof impl.saveMemory === "function" && typeof impl.saveLesson === "function"
+
+      // then
+      expect(hasBoth).toBe(true)
+    })
+  })
+
+  describe("LessonLearned", () => {
+    test("CLT6: has all required fields", () => {
+      // given
+      const lesson: LessonLearned = {
+        id: "L-abc",
+        title: "stop on config-change",
+        content: "When X then Y",
+        type: "pattern",
+        concepts: ["config-change", "grave"],
+        confidence: 0.7,
+        files: ["src/foo.ts"],
+        sessionID: "ses_test",
+      }
+
+      // when
+      const isValid =
+        typeof lesson.id === "string" &&
+        typeof lesson.title === "string" &&
+        typeof lesson.content === "string" &&
+        ["pattern", "bug", "architecture", "workflow"].includes(lesson.type) &&
+        lesson.confidence >= 0 && lesson.confidence <= 1
+
+      // then
+      expect(isValid).toBe(true)
+    })
+  })
+
+  describe("LearnFromOutcomeInput / Output", () => {
+    test("CLT7: Input carries decision, memoryRead, config, sessionID, directory, filesChanged", () => {
+      // given
+      const input: LearnFromOutcomeInput = {
+        decision: { action: "warn", score: -0.5, reasoning: "test", evidence: [], shouldEscalateTo: null },
+        memoryRead: {
+          query: "test",
+          timestampISO: "2026-06-09T12:00:00.000Z",
+          agentmemory: { available: true, lessons: [] },
+          magicContext: { available: true, slots: [] },
+          boulderState: { available: true, tasks: [], planProgress: 0 },
+          degradedSources: [],
+        },
+        config: { enabled: true, minSeverityToLearn: "media", maxLessonsPerSession: 20, saveDecisions: true },
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        filesChanged: ["src/foo.ts"],
+      }
+
+      // when
+      const hasAll =
+        typeof input.sessionID === "string" &&
+        typeof input.directory === "string" &&
+        Array.isArray(input.filesChanged)
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+
+    test("CLT8: Output has lessonSaved, decisionSaved, reason", () => {
+      // given
+      const output: import("./types").LearnFromOutcomeOutput = {
+        lessonSaved: null,
+        decisionSaved: null,
+        reason: "no action",
+      }
+
+      // when
+      const hasAll =
+        "lessonSaved" in output &&
+        "decisionSaved" in output &&
+        typeof output.reason === "string"
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+  })
+
+  describe("TokenPredictorConfig", () => {
+    test("S1: accepts valid config with all thresholds", () => {
+      // given
+      const config: TokenPredictorConfig = {
+        compactBurnRateThreshold: 500,
+        compactUsageThreshold: 0.85,
+        switchModelUsageThreshold: 0.95,
+        delegateConsecutiveHighBurn: 5,
+        windowSize: 10,
+      }
+
+      // when + then - type check passes
+      expect(config.compactBurnRateThreshold).toBe(500)
+      expect(config.windowSize).toBe(10)
+    })
+  })
+
+  describe("TokenPredictorInput", () => {
+    test("S1: accepts valid input with all fields", () => {
+      // given
+      const input: TokenPredictorInput = {
+        currentUsage: 100000,
+        modelLimit: 200000,
+        recentTurnTokens: [100, 200, 150],
+        timestampISO: new Date().toISOString(),
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-20250514",
+        config: {
+          compactBurnRateThreshold: 500,
+          compactUsageThreshold: 0.85,
+          switchModelUsageThreshold: 0.95,
+          delegateConsecutiveHighBurn: 5,
+          windowSize: 10,
+        },
+      }
+
+      // when + then - type check passes
+      expect(input.currentUsage).toBe(100000)
+      expect(input.recentTurnTokens).toHaveLength(3)
+    })
+  })
+
+  describe("TokenPredictorOutput", () => {
+    test("S1: extends TokenPrediction with input metadata", () => {
+      // given
+      const output: TokenPredictorOutput = {
+        currentUsage: 100000,
+        burnRate: 100,
+        budgetLeft: 100000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.8,
+        modelLimit: 200000,
+        windowRemaining: 100000,
+        input: {
+          currentUsage: 100000,
+          modelLimit: 200000,
+          recentTurnTokens: [100],
+          timestampISO: "2025-01-01T00:00:00Z",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-20250514",
+          config: {
+            compactBurnRateThreshold: 500,
+            compactUsageThreshold: 0.85,
+            switchModelUsageThreshold: 0.95,
+            delegateConsecutiveHighBurn: 5,
+            windowSize: 10,
+          },
+        },
+        computedAtISO: "2025-01-01T00:00:00Z",
+        turnsAnalyzed: 1,
+      }
+
+      // when + then - type check passes
+      expect(output.input.currentUsage).toBe(100000)
+      expect(output.turnsAnalyzed).toBe(1)
+      expect(typeof output.computedAtISO).toBe("string")
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/types.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.ts
@@ -1,0 +1,513 @@
+/**
+ * MetaGovernor type contracts.
+ *
+ * PR 1 of 8. Defines ONLY the type surface that later PRs implement against.
+ * No logic, no I/O, no MCP calls. This file is the source of truth for the
+ * MetaGovernor architecture; later PRs import these types and conform to them.
+ *
+ * Architectural invariants (from AGENTS.md, must respect):
+ * - All session.promptAsync calls go through prompt-async-gate (not enforced here)
+ * - MetaGovernor composes AFT + agentmemory + magic-context + boulder-state
+ * - 5 recovery hooks wrap into post-repair-recorder (not enforced here)
+ *
+ * Public surface (5 contracts):
+ * - DecisionContext: input to score()
+ * - Decision: output of score()
+ * - Evidence: atomic evidence unit attached to a Decision
+ * - MemoryRead: cross-system read result
+ * - TokenPrediction: token burn rate prediction
+ *
+ * All enums/actions are union string types (no enums) for Zod compat and
+ * JSON-serialisability across the prompt-async-gate.
+ */
+
+/**
+ * What the judge sees when deciding continue|warn|escalate|stop.
+ *
+ * All fields are required. `undefined` is not a valid DecisionContext —
+ * collectors must fill every field even if the value is an empty array,
+ * false, or 0. Empty inputs are signals, not bugs.
+ */
+export interface DecisionContext {
+  /** Whether the last Oracle invocation returned verified=true. */
+  readonly oracleVerified: boolean
+  /** Whether the last assistant turn produced no progress (zero tokens, no content). */
+  readonly noProgress: boolean
+  /** Detected deviations from expected behavior. Empty array = no deviations. */
+  readonly deviations: readonly Deviation[]
+  /** iteration / maxIterations. 0..1. 1.0 = at the cap. */
+  readonly iterationRatio: number
+  /** Lessons retrieved from agentmemory that match the current decision pattern. */
+  readonly lessonsRelevant: readonly RelevantLesson[]
+  /** Cross-session memory snapshot from the meta_state slot. */
+  readonly slotMemory: SlotMemory
+  /** Free-form context the calling site can attach (sessionID, directory, mode). */
+  readonly ambient: AmbientContext
+}
+
+/**
+ * Decision the judge returns. Always carries evidence (cite-or-abstain).
+ *
+ * Score ∈ [-1, +1]:
+ *   >= +0.3 → continue silently
+ *   -0.3..+0.3 → continue with log
+ *   -0.6..-0.3 → continue with warn
+ *   -0.8..-0.6 → escalate (oracle or user)
+ *   < -0.8 → stop loop
+ *
+ * Note: actual thresholds are config-driven in PR 8. Defaults are above.
+ */
+export interface Decision {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly score: number
+  /** Human-readable one-sentence explanation. Required, never empty. */
+  readonly reasoning: string
+  /** Cite-or-abstain: at least 1 evidence unit when action !== "continue" silently. */
+  readonly evidence: readonly Evidence[]
+  /** When action === "escalate", which actor should be invoked. */
+  readonly shouldEscalateTo: EscalationTarget | null
+}
+
+export type EscalationTarget = "oracle" | "user"
+
+/**
+ * Atomic evidence unit. Carries provenance so the judge can be audited.
+ *
+ * `confidence` ∈ [0, 1]: how sure the source is about `value`.
+ * `weight` ∈ [0, 1]: how much this evidence influences the score
+ *  (assigned by the scoring function, not the collector).
+ */
+export interface Evidence {
+  readonly source: EvidenceSource
+  readonly value: string
+  readonly confidence: number
+  readonly weight: number
+}
+
+export type EvidenceSource =
+  | "oracle-verified"
+  | "no-progress-detector"
+  | "deviation-detector"
+  | "iteration-budget"
+  | "lesson-recall"
+  | "slot-memory"
+  | "ambient"
+  | "token-predictor"
+
+/**
+ * A deviation from expected behavior. Severity follows the prior
+ * moderator-gate (PR 4405) taxonomy for backward compat.
+ */
+export interface Deviation {
+  readonly severity: "leve" | "media" | "grave"
+  readonly category: string
+  readonly detail: string
+  readonly filePath?: string
+}
+
+/**
+ * A lesson retrieved from agentmemory.lesson_recall. Confidence is the
+ * stored confidence in the memory store, not the relevance to this query.
+ */
+export interface RelevantLesson {
+  readonly id: string
+  readonly title: string
+  readonly advice: "continue" | "stop" | "warn" | "info"
+  readonly confidence: number
+  readonly concepts: readonly string[]
+}
+
+/**
+ * Cross-session state held in the magic-context `meta_state` slot.
+ *
+ * `consecutiveStops` is read by the judge to detect paralysis (3 stops
+ * in a row → force continue with warning, prevents infinite conservatism).
+ */
+export interface SlotMemory {
+  readonly lastDecision?: Decision
+  readonly consecutiveStops: number
+  readonly consecutiveContinues: number
+  readonly lastUpdatedISO: string
+}
+
+/**
+ * Free-form context the calling site can attach. Used for audit trails
+ * and to enable the judge to factor in mode (ultrawork vs simple) or
+ * session state. Fields are optional to keep the contract lean.
+ */
+export interface AmbientContext {
+  readonly sessionID: string
+  readonly directory: string
+  readonly mode: "ultrawork" | "ulw" | "simple" | "ralph-loop"
+  readonly agentName: string
+  readonly iteration: number
+  readonly maxIterations: number
+}
+
+/**
+ * Cross-system memory read result. All three sources read in parallel;
+ * any of them may be unavailable (graceful degradation in PR 2).
+ *
+ * `query` is echoed back so callers can correlate the read with the
+ * query that produced it.
+ */
+export interface MemoryRead {
+  readonly query: string
+  readonly timestampISO: string
+  readonly agentmemory: AgentMemoryRead
+  readonly magicContext: MagicContextRead
+  readonly boulderState: BoulderStateRead
+  readonly degradedSources: readonly MemorySource[]
+}
+
+export type MemorySource = "agentmemory" | "magicContext" | "boulderState"
+
+export interface AgentMemoryRead {
+  readonly available: boolean
+  readonly lessons: readonly RelevantLesson[]
+  readonly errorMessage?: string
+}
+
+export interface MagicContextRead {
+  readonly available: boolean
+  readonly slots: readonly { readonly label: string; readonly content: string }[]
+  readonly errorMessage?: string
+}
+
+export interface BoulderStateRead {
+  readonly available: boolean
+  readonly tasks: readonly { readonly id: string; readonly status: string; readonly title: string }[]
+  readonly planProgress: number
+  readonly errorMessage?: string
+}
+
+/**
+ * Token burn rate prediction. Computed from recent turn metrics.
+ *
+ * `willOverflowAt` is an ISO timestamp predicted from current usage +
+ * burn rate + model limit. `null` when not expected to overflow.
+ *
+ * `recommendation` is action-typed; the caller (PR 7 integration) maps
+ * these to actual hook invocations:
+ *   - "compact-now" → invoke preemptive-compaction-degradation-monitor
+ *   - "switch-model" → invoke model-fallback chat-message-fallback-handler
+ *   - "delegate-to-subagent" → invoke delegate-task with a sub-scope
+ *   - "no-action" → silent
+ */
+export interface TokenPrediction {
+  readonly currentUsage: number
+  readonly burnRate: number
+  readonly budgetLeft: number
+  readonly willOverflowAt: string | null
+  readonly recommendation: TokenRecommendation
+  readonly confidence: number
+  readonly modelLimit: number
+  readonly windowRemaining: number
+}
+
+export type TokenRecommendation =
+  | "compact-now"
+  | "switch-model"
+  | "delegate-to-subagent"
+  | "no-action"
+
+/**
+ * Closed-loop learning types. PR 3 of 8.
+ *
+ * After every repair/action cycle, observeAndLearn() decides whether to
+ * persist a lesson or decision record to agentmemory. Future sessions
+ * retrieve these via aggregateRead() (PR 2) and factor them into
+ * scoring (PR 5).
+ */
+
+/**
+ * Configuration for the closed-loop learning system.
+ */
+export interface ClosedLoopConfig {
+  /** Master switch. false = observe only, never write. */
+  readonly enabled: boolean
+  /** Minimum severity to trigger a lesson write. */
+  readonly minSeverityToLearn: "leve" | "media" | "grave"
+  /** Maximum lessons to save per session (prevents flooding). Default 20. */
+  readonly maxLessonsPerSession: number
+  /** Whether to save decision records (lighter than lessons). Default true. */
+  readonly saveDecisions: boolean
+}
+
+/**
+ * A record of a decision that was made, saved to agentmemory for future retrieval.
+ */
+export interface MemoryDecision {
+  readonly id: string
+  readonly timestampISO: string
+  readonly action: Decision["action"]
+  readonly score: number
+  readonly reasoning: string
+  readonly sessionID: string
+  readonly directory: string
+  readonly deviations: readonly Deviation[]
+}
+
+/**
+ * A lesson extracted from an outcome, saved to agentmemory.
+ */
+export interface LessonLearned {
+  readonly id: string
+  readonly title: string
+  readonly content: string
+  readonly type: "pattern" | "bug" | "architecture" | "workflow"
+  readonly concepts: readonly string[]
+  readonly confidence: number
+  readonly files: readonly string[]
+  readonly sessionID: string
+}
+
+/**
+ * Interface for writing to agentmemory. DI pattern — same as AgentmemoryBackend for reads.
+ * The real implementation calls agentmemory_memory_save / agentmemory_memory_lesson_save via MCP.
+ */
+export interface AgentmemoryWriteBackend {
+  saveMemory(input: {
+    content: string
+    concepts: string[]
+    type: string
+    files?: string[]
+  }): Promise<{ id: string }>
+
+  saveLesson(input: {
+    content: string
+    context: string
+    confidence?: number
+    tags?: string[]
+  }): Promise<{ id: string }>
+}
+
+/** Backend interfaces for memory-aggregator DI. Re-uses existing BoulderStateBackend from memory-aggregator. */
+export interface OrchestratorAgentmemoryBackend {
+  smartSearch(input: {
+    query: string
+    limit?: number
+  }): Promise<{ lessons: Array<{ title: string; content: string; type: string; confidence: number }>; crystals: unknown[] }>
+}
+
+export interface OrchestratorMagicContextBackend {
+slotList(input: { directory?: string; labelPrefix?: string }): Promise<Array<{ label: string; content: string }>>
+}
+
+export interface OrchestratorBoulderStateBackend {
+  boulderRead(input: { directory: string; sessionID: string; query?: string }): Promise<Array<{ id: string; title: string; priority: number; status: string; createdAtMs: number; updatedAtMs: number }>>
+}
+
+export interface MemoryBackends {
+  agentmemory: OrchestratorAgentmemoryBackend
+  magicContext: OrchestratorMagicContextBackend
+  boulderState: OrchestratorBoulderStateBackend
+}
+
+/**
+ * Input to observeAndLearn(). Carries everything the learning function needs
+ * to decide WHAT to learn and WHETHER to learn it.
+ */
+export interface LearnFromOutcomeInput {
+  readonly decision: Decision
+  readonly memoryRead: MemoryRead
+  readonly config: ClosedLoopConfig
+  readonly sessionID: string
+  readonly directory: string
+  readonly filesChanged: readonly string[]
+}
+
+/**
+ * Output from observeAndLearn(). Reports what was persisted (if anything).
+ */
+export interface LearnFromOutcomeOutput {
+  readonly lessonSaved: LessonLearned | null
+  readonly decisionSaved: MemoryDecision | null
+  readonly reason: string
+}
+
+/**
+ * Token Predictor types. PR 4 of 8.
+ *
+ * Computes token burn rate from recent turn metrics and recommends
+ * preemptive actions (compact, switch model, delegate) before context
+ * window exhaustion.
+ */
+
+export interface TokenPredictorConfig {
+  /** Burn rate threshold (tokens/sec) above which to recommend compact-now. Default: 500. */
+  readonly compactBurnRateThreshold: number
+  /** Context usage ratio (0..1) above which to recommend compact-now. Default: 0.85. */
+  readonly compactUsageThreshold: number
+  /** Context usage ratio above which to recommend switch-model. Default: 0.95. */
+  readonly switchModelUsageThreshold: number
+  /** Max consecutive high-burn turns before recommending delegate. Default: 5. */
+  readonly delegateConsecutiveHighBurn: number
+  /** Number of recent turns to use for burn rate calculation. Default: 10. */
+  readonly windowSize: number
+}
+
+export interface TokenPredictorInput {
+  readonly currentUsage: number
+  readonly modelLimit: number
+  readonly recentTurnTokens: readonly number[]
+  readonly timestampISO: string
+  readonly providerID: string
+  readonly modelID: string
+  readonly config: TokenPredictorConfig
+}
+
+export interface TokenPredictorOutput extends TokenPrediction {
+  readonly input: TokenPredictorInput
+  readonly computedAtISO: string
+  readonly turnsAnalyzed: number
+}
+
+/**
+ * Scoring Engine types. PR 5 of 8.
+ *
+ * Configuration for the weighted evidence scoring system that maps
+ * a DecisionContext to a Decision. Thresholds are configurable; defaults
+ * match the Decision contract in types.ts (lines 50-59).
+ */
+
+export interface ScoringConfig {
+  /** Score >= this → continue silently. Default: 0.3. */
+  readonly continueThreshold: number
+  /** Score in [-warnThreshold, +warnThreshold] → continue with log. Default: 0.3. */
+  readonly warnThreshold: number
+  /** Score <= -warnThreshold && > -escalateThreshold → warn. Default: 0.6. */
+  readonly escalateThreshold: number
+  /** Score <= -escalateThreshold && > -stopThreshold → escalate. Default: 0.8. */
+  readonly stopThreshold: number
+  /** Number of consecutive stops that triggers paralysis override. Default: 3. */
+  readonly paralysisThreshold: number
+  /** Default escalation target when action is escalate. Default: "oracle". */
+  readonly defaultEscalationTarget: EscalationTarget
+}
+
+/**
+ * Weighted evidence contribution for a single signal.
+ */
+export interface EvidenceContribution {
+  readonly source: EvidenceSource
+  readonly rawScore: number
+  readonly weight: number
+  readonly weightedScore: number
+  readonly description: string
+}
+
+/**
+ * Full scoring result with per-signal breakdown.
+ */
+export interface ScoringResult {
+  readonly decision: Decision
+  readonly contributions: readonly EvidenceContribution[]
+  readonly rawScore: number
+  readonly paralysisOverride: boolean
+  readonly computedAtISO: string
+}
+
+// ─── Decision Handler Types (PR 6) ────────────────────────────────
+
+export interface DecisionHandlerConfig {
+  /** Master switch: false = always continue (pass-through) */
+  readonly enabled: boolean
+  /** Max history entries per session before oldest are trimmed */
+  readonly maxHistoryPerSession: number
+  /** How many consecutive stops before forcing continue */
+  readonly forceContinueAfterStops: number
+  /** Template for warn messages. Placeholders: {score}, {reasoning}, {evidenceCount} */
+  readonly warnMessageTemplate: string
+  /** Template for escalation messages. Placeholders: {target}, {reasoning} */
+  readonly escalateMessageTemplate: string
+  /** Template for stop messages. Placeholders: {reasoning}, {evidenceCount} */
+  readonly stopMessageTemplate: string
+  /** Default escalation target when Decision.shouldEscalateTo is null */
+  readonly defaultEscalationTarget?: string
+}
+
+export interface DecisionHandlerInput {
+  readonly scoringResult: ScoringResult
+  readonly sessionID: string
+}
+
+export interface DecisionHistoryEntry {
+  readonly decision: Decision
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly timestampISO: string
+  readonly sessionID: string
+  readonly reasoning: string
+}
+
+export interface DecisionHandlerOutput {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly message: string | null
+  readonly historyEntry: DecisionHistoryEntry
+}
+
+// ─── Orchestrator Types (PR 7) ────────────────────────────────────
+
+/**
+ * Configuration for the orchestrator. Each sub-config overrides the
+ * corresponding module's defaults. The orchestrator merges these onto
+ * the per-module defaults at init time.
+ */
+export interface OrchestratorConfig {
+  /** Master switch. false = skip all MetaGovernor processing. */
+  readonly enabled: boolean
+  /** Memory aggregator config. */
+  readonly memory: {
+    readonly enabled: boolean
+    readonly query: string
+    readonly timeoutMs?: number
+  }
+  /** Token predictor config overrides. */
+  readonly tokenPredictor: Partial<TokenPredictorConfig>
+  /** Scoring config overrides. */
+  readonly scoring: Partial<ScoringConfig>
+  /** Decision handler config overrides. */
+  readonly decision: Partial<DecisionHandlerConfig>
+  /** Closed-loop learning config overrides. */
+  readonly closedLoop: Partial<ClosedLoopConfig>
+}
+
+/**
+ * Input to runMetaGovernor(). All signals the orchestrator needs to
+ * build a DecisionContext and dispatch a decision.
+ */
+export interface MetaGovernorInput {
+  readonly sessionID: string
+  readonly toolName: string
+  readonly toolInput?: unknown
+  readonly toolOutput?: unknown
+  readonly agentName?: string
+  readonly providerID?: string
+  readonly modelID?: string
+  readonly iteration: number
+  readonly maxIterations: number
+  readonly oracleVerified: boolean
+  readonly noProgress: boolean
+  readonly filesChanged: number
+  readonly recentTurnTokens: readonly number[]
+  readonly deviations: readonly Deviation[]
+  readonly consecutiveStops?: number
+  readonly backends: MemoryBackends
+  readonly writeBackend: AgentmemoryWriteBackend
+  readonly config?: Partial<OrchestratorConfig>
+}
+
+/**
+ * Output from runMetaGovernor(). Contains all intermediate results
+ * so the caller can log, inject messages, or escalate.
+ */
+export interface MetaGovernorOutput {
+  readonly memoryRead: MemoryRead
+  readonly tokenPrediction: TokenPredictorOutput
+  readonly scoringResult: ScoringResult
+  readonly decision: DecisionHandlerOutput
+  readonly lessonSaved: LearnFromOutcomeOutput | null
+  readonly decisionHistory: readonly DecisionHistoryEntry[]
+  readonly skipped: boolean
+  readonly skipReason?: string
+}


### PR DESCRIPTION
## Summary

PR 4 of v2 series. Builds on PR 1 (types, #5206).

Adds `token-predictor.ts` — computes token burn rate from recent turns and recommends preemptive actions.

## What's in this PR

- `packages/omo-opencode/src/features/meta-governor/token-predictor.ts` — 162 LOC
- `packages/omo-opencode/src/features/meta-governor/token-predictor.test.ts` — 19 test scenarios
- `packages/omo-opencode/src/features/meta-governor/index.ts` — barrel updated

**+376 LOC across 3 files, 0 deletions.**

## Design

- Pure function, no side effects
- Burn rate in tokens/sec from recent turn history
- Predicts overflow time from trajectory
- Recommendations: `compact-now` | `switch-model` | `delegate-to-subagent` | `no-action`
- Configurable thresholds via `TokenPredictorConfig`
- Safe with missing/empty data

## Tests

```
bun test src/features/meta-governor/
  44 pass, 0 fail, 77 expect() calls
```

(25 from PR 1 types + 19 new for token-predictor)

Refs: #5116, #5206

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MetaGovernor token predictor that estimates token burn from recent turns and recommends preemptive actions to avoid context overflow. Exposes pure, configurable APIs and updates the barrel for easy import.

- New Features
  - Added `packages/omo-opencode/src/features/meta-governor/token-predictor.ts`: pure function that computes avg tokens/turn over a sliding window, predicts overflow ETA, and returns one of: `compact-now` | `switch-model` | `delegate-to-subagent` | `no-action`.
  - Configurable thresholds via `TokenPredictorConfig`; safe with empty/missing data; respects `windowSize`.
  - Barrel export in `packages/omo-opencode/src/features/meta-governor/index.ts`: `predict`, `defaultTokenPredictorConfig`, `calculateBurnRate`.
  - 19 tests in `token-predictor.test.ts` covering normal usage, high usage, consecutive high-burn delegation, window limiting, and overflow prediction.

<sup>Written for commit 39b548e13b5d61be56b7a08bf3d9542227894459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

