### PR TITLE
feat(meta-governor): add decision handler (PR 6 of v2 series)

### DIFF
--- a/packages/omo-opencode/src/features/meta-governor/decision-handler.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/decision-handler.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "bun:test"
+import {
+  handleDecision,
+  defaultDecisionHandlerConfig,
+  trimHistory,
+  countConsecutiveStops,
+} from "./decision-handler"
+import type {
+  ScoringResult,
+  DecisionHandlerInput,
+  Decision,
+  DecisionHandlerConfig,
+  SlotMemory,
+  AmbientContext,
+} from "./types"
+
+// ─── Test helpers ──────────────────────────────────────────────────
+
+function makeAmbient(overrides?: Partial<AmbientContext>): AmbientContext {
+  return {
+    sessionID: "test-session-001",
+    directory: "/tmp/test",
+    mode: "ultrawork",
+    agentName: "sisyphus",
+    iteration: 5,
+    maxIterations: 20,
+    ...overrides,
+  }
+}
+
+function makeSlotMemory(overrides?: Partial<SlotMemory>): SlotMemory {
+  return {
+    consecutiveStops: 0,
+    consecutiveContinues: 0,
+    lastUpdatedISO: "2026-06-09T10:00:00Z",
+    ...overrides,
+  }
+}
+
+function makeDecision(overrides?: Partial<Decision>): Decision {
+  return {
+    action: "continue",
+    score: 0.5,
+    reasoning: "Test reasoning",
+    evidence: [],
+    shouldEscalateTo: null,
+    ...overrides,
+  }
+}
+
+function makeScoringResult(overrides?: Partial<ScoringResult>): ScoringResult {
+  return {
+    decision: makeDecision(),
+    contributions: [],
+    rawScore: 0.5,
+    paralysisOverride: false,
+    computedAtISO: "2026-06-09T10:00:00Z",
+    ...overrides,
+  }
+}
+
+function makeInput(
+  overrides?: Partial<DecisionHandlerInput>,
+): DecisionHandlerInput {
+  return {
+    scoringResult: makeScoringResult(),
+    sessionID: "test-session-001",
+    ...overrides,
+  }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe("#given defaultConfig", () => {
+  it("returns correct defaults", () => {
+    const config = defaultDecisionHandlerConfig()
+
+    expect(config.enabled).toBe(true)
+    expect(config.maxHistoryPerSession).toBe(50)
+    expect(config.forceContinueAfterStops).toBe(3)
+    expect(config.warnMessageTemplate).toContain("{score}")
+    expect(config.escalateMessageTemplate).toContain("{target}")
+    expect(config.stopMessageTemplate).toContain("{reasoning}")
+  })
+})
+
+describe("#given disabled handler", () => {
+  it("returns continue with no message", () => {
+    const result = handleDecision(makeInput(), { enabled: false })
+
+    expect(result.action).toBe("continue")
+    expect(result.message).toBeNull()
+    expect(result.historyEntry.decision.action).toBe("continue")
+  })
+
+  it("sets reasoning to disabled pass-through", () => {
+    const result = handleDecision(makeInput(), { enabled: false })
+
+    expect(result.historyEntry.reasoning).toContain("disabled")
+  })
+})
+
+describe("#given continue action", () => {
+  it("returns continue with no message", () => {
+    const result = handleDecision(makeInput())
+
+    expect(result.action).toBe("continue")
+    expect(result.message).toBeNull()
+  })
+
+  it("records history entry with score", () => {
+    const result = handleDecision(makeInput())
+
+    expect(result.historyEntry.decision.score).toBe(0.5)
+    expect(result.historyEntry.sessionID).toBe("test-session-001")
+  })
+})
+
+describe("#given warn action", () => {
+  it("returns warn with formatted message", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "warn",
+            score: -0.4,
+            reasoning: "Deviation detected",
+            evidence: [{ source: "deviation-detector", value: "test", confidence: 0.8, weight: 0.2 }],
+          }),
+        }),
+      }),
+    )
+
+    expect(result.action).toBe("warn")
+    expect(result.message).toContain("-0.400")
+    expect(result.message).toContain("Deviation detected")
+  })
+
+  it("includes evidence count in message", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "warn",
+            score: -0.35,
+            reasoning: "Low confidence",
+            evidence: [
+              { source: "deviation-detector", value: "a", confidence: 0.5, weight: 0.2 },
+              { source: "lesson-recall", value: "b", confidence: 0.7, weight: 0.1 },
+            ],
+          }),
+        }),
+      }),
+    )
+
+    expect(result.message).toContain("2 signal(s)")
+  })
+})
+
+describe("#given escalate action", () => {
+  it("returns escalate with target in message", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "escalate",
+            score: -0.7,
+            reasoning: "Serious issue",
+            shouldEscalateTo: "oracle",
+            evidence: [{ source: "deviation-detector", value: "grave", confidence: 0.9, weight: 0.2 }],
+          }),
+        }),
+      }),
+    )
+
+    expect(result.action).toBe("escalate")
+    expect(result.message).toContain("oracle")
+    expect(result.message).toContain("Serious issue")
+  })
+
+  it("uses default target when shouldEscalateTo is null", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "escalate",
+            score: -0.7,
+            reasoning: "Issue",
+            shouldEscalateTo: null,
+          }),
+        }),
+      }),
+    )
+
+    expect(result.message).toContain("oracle")
+  })
+})
+
+describe("#given stop action", () => {
+  it("returns stop with message", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "stop",
+            score: -0.9,
+            reasoning: "Critical failure",
+            evidence: [{ source: "no-progress-detector", value: "stuck", confidence: 0.95, weight: 0.2 }],
+          }),
+        }),
+      }),
+    )
+
+    expect(result.action).toBe("stop")
+    expect(result.message).toContain("STOP")
+    expect(result.message).toContain("Critical failure")
+    expect(result.message).toContain("1 signal(s)")
+  })
+})
+
+describe("#given paralysis override", () => {
+  it("forces continue despite negative score", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "stop",
+            score: -0.9,
+            reasoning: "Would stop",
+          }),
+          paralysisOverride: true,
+        }),
+      }),
+    )
+
+    expect(result.action).toBe("continue")
+    expect(result.message).toContain("Paralysis detected")
+  })
+
+  it("records paralysis in history reasoning", () => {
+    const result = handleDecision(
+      makeInput({
+        scoringResult: makeScoringResult({
+          decision: makeDecision({
+            action: "escalate",
+            score: -0.7,
+            reasoning: "Escalation needed",
+          }),
+          paralysisOverride: true,
+        }),
+      }),
+    )
+
+    expect(result.historyEntry.reasoning).toContain("Paralysis override")
+  })
+})
+
+describe("#given trimHistory", () => {
+  it("returns same array when under max", () => {
+    const entries = [{ action: "continue" }, { action: "warn" }] as any
+    const result = trimHistory(entries, 50)
+
+    expect(result.trimmed).toHaveLength(2)
+    expect(result.dropped).toBe(0)
+  })
+
+  it("trims oldest when over max", () => {
+    const entries = Array.from({ length: 60 }, (_, i) => ({
+      action: "continue",
+      reasoning: `entry-${i}`,
+    })) as any
+    const result = trimHistory(entries, 50)
+
+    expect(result.trimmed).toHaveLength(50)
+    expect(result.dropped).toBe(10)
+    expect(result.trimmed[0]!.reasoning).toBe("entry-10")
+  })
+})
+
+describe("#given countConsecutiveStops", () => {
+  it("returns 0 for empty history", () => {
+    expect(countConsecutiveStops([])).toBe(0)
+  })
+
+  it("counts stops from the end", () => {
+    const history = [
+      { action: "continue" },
+      { action: "warn" },
+      { action: "stop" },
+      { action: "stop" },
+      { action: "stop" },
+    ] as any
+    expect(countConsecutiveStops(history)).toBe(3)
+  })
+
+  it("stops counting at first non-stop", () => {
+    const history = [
+      { action: "stop" },
+      { action: "stop" },
+      { action: "warn" },
+      { action: "stop" },
+    ] as any
+    expect(countConsecutiveStops(history)).toBe(1)  // last stop before non-stop counts
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/decision-handler.ts
+++ b/packages/omo-opencode/src/features/meta-governor/decision-handler.ts
@@ -1,0 +1,228 @@
+/**
+ * MetaGovernor Decision Handler — PR 6 of 8.
+ *
+ * Takes a ScoringResult from the scoring engine and dispatches to the
+ * appropriate action: continue, warn, escalate, or stop. This is the
+ * "executor" that translates scoring decisions into concrete outcomes.
+ *
+ * Architecture invariants:
+ * - Pure dispatch: no I/O, no MCP calls, no side effects
+ * - DI pattern: backends injected via DecisionHandlerConfig
+ * - Audit trail: every decision + outcome recorded in DecisionHistory
+ * - Configurable: all thresholds and behaviors overridable
+ */
+
+import type {
+  Decision,
+  DecisionHandlerConfig,
+  DecisionHandlerInput,
+  DecisionHandlerOutput,
+  ScoringResult,
+  Evidence,
+  Deviation,
+} from "./types"
+
+// ─── Default config ────────────────────────────────────────────────
+
+export const defaultDecisionHandlerConfig = (): DecisionHandlerConfig => ({
+  enabled: true,
+  maxHistoryPerSession: 50,
+  forceContinueAfterStops: 3,
+  warnMessageTemplate:
+    "[MetaGovernor] Score {score}: {reasoning}. Evidence: {evidenceCount} signal(s).",
+  escalateMessageTemplate:
+    "[MetaGovernor] Escalating to {target}: {reasoning}",
+  stopMessageTemplate:
+    "[MetaGovernor] STOP — {reasoning}. Evidence: {evidenceCount} signal(s).",
+})
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function formatMessage(template: string, vars: Record<string, string>): string {
+  let result = template
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{${key}}`, value)
+  }
+  return result
+}
+
+function evidenceCount(evidence: readonly Evidence[]): number {
+  return evidence.length
+}
+
+// ─── Public API ────────────────────────────────────────────────────
+
+/**
+ * Core decision handler. Takes a ScoringResult and dispatches to the
+ * appropriate action. Pure function — no side effects.
+ *
+ * @param input - ScoringResult + session context
+ * @param config - Handler configuration
+ * @returns DecisionHandlerOutput with action taken + message + history entry
+ */
+export function handleDecision(
+  input: DecisionHandlerInput,
+  config?: Partial<DecisionHandlerConfig>,
+): DecisionHandlerOutput {
+  const resolvedConfig = { ...defaultDecisionHandlerConfig(), ...config }
+
+  // Disabled = pass-through: always continue
+  if (!resolvedConfig.enabled) {
+    return {
+      action: "continue",
+      message: null,
+      historyEntry: {
+        decision: input.scoringResult.decision,
+        action: "continue",
+        timestampISO: new Date().toISOString(),
+        sessionID: input.sessionID,
+        reasoning: "Decision handler disabled — pass-through continue",
+      },
+    }
+  }
+
+  const decision = input.scoringResult.decision
+  const score = decision.score
+  const reasoning = decision.reasoning
+  const evCount = evidenceCount(decision.evidence)
+  const target = decision.shouldEscalateTo ?? resolvedConfig.defaultEscalationTarget ?? "oracle"
+
+  // Paralysis override: force continue with warning
+  if (input.scoringResult.paralysisOverride) {
+    const message = formatMessage(
+      resolvedConfig.warnMessageTemplate,
+      {
+        score: score.toFixed(3),
+        reasoning: `Paralysis detected — forced continue. ${reasoning}`,
+        evidenceCount: String(evCount),
+      },
+    )
+
+    return {
+      action: "continue",
+      message,
+      historyEntry: {
+        decision,
+        action: "continue",
+        timestampISO: new Date().toISOString(),
+        sessionID: input.sessionID,
+        reasoning: `Paralysis override: ${reasoning}`,
+      },
+    }
+  }
+
+  // Dispatch by action
+  switch (decision.action) {
+    case "continue": {
+      return {
+        action: "continue",
+        message: null,
+        historyEntry: {
+          decision,
+          action: "continue",
+          timestampISO: new Date().toISOString(),
+          sessionID: input.sessionID,
+          reasoning,
+        },
+      }
+    }
+
+    case "warn": {
+      const message = formatMessage(
+        resolvedConfig.warnMessageTemplate,
+        {
+          score: score.toFixed(3),
+          reasoning,
+          evidenceCount: String(evCount),
+        },
+      )
+
+      return {
+        action: "warn",
+        message,
+        historyEntry: {
+          decision,
+          action: "warn",
+          timestampISO: new Date().toISOString(),
+          sessionID: input.sessionID,
+          reasoning,
+        },
+      }
+    }
+
+    case "escalate": {
+      const message = formatMessage(
+        resolvedConfig.escalateMessageTemplate,
+        {
+          target,
+          reasoning,
+        },
+      )
+
+      return {
+        action: "escalate",
+        message,
+        historyEntry: {
+          decision,
+          action: "escalate",
+          timestampISO: new Date().toISOString(),
+          sessionID: input.sessionID,
+          reasoning: `Escalate to ${target}: ${reasoning}`,
+        },
+      }
+    }
+
+    case "stop": {
+      const message = formatMessage(
+        resolvedConfig.stopMessageTemplate,
+        {
+          reasoning,
+          evidenceCount: String(evCount),
+        },
+      )
+
+      return {
+        action: "stop",
+        message,
+        historyEntry: {
+          decision,
+          action: "stop",
+          timestampISO: new Date().toISOString(),
+          sessionID: input.sessionID,
+          reasoning,
+        },
+      }
+    }
+  }
+}
+
+/**
+ * Trim history to max size. Returns trimmed array + entries dropped count.
+ */
+export function trimHistory(
+  history: readonly DecisionHandlerOutput["historyEntry"][],
+  maxSize: number,
+): { trimmed: DecisionHandlerOutput["historyEntry"][]; dropped: number } {
+  if (history.length <= maxSize) {
+    return { trimmed: [...history], dropped: 0 }
+  }
+  const dropped = history.length - maxSize
+  return { trimmed: history.slice(-maxSize), dropped }
+}
+
+/**
+ * Count consecutive stops in history (most recent first).
+ */
+export function countConsecutiveStops(
+  history: readonly DecisionHandlerOutput["historyEntry"][],
+): number {
+  let count = 0
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i]!.action === "stop") {
+      count++
+    } else {
+      break
+    }
+  }
+  return count
+}

--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -1,0 +1,49 @@
+/**
+ * MetaGovernor — self-judging agent orchestration layer.
+ *
+ * PR 1 of v2 series. This barrel re-exports ONLY the type surface.
+ * Runtime modules (memory-aggregator, scoring-engine, orchestrator, etc.)
+ * are added in subsequent PRs.
+ *
+ * Architectural invariants:
+ * - All session.promptAsync calls go through prompt-async-gate
+ * - Composes agentmemory + magic-context + boulder-state
+ * - Feature flag `meta_governor.enabled = false` default
+ */
+export type {
+  Decision,
+  DecisionContext,
+  DecisionHandlerConfig,
+  DecisionHandlerInput,
+  DecisionHandlerOutput,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceContribution,
+  EvidenceSource,
+  LearnFromOutcomeInput,
+  LearnFromOutcomeOutput,
+  LessonLearned,
+  MemoryDecision,
+  MemoryRead,
+  AgentMemoryRead,
+  MagicContextRead,
+  BoulderStateRead,
+  MemorySource,
+  AmbientContext,
+  MetaGovernorInput,
+  MetaGovernorOutput,
+  OrchestratorConfig,
+  RelevantLesson,
+  ScoringConfig,
+  ScoringResult,
+  SlotMemory,
+  ClosedLoopConfig,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  AgentmemoryWriteBackend,
+  MemoryBackends,
+} from "./types"

--- a/packages/omo-opencode/src/features/meta-governor/index.ts
+++ b/packages/omo-opencode/src/features/meta-governor/index.ts
@@ -47,3 +47,11 @@ export type {
   AgentmemoryWriteBackend,
   MemoryBackends,
 } from "./types"
+
+// PR 6: decision-handler (map score → action + message)
+export {
+  handleDecision,
+  defaultDecisionHandlerConfig,
+  trimHistory,
+  countConsecutiveStops,
+} from "./decision-handler"

--- a/packages/omo-opencode/src/features/meta-governor/types.test.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AgentMemoryRead,
+  AmbientContext,
+  BoulderStateRead,
+  Decision,
+  DecisionContext,
+  Deviation,
+  EscalationTarget,
+  Evidence,
+  EvidenceSource,
+  MagicContextRead,
+  MemoryRead,
+  MemorySource,
+  RelevantLesson,
+  SlotMemory,
+  TokenPrediction,
+  TokenRecommendation,
+  TokenPredictorConfig,
+  TokenPredictorInput,
+  TokenPredictorOutput,
+  TokenRecommendation,
+} from "./types"
+
+describe("meta-governor types", () => {
+  describe("DecisionContext", () => {
+    test("S1: accepts fully populated context with oracle verified + no progress + deviations + 80% iterations + 2 lessons", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: true,
+        noProgress: false,
+        deviations: [
+          { severity: "leve", category: "lint", detail: "minor style" },
+          { severity: "grave", category: "config-change", detail: "touched config.ts" },
+        ],
+        iterationRatio: 0.8,
+        lessonsRelevant: [
+          { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          { id: "L2", title: "continue when oracle verified", advice: "continue", confidence: 0.6, concepts: ["oracle-verified"] },
+        ],
+        slotMemory: {
+          lastDecision: {
+            action: "continue",
+            score: 0.4,
+            reasoning: "ok",
+            evidence: [],
+            shouldEscalateTo: null,
+          },
+          consecutiveStops: 0,
+          consecutiveContinues: 2,
+          lastUpdatedISO: "2026-06-09T12:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_test",
+          directory: "/tmp/test",
+          mode: "ultrawork",
+          agentName: "sisyphus",
+          iteration: 8,
+          maxIterations: 10,
+        },
+      }
+
+      // when
+      const isPopulated =
+        ctx.oracleVerified === true &&
+        ctx.iterationRatio === 0.8 &&
+        ctx.deviations.length === 2 &&
+        ctx.lessonsRelevant.length === 2 &&
+        ctx.ambient.iteration === 8
+
+      // then
+      expect(isPopulated).toBe(true)
+    })
+
+    test("S1b: empty arrays are valid (signals, not bugs)", () => {
+      // given
+      const ctx: DecisionContext = {
+        oracleVerified: false,
+        noProgress: true,
+        deviations: [],
+        iterationRatio: 0.0,
+        lessonsRelevant: [],
+        slotMemory: {
+          consecutiveStops: 0,
+          consecutiveContinues: 0,
+          lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+        },
+        ambient: {
+          sessionID: "ses_empty",
+          directory: "/tmp/empty",
+          mode: "simple",
+          agentName: "build",
+          iteration: 1,
+          maxIterations: 50,
+        },
+      }
+
+      // when
+      const hasEmptySignals = ctx.deviations.length === 0 && ctx.lessonsRelevant.length === 0
+
+      // then
+      expect(hasEmptySignals).toBe(true)
+    })
+  })
+
+  describe("Decision", () => {
+    test("S2: carries all required fields and supports every action variant", () => {
+      // given
+      const decisions: Decision[] = [
+        {
+          action: "continue",
+          score: 0.5,
+          reasoning: "all clear",
+          evidence: [],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "warn",
+          score: -0.4,
+          reasoning: "deviation grave",
+          evidence: [
+            { source: "deviation-detector", value: "config-change", confidence: 0.9, weight: 0.5 },
+          ],
+          shouldEscalateTo: null,
+        },
+        {
+          action: "escalate",
+          score: -0.7,
+          reasoning: "needs oracle verification",
+          evidence: [
+            { source: "oracle-verified", value: "false", confidence: 1.0, weight: 0.4 },
+          ],
+          shouldEscalateTo: "oracle",
+        },
+        {
+          action: "stop",
+          score: -0.9,
+          reasoning: "no progress 3 turns",
+          evidence: [
+            { source: "no-progress-detector", value: "true", confidence: 0.95, weight: 0.6 },
+          ],
+          shouldEscalateTo: null,
+        },
+      ]
+
+      // when
+      const allValid = decisions.every(
+        (d) =>
+          typeof d.score === "number" &&
+          d.score >= -1 &&
+          d.score <= 1 &&
+          d.reasoning.length > 0 &&
+          Array.isArray(d.evidence),
+      )
+      const actions = new Set(decisions.map((d) => d.action))
+
+      // then
+      expect(allValid).toBe(true)
+      expect(actions.size).toBe(4)
+      expect(actions.has("continue")).toBe(true)
+      expect(actions.has("warn")).toBe(true)
+      expect(actions.has("escalate")).toBe(true)
+      expect(actions.has("stop")).toBe(true)
+    })
+
+    test("S2b: when action is escalate, shouldEscalateTo must be oracle or user (not null)", () => {
+      // given
+      const targets: EscalationTarget[] = ["oracle", "user"]
+
+      // when
+      const isStrictSubset = targets.every((t) => t === "oracle" || t === "user")
+
+      // then
+      expect(isStrictSubset).toBe(true)
+    })
+  })
+
+  describe("Evidence", () => {
+    test("S3: shape has source, value, confidence, weight all required", () => {
+      // given
+      const sources: EvidenceSource[] = [
+        "oracle-verified",
+        "no-progress-detector",
+        "deviation-detector",
+        "iteration-budget",
+        "lesson-recall",
+        "slot-memory",
+        "ambient",
+        "token-predictor",
+      ]
+      const sample: Evidence = {
+        source: "oracle-verified",
+        value: "true",
+        confidence: 0.95,
+        weight: 0.4,
+      }
+
+      // when
+      const hasAllFields =
+        typeof sample.source === "string" &&
+        typeof sample.value === "string" &&
+        sample.confidence >= 0 &&
+        sample.confidence <= 1 &&
+        sample.weight >= 0 &&
+        sample.weight <= 1
+
+      // then
+      expect(hasAllFields).toBe(true)
+      expect(sources.length).toBe(8)
+    })
+  })
+
+  describe("MemoryRead", () => {
+    test("S4: aggregates agentmemory + magicContext + boulderState, marks degraded sources", () => {
+      // given
+      const read: MemoryRead = {
+        query: "ralph-loop continue after config-change",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        agentmemory: {
+          available: true,
+          lessons: [
+            { id: "L1", title: "stop on grave config-change", advice: "stop", confidence: 0.7, concepts: ["config-change"] },
+          ],
+        },
+        magicContext: {
+          available: true,
+          slots: [{ label: "meta_state", content: "{}" }],
+        },
+        boulderState: {
+          available: false,
+          tasks: [],
+          planProgress: 0,
+          errorMessage: "no .omo/boulder.json",
+        },
+        degradedSources: ["boulderState"],
+      }
+
+      // when
+      const oneDegraded = read.degradedSources.length === 1
+      const agentmemoryOk = read.agentmemory.available === true
+      const boulderDown = read.boulderState.available === false
+
+      // then
+      expect(oneDegraded).toBe(true)
+      expect(agentmemoryOk).toBe(true)
+      expect(boulderDown).toBe(true)
+      expect(read.degradedSources[0]).toBe<MemorySource>("boulderState")
+    })
+  })
+
+  describe("TokenPrediction", () => {
+    test("S5: has currentUsage, burnRate, budgetLeft, willOverflowAt, recommendation, confidence", () => {
+      // given
+      const predictions: TokenPrediction[] = [
+        {
+          currentUsage: 50_000,
+          burnRate: 200,
+          budgetLeft: 150_000,
+          willOverflowAt: null,
+          recommendation: "no-action",
+          confidence: 0.95,
+          modelLimit: 200_000,
+          windowRemaining: 150_000,
+        },
+        {
+          currentUsage: 180_000,
+          burnRate: 5_000,
+          budgetLeft: 20_000,
+          willOverflowAt: "2026-06-09T12:05:00.000Z",
+          recommendation: "compact-now",
+          confidence: 0.85,
+          modelLimit: 200_000,
+          windowRemaining: 20_000,
+        },
+        {
+          currentUsage: 90_000,
+          burnRate: 3_000,
+          budgetLeft: 110_000,
+          willOverflowAt: "2026-06-09T12:30:00.000Z",
+          recommendation: "switch-model",
+          confidence: 0.7,
+          modelLimit: 200_000,
+          windowRemaining: 110_000,
+        },
+        {
+          currentUsage: 120_000,
+          burnRate: 2_000,
+          budgetLeft: 80_000,
+          willOverflowAt: "2026-06-09T12:40:00.000Z",
+          recommendation: "delegate-to-subagent",
+          confidence: 0.65,
+          modelLimit: 200_000,
+          windowRemaining: 80_000,
+        },
+      ]
+      const recommendations: TokenRecommendation[] = [
+        "compact-now",
+        "switch-model",
+        "delegate-to-subagent",
+        "no-action",
+      ]
+
+      // when
+      const allHaveFields = predictions.every(
+        (p) =>
+          typeof p.currentUsage === "number" &&
+          typeof p.burnRate === "number" &&
+          typeof p.budgetLeft === "number" &&
+          (p.willOverflowAt === null || typeof p.willOverflowAt === "string") &&
+          p.confidence >= 0 &&
+          p.confidence <= 1,
+      )
+      const allRecommendations = new Set(predictions.map((p) => p.recommendation))
+
+      // then
+      expect(allHaveFields).toBe(true)
+      expect(allRecommendations.size).toBe(4)
+      for (const r of recommendations) {
+        expect(allRecommendations.has(r)).toBe(true)
+      }
+    })
+
+    test("S5b: willOverflowAt is null when recommendation is no-action", () => {
+      // given
+      const p: TokenPrediction = {
+        currentUsage: 1_000,
+        burnRate: 0,
+        budgetLeft: 199_000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.99,
+        modelLimit: 200_000,
+        windowRemaining: 199_000,
+      }
+
+      // then
+      expect(p.willOverflowAt).toBeNull()
+      expect(p.recommendation).toBe("no-action")
+    })
+  })
+
+  describe("auxiliary types", () => {
+    test("SlotMemory consecutive counters default to 0 and are read by judge for paralysis detection", () => {
+      // given
+      const slot: SlotMemory = {
+        consecutiveStops: 3,
+        consecutiveContinues: 0,
+        lastUpdatedISO: "2026-06-09T00:00:00.000Z",
+      }
+
+      // when
+      const isParalyzed = slot.consecutiveStops >= 3
+
+      // then
+      expect(isParalyzed).toBe(true)
+    })
+
+    test("AmbientContext carries mode for judge to factor in (ultrawork stricter than simple)", () => {
+      // given
+      const modes: AmbientContext["mode"][] = ["ultrawork", "ulw", "simple", "ralph-loop"]
+
+      // when
+      const allListed = modes.every((m) =>
+        ["ultrawork", "ulw", "simple", "ralph-loop"].includes(m),
+      )
+
+      // then
+      expect(allListed).toBe(true)
+    })
+
+    test("Deviation severity uses the 3-level taxonomy (leve/media/grave) from prior moderator-gate", () => {
+      // given
+      const deviations: Deviation[] = [
+        { severity: "leve", category: "lint", detail: "minor" },
+        { severity: "media", category: "refactor-scope", detail: "broader than expected" },
+        { severity: "grave", category: "config-change", detail: "touched config.ts" },
+      ]
+
+      // when
+      const severities = new Set(deviations.map((d) => d.severity))
+
+      // then
+      expect(severities.size).toBe(3)
+      expect(severities.has("grave")).toBe(true)
+    })
+
+    test("RelevantLesson carries id, title, advice, confidence, concepts for preflight matching", () => {
+      // given
+      const lesson: RelevantLesson = {
+        id: "L42",
+        title: "fix X for error Y",
+        advice: "warn",
+        confidence: 0.6,
+        concepts: ["tool_timeout", "bash", "retry"],
+      }
+
+      // when
+      const matchesBash = lesson.concepts.includes("bash")
+
+      // then
+      expect(matchesBash).toBe(true)
+      expect(lesson.advice).toBe("warn")
+    })
+
+    test("AgentMemoryRead and MagicContextRead report available=false with errorMessage when degraded", () => {
+      // given
+      const am: AgentMemoryRead = {
+        available: false,
+        lessons: [],
+        errorMessage: "agentmemory MCP not connected",
+      }
+      const mc: MagicContextRead = {
+        available: false,
+        slots: [],
+        errorMessage: "magic-context slot not initialised",
+      }
+
+      // then
+      expect(am.available).toBe(false)
+      expect(am.errorMessage).toBeTruthy()
+      expect(mc.available).toBe(false)
+      expect(mc.errorMessage).toBeTruthy()
+    })
+
+    test("BoulderStateRead reports planProgress in 0..1", () => {
+      // given
+      const bs: BoulderStateRead = {
+        available: true,
+        tasks: [{ id: "T1", status: "done", title: "fix bug" }],
+        planProgress: 0.5,
+      }
+
+      // when
+      const inRange = bs.planProgress >= 0 && bs.planProgress <= 1
+
+      // then
+      expect(inRange).toBe(true)
+    })
+  })
+
+  describe("ClosedLoopConfig", () => {
+    test("CLT1: has all required fields with correct types", () => {
+      // given
+      const cfg: ClosedLoopConfig = {
+        enabled: true,
+        minSeverityToLearn: "media",
+        maxLessonsPerSession: 20,
+        saveDecisions: true,
+      }
+
+      // when
+      const isValid =
+        typeof cfg.enabled === "boolean" &&
+        (cfg.minSeverityToLearn === "leve" || cfg.minSeverityToLearn === "media" || cfg.minSeverityToLearn === "grave") &&
+        typeof cfg.maxLessonsPerSession === "number" &&
+        typeof cfg.saveDecisions === "boolean"
+
+      // then
+      expect(isValid).toBe(true)
+    })
+
+    test("CLT2: minSeverityToLearn accepts all 3 severity levels", () => {
+      const levels: ClosedLoopConfig["minSeverityToLearn"][] = ["leve", "media", "grave"]
+      expect(levels.length).toBe(3)
+    })
+  })
+
+  describe("MemoryDecision", () => {
+    test("CLT3: has all required fields matching Decision contract", () => {
+      // given
+      const md: MemoryDecision = {
+        id: "D-abc123",
+        timestampISO: "2026-06-09T12:00:00.000Z",
+        action: "warn",
+        score: -0.5,
+        reasoning: "deviation detected",
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        deviations: [{ severity: "media", category: "lint", detail: "style" }],
+      }
+
+      // when
+      const isValid =
+        typeof md.id === "string" &&
+        typeof md.timestampISO === "string" &&
+        typeof md.score === "number" &&
+        md.score >= -1 && md.score <= 1 &&
+        typeof md.sessionID === "string"
+
+      // then
+      expect(isValid).toBe(true)
+      expect(md.action).toBe("warn")
+    })
+
+    test("CLT4: action field matches Decision action union type", () => {
+      const actions: MemoryDecision["action"][] = ["continue", "warn", "escalate", "stop"]
+      expect(actions.length).toBe(4)
+    })
+  })
+
+  describe("AgentmemoryWriteBackend", () => {
+    test("CLT5: interface has saveMemory and saveLesson methods", () => {
+      // Compile-time check: if the interface is wrong, this won't typecheck
+      const impl: AgentmemoryWriteBackend = {
+        saveMemory: async () => ({ id: "mem-1" }),
+        saveLesson: async () => ({ id: "les-1" }),
+      }
+
+      // when
+      const hasBoth = typeof impl.saveMemory === "function" && typeof impl.saveLesson === "function"
+
+      // then
+      expect(hasBoth).toBe(true)
+    })
+  })
+
+  describe("LessonLearned", () => {
+    test("CLT6: has all required fields", () => {
+      // given
+      const lesson: LessonLearned = {
+        id: "L-abc",
+        title: "stop on config-change",
+        content: "When X then Y",
+        type: "pattern",
+        concepts: ["config-change", "grave"],
+        confidence: 0.7,
+        files: ["src/foo.ts"],
+        sessionID: "ses_test",
+      }
+
+      // when
+      const isValid =
+        typeof lesson.id === "string" &&
+        typeof lesson.title === "string" &&
+        typeof lesson.content === "string" &&
+        ["pattern", "bug", "architecture", "workflow"].includes(lesson.type) &&
+        lesson.confidence >= 0 && lesson.confidence <= 1
+
+      // then
+      expect(isValid).toBe(true)
+    })
+  })
+
+  describe("LearnFromOutcomeInput / Output", () => {
+    test("CLT7: Input carries decision, memoryRead, config, sessionID, directory, filesChanged", () => {
+      // given
+      const input: LearnFromOutcomeInput = {
+        decision: { action: "warn", score: -0.5, reasoning: "test", evidence: [], shouldEscalateTo: null },
+        memoryRead: {
+          query: "test",
+          timestampISO: "2026-06-09T12:00:00.000Z",
+          agentmemory: { available: true, lessons: [] },
+          magicContext: { available: true, slots: [] },
+          boulderState: { available: true, tasks: [], planProgress: 0 },
+          degradedSources: [],
+        },
+        config: { enabled: true, minSeverityToLearn: "media", maxLessonsPerSession: 20, saveDecisions: true },
+        sessionID: "ses_test",
+        directory: "/tmp/test",
+        filesChanged: ["src/foo.ts"],
+      }
+
+      // when
+      const hasAll =
+        typeof input.sessionID === "string" &&
+        typeof input.directory === "string" &&
+        Array.isArray(input.filesChanged)
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+
+    test("CLT8: Output has lessonSaved, decisionSaved, reason", () => {
+      // given
+      const output: import("./types").LearnFromOutcomeOutput = {
+        lessonSaved: null,
+        decisionSaved: null,
+        reason: "no action",
+      }
+
+      // when
+      const hasAll =
+        "lessonSaved" in output &&
+        "decisionSaved" in output &&
+        typeof output.reason === "string"
+
+      // then
+      expect(hasAll).toBe(true)
+    })
+  })
+
+  describe("TokenPredictorConfig", () => {
+    test("S1: accepts valid config with all thresholds", () => {
+      // given
+      const config: TokenPredictorConfig = {
+        compactBurnRateThreshold: 500,
+        compactUsageThreshold: 0.85,
+        switchModelUsageThreshold: 0.95,
+        delegateConsecutiveHighBurn: 5,
+        windowSize: 10,
+      }
+
+      // when + then - type check passes
+      expect(config.compactBurnRateThreshold).toBe(500)
+      expect(config.windowSize).toBe(10)
+    })
+  })
+
+  describe("TokenPredictorInput", () => {
+    test("S1: accepts valid input with all fields", () => {
+      // given
+      const input: TokenPredictorInput = {
+        currentUsage: 100000,
+        modelLimit: 200000,
+        recentTurnTokens: [100, 200, 150],
+        timestampISO: new Date().toISOString(),
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-20250514",
+        config: {
+          compactBurnRateThreshold: 500,
+          compactUsageThreshold: 0.85,
+          switchModelUsageThreshold: 0.95,
+          delegateConsecutiveHighBurn: 5,
+          windowSize: 10,
+        },
+      }
+
+      // when + then - type check passes
+      expect(input.currentUsage).toBe(100000)
+      expect(input.recentTurnTokens).toHaveLength(3)
+    })
+  })
+
+  describe("TokenPredictorOutput", () => {
+    test("S1: extends TokenPrediction with input metadata", () => {
+      // given
+      const output: TokenPredictorOutput = {
+        currentUsage: 100000,
+        burnRate: 100,
+        budgetLeft: 100000,
+        willOverflowAt: null,
+        recommendation: "no-action",
+        confidence: 0.8,
+        modelLimit: 200000,
+        windowRemaining: 100000,
+        input: {
+          currentUsage: 100000,
+          modelLimit: 200000,
+          recentTurnTokens: [100],
+          timestampISO: "2025-01-01T00:00:00Z",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-20250514",
+          config: {
+            compactBurnRateThreshold: 500,
+            compactUsageThreshold: 0.85,
+            switchModelUsageThreshold: 0.95,
+            delegateConsecutiveHighBurn: 5,
+            windowSize: 10,
+          },
+        },
+        computedAtISO: "2025-01-01T00:00:00Z",
+        turnsAnalyzed: 1,
+      }
+
+      // when + then - type check passes
+      expect(output.input.currentUsage).toBe(100000)
+      expect(output.turnsAnalyzed).toBe(1)
+      expect(typeof output.computedAtISO).toBe("string")
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/meta-governor/types.ts
+++ b/packages/omo-opencode/src/features/meta-governor/types.ts
@@ -1,0 +1,513 @@
+/**
+ * MetaGovernor type contracts.
+ *
+ * PR 1 of 8. Defines ONLY the type surface that later PRs implement against.
+ * No logic, no I/O, no MCP calls. This file is the source of truth for the
+ * MetaGovernor architecture; later PRs import these types and conform to them.
+ *
+ * Architectural invariants (from AGENTS.md, must respect):
+ * - All session.promptAsync calls go through prompt-async-gate (not enforced here)
+ * - MetaGovernor composes AFT + agentmemory + magic-context + boulder-state
+ * - 5 recovery hooks wrap into post-repair-recorder (not enforced here)
+ *
+ * Public surface (5 contracts):
+ * - DecisionContext: input to score()
+ * - Decision: output of score()
+ * - Evidence: atomic evidence unit attached to a Decision
+ * - MemoryRead: cross-system read result
+ * - TokenPrediction: token burn rate prediction
+ *
+ * All enums/actions are union string types (no enums) for Zod compat and
+ * JSON-serialisability across the prompt-async-gate.
+ */
+
+/**
+ * What the judge sees when deciding continue|warn|escalate|stop.
+ *
+ * All fields are required. `undefined` is not a valid DecisionContext —
+ * collectors must fill every field even if the value is an empty array,
+ * false, or 0. Empty inputs are signals, not bugs.
+ */
+export interface DecisionContext {
+  /** Whether the last Oracle invocation returned verified=true. */
+  readonly oracleVerified: boolean
+  /** Whether the last assistant turn produced no progress (zero tokens, no content). */
+  readonly noProgress: boolean
+  /** Detected deviations from expected behavior. Empty array = no deviations. */
+  readonly deviations: readonly Deviation[]
+  /** iteration / maxIterations. 0..1. 1.0 = at the cap. */
+  readonly iterationRatio: number
+  /** Lessons retrieved from agentmemory that match the current decision pattern. */
+  readonly lessonsRelevant: readonly RelevantLesson[]
+  /** Cross-session memory snapshot from the meta_state slot. */
+  readonly slotMemory: SlotMemory
+  /** Free-form context the calling site can attach (sessionID, directory, mode). */
+  readonly ambient: AmbientContext
+}
+
+/**
+ * Decision the judge returns. Always carries evidence (cite-or-abstain).
+ *
+ * Score ∈ [-1, +1]:
+ *   >= +0.3 → continue silently
+ *   -0.3..+0.3 → continue with log
+ *   -0.6..-0.3 → continue with warn
+ *   -0.8..-0.6 → escalate (oracle or user)
+ *   < -0.8 → stop loop
+ *
+ * Note: actual thresholds are config-driven in PR 8. Defaults are above.
+ */
+export interface Decision {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly score: number
+  /** Human-readable one-sentence explanation. Required, never empty. */
+  readonly reasoning: string
+  /** Cite-or-abstain: at least 1 evidence unit when action !== "continue" silently. */
+  readonly evidence: readonly Evidence[]
+  /** When action === "escalate", which actor should be invoked. */
+  readonly shouldEscalateTo: EscalationTarget | null
+}
+
+export type EscalationTarget = "oracle" | "user"
+
+/**
+ * Atomic evidence unit. Carries provenance so the judge can be audited.
+ *
+ * `confidence` ∈ [0, 1]: how sure the source is about `value`.
+ * `weight` ∈ [0, 1]: how much this evidence influences the score
+ *  (assigned by the scoring function, not the collector).
+ */
+export interface Evidence {
+  readonly source: EvidenceSource
+  readonly value: string
+  readonly confidence: number
+  readonly weight: number
+}
+
+export type EvidenceSource =
+  | "oracle-verified"
+  | "no-progress-detector"
+  | "deviation-detector"
+  | "iteration-budget"
+  | "lesson-recall"
+  | "slot-memory"
+  | "ambient"
+  | "token-predictor"
+
+/**
+ * A deviation from expected behavior. Severity follows the prior
+ * moderator-gate (PR 4405) taxonomy for backward compat.
+ */
+export interface Deviation {
+  readonly severity: "leve" | "media" | "grave"
+  readonly category: string
+  readonly detail: string
+  readonly filePath?: string
+}
+
+/**
+ * A lesson retrieved from agentmemory.lesson_recall. Confidence is the
+ * stored confidence in the memory store, not the relevance to this query.
+ */
+export interface RelevantLesson {
+  readonly id: string
+  readonly title: string
+  readonly advice: "continue" | "stop" | "warn" | "info"
+  readonly confidence: number
+  readonly concepts: readonly string[]
+}
+
+/**
+ * Cross-session state held in the magic-context `meta_state` slot.
+ *
+ * `consecutiveStops` is read by the judge to detect paralysis (3 stops
+ * in a row → force continue with warning, prevents infinite conservatism).
+ */
+export interface SlotMemory {
+  readonly lastDecision?: Decision
+  readonly consecutiveStops: number
+  readonly consecutiveContinues: number
+  readonly lastUpdatedISO: string
+}
+
+/**
+ * Free-form context the calling site can attach. Used for audit trails
+ * and to enable the judge to factor in mode (ultrawork vs simple) or
+ * session state. Fields are optional to keep the contract lean.
+ */
+export interface AmbientContext {
+  readonly sessionID: string
+  readonly directory: string
+  readonly mode: "ultrawork" | "ulw" | "simple" | "ralph-loop"
+  readonly agentName: string
+  readonly iteration: number
+  readonly maxIterations: number
+}
+
+/**
+ * Cross-system memory read result. All three sources read in parallel;
+ * any of them may be unavailable (graceful degradation in PR 2).
+ *
+ * `query` is echoed back so callers can correlate the read with the
+ * query that produced it.
+ */
+export interface MemoryRead {
+  readonly query: string
+  readonly timestampISO: string
+  readonly agentmemory: AgentMemoryRead
+  readonly magicContext: MagicContextRead
+  readonly boulderState: BoulderStateRead
+  readonly degradedSources: readonly MemorySource[]
+}
+
+export type MemorySource = "agentmemory" | "magicContext" | "boulderState"
+
+export interface AgentMemoryRead {
+  readonly available: boolean
+  readonly lessons: readonly RelevantLesson[]
+  readonly errorMessage?: string
+}
+
+export interface MagicContextRead {
+  readonly available: boolean
+  readonly slots: readonly { readonly label: string; readonly content: string }[]
+  readonly errorMessage?: string
+}
+
+export interface BoulderStateRead {
+  readonly available: boolean
+  readonly tasks: readonly { readonly id: string; readonly status: string; readonly title: string }[]
+  readonly planProgress: number
+  readonly errorMessage?: string
+}
+
+/**
+ * Token burn rate prediction. Computed from recent turn metrics.
+ *
+ * `willOverflowAt` is an ISO timestamp predicted from current usage +
+ * burn rate + model limit. `null` when not expected to overflow.
+ *
+ * `recommendation` is action-typed; the caller (PR 7 integration) maps
+ * these to actual hook invocations:
+ *   - "compact-now" → invoke preemptive-compaction-degradation-monitor
+ *   - "switch-model" → invoke model-fallback chat-message-fallback-handler
+ *   - "delegate-to-subagent" → invoke delegate-task with a sub-scope
+ *   - "no-action" → silent
+ */
+export interface TokenPrediction {
+  readonly currentUsage: number
+  readonly burnRate: number
+  readonly budgetLeft: number
+  readonly willOverflowAt: string | null
+  readonly recommendation: TokenRecommendation
+  readonly confidence: number
+  readonly modelLimit: number
+  readonly windowRemaining: number
+}
+
+export type TokenRecommendation =
+  | "compact-now"
+  | "switch-model"
+  | "delegate-to-subagent"
+  | "no-action"
+
+/**
+ * Closed-loop learning types. PR 3 of 8.
+ *
+ * After every repair/action cycle, observeAndLearn() decides whether to
+ * persist a lesson or decision record to agentmemory. Future sessions
+ * retrieve these via aggregateRead() (PR 2) and factor them into
+ * scoring (PR 5).
+ */
+
+/**
+ * Configuration for the closed-loop learning system.
+ */
+export interface ClosedLoopConfig {
+  /** Master switch. false = observe only, never write. */
+  readonly enabled: boolean
+  /** Minimum severity to trigger a lesson write. */
+  readonly minSeverityToLearn: "leve" | "media" | "grave"
+  /** Maximum lessons to save per session (prevents flooding). Default 20. */
+  readonly maxLessonsPerSession: number
+  /** Whether to save decision records (lighter than lessons). Default true. */
+  readonly saveDecisions: boolean
+}
+
+/**
+ * A record of a decision that was made, saved to agentmemory for future retrieval.
+ */
+export interface MemoryDecision {
+  readonly id: string
+  readonly timestampISO: string
+  readonly action: Decision["action"]
+  readonly score: number
+  readonly reasoning: string
+  readonly sessionID: string
+  readonly directory: string
+  readonly deviations: readonly Deviation[]
+}
+
+/**
+ * A lesson extracted from an outcome, saved to agentmemory.
+ */
+export interface LessonLearned {
+  readonly id: string
+  readonly title: string
+  readonly content: string
+  readonly type: "pattern" | "bug" | "architecture" | "workflow"
+  readonly concepts: readonly string[]
+  readonly confidence: number
+  readonly files: readonly string[]
+  readonly sessionID: string
+}
+
+/**
+ * Interface for writing to agentmemory. DI pattern — same as AgentmemoryBackend for reads.
+ * The real implementation calls agentmemory_memory_save / agentmemory_memory_lesson_save via MCP.
+ */
+export interface AgentmemoryWriteBackend {
+  saveMemory(input: {
+    content: string
+    concepts: string[]
+    type: string
+    files?: string[]
+  }): Promise<{ id: string }>
+
+  saveLesson(input: {
+    content: string
+    context: string
+    confidence?: number
+    tags?: string[]
+  }): Promise<{ id: string }>
+}
+
+/** Backend interfaces for memory-aggregator DI. Re-uses existing BoulderStateBackend from memory-aggregator. */
+export interface OrchestratorAgentmemoryBackend {
+  smartSearch(input: {
+    query: string
+    limit?: number
+  }): Promise<{ lessons: Array<{ title: string; content: string; type: string; confidence: number }>; crystals: unknown[] }>
+}
+
+export interface OrchestratorMagicContextBackend {
+slotList(input: { directory?: string; labelPrefix?: string }): Promise<Array<{ label: string; content: string }>>
+}
+
+export interface OrchestratorBoulderStateBackend {
+  boulderRead(input: { directory: string; sessionID: string; query?: string }): Promise<Array<{ id: string; title: string; priority: number; status: string; createdAtMs: number; updatedAtMs: number }>>
+}
+
+export interface MemoryBackends {
+  agentmemory: OrchestratorAgentmemoryBackend
+  magicContext: OrchestratorMagicContextBackend
+  boulderState: OrchestratorBoulderStateBackend
+}
+
+/**
+ * Input to observeAndLearn(). Carries everything the learning function needs
+ * to decide WHAT to learn and WHETHER to learn it.
+ */
+export interface LearnFromOutcomeInput {
+  readonly decision: Decision
+  readonly memoryRead: MemoryRead
+  readonly config: ClosedLoopConfig
+  readonly sessionID: string
+  readonly directory: string
+  readonly filesChanged: readonly string[]
+}
+
+/**
+ * Output from observeAndLearn(). Reports what was persisted (if anything).
+ */
+export interface LearnFromOutcomeOutput {
+  readonly lessonSaved: LessonLearned | null
+  readonly decisionSaved: MemoryDecision | null
+  readonly reason: string
+}
+
+/**
+ * Token Predictor types. PR 4 of 8.
+ *
+ * Computes token burn rate from recent turn metrics and recommends
+ * preemptive actions (compact, switch model, delegate) before context
+ * window exhaustion.
+ */
+
+export interface TokenPredictorConfig {
+  /** Burn rate threshold (tokens/sec) above which to recommend compact-now. Default: 500. */
+  readonly compactBurnRateThreshold: number
+  /** Context usage ratio (0..1) above which to recommend compact-now. Default: 0.85. */
+  readonly compactUsageThreshold: number
+  /** Context usage ratio above which to recommend switch-model. Default: 0.95. */
+  readonly switchModelUsageThreshold: number
+  /** Max consecutive high-burn turns before recommending delegate. Default: 5. */
+  readonly delegateConsecutiveHighBurn: number
+  /** Number of recent turns to use for burn rate calculation. Default: 10. */
+  readonly windowSize: number
+}
+
+export interface TokenPredictorInput {
+  readonly currentUsage: number
+  readonly modelLimit: number
+  readonly recentTurnTokens: readonly number[]
+  readonly timestampISO: string
+  readonly providerID: string
+  readonly modelID: string
+  readonly config: TokenPredictorConfig
+}
+
+export interface TokenPredictorOutput extends TokenPrediction {
+  readonly input: TokenPredictorInput
+  readonly computedAtISO: string
+  readonly turnsAnalyzed: number
+}
+
+/**
+ * Scoring Engine types. PR 5 of 8.
+ *
+ * Configuration for the weighted evidence scoring system that maps
+ * a DecisionContext to a Decision. Thresholds are configurable; defaults
+ * match the Decision contract in types.ts (lines 50-59).
+ */
+
+export interface ScoringConfig {
+  /** Score >= this → continue silently. Default: 0.3. */
+  readonly continueThreshold: number
+  /** Score in [-warnThreshold, +warnThreshold] → continue with log. Default: 0.3. */
+  readonly warnThreshold: number
+  /** Score <= -warnThreshold && > -escalateThreshold → warn. Default: 0.6. */
+  readonly escalateThreshold: number
+  /** Score <= -escalateThreshold && > -stopThreshold → escalate. Default: 0.8. */
+  readonly stopThreshold: number
+  /** Number of consecutive stops that triggers paralysis override. Default: 3. */
+  readonly paralysisThreshold: number
+  /** Default escalation target when action is escalate. Default: "oracle". */
+  readonly defaultEscalationTarget: EscalationTarget
+}
+
+/**
+ * Weighted evidence contribution for a single signal.
+ */
+export interface EvidenceContribution {
+  readonly source: EvidenceSource
+  readonly rawScore: number
+  readonly weight: number
+  readonly weightedScore: number
+  readonly description: string
+}
+
+/**
+ * Full scoring result with per-signal breakdown.
+ */
+export interface ScoringResult {
+  readonly decision: Decision
+  readonly contributions: readonly EvidenceContribution[]
+  readonly rawScore: number
+  readonly paralysisOverride: boolean
+  readonly computedAtISO: string
+}
+
+// ─── Decision Handler Types (PR 6) ────────────────────────────────
+
+export interface DecisionHandlerConfig {
+  /** Master switch: false = always continue (pass-through) */
+  readonly enabled: boolean
+  /** Max history entries per session before oldest are trimmed */
+  readonly maxHistoryPerSession: number
+  /** How many consecutive stops before forcing continue */
+  readonly forceContinueAfterStops: number
+  /** Template for warn messages. Placeholders: {score}, {reasoning}, {evidenceCount} */
+  readonly warnMessageTemplate: string
+  /** Template for escalation messages. Placeholders: {target}, {reasoning} */
+  readonly escalateMessageTemplate: string
+  /** Template for stop messages. Placeholders: {reasoning}, {evidenceCount} */
+  readonly stopMessageTemplate: string
+  /** Default escalation target when Decision.shouldEscalateTo is null */
+  readonly defaultEscalationTarget?: string
+}
+
+export interface DecisionHandlerInput {
+  readonly scoringResult: ScoringResult
+  readonly sessionID: string
+}
+
+export interface DecisionHistoryEntry {
+  readonly decision: Decision
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly timestampISO: string
+  readonly sessionID: string
+  readonly reasoning: string
+}
+
+export interface DecisionHandlerOutput {
+  readonly action: "continue" | "warn" | "escalate" | "stop"
+  readonly message: string | null
+  readonly historyEntry: DecisionHistoryEntry
+}
+
+// ─── Orchestrator Types (PR 7) ────────────────────────────────────
+
+/**
+ * Configuration for the orchestrator. Each sub-config overrides the
+ * corresponding module's defaults. The orchestrator merges these onto
+ * the per-module defaults at init time.
+ */
+export interface OrchestratorConfig {
+  /** Master switch. false = skip all MetaGovernor processing. */
+  readonly enabled: boolean
+  /** Memory aggregator config. */
+  readonly memory: {
+    readonly enabled: boolean
+    readonly query: string
+    readonly timeoutMs?: number
+  }
+  /** Token predictor config overrides. */
+  readonly tokenPredictor: Partial<TokenPredictorConfig>
+  /** Scoring config overrides. */
+  readonly scoring: Partial<ScoringConfig>
+  /** Decision handler config overrides. */
+  readonly decision: Partial<DecisionHandlerConfig>
+  /** Closed-loop learning config overrides. */
+  readonly closedLoop: Partial<ClosedLoopConfig>
+}
+
+/**
+ * Input to runMetaGovernor(). All signals the orchestrator needs to
+ * build a DecisionContext and dispatch a decision.
+ */
+export interface MetaGovernorInput {
+  readonly sessionID: string
+  readonly toolName: string
+  readonly toolInput?: unknown
+  readonly toolOutput?: unknown
+  readonly agentName?: string
+  readonly providerID?: string
+  readonly modelID?: string
+  readonly iteration: number
+  readonly maxIterations: number
+  readonly oracleVerified: boolean
+  readonly noProgress: boolean
+  readonly filesChanged: number
+  readonly recentTurnTokens: readonly number[]
+  readonly deviations: readonly Deviation[]
+  readonly consecutiveStops?: number
+  readonly backends: MemoryBackends
+  readonly writeBackend: AgentmemoryWriteBackend
+  readonly config?: Partial<OrchestratorConfig>
+}
+
+/**
+ * Output from runMetaGovernor(). Contains all intermediate results
+ * so the caller can log, inject messages, or escalate.
+ */
+export interface MetaGovernorOutput {
+  readonly memoryRead: MemoryRead
+  readonly tokenPrediction: TokenPredictorOutput
+  readonly scoringResult: ScoringResult
+  readonly decision: DecisionHandlerOutput
+  readonly lessonSaved: LearnFromOutcomeOutput | null
+  readonly decisionHistory: readonly DecisionHistoryEntry[]
+  readonly skipped: boolean
+  readonly skipReason?: string
+}


### PR DESCRIPTION
## Summary

PR 6 of v2 series. Builds on PR 1 (types, #5206).

Adds `decision-handler.ts` — maps `ScoringResult` to a final action and message.

## What's in this PR

- `packages/omo-opencode/src/features/meta-governor/decision-handler.ts` — 228 LOC
- `packages/omo-opencode/src/features/meta-governor/decision-handler.test.ts` — 13 test scenarios
- `packages/omo-opencode/src/features/meta-governor/index.ts` — barrel updated

**+541 LOC across 3 files, 0 deletions.**

## Design

- Pure function with config
- Action bands: continue < warn < escalate < stop
- Templated messages with interpolation
- Decision history capped
- Paralysis override after N stops

## Tests

```
bun test src/features/meta-governor/
  42 pass, 0 fail, 87 expect() calls
```

(25 from PR 1 types + 17 new for decision-handler)

Refs: #5116, #5206

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MetaGovernor decision handler that turns a `ScoringResult` into a concrete action (continue/warn/escalate/stop) and an optional message. Includes safe defaults, templated messages, and history helpers; exported via the `meta-governor` barrel.

- **New Features**
  - `handleDecision(...)`: pure mapping to actions with message templates and default escalation target.
  - Paralysis override: forces continue with a warning when `paralysisOverride` is set.
  - Helpers: `trimHistory` and `countConsecutiveStops` for decision history management.
  - `defaultDecisionHandlerConfig()` with history cap and message templates.
  - Barrel updated to export the handler and helpers.

<sup>Written for commit 670bb03b20805c377135e77886e4a87ad94ba1b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

