### PR TITLE
docs(contributing): add branch naming guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ First off, thanks for taking the time to contribute! This document provides guid
   - [Adding a New Tool](#adding-a-new-tool)
   - [Adding a New MCP Server](#adding-a-new-mcp-server)
 - [Pull Request Process](#pull-request-process)
+  - [Branch Naming](#branch-naming)
 - [Publishing](#publishing)
 - [Getting Help](#getting-help)
 
@@ -240,6 +241,23 @@ export function createMyHook(input: PluginInput) {
    - Reference issues if applicable ("Fix #123")
 6. **Push** to your fork and create a Pull Request
 7. **Describe** your changes clearly in the PR description
+
+### Branch Naming
+
+Use short, issue-linked branch names when possible:
+
+```text
+<type>/<issue-number>-<short-slug>
+```
+
+Good examples:
+
+- `fix/123-handle-missing-config`
+- `feat/456-add-runtime-check`
+- `docs/3103-branch-naming`
+- `chore/789-update-ci-cache`
+
+Choose a type that matches the work, such as `fix`, `feat`, `docs`, `test`, `refactor`, or `chore`. Keep the slug lowercase and descriptive enough to recognize in the branch list.
 
 ### PR Checklist
 


### PR DESCRIPTION
Refs #3103.

I added a short Branch Naming subsection to `CONTRIBUTING.md` under Pull Request Process. It documents the preferred `<type>/<issue-number>-<short-slug>` format, gives examples, and leaves enforcement out because the issue thread asked to keep this docs-only.

Validation:
- `git diff --check`
- `rg -n "Branch Naming|<type>/<issue-number>-<short-slug>|docs/3103-branch-naming" CONTRIBUTING.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Branch Naming section in CONTRIBUTING.md documenting the preferred <type>/<issue-number>-<short-slug> format with examples. Addresses #3103 by providing docs-only guidance (no enforcement).

<sup>Written for commit 358515dfecccd3e66e14b660ff79d40e1f75dec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

