### PR TITLE
docs(config): clarify project config path

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,6 +48,10 @@ User config loads first. Project configs are discovered by walking from the work
 1. Walked configs: `.opencode/oh-my-openagent.json[c]` or legacy `.opencode/oh-my-opencode.json[c]`
 2. User config (`.jsonc` preferred over `.json`):
 
+Project config files must live under `.opencode/`. A root-level
+`oh-my-openagent.json` or `oh-my-openagent.jsonc` file in the workspace
+root is not discovered.
+
 | Platform    | Path candidates |
 | ----------- | --------------- |
 | macOS/Linux | `~/.config/opencode/oh-my-openagent.json[c]`, `~/.config/opencode/oh-my-opencode.json[c]` |


### PR DESCRIPTION
Refs #3977.

I added an explicit note to the config reference that project config files must live under `.opencode/`. A workspace-root `oh-my-openagent.json` or `.jsonc` file is not discovered, which matches the current config discovery behavior described in the issue thread.

Validation:
- `rg -n "root-level|not discovered|Project config files must live under" docs/reference/configuration.md`
- `git diff --check`
- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-13-project-config-path-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the configuration reference: project config files must live under `.opencode/`, and workspace-root `oh-my-openagent.json` or `oh-my-openagent.jsonc` files are not discovered. Updates the docs to match current discovery behavior.

<sup>Written for commit d0f0e245f0dc722ec311727a4151a47d421c1bfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

