### PR TITLE
docs(install): add Windows proxy workaround

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -711,6 +711,7 @@ The Codex CLI Light edition is fully independent of the OpenCode plugin. You can
 | `Ignoring malformed agent role definition: agents.*.config_file must point to an existing file` | Re-run `npx lazycodex-ai install`. The installer repairs stale managed `[agents.*]` entries and recreates `~/.codex/agents/*.toml`. |
 | `agents.max_threads cannot be set when multi_agent_v2 is enabled` in one project | Re-run `npx lazycodex-ai install` from that project. The installer repairs project-local `.codex/config.toml` layers, creates `.backup-<timestamp>` files for changed configs, and leaves user-authored `.codex` artifacts in place. |
 | `SessionStart hook (failed)` / `UserPromptSubmit hook (failed)` with `MODULE_NOT_FOUND` for `components/*/dist/cli.js` | Re-run the installer so the cached plugin is rebuilt with component `dist/` files. If the cache was manually edited, remove `~/.codex/plugins/cache/sisyphuslabs` first. |
+| Windows behind an HTTP proxy shows only default OpenCode agents, and logs include `fetch() proxy.url must be a non-empty string` while loading `oh-my-openagent@latest` | This fails before OMO code loads. Configure npm/proxy outside OpenCode, or preinstall the plugin with system npm: `npm install oh-my-openagent@latest --prefix "%APPDATA%\\opencode"` (PowerShell/cmd). Restart OpenCode and run with logs if agents still do not appear. |
 | Hook trust hash mismatch warnings | Re-run the installer; hashes are regenerated each install |
 
 ### Step 8: Team Mode (optional, opt-in)


### PR DESCRIPTION
Refs #3303.

I added a troubleshooting row for Windows users behind an HTTP proxy when OpenCode fails before OMO loads. It includes the reported `fetch() proxy.url must be a non-empty string` log text and the system npm preinstall workaround from the issue.

Validation:
- `rg -n "fetch\(\) proxy\.url must be a non-empty string|HTTP_PROXY|npm install oh-my-openagent@latest --prefix" docs/guide/installation.md docs/reference/known-issues.md README.md`
- `git diff --check`
- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-14-windows-proxy-plugin-install-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows HTTP proxy troubleshooting entry to the install guide for cases where OpenCode shows only default agents and logs "fetch() proxy.url must be a non-empty string" while loading `oh-my-openagent@latest`. Documents a system npm preinstall (`npm install oh-my-openagent@latest --prefix "%APPDATA%\\opencode"`) and proxy setup guidance to unblock installs (addresses #3303).

<sup>Written for commit 8126bde133c6d668f3046d5f1e94068d26edfd46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

