### PR TITLE
docs(install): clarify OpenCode update path

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -139,6 +139,8 @@ bunx oh-my-openagent install
 
 The TUI walks you through it. **Do NOT use `npm install -g`, `bun add -g`, or `bun install -g`** — global installation is not officially supported. oh-my-openagent is a plugin that must resolve from where OpenCode/Codex loads plugins, and the `prepare` script requires Bun. Always invoke via `bunx`.
 
+**OpenCode update path.** `opencode plugin install` can refresh the package metadata under an OpenCode-managed `packages/` directory while the running plugin still resolves from OpenCode's runtime cache under `~/.cache/opencode/node_modules/`. If `bunx oh-my-openagent doctor` still reports the old version after an OpenCode plugin install, relaunch OpenCode once and rerun `bunx oh-my-openagent install --platform=opencode` so the plugin entry and runtime package path line up again. Use `bunx oh-my-openagent get-local-version` or `bunx oh-my-openagent doctor` to confirm the version OpenCode is loading.
+
 ## For LLM Agents
 
 > **IMPORTANT: Use `curl` to fetch this file, NOT WebFetch.** WebFetch summarizes content and loses critical flags like `--platform`, subscription questions, and Codex verification details. Always use:


### PR DESCRIPTION
Refs #3535.

I added the missing OpenCode update-path note to the install guide. It explains why `opencode plugin install` can leave `doctor` showing the old runtime copy, and points users back to the `bunx oh-my-openagent install --platform=opencode` plus `doctor`/`get-local-version` check.

No runtime behavior changed.

Validation:
- `rg -n "OpenCode update path|~/.cache/opencode/node_modules|opencode plugin install|bunx oh-my-openagent get-local-version" docs/guide/installation.md`
- `git diff --check`
- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-16-update-path-clarity-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the OpenCode update path in the install guide to explain why `opencode plugin install` can leave `doctor` reporting an old plugin and how to fix it. Instructs users to relaunch OpenCode, run `bunx oh-my-openagent install --platform=opencode`, then verify with `bunx oh-my-openagent get-local-version` or `bunx oh-my-openagent doctor`.

<sup>Written for commit 286e32fe29935d4638133df09e57f99b11da265f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

