### PR TITLE
docs(cli): warn against bunx omo

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,8 +13,10 @@ All published packages expose the same compiled CLI with these bin entries:
 
 - `oh-my-opencode` (legacy name, still primary)
 - `oh-my-openagent` (renamed primary)
-- `omo` (short alias, recommended in docs and prompts)
-- `lazycodex-ai` (Light edition shortcut; `lazycodex-ai install` is equivalent to `omo install --platform=codex` unless `--platform` is explicitly overridden)
+- `omo` (short alias after the package has already resolved to oh-my-openagent)
+- `lazycodex-ai` (Light edition shortcut; `lazycodex-ai install` is equivalent to `oh-my-openagent install --platform=codex` unless `--platform` is explicitly overridden)
+
+Do not use `bunx omo` or `npx omo` for installation. The npm name `omo` belongs to a different package, so package managers can resolve the wrong project. Use `bunx oh-my-openagent install` for Ultimate/OpenCode or `npx lazycodex-ai install` for Light/Codex.
 
 ## Basic Usage
 


### PR DESCRIPTION
Refs #4657.

I updated the CLI reference so it no longer recommends `omo` as a package-manager install target. The page now points `lazycodex-ai install` at `oh-my-openagent install --platform=codex` and warns users not to run `bunx omo` or `npx omo`, since npm can resolve a different package.

No runtime behavior changed.

Validation:
- `rg -n 'short alias, recommended|equivalent to `omo install --platform=codex`' docs/reference/cli.md` exits 1\n- `rg -n 'Do not use `bunx omo`|npm name `omo` belongs to a different package|oh-my-openagent install --platform=codex' docs/reference/cli.md`\n- `git diff --check`\n- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-17-omo-bin-warning-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CLI docs to stop recommending `omo` as an install target and warn against `bunx omo`/`npx omo` because the `omo` npm name resolves to a different package. Redirects `lazycodex-ai install` to `oh-my-openagent install --platform=codex` and clarifies `omo` is only a short alias after resolution to `oh-my-openagent` (Linear #4657).

<sup>Written for commit fdc70d7edd34ace7a8296360858b4d044710c2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

