### PR TITLE
docs(config): clarify fallback chain design

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -489,6 +489,8 @@ Resolution pipeline (from [`packages/omo-opencode/src/shared/model-resolution-pi
 5. System default    → Ultimate safety net
 ```
 
+Delegated `task` calls run through Sisyphus-Junior, but a category can still choose the effective model for that delegated worker. For example, `task({ category: "ultrabrain" })` uses the category model and category `fallback_models` before the generic Sisyphus-Junior chain. If a category is likely to hit a provider quota, configure the backup chain on that category instead of relying only on the agent-wide fallback.
+
 Core-agent tab cycling is deterministic via injected runtime order field. The fixed priority order is Sisyphus (order: 0), Hephaestus (order: 1), Prometheus (order: 2), and Atlas (order: 3), then the remaining agents follow.
 
 Your explicit configuration always wins. If you set a specific model for an agent, that choice takes precedence even when resolution data is cold.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -722,6 +722,30 @@ Define `fallback_models` per agent or category:
 }
 ```
 
+#### Designing Fallback Chains
+
+Keep each fallback chain short and mix quota families on purpose. If the primary model and every fallback route through the same subscription, quota, or proxy account, a quota-exhaustion error can still leave the session without a useful recovery path.
+
+For delegated `task` work, category config can select a different model from the base `sisyphus-junior` agent config. Put category-specific fallbacks under `categories.<name>.fallback_models` when the risk belongs to that task type. Put agent-wide fallbacks under `agents.sisyphus-junior.fallback_models` only when they are safe for every category that uses the delegated executor.
+
+Prefer one reliable backup per quota family before adding another model from the same family:
+
+```jsonc
+{
+  "agents": {
+    "sisyphus-junior": {
+      "model": "github-copilot/claude-sonnet-4.6",
+      "fallback_models": [
+        { "model": "openai/gpt-5.5", "variant": "medium" },
+        "opencode-go/minimax-m3"
+      ]
+    }
+  }
+}
+```
+
+Use `max_fallback_attempts` as a bounded safety net. It limits retries, but it does not make two exhausted models from the same subscription family independent.
+
 `fallback_models` also supports object-style entries so you can attach settings to a specific fallback model:
 
 ```json


### PR DESCRIPTION
Refs #3886.

I added guidance for safer multi-provider fallback chains: keep chains short, avoid putting every backup on the same quota family, and put category-specific fallback risk under the category config. I also clarified that delegated task calls use Sisyphus-Junior while category model settings can still choose the effective worker model.

Validation:
- `rg -n "quota family|category can still choose|same subscription family" docs/reference/configuration.md docs/guide/agent-model-matching.md`
- `git diff --check`
- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-19-fallback-config-guidance-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to design safer `fallback_models` chains: keep them short, mix different quota families, and put category-specific backups in the category config. Also explains that delegated `task` calls run through `sisyphus-junior` while categories still choose the effective model and backups, and that `max_fallback_attempts` doesn’t make same-quota models independent.

<sup>Written for commit 7d21f0c9b5b55e777617732e98099ae45cadd28e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

