### PR TITLE
docs(config): fix rename precedence note

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -55,7 +55,7 @@ User config loads first. Project configs are discovered by walking from the work
 
 **Security note:** `mcp_env_allowlist` is user-only. Walked configs cannot extend it.
 
-**Rename compatibility:** The published package and CLI binary remain `oh-my-opencode`. OpenCode plugin registration prefers `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. Config detection checks `oh-my-opencode` before `oh-my-openagent`, so if both plugin config basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
+**Rename compatibility:** The published package and CLI binary remain `oh-my-opencode`. OpenCode plugin registration prefers `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. Config detection checks `oh-my-openagent` before `oh-my-opencode`, so if both plugin config basenames exist in the same directory, the canonical `oh-my-openagent.*` file currently wins and edits to the legacy `oh-my-opencode.*` file can look ignored. Run `ls -la ~/.config/opencode/oh-my-openagent.json* ~/.config/opencode/oh-my-opencode.json*` and the same check in project `.opencode/` directories when model routing appears stale after restart.
 JSONC supports `// line comments`, `/* block comments */`, and trailing commas.
 
 Enable schema autocomplete:


### PR DESCRIPTION
Refs #3570.

I corrected the rename compatibility note in the configuration reference. It now says the canonical `oh-my-openagent.*` config wins when both canonical and legacy basenames exist in the same directory, and points users at a quick file check when legacy edits appear ignored after restart.

Validation:
- `rg -n 'Config detection checks `oh-my-opencode` before `oh-my-openagent`|legacy `oh-my-opencode\\.\\*` file currently wins' docs/reference/configuration.md; test $? -eq 1`\n- `rg -n 'canonical `oh-my-openagent\\.\\*` file currently wins|legacy `oh-my-opencode\\.\\*` file can look ignored' docs/reference/configuration.md`\n- `git diff --check`\n- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-20-config-precedence-docs-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the configuration reference to clarify that detection prefers `oh-my-openagent` over `oh-my-opencode`, so the canonical file wins. Added a quick `ls` check to debug ignored edits after restart; addresses #3570.

<sup>Written for commit fa5d44572af4a143c06d8efcfd1a3fac51b8d201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

