### PR TITLE
docs(config): clarify dcp runtime scope

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -989,9 +989,11 @@ When enabled, OmO registers the hash-anchored `edit` tool and activates the `has
 | `dynamic_context_pruning.notification`   | `detailed` | Pruning notifications: `off` / `minimal` / `detailed`                                |
 | `turn_protection.turns`                  | `3`        | Recent turns protected from pruning (1–10)                                           |
 | `strategies.deduplication`               | `true`     | Remove duplicate tool calls                                                          |
-| `strategies.supersede_writes`            | `true`     | Prune write inputs when file later read                                              |
-| `strategies.supersede_writes.aggressive` | `false`    | Prune any write if ANY subsequent read exists                                        |
-| `strategies.purge_errors.turns`          | `5`        | Turns before pruning errored tool inputs                                             |
+| `strategies.supersede_writes`            | `true`     | Schema-visible experimental option; no active runtime pruning path in current `dev`   |
+| `strategies.supersede_writes.aggressive` | `false`    | Schema-visible experimental option; no active runtime pruning path in current `dev`   |
+| `strategies.purge_errors.turns`          | `5`        | Schema-visible experimental option; no active runtime pruning path in current `dev`   |
+
+Current runtime scope: dynamic context pruning currently wires the deduplication recovery path. `supersede_writes` and `purge_errors` remain accepted by the schema for compatibility, but do not rely on them to prune context until a runtime implementation lands.
 
 ---
 


### PR DESCRIPTION
Refs #3351.

I clarified the dynamic context pruning reference so `supersede_writes` and `purge_errors` no longer read like active runtime behavior. The docs now mark those knobs as schema-visible experimental options and say the current runtime path wires deduplication recovery.

Validation:
- `git show upstream/dev:docs/reference/configuration.md | rg -n 'no active runtime pruning path|Current runtime scope|schema-visible experimental option'; test $? -eq 1`\n- `rg -n 'no active runtime pruning path|Current runtime scope|schema-visible experimental option|deduplication recovery path' docs/reference/configuration.md`\n- `git diff --check`\n- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-22-dcp-runtime-scope-docs-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified dynamic context pruning docs to align with Linear #3351. Marked `strategies.supersede_writes` (incl. `.aggressive`) and `strategies.purge_errors.turns` as schema-visible experimental options with no active runtime pruning path, and noted that the current runtime only wires the deduplication recovery path.

<sup>Written for commit 85e5664703510de2873b3d5d480eb6f05c2bf176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

