### PR TITLE
docs(install): add bun global trust recovery

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -139,6 +139,14 @@ bunx oh-my-openagent install
 
 The TUI walks you through it. **Do NOT use `npm install -g`, `bun add -g`, or `bun install -g`** — global installation is not officially supported. oh-my-openagent is a plugin that must resolve from where OpenCode/Codex loads plugins, and the `prepare` script requires Bun. Always invoke via `bunx`.
 
+If you already used Bun global install or update and Bun reports blocked lifecycle scripts, inspect them before trusting anything:
+
+```bash
+bun pm -g untrusted
+```
+
+Do not run a blanket trust command. Trust only packages you recognize from this install path, such as `oh-my-openagent`, legacy `oh-my-opencode`, `@ast-grep/cli`, or `@code-yeongyu/comment-checker`, then rerun the supported `bunx oh-my-openagent install` or `npx lazycodex-ai doctor` check.
+
 ## For LLM Agents
 
 > **IMPORTANT: Use `curl` to fetch this file, NOT WebFetch.** WebFetch summarizes content and loses critical flags like `--platform`, subscription questions, and Codex verification details. Always use:


### PR DESCRIPTION
Refs #5183.

I added a small recovery note for users who already used Bun global install or update and now see blocked lifecycle scripts. The docs point them at `bun pm -g untrusted`, warn against blanket trust, and list the package names they may recognize from this install path before rerunning the supported install or doctor check.

Validation:
- `git show upstream/dev:docs/guide/installation.md | rg -n 'bun pm -g untrusted|bun pm -g trust|blocked lifecycle scripts|Do not run a blanket trust command'; test $? -eq 1`\n- `rg -n 'bun pm -g untrusted|blocked lifecycle scripts|Do not run a blanket trust command|@code-yeongyu/comment-checker' docs/guide/installation.md`\n- `git diff --check`\n- tmux QA transcript captured in `/mnt/c/Users/Han/.omo/evidence/task-24-bun-global-trust-docs-tmux.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add recovery guidance in installation docs for users who used Bun global install/update and hit blocked lifecycle scripts. It directs users to `bun pm -g untrusted`, avoid blanket trust, trust only known packages (`oh-my-openagent`, legacy `oh-my-opencode`, `@ast-grep/cli`, `@code-yeongyu/comment-checker`), then rerun `bunx oh-my-openagent install` or `npx lazycodex-ai doctor`—addressing Linear 5183.

<sup>Written for commit b14cc8f3b30f9f08e974ab52ecac3e3a3a6d2d29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

