### PR TITLE
fix: clear completed background subagent fallback eligibility

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -11,6 +11,7 @@ import { clearSessionPromptParams, getSessionPromptParams } from "../../shared/s
 import {
   getSessionAgent,
   registerAgentName,
+  setSessionAgent,
   _resetForTesting as resetClaudeCodeSessionState,
   subagentSessions,
 } from "../claude-code-session-state"
@@ -2411,6 +2412,38 @@ describe("BackgroundManager.tryCompleteTask", () => {
 
     // #then
     expect(deletedSessionIDs).toEqual(["session-deleted-cb"])
+  })
+
+  test("should immediately clear completed subagent runtime-fallback eligibility", async () => {
+    // #given
+    resetClaudeCodeSessionState()
+    const sessionID = "session-completed-runtime-fallback"
+    subagentSessions.add(sessionID)
+    setSessionAgent(sessionID, "explore")
+
+    const task: BackgroundTask = {
+      id: "task-completed-runtime-fallback",
+      sessionId: sessionID,
+      parentSessionId: "session-parent",
+      parentMessageId: "msg-1",
+      description: "completed task should not be retried by runtime fallback",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+
+    try {
+      // #when
+      await tryCompleteTaskForTest(manager, task)
+
+      // #then
+      expect(task.status).toBe("completed")
+      expect(subagentSessions.has(sessionID)).toBe(false)
+      expect(getSessionAgent(sessionID)).toBeUndefined()
+    } finally {
+      resetClaudeCodeSessionState()
+    }
   })
 
   test("should clean pendingByParent even when promptAsync notification fails", async () => {

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -2487,6 +2487,11 @@ The task was re-queued on a fallback model after a retryable failure.
     }
 
     if (task.sessionId) {
+      subagentSessions.delete(task.sessionId)
+      clearSessionAgent(task.sessionId)
+      clearDelegatedChildSessionBootstrap(task.sessionId)
+      SessionCategoryRegistry.remove(task.sessionId)
+
       // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT)
       await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
 
@@ -2496,9 +2501,6 @@ The task was re-queued on a fallback model after a retryable failure.
       await this.onSubagentSessionDeleted?.({ sessionID: task.sessionId }).catch((error) => {
         log("[background-agent] onSubagentSessionDeleted callback failed:", { taskId: task.id, sessionID: task.sessionId, error: String(error) })
       })
-
-      clearDelegatedChildSessionBootstrap(task.sessionId)
-      SessionCategoryRegistry.remove(task.sessionId)
     }
 
     // Update continuation marker for CLI run mode

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-timeout.ts
@@ -3,6 +3,7 @@ import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { getFallbackModelsForSession } from "./fallback-models"
 import { prepareFallback } from "./fallback-state"
+import { subagentSessions } from "../../features/claude-code-session-state"
 
 declare function setTimeout(callback: () => void | Promise<void>, delay?: number): RuntimeFallbackTimeout
 declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
@@ -39,9 +40,15 @@ export function createFallbackTimeoutHelpers(
 
     const timeoutMs = options?.session_timeout_ms ?? config.timeout_seconds * 1000
     if (timeoutMs <= 0) return
+    const wasSubagentSession = subagentSessions.has(sessionID)
 
     const timer = setTimeout(async () => {
       sessionFallbackTimeouts.delete(sessionID)
+
+      if (wasSubagentSession && !subagentSessions.has(sessionID)) {
+        log(`[${HOOK_NAME}] Session fallback timeout skipped for completed subagent`, { sessionID })
+        return
+      }
 
       const state = sessionStates.get(sessionID)
       if (!state) return

--- a/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts
@@ -9,6 +9,10 @@ import {
 import * as loggerModule from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import {
+  _resetForTesting as resetClaudeCodeSessionState,
+  subagentSessions,
+} from "../../features/claude-code-session-state"
+import {
   releaseAllPromptAsyncReservationsForTesting,
   releasePromptAsyncReservation,
 } from "../shared/prompt-async-gate"
@@ -26,6 +30,7 @@ describe("runtime-fallback", () => {
     logCalls = []
     toastCalls = []
     SessionCategoryRegistry.clear()
+    resetClaudeCodeSessionState()
     clearAllDelegatedChildSessionBootstrap()
     releaseAllPromptAsyncReservationsForTesting()
 
@@ -44,6 +49,7 @@ describe("runtime-fallback", () => {
 
   afterEach(() => {
     SessionCategoryRegistry.clear()
+    resetClaudeCodeSessionState()
     clearAllDelegatedChildSessionBootstrap()
     releaseAllPromptAsyncReservationsForTesting()
     mock.restore()
@@ -1804,6 +1810,79 @@ describe("runtime-fallback", () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
 
       expect(retriedModels).toHaveLength(1)
+    })
+
+    test("should not advance fallback timeout after completed subagent clears eligibility", async () => {
+      const retriedModels: string[] = []
+      const abortCalls: Array<{ path?: { id?: string } }> = []
+
+      const hook = createRuntimeFallbackHook(
+        createMockPluginInput({
+          session: {
+            messages: async () => ({
+              data: [{ info: { role: "user" }, parts: [{ type: "text", text: "hello" }] }],
+            }),
+            promptAsync: async (args: unknown) => {
+              const model = (args as { body?: { model?: { providerID?: string; modelID?: string } } })?.body?.model
+              if (model?.providerID && model?.modelID) {
+                retriedModels.push(`${model.providerID}/${model.modelID}`)
+              }
+              return {}
+            },
+            abort: async (args: unknown) => {
+              abortCalls.push(args as { path?: { id?: string } })
+              return {}
+            },
+          },
+        }),
+        {
+          config: createMockConfig({ notify_on_fallback: false, timeout_seconds: 30 }),
+          pluginConfig: createMockPluginConfigWithCategoryFallback([
+            "github-copilot/claude-opus-4.7",
+            "anthropic/claude-opus-4-7",
+            "openai/gpt-5.4",
+          ]),
+          session_timeout_ms: 20,
+        }
+      )
+
+      const sessionID = "test-completed-subagent-cancels-timeout-fallback"
+      subagentSessions.add(sessionID)
+      SessionCategoryRegistry.register(sessionID, "test")
+
+      await hook.event({
+        event: {
+          type: "session.created",
+          properties: { info: { id: sessionID, model: "google/gemini-2.5-pro" } },
+        },
+      })
+
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: {
+              name: "ProviderAuthError",
+              data: {
+                providerID: "google",
+                message:
+                  "Google Generative AI API key is missing. Pass it using the 'apiKey' parameter or the GOOGLE_GENERATIVE_AI_API_KEY environment variable.",
+              },
+            },
+          },
+        },
+      })
+
+      expect(retriedModels).toEqual(["github-copilot/claude-opus-4.7"])
+
+      subagentSessions.delete(sessionID)
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(retriedModels).toEqual(["github-copilot/claude-opus-4.7"])
+      expect(abortCalls).toEqual([])
+      const skipLog = logCalls.find((c) => c.msg.includes("Session fallback timeout skipped for completed subagent"))
+      expect(skipLog).toBeDefined()
     })
 
     test("should not trigger second fallback after successful assistant reply", async () => {


### PR DESCRIPTION
## Summary

Fixes #5240 by removing completed background child sessions from runtime-fallback eligibility immediately when the background task reaches terminal completion.

## Changes

- Clear `subagentSessions` and session-agent state before the completed child session teardown awaits `session.abort`.
- Keep existing delegated-child bootstrap and session-category cleanup, but move it before async teardown so fallback hooks cannot observe stale live-subagent state.
- Skip pre-armed runtime-fallback session timeouts when they were scheduled for a subagent session that has since completed and left `subagentSessions`.
- Add a regression test proving `tryCompleteTask()` immediately removes completed child sessions from runtime-fallback eligibility.
- Add a runtime-fallback regression test proving completed subagents do not advance timeout-driven fallback, while existing primary-session timeout fallback behavior remains intact.

## Testing

- `bun test packages/omo-opencode/src/features/background-agent/manager.test.ts --test-name-pattern "should immediately clear completed subagent runtime-fallback eligibility"` - passes after fix, failed before fix
- `bun test packages/omo-opencode/src/features/background-agent/manager.test.ts` - passes, 188 tests
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts --test-name-pattern "completed subagent clears eligibility"` - passes
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts --test-name-pattern "should advance fallback after session timeout"` - passes, confirms primary-session timeout fallback remains active
- `bun test packages/omo-opencode/src/hooks/runtime-fallback/index.test.ts` - passes, 67 tests
- `bun run typecheck` - passes
- `bun run build` - passes
- `bash .agents/skills/opencode-qa/scripts/lib/common.sh --self-check` - passes
- `bash .agents/skills/opencode-qa/scripts/sse-hook-probe.sh --self-test` - passes

## Notes

- `bun test` was also run. The changed `background-agent/manager.test.ts` suite passed, but the root suite still reports unrelated pre-existing failures in launcher, Windows shell, global agent, and SDK message fixer tests.
- `lsp_diagnostics` could not run because the local Codex LSP daemon socket did not become reachable; `bun run typecheck` passed.
