### PR TITLE
docs(features): explain background agent work directories

### DIFF
--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -71,6 +71,32 @@ task(subagent_type="explore", load_skills=[], prompt="Find auth implementations"
 background_output(task_id="bg_abc123")
 ```
 
+#### Background Agent Work Directories
+
+Background agents inherit the session working directory from OpenCode and OMO when
+the task tool starts them. OMO does not force the model's own shell commands to
+stay inside that directory after launch. If a model decides to clone a repo,
+download docs, or create scratch files under `/tmp` or macOS `/var/folders/...`,
+the filesystem prompt comes from that command, not from a separate OMO storage
+root.
+
+`APP_DIR` is an OpenCode process environment value. Treat it as process context,
+not as a guarantee that every background agent artifact will land there.
+
+For projects that must keep all agent scratch work under the repository, add a
+project `AGENTS.md` rule with an explicit writable path:
+
+```md
+Use ./.omo/session-work/ for clones, downloaded docs, scratch files, and
+temporary outputs. Do not write under /tmp, /var, or other OS temp directories
+unless the user approves it.
+```
+
+If you use tmux panes for background agents, each pane still follows the same
+model instructions. A project rule is more reliable than repeating the
+constraint in one prompt, because every subagent receives the rule with the
+project context.
+
 #### Visual Multi-Agent with Tmux
 
 Enable `tmux.enabled` to see background agents in separate tmux panes:


### PR DESCRIPTION
Fixes #4124.

Background agents now have a short docs note that explains where their scratch files may land.

Changed:

- Added `Background Agent Work Directories` to the features reference.
- Clarified that OMO starts background agents from the session working directory, but the model can still run shell commands that write under `/tmp` or macOS `/var/folders/...`.
- Explained that `APP_DIR` is process context, not a storage guarantee.
- Added a small `AGENTS.md` rule users can copy when they need repo-local scratch work.

Validation:

- `rg -n "Background Agent Work Directories|APP_DIR|\\.omo/session-work|Do not write under /tmp" docs/reference/features.md`
- `git diff --check`
- tmux QA transcript captured the new section lookup and cleanup receipt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Background Agent Work Directories” note to the features reference to explain where background agents may write scratch files and how to keep them in-repo. Addresses #4124 by clarifying that agents inherit the session working directory, models may still write to `/tmp` or macOS `/var/folders/...`, `APP_DIR` is process context (not a storage guarantee), and by recommending an `AGENTS.md` rule to use `./.omo/session-work/`.

<sup>Written for commit 08d4fb98aef2a4bfe2217432e3970cac832df93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

