### PR TITLE
docs(config): explain split Claude routing

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1038,6 +1038,45 @@ The installer prepares Git Bash with normal detection, `OMO_CODEX_GIT_BASH_PATH`
 
 Install [`opencode-antigravity-auth`](https://github.com/NoeFabris/opencode-antigravity-auth) for Google Gemini. Provides multi-account load balancing, dual quota, and variant-based thinking.
 
+##### Split Claude Routing
+
+Provider path affects the effective Claude context limit. Antigravity Claude
+models are the stable 200k lane. Direct Anthropic Claude models are the 1M lane
+for accounts and model IDs that support long context.
+
+Use Antigravity for cheaper or quota-balanced work where 200k context is enough.
+Use direct Anthropic for long-context planning, review, and research sessions
+where early compaction would lose important context.
+
+```jsonc
+{
+  "agents": {
+    // 200k lane: Google Antigravity Claude.
+    "explore": {
+      "model": "google/antigravity-claude-sonnet-4-6"
+    },
+    "librarian": {
+      "model": "google/antigravity-claude-sonnet-4-6"
+    },
+
+    // 1M lane: direct Anthropic, only for eligible long-context accounts/models.
+    "sisyphus": {
+      "model": "anthropic/claude-opus-4-6",
+      "variant": "max"
+    },
+    "oracle": {
+      "model": "anthropic/claude-opus-4-6"
+    }
+  }
+}
+```
+
+If you see an error like `prompt is too long ... > 200000`, check whether the
+agent is routed through `google/antigravity-*`. Move that agent to a direct
+`anthropic/*` model only when the account, model, and required beta/header setup
+support 1M context. Keep the Antigravity lane explicit when you want predictable
+200k behavior.
+
 #### Ollama
 
 **Must** disable streaming to avoid JSON parse errors:


### PR DESCRIPTION
Fixes #2206.

Added provider-specific docs for split Claude routing.

Changed:

- Documented Antigravity Claude as the predictable 200k lane.
- Documented direct Anthropic Claude as the 1M lane for eligible accounts and models.
- Added a side-by-side config example for Explore/Librarian vs Sisyphus/Oracle.
- Added the `prompt is too long ... > 200000` troubleshooting clue.

Validation:

- `rg -n "Split Claude Routing|200k lane|1M lane|prompt is too long|google/antigravity-\\*|anthropic/\\*" docs/reference/configuration.md`
- `git diff --check`
- tmux QA transcript captured the new section and troubleshooting lookup, then killed the tmux session.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2206 by documenting split Claude routing: `google/antigravity-claude-*` is the predictable 200k lane; direct `anthropic/claude-*` is the 1M lane for eligible accounts. Adds a side-by-side config example and a troubleshooting note for `prompt is too long ... > 200000`.

<sup>Written for commit 46a09f8b690d16ab80c97ef0215a8dcb9737645d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

