### PR TITLE
docs(agents): add OMO AGENTS template

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,7 @@
 | Privacy & ToS | [docs/legal/](legal) |
 | Manifesto | [docs/manifesto.md](manifesto.md) |
 | Ollama troubleshooting | [docs/troubleshooting/ollama.md](troubleshooting/ollama.md) |
+| Copyable project rules template | [docs/templates/AGENTS.md.example](templates/AGENTS.md.example) |
 
 ## STRUCTURE
 
@@ -39,6 +40,8 @@ docs/
 ├── reference/                                # API / config / CLI reference (8 files)
 ├── examples/                                 # Sample JSONC configs (3 files)
 ├── legal/                                    # privacy-policy.md + terms-of-service.md
+├── templates/
+│   └── AGENTS.md.example                     # Copyable OMO project rules template
 └── troubleshooting/
     └── ollama.md
 ```

--- a/docs/templates/AGENTS.md.example
+++ b/docs/templates/AGENTS.md.example
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+This project uses Oh My OpenAgent with OpenCode. Read this file before planning
+or changing files.
+
+## Orchestrator Contract
+
+- Start by identifying the real user goal and the smallest observable result
+  that satisfies it.
+- Delegate independent search, implementation, and verification work to
+  background agents when the task has separable parts.
+- Keep direct edits focused on work that does not need specialist context.
+- Verify worker results yourself before using them as evidence.
+
+## Agent Selection Rules
+
+- Use `explore` for fast codebase search, policy lookup, and path discovery.
+- Use `librarian` for docs, external references, and examples from other repos.
+- Use `oracle` for architecture review, risk checks, and debugging analysis.
+- Use `sisyphus` or `sisyphus-junior` for execution work that needs file edits.
+- Use `prometheus` for plans that need user approval before implementation.
+
+## Calling Conventions
+
+- Give each delegated agent one goal, a clear deliverable, and exact paths or
+  commands to inspect.
+- Ask read-only agents for findings with file paths and evidence, not edits.
+- Ask implementation agents to include the verification commands they ran.
+- Retrieve background output before marking a delegated task complete.
+
+## Instruction Phrasing
+
+- Prefer affirmative constraints: "Keep scratch files under ./.omo/session-work/"
+  instead of broad negative phrasing.
+- State required artifacts directly: evidence files, screenshots, transcripts,
+  command output, or PR links.
+- Name the allowed work area when the task must avoid unrelated files.
+
+## Workflow Loop
+
+- Plan the work, then split independent tasks before starting edits.
+- Run the cheapest useful failing check or missing-docs search before the fix.
+- Apply the smallest change that satisfies the request.
+- Run targeted checks and one real surface QA step.
+- Summarize what changed, what passed, and any remaining risk.
+
+## Project Scratch Space
+
+Use `./.omo/session-work/` for temporary clones, downloaded references, logs, and
+agent scratch files. Keep generated evidence under `./.omo/evidence/` when the
+project wants durable QA records.


### PR DESCRIPTION
Fixes #614.

Added a copyable AGENTS.md starter template for OMO projects.

Changed:

- Added `docs/templates/AGENTS.md.example`.
- Included the requested sections for orchestration, agent selection, calling conventions, phrasing, and workflow loop.
- Added scratch-space guidance for `.omo/session-work/` and `.omo/evidence/`.
- Updated `docs/AGENTS.md` so contributors can find the template.

Validation:

- `rg -n "AGENTS\\.md\\.example|Orchestrator Contract|Agent Selection Rules|Calling Conventions|Instruction Phrasing|Workflow Loop" docs/AGENTS.md docs/templates/AGENTS.md.example`
- `git diff --check`
- tmux QA transcript captured the docs index entry and key template headings, then killed the tmux session.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copyable `AGENTS.md` template for OMO projects and links it from the docs index. Addresses Linear #614 by providing a standard, ready-to-use agent rules doc.

- **New Features**
  - Added `docs/templates/AGENTS.md.example`; linked from `docs/AGENTS.md`.
  - Includes: Orchestrator Contract, Agent Selection Rules, Calling Conventions, Instruction Phrasing, Workflow Loop.
  - Adds scratch-space guidance for `./.omo/session-work/` and `./.omo/evidence/`.

<sup>Written for commit 2bc8fe2eed6e6da46954820ca7014269066bc81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

