### PR TITLE
docs(known-issues): note Anthropic opencode filtering

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,11 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #3435 — Anthropic subscription auth may reject prompts containing `opencode`
+
+- **Affects**: Anthropic subscription-token routes and third-party auth plugins. API-key routes may behave differently.
+- **Symptom**: Anthropic returns `Third-party apps now draw from extra usage, not plan limits...` for one project while similar projects still work.
+- **Likely trigger**: Upstream Anthropic filtering appears sensitive to the literal string `opencode` in custom project rules, system prompt text, or OMO's legacy prompt identifiers.
+- **Workaround**: In user-controlled project files such as `AGENTS.md`, prefer `oh-my-openagent`, `OMO`, or `OpenCode` wording instead of the lowercase literal `opencode` when targeting Anthropic subscription providers.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/3435. The runtime prompt-identity cleanup still needs maintainer direction, so this workaround does not close the underlying issue.


### PR DESCRIPTION
Refs #3435.

Added the Anthropic subscription-auth `opencode` literal problem to known issues.

Changed:

- Documented the `Third-party apps now draw from extra usage...` symptom.
- Captured the likely trigger around lowercase `opencode` in user-controlled prompts or project rules.
- Added the current workaround: use `oh-my-openagent`, `OMO`, or `OpenCode` wording in project `AGENTS.md` when targeting Anthropic subscription providers.
- Left the status open because runtime prompt-identity cleanup still needs maintainer direction.

Validation:

- `git show upstream/dev:docs/reference/known-issues.md | rg -n '#3435|Third-party apps now draw|literal string \\`opencode\\`|oh-my-openagent.*OMO.*OpenCode|runtime prompt-identity'`
- `rg -n '#3435|Third-party apps now draw|literal string \\`opencode\\`|oh-my-openagent.*OMO.*OpenCode|runtime prompt-identity' docs/reference/known-issues.md`
- `git diff --check`
- tmux QA transcript captured the known-issues lookup and cleanup receipt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a new Known Issues entry for Anthropic subscription-auth rejecting prompts that include `opencode`. It explains the symptom, the likely trigger, a workaround (use `oh-my-openagent`, `OMO`, or `OpenCode` wording), and links to #3435 with the status left open.

<sup>Written for commit 17a3a4904d99068e88c7ab6683fd30fc1a024bb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

