### PR TITLE
docs(known-issues): note Desktop agent visibility triage

### DIFF
--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -38,3 +38,12 @@ Issue #4059 tracks the reland with stabilized regression coverage. The reland is
 - **Symptom**: Custom LSP server configuration in your project's `oh-my-openagent.jsonc` is not applied at runtime.
 - **Workaround**: Configure your LSP server through OpenCode's native `lsp` config instead.
 - **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/4225.
+
+## #3835 / #3456 — OpenCode Desktop shows only native agents
+
+- **Affects**: OpenCode Desktop sessions where `opencode agent list` or the TUI still shows OMO agents, but the Desktop agent selector only shows native agents such as Build and Plan.
+- **Symptom**: Desktop hides Sisyphus, Hephaestus, Prometheus, Atlas, or other OMO agents even though `oh-my-openagent doctor` passes.
+- **First check**: Inspect the OpenCode Desktop log for `Failed to load plugin oh-my-openagent@latest` and missing files under `~/.cache/opencode/packages/oh-my-openagent@latest/node_modules`.
+- **Cache workaround**: Close Desktop, remove the `oh-my-openagent@latest` package cache, then reinstall the plugin from the same working directory with `opencode plugin oh-my-openagent@latest`.
+- **Scope workaround**: If the plugin loads in one shell but not Desktop, compare the active user and project `opencode.json` files. OpenCode can read a closer project `.opencode/opencode.json` instead of the user config you inspected.
+- **Status**: Open. Tracked at https://github.com/code-yeongyu/oh-my-openagent/issues/3835 and https://github.com/code-yeongyu/oh-my-openagent/issues/3456. This entry documents current triage steps; it does not resolve Desktop GUI rendering regressions.


### PR DESCRIPTION
Refs #3835 and #3456.

Added a known-issues note for the OpenCode Desktop agent selector problem.

Changed:

- Documented the case where CLI/TUI can see OMO agents but Desktop only shows native agents like Build and Plan.
- Added the plugin-cache log signature: `Failed to load plugin oh-my-openagent@latest` with missing files under the OpenCode package cache.
- Added two triage steps: rebuild the plugin cache from the same working directory, and compare user vs project `opencode.json` scope.
- Kept the status open because the broader Desktop GUI rendering issue still needs upstream or maintainer follow-up.

Validation:

- `rg -n 'Desktop shows only native agents|Build and Plan|Failed to load plugin oh-my-openagent@latest|opencode plugin oh-my-openagent@latest|project .opencode/opencode.json' docs/reference/known-issues.md`
- `git diff --check`
- tmux QA transcript captured the known-issues lookup and cleanup receipt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Known Issues entry for the Desktop agent selector bug where OpenCode Desktop shows only native agents while CLI/TUI still list OMO agents. It highlights the "Failed to load plugin `oh-my-openagent@latest`" log and adds two triage steps: rebuild the plugin cache from the same working directory and compare user vs project `opencode.json`; references #3835 and #3456 (still open).

<sup>Written for commit b9b7b5c6afb9835507c1d1f225b39a34f2b92c7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

