### PR TITLE
docs(codex): add hook code 1 recovery note

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -711,6 +711,7 @@ The Codex CLI Light edition is fully independent of the OpenCode plugin. You can
 | `Ignoring malformed agent role definition: agents.*.config_file must point to an existing file` | Re-run `npx lazycodex-ai install`. The installer repairs stale managed `[agents.*]` entries and recreates `~/.codex/agents/*.toml`. |
 | `agents.max_threads cannot be set when multi_agent_v2 is enabled` in one project | Re-run `npx lazycodex-ai install` from that project. The installer repairs project-local `.codex/config.toml` layers, creates `.backup-<timestamp>` files for changed configs, and leaves user-authored `.codex` artifacts in place. |
 | `SessionStart hook (failed)` / `UserPromptSubmit hook (failed)` with `MODULE_NOT_FOUND` for `components/*/dist/cli.js` | Re-run the installer so the cached plugin is rebuilt with component `dist/` files. If the cache was manually edited, remove `~/.codex/plugins/cache/sisyphuslabs` first. |
+| `SessionStart hook (failed)` / `UserPromptSubmit hook (failed)` with only `hook exited with code 1` after install | Re-run `npx lazycodex-ai install`, then start a fresh Codex session or restart the Codex app. If the same hook fails again in the fresh session, inspect the saved hook output to identify the component command before deleting cache state. |
 | Hook trust hash mismatch warnings | Re-run the installer; hashes are regenerated each install |
 
 ### Step 8: Team Mode (optional, opt-in)


### PR DESCRIPTION
Refs #4722.

Added a Codex troubleshooting note for bare hook code-1 failures right after install.

Changed:

- Added a row for `SessionStart` / `UserPromptSubmit` hook failures that only show `hook exited with code 1`.
- Recommended rerunning `npx lazycodex-ai install`.
- Added the follow-up step to start a fresh Codex session or restart the Codex app.
- Kept cache deletion behind saved hook-output inspection.

Validation:

- `rg -n 'hook exited with code 1|fresh Codex session|restart the Codex app|saved hook output' docs/guide/installation.md`
- `git diff --check`
- tmux QA transcript captured the troubleshooting row and cleanup receipt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a troubleshooting note to the installation guide for `SessionStart`/`UserPromptSubmit` hook failures that only show "hook exited with code 1" right after install (addresses #4722).
It advises rerunning `npx lazycodex-ai install`, then starting a fresh Codex session or restarting the app, and inspecting saved hook output before deleting cache state.

<sup>Written for commit 86241c2a7f2b1baf42c1a449e3f948885bbd7345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/5252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

